### PR TITLE
feat(tool): add Model Context Protocol (MCP) support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -97,6 +97,14 @@
             <scope>provided</scope>
         </dependency>
 
+        <!-- Model Context Protocol (MCP) SDK -->
+        <dependency>
+            <groupId>io.modelcontextprotocol.sdk</groupId>
+            <artifactId>mcp</artifactId>
+            <version>0.14.1</version>
+            <scope>provided</scope>
+        </dependency>
+
         <!-- Jackson for JSON serialization/deserialization -->
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>

--- a/src/main/java/io/agentscope/core/tool/Toolkit.java
+++ b/src/main/java/io/agentscope/core/tool/Toolkit.java
@@ -19,6 +19,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.agentscope.core.message.ToolResultBlock;
 import io.agentscope.core.message.ToolUseBlock;
 import io.agentscope.core.model.ToolSchema;
+import io.agentscope.core.tool.mcp.McpClientWrapper;
+import io.agentscope.core.tool.mcp.McpTool;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -28,6 +30,10 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.BiConsumer;
+import java.util.stream.Collectors;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 /**
@@ -40,7 +46,10 @@ import reactor.core.publisher.Mono;
  */
 public class Toolkit {
 
+    private static final Logger logger = LoggerFactory.getLogger(Toolkit.class);
+
     private final Map<String, AgentTool> tools = new ConcurrentHashMap<>();
+    private final Map<String, McpClientWrapper> mcpClients = new ConcurrentHashMap<>();
     private final ObjectMapper objectMapper = new ObjectMapper();
     private final ToolSchemaGenerator schemaGenerator = new ToolSchemaGenerator();
     private final ToolResultConverter responseConverter;
@@ -280,5 +289,165 @@ public class Toolkit {
      */
     public ToolkitConfig getConfig() {
         return config;
+    }
+
+    // ==================== MCP Client Registration ====================
+
+    /**
+     * Registers an MCP client and all its tools.
+     *
+     * @param mcpClientWrapper the MCP client wrapper
+     * @return Mono that completes when registration is finished
+     */
+    public Mono<Void> registerMcpClient(McpClientWrapper mcpClientWrapper) {
+        return registerMcpClient(mcpClientWrapper, null, null);
+    }
+
+    /**
+     * Registers an MCP client with tool filtering.
+     *
+     * @param mcpClientWrapper the MCP client wrapper
+     * @param enableTools list of tool names to enable (null means enable all)
+     * @return Mono that completes when registration is finished
+     */
+    public Mono<Void> registerMcpClient(
+            McpClientWrapper mcpClientWrapper, List<String> enableTools) {
+        return registerMcpClient(mcpClientWrapper, enableTools, null);
+    }
+
+    /**
+     * Registers an MCP client with tool filtering.
+     *
+     * @param mcpClientWrapper the MCP client wrapper
+     * @param enableTools list of tool names to enable (null means enable all)
+     * @param disableTools list of tool names to disable (null means disable none)
+     * @return Mono that completes when registration is finished
+     */
+    public Mono<Void> registerMcpClient(
+            McpClientWrapper mcpClientWrapper,
+            List<String> enableTools,
+            List<String> disableTools) {
+
+        if (mcpClientWrapper == null) {
+            return Mono.error(new IllegalArgumentException("MCP client wrapper cannot be null"));
+        }
+
+        logger.info("Registering MCP client: {}", mcpClientWrapper.getName());
+
+        return mcpClientWrapper
+                .initialize()
+                .then(Mono.defer(mcpClientWrapper::listTools))
+                .flatMapMany(Flux::fromIterable)
+                .filter(tool -> shouldRegisterTool(tool.name(), enableTools, disableTools))
+                .doOnNext(
+                        mcpTool -> {
+                            logger.debug(
+                                    "Registering MCP tool: {} from client {}",
+                                    mcpTool.name(),
+                                    mcpClientWrapper.getName());
+
+                            McpTool agentTool =
+                                    new McpTool(
+                                            mcpTool.name(),
+                                            mcpTool.description() != null
+                                                    ? mcpTool.description()
+                                                    : "",
+                                            McpTool.convertMcpSchemaToParameters(
+                                                    mcpTool.inputSchema()),
+                                            mcpClientWrapper);
+                            registerAgentTool(agentTool);
+                        })
+                .then()
+                .doOnSuccess(
+                        v -> {
+                            mcpClients.put(mcpClientWrapper.getName(), mcpClientWrapper);
+                            logger.info(
+                                    "MCP client '{}' registered successfully",
+                                    mcpClientWrapper.getName());
+                        })
+                .doOnError(
+                        e ->
+                                logger.error(
+                                        "Failed to register MCP client: {}",
+                                        mcpClientWrapper.getName(),
+                                        e));
+    }
+
+    /**
+     * Removes an MCP client and all its tools.
+     *
+     * @param mcpClientName the name of the MCP client to remove
+     * @return Mono that completes when removal is finished
+     */
+    public Mono<Void> removeMcpClient(String mcpClientName) {
+        McpClientWrapper wrapper = mcpClients.remove(mcpClientName);
+        if (wrapper == null) {
+            logger.warn("MCP client not found: {}", mcpClientName);
+            return Mono.empty();
+        }
+
+        logger.info("Removing MCP client: {}", mcpClientName);
+
+        // Remove all tools from this MCP client
+        List<String> toolsToRemove =
+                tools.values().stream()
+                        .filter(tool -> tool instanceof McpTool)
+                        .filter(tool -> ((McpTool) tool).getClientName().equals(mcpClientName))
+                        .map(AgentTool::getName)
+                        .collect(Collectors.toList());
+
+        toolsToRemove.forEach(
+                toolName -> {
+                    tools.remove(toolName);
+                    logger.debug("Removed MCP tool: {}", toolName);
+                });
+
+        return Mono.fromRunnable(wrapper::close)
+                .then()
+                .doOnSuccess(
+                        v -> logger.info("MCP client '{}' removed successfully", mcpClientName));
+    }
+
+    /**
+     * Gets all registered MCP client names.
+     *
+     * @return set of MCP client names
+     */
+    public Set<String> getMcpClientNames() {
+        return new HashSet<>(mcpClients.keySet());
+    }
+
+    /**
+     * Gets an MCP client wrapper by name.
+     *
+     * @param name the MCP client name
+     * @return the MCP client wrapper, or null if not found
+     */
+    public McpClientWrapper getMcpClient(String name) {
+        return mcpClients.get(name);
+    }
+
+    /**
+     * Determines if a tool should be registered based on enable/disable lists.
+     *
+     * @param toolName the tool name
+     * @param enableTools list of tools to enable (null means all)
+     * @param disableTools list of tools to disable (null means none)
+     * @return true if the tool should be registered
+     */
+    private boolean shouldRegisterTool(
+            String toolName, List<String> enableTools, List<String> disableTools) {
+        // If enableTools is specified, only register tools in the list
+        if (enableTools != null && !enableTools.isEmpty()) {
+            return enableTools.contains(toolName);
+        }
+
+        // If disableTools is specified, exclude tools in the list
+        if (disableTools != null && !disableTools.isEmpty()) {
+            return !disableTools.contains(toolName);
+        }
+
+        // Default: register all tools
+        return true;
     }
 }

--- a/src/main/java/io/agentscope/core/tool/mcp/McpAsyncClientWrapper.java
+++ b/src/main/java/io/agentscope/core/tool/mcp/McpAsyncClientWrapper.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2024-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.core.tool.mcp;
+
+import io.modelcontextprotocol.client.McpAsyncClient;
+import io.modelcontextprotocol.spec.McpSchema;
+import java.util.List;
+import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import reactor.core.publisher.Mono;
+
+/**
+ * Wrapper for asynchronous MCP clients using Project Reactor.
+ * This implementation delegates to {@link McpAsyncClient} and provides
+ * reactive operations that return Mono types.
+ *
+ * <p>Example usage:
+ * <pre>{@code
+ * McpAsyncClient client = ... // created via McpClient.async()
+ * McpAsyncClientWrapper wrapper = new McpAsyncClientWrapper("my-mcp", client);
+ * wrapper.initialize()
+ *     .then(wrapper.callTool("tool_name", Map.of("arg1", "value1")))
+ *     .subscribe(result -> System.out.println(result));
+ * }</pre>
+ */
+public class McpAsyncClientWrapper extends McpClientWrapper {
+
+    private static final Logger logger = LoggerFactory.getLogger(McpAsyncClientWrapper.class);
+
+    private final McpAsyncClient client;
+
+    /**
+     * Constructs a new asynchronous MCP client wrapper.
+     *
+     * @param name unique identifier for this client
+     * @param client the underlying async MCP client
+     */
+    public McpAsyncClientWrapper(String name, McpAsyncClient client) {
+        super(name);
+        this.client = client;
+    }
+
+    @Override
+    public Mono<Void> initialize() {
+        if (initialized) {
+            return Mono.empty();
+        }
+
+        logger.info("Initializing MCP async client: {}", name);
+
+        return client.initialize()
+                .doOnSuccess(
+                        result ->
+                                logger.debug(
+                                        "MCP client '{}' initialized with server: {}",
+                                        name,
+                                        result.serverInfo().name()))
+                .then(client.listTools())
+                .doOnNext(
+                        result -> {
+                            logger.debug(
+                                    "MCP client '{}' discovered {} tools",
+                                    name,
+                                    result.tools().size());
+                            // Cache all tools
+                            result.tools().forEach(tool -> cachedTools.put(tool.name(), tool));
+                        })
+                .doOnSuccess(v -> initialized = true)
+                .doOnError(e -> logger.error("Failed to initialize MCP client: {}", name, e))
+                .then();
+    }
+
+    @Override
+    public Mono<List<McpSchema.Tool>> listTools() {
+        if (!initialized) {
+            return Mono.error(
+                    new IllegalStateException("MCP client '" + name + "' not initialized"));
+        }
+
+        return client.listTools().map(McpSchema.ListToolsResult::tools);
+    }
+
+    @Override
+    public Mono<McpSchema.CallToolResult> callTool(String toolName, Map<String, Object> arguments) {
+        if (!initialized) {
+            return Mono.error(
+                    new IllegalStateException("MCP client '" + name + "' not initialized"));
+        }
+
+        logger.debug("Calling MCP tool '{}' on client '{}'", toolName, name);
+
+        McpSchema.CallToolRequest request = new McpSchema.CallToolRequest(toolName, arguments);
+
+        return client.callTool(request)
+                .doOnSuccess(
+                        result -> {
+                            if (Boolean.TRUE.equals(result.isError())) {
+                                logger.warn(
+                                        "MCP tool '{}' returned error: {}",
+                                        toolName,
+                                        result.content());
+                            } else {
+                                logger.debug("MCP tool '{}' completed successfully", toolName);
+                            }
+                        })
+                .doOnError(
+                        e ->
+                                logger.error(
+                                        "Failed to call MCP tool '{}': {}",
+                                        toolName,
+                                        e.getMessage()));
+    }
+
+    @Override
+    public void close() {
+        if (client != null) {
+            logger.info("Closing MCP async client: {}", name);
+            try {
+                client.closeGracefully()
+                        .doOnSuccess(v -> logger.debug("MCP client '{}' closed", name))
+                        .doOnError(e -> logger.error("Error closing MCP client '{}'", name, e))
+                        .block();
+            } catch (Exception e) {
+                logger.error("Exception during MCP client close", e);
+                client.close();
+            }
+        }
+        initialized = false;
+        cachedTools.clear();
+    }
+}

--- a/src/main/java/io/agentscope/core/tool/mcp/McpClientBuilder.java
+++ b/src/main/java/io/agentscope/core/tool/mcp/McpClientBuilder.java
@@ -1,0 +1,354 @@
+/*
+ * Copyright 2024-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.core.tool.mcp;
+
+import io.modelcontextprotocol.client.McpAsyncClient;
+import io.modelcontextprotocol.client.McpClient;
+import io.modelcontextprotocol.client.McpSyncClient;
+import io.modelcontextprotocol.client.transport.HttpClientSseClientTransport;
+import io.modelcontextprotocol.client.transport.HttpClientStreamableHttpTransport;
+import io.modelcontextprotocol.client.transport.ServerParameters;
+import io.modelcontextprotocol.client.transport.StdioClientTransport;
+import io.modelcontextprotocol.json.McpJsonMapper;
+import io.modelcontextprotocol.spec.McpClientTransport;
+import io.modelcontextprotocol.spec.McpSchema;
+import java.net.URI;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import reactor.core.publisher.Mono;
+
+/**
+ * Builder for creating MCP client wrappers with fluent configuration.
+ *
+ * <p>Supports three transport types:
+ * <ul>
+ *   <li>StdIO - for local process communication</li>
+ *   <li>SSE - for HTTP Server-Sent Events (stateful)</li>
+ *   <li>StreamableHTTP - for HTTP streaming (stateless)</li>
+ * </ul>
+ *
+ * <p>Example usage:
+ * <pre>{@code
+ * // StdIO transport
+ * McpClientWrapper client = McpClientBuilder.create("git-mcp")
+ *     .stdioTransport("python", "-m", "mcp_server_git")
+ *     .buildAsync()
+ *     .block();
+ *
+ * // SSE transport with headers
+ * McpClientWrapper client = McpClientBuilder.create("remote-mcp")
+ *     .sseTransport("https://mcp.example.com/sse")
+ *     .header("Authorization", "Bearer " + token)
+ *     .timeout(Duration.ofSeconds(60))
+ *     .buildAsync()
+ *     .block();
+ *
+ * // Synchronous client
+ * McpClientWrapper client = McpClientBuilder.create("sync-mcp")
+ *     .streamableHttpTransport("https://mcp.example.com/http")
+ *     .buildSync();
+ * }</pre>
+ */
+public class McpClientBuilder {
+
+    private static final Duration DEFAULT_REQUEST_TIMEOUT = Duration.ofSeconds(120);
+    private static final Duration DEFAULT_INIT_TIMEOUT = Duration.ofSeconds(30);
+
+    private final String name;
+    private TransportConfig transportConfig;
+    private Duration requestTimeout = DEFAULT_REQUEST_TIMEOUT;
+    private Duration initializationTimeout = DEFAULT_INIT_TIMEOUT;
+
+    private McpClientBuilder(String name) {
+        this.name = name;
+    }
+
+    /**
+     * Creates a new MCP client builder with the specified name.
+     *
+     * @param name unique identifier for the MCP client
+     * @return new builder instance
+     */
+    public static McpClientBuilder create(String name) {
+        if (name == null || name.trim().isEmpty()) {
+            throw new IllegalArgumentException("MCP client name cannot be null or empty");
+        }
+        return new McpClientBuilder(name);
+    }
+
+    /**
+     * Configures StdIO transport for local process communication.
+     *
+     * @param command the executable command
+     * @param args command arguments
+     * @return this builder
+     */
+    public McpClientBuilder stdioTransport(String command, String... args) {
+        this.transportConfig = new StdioTransportConfig(command, Arrays.asList(args));
+        return this;
+    }
+
+    /**
+     * Configures StdIO transport with environment variables.
+     *
+     * @param command the executable command
+     * @param args command arguments list
+     * @param env environment variables
+     * @return this builder
+     */
+    public McpClientBuilder stdioTransport(
+            String command, List<String> args, Map<String, String> env) {
+        this.transportConfig = new StdioTransportConfig(command, args, env);
+        return this;
+    }
+
+    /**
+     * Configures HTTP SSE (Server-Sent Events) transport for stateful connections.
+     *
+     * @param url the server URL
+     * @return this builder
+     */
+    public McpClientBuilder sseTransport(String url) {
+        this.transportConfig = new SseTransportConfig(url);
+        return this;
+    }
+
+    /**
+     * Configures HTTP StreamableHTTP transport for stateless connections.
+     *
+     * @param url the server URL
+     * @return this builder
+     */
+    public McpClientBuilder streamableHttpTransport(String url) {
+        this.transportConfig = new StreamableHttpTransportConfig(url);
+        return this;
+    }
+
+    /**
+     * Adds an HTTP header (only applicable for HTTP transports).
+     *
+     * @param key header name
+     * @param value header value
+     * @return this builder
+     */
+    public McpClientBuilder header(String key, String value) {
+        if (transportConfig instanceof HttpTransportConfig) {
+            ((HttpTransportConfig) transportConfig).addHeader(key, value);
+        }
+        return this;
+    }
+
+    /**
+     * Sets multiple HTTP headers (only applicable for HTTP transports).
+     *
+     * @param headers map of header name-value pairs
+     * @return this builder
+     */
+    public McpClientBuilder headers(Map<String, String> headers) {
+        if (transportConfig instanceof HttpTransportConfig) {
+            ((HttpTransportConfig) transportConfig).setHeaders(headers);
+        }
+        return this;
+    }
+
+    /**
+     * Sets the request timeout duration.
+     *
+     * @param timeout timeout duration
+     * @return this builder
+     */
+    public McpClientBuilder timeout(Duration timeout) {
+        this.requestTimeout = timeout;
+        return this;
+    }
+
+    /**
+     * Sets the initialization timeout duration.
+     *
+     * @param timeout timeout duration
+     * @return this builder
+     */
+    public McpClientBuilder initializationTimeout(Duration timeout) {
+        this.initializationTimeout = timeout;
+        return this;
+    }
+
+    /**
+     * Builds an asynchronous MCP client wrapper.
+     *
+     * @return Mono emitting the async client wrapper
+     */
+    public Mono<McpClientWrapper> buildAsync() {
+        if (transportConfig == null) {
+            return Mono.error(new IllegalStateException("Transport must be configured"));
+        }
+
+        return Mono.fromCallable(
+                () -> {
+                    McpClientTransport transport = transportConfig.createTransport();
+
+                    McpSchema.Implementation clientInfo =
+                            new McpSchema.Implementation(
+                                    "agentscope-java", "AgentScope Java Framework", "1.0.0");
+
+                    McpSchema.ClientCapabilities clientCapabilities =
+                            McpSchema.ClientCapabilities.builder().build();
+
+                    McpAsyncClient mcpClient =
+                            McpClient.async(transport)
+                                    .requestTimeout(requestTimeout)
+                                    .initializationTimeout(initializationTimeout)
+                                    .clientInfo(clientInfo)
+                                    .capabilities(clientCapabilities)
+                                    .build();
+
+                    return new McpAsyncClientWrapper(name, mcpClient);
+                });
+    }
+
+    /**
+     * Builds a synchronous MCP client wrapper (blocking operations).
+     *
+     * @return synchronous client wrapper
+     */
+    public McpClientWrapper buildSync() {
+        if (transportConfig == null) {
+            throw new IllegalStateException("Transport must be configured");
+        }
+
+        McpClientTransport transport = transportConfig.createTransport();
+
+        McpSchema.Implementation clientInfo =
+                new McpSchema.Implementation(
+                        "agentscope-java", "AgentScope Java Framework", "1.0.0");
+
+        McpSchema.ClientCapabilities clientCapabilities =
+                McpSchema.ClientCapabilities.builder().build();
+
+        McpSyncClient mcpClient =
+                McpClient.sync(transport)
+                        .requestTimeout(requestTimeout)
+                        .initializationTimeout(initializationTimeout)
+                        .clientInfo(clientInfo)
+                        .capabilities(clientCapabilities)
+                        .build();
+
+        return new McpSyncClientWrapper(name, mcpClient);
+    }
+
+    // ==================== Internal Transport Configuration Classes ====================
+
+    private interface TransportConfig {
+        McpClientTransport createTransport();
+    }
+
+    private static class StdioTransportConfig implements TransportConfig {
+        private final String command;
+        private final List<String> args;
+        private final Map<String, String> env;
+
+        public StdioTransportConfig(String command, List<String> args) {
+            this(command, args, new HashMap<>());
+        }
+
+        public StdioTransportConfig(String command, List<String> args, Map<String, String> env) {
+            this.command = command;
+            this.args = new ArrayList<>(args);
+            this.env = new HashMap<>(env);
+        }
+
+        @Override
+        public McpClientTransport createTransport() {
+            ServerParameters.Builder paramsBuilder = ServerParameters.builder(command);
+
+            if (!args.isEmpty()) {
+                paramsBuilder.args(args);
+            }
+
+            if (!env.isEmpty()) {
+                paramsBuilder.env(env);
+            }
+
+            ServerParameters params = paramsBuilder.build();
+            return new StdioClientTransport(params, McpJsonMapper.getDefault());
+        }
+    }
+
+    private abstract static class HttpTransportConfig implements TransportConfig {
+        protected final String url;
+        protected Map<String, String> headers = new HashMap<>();
+
+        protected HttpTransportConfig(String url) {
+            this.url = url;
+        }
+
+        public void addHeader(String key, String value) {
+            headers.put(key, value);
+        }
+
+        public void setHeaders(Map<String, String> headers) {
+            this.headers = new HashMap<>(headers);
+        }
+    }
+
+    private static class SseTransportConfig extends HttpTransportConfig {
+        public SseTransportConfig(String url) {
+            super(url);
+        }
+
+        @Override
+        public McpClientTransport createTransport() {
+            HttpClientSseClientTransport.Builder builder =
+                    HttpClientSseClientTransport.builder(url)
+                            .sseEndpoint(URI.create(url).getPath());
+
+            if (!headers.isEmpty()) {
+                builder.customizeRequest(
+                        requestBuilder -> {
+                            headers.forEach(requestBuilder::header);
+                        });
+            }
+
+            return builder.build();
+        }
+    }
+
+    private static class StreamableHttpTransportConfig extends HttpTransportConfig {
+        public StreamableHttpTransportConfig(String url) {
+            super(url);
+        }
+
+        @Override
+        public McpClientTransport createTransport() {
+            HttpClientStreamableHttpTransport.Builder builder =
+                    HttpClientStreamableHttpTransport.builder(url)
+                            .endpoint(URI.create(url).getPath());
+
+            if (!headers.isEmpty()) {
+                builder.customizeRequest(
+                        requestBuilder -> {
+                            headers.forEach(requestBuilder::header);
+                        });
+            }
+
+            return builder.build();
+        }
+    }
+}

--- a/src/main/java/io/agentscope/core/tool/mcp/McpClientWrapper.java
+++ b/src/main/java/io/agentscope/core/tool/mcp/McpClientWrapper.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2024-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.core.tool.mcp;
+
+import io.modelcontextprotocol.spec.McpSchema;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import reactor.core.publisher.Mono;
+
+/**
+ * Abstract wrapper for MCP (Model Context Protocol) clients.
+ * This class manages the lifecycle of MCP client connections and provides
+ * a unified interface for both asynchronous and synchronous client implementations.
+ *
+ * <p>The wrapper handles:
+ * <ul>
+ *   <li>Client initialization and connection management</li>
+ *   <li>Tool discovery and caching</li>
+ *   <li>Tool invocation through the MCP protocol</li>
+ *   <li>Resource cleanup on close</li>
+ * </ul>
+ *
+ * @see McpAsyncClientWrapper
+ * @see McpSyncClientWrapper
+ */
+public abstract class McpClientWrapper implements AutoCloseable {
+
+    /** Unique identifier for this MCP client */
+    protected final String name;
+
+    /** Cache of tools available from this MCP server */
+    protected final Map<String, McpSchema.Tool> cachedTools;
+
+    /** Flag indicating whether the client has been initialized */
+    protected volatile boolean initialized = false;
+
+    /**
+     * Constructs a new MCP client wrapper.
+     *
+     * @param name unique identifier for this client
+     */
+    protected McpClientWrapper(String name) {
+        this.name = name;
+        this.cachedTools = new ConcurrentHashMap<>();
+    }
+
+    /**
+     * Gets the unique name of this MCP client.
+     *
+     * @return the client name
+     */
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * Checks if this client has been initialized.
+     *
+     * @return true if initialized, false otherwise
+     */
+    public boolean isInitialized() {
+        return initialized;
+    }
+
+    /**
+     * Initializes the MCP client connection and caches available tools.
+     * This method must be called before any tool operations.
+     *
+     * @return a Mono that completes when initialization is finished
+     */
+    public abstract Mono<Void> initialize();
+
+    /**
+     * Lists all tools available from this MCP server.
+     *
+     * @return a Mono emitting the list of available tools
+     */
+    public abstract Mono<List<McpSchema.Tool>> listTools();
+
+    /**
+     * Invokes a tool on the MCP server.
+     *
+     * @param toolName the name of the tool to call
+     * @param arguments the arguments to pass to the tool
+     * @return a Mono emitting the tool call result
+     */
+    public abstract Mono<McpSchema.CallToolResult> callTool(
+            String toolName, Map<String, Object> arguments);
+
+    /**
+     * Gets a cached tool definition by name.
+     *
+     * @param toolName the name of the tool
+     * @return the tool definition, or null if not found
+     */
+    public McpSchema.Tool getCachedTool(String toolName) {
+        return cachedTools.get(toolName);
+    }
+
+    /**
+     * Closes this MCP client and releases all resources.
+     * This method is idempotent and can be called multiple times safely.
+     */
+    @Override
+    public abstract void close();
+}

--- a/src/main/java/io/agentscope/core/tool/mcp/McpContentConverter.java
+++ b/src/main/java/io/agentscope/core/tool/mcp/McpContentConverter.java
@@ -1,0 +1,204 @@
+/*
+ * Copyright 2024-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.core.tool.mcp;
+
+import io.agentscope.core.message.Base64Source;
+import io.agentscope.core.message.ContentBlock;
+import io.agentscope.core.message.ImageBlock;
+import io.agentscope.core.message.TextBlock;
+import io.agentscope.core.message.ToolResultBlock;
+import io.modelcontextprotocol.spec.McpSchema;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Utility class for converting between MCP content types and AgentScope content blocks.
+ * This converter handles the translation of MCP protocol data structures to AgentScope's
+ * internal representation.
+ *
+ * <p>Supported conversions:
+ * <ul>
+ *   <li>MCP CallToolResult → AgentScope ToolResultBlock</li>
+ *   <li>MCP TextContent → AgentScope TextBlock</li>
+ *   <li>MCP ImageContent → AgentScope ImageBlock</li>
+ *   <li>MCP AudioContent → AgentScope AudioBlock (future)</li>
+ * </ul>
+ */
+public class McpContentConverter {
+
+    /**
+     * Private constructor to prevent instantiation.
+     */
+    private McpContentConverter() {
+        throw new UnsupportedOperationException("Utility class cannot be instantiated");
+    }
+
+    /**
+     * Converts an MCP CallToolResult to an AgentScope ToolResultBlock.
+     *
+     * @param mcpResult the MCP tool call result
+     * @return the converted ToolResultBlock
+     */
+    public static ToolResultBlock convertCallToolResult(McpSchema.CallToolResult mcpResult) {
+        if (mcpResult == null) {
+            return ToolResultBlock.error("MCP tool returned null result");
+        }
+
+        // Check if the result is an error
+        if (Boolean.TRUE.equals(mcpResult.isError())) {
+            String errorMsg = extractErrorMessage(mcpResult.content());
+            return ToolResultBlock.error(errorMsg);
+        }
+
+        // Convert successful result
+        List<ContentBlock> contentBlocks = convertContentList(mcpResult.content());
+
+        return ToolResultBlock.fromContentBlocks(contentBlocks);
+    }
+
+    /**
+     * Converts a list of MCP Content to AgentScope ContentBlocks.
+     *
+     * @param mcpContents the list of MCP content
+     * @return list of converted ContentBlocks
+     */
+    public static List<ContentBlock> convertContentList(List<McpSchema.Content> mcpContents) {
+        if (mcpContents == null || mcpContents.isEmpty()) {
+            return List.of(TextBlock.builder().text("").build());
+        }
+
+        List<ContentBlock> blocks = new ArrayList<>();
+
+        for (McpSchema.Content content : mcpContents) {
+            ContentBlock block = convertContent(content);
+            if (block != null) {
+                blocks.add(block);
+            }
+        }
+
+        return blocks.isEmpty() ? List.of(TextBlock.builder().text("").build()) : blocks;
+    }
+
+    /**
+     * Converts a single MCP Content to an AgentScope ContentBlock.
+     *
+     * @param content the MCP content
+     * @return the converted ContentBlock, or null if conversion is not supported
+     */
+    public static ContentBlock convertContent(McpSchema.Content content) {
+        if (content == null) {
+            return null;
+        }
+
+        if (content instanceof McpSchema.TextContent textContent) {
+            return convertTextContent(textContent);
+        } else if (content instanceof McpSchema.ImageContent imageContent) {
+            return convertImageContent(imageContent);
+        } else if (content instanceof McpSchema.AudioContent audioContent) {
+            // Audio content not yet supported in AgentScope ContentBlock
+            return TextBlock.builder()
+                    .text("[Audio content: " + audioContent.mimeType() + "]")
+                    .build();
+        } else if (content instanceof McpSchema.EmbeddedResource embeddedResource) {
+            return convertEmbeddedResource(embeddedResource);
+        }
+
+        return TextBlock.builder()
+                .text("[Unsupported content type: " + content.getClass().getSimpleName() + "]")
+                .build();
+    }
+
+    /**
+     * Converts MCP TextContent to AgentScope TextBlock.
+     *
+     * @param textContent the MCP text content
+     * @return the converted TextBlock
+     */
+    private static TextBlock convertTextContent(McpSchema.TextContent textContent) {
+        return TextBlock.builder()
+                .text(textContent.text() != null ? textContent.text() : "")
+                .build();
+    }
+
+    /**
+     * Converts MCP ImageContent to AgentScope ImageBlock.
+     *
+     * @param imageContent the MCP image content
+     * @return the converted ImageBlock
+     */
+    private static ImageBlock convertImageContent(McpSchema.ImageContent imageContent) {
+        String base64Data = imageContent.data();
+        String mimeType = imageContent.mimeType();
+
+        if (base64Data == null || base64Data.isEmpty()) {
+            return null;
+        }
+
+        Base64Source source = new Base64Source(mimeType, base64Data);
+        return new ImageBlock(source);
+    }
+
+    /**
+     * Converts MCP EmbeddedResource to AgentScope ContentBlock.
+     *
+     * @param embeddedResource the MCP embedded resource
+     * @return the converted ContentBlock
+     */
+    private static ContentBlock convertEmbeddedResource(
+            McpSchema.EmbeddedResource embeddedResource) {
+        McpSchema.ResourceContents resource = embeddedResource.resource();
+
+        if (resource instanceof McpSchema.TextResourceContents textResource) {
+            return TextBlock.builder().text(textResource.text()).build();
+        } else if (resource instanceof McpSchema.BlobResourceContents blobResource) {
+            // Convert blob to image if mime type indicates image
+            String mimeType = blobResource.mimeType();
+            if (mimeType != null && mimeType.startsWith("image/")) {
+                Base64Source source = new Base64Source(mimeType, blobResource.blob());
+                return new ImageBlock(source);
+            } else {
+                return TextBlock.builder()
+                        .text(
+                                "[Binary resource: "
+                                        + mimeType
+                                        + ", URI: "
+                                        + blobResource.uri()
+                                        + "]")
+                        .build();
+            }
+        }
+
+        return TextBlock.builder().text("[Unknown resource type]").build();
+    }
+
+    /**
+     * Extracts error message from MCP content list.
+     *
+     * @param contents the list of MCP content
+     * @return the extracted error message
+     */
+    private static String extractErrorMessage(List<McpSchema.Content> contents) {
+        if (contents == null || contents.isEmpty()) {
+            return "Unknown error";
+        }
+
+        return contents.stream()
+                .filter(c -> c instanceof McpSchema.TextContent)
+                .map(c -> ((McpSchema.TextContent) c).text())
+                .collect(Collectors.joining("\n"));
+    }
+}

--- a/src/main/java/io/agentscope/core/tool/mcp/McpSyncClientWrapper.java
+++ b/src/main/java/io/agentscope/core/tool/mcp/McpSyncClientWrapper.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright 2024-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.core.tool.mcp;
+
+import io.modelcontextprotocol.client.McpSyncClient;
+import io.modelcontextprotocol.spec.McpSchema;
+import java.util.List;
+import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
+
+/**
+ * Wrapper for synchronous MCP clients that converts blocking calls to reactive Mono types.
+ * This implementation delegates to {@link McpSyncClient} and wraps blocking operations
+ * in Reactor's boundedElastic scheduler to avoid blocking the event loop.
+ *
+ * <p>Example usage:
+ * <pre>{@code
+ * McpSyncClient client = ... // created via McpClient.sync()
+ * McpSyncClientWrapper wrapper = new McpSyncClientWrapper("my-mcp", client);
+ * wrapper.initialize()
+ *     .then(wrapper.callTool("tool_name", Map.of("arg1", "value1")))
+ *     .subscribe(result -> System.out.println(result));
+ * }</pre>
+ */
+public class McpSyncClientWrapper extends McpClientWrapper {
+
+    private static final Logger logger = LoggerFactory.getLogger(McpSyncClientWrapper.class);
+
+    private final McpSyncClient client;
+
+    /**
+     * Constructs a new synchronous MCP client wrapper.
+     *
+     * @param name unique identifier for this client
+     * @param client the underlying sync MCP client
+     */
+    public McpSyncClientWrapper(String name, McpSyncClient client) {
+        super(name);
+        this.client = client;
+    }
+
+    @Override
+    public Mono<Void> initialize() {
+        if (initialized) {
+            return Mono.empty();
+        }
+
+        logger.info("Initializing MCP sync client: {}", name);
+
+        return Mono.fromCallable(
+                        () -> {
+                            // Initialize the client (blocking)
+                            McpSchema.InitializeResult result = client.initialize();
+                            logger.debug(
+                                    "MCP client '{}' initialized with server: {}",
+                                    name,
+                                    result.serverInfo().name());
+
+                            // List and cache tools (blocking)
+                            McpSchema.ListToolsResult toolsResult = client.listTools();
+                            logger.debug(
+                                    "MCP client '{}' discovered {} tools",
+                                    name,
+                                    toolsResult.tools().size());
+
+                            toolsResult.tools().forEach(tool -> cachedTools.put(tool.name(), tool));
+
+                            initialized = true;
+                            return null;
+                        })
+                .subscribeOn(Schedulers.boundedElastic())
+                .doOnError(e -> logger.error("Failed to initialize MCP client: {}", name, e))
+                .then();
+    }
+
+    @Override
+    public Mono<List<McpSchema.Tool>> listTools() {
+        if (!initialized) {
+            return Mono.error(
+                    new IllegalStateException("MCP client '" + name + "' not initialized"));
+        }
+
+        return Mono.fromCallable(() -> client.listTools().tools())
+                .subscribeOn(Schedulers.boundedElastic());
+    }
+
+    @Override
+    public Mono<McpSchema.CallToolResult> callTool(String toolName, Map<String, Object> arguments) {
+        if (!initialized) {
+            return Mono.error(
+                    new IllegalStateException("MCP client '" + name + "' not initialized"));
+        }
+
+        logger.debug("Calling MCP tool '{}' on client '{}'", toolName, name);
+
+        return Mono.fromCallable(
+                        () -> {
+                            McpSchema.CallToolRequest request =
+                                    new McpSchema.CallToolRequest(toolName, arguments);
+                            McpSchema.CallToolResult result = client.callTool(request);
+
+                            if (Boolean.TRUE.equals(result.isError())) {
+                                logger.warn(
+                                        "MCP tool '{}' returned error: {}",
+                                        toolName,
+                                        result.content());
+                            } else {
+                                logger.debug("MCP tool '{}' completed successfully", toolName);
+                            }
+
+                            return result;
+                        })
+                .subscribeOn(Schedulers.boundedElastic())
+                .doOnError(
+                        e ->
+                                logger.error(
+                                        "Failed to call MCP tool '{}': {}",
+                                        toolName,
+                                        e.getMessage()));
+    }
+
+    @Override
+    public void close() {
+        if (client != null) {
+            logger.info("Closing MCP sync client: {}", name);
+            try {
+                client.closeGracefully();
+                logger.debug("MCP client '{}' closed", name);
+            } catch (Exception e) {
+                logger.error("Exception during MCP client close", e);
+                client.close();
+            }
+        }
+        initialized = false;
+        cachedTools.clear();
+    }
+}

--- a/src/main/java/io/agentscope/core/tool/mcp/McpTool.java
+++ b/src/main/java/io/agentscope/core/tool/mcp/McpTool.java
@@ -1,0 +1,216 @@
+/*
+ * Copyright 2024-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.core.tool.mcp;
+
+import io.agentscope.core.message.ToolResultBlock;
+import io.agentscope.core.message.ToolUseBlock;
+import io.agentscope.core.tool.AgentTool;
+import io.modelcontextprotocol.spec.McpSchema;
+import java.util.HashMap;
+import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import reactor.core.publisher.Mono;
+
+/**
+ * AgentTool implementation that wraps an MCP (Model Context Protocol) tool.
+ * This class bridges MCP tools to the AgentScope tool system, allowing
+ * agents to invoke remote MCP tools seamlessly.
+ *
+ * <p>Features:
+ * <ul>
+ *   <li>Converts AgentScope tool calls to MCP protocol calls</li>
+ *   <li>Handles parameter merging with preset arguments</li>
+ *   <li>Converts MCP results to AgentScope ToolResultBlocks</li>
+ *   <li>Supports reactive execution with Mono</li>
+ * </ul>
+ *
+ * <p>Example usage:
+ * <pre>{@code
+ * McpTool tool = new McpTool(
+ *     "get_weather",
+ *     "Get current weather for a location",
+ *     parametersSchema,
+ *     mcpClientWrapper,
+ *     Map.of("units", "celsius")  // preset args
+ * );
+ *
+ * ToolResultBlock result = tool.callAsync(Map.of("location", "Beijing")).block();
+ * }</pre>
+ */
+public class McpTool implements AgentTool {
+
+    private static final Logger logger = LoggerFactory.getLogger(McpTool.class);
+
+    private final String name;
+    private final String description;
+    private final Map<String, Object> parameters;
+    private final McpClientWrapper clientWrapper;
+    private final Map<String, Object> presetArguments;
+
+    private ToolUseBlock currentToolUseBlock;
+
+    /**
+     * Constructs a new McpTool without preset arguments.
+     *
+     * @param name the tool name
+     * @param description the tool description
+     * @param parameters the JSON schema for tool parameters
+     * @param clientWrapper the MCP client wrapper
+     */
+    public McpTool(
+            String name,
+            String description,
+            Map<String, Object> parameters,
+            McpClientWrapper clientWrapper) {
+        this(name, description, parameters, clientWrapper, null);
+    }
+
+    /**
+     * Constructs a new McpTool with preset arguments.
+     *
+     * @param name the tool name
+     * @param description the tool description
+     * @param parameters the JSON schema for tool parameters
+     * @param clientWrapper the MCP client wrapper
+     * @param presetArguments preset arguments to merge with each call (can be null)
+     */
+    public McpTool(
+            String name,
+            String description,
+            Map<String, Object> parameters,
+            McpClientWrapper clientWrapper,
+            Map<String, Object> presetArguments) {
+        this.name = name;
+        this.description = description;
+        this.parameters = parameters;
+        this.clientWrapper = clientWrapper;
+        this.presetArguments = presetArguments != null ? new HashMap<>(presetArguments) : null;
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public String getDescription() {
+        return description;
+    }
+
+    @Override
+    public Map<String, Object> getParameters() {
+        return parameters;
+    }
+
+    @Override
+    public void setCurrentToolUseBlock(ToolUseBlock toolUseBlock) {
+        this.currentToolUseBlock = toolUseBlock;
+    }
+
+    @Override
+    public Mono<ToolResultBlock> callAsync(Map<String, Object> input) {
+        logger.debug("Calling MCP tool '{}' with input: {}", name, input);
+
+        // Merge preset arguments with input arguments
+        Map<String, Object> mergedArgs = mergeArguments(input);
+
+        return clientWrapper
+                .callTool(name, mergedArgs)
+                .map(McpContentConverter::convertCallToolResult)
+                .doOnSuccess(result -> logger.debug("MCP tool '{}' completed successfully", name))
+                .onErrorResume(
+                        e -> {
+                            logger.error("Error calling MCP tool '{}': {}", name, e.getMessage());
+                            String errorMsg =
+                                    e.getMessage() != null
+                                            ? e.getMessage()
+                                            : e.getClass().getSimpleName();
+                            return Mono.just(ToolResultBlock.error("MCP tool error: " + errorMsg));
+                        });
+    }
+
+    /**
+     * Gets the name of the MCP client that provides this tool.
+     *
+     * @return the MCP client name
+     */
+    public String getClientName() {
+        return clientWrapper.getName();
+    }
+
+    /**
+     * Gets the preset arguments configured for this tool.
+     *
+     * @return the preset arguments, or null if none configured
+     */
+    public Map<String, Object> getPresetArguments() {
+        return presetArguments != null ? new HashMap<>(presetArguments) : null;
+    }
+
+    /**
+     * Merges input arguments with preset arguments.
+     * Input arguments take precedence over preset arguments.
+     *
+     * @param input the input arguments
+     * @return merged arguments
+     */
+    private Map<String, Object> mergeArguments(Map<String, Object> input) {
+        if (presetArguments == null || presetArguments.isEmpty()) {
+            return input != null ? input : new HashMap<>();
+        }
+
+        Map<String, Object> merged = new HashMap<>(presetArguments);
+        if (input != null) {
+            merged.putAll(input);
+        }
+        return merged;
+    }
+
+    /**
+     * Converts MCP JsonSchema to AgentScope parameters format.
+     *
+     * @param inputSchema the MCP JsonSchema
+     * @return parameters map in AgentScope format
+     */
+    public static Map<String, Object> convertMcpSchemaToParameters(
+            McpSchema.JsonSchema inputSchema) {
+        Map<String, Object> parameters = new HashMap<>();
+
+        if (inputSchema == null) {
+            parameters.put("type", "object");
+            parameters.put("properties", new HashMap<>());
+            parameters.put("required", new java.util.ArrayList<>());
+            return parameters;
+        }
+
+        parameters.put("type", inputSchema.type() != null ? inputSchema.type() : "object");
+        parameters.put(
+                "properties",
+                inputSchema.properties() != null ? inputSchema.properties() : new HashMap<>());
+        parameters.put(
+                "required",
+                inputSchema.required() != null
+                        ? inputSchema.required()
+                        : new java.util.ArrayList<>());
+
+        if (inputSchema.additionalProperties() != null) {
+            parameters.put("additionalProperties", inputSchema.additionalProperties());
+        }
+
+        return parameters;
+    }
+}

--- a/src/test/java/io/agentscope/core/tool/mcp/McpAsyncClientWrapperTest.java
+++ b/src/test/java/io/agentscope/core/tool/mcp/McpAsyncClientWrapperTest.java
@@ -1,0 +1,228 @@
+/*
+ * Copyright 2024-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.core.tool.mcp;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.modelcontextprotocol.client.McpAsyncClient;
+import io.modelcontextprotocol.spec.McpSchema;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Mono;
+
+class McpAsyncClientWrapperTest {
+
+    private McpAsyncClient mockClient;
+    private McpAsyncClientWrapper wrapper;
+
+    @BeforeEach
+    void setUp() {
+        mockClient = mock(McpAsyncClient.class);
+        wrapper = new McpAsyncClientWrapper("test-async-client", mockClient);
+    }
+
+    @Test
+    void testConstructor() {
+        assertNotNull(wrapper);
+        assertEquals("test-async-client", wrapper.getName());
+        assertFalse(wrapper.isInitialized());
+    }
+
+    @Test
+    void testInitialize_Success() {
+        // Mock initialization
+        McpSchema.Implementation serverInfo =
+                new McpSchema.Implementation("TestServer", "Test Server", "1.0.0");
+        McpSchema.InitializeResult initResult =
+                new McpSchema.InitializeResult(
+                        "1.0",
+                        McpSchema.ServerCapabilities.builder().build(),
+                        serverInfo,
+                        null,
+                        null);
+
+        McpSchema.Tool tool1 =
+                new McpSchema.Tool(
+                        "tool1",
+                        null,
+                        "First tool",
+                        new McpSchema.JsonSchema("object", null, null, null, null, null),
+                        null,
+                        null,
+                        null);
+        McpSchema.Tool tool2 =
+                new McpSchema.Tool(
+                        "tool2",
+                        null,
+                        "Second tool",
+                        new McpSchema.JsonSchema("object", null, null, null, null, null),
+                        null,
+                        null,
+                        null);
+        McpSchema.ListToolsResult toolsResult =
+                new McpSchema.ListToolsResult(List.of(tool1, tool2), null);
+
+        when(mockClient.initialize()).thenReturn(Mono.just(initResult));
+        when(mockClient.listTools()).thenReturn(Mono.just(toolsResult));
+
+        // Execute
+        wrapper.initialize().block();
+
+        // Verify
+        assertTrue(wrapper.isInitialized());
+        assertEquals(2, wrapper.cachedTools.size());
+        assertNotNull(wrapper.getCachedTool("tool1"));
+        assertNotNull(wrapper.getCachedTool("tool2"));
+    }
+
+    @Test
+    void testInitialize_AlreadyInitialized() {
+        McpSchema.Implementation serverInfo =
+                new McpSchema.Implementation("TestServer", "Test Server", "1.0.0");
+        McpSchema.InitializeResult initResult =
+                new McpSchema.InitializeResult(
+                        "1.0",
+                        McpSchema.ServerCapabilities.builder().build(),
+                        serverInfo,
+                        null,
+                        null);
+        McpSchema.ListToolsResult toolsResult = new McpSchema.ListToolsResult(List.of(), null);
+
+        when(mockClient.initialize()).thenReturn(Mono.just(initResult));
+        when(mockClient.listTools()).thenReturn(Mono.just(toolsResult));
+
+        wrapper.initialize().block();
+        assertTrue(wrapper.isInitialized());
+
+        // Second initialization should complete without calling client
+        wrapper.initialize().block();
+
+        verify(mockClient, times(1)).initialize();
+        verify(mockClient, times(1)).listTools();
+    }
+
+    @Test
+    void testListTools_Success() {
+        setupSuccessfulInitialization();
+        wrapper.initialize().block();
+
+        McpSchema.Tool tool =
+                new McpSchema.Tool(
+                        "test-tool",
+                        null,
+                        "Test tool",
+                        new McpSchema.JsonSchema("object", null, null, null, null, null),
+                        null,
+                        null,
+                        null);
+        McpSchema.ListToolsResult toolsResult = new McpSchema.ListToolsResult(List.of(tool), null);
+
+        when(mockClient.listTools()).thenReturn(Mono.just(toolsResult));
+
+        List<McpSchema.Tool> tools = wrapper.listTools().block();
+        assertNotNull(tools);
+        assertEquals(1, tools.size());
+        assertEquals("test-tool", tools.get(0).name());
+    }
+
+    @Test
+    void testCallTool_Success() {
+        setupSuccessfulInitialization();
+        wrapper.initialize().block();
+
+        Map<String, Object> args = new HashMap<>();
+        args.put("param1", "value1");
+
+        McpSchema.TextContent resultContent =
+                new McpSchema.TextContent("Tool executed successfully");
+        McpSchema.CallToolResult callResult =
+                new McpSchema.CallToolResult(List.of(resultContent), false);
+
+        when(mockClient.callTool(any(McpSchema.CallToolRequest.class)))
+                .thenReturn(Mono.just(callResult));
+
+        McpSchema.CallToolResult result = wrapper.callTool("test-tool", args).block();
+        assertNotNull(result);
+        assertFalse(Boolean.TRUE.equals(result.isError()));
+        assertEquals(1, result.content().size());
+    }
+
+    @Test
+    void testGetCachedTool() {
+        setupSuccessfulInitialization();
+        wrapper.initialize().block();
+
+        McpSchema.Tool cached = wrapper.getCachedTool("tool1");
+        assertNotNull(cached);
+        assertEquals("tool1", cached.name());
+
+        assertNull(wrapper.getCachedTool("non-existent"));
+    }
+
+    @Test
+    void testClose_Success() {
+        setupSuccessfulInitialization();
+        wrapper.initialize().block();
+        assertTrue(wrapper.isInitialized());
+        assertFalse(wrapper.cachedTools.isEmpty());
+
+        when(mockClient.closeGracefully()).thenReturn(Mono.empty());
+
+        wrapper.close();
+
+        assertFalse(wrapper.isInitialized());
+        assertTrue(wrapper.cachedTools.isEmpty());
+        verify(mockClient, times(1)).closeGracefully();
+    }
+
+    private void setupSuccessfulInitialization() {
+        McpSchema.Implementation serverInfo =
+                new McpSchema.Implementation("TestServer", "Test Server", "1.0.0");
+        McpSchema.InitializeResult initResult =
+                new McpSchema.InitializeResult(
+                        "1.0",
+                        McpSchema.ServerCapabilities.builder().build(),
+                        serverInfo,
+                        null,
+                        null);
+
+        McpSchema.Tool tool1 =
+                new McpSchema.Tool(
+                        "tool1",
+                        null,
+                        "First tool",
+                        new McpSchema.JsonSchema("object", null, null, null, null, null),
+                        null,
+                        null,
+                        null);
+        McpSchema.ListToolsResult toolsResult = new McpSchema.ListToolsResult(List.of(tool1), null);
+
+        when(mockClient.initialize()).thenReturn(Mono.just(initResult));
+        when(mockClient.listTools()).thenReturn(Mono.just(toolsResult));
+    }
+}

--- a/src/test/java/io/agentscope/core/tool/mcp/McpClientBuilderTest.java
+++ b/src/test/java/io/agentscope/core/tool/mcp/McpClientBuilderTest.java
@@ -1,0 +1,450 @@
+/*
+ * Copyright 2024-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.core.tool.mcp;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class McpClientBuilderTest {
+
+    @Test
+    void testCreate_WithValidName() {
+        McpClientBuilder builder = McpClientBuilder.create("test-client");
+        assertNotNull(builder);
+    }
+
+    @Test
+    void testCreate_WithNullName() {
+        assertThrows(IllegalArgumentException.class, () -> McpClientBuilder.create(null));
+    }
+
+    @Test
+    void testCreate_WithEmptyName() {
+        assertThrows(IllegalArgumentException.class, () -> McpClientBuilder.create(""));
+    }
+
+    @Test
+    void testCreate_WithWhitespaceName() {
+        assertThrows(IllegalArgumentException.class, () -> McpClientBuilder.create("   "));
+    }
+
+    @Test
+    void testStdioTransport_BasicCommand() {
+        McpClientBuilder builder =
+                McpClientBuilder.create("stdio-client")
+                        .stdioTransport("python", "-m", "mcp_server_time");
+
+        assertNotNull(builder);
+    }
+
+    @Test
+    void testStdioTransport_WithNoArgs() {
+        McpClientBuilder builder = McpClientBuilder.create("stdio-client").stdioTransport("node");
+
+        assertNotNull(builder);
+    }
+
+    @Test
+    void testStdioTransport_WithEnvironmentVariables() {
+        Map<String, String> env = new HashMap<>();
+        env.put("DEBUG", "true");
+        env.put("LOG_LEVEL", "info");
+
+        McpClientBuilder builder =
+                McpClientBuilder.create("stdio-client")
+                        .stdioTransport("python", List.of("-m", "mcp_server_time"), env);
+
+        assertNotNull(builder);
+    }
+
+    @Test
+    void testSseTransport() {
+        McpClientBuilder builder =
+                McpClientBuilder.create("sse-client").sseTransport("https://mcp.example.com/sse");
+
+        assertNotNull(builder);
+    }
+
+    @Test
+    void testStreamableHttpTransport() {
+        McpClientBuilder builder =
+                McpClientBuilder.create("http-client")
+                        .streamableHttpTransport("https://mcp.example.com/http");
+
+        assertNotNull(builder);
+    }
+
+    @Test
+    void testHeader_OnHttpTransport() {
+        McpClientBuilder builder =
+                McpClientBuilder.create("http-client")
+                        .sseTransport("https://mcp.example.com/sse")
+                        .header("Authorization", "Bearer token123")
+                        .header("X-Custom-Header", "custom-value");
+
+        assertNotNull(builder);
+    }
+
+    @Test
+    void testHeader_OnStdioTransport() {
+        // Adding headers to stdio transport should not cause errors (just ignored)
+        McpClientBuilder builder =
+                McpClientBuilder.create("stdio-client")
+                        .stdioTransport("python", "-m", "mcp_server_time")
+                        .header("Authorization", "Bearer token123");
+
+        assertNotNull(builder);
+    }
+
+    @Test
+    void testHeaders_MultipleHeaders() {
+        Map<String, String> headers = new HashMap<>();
+        headers.put("Authorization", "Bearer token123");
+        headers.put("X-API-Key", "api-key-456");
+        headers.put("Content-Type", "application/json");
+
+        McpClientBuilder builder =
+                McpClientBuilder.create("http-client")
+                        .sseTransport("https://mcp.example.com/sse")
+                        .headers(headers);
+
+        assertNotNull(builder);
+    }
+
+    @Test
+    void testTimeout() {
+        McpClientBuilder builder =
+                McpClientBuilder.create("client").timeout(Duration.ofSeconds(90));
+
+        assertNotNull(builder);
+    }
+
+    @Test
+    void testInitializationTimeout() {
+        McpClientBuilder builder =
+                McpClientBuilder.create("client").initializationTimeout(Duration.ofSeconds(45));
+
+        assertNotNull(builder);
+    }
+
+    @Test
+    void testFluentApi_ChainedCalls() {
+        McpClientBuilder builder =
+                McpClientBuilder.create("test-client")
+                        .sseTransport("https://mcp.example.com/sse")
+                        .header("Authorization", "Bearer token")
+                        .timeout(Duration.ofSeconds(60))
+                        .initializationTimeout(Duration.ofSeconds(30));
+
+        assertNotNull(builder);
+    }
+
+    @Test
+    void testBuildAsync_WithoutTransport() {
+        McpClientBuilder builder = McpClientBuilder.create("client");
+
+        Exception exception =
+                assertThrows(IllegalStateException.class, () -> builder.buildAsync().block());
+
+        assertTrue(exception.getMessage().contains("Transport must be configured"));
+    }
+
+    @Test
+    void testBuildSync_WithoutTransport() {
+        McpClientBuilder builder = McpClientBuilder.create("client");
+
+        assertThrows(
+                IllegalStateException.class,
+                () -> builder.buildSync(),
+                "Transport must be configured");
+    }
+
+    @Test
+    void testBuildAsync_ReturnsWrapper() {
+        McpClientBuilder builder =
+                McpClientBuilder.create("test-client").stdioTransport("echo", "hello");
+
+        McpClientWrapper wrapper = builder.buildAsync().block();
+        assertNotNull(wrapper);
+        assertEquals("test-client", wrapper.getName());
+        assertFalse(wrapper.isInitialized());
+        assertTrue(wrapper instanceof McpAsyncClientWrapper);
+    }
+
+    @Test
+    void testBuildSync_ReturnsWrapper() {
+        McpClientBuilder builder =
+                McpClientBuilder.create("test-sync-client").stdioTransport("echo", "hello");
+
+        McpClientWrapper wrapper = builder.buildSync();
+
+        assertNotNull(wrapper);
+        assertEquals("test-sync-client", wrapper.getName());
+        assertFalse(wrapper.isInitialized());
+        assertTrue(wrapper instanceof McpSyncClientWrapper);
+    }
+
+    @Test
+    void testBuildAsync_WithStdioTransport() {
+        McpClientBuilder builder =
+                McpClientBuilder.create("stdio-client")
+                        .stdioTransport("python", "-m", "mcp_server_time")
+                        .timeout(Duration.ofSeconds(60))
+                        .initializationTimeout(Duration.ofSeconds(30));
+
+        McpClientWrapper wrapper = builder.buildAsync().block();
+        assertNotNull(wrapper);
+        assertTrue(wrapper instanceof McpAsyncClientWrapper);
+    }
+
+    @Test
+    void testBuildAsync_WithSseTransport() {
+        McpClientBuilder builder =
+                McpClientBuilder.create("sse-client")
+                        .sseTransport("https://mcp.example.com/sse")
+                        .header("Authorization", "Bearer token")
+                        .timeout(Duration.ofSeconds(120));
+
+        McpClientWrapper wrapper = builder.buildAsync().block();
+        assertNotNull(wrapper);
+        assertEquals("sse-client", wrapper.getName());
+        assertTrue(wrapper instanceof McpAsyncClientWrapper);
+    }
+
+    @Test
+    void testBuildAsync_WithStreamableHttpTransport() {
+        McpClientBuilder builder =
+                McpClientBuilder.create("http-client")
+                        .streamableHttpTransport("https://mcp.example.com/http")
+                        .header("X-API-Key", "key123")
+                        .timeout(Duration.ofSeconds(90))
+                        .initializationTimeout(Duration.ofSeconds(20));
+
+        McpClientWrapper wrapper = builder.buildAsync().block();
+        assertNotNull(wrapper);
+        assertTrue(wrapper instanceof McpAsyncClientWrapper);
+    }
+
+    @Test
+    void testBuildSync_WithStdioTransport() {
+        McpClientBuilder builder =
+                McpClientBuilder.create("stdio-sync-client")
+                        .stdioTransport("node", "server.js")
+                        .timeout(Duration.ofSeconds(45));
+
+        McpClientWrapper wrapper = builder.buildSync();
+
+        assertNotNull(wrapper);
+        assertTrue(wrapper instanceof McpSyncClientWrapper);
+        assertEquals("stdio-sync-client", wrapper.getName());
+    }
+
+    @Test
+    void testBuildSync_WithSseTransport() {
+        McpClientBuilder builder =
+                McpClientBuilder.create("sse-sync-client")
+                        .sseTransport("https://mcp.example.com/sse");
+
+        McpClientWrapper wrapper = builder.buildSync();
+
+        assertNotNull(wrapper);
+        assertTrue(wrapper instanceof McpSyncClientWrapper);
+    }
+
+    @Test
+    void testBuildSync_WithStreamableHttpTransport() {
+        McpClientBuilder builder =
+                McpClientBuilder.create("http-sync-client")
+                        .streamableHttpTransport("https://mcp.example.com/http");
+
+        McpClientWrapper wrapper = builder.buildSync();
+
+        assertNotNull(wrapper);
+        assertTrue(wrapper instanceof McpSyncClientWrapper);
+    }
+
+    @Test
+    void testMultipleBuilds_FromSameBuilder() {
+        McpClientBuilder builder =
+                McpClientBuilder.create("multi-client").stdioTransport("echo", "test");
+
+        // Build async
+        McpClientWrapper asyncWrapper = builder.buildAsync().block();
+        assertNotNull(asyncWrapper);
+
+        // Build sync (reusing same builder)
+        McpClientWrapper syncWrapper = builder.buildSync();
+        assertNotNull(syncWrapper);
+    }
+
+    @Test
+    void testStdioTransport_EmptyArgs() {
+        McpClientBuilder builder = McpClientBuilder.create("client").stdioTransport("command");
+
+        assertNotNull(builder);
+    }
+
+    @Test
+    void testStdioTransport_WithEmptyEnv() {
+        McpClientBuilder builder =
+                McpClientBuilder.create("client")
+                        .stdioTransport("python", List.of("-m", "server"), new HashMap<>());
+
+        assertNotNull(builder);
+    }
+
+    @Test
+    void testHeaders_OnStdioTransport() {
+        Map<String, String> headers = new HashMap<>();
+        headers.put("key", "value");
+
+        McpClientBuilder builder =
+                McpClientBuilder.create("client")
+                        .stdioTransport("python", "server.py")
+                        .headers(headers);
+
+        // Should not throw, just ignored for stdio transport
+        assertNotNull(builder);
+    }
+
+    @Test
+    void testHeaders_OverwritePreviousHeaders() {
+        Map<String, String> headers1 = new HashMap<>();
+        headers1.put("key1", "value1");
+
+        Map<String, String> headers2 = new HashMap<>();
+        headers2.put("key2", "value2");
+
+        McpClientBuilder builder =
+                McpClientBuilder.create("client")
+                        .sseTransport("https://example.com")
+                        .headers(headers1)
+                        .headers(headers2); // Should overwrite
+
+        assertNotNull(builder);
+    }
+
+    @Test
+    void testHeader_AddMultipleTimes() {
+        McpClientBuilder builder =
+                McpClientBuilder.create("client")
+                        .sseTransport("https://example.com")
+                        .header("key1", "value1")
+                        .header("key2", "value2")
+                        .header("key3", "value3");
+
+        assertNotNull(builder);
+    }
+
+    @Test
+    void testComplexConfiguration() {
+        Map<String, String> env = new HashMap<>();
+        env.put("DEBUG", "true");
+
+        McpClientBuilder builder =
+                McpClientBuilder.create("complex-client")
+                        .stdioTransport(
+                                "uvx", List.of("mcp-server-time", "--local-timezone=UTC"), env)
+                        .timeout(Duration.ofSeconds(120))
+                        .initializationTimeout(Duration.ofSeconds(45));
+
+        McpClientWrapper wrapper = builder.buildAsync().block();
+        assertNotNull(wrapper);
+        assertEquals("complex-client", wrapper.getName());
+    }
+
+    @Test
+    void testSseTransport_WithCompleteConfiguration() {
+        Map<String, String> headers = new HashMap<>();
+        headers.put("Authorization", "Bearer token");
+        headers.put("X-Client-Version", "1.0.0");
+
+        McpClientBuilder builder =
+                McpClientBuilder.create("full-sse-client")
+                        .sseTransport("https://mcp.higress.ai/sse")
+                        .headers(headers)
+                        .timeout(Duration.ofSeconds(90))
+                        .initializationTimeout(Duration.ofSeconds(30));
+
+        McpClientWrapper wrapper = builder.buildAsync().block();
+        assertNotNull(wrapper);
+        assertEquals("full-sse-client", wrapper.getName());
+    }
+
+    @Test
+    void testStreamableHttpTransport_WithCompleteConfiguration() {
+        McpClientBuilder builder =
+                McpClientBuilder.create("full-http-client")
+                        .streamableHttpTransport("https://mcp.higress.ai/http")
+                        .header("X-API-Key", "secret-key")
+                        .header("X-Request-ID", "request-123")
+                        .timeout(Duration.ofMinutes(2))
+                        .initializationTimeout(Duration.ofSeconds(45));
+
+        McpClientWrapper wrapper = builder.buildSync();
+
+        assertNotNull(wrapper);
+        assertEquals("full-http-client", wrapper.getName());
+        assertFalse(wrapper.isInitialized());
+    }
+
+    @Test
+    void testDefaultTimeouts() {
+        // Test that builder works with default timeouts (not explicitly set)
+        McpClientBuilder builder =
+                McpClientBuilder.create("default-timeouts").stdioTransport("echo", "test");
+
+        McpClientWrapper wrapper = builder.buildAsync().block();
+        assertNotNull(wrapper);
+    }
+
+    @Test
+    void testBuildAsync_CreatesNewInstanceEachTime() {
+        McpClientBuilder builder =
+                McpClientBuilder.create("multi-instance").stdioTransport("echo", "test");
+
+        McpClientWrapper wrapper1 = builder.buildAsync().block();
+        McpClientWrapper wrapper2 = builder.buildAsync().block();
+
+        assertNotNull(wrapper1);
+        assertNotNull(wrapper2);
+        // Each build should create a new instance
+        assertTrue(wrapper1 != wrapper2);
+    }
+
+    @Test
+    void testBuildSync_CreatesNewInstanceEachTime() {
+        McpClientBuilder builder =
+                McpClientBuilder.create("multi-instance-sync").stdioTransport("echo", "test");
+
+        McpClientWrapper wrapper1 = builder.buildSync();
+        McpClientWrapper wrapper2 = builder.buildSync();
+
+        assertNotNull(wrapper1);
+        assertNotNull(wrapper2);
+        // Each build should create a new instance
+        assertTrue(wrapper1 != wrapper2);
+    }
+}

--- a/src/test/java/io/agentscope/core/tool/mcp/McpClientWrapperTest.java
+++ b/src/test/java/io/agentscope/core/tool/mcp/McpClientWrapperTest.java
@@ -1,0 +1,239 @@
+/*
+ * Copyright 2024-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.core.tool.mcp;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.modelcontextprotocol.spec.McpSchema;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Mono;
+
+class McpClientWrapperTest {
+
+    private TestMcpClientWrapper wrapper;
+
+    @BeforeEach
+    void setUp() {
+        wrapper = new TestMcpClientWrapper("test-client");
+    }
+
+    @Test
+    void testGetName() {
+        assertEquals("test-client", wrapper.getName());
+    }
+
+    @Test
+    void testInitializedFlag_DefaultFalse() {
+        assertFalse(wrapper.isInitialized());
+    }
+
+    @Test
+    void testInitializedFlag_AfterInitialize() {
+        wrapper.initialize().block();
+        assertTrue(wrapper.isInitialized());
+    }
+
+    @Test
+    void testCachedTools_EmptyByDefault() {
+        assertNotNull(wrapper.cachedTools);
+        assertTrue(wrapper.cachedTools.isEmpty());
+    }
+
+    @Test
+    void testGetCachedTool_NonExistent() {
+        assertNull(wrapper.getCachedTool("non-existent-tool"));
+    }
+
+    @Test
+    void testGetCachedTool_Exists() {
+        // Add a tool to cache
+        McpSchema.Tool tool =
+                new McpSchema.Tool(
+                        "test-tool",
+                        null,
+                        "A test tool",
+                        new McpSchema.JsonSchema("object", null, null, null, null, null),
+                        null,
+                        null,
+                        null);
+        wrapper.cachedTools.put("test-tool", tool);
+
+        McpSchema.Tool retrieved = wrapper.getCachedTool("test-tool");
+        assertNotNull(retrieved);
+        assertEquals("test-tool", retrieved.name());
+        assertEquals("A test tool", retrieved.description());
+    }
+
+    @Test
+    void testCachedTools_MultipleTools() {
+        // Add multiple tools
+        McpSchema.Tool tool1 =
+                new McpSchema.Tool(
+                        "tool1",
+                        null,
+                        "First tool",
+                        new McpSchema.JsonSchema("object", null, null, null, null, null),
+                        null,
+                        null,
+                        null);
+        McpSchema.Tool tool2 =
+                new McpSchema.Tool(
+                        "tool2",
+                        null,
+                        "Second tool",
+                        new McpSchema.JsonSchema("object", null, null, null, null, null),
+                        null,
+                        null,
+                        null);
+
+        wrapper.cachedTools.put("tool1", tool1);
+        wrapper.cachedTools.put("tool2", tool2);
+
+        assertEquals(2, wrapper.cachedTools.size());
+        assertNotNull(wrapper.getCachedTool("tool1"));
+        assertNotNull(wrapper.getCachedTool("tool2"));
+    }
+
+    @Test
+    void testConcurrentAccess_CachedTools() {
+        // Test that ConcurrentHashMap is used (thread-safe)
+        McpSchema.Tool tool =
+                new McpSchema.Tool(
+                        "concurrent-tool",
+                        null,
+                        "Test",
+                        new McpSchema.JsonSchema("object", null, null, null, null, null),
+                        null,
+                        null,
+                        null);
+
+        // This should not throw ConcurrentModificationException
+        wrapper.cachedTools.put("concurrent-tool", tool);
+        assertNotNull(wrapper.getCachedTool("concurrent-tool"));
+    }
+
+    @Test
+    void testClose() {
+        wrapper.initialize().block();
+        assertTrue(wrapper.isInitialized());
+
+        wrapper.close();
+
+        assertFalse(wrapper.isInitialized());
+        assertTrue(wrapper.cachedTools.isEmpty());
+    }
+
+    @Test
+    void testClose_MultipleCallsSafe() {
+        wrapper.initialize().block();
+
+        // Close multiple times should be safe
+        wrapper.close();
+        wrapper.close();
+        wrapper.close();
+
+        assertFalse(wrapper.isInitialized());
+    }
+
+    @Test
+    void testInitialize_Idempotent() {
+        // Initialize multiple times
+        wrapper.initialize().block();
+        assertTrue(wrapper.isInitialized());
+
+        wrapper.initialize().block();
+        assertTrue(wrapper.isInitialized());
+
+        // Should still be initialized
+        assertEquals(1, wrapper.initializeCallCount);
+    }
+
+    // ==================== Test Implementation ====================
+
+    /**
+     * Concrete implementation of McpClientWrapper for testing purposes.
+     */
+    private static class TestMcpClientWrapper extends McpClientWrapper {
+
+        private int initializeCallCount = 0;
+
+        public TestMcpClientWrapper(String name) {
+            super(name);
+        }
+
+        @Override
+        public Mono<Void> initialize() {
+            if (initialized) {
+                return Mono.empty();
+            }
+
+            return Mono.fromRunnable(
+                    () -> {
+                        initializeCallCount++;
+                        // Simulate caching tools during initialization
+                        McpSchema.Tool tool =
+                                new McpSchema.Tool(
+                                        "test-tool",
+                                        null,
+                                        "A test tool",
+                                        new McpSchema.JsonSchema(
+                                                "object", null, null, null, null, null),
+                                        null,
+                                        null,
+                                        null);
+                        cachedTools.put("test-tool", tool);
+                        initialized = true;
+                    });
+        }
+
+        @Override
+        public Mono<List<McpSchema.Tool>> listTools() {
+            if (!initialized) {
+                return Mono.error(new IllegalStateException("Client not initialized: " + name));
+            }
+            return Mono.just(List.copyOf(cachedTools.values()));
+        }
+
+        @Override
+        public Mono<McpSchema.CallToolResult> callTool(
+                String toolName, Map<String, Object> arguments) {
+            if (!initialized) {
+                return Mono.error(new IllegalStateException("Client not initialized: " + name));
+            }
+
+            if (!cachedTools.containsKey(toolName)) {
+                return Mono.error(new IllegalArgumentException("Tool not found: " + toolName));
+            }
+
+            // Return a simple success result
+            McpSchema.TextContent content = new McpSchema.TextContent("Success");
+            return Mono.just(new McpSchema.CallToolResult(List.of(content), false));
+        }
+
+        @Override
+        public void close() {
+            initialized = false;
+            cachedTools.clear();
+        }
+    }
+}

--- a/src/test/java/io/agentscope/core/tool/mcp/McpContentConverterTest.java
+++ b/src/test/java/io/agentscope/core/tool/mcp/McpContentConverterTest.java
@@ -1,0 +1,447 @@
+/*
+ * Copyright 2024-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.core.tool.mcp;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.agentscope.core.message.ContentBlock;
+import io.agentscope.core.message.ImageBlock;
+import io.agentscope.core.message.TextBlock;
+import io.agentscope.core.message.ToolResultBlock;
+import io.modelcontextprotocol.spec.McpSchema;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class McpContentConverterTest {
+
+    @Test
+    void testConstructorThrowsException() {
+        // Test that utility class cannot be instantiated
+        var exception =
+                assertThrows(
+                        java.lang.reflect.InvocationTargetException.class,
+                        () -> {
+                            var constructor = McpContentConverter.class.getDeclaredConstructor();
+                            constructor.setAccessible(true);
+                            constructor.newInstance();
+                        });
+        // The InvocationTargetException should wrap UnsupportedOperationException
+        assertTrue(exception.getCause() instanceof UnsupportedOperationException);
+    }
+
+    @Test
+    void testConvertCallToolResult_Success() {
+        // Create successful MCP result with text content
+        McpSchema.TextContent textContent = new McpSchema.TextContent("Operation successful");
+        McpSchema.CallToolResult mcpResult =
+                new McpSchema.CallToolResult(List.of(textContent), false);
+
+        ToolResultBlock result = McpContentConverter.convertCallToolResult(mcpResult);
+
+        assertNotNull(result);
+        ContentBlock output = result.getOutput();
+        assertTrue(output instanceof TextBlock);
+        String text = ((TextBlock) output).getText();
+        assertEquals("Operation successful", text);
+        assertFalse(text.startsWith("Error:"));
+    }
+
+    @Test
+    void testConvertCallToolResult_Error() {
+        // Create error MCP result
+        McpSchema.TextContent errorContent = new McpSchema.TextContent("File not found");
+        McpSchema.CallToolResult mcpResult =
+                new McpSchema.CallToolResult(List.of(errorContent), true);
+
+        ToolResultBlock result = McpContentConverter.convertCallToolResult(mcpResult);
+
+        assertNotNull(result);
+        ContentBlock output = result.getOutput();
+        assertTrue(output instanceof TextBlock);
+        String text = ((TextBlock) output).getText();
+        assertTrue(text.startsWith("Error:"));
+        assertTrue(text.contains("File not found"));
+    }
+
+    @Test
+    void testConvertCallToolResult_NullResult() {
+        ToolResultBlock result = McpContentConverter.convertCallToolResult(null);
+
+        assertNotNull(result);
+        ContentBlock output = result.getOutput();
+        assertTrue(output instanceof TextBlock);
+        String text = ((TextBlock) output).getText();
+        assertTrue(text.startsWith("Error:"));
+        assertTrue(text.contains("null result"));
+    }
+
+    @Test
+    void testConvertCallToolResult_EmptyContent() {
+        // Create result with empty content list
+        McpSchema.CallToolResult mcpResult = new McpSchema.CallToolResult(List.of(), false);
+
+        ToolResultBlock result = McpContentConverter.convertCallToolResult(mcpResult);
+
+        assertNotNull(result);
+        ContentBlock output = result.getOutput();
+        assertTrue(output instanceof TextBlock);
+        String text = ((TextBlock) output).getText();
+        assertEquals("", text);
+        assertFalse(text.startsWith("Error:"));
+    }
+
+    @Test
+    void testConvertCallToolResult_MultipleErrorMessages() {
+        // Create error result with multiple text contents
+        McpSchema.TextContent error1 = new McpSchema.TextContent("Error 1");
+        McpSchema.TextContent error2 = new McpSchema.TextContent("Error 2");
+        McpSchema.CallToolResult mcpResult =
+                new McpSchema.CallToolResult(List.of(error1, error2), true);
+
+        ToolResultBlock result = McpContentConverter.convertCallToolResult(mcpResult);
+
+        assertNotNull(result);
+        ContentBlock output = result.getOutput();
+        assertTrue(output instanceof TextBlock);
+        String text = ((TextBlock) output).getText();
+        assertTrue(text.startsWith("Error:"));
+        assertTrue(text.contains("Error 1"));
+        assertTrue(text.contains("Error 2"));
+    }
+
+    @Test
+    void testConvertContentList_MixedContent() {
+        // Create a list with multiple content types
+        McpSchema.TextContent textContent = new McpSchema.TextContent("Hello");
+        McpSchema.ImageContent imageContent =
+                new McpSchema.ImageContent(null, "base64data==", "image/png");
+
+        List<McpSchema.Content> contents = List.of(textContent, imageContent);
+
+        List<ContentBlock> blocks = McpContentConverter.convertContentList(contents);
+
+        assertNotNull(blocks);
+        assertEquals(2, blocks.size());
+
+        // First block should be TextBlock with "Hello"
+        assertTrue(blocks.get(0) instanceof TextBlock);
+        assertEquals("Hello", ((TextBlock) blocks.get(0)).getText());
+
+        // Second block should be ImageBlock
+        assertTrue(blocks.get(1) instanceof ImageBlock);
+    }
+
+    @Test
+    void testConvertContentList_NullOrEmpty() {
+        // Test null list
+        List<ContentBlock> nullResult = McpContentConverter.convertContentList(null);
+        assertNotNull(nullResult);
+        assertEquals(1, nullResult.size());
+        assertTrue(nullResult.get(0) instanceof TextBlock);
+        assertEquals("", ((TextBlock) nullResult.get(0)).getText());
+
+        // Test empty list
+        List<ContentBlock> emptyResult = McpContentConverter.convertContentList(List.of());
+        assertNotNull(emptyResult);
+        assertEquals(1, emptyResult.size());
+        assertTrue(emptyResult.get(0) instanceof TextBlock);
+        assertEquals("", ((TextBlock) emptyResult.get(0)).getText());
+    }
+
+    @Test
+    void testConvertContentList_WithNullElements() {
+        // Create list with null element (should be filtered out)
+        List<McpSchema.Content> contents = new ArrayList<>();
+        contents.add(new McpSchema.TextContent("Valid text"));
+        contents.add(null);
+
+        List<ContentBlock> blocks = McpContentConverter.convertContentList(contents);
+
+        assertNotNull(blocks);
+        // Only valid content should be included
+        assertEquals(1, blocks.size());
+        assertTrue(blocks.get(0) instanceof TextBlock);
+    }
+
+    @Test
+    void testConvertContent_TextContent() {
+        McpSchema.TextContent textContent = new McpSchema.TextContent("Test message");
+
+        ContentBlock block = McpContentConverter.convertContent(textContent);
+
+        assertNotNull(block);
+        assertTrue(block instanceof TextBlock);
+        assertEquals("Test message", ((TextBlock) block).getText());
+    }
+
+    @Test
+    void testConvertContent_TextContent_EmptyText() {
+        McpSchema.TextContent textContent = new McpSchema.TextContent("");
+
+        ContentBlock block = McpContentConverter.convertContent(textContent);
+
+        assertNotNull(block);
+        assertTrue(block instanceof TextBlock);
+        assertEquals("", ((TextBlock) block).getText());
+    }
+
+    @Test
+    void testConvertContent_TextContent_NullText() {
+        McpSchema.TextContent textContent = new McpSchema.TextContent(null);
+
+        ContentBlock block = McpContentConverter.convertContent(textContent);
+
+        assertNotNull(block);
+        assertTrue(block instanceof TextBlock);
+        assertEquals("", ((TextBlock) block).getText());
+    }
+
+    @Test
+    void testConvertContent_ImageContent() {
+        McpSchema.ImageContent imageContent =
+                new McpSchema.ImageContent(null, "SGVsbG8gV29ybGQ=", "image/jpeg");
+
+        ContentBlock block = McpContentConverter.convertContent(imageContent);
+
+        assertNotNull(block);
+        assertTrue(block instanceof ImageBlock);
+
+        ImageBlock imageBlock = (ImageBlock) block;
+        assertNotNull(imageBlock.getSource());
+    }
+
+    @Test
+    void testConvertContent_ImageContent_EmptyData() {
+        McpSchema.ImageContent imageContent = new McpSchema.ImageContent(null, "", "image/png");
+
+        ContentBlock block = McpContentConverter.convertContent(imageContent);
+
+        // Empty image data should return null (filtered out)
+        assertNull(block);
+    }
+
+    @Test
+    void testConvertContent_ImageContent_NullData() {
+        McpSchema.ImageContent imageContent = new McpSchema.ImageContent(null, null, "image/png");
+
+        ContentBlock block = McpContentConverter.convertContent(imageContent);
+
+        assertNull(block);
+    }
+
+    @Test
+    void testConvertContent_AudioContent() {
+        McpSchema.AudioContent audioContent =
+                new McpSchema.AudioContent(null, "audiodata", "audio/mp3");
+
+        ContentBlock block = McpContentConverter.convertContent(audioContent);
+
+        assertNotNull(block);
+        assertTrue(block instanceof TextBlock);
+        String text = ((TextBlock) block).getText();
+        assertTrue(text.contains("Audio content"));
+        assertTrue(text.contains("audio/mp3"));
+    }
+
+    @Test
+    void testConvertContent_EmbeddedResource_TextResource() {
+        McpSchema.TextResourceContents textResource =
+                new McpSchema.TextResourceContents(
+                        "file:///test.txt", "text/plain", "File content");
+        McpSchema.EmbeddedResource embeddedResource =
+                new McpSchema.EmbeddedResource(null, textResource);
+
+        ContentBlock block = McpContentConverter.convertContent(embeddedResource);
+
+        assertNotNull(block);
+        assertTrue(block instanceof TextBlock);
+        assertEquals("File content", ((TextBlock) block).getText());
+    }
+
+    @Test
+    void testConvertContent_EmbeddedResource_BlobResource_Image() {
+        McpSchema.BlobResourceContents blobResource =
+                new McpSchema.BlobResourceContents("file:///image.png", "image/png", "blobdata123");
+        McpSchema.EmbeddedResource embeddedResource =
+                new McpSchema.EmbeddedResource(null, blobResource);
+
+        ContentBlock block = McpContentConverter.convertContent(embeddedResource);
+
+        assertNotNull(block);
+        assertTrue(block instanceof ImageBlock);
+    }
+
+    @Test
+    void testConvertContent_EmbeddedResource_BlobResource_NonImage() {
+        McpSchema.BlobResourceContents blobResource =
+                new McpSchema.BlobResourceContents(
+                        "file:///data.bin", "application/octet-stream", "binarydata");
+        McpSchema.EmbeddedResource embeddedResource =
+                new McpSchema.EmbeddedResource(null, blobResource);
+
+        ContentBlock block = McpContentConverter.convertContent(embeddedResource);
+
+        assertNotNull(block);
+        assertTrue(block instanceof TextBlock);
+        String text = ((TextBlock) block).getText();
+        assertTrue(text.contains("Binary resource"));
+        assertTrue(text.contains("application/octet-stream"));
+        assertTrue(text.contains("file:///data.bin"));
+    }
+
+    @Test
+    void testConvertContent_EmbeddedResource_BlobResource_NullMimeType() {
+        McpSchema.BlobResourceContents blobResource =
+                new McpSchema.BlobResourceContents("file:///data.bin", null, "binarydata");
+        McpSchema.EmbeddedResource embeddedResource =
+                new McpSchema.EmbeddedResource(null, blobResource);
+
+        ContentBlock block = McpContentConverter.convertContent(embeddedResource);
+
+        assertNotNull(block);
+        assertTrue(block instanceof TextBlock);
+    }
+
+    @Test
+    void testConvertContent_NullContent() {
+        ContentBlock block = McpContentConverter.convertContent(null);
+        assertNull(block);
+    }
+
+    // Note: Cannot test unsupported Content type because Content is a sealed class
+    // The MCP SDK only allows specific Content implementations (Text, Image, Audio,
+    // EmbeddedResource)
+
+    @Test
+    void testExtractErrorMessage_EmptyContent() {
+        // Test indirect through convertCallToolResult with empty error content
+        List<McpSchema.Content> emptyList = List.of();
+        McpSchema.CallToolResult mcpResult = new McpSchema.CallToolResult(emptyList, true);
+
+        ToolResultBlock result = McpContentConverter.convertCallToolResult(mcpResult);
+
+        assertNotNull(result);
+        ContentBlock output = result.getOutput();
+        assertTrue(output instanceof TextBlock);
+        String text = ((TextBlock) output).getText();
+        assertTrue(text.startsWith("Error:"));
+        // Empty error content should result in "Unknown error"
+        assertTrue(text.contains("Unknown error"));
+    }
+
+    @Test
+    void testExtractErrorMessage_NullContent() {
+        // Test indirect through convertCallToolResult with null content
+        List<McpSchema.Content> nullList = null;
+        McpSchema.CallToolResult mcpResult = new McpSchema.CallToolResult(nullList, true);
+
+        ToolResultBlock result = McpContentConverter.convertCallToolResult(mcpResult);
+
+        assertNotNull(result);
+        ContentBlock output = result.getOutput();
+        assertTrue(output instanceof TextBlock);
+        String text = ((TextBlock) output).getText();
+        assertTrue(text.startsWith("Error:"));
+        assertTrue(text.contains("Unknown error"));
+    }
+
+    @Test
+    void testComplexScenario_MultipleContentTypes() {
+        // Create a complex result with multiple content types
+        McpSchema.TextContent text1 = new McpSchema.TextContent("Header text");
+        McpSchema.ImageContent image = new McpSchema.ImageContent(null, "imagedata", "image/png");
+        McpSchema.TextContent text2 = new McpSchema.TextContent("Footer text");
+        McpSchema.AudioContent audio = new McpSchema.AudioContent(null, "audiodata", "audio/wav");
+
+        List<McpSchema.Content> contents = List.of(text1, image, text2, audio);
+        McpSchema.CallToolResult mcpResult = new McpSchema.CallToolResult(contents, false);
+
+        ToolResultBlock result = McpContentConverter.convertCallToolResult(mcpResult);
+
+        assertNotNull(result);
+        ContentBlock output = result.getOutput();
+        assertNotNull(output);
+        // When multiple blocks are aggregated, the result is a TextBlock with combined text
+        // The aggregation logic is in ToolResultBlock.fromContentBlocks()
+        assertTrue(output instanceof TextBlock);
+        String text = ((TextBlock) output).getText();
+        assertFalse(text.startsWith("Error:"));
+        // The aggregated text should contain elements from the original blocks
+        assertTrue(text.contains("Header text") || text.contains("ImageBlock"));
+    }
+
+    // Note: Cannot test unknown ResourceContents type because it's a sealed class
+    // The MCP SDK only allows TextResourceContents and BlobResourceContents implementations
+
+    @Test
+    void testContentList_AllNullElements() {
+        // Create list with all null elements
+        List<McpSchema.Content> contents = new ArrayList<>();
+        contents.add(null);
+        contents.add(null);
+        contents.add(null);
+
+        List<ContentBlock> blocks = McpContentConverter.convertContentList(contents);
+
+        assertNotNull(blocks);
+        // All nulls filtered out, should return empty text block
+        assertEquals(1, blocks.size());
+        assertTrue(blocks.get(0) instanceof TextBlock);
+        assertEquals("", ((TextBlock) blocks.get(0)).getText());
+    }
+
+    @Test
+    void testImageContent_WithDifferentMimeTypes() {
+        // Test various image mime types
+        String[] mimeTypes = {"image/png", "image/jpeg", "image/gif", "image/webp"};
+
+        for (String mimeType : mimeTypes) {
+            McpSchema.ImageContent imageContent =
+                    new McpSchema.ImageContent(null, "imagedata", mimeType);
+
+            ContentBlock block = McpContentConverter.convertContent(imageContent);
+
+            assertNotNull(block, "Failed for mime type: " + mimeType);
+            assertTrue(block instanceof ImageBlock, "Failed for mime type: " + mimeType);
+        }
+    }
+
+    @Test
+    void testBlobResource_ImageMimeTypeVariations() {
+        // Test blob resources with various image mime types
+        String[] imageMimeTypes = {
+            "image/png", "image/jpeg", "image/gif", "image/svg+xml", "image/bmp"
+        };
+
+        for (String mimeType : imageMimeTypes) {
+            McpSchema.BlobResourceContents blobResource =
+                    new McpSchema.BlobResourceContents("file:///test", mimeType, "data");
+            McpSchema.EmbeddedResource embeddedResource =
+                    new McpSchema.EmbeddedResource(null, blobResource);
+
+            ContentBlock block = McpContentConverter.convertContent(embeddedResource);
+
+            assertNotNull(block, "Failed for mime type: " + mimeType);
+            assertTrue(block instanceof ImageBlock, "Failed for mime type: " + mimeType);
+        }
+    }
+}

--- a/src/test/java/io/agentscope/core/tool/mcp/McpSyncClientWrapperTest.java
+++ b/src/test/java/io/agentscope/core/tool/mcp/McpSyncClientWrapperTest.java
@@ -1,0 +1,342 @@
+/*
+ * Copyright 2024-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.core.tool.mcp;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.modelcontextprotocol.client.McpSyncClient;
+import io.modelcontextprotocol.spec.McpSchema;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class McpSyncClientWrapperTest {
+
+    private McpSyncClient mockClient;
+    private McpSyncClientWrapper wrapper;
+
+    @BeforeEach
+    void setUp() {
+        mockClient = mock(McpSyncClient.class);
+        wrapper = new McpSyncClientWrapper("test-sync-client", mockClient);
+    }
+
+    @Test
+    void testConstructor() {
+        assertNotNull(wrapper);
+        assertEquals("test-sync-client", wrapper.getName());
+        assertFalse(wrapper.isInitialized());
+    }
+
+    @Test
+    void testInitialize_Success() {
+        // Mock initialization with correct constructors
+        McpSchema.Implementation serverInfo =
+                new McpSchema.Implementation("TestServer", "Test Server", "1.0.0");
+        McpSchema.InitializeResult initResult =
+                new McpSchema.InitializeResult(
+                        "1.0",
+                        McpSchema.ServerCapabilities.builder().build(),
+                        serverInfo,
+                        null,
+                        null);
+
+        McpSchema.Tool tool1 =
+                new McpSchema.Tool(
+                        "tool1",
+                        null,
+                        "First tool",
+                        new McpSchema.JsonSchema("object", null, null, null, null, null),
+                        null,
+                        null,
+                        null);
+        McpSchema.Tool tool2 =
+                new McpSchema.Tool(
+                        "tool2",
+                        null,
+                        "Second tool",
+                        new McpSchema.JsonSchema("object", null, null, null, null, null),
+                        null,
+                        null,
+                        null);
+        McpSchema.ListToolsResult toolsResult =
+                new McpSchema.ListToolsResult(List.of(tool1, tool2), null);
+
+        when(mockClient.initialize()).thenReturn(initResult);
+        when(mockClient.listTools()).thenReturn(toolsResult);
+
+        // Execute
+        wrapper.initialize().block();
+
+        // Verify
+        assertTrue(wrapper.isInitialized());
+        assertEquals(2, wrapper.cachedTools.size());
+        assertNotNull(wrapper.getCachedTool("tool1"));
+        assertNotNull(wrapper.getCachedTool("tool2"));
+    }
+
+    @Test
+    void testInitialize_AlreadyInitialized() {
+        McpSchema.Implementation serverInfo =
+                new McpSchema.Implementation("TestServer", "Test Server", "1.0.0");
+        McpSchema.InitializeResult initResult =
+                new McpSchema.InitializeResult(
+                        "1.0",
+                        McpSchema.ServerCapabilities.builder().build(),
+                        serverInfo,
+                        null,
+                        null);
+        McpSchema.ListToolsResult toolsResult = new McpSchema.ListToolsResult(List.of(), null);
+
+        when(mockClient.initialize()).thenReturn(initResult);
+        when(mockClient.listTools()).thenReturn(toolsResult);
+
+        wrapper.initialize().block();
+        assertTrue(wrapper.isInitialized());
+
+        // Second initialization should complete without calling client
+        wrapper.initialize().block();
+
+        verify(mockClient, times(1)).initialize();
+        verify(mockClient, times(1)).listTools();
+    }
+
+    @Test
+    void testInitialize_Failure() {
+        // Mock initialization failure
+        when(mockClient.initialize()).thenThrow(new RuntimeException("Connection failed"));
+
+        // Execute and expect error
+        Exception exception =
+                assertThrows(RuntimeException.class, () -> wrapper.initialize().block());
+
+        assertEquals("Connection failed", exception.getMessage());
+        assertFalse(wrapper.isInitialized());
+    }
+
+    @Test
+    void testListTools_Success() {
+        setupSuccessfulInitialization();
+        wrapper.initialize().block();
+
+        McpSchema.Tool tool =
+                new McpSchema.Tool(
+                        "test-tool",
+                        null,
+                        "Test tool",
+                        new McpSchema.JsonSchema("object", null, null, null, null, null),
+                        null,
+                        null,
+                        null);
+        McpSchema.ListToolsResult toolsResult = new McpSchema.ListToolsResult(List.of(tool), null);
+
+        when(mockClient.listTools()).thenReturn(toolsResult);
+
+        List<McpSchema.Tool> tools = wrapper.listTools().block();
+        assertNotNull(tools);
+        assertEquals(1, tools.size());
+        assertEquals("test-tool", tools.get(0).name());
+    }
+
+    @Test
+    void testListTools_NotInitialized() {
+        Exception exception =
+                assertThrows(IllegalStateException.class, () -> wrapper.listTools().block());
+
+        assertTrue(exception.getMessage().contains("not initialized"));
+    }
+
+    @Test
+    void testCallTool_Success() {
+        setupSuccessfulInitialization();
+        wrapper.initialize().block();
+
+        Map<String, Object> args = new HashMap<>();
+        args.put("param1", "value1");
+
+        McpSchema.TextContent resultContent =
+                new McpSchema.TextContent("Tool executed successfully");
+        McpSchema.CallToolResult callResult =
+                new McpSchema.CallToolResult(List.of(resultContent), false);
+
+        when(mockClient.callTool(any(McpSchema.CallToolRequest.class))).thenReturn(callResult);
+
+        McpSchema.CallToolResult result = wrapper.callTool("test-tool", args).block();
+        assertNotNull(result);
+        assertFalse(Boolean.TRUE.equals(result.isError()));
+        assertEquals(1, result.content().size());
+    }
+
+    @Test
+    void testCallTool_ReturnsError() {
+        setupSuccessfulInitialization();
+        wrapper.initialize().block();
+
+        McpSchema.TextContent errorContent = new McpSchema.TextContent("Tool execution failed");
+        McpSchema.CallToolResult callResult =
+                new McpSchema.CallToolResult(List.of(errorContent), true);
+
+        when(mockClient.callTool(any(McpSchema.CallToolRequest.class))).thenReturn(callResult);
+
+        McpSchema.CallToolResult result = wrapper.callTool("test-tool", new HashMap<>()).block();
+        assertNotNull(result);
+        assertTrue(Boolean.TRUE.equals(result.isError()));
+    }
+
+    @Test
+    void testCallTool_NotInitialized() {
+        Exception exception =
+                assertThrows(
+                        IllegalStateException.class,
+                        () -> wrapper.callTool("test-tool", new HashMap<>()).block());
+
+        assertTrue(exception.getMessage().contains("not initialized"));
+    }
+
+    @Test
+    void testCallTool_ThrowsException() {
+        setupSuccessfulInitialization();
+        wrapper.initialize().block();
+
+        when(mockClient.callTool(any(McpSchema.CallToolRequest.class)))
+                .thenThrow(new RuntimeException("Network error"));
+
+        Exception exception =
+                assertThrows(
+                        RuntimeException.class,
+                        () -> wrapper.callTool("test-tool", new HashMap<>()).block());
+
+        assertEquals("Network error", exception.getMessage());
+    }
+
+    @Test
+    void testGetCachedTool() {
+        setupSuccessfulInitialization();
+        wrapper.initialize().block();
+
+        McpSchema.Tool cached = wrapper.getCachedTool("tool1");
+        assertNotNull(cached);
+        assertEquals("tool1", cached.name());
+
+        assertNull(wrapper.getCachedTool("non-existent"));
+    }
+
+    @Test
+    void testClose_Success() {
+        setupSuccessfulInitialization();
+        wrapper.initialize().block();
+        assertTrue(wrapper.isInitialized());
+        assertFalse(wrapper.cachedTools.isEmpty());
+
+        wrapper.close();
+
+        assertFalse(wrapper.isInitialized());
+        assertTrue(wrapper.cachedTools.isEmpty());
+        verify(mockClient, times(1)).closeGracefully();
+    }
+
+    @Test
+    void testClose_GracefulCloseFails() {
+        setupSuccessfulInitialization();
+        wrapper.initialize().block();
+
+        doThrow(new RuntimeException("Close failed")).when(mockClient).closeGracefully();
+
+        wrapper.close();
+
+        assertFalse(wrapper.isInitialized());
+        assertTrue(wrapper.cachedTools.isEmpty());
+        verify(mockClient, times(1)).closeGracefully();
+        verify(mockClient, times(1)).close();
+    }
+
+    @Test
+    void testClose_NullClient() {
+        McpSyncClientWrapper nullWrapper = new McpSyncClientWrapper("null-client", null);
+
+        nullWrapper.close();
+
+        assertFalse(nullWrapper.isInitialized());
+    }
+
+    @Test
+    void testClose_MultipleCallsSafe() {
+        setupSuccessfulInitialization();
+        wrapper.initialize().block();
+
+        wrapper.close();
+        wrapper.close();
+        wrapper.close();
+
+        assertFalse(wrapper.isInitialized());
+        assertTrue(wrapper.cachedTools.isEmpty());
+    }
+
+    @Test
+    void testCallTool_WithNullArguments() {
+        setupSuccessfulInitialization();
+        wrapper.initialize().block();
+
+        McpSchema.TextContent resultContent = new McpSchema.TextContent("Success");
+        McpSchema.CallToolResult callResult =
+                new McpSchema.CallToolResult(List.of(resultContent), false);
+
+        when(mockClient.callTool(any(McpSchema.CallToolRequest.class))).thenReturn(callResult);
+
+        McpSchema.CallToolResult result = wrapper.callTool("test-tool", null).block();
+        assertNotNull(result);
+        assertFalse(Boolean.TRUE.equals(result.isError()));
+    }
+
+    private void setupSuccessfulInitialization() {
+        McpSchema.Implementation serverInfo =
+                new McpSchema.Implementation("TestServer", "Test Server", "1.0.0");
+        McpSchema.InitializeResult initResult =
+                new McpSchema.InitializeResult(
+                        "1.0",
+                        McpSchema.ServerCapabilities.builder().build(),
+                        serverInfo,
+                        null,
+                        null);
+
+        McpSchema.Tool tool1 =
+                new McpSchema.Tool(
+                        "tool1",
+                        null,
+                        "First tool",
+                        new McpSchema.JsonSchema("object", null, null, null, null, null),
+                        null,
+                        null,
+                        null);
+        McpSchema.ListToolsResult toolsResult = new McpSchema.ListToolsResult(List.of(tool1), null);
+
+        when(mockClient.initialize()).thenReturn(initResult);
+        when(mockClient.listTools()).thenReturn(toolsResult);
+    }
+}

--- a/src/test/java/io/agentscope/core/tool/mcp/McpToolTest.java
+++ b/src/test/java/io/agentscope/core/tool/mcp/McpToolTest.java
@@ -1,0 +1,419 @@
+/*
+ * Copyright 2024-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.core.tool.mcp;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.agentscope.core.message.TextBlock;
+import io.agentscope.core.message.ToolResultBlock;
+import io.agentscope.core.message.ToolUseBlock;
+import io.modelcontextprotocol.spec.McpSchema;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Mono;
+
+class McpToolTest {
+
+    private McpClientWrapper mockClientWrapper;
+    private Map<String, Object> parameters;
+
+    @BeforeEach
+    void setUp() {
+        mockClientWrapper = mock(McpClientWrapper.class);
+        when(mockClientWrapper.getName()).thenReturn("test-client");
+
+        parameters = new HashMap<>();
+        parameters.put("type", "object");
+        parameters.put("properties", new HashMap<>());
+    }
+
+    @Test
+    void testConstructor_WithoutPresetArgs() {
+        McpTool tool = new McpTool("test-tool", "A test tool", parameters, mockClientWrapper);
+
+        assertEquals("test-tool", tool.getName());
+        assertEquals("A test tool", tool.getDescription());
+        assertEquals(parameters, tool.getParameters());
+        assertEquals("test-client", tool.getClientName());
+        assertNull(tool.getPresetArguments());
+    }
+
+    @Test
+    void testConstructor_WithPresetArgs() {
+        Map<String, Object> presetArgs = new HashMap<>();
+        presetArgs.put("preset1", "value1");
+        presetArgs.put("preset2", 42);
+
+        McpTool tool =
+                new McpTool("test-tool", "A test tool", parameters, mockClientWrapper, presetArgs);
+
+        assertEquals("test-tool", tool.getName());
+        assertNotNull(tool.getPresetArguments());
+        assertEquals(2, tool.getPresetArguments().size());
+        assertEquals("value1", tool.getPresetArguments().get("preset1"));
+        assertEquals(42, tool.getPresetArguments().get("preset2"));
+    }
+
+    @Test
+    void testConstructor_WithNullPresetArgs() {
+        McpTool tool = new McpTool("test-tool", "A test tool", parameters, mockClientWrapper, null);
+
+        assertNull(tool.getPresetArguments());
+    }
+
+    @Test
+    void testGetName() {
+        McpTool tool = new McpTool("my-tool", "Description", parameters, mockClientWrapper);
+        assertEquals("my-tool", tool.getName());
+    }
+
+    @Test
+    void testGetDescription() {
+        McpTool tool =
+                new McpTool("tool", "This is a test description", parameters, mockClientWrapper);
+        assertEquals("This is a test description", tool.getDescription());
+    }
+
+    @Test
+    void testGetParameters() {
+        Map<String, Object> customParams = new HashMap<>();
+        customParams.put("type", "object");
+        customParams.put("required", List.of("param1"));
+
+        McpTool tool = new McpTool("tool", "Description", customParams, mockClientWrapper);
+
+        Map<String, Object> result = tool.getParameters();
+        assertEquals("object", result.get("type"));
+        assertTrue(result.containsKey("required"));
+    }
+
+    @Test
+    void testGetClientName() {
+        McpTool tool = new McpTool("tool", "Description", parameters, mockClientWrapper);
+        assertEquals("test-client", tool.getClientName());
+    }
+
+    @Test
+    void testSetCurrentToolUseBlock() {
+        McpTool tool = new McpTool("tool", "Description", parameters, mockClientWrapper);
+
+        ToolUseBlock toolUseBlock = new ToolUseBlock("id-123", "tool", new HashMap<>());
+        tool.setCurrentToolUseBlock(toolUseBlock);
+
+        // No getter for this field, but we verify it doesn't throw exception
+        assertNotNull(tool);
+    }
+
+    @Test
+    void testCallAsync_Success() {
+        McpTool tool = new McpTool("test-tool", "Description", parameters, mockClientWrapper);
+
+        Map<String, Object> input = new HashMap<>();
+        input.put("param1", "value1");
+
+        McpSchema.TextContent resultContent = new McpSchema.TextContent("Success result");
+        McpSchema.CallToolResult mcpResult =
+                new McpSchema.CallToolResult(List.of(resultContent), false);
+
+        when(mockClientWrapper.callTool(eq("test-tool"), any())).thenReturn(Mono.just(mcpResult));
+
+        ToolResultBlock result = tool.callAsync(input).block();
+        assertNotNull(result);
+        String outputText = ((TextBlock) result.getOutput()).getText();
+        assertFalse(outputText.startsWith("Error:"));
+
+        verify(mockClientWrapper).callTool(eq("test-tool"), any());
+    }
+
+    @Test
+    void testCallAsync_WithEmptyInput() {
+        McpTool tool = new McpTool("test-tool", "Description", parameters, mockClientWrapper);
+
+        McpSchema.TextContent resultContent = new McpSchema.TextContent("Success");
+        McpSchema.CallToolResult mcpResult =
+                new McpSchema.CallToolResult(List.of(resultContent), false);
+
+        when(mockClientWrapper.callTool(eq("test-tool"), any())).thenReturn(Mono.just(mcpResult));
+
+        ToolResultBlock result = tool.callAsync(new HashMap<>()).block();
+        assertNotNull(result);
+        String outputText = ((TextBlock) result.getOutput()).getText();
+        assertFalse(outputText.startsWith("Error:"));
+    }
+
+    @Test
+    void testCallAsync_WithNullInput() {
+        McpTool tool = new McpTool("test-tool", "Description", parameters, mockClientWrapper);
+
+        McpSchema.TextContent resultContent = new McpSchema.TextContent("Success");
+        McpSchema.CallToolResult mcpResult =
+                new McpSchema.CallToolResult(List.of(resultContent), false);
+
+        when(mockClientWrapper.callTool(eq("test-tool"), any())).thenReturn(Mono.just(mcpResult));
+
+        ToolResultBlock result = tool.callAsync(null).block();
+        assertNotNull(result);
+        String outputText = ((TextBlock) result.getOutput()).getText();
+        assertFalse(outputText.startsWith("Error:"));
+    }
+
+    @Test
+    void testCallAsync_MergesPresetArguments() {
+        Map<String, Object> presetArgs = new HashMap<>();
+        presetArgs.put("preset_key", "preset_value");
+        presetArgs.put("override_me", "old_value");
+
+        McpTool tool =
+                new McpTool("test-tool", "Description", parameters, mockClientWrapper, presetArgs);
+
+        Map<String, Object> input = new HashMap<>();
+        input.put("input_key", "input_value");
+        input.put("override_me", "new_value"); // Should override preset
+
+        McpSchema.TextContent resultContent = new McpSchema.TextContent("Success");
+        McpSchema.CallToolResult mcpResult =
+                new McpSchema.CallToolResult(List.of(resultContent), false);
+
+        when(mockClientWrapper.callTool(eq("test-tool"), any())).thenReturn(Mono.just(mcpResult));
+
+        ToolResultBlock result = tool.callAsync(input).block();
+        assertNotNull(result);
+        String outputText = ((TextBlock) result.getOutput()).getText();
+        assertFalse(outputText.startsWith("Error:"));
+
+        // Verify the merged arguments were passed
+        verify(mockClientWrapper).callTool(eq("test-tool"), any(Map.class));
+    }
+
+    @Test
+    void testCallAsync_PresetArgsOnly() {
+        Map<String, Object> presetArgs = new HashMap<>();
+        presetArgs.put("preset1", "value1");
+        presetArgs.put("preset2", "value2");
+
+        McpTool tool =
+                new McpTool("test-tool", "Description", parameters, mockClientWrapper, presetArgs);
+
+        McpSchema.TextContent resultContent = new McpSchema.TextContent("Success");
+        McpSchema.CallToolResult mcpResult =
+                new McpSchema.CallToolResult(List.of(resultContent), false);
+
+        when(mockClientWrapper.callTool(eq("test-tool"), any())).thenReturn(Mono.just(mcpResult));
+
+        // Call with null input - should use preset args only
+        ToolResultBlock result = tool.callAsync(null).block();
+        assertNotNull(result);
+        String outputText = ((TextBlock) result.getOutput()).getText();
+        assertFalse(outputText.startsWith("Error:"));
+    }
+
+    @Test
+    void testCallAsync_ErrorHandling() {
+        McpTool tool = new McpTool("test-tool", "Description", parameters, mockClientWrapper);
+
+        when(mockClientWrapper.callTool(eq("test-tool"), any()))
+                .thenReturn(Mono.error(new RuntimeException("Network error")));
+
+        ToolResultBlock result = tool.callAsync(new HashMap<>()).block();
+        assertNotNull(result);
+        String outputText = ((TextBlock) result.getOutput()).getText();
+        assertTrue(outputText.startsWith("Error:"));
+        assertTrue(outputText.contains("MCP tool error"));
+        assertTrue(outputText.contains("Network error"));
+    }
+
+    @Test
+    void testCallAsync_ErrorWithNullMessage() {
+        McpTool tool = new McpTool("test-tool", "Description", parameters, mockClientWrapper);
+
+        when(mockClientWrapper.callTool(eq("test-tool"), any()))
+                .thenReturn(Mono.error(new NullPointerException()));
+
+        ToolResultBlock result = tool.callAsync(new HashMap<>()).block();
+        assertNotNull(result);
+        String outputText = ((TextBlock) result.getOutput()).getText();
+        assertTrue(outputText.startsWith("Error:"));
+        assertTrue(outputText.contains("MCP tool error"));
+        assertTrue(outputText.contains("NullPointerException"));
+    }
+
+    @Test
+    void testGetPresetArguments_ReturnsDefensiveCopy() {
+        Map<String, Object> presetArgs = new HashMap<>();
+        presetArgs.put("key", "value");
+
+        McpTool tool =
+                new McpTool("test-tool", "Description", parameters, mockClientWrapper, presetArgs);
+
+        Map<String, Object> retrieved1 = tool.getPresetArguments();
+        Map<String, Object> retrieved2 = tool.getPresetArguments();
+
+        // Should return different instances (defensive copy)
+        assertTrue(retrieved1 != retrieved2);
+        assertEquals(retrieved1, retrieved2);
+
+        // Modifying returned map should not affect the tool's internal state
+        retrieved1.put("new_key", "new_value");
+        Map<String, Object> retrieved3 = tool.getPresetArguments();
+        assertFalse(retrieved3.containsKey("new_key"));
+    }
+
+    @Test
+    void testConvertMcpSchemaToParameters_NullSchema() {
+        Map<String, Object> result = McpTool.convertMcpSchemaToParameters(null);
+
+        assertNotNull(result);
+        assertEquals("object", result.get("type"));
+        assertTrue(result.containsKey("properties"));
+        assertTrue(result.containsKey("required"));
+        assertTrue(((Map<?, ?>) result.get("properties")).isEmpty());
+        assertTrue(((List<?>) result.get("required")).isEmpty());
+    }
+
+    @Test
+    void testConvertMcpSchemaToParameters_CompleteSchema() {
+        Map<String, Object> properties = new HashMap<>();
+        properties.put("param1", Map.of("type", "string"));
+        properties.put("param2", Map.of("type", "number"));
+
+        List<String> required = List.of("param1");
+
+        McpSchema.JsonSchema schema =
+                new McpSchema.JsonSchema("object", properties, required, true, null, null);
+
+        Map<String, Object> result = McpTool.convertMcpSchemaToParameters(schema);
+
+        assertNotNull(result);
+        assertEquals("object", result.get("type"));
+        assertEquals(properties, result.get("properties"));
+        assertEquals(required, result.get("required"));
+        assertEquals(true, result.get("additionalProperties"));
+    }
+
+    @Test
+    void testConvertMcpSchemaToParameters_NullType() {
+        McpSchema.JsonSchema schema = new McpSchema.JsonSchema(null, null, null, null, null, null);
+
+        Map<String, Object> result = McpTool.convertMcpSchemaToParameters(schema);
+
+        assertNotNull(result);
+        assertEquals("object", result.get("type")); // Defaults to "object"
+        assertNotNull(result.get("properties"));
+        assertNotNull(result.get("required"));
+    }
+
+    @Test
+    void testConvertMcpSchemaToParameters_EmptyProperties() {
+        McpSchema.JsonSchema schema =
+                new McpSchema.JsonSchema(
+                        "object", new HashMap<>(), new ArrayList<>(), null, null, null);
+
+        Map<String, Object> result = McpTool.convertMcpSchemaToParameters(schema);
+
+        assertNotNull(result);
+        assertTrue(((Map<?, ?>) result.get("properties")).isEmpty());
+        assertTrue(((List<?>) result.get("required")).isEmpty());
+        assertFalse(result.containsKey("additionalProperties")); // Should be omitted if null
+    }
+
+    @Test
+    void testConvertMcpSchemaToParameters_WithAdditionalProperties() {
+        McpSchema.JsonSchema schema =
+                new McpSchema.JsonSchema("object", null, null, false, null, null);
+
+        Map<String, Object> result = McpTool.convertMcpSchemaToParameters(schema);
+
+        assertNotNull(result);
+        assertTrue(result.containsKey("additionalProperties"));
+        assertEquals(false, result.get("additionalProperties"));
+    }
+
+    @Test
+    void testConvertMcpSchemaToParameters_ComplexProperties() {
+        Map<String, Object> properties = new HashMap<>();
+        properties.put(
+                "user",
+                Map.of("type", "object", "properties", Map.of("name", Map.of("type", "string"))));
+
+        List<String> required = List.of("user");
+
+        McpSchema.JsonSchema schema =
+                new McpSchema.JsonSchema("object", properties, required, null, null, null);
+
+        Map<String, Object> result = McpTool.convertMcpSchemaToParameters(schema);
+
+        assertNotNull(result);
+        Map<?, ?> resultProperties = (Map<?, ?>) result.get("properties");
+        assertTrue(resultProperties.containsKey("user"));
+        Map<?, ?> userProperty = (Map<?, ?>) resultProperties.get("user");
+        assertEquals("object", userProperty.get("type"));
+    }
+
+    @Test
+    void testMergeArguments_BothEmpty() {
+        McpTool tool =
+                new McpTool(
+                        "test-tool", "Description", parameters, mockClientWrapper, new HashMap<>());
+
+        McpSchema.TextContent resultContent = new McpSchema.TextContent("Success");
+        McpSchema.CallToolResult mcpResult =
+                new McpSchema.CallToolResult(List.of(resultContent), false);
+
+        when(mockClientWrapper.callTool(eq("test-tool"), any())).thenReturn(Mono.just(mcpResult));
+
+        ToolResultBlock result = tool.callAsync(new HashMap<>()).block();
+        assertNotNull(result);
+        String outputText = ((TextBlock) result.getOutput()).getText();
+        assertFalse(outputText.startsWith("Error:"));
+    }
+
+    @Test
+    void testMergeArguments_InputOverridesPreset() {
+        Map<String, Object> presetArgs = new HashMap<>();
+        presetArgs.put("key", "preset_value");
+
+        McpTool tool =
+                new McpTool("test-tool", "Description", parameters, mockClientWrapper, presetArgs);
+
+        Map<String, Object> input = new HashMap<>();
+        input.put("key", "input_value");
+
+        McpSchema.TextContent resultContent = new McpSchema.TextContent("Success");
+        McpSchema.CallToolResult mcpResult =
+                new McpSchema.CallToolResult(List.of(resultContent), false);
+
+        when(mockClientWrapper.callTool(eq("test-tool"), any())).thenReturn(Mono.just(mcpResult));
+
+        // The merged args should have input_value (not preset_value)
+        ToolResultBlock result = tool.callAsync(input).block();
+        assertNotNull(result);
+        String outputText = ((TextBlock) result.getOutput()).getText();
+        assertFalse(outputText.startsWith("Error:"));
+    }
+}


### PR DESCRIPTION
  Add comprehensive MCP integration with client wrappers, tool implementation,
  and content conversion utilities.

  Changes:
  - Add MCP SDK dependency (io.modelcontextprotocol:mcp:0.14.1)
  - Implement MCP client wrapper architecture:
    - McpClientWrapper: Abstract base class for MCP clients
    - McpAsyncClientWrapper: Async client with reactive support
    - McpSyncClientWrapper: Synchronous client wrapper
  - Add McpClientBuilder: Fluent builder for creating MCP clients
    - Support for StdIO, SSE, StreamableHTTP, and HTTP transports
    - Configurable headers, timeouts, and initialization options
  - Implement McpTool: Tool adapter for MCP protocol
    - Supports preset arguments merging
    - Async tool execution with reactive streams
  - Add McpContentConverter: Converts MCP content to AgentScope blocks
    - TextContent → TextBlock
    - ImageContent → ImageBlock
    - AudioContent → TextBlock (placeholder)
    - EmbeddedResource → TextBlock or ImageBlock
  - Extend Toolkit with MCP client management APIs
    - addMcpClient(): Register MCP clients
    - loadMcpTools(): Load tools from MCP clients
    - closeMcpClients(): Graceful shutdown

Change-Id: I9766d4c09ffe4a49506daae449f0352b093dd325