### PR TITLE
fix: change rag&longtermmemory hook from prereasoning to pre call

### DIFF
--- a/agentscope-core/pom.xml
+++ b/agentscope-core/pom.xml
@@ -40,7 +40,7 @@
         <maven-compiler-plugin.version>3.11.0</maven-compiler-plugin.version>
         <maven-surefire-plugin.version>3.1.2</maven-surefire-plugin.version>
         <maven-deploy-plugin.version>3.1.1</maven-deploy-plugin.version>
-        <maven-source-plugin.version>3.3.0</maven-source-plugin.version>
+        <maven-source-plugin.version>3.3.1</maven-source-plugin.version>
         <flatten-maven-plugin.version>1.5.0</flatten-maven-plugin.version>
         <maven-javadoc-plugin.version>3.5.0</maven-javadoc-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/agentscope-core/src/main/java/io/agentscope/core/hook/PreCallEvent.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/hook/PreCallEvent.java
@@ -16,6 +16,8 @@
 package io.agentscope.core.hook;
 
 import io.agentscope.core.agent.Agent;
+import io.agentscope.core.message.Msg;
+import java.util.List;
 
 /**
  * Event fired before agent starts processing.
@@ -37,13 +39,24 @@ import io.agentscope.core.agent.Agent;
  */
 public final class PreCallEvent extends HookEvent {
 
+    private List<Msg> inputMessages;
+
     /**
      * Constructor for PreCallEvent.
      *
      * @param agent The agent instance (must not be null)
      * @throws NullPointerException if agent is null
      */
-    public PreCallEvent(Agent agent) {
+    public PreCallEvent(Agent agent, List<Msg> inputMessages) {
         super(HookEventType.PRE_CALL, agent);
+        this.inputMessages = inputMessages;
+    }
+
+    public List<Msg> getInputMessages() {
+        return inputMessages;
+    }
+
+    public void setInputMessages(List<Msg> inputMessages) {
+        this.inputMessages = inputMessages;
     }
 }

--- a/agentscope-core/src/main/java/io/agentscope/core/memory/LongTermMemoryTools.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/memory/LongTermMemoryTools.java
@@ -79,6 +79,18 @@ public class LongTermMemoryTools {
         this.memory = memory;
     }
 
+    /*
+     * Wraps the given text in a special format to indicate that it is retrieved from long-term memory.
+     */
+    public static String wrap(String text) {
+        return "Below is content retrieved from the long-term memory associated with the current"
+                + " user, Please extract useful information from it in the context of the"
+                + " current conversation.\n"
+                + "<long_term_memory>\n"
+                + text
+                + "\n</long_term_memory>";
+    }
+
     /**
      * Tool function for agent to record important information to long-term memory.
      *
@@ -194,7 +206,7 @@ public class LongTermMemoryTools {
                             if (result == null || result.isEmpty()) {
                                 return "No relevant memories found";
                             }
-                            return result;
+                            return wrap(result);
                         })
                 .onErrorResume(e -> Mono.just("Error retrieving memory: " + e.getMessage()));
     }

--- a/agentscope-core/src/main/java/io/agentscope/core/tool/file/WriteFileTool.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/tool/file/WriteFileTool.java
@@ -277,6 +277,12 @@ public class WriteFileTool {
                             if (!Files.exists(path)) {
                                 logger.debug(
                                         "File does not exist, creating new file: {}", filePath);
+                                // Create parent directories if they don't exist
+                                Path parentDir = path.getParent();
+                                if (parentDir != null && !Files.exists(parentDir)) {
+                                    Files.createDirectories(parentDir);
+                                    logger.debug("Created parent directories: {}", parentDir);
+                                }
                                 Files.writeString(path, content, StandardCharsets.UTF_8);
                                 logger.info(
                                         "Successfully created and wrote to new file: {}", filePath);

--- a/agentscope-core/src/test/java/io/agentscope/core/hook/HookEventTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/hook/HookEventTest.java
@@ -102,7 +102,7 @@ class HookEventTest {
         @Test
         @DisplayName("Should create and access event")
         void testCreationAndAccess() {
-            PreCallEvent event = new PreCallEvent(testAgent);
+            PreCallEvent event = new PreCallEvent(testAgent, null);
 
             assertEquals(HookEventType.PRE_CALL, event.getType());
             assertEquals(testAgent, event.getAgent());
@@ -113,7 +113,7 @@ class HookEventTest {
         @Test
         @DisplayName("Should reject null agent")
         void testNullAgent() {
-            assertThrows(NullPointerException.class, () -> new PreCallEvent(null));
+            assertThrows(NullPointerException.class, () -> new PreCallEvent(null, null));
         }
     }
 

--- a/agentscope-core/src/test/java/io/agentscope/core/memory/LongTermMemoryToolsTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/memory/LongTermMemoryToolsTest.java
@@ -181,7 +181,7 @@ class LongTermMemoryToolsTest {
         List<String> keywords = List.of("travel", "preferences");
 
         StepVerifier.create(tools.retrieveFromMemory(keywords))
-                .expectNext("Relevant memory found")
+                .expectNext(LongTermMemoryTools.wrap("Relevant memory found"))
                 .verifyComplete();
 
         ArgumentCaptor<Msg> captor = ArgumentCaptor.forClass(Msg.class);
@@ -200,7 +200,7 @@ class LongTermMemoryToolsTest {
         List<String> keywords = List.of("coffee");
 
         StepVerifier.create(tools.retrieveFromMemory(keywords))
-                .expectNext("Single result")
+                .expectNext(LongTermMemoryTools.wrap("Single result"))
                 .verifyComplete();
 
         verify(mockMemory, times(1)).retrieve(any(Msg.class));
@@ -287,7 +287,7 @@ class LongTermMemoryToolsTest {
         List<String> keywords = List.of("word1", "word2", "word3");
 
         StepVerifier.create(tools.retrieveFromMemory(keywords))
-                .expectNext("result")
+                .expectNext(LongTermMemoryTools.wrap("result"))
                 .verifyComplete();
 
         ArgumentCaptor<Msg> captor = ArgumentCaptor.forClass(Msg.class);
@@ -324,11 +324,11 @@ class LongTermMemoryToolsTest {
                 .thenReturn(Mono.just("result2"));
 
         StepVerifier.create(tools.retrieveFromMemory(List.of("query1")))
-                .expectNext("result1")
+                .expectNext(LongTermMemoryTools.wrap("result1"))
                 .verifyComplete();
 
         StepVerifier.create(tools.retrieveFromMemory(List.of("query2")))
-                .expectNext("result2")
+                .expectNext(LongTermMemoryTools.wrap("result2"))
                 .verifyComplete();
 
         verify(mockMemory, times(2)).retrieve(any(Msg.class));

--- a/agentscope-core/src/test/java/io/agentscope/core/memory/StaticLongTermMemoryHookTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/memory/StaticLongTermMemoryHookTest.java
@@ -30,6 +30,7 @@ import static org.mockito.Mockito.when;
 import io.agentscope.core.agent.Agent;
 import io.agentscope.core.agent.AgentBase;
 import io.agentscope.core.hook.PostCallEvent;
+import io.agentscope.core.hook.PreCallEvent;
 import io.agentscope.core.hook.PreReasoningEvent;
 import io.agentscope.core.interruption.InterruptContext;
 import io.agentscope.core.message.Msg;
@@ -127,8 +128,7 @@ class StaticLongTermMemoryHookTest {
                         .content(TextBlock.builder().text("What do you know about me?").build())
                         .build());
 
-        PreReasoningEvent event =
-                new PreReasoningEvent(mockAgent, "test-model", null, inputMessages);
+        PreCallEvent event = new PreCallEvent(mockAgent, inputMessages);
 
         when(mockLongTermMemory.retrieve(any(Msg.class)))
                 .thenReturn(Mono.just("User prefers dark mode"));
@@ -138,13 +138,13 @@ class StaticLongTermMemoryHookTest {
                         resultEvent -> {
                             List<Msg> messages = resultEvent.getInputMessages();
                             assertEquals(2, messages.size());
-                            assertEquals(MsgRole.SYSTEM, messages.get(0).getRole());
+                            assertEquals(MsgRole.SYSTEM, messages.get(1).getRole());
                             assertTrue(
-                                    messages.get(0)
+                                    messages.get(1)
                                             .getTextContent()
                                             .contains("<long_term_memory>"));
                             assertTrue(
-                                    messages.get(0)
+                                    messages.get(1)
                                             .getTextContent()
                                             .contains("User prefers dark mode"));
                         })

--- a/agentscope-extensions/agentscope-extensions-studio/src/test/java/io/agentscope/core/studio/StudioMessageHookTest.java
+++ b/agentscope-extensions/agentscope-extensions-studio/src/test/java/io/agentscope/core/studio/StudioMessageHookTest.java
@@ -31,6 +31,8 @@ import io.agentscope.core.message.Msg;
 import io.agentscope.core.message.MsgRole;
 import io.agentscope.core.message.TextBlock;
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -132,7 +134,7 @@ class StudioMessageHookTest {
                         .content(TextBlock.builder().text("Input").build())
                         .build();
 
-        PreCallEvent event = new PreCallEvent(mockAgent);
+        PreCallEvent event = new PreCallEvent(mockAgent, new ArrayList<>(List.of(msg)));
 
         // Process event
         Mono<HookEvent> result = hook.onEvent(event);


### PR DESCRIPTION
This pull request refactors the agent hook system to streamline how input messages are modified by hooks before agent processing, and improves the handling and formatting of retrieved long-term memory and RAG knowledge. The most impactful changes are the consolidation of pre-processing hooks to use `PreCallEvent`, enhanced message wrapping for memory and knowledge retrieval, and improved file writing robustness.

### Agent Hook System Refactor
* Unified pre-processing hooks to use `PreCallEvent` instead of `PreReasoningEvent`, allowing hooks to modify input messages sequentially and simplifying hook implementations (`AgentBase.java`, `PreCallEvent.java`, `StaticLongTermMemoryHook.java`, `GenericRAGHook.java`). [[1]](diffhunk://#diff-78055bc4fd375c260347f52699751912b16a8d13f713a0ab4029d60541b57586R419-R431) [[2]](diffhunk://#diff-a1223bca21a65efb47783d70bf68577cee878412752452c01de46a68c595e0daR42-R60) [[3]](diffhunk://#diff-b9c9e77ab496201a459318bc53dba279defe52f0e29c2d90494f7bda6c2b612bL98-R102) [[4]](diffhunk://#diff-253c31ce4647fe2cfa6a6ddc3ee2146e1427d4447a0bc3406445cf7a6331fea7L113-R116)
* Updated tests to reflect the new `PreCallEvent` constructor and usage. [[1]](diffhunk://#diff-d37d94ff929cb121dd206f44c5234bb6e0e2b0fa5b1b5d4635742bb6ce834dd1L105-R105) [[2]](diffhunk://#diff-d37d94ff929cb121dd206f44c5234bb6e0e2b0fa5b1b5d4635742bb6ce834dd1L116-R116) [[3]](diffhunk://#diff-721c837c53d5a6a61a591f74fdf8366c1d9f1f4c81f6adf2f394882419c376cfR33)

### Long-Term Memory and RAG Knowledge Formatting
* Introduced a standardized `wrap` method in `LongTermMemoryTools` to clearly mark retrieved memory content in messages, and updated all relevant usages and tests to utilize this format. [[1]](diffhunk://#diff-0da4018feb4e3c61f1f53572f5095228de646225e06a4cbedee9c03d67634868R82-R93) [[2]](diffhunk://#diff-0da4018feb4e3c61f1f53572f5095228de646225e06a4cbedee9c03d67634868L197-R209) [[3]](diffhunk://#diff-b9c9e77ab496201a459318bc53dba279defe52f0e29c2d90494f7bda6c2b612bL126-R146) [[4]](diffhunk://#diff-bf23cf9808072f8ea8936de5727efbf31a7e6ad57fd55bc4022ad8f14168149cL184-R184) [[5]](diffhunk://#diff-bf23cf9808072f8ea8936de5727efbf31a7e6ad57fd55bc4022ad8f14168149cL203-R203) [[6]](diffhunk://#diff-bf23cf9808072f8ea8936de5727efbf31a7e6ad57fd55bc4022ad8f14168149cL290-R290) [[7]](diffhunk://#diff-bf23cf9808072f8ea8936de5727efbf31a7e6ad57fd55bc4022ad8f14168149cL327-R331)
* RAG knowledge context is now wrapped in `<retrieved_knowledge>` tags for clarity, and injected as a system message at the end of the input message list. [[1]](diffhunk://#diff-253c31ce4647fe2cfa6a6ddc3ee2146e1427d4447a0bc3406445cf7a6331fea7L161-L166) [[2]](diffhunk://#diff-253c31ce4647fe2cfa6a6ddc3ee2146e1427d4447a0bc3406445cf7a6331fea7L201-L220) [[3]](diffhunk://#diff-253c31ce4647fe2cfa6a6ddc3ee2146e1427d4447a0bc3406445cf7a6331fea7L233-R234)

### File Tool Robustness
* Enhanced file writing tool to automatically create parent directories if they do not exist before writing a new file.

### Dependency Update
* Updated `maven-source-plugin.version` from `3.3.0` to `3.3.1` in `pom.xml`.此提交为从长期记忆检索到的内容添加了一个包装方法，并相应地调整了相关的测试和依赖项。此外，还改进了`PreCallEvent`处理逻辑，使其更通用且适用于更多场景。

Change-Id: I7cfedf2df9c37e09899e94636d551ca48f53f6e2
Co-developed-by: Aone Copilot <noreply@alibaba-inc.com>

## AgentScope-Java Version

[The version of AgentScope-Java you are working on, e.g. 1.0.1, check your pom.xml dependency version or run `mvn dependency:tree | grep agentscope-parent:pom`(only mac/linux)]

## Description

[Please describe the background, purpose, changes made, and how to test this PR]

## Checklist

Please check the following items before code is ready to be reviewed.

- [ ]  Code has been formatted with `mvn spotless:apply`
- [ ]  All tests are passing (`mvn test`)
- [ ]  Javadoc comments are complete and follow project conventions
- [ ]  Related documentation has been updated (e.g. links, examples, etc.)
- [ ]  Code is ready for review
