### PR TITLE
refactor(hook): align hook system with Python implementation using pre/post naming convention

### DIFF
--- a/examples/src/main/java/io/agentscope/examples/HookExample.java
+++ b/examples/src/main/java/io/agentscope/examples/HookExample.java
@@ -109,8 +109,8 @@ public class HookExample {
     static class MonitoringHook implements Hook {
 
         @Override
-        public Mono<Void> onStart(Agent agent) {
-            System.out.println("\n[HOOK] onStart - Agent started: " + agent.getName());
+        public Mono<Void> preCall(Agent agent) {
+            System.out.println("\n[HOOK] preCall - Agent started: " + agent.getName());
             return Mono.empty();
         }
 
@@ -121,25 +121,25 @@ public class HookExample {
         }
 
         @Override
-        public Mono<Msg> onReasoningChunk(Agent agent, Msg chunk) {
+        public Mono<Void> onReasoningChunk(Agent agent, Msg chunk) {
             // Print streaming reasoning content as it arrives
             String text = chunk.getContentAsText();
             if (text != null && !text.isEmpty()) {
                 System.out.print(text);
             }
-            return Mono.just(chunk);
+            return Mono.empty();
         }
 
         @Override
-        public Mono<Msg> onReasoning(Agent agent, Msg msg) {
+        public Mono<Msg> postReasoning(Agent agent, Msg msg) {
             // Called with complete reasoning message
             return Mono.just(msg);
         }
 
         @Override
-        public Mono<ToolUseBlock> onToolCall(Agent agent, ToolUseBlock toolUse) {
+        public Mono<ToolUseBlock> preActing(Agent agent, ToolUseBlock toolUse) {
             System.out.println(
-                    "\n[HOOK] onToolCall - Tool: "
+                    "\n[HOOK] preActing - Tool: "
                             + toolUse.getName()
                             + ", Input: "
                             + toolUse.getInput());
@@ -147,10 +147,10 @@ public class HookExample {
         }
 
         @Override
-        public Mono<Void> onToolChunk(Agent agent, ToolUseBlock toolUse, ToolResultBlock chunk) {
+        public Mono<Void> onActingChunk(Agent agent, ToolUseBlock toolUse, ToolResultBlock chunk) {
             // Receive progress updates from ToolEmitter
             System.out.println(
-                    "[HOOK] onToolChunk - Tool: "
+                    "[HOOK] onActingChunk - Tool: "
                             + toolUse.getName()
                             + ", Progress: "
                             + chunk.getOutput());
@@ -158,7 +158,7 @@ public class HookExample {
         }
 
         @Override
-        public Mono<ToolResultBlock> onToolResult(
+        public Mono<ToolResultBlock> postActing(
                 Agent agent, ToolUseBlock toolUse, ToolResultBlock result) {
             System.out.println(
                     "[HOOK] onToolResult - Tool: "
@@ -169,7 +169,7 @@ public class HookExample {
         }
 
         @Override
-        public Mono<Msg> onComplete(Agent agent, Msg finalMsg) {
+        public Mono<Msg> postCall(Agent agent, Msg finalMsg) {
             System.out.println("[HOOK] onComplete - Agent execution finished\n");
             return Mono.just(finalMsg);
         }

--- a/examples/src/main/java/io/agentscope/examples/InterruptionExample.java
+++ b/examples/src/main/java/io/agentscope/examples/InterruptionExample.java
@@ -172,26 +172,26 @@ public class InterruptionExample {
     static class MonitoringHook implements Hook {
 
         @Override
-        public Mono<Void> onStart(Agent agent) {
-            System.out.println("[Hook] Agent started: " + agent.getName());
+        public Mono<Void> preCall(Agent agent) {
+            System.out.println("[Hook] Agent preCall: " + agent.getName());
             return Mono.empty();
         }
 
         @Override
-        public Mono<ToolUseBlock> onToolCall(Agent agent, ToolUseBlock toolUse) {
+        public Mono<ToolUseBlock> preActing(Agent agent, ToolUseBlock toolUse) {
             System.out.println("[Hook] Tool call: " + toolUse.getName());
             System.out.println("       Input: " + toolUse.getInput());
             return Mono.just(toolUse);
         }
 
         @Override
-        public Mono<Void> onToolChunk(Agent agent, ToolUseBlock toolUse, ToolResultBlock chunk) {
+        public Mono<Void> onActingChunk(Agent agent, ToolUseBlock toolUse, ToolResultBlock chunk) {
             System.out.println("[Hook] Tool progress: " + chunk.getOutput());
             return Mono.empty();
         }
 
         @Override
-        public Mono<ToolResultBlock> onToolResult(
+        public Mono<ToolResultBlock> postActing(
                 Agent agent, ToolUseBlock toolUse, ToolResultBlock toolResult) {
             String output = extractOutput(toolResult);
             if (output.contains("fake")) {
@@ -203,7 +203,7 @@ public class InterruptionExample {
         }
 
         @Override
-        public Mono<Msg> onComplete(Agent agent, Msg finalMsg) {
+        public Mono<Msg> postCall(Agent agent, Msg finalMsg) {
             System.out.println("[Hook] Agent execution completed");
             return Mono.just(finalMsg);
         }

--- a/examples/src/main/java/io/agentscope/examples/StreamingWebExample.java
+++ b/examples/src/main/java/io/agentscope/examples/StreamingWebExample.java
@@ -142,16 +142,16 @@ public class StreamingWebExample {
                         }
 
                         @Override
-                        public Mono<Msg> onReasoningChunk(Agent agent, Msg chunk) {
+                        public Mono<Void> onReasoningChunk(Agent agent, Msg chunk) {
                             String text = chunk.getContentAsText();
                             if (text != null && !text.isEmpty()) {
                                 sink.tryEmitNext(text);
                             }
-                            return Mono.just(chunk);
+                            return Mono.empty();
                         }
 
                         @Override
-                        public Mono<Msg> onComplete(Agent agent, Msg finalMsg) {
+                        public Mono<Msg> postCall(Agent agent, Msg finalMsg) {
                             sink.tryEmitComplete();
                             return Mono.just(finalMsg);
                         }

--- a/src/main/java/io/agentscope/core/hook/Hook.java
+++ b/src/main/java/io/agentscope/core/hook/Hook.java
@@ -24,22 +24,25 @@ import reactor.core.publisher.Mono;
 /**
  * Hook interface for monitoring and intercepting agent execution.
  *
- * <p>All callback methods return Mono to support async operations. Methods can modify the data
- * being processed by returning a modified version. The default implementation returns the original
- * data unchanged.
+ * <p>All callback methods return Mono to support async operations.
+ * Pre-hooks can modify input data, post-hooks can modify output data.
+ * The default implementation returns the original data unchanged.
+ *
+ * <p>This interface is designed to align with Python's hook system while
+ * adding Java-specific enhancements like streaming support and error handling.
  *
  * <p>Example usage:
  *
  * <pre>{@code
  * agent.addHook(new Hook() {
  *     @Override
- *     public Mono<Msg> onReasoning(Agent agent, Msg msg) {
+ *     public Mono<Msg> postReasoning(Agent agent, Msg msg) {
  *         System.out.println("Thinking: " + msg.getTextContent());
  *         return Mono.just(msg);  // Return original or modified
  *     }
  *
  *     @Override
- *     public Mono<ToolUseBlock> onToolCall(Agent agent, ToolUseBlock toolUse) {
+ *     public Mono<ToolUseBlock> preActing(Agent agent, ToolUseBlock toolUse) {
  *         System.out.println("Calling tool: " + toolUse.getName());
  *         // Can modify tool parameters here
  *         return Mono.just(toolUse);
@@ -49,29 +52,118 @@ import reactor.core.publisher.Mono;
  */
 public interface Hook {
 
+    // ========================================================================
+    // Agent Call Lifecycle
+    // ========================================================================
+
     /**
-     * Called before agent starts processing. Hook can access messages from agent.getMemory().
+     * Called before agent starts processing (before call() execution).
+     * Notification-only, cannot modify data.
      *
-     * @param agent The agent instance
+     * <p>At this point, the input message(s) have already been added to memory.
+     * This hook is a notification point before the reasoning-acting loop starts.
+     *
+     * <p>Use this hook to:
+     * <ul>
+     *   <li>Log the start of agent execution</li>
+     *   <li>Initialize execution-specific resources</li>
+     *   <li>Track agent invocation metrics</li>
+     * </ul>
+     *
+     * <p><b>Python equivalent:</b> {@code pre_reply}
+     *
+     * @param agent The agent instance (use agent.getMemory() to access all messages)
      * @return Mono that completes when processing is done
      */
-    default Mono<Void> onStart(Agent agent) {
+    default Mono<Void> preCall(Agent agent) {
         return Mono.empty();
     }
 
     /**
-     * Called when agent emits a reasoning message (text/thinking). Can modify the reasoning
-     * message.
+     * Called after agent completes processing (after call() execution).
+     * Can modify the final message returned by the agent.
      *
-     * <p>Note: This is called for each complete message. For real-time streaming chunks,
-     * use {@link #onReasoningChunk(Agent, Msg)} instead.
+     * <p>This is the final hook before returning the result to the caller.
+     * The message passed here is the final response from the agent.
+     *
+     * <p>Use this hook to:
+     * <ul>
+     *   <li>Post-process the final agent response</li>
+     *   <li>Add final metadata or formatting</li>
+     *   <li>Filter or sanitize output</li>
+     *   <li>Log outgoing responses</li>
+     * </ul>
+     *
+     * <p><b>Python equivalent:</b> {@code post_reply}
      *
      * @param agent The agent instance
-     * @param msg The message emitted during reasoning
+     * @param finalMsg The final message returned by the agent
      * @return Mono containing potentially modified message
      */
-    default Mono<Msg> onReasoning(Agent agent, Msg msg) {
-        return Mono.just(msg);
+    default Mono<Msg> postCall(Agent agent, Msg finalMsg) {
+        return Mono.just(finalMsg);
+    }
+
+    // ========================================================================
+    // Reasoning Lifecycle
+    // ========================================================================
+
+    /**
+     * Called before agent starts reasoning (before reasoning() execution).
+     * Notification-only, no parameters.
+     *
+     * <p>The reasoning process internally retrieves messages from memory and
+     * constructs the prompt. This hook cannot modify the input since reasoning()
+     * has no parameters - it builds context internally from agent state.
+     *
+     * <p>Use this hook to:
+     * <ul>
+     *   <li>Inspect the current memory state via agent.getMemory()</li>
+     *   <li>Log reasoning start events</li>
+     *   <li>Initialize reasoning-specific resources</li>
+     * </ul>
+     *
+     * <p><b>Python equivalent:</b> {@code pre_reasoning}
+     * <br><b>Python method signature:</b> {@code async def _reasoning(self) -> Msg}
+     *
+     * @param agent The agent instance
+     * @return Mono that completes when processing is done
+     */
+    default Mono<Void> preReasoning(Agent agent) {
+        return Mono.empty();
+    }
+
+    /**
+     * Called after agent completes reasoning (after reasoning() execution).
+     * Can modify the reasoning result message.
+     *
+     * <p><b>IMPORTANT:</b> The message content is a list that may contain multiple blocks:
+     * <ul>
+     *   <li>Text blocks - regular text output</li>
+     *   <li>Thinking blocks - model's reasoning process</li>
+     *   <li>Multiple tool use blocks - if model returns multiple tool calls</li>
+     * </ul>
+     *
+     * <p>You can modify this message, including:
+     * <ul>
+     *   <li>Filtering or modifying tool calls before execution</li>
+     *   <li>Adding/removing content blocks</li>
+     *   <li>Modifying text or thinking content</li>
+     *   <li>Adding metadata</li>
+     * </ul>
+     *
+     * <p>This is called for each complete reasoning message. For real-time streaming,
+     * use {@link #onReasoningChunk(Agent, Msg)} instead.
+     *
+     * <p><b>Python equivalent:</b> {@code post_reasoning}
+     * <br><b>Python method signature:</b> {@code async def _reasoning(self) -> Msg}
+     *
+     * @param agent The agent instance
+     * @param reasoningMsg The reasoning result message (content is a list)
+     * @return Mono containing potentially modified message
+     */
+    default Mono<Msg> postReasoning(Agent agent, Msg reasoningMsg) {
+        return Mono.just(reasoningMsg);
     }
 
     /**
@@ -90,78 +182,145 @@ public interface Hook {
     }
 
     /**
-     * Called when agent emits a reasoning chunk during streaming. This is called for each
-     * chunk as it arrives from the model, allowing real-time streaming display.
+     * Called when agent emits a reasoning chunk during streaming.
+     * Notification-only, cannot modify the chunk.
      *
-     * <p>The content of the message depends on the mode returned by {@link #reasoningChunkMode()}:
+     * <p>The content of the message depends on {@link #reasoningChunkMode()}:
      * <ul>
      *   <li>{@link ChunkMode#INCREMENTAL}: msg contains only the new content chunk</li>
      *   <li>{@link ChunkMode#CUMULATIVE}: msg contains all accumulated content so far</li>
      * </ul>
      *
-     * @param agent The agent instance
-     * @param msg The chunk message (incremental) or accumulated message (cumulative)
-     * @return Mono containing potentially modified message
-     */
-    default Mono<Msg> onReasoningChunk(Agent agent, Msg msg) {
-        return Mono.just(msg);
-    }
-
-    /**
-     * Called when agent makes a tool call. Can modify the tool use block.
+     * <p>Use this hook to:
+     * <ul>
+     *   <li>Display streaming output in real-time</li>
+     *   <li>Monitor reasoning progress</li>
+     *   <li>Log streaming content</li>
+     * </ul>
+     *
+     * <p><b>Note:</b> Python does not have an equivalent streaming hook.
+     * This is a Java-specific enhancement.
      *
      * @param agent The agent instance
-     * @param toolUse The tool use block
+     * @param chunkMsg The chunk message (read-only)
+     * @return Mono that completes when processing is done
+     */
+    default Mono<Void> onReasoningChunk(Agent agent, Msg chunkMsg) {
+        return Mono.empty();
+    }
+
+    // ========================================================================
+    // Acting/Tool Lifecycle
+    // ========================================================================
+
+    /**
+     * Called before agent executes a single tool call (before acting() execution).
+     * Can modify the tool use block.
+     *
+     * <p><b>IMPORTANT - Per-Tool Invocation:</b> This hook is called <b>ONCE PER TOOL</b>.
+     * If the reasoning result contains multiple tool calls, this hook will be invoked
+     * multiple times, once for each tool call.
+     *
+     * <p>This matches Python's behavior where {@code _acting(tool_call)} is called
+     * individually for each tool, either in parallel or sequentially depending on
+     * the {@code parallel_tool_calls} setting.
+     *
+     * <p>Use this hook to:
+     * <ul>
+     *   <li>Validate or modify tool parameters for each tool call</li>
+     *   <li>Add authentication or context to individual tool calls</li>
+     *   <li>Implement per-tool authorization checks</li>
+     *   <li>Log or monitor individual tool invocations</li>
+     * </ul>
+     *
+     * <p><b>Python equivalent:</b> {@code pre_acting}
+     * <br><b>Python method signature:</b> {@code async def _acting(self, tool_call: ToolUseBlock) -> Msg | None}
+     *
+     * @param agent The agent instance
+     * @param toolUse The tool use block for this specific tool call
      * @return Mono containing potentially modified tool use block
      */
-    default Mono<ToolUseBlock> onToolCall(Agent agent, ToolUseBlock toolUse) {
+    default Mono<ToolUseBlock> preActing(Agent agent, ToolUseBlock toolUse) {
         return Mono.just(toolUse);
     }
 
     /**
-     * Called when a tool emits a streaming chunk during execution.
+     * Called after a single tool execution completes (after acting() execution).
+     * Can modify the tool result.
      *
-     * <p>This is called for intermediate messages emitted by tools via {@link
-     * io.agentscope.core.tool.ToolEmitter}. These chunks are NOT sent to the LLM - only the final
-     * return value of the tool method is sent to the LLM.
+     * <p><b>IMPORTANT - Per-Tool Invocation:</b> This hook is called <b>ONCE PER TOOL</b>
+     * execution. It receives the tool result for the single tool that was just executed.
      *
-     * <p>This callback is purely observational and cannot modify the chunk data.
+     * <p>This matches Python's behavior where {@code _acting()} processes one tool at
+     * a time and post hooks are triggered for each individual tool execution.
+     *
+     * <p>Use this hook to:
+     * <ul>
+     *   <li>Post-process individual tool results</li>
+     *   <li>Filter or sanitize tool output</li>
+     *   <li>Add metadata to results</li>
+     *   <li>Handle tool execution errors</li>
+     *   <li>Transform result format</li>
+     * </ul>
+     *
+     * <p><b>Python equivalent:</b> {@code post_acting}
+     * <br><b>Python method signature:</b> {@code async def _acting(self, tool_call: ToolUseBlock) -> Msg | None}
      *
      * @param agent The agent instance
      * @param toolUse The tool use block identifying the tool call
-     * @param chunk The streaming chunk emitted by the tool
-     * @return Mono that completes when processing is done
-     */
-    default Mono<Void> onToolChunk(Agent agent, ToolUseBlock toolUse, ToolResultBlock chunk) {
-        return Mono.empty();
-    }
-
-    /**
-     * Called when tool execution completes. Can modify the tool result.
-     *
-     * @param agent The agent instance
-     * @param toolUse The tool use block identifying the tool call
-     * @param toolResult The tool result block
+     * @param toolResult The tool result block for this specific tool execution
      * @return Mono containing potentially modified tool result
      */
-    default Mono<ToolResultBlock> onToolResult(
+    default Mono<ToolResultBlock> postActing(
             Agent agent, ToolUseBlock toolUse, ToolResultBlock toolResult) {
         return Mono.just(toolResult);
     }
 
     /**
-     * Called when agent completes processing. Can modify the final message.
+     * Called when a tool emits a streaming chunk during execution.
+     * Notification-only, cannot modify the chunk.
+     *
+     * <p>This is called for intermediate messages emitted by tools via {@link
+     * io.agentscope.core.tool.ToolEmitter}. These chunks are NOT sent to the LLM -
+     * only the final return value of the tool method is sent to the LLM.
+     *
+     * <p>Use this hook to:
+     * <ul>
+     *   <li>Display tool execution progress</li>
+     *   <li>Log intermediate tool outputs</li>
+     *   <li>Monitor long-running tool operations</li>
+     * </ul>
+     *
+     * <p><b>Note:</b> Python does not have an equivalent streaming hook.
+     * This is a Java-specific enhancement.
      *
      * @param agent The agent instance
-     * @param finalMsg The final aggregated message
-     * @return Mono containing potentially modified final message
+     * @param toolUse The tool use block identifying the tool call
+     * @param chunk The streaming chunk emitted by the tool (read-only)
+     * @return Mono that completes when processing is done
      */
-    default Mono<Msg> onComplete(Agent agent, Msg finalMsg) {
-        return Mono.just(finalMsg);
+    default Mono<Void> onActingChunk(Agent agent, ToolUseBlock toolUse, ToolResultBlock chunk) {
+        return Mono.empty();
     }
 
+    // ========================================================================
+    // Error Handling
+    // ========================================================================
+
     /**
-     * Called when an error occurs. Cannot modify the error, only for notification.
+     * Called when an error occurs during agent execution.
+     * Cannot modify the error, only for notification.
+     *
+     * <p>Use this hook to:
+     * <ul>
+     *   <li>Log errors with context</li>
+     *   <li>Send error notifications</li>
+     *   <li>Collect error metrics</li>
+     *   <li>Implement custom error handling</li>
+     * </ul>
+     *
+     * <p><b>Note:</b> Python does not have an equivalent error hook.
+     * This is a Java-specific enhancement.
      *
      * @param agent The agent instance
      * @param error The error

--- a/src/test/java/io/agentscope/core/tool/ToolEmitterIntegrationTest.java
+++ b/src/test/java/io/agentscope/core/tool/ToolEmitterIntegrationTest.java
@@ -204,16 +204,16 @@ class ToolEmitterIntegrationTest {
     }
 
     @Test
-    @DisplayName("Hook.onToolChunk should be called with correct parameters")
-    void testHookOnToolChunk() {
+    @DisplayName("Hook.onActingChunk should be called with correct parameters")
+    void testHookOnActingChunk() {
         List<String> hookMessages = new ArrayList<>();
         List<String> hookToolNames = new ArrayList<>();
 
-        // Create a hook that captures onToolChunk calls
+        // Create a hook that captures onActingChunk calls
         Hook testHook =
                 new Hook() {
                     @Override
-                    public Mono<Void> onToolChunk(
+                    public Mono<Void> onActingChunk(
                             Agent agent, ToolUseBlock toolUse, ToolResultBlock chunk) {
                         hookMessages.add(extractText(chunk));
                         hookToolNames.add(toolUse.getName());
@@ -236,7 +236,7 @@ class ToolEmitterIntegrationTest {
         toolkit.setChunkCallback(
                 (toolUse, chunk) -> {
                     // Simulate hook invocation (normally done by ReActAgent)
-                    testHook.onToolChunk(null, toolUse, chunk).block();
+                    testHook.onActingChunk(null, toolUse, chunk).block();
                 });
 
         // Call tool


### PR DESCRIPTION
  Breaking changes:
  - Rename hook methods to follow Python's pre/post/on naming pattern
  - Old method names are not backward compatible and must be updated

  Hook method name changes:
  - onStart() → preCall() - before agent call starts
  - onReasoning() → postReasoning() - after reasoning completes
  - onToolCall() → preActing() - before each tool execution
  - onToolResult() → postActing() - after each tool execution
  - onToolChunk() → onActingChunk() - during tool streaming
  - onComplete() → postCall() - after agent call completes

  New hooks added:
  - preReasoning() - called before reasoning step starts (new, matches Python pre_reasoning)

  Hook interface improvements:
  - Add comprehensive documentation for each hook method
  - Add Python equivalent method names in Javadoc (@code pre_reply, post_reply, pre_reasoning, post_reasoning, pre_acting, post_acting)
  - Add detailed usage examples and use cases for each hook
  - Clarify which hooks can modify data vs notification-only
  - Group hooks by lifecycle: Agent Call, Reasoning, Acting/Tool, Error Handling

  AgentBase updates:
  - Add preCall() invocation at start of all call() methods
  - Rename internal notify methods to match new hook names
  - Add notifyPreReasoning() support for subclasses
  - Update postCall() to replace onComplete() at end of call()
  - Add no-arg notifyPreCall() variant for call() with no parameters

  ReActAgent updates:
  - Add preReasoning() hook call at start of reasoning() method
  - Call postReasoning() after reasoning completes and before saving to memory
  - Update tool-related hooks to use preActing()/postActing()/onActingChunk()
  - Ensure postReasoning() can modify reasoning message before it's saved

Change-Id: I340a4316cbbc9fc098587c6d40c9aa223bf80cd1