### PR TITLE
refactor(message): change Msg.content to List and implement Jackson serialization with type-safe API

### DIFF
--- a/src/main/java/io/agentscope/core/agent/user/UserAgent.java
+++ b/src/main/java/io/agentscope/core/agent/user/UserAgent.java
@@ -97,20 +97,14 @@ public class UserAgent extends AgentBase {
         List<ContentBlock> blocksInput = inputData.getBlocksInput();
         Map<String, Object> structuredInput = inputData.getStructuredInput();
 
-        // Convert blocks input to content
-        ContentBlock content;
-        if (blocksInput != null
-                && blocksInput.size() == 1
-                && blocksInput.get(0) instanceof TextBlock) {
-            // If only one text block, use it directly
-            content = blocksInput.get(0);
-        } else if (blocksInput != null && !blocksInput.isEmpty()) {
-            // For multiple blocks, we'd need a MultiContentBlock or similar
-            // For now, just use the first block
-            content = blocksInput.get(0);
+        // Convert blocks input to content list
+        List<ContentBlock> content;
+        if (blocksInput != null && !blocksInput.isEmpty()) {
+            // Use the blocks directly as List<ContentBlock>
+            content = blocksInput;
         } else {
             // Create empty text block if no content
-            content = TextBlock.builder().text("").build();
+            content = List.of(TextBlock.builder().text("").build());
         }
 
         // Create the message
@@ -130,22 +124,7 @@ public class UserAgent extends AgentBase {
      */
     private void printMessage(Msg msg) {
         System.out.println(
-                "["
-                        + msg.getName()
-                        + " ("
-                        + msg.getRole()
-                        + ")]: "
-                        + getTextFromContent(msg.getContent()));
-    }
-
-    /**
-     * Extract text content from a ContentBlock.
-     */
-    private String getTextFromContent(ContentBlock content) {
-        if (content instanceof TextBlock) {
-            return ((TextBlock) content).getText();
-        }
-        return content.toString();
+                "[" + msg.getName() + " (" + msg.getRole() + ")]: " + msg.getTextContent());
     }
 
     /**

--- a/src/main/java/io/agentscope/core/formatter/OpenAIMultiAgentFormatter.java
+++ b/src/main/java/io/agentscope/core/formatter/OpenAIMultiAgentFormatter.java
@@ -15,7 +15,6 @@
  */
 package io.agentscope.core.formatter;
 
-import io.agentscope.core.message.ContentBlock;
 import io.agentscope.core.message.ImageBlock;
 import io.agentscope.core.message.Msg;
 import io.agentscope.core.message.MsgRole;
@@ -123,8 +122,7 @@ public class OpenAIMultiAgentFormatter extends OpenAIChatFormatter {
             case USER:
             case ASSISTANT:
                 // Check if this is part of a tool sequence
-                ContentBlock content = msg.getContent();
-                if (content instanceof ToolUseBlock) {
+                if (msg.hasContentBlocks(ToolUseBlock.class)) {
                     return MessageGroupType.TOOL_SEQUENCE;
                 }
                 return MessageGroupType.AGENT_CONVERSATION;

--- a/src/main/java/io/agentscope/core/hook/Hook.java
+++ b/src/main/java/io/agentscope/core/hook/Hook.java
@@ -34,7 +34,7 @@ import reactor.core.publisher.Mono;
  * agent.addHook(new Hook() {
  *     @Override
  *     public Mono<Msg> onReasoning(Agent agent, Msg msg) {
- *         System.out.println("Thinking: " + msg.getContent());
+ *         System.out.println("Thinking: " + msg.getTextContent());
  *         return Mono.just(msg);  // Return original or modified
  *     }
  *

--- a/src/main/java/io/agentscope/core/message/AudioBlock.java
+++ b/src/main/java/io/agentscope/core/message/AudioBlock.java
@@ -15,11 +15,15 @@
  */
 package io.agentscope.core.message;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 public class AudioBlock extends ContentBlock {
 
     private final Source source;
 
-    public AudioBlock(Source source) {
+    @JsonCreator
+    public AudioBlock(@JsonProperty("source") Source source) {
         this.source = source;
     }
 

--- a/src/main/java/io/agentscope/core/message/Base64Source.java
+++ b/src/main/java/io/agentscope/core/message/Base64Source.java
@@ -15,13 +15,19 @@
  */
 package io.agentscope.core.message;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 public class Base64Source extends Source {
 
+    @JsonProperty("media_type")
     private final String mediaType;
 
     private final String data;
 
-    public Base64Source(String mediaType, String data) {
+    @JsonCreator
+    public Base64Source(
+            @JsonProperty("media_type") String mediaType, @JsonProperty("data") String data) {
         this.mediaType = mediaType;
         this.data = data;
     }

--- a/src/main/java/io/agentscope/core/message/ContentBlock.java
+++ b/src/main/java/io/agentscope/core/message/ContentBlock.java
@@ -15,16 +15,33 @@
  */
 package io.agentscope.core.message;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
 /**
  * Base class for all content blocks in messages.
  * Content blocks represent different types of content that can be included in a message,
  * such as text, images, audio, video, or thinking content.
+ *
+ * Uses Jackson annotations for polymorphic JSON serialization compatible with Python version.
  */
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "type")
+@JsonSubTypes({
+    @JsonSubTypes.Type(value = TextBlock.class, name = "text"),
+    @JsonSubTypes.Type(value = ThinkingBlock.class, name = "thinking"),
+    @JsonSubTypes.Type(value = ImageBlock.class, name = "image"),
+    @JsonSubTypes.Type(value = AudioBlock.class, name = "audio"),
+    @JsonSubTypes.Type(value = VideoBlock.class, name = "video"),
+    @JsonSubTypes.Type(value = ToolUseBlock.class, name = "tool_use"),
+    @JsonSubTypes.Type(value = ToolResultBlock.class, name = "tool_result")
+})
 public abstract class ContentBlock {
 
     /**
      * Get the type of this content block.
      * @return the content block type
      */
+    @JsonIgnore
     public abstract ContentBlockType getType();
 }

--- a/src/main/java/io/agentscope/core/message/ImageBlock.java
+++ b/src/main/java/io/agentscope/core/message/ImageBlock.java
@@ -15,11 +15,15 @@
  */
 package io.agentscope.core.message;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 public class ImageBlock extends ContentBlock {
 
     private final Source source;
 
-    public ImageBlock(Source source) {
+    @JsonCreator
+    public ImageBlock(@JsonProperty("source") Source source) {
         this.source = source;
     }
 

--- a/src/main/java/io/agentscope/core/message/Source.java
+++ b/src/main/java/io/agentscope/core/message/Source.java
@@ -16,4 +16,17 @@
 
 package io.agentscope.core.message;
 
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+/**
+ * Base class for media sources (URL or Base64).
+ *
+ * Uses Jackson annotations for polymorphic JSON serialization compatible with Python version.
+ */
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "type")
+@JsonSubTypes({
+    @JsonSubTypes.Type(value = URLSource.class, name = "url"),
+    @JsonSubTypes.Type(value = Base64Source.class, name = "base64")
+})
 public class Source {}

--- a/src/main/java/io/agentscope/core/message/TextBlock.java
+++ b/src/main/java/io/agentscope/core/message/TextBlock.java
@@ -15,11 +15,15 @@
  */
 package io.agentscope.core.message;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 public class TextBlock extends ContentBlock {
 
     private final String text;
 
-    private TextBlock(String text) {
+    @JsonCreator
+    private TextBlock(@JsonProperty("text") String text) {
         this.text = text;
     }
 

--- a/src/main/java/io/agentscope/core/message/ThinkingBlock.java
+++ b/src/main/java/io/agentscope/core/message/ThinkingBlock.java
@@ -15,11 +15,15 @@
  */
 package io.agentscope.core.message;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 public class ThinkingBlock extends ContentBlock {
 
     private final String thinking;
 
-    private ThinkingBlock(String text) {
+    @JsonCreator
+    private ThinkingBlock(@JsonProperty("thinking") String text) {
         this.thinking = text;
     }
 

--- a/src/main/java/io/agentscope/core/message/ToolResultBlock.java
+++ b/src/main/java/io/agentscope/core/message/ToolResultBlock.java
@@ -15,6 +15,8 @@
  */
 package io.agentscope.core.message;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.List;
 import java.util.Map;
 
@@ -34,8 +36,12 @@ public class ToolResultBlock extends ContentBlock {
     private final ContentBlock output;
     private final Map<String, Object> metadata;
 
+    @JsonCreator
     public ToolResultBlock(
-            String id, String name, ContentBlock output, Map<String, Object> metadata) {
+            @JsonProperty("id") String id,
+            @JsonProperty("name") String name,
+            @JsonProperty("output") ContentBlock output,
+            @JsonProperty("metadata") Map<String, Object> metadata) {
         this.id = id;
         this.name = name;
         this.output = output;

--- a/src/main/java/io/agentscope/core/message/ToolUseBlock.java
+++ b/src/main/java/io/agentscope/core/message/ToolUseBlock.java
@@ -15,17 +15,24 @@
  */
 package io.agentscope.core.message;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.Map;
 
 public class ToolUseBlock extends ContentBlock {
 
-    private final ContentBlockType type = ContentBlockType.TOOL_USE;
+    @JsonIgnore private final ContentBlockType type = ContentBlockType.TOOL_USE;
     private final String id;
     private final String name;
     private final Map<String, Object> input;
     private final String content; // Raw content for streaming tool calls
 
-    public ToolUseBlock(String id, String name, Map<String, Object> input) {
+    @JsonCreator
+    public ToolUseBlock(
+            @JsonProperty("id") String id,
+            @JsonProperty("name") String name,
+            @JsonProperty("input") Map<String, Object> input) {
         this.id = id;
         this.name = name;
         this.input = input;

--- a/src/main/java/io/agentscope/core/message/URLSource.java
+++ b/src/main/java/io/agentscope/core/message/URLSource.java
@@ -15,11 +15,15 @@
  */
 package io.agentscope.core.message;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 public class URLSource extends Source {
 
     private final String url;
 
-    public URLSource(String url) {
+    @JsonCreator
+    public URLSource(@JsonProperty("url") String url) {
         this.url = url;
     }
 

--- a/src/main/java/io/agentscope/core/message/VideoBlock.java
+++ b/src/main/java/io/agentscope/core/message/VideoBlock.java
@@ -15,11 +15,15 @@
  */
 package io.agentscope.core.message;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 public class VideoBlock extends ContentBlock {
 
     private final Source source;
 
-    public VideoBlock(Source source) {
+    @JsonCreator
+    public VideoBlock(@JsonProperty("source") Source source) {
         this.source = source;
     }
 

--- a/src/main/java/io/agentscope/core/tool/Toolkit.java
+++ b/src/main/java/io/agentscope/core/tool/Toolkit.java
@@ -326,18 +326,6 @@ public class Toolkit extends StateModuleBase {
     }
 
     /**
-     * Call a tool using a ToolUseBlock and return a ToolResultBlock (synchronous).
-     *
-     * @param toolCall The tool use block containing tool name and arguments
-     * @return ToolResultBlock containing the result
-     * @deprecated Use {@link #callToolAsync(ToolUseBlock)} instead
-     */
-    @Deprecated
-    public ToolResultBlock callTool(ToolUseBlock toolCall) {
-        return callToolAsync(toolCall).block();
-    }
-
-    /**
      * Call a tool using a ToolUseBlock and return a Mono of ToolResultBlock (asynchronous).
      *
      * @param toolCall The tool use block containing tool name and arguments

--- a/src/test/java/io/agentscope/core/agent/ReActAgentTest.java
+++ b/src/test/java/io/agentscope/core/agent/ReActAgentTest.java
@@ -218,9 +218,8 @@ class ReActAgentTest {
                 messages.stream()
                         .anyMatch(
                                 m ->
-                                        m.getContent()
-                                                instanceof
-                                                io.agentscope.core.message.ToolResultBlock);
+                                        m.hasContentBlocks(
+                                                io.agentscope.core.message.ToolResultBlock.class));
         assertTrue(hasToolResult, "Memory should contain tool result");
     }
 
@@ -363,9 +362,11 @@ class ReActAgentTest {
                 messages.stream()
                         .anyMatch(
                                 m -> {
-                                    if (m.getContent()
-                                            instanceof
-                                            io.agentscope.core.message.ToolResultBlock trb) {
+                                    io.agentscope.core.message.ToolResultBlock trb =
+                                            m.getFirstContentBlock(
+                                                    io.agentscope.core.message.ToolResultBlock
+                                                            .class);
+                                    if (trb != null) {
                                         // Check if output contains error text
                                         if (trb.getOutput()
                                                 instanceof
@@ -437,16 +438,16 @@ class ReActAgentTest {
                 messages.stream()
                         .filter(
                                 m ->
-                                        m.getContent()
-                                                instanceof
-                                                io.agentscope.core.message.ToolResultBlock)
+                                        m.hasContentBlocks(
+                                                io.agentscope.core.message.ToolResultBlock.class))
                         .findFirst()
                         .orElse(null);
 
         assertNotNull(toolResultMsg, "Tool result message should be in memory");
 
         io.agentscope.core.message.ToolResultBlock toolResult =
-                (io.agentscope.core.message.ToolResultBlock) toolResultMsg.getContent();
+                toolResultMsg.getFirstContentBlock(
+                        io.agentscope.core.message.ToolResultBlock.class);
         assertEquals("calc_123", toolResult.getId(), "Tool call ID should match");
         // Verify tool executed successfully by checking output doesn't contain error
         if (toolResult.getOutput() instanceof io.agentscope.core.message.TextBlock tb) {

--- a/src/test/java/io/agentscope/core/agent/test/TestUtils.java
+++ b/src/test/java/io/agentscope/core/agent/test/TestUtils.java
@@ -15,7 +15,6 @@
  */
 package io.agentscope.core.agent.test;
 
-import io.agentscope.core.message.ContentBlock;
 import io.agentscope.core.message.Msg;
 import io.agentscope.core.message.MsgRole;
 import io.agentscope.core.message.TextBlock;
@@ -105,35 +104,28 @@ public class TestUtils {
             return null;
         }
 
-        ContentBlock content = msg.getContent();
-        if (content instanceof TextBlock) {
-            return ((TextBlock) content).getText();
-        } else if (content instanceof ThinkingBlock) {
-            return ((ThinkingBlock) content).getThinking();
-        }
-
-        return content != null ? content.toString() : null;
+        return msg.getTextContent();
     }
 
     /**
      * Check if a message is a tool use message.
      */
     public static boolean isToolUseMessage(Msg msg) {
-        return msg != null && msg.getContent() instanceof ToolUseBlock;
+        return msg != null && msg.hasContentBlocks(ToolUseBlock.class);
     }
 
     /**
      * Check if a message is a text message.
      */
     public static boolean isTextMessage(Msg msg) {
-        return msg != null && msg.getContent() instanceof TextBlock;
+        return msg != null && msg.hasContentBlocks(TextBlock.class);
     }
 
     /**
      * Check if a message is a thinking message.
      */
     public static boolean isThinkingMessage(Msg msg) {
-        return msg != null && msg.getContent() instanceof ThinkingBlock;
+        return msg != null && msg.hasContentBlocks(ThinkingBlock.class);
     }
 
     /**
@@ -144,7 +136,7 @@ public class TestUtils {
             return null;
         }
 
-        ToolUseBlock toolUse = (ToolUseBlock) msg.getContent();
+        ToolUseBlock toolUse = msg.getFirstContentBlock(ToolUseBlock.class);
         return toolUse.getName();
     }
 
@@ -156,7 +148,7 @@ public class TestUtils {
             return null;
         }
 
-        ToolUseBlock toolUse = (ToolUseBlock) msg.getContent();
+        ToolUseBlock toolUse = msg.getFirstContentBlock(ToolUseBlock.class);
         return toolUse.getId();
     }
 

--- a/src/test/java/io/agentscope/core/formatter/DashScopeChatFormatterTest.java
+++ b/src/test/java/io/agentscope/core/formatter/DashScopeChatFormatterTest.java
@@ -400,7 +400,12 @@ public class DashScopeChatFormatterTest {
         DashScopeChatFormatter formatter = new DashScopeChatFormatter();
 
         List<Msg> messages =
-                List.of(Msg.builder().name("user").role(MsgRole.USER).content(null).build());
+                List.of(
+                        Msg.builder()
+                                .name("user")
+                                .role(MsgRole.USER)
+                                .content((List<io.agentscope.core.message.ContentBlock>) null)
+                                .build());
 
         FormattedMessageList formatted = formatter.format(messages);
 

--- a/src/test/java/io/agentscope/core/formatter/OpenAIChatFormatterTest.java
+++ b/src/test/java/io/agentscope/core/formatter/OpenAIChatFormatterTest.java
@@ -455,8 +455,7 @@ public class OpenAIChatFormatterTest {
     public void testNullContent() {
         OpenAIChatFormatter formatter = new OpenAIChatFormatter();
 
-        List<Msg> messages =
-                List.of(Msg.builder().name("user").role(MsgRole.USER).content(null).build());
+        List<Msg> messages = List.of(Msg.builder().name("user").role(MsgRole.USER).build());
 
         FormattedMessageList formatted = formatter.format(messages);
 

--- a/src/test/java/io/agentscope/core/formatter/OpenAIMultiAgentFormatterTest.java
+++ b/src/test/java/io/agentscope/core/formatter/OpenAIMultiAgentFormatterTest.java
@@ -342,7 +342,12 @@ public class OpenAIMultiAgentFormatterTest {
         OpenAIMultiAgentFormatter formatter = new OpenAIMultiAgentFormatter();
 
         List<Msg> messages =
-                List.of(Msg.builder().name("Alice").role(MsgRole.USER).content(null).build());
+                List.of(
+                        Msg.builder()
+                                .name("Alice")
+                                .role(MsgRole.USER)
+                                .content((List<io.agentscope.core.message.ContentBlock>) null)
+                                .build());
 
         FormattedMessageList formatted = formatter.format(messages);
 

--- a/src/test/java/io/agentscope/core/message/MsgTest.java
+++ b/src/test/java/io/agentscope/core/message/MsgTest.java
@@ -31,7 +31,7 @@ class MsgTest {
 
         assertEquals("user", msg.getName());
         assertEquals(MsgRole.USER, msg.getRole());
-        assertEquals(textBlock, msg.getContent());
+        assertEquals(textBlock, msg.getFirstContentBlock());
     }
 
     @Test
@@ -42,7 +42,7 @@ class MsgTest {
         assertFalse(msg.hasMediaContent());
         assertEquals("Hello World", msg.getTextContent());
         assertEquals("Hello World", msg.getContentAsText());
-        assertTrue(msg.getContent() instanceof TextBlock);
+        assertTrue(msg.getFirstContentBlock() instanceof TextBlock);
     }
 
     @Test
@@ -54,7 +54,7 @@ class MsgTest {
         assertTrue(msg.hasMediaContent());
         assertEquals("", msg.getTextContent());
         assertTrue(msg.getContentAsText().contains("[Image content"));
-        assertTrue(msg.getContent() instanceof ImageBlock);
+        assertTrue(msg.getFirstContentBlock() instanceof ImageBlock);
     }
 
     @Test
@@ -66,7 +66,7 @@ class MsgTest {
         assertFalse(msg.hasTextContent());
         assertTrue(msg.hasMediaContent());
         assertTrue(msg.getContentAsText().contains("[Audio content"));
-        assertTrue(msg.getContent() instanceof AudioBlock);
+        assertTrue(msg.getFirstContentBlock() instanceof AudioBlock);
     }
 
     @Test
@@ -77,7 +77,7 @@ class MsgTest {
         assertFalse(msg.hasTextContent());
         assertTrue(msg.hasMediaContent());
         assertTrue(msg.getContentAsText().contains("[Video content"));
-        assertTrue(msg.getContent() instanceof VideoBlock);
+        assertTrue(msg.getFirstContentBlock() instanceof VideoBlock);
     }
 
     @Test
@@ -92,7 +92,7 @@ class MsgTest {
         assertTrue(msg.hasTextContent());
         assertFalse(msg.hasMediaContent());
         assertEquals("Let me think about this...", msg.getTextContent());
-        assertTrue(msg.getContent() instanceof ThinkingBlock);
+        assertTrue(msg.getFirstContentBlock() instanceof ThinkingBlock);
     }
 
     @Test

--- a/src/test/java/io/agentscope/core/tool/ToolResultMessageBuilderTest.java
+++ b/src/test/java/io/agentscope/core/tool/ToolResultMessageBuilderTest.java
@@ -55,7 +55,7 @@ class ToolResultMessageBuilderTest {
         assertEquals("TestAgent", result.getName());
         assertEquals(MsgRole.TOOL, result.getRole());
 
-        ContentBlock content = result.getContent();
+        ContentBlock content = result.getFirstContentBlock();
         assertTrue(content instanceof ToolResultBlock);
 
         ToolResultBlock toolResult = (ToolResultBlock) content;
@@ -81,7 +81,7 @@ class ToolResultMessageBuilderTest {
                 ToolResultMessageBuilder.buildToolResultMsg(response, originalCall, "TestAgent");
 
         // Assert
-        ToolResultBlock toolResult = (ToolResultBlock) result.getContent();
+        ToolResultBlock toolResult = (ToolResultBlock) result.getFirstContentBlock();
         TextBlock output = (TextBlock) toolResult.getOutput();
         assertNull(output);
     }
@@ -106,7 +106,7 @@ class ToolResultMessageBuilderTest {
         Msg result = ToolResultMessageBuilder.buildToolResultMsg(response, originalCall, "Agent");
 
         // Assert
-        ToolResultBlock toolResult = (ToolResultBlock) result.getContent();
+        ToolResultBlock toolResult = (ToolResultBlock) result.getFirstContentBlock();
         assertEquals(toolId, toolResult.getId());
         assertEquals(toolName, toolResult.getName());
     }


### PR DESCRIPTION
  Breaking changes:
  - Change Msg.content from single ContentBlock to List<ContentBlock>
  - This allows messages to contain multiple content blocks (e.g., text + images, multiple tool calls)
  - Add convenience methods: getFirstContentBlock(), getContentBlocks(Class<T>), hasContentBlocks(Class<T>)

  Jackson serialization implementation:
  - Add Jackson polymorphic serialization annotations (@JsonTypeInfo, @JsonSubTypes) to ContentBlock and Source hierarchies
  - Add @JsonCreator constructors with @JsonProperty annotations to all message components:
    * Content blocks: TextBlock, ThinkingBlock, ToolUseBlock, ToolResultBlock, ImageBlock, AudioBlock, VideoBlock
    * Sources: Base64Source, URLSource
  - Add @JsonIgnore to computed properties (getType(), getFirstContentBlock(), etc.) to prevent serialization conflicts
  - Add @JsonIgnoreProperties(ignoreUnknown = true) to Msg for forward compatibility
  - Replace manual serialization in InMemoryMemory with ObjectMapper.convertValue() for complete data preservation
  - Ensure field naming compatibility with Python version (media_type, tool_use, tool_result, etc.)