### PR TITLE
feat: add preset parameters and refactor tool registration API

### DIFF
--- a/examples/src/main/java/io/agentscope/examples/ToolGroupExample.java
+++ b/examples/src/main/java/io/agentscope/examples/ToolGroupExample.java
@@ -22,6 +22,7 @@ import io.agentscope.core.model.DashScopeChatModel;
 import io.agentscope.core.tool.Tool;
 import io.agentscope.core.tool.ToolParam;
 import io.agentscope.core.tool.Toolkit;
+
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -97,16 +98,25 @@ public class ToolGroupExample {
 
         // Create file operations group (initially inactive)
         toolkit.createToolGroup("file_ops", "File system operations (read, write, list)", false);
-        toolkit.registerTool(new FileTools(), "file_ops");
+        toolkit.registration()
+                .tool(new FileTools())
+                .group("file_ops")
+                .apply();
 
         // Create math operations group (initially inactive)
         toolkit.createToolGroup(
                 "math_ops", "Mathematical calculations (factorial, is_prime)", false);
-        toolkit.registerTool(new MathTools(), "math_ops");
+        toolkit.registration()
+                .tool(new MathTools())
+                .group("math_ops")
+                .apply();
 
         // Create network operations group (initially inactive)
         toolkit.createToolGroup("network_ops", "Network operations (ping, dns_lookup)", false);
-        toolkit.registerTool(new NetworkTools(), "network_ops");
+        toolkit.registration()
+                .tool(new NetworkTools())
+                .group("network_ops")
+                .apply();
 
         System.out.println("=== Tool Groups Created ===");
         System.out.println("All tool groups start as INACTIVE.");
@@ -148,7 +158,9 @@ public class ToolGroupExample {
         System.out.println("==================================\n");
     }
 
-    /** File operation tools. */
+    /**
+     * File operation tools.
+     */
     public static class FileTools {
 
         @Tool(name = "read_file", description = "Read contents of a file")
@@ -199,7 +211,9 @@ public class ToolGroupExample {
         }
     }
 
-    /** Mathematical operation tools. */
+    /**
+     * Mathematical operation tools.
+     */
     public static class MathTools {
 
         @Tool(name = "factorial", description = "Calculate factorial of a number")
@@ -234,7 +248,9 @@ public class ToolGroupExample {
         }
     }
 
-    /** Network operation tools. */
+    /**
+     * Network operation tools.
+     */
     public static class NetworkTools {
 
         @Tool(name = "ping", description = "Ping a host (simulated)")

--- a/src/main/java/io/agentscope/core/ReActAgent.java
+++ b/src/main/java/io/agentscope/core/ReActAgent.java
@@ -451,7 +451,7 @@ public class ReActAgent extends AgentBase {
                             ? handler.createOptionsWithForcedTool(buildGenerateOptions())
                             : buildGenerateOptions();
 
-            List<ToolSchema> toolSchemas = toolkit.getToolSchemasForModel();
+            List<ToolSchema> toolSchemas = toolkit.getToolSchemas();
 
             return hookNotifier
                     .notifyPreReasoning(ReActAgent.this, messageList)
@@ -908,26 +908,79 @@ public class ReActAgent extends AgentBase {
             return this;
         }
 
+        /**
+         * Adds a hook for monitoring and intercepting agent execution events.
+         *
+         * <p>Hooks can observe or modify events during reasoning, acting, and other phases.
+         * Multiple hooks can be added and will be executed in priority order (lower priority
+         * values execute first).
+         *
+         * @param hook The hook to add, must not be null
+         * @return This builder instance for method chaining
+         * @see Hook
+         */
         public Builder hook(Hook hook) {
             this.hooks.add(hook);
             return this;
         }
 
+        /**
+         * Adds multiple hooks for monitoring and intercepting agent execution events.
+         *
+         * <p>Hooks can observe or modify events during reasoning, acting, and other phases.
+         * All hooks will be executed in priority order (lower priority values execute first).
+         *
+         * @param hooks The list of hooks to add, must not be null
+         * @return This builder instance for method chaining
+         * @see Hook
+         */
         public Builder hooks(List<Hook> hooks) {
             this.hooks.addAll(hooks);
             return this;
         }
 
+        /**
+         * Enables or disables the meta-tool functionality.
+         *
+         * <p>When enabled, the toolkit will automatically register a meta-tool that provides
+         * information about available tools to the agent. This can help the agent understand
+         * what tools are available without relying solely on the system prompt.
+         *
+         * @param enableMetaTool true to enable meta-tool, false to disable
+         * @return This builder instance for method chaining
+         */
         public Builder enableMetaTool(boolean enableMetaTool) {
             this.enableMetaTool = enableMetaTool;
             return this;
         }
 
+        /**
+         * Sets the execution configuration for model API calls.
+         *
+         * <p>This configuration controls timeout, retry behavior, and backoff strategy for
+         * model requests during the reasoning phase. If not set, the agent will use the
+         * model's default execution configuration.
+         *
+         * @param modelExecutionConfig The execution configuration for model calls, can be null
+         * @return This builder instance for method chaining
+         * @see ExecutionConfig
+         */
         public Builder modelExecutionConfig(ExecutionConfig modelExecutionConfig) {
             this.modelExecutionConfig = modelExecutionConfig;
             return this;
         }
 
+        /**
+         * Sets the execution configuration for tool executions.
+         *
+         * <p>This configuration controls timeout, retry behavior, and backoff strategy for
+         * tool calls during the acting phase. If not set, the toolkit will use its default
+         * execution configuration.
+         *
+         * @param toolExecutionConfig The execution configuration for tool calls, can be null
+         * @return This builder instance for method chaining
+         * @see ExecutionConfig
+         */
         public Builder toolExecutionConfig(ExecutionConfig toolExecutionConfig) {
             this.toolExecutionConfig = toolExecutionConfig;
             return this;

--- a/src/main/java/io/agentscope/core/message/Msg.java
+++ b/src/main/java/io/agentscope/core/message/Msg.java
@@ -24,9 +24,6 @@ import java.beans.Transient;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -85,13 +82,9 @@ public class Msg {
         this.id = id;
         this.name = name;
         this.role = role;
-        this.content =
-                content == null
-                        ? List.of()
-                        : Collections.unmodifiableList(new ArrayList<>(content));
-        this.metadata =
-                metadata == null ? null : Collections.unmodifiableMap(new HashMap<>(metadata));
-        this.timestamp = timestamp != null ? timestamp : TIMESTAMP_FORMATTER.format(Instant.now());
+        this.content = List.copyOf(content);
+        this.metadata = Map.copyOf(metadata);
+        this.timestamp = timestamp;
     }
 
     /**
@@ -295,13 +288,13 @@ public class Msg {
 
         private String name;
 
-        private MsgRole role;
+        private MsgRole role = MsgRole.USER;
 
-        private List<ContentBlock> content;
+        private List<ContentBlock> content = List.of();
 
-        private Map<String, Object> metadata;
+        private Map<String, Object> metadata = Map.of();
 
-        private String timestamp;
+        private String timestamp = TIMESTAMP_FORMATTER.format(Instant.now());
 
         /**
          * Creates a new builder with a randomly generated message ID.
@@ -387,7 +380,7 @@ public class Msg {
          * @return This builder
          */
         public Builder metadata(Map<String, Object> metadata) {
-            this.metadata = metadata;
+            this.metadata = metadata == null ? Map.of() : metadata;
             return this;
         }
 
@@ -398,7 +391,8 @@ public class Msg {
          * @return This builder for chaining
          */
         public Builder timestamp(String timestamp) {
-            this.timestamp = timestamp;
+            this.timestamp =
+                    timestamp == null ? TIMESTAMP_FORMATTER.format(Instant.now()) : timestamp;
             return this;
         }
 

--- a/src/main/java/io/agentscope/core/tool/ParallelToolExecutor.java
+++ b/src/main/java/io/agentscope/core/tool/ParallelToolExecutor.java
@@ -97,7 +97,7 @@ class ParallelToolExecutor {
     private Mono<ToolResultBlock> executeToolCallReactive(
             ToolUseBlock toolCall, ExecutionConfig executionConfig) {
         // Use the async API from toolkit
-        Mono<ToolResultBlock> execution = toolkit.callToolAsync(toolCall);
+        Mono<ToolResultBlock> execution = toolkit.callTool(toolCall);
 
         // Choose scheduler: Reactor's boundedElastic or custom executor
         // Only apply scheduler for synchronous tools (async tools manage their own threads)

--- a/src/main/java/io/agentscope/core/tool/ToolSchemaProvider.java
+++ b/src/main/java/io/agentscope/core/tool/ToolSchemaProvider.java
@@ -17,9 +17,7 @@ package io.agentscope.core.tool;
 
 import io.agentscope.core.model.ToolSchema;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 /**
  * Provides tool schemas in various formats for model consumption.
@@ -59,46 +57,12 @@ class ToolSchemaProvider {
     }
 
     /**
-     * Get tool schemas in OpenAI format, respecting active tool groups.
-     *
-     * @return List of tool schemas in OpenAI format
-     */
-    List<Map<String, Object>> getToolSchemas() {
-        List<Map<String, Object>> schemas = new ArrayList<>();
-
-        for (RegisteredToolFunction registered : toolRegistry.getAllRegisteredTools().values()) {
-            AgentTool tool = registered.getTool();
-            String groupName = registered.getGroupName();
-
-            // Filter: Only include if ungrouped OR in active group
-            if (!groupManager.isInActiveGroup(groupName)) {
-                continue; // Skip inactive tools
-            }
-
-            Map<String, Object> schema = new HashMap<>();
-            schema.put("type", "function");
-
-            Map<String, Object> function = new HashMap<>();
-            function.put("name", tool.getName());
-            function.put("description", tool.getDescription());
-
-            // Use extended parameters if available
-            function.put("parameters", registered.getExtendedParameters());
-
-            schema.put("function", function);
-            schemas.add(schema);
-        }
-
-        return schemas;
-    }
-
-    /**
      * Get tool schemas as ToolSchema objects for model consumption.
      * Updated to respect active tool groups.
      *
      * @return List of ToolSchema objects
      */
-    List<ToolSchema> getToolSchemasForModel() {
+    List<ToolSchema> getToolSchemas() {
         List<ToolSchema> schemas = new ArrayList<>();
 
         for (RegisteredToolFunction registered : toolRegistry.getAllRegisteredTools().values()) {

--- a/src/test/java/io/agentscope/core/e2e/VisionToolIntegrationE2ETest.java
+++ b/src/test/java/io/agentscope/core/e2e/VisionToolIntegrationE2ETest.java
@@ -229,8 +229,7 @@ class VisionToolIntegrationE2ETest {
         assertTrue(toolkit.getToolSchemas().size() > 0, "Toolkit should have tools registered");
 
         System.out.println("Toolkit contains " + toolkit.getToolSchemas().size() + " tools");
-        toolkit.getToolSchemasForModel()
-                .forEach(tool -> System.out.println("  - " + tool.getName()));
+        toolkit.getToolSchemas().forEach(tool -> System.out.println("  - " + tool.getName()));
 
         System.out.println("✓ MultiModal API tool formatting structure verified");
     }

--- a/src/test/java/io/agentscope/core/tool/AsyncToolTest.java
+++ b/src/test/java/io/agentscope/core/tool/AsyncToolTest.java
@@ -59,7 +59,7 @@ class AsyncToolTest {
                         .input(Map.of("a", 10, "b", 20))
                         .build();
 
-        ToolResultBlock response = toolkit.callToolAsync(toolCall).block(TIMEOUT);
+        ToolResultBlock response = toolkit.callTool(toolCall).block(TIMEOUT);
 
         assertNotNull(response, "Response should not be null");
         assertEquals("30", extractFirstText(response));
@@ -75,7 +75,7 @@ class AsyncToolTest {
                         .input(Map.of("str1", "Hello", "str2", "World"))
                         .build();
 
-        ToolResultBlock response = toolkit.callToolAsync(toolCall).block(TIMEOUT);
+        ToolResultBlock response = toolkit.callTool(toolCall).block(TIMEOUT);
 
         assertNotNull(response, "Response should not be null");
         assertEquals("\"HelloWorld\"", extractFirstText(response));
@@ -91,7 +91,7 @@ class AsyncToolTest {
                         .input(Map.of("delayMs", 100))
                         .build();
 
-        ToolResultBlock response = toolkit.callToolAsync(toolCall).block(TIMEOUT);
+        ToolResultBlock response = toolkit.callTool(toolCall).block(TIMEOUT);
 
         assertNotNull(response, "Response should not be null");
         String result = extractFirstText(response);
@@ -108,7 +108,7 @@ class AsyncToolTest {
                         .input(Map.of("message", "test failure"))
                         .build();
 
-        ToolResultBlock response = toolkit.callToolAsync(toolCall).block(TIMEOUT);
+        ToolResultBlock response = toolkit.callTool(toolCall).block(TIMEOUT);
 
         assertNotNull(response, "Response should not be null");
         String result = extractFirstText(response);

--- a/src/test/java/io/agentscope/core/tool/ToolEmitterIntegrationTest.java
+++ b/src/test/java/io/agentscope/core/tool/ToolEmitterIntegrationTest.java
@@ -81,7 +81,7 @@ class ToolEmitterIntegrationTest {
                         .build();
 
         // Call the tool
-        ToolResultBlock finalResponse = toolkit.callToolAsync(toolUseBlock).block();
+        ToolResultBlock finalResponse = toolkit.callTool(toolUseBlock).block();
 
         // Verify final response
         assertNotNull(finalResponse);
@@ -131,7 +131,7 @@ class ToolEmitterIntegrationTest {
                         .input(Map.of("input", "hello"))
                         .build();
 
-        ToolResultBlock finalResponse = toolkit.callToolAsync(toolUseBlock).block();
+        ToolResultBlock finalResponse = toolkit.callTool(toolUseBlock).block();
 
         // Verify final response
         assertNotNull(finalResponse);
@@ -180,7 +180,7 @@ class ToolEmitterIntegrationTest {
                         .name("task_a")
                         .input(Map.of("data", "x"))
                         .build();
-        toolkit.callToolAsync(toolA).block();
+        toolkit.callTool(toolA).block();
 
         // Call task_b
         ToolUseBlock toolB =
@@ -189,7 +189,7 @@ class ToolEmitterIntegrationTest {
                         .name("task_b")
                         .input(Map.of("data", "y"))
                         .build();
-        toolkit.callToolAsync(toolB).block();
+        toolkit.callTool(toolB).block();
 
         // Verify chunks
         assertEquals(3, capturedChunks.size());


### PR DESCRIPTION
  Add preset parameters support for automatic context injection (API keys,
  session data) and introduce builder-based registration API.

  BREAKING CHANGES:

  1. Tool registration now uses builder pattern:
     - Old: toolkit.registerTool(tool, groupName)
     - New: toolkit.registration().tool(tool).group(groupName).apply()
     Reason: Builder pattern provides clarity and extensibility.