### PR TITLE
feat(memory):support long term memory for ReMe

### DIFF
--- a/agentscope-examples/advanced/pom.xml
+++ b/agentscope-examples/advanced/pom.xml
@@ -57,6 +57,12 @@
 
         <dependency>
             <groupId>io.agentscope</groupId>
+            <artifactId>agentscope-extensions-reme</artifactId>
+            <version>${revision}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.agentscope</groupId>
             <artifactId>agentscope-extensions-studio</artifactId>
         </dependency>
 

--- a/agentscope-examples/advanced/src/main/java/io/agentscope/examples/advanced/ReMeExample.java
+++ b/agentscope-examples/advanced/src/main/java/io/agentscope/examples/advanced/ReMeExample.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2024-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.examples.advanced;
+
+import io.agentscope.core.ReActAgent;
+import io.agentscope.core.agent.user.UserAgent;
+import io.agentscope.core.memory.LongTermMemoryMode;
+import io.agentscope.core.memory.reme.ReMeLongTermMemory;
+import io.agentscope.core.message.Msg;
+import io.agentscope.core.model.DashScopeChatModel;
+
+/**
+ * ReMeExample - Demonstrates long-term memory using ReMe backend.
+ *
+ * <p><b>Install from Source:</b>
+ * <pre>
+ * git clone https://github.com/agentscope-ai/ReMe.git
+ * cd ReMe
+ * pip install .
+ * </pre>
+ *
+ * <p><b>Environment Configuration:</b>
+ * Copy example.env to .env and modify the corresponding parameters:
+ * <pre>
+ * FLOW_LLM_API_KEY=sk-xxxx
+ * FLOW_LLM_BASE_URL=https://xxxx/v1
+ * FLOW_EMBEDDING_API_KEY=sk-xxxx
+ * FLOW_EMBEDDING_BASE_URL=https://xxxx/v1
+ * </pre>
+ *
+ * <p><b>Quick Start - HTTP Service:</b>
+ * <pre>
+ * reme \
+ *   backend=http \
+ *   http.port=8002 \
+ *   llm.default.model_name=qwen3-30b-a3b-thinking-2507 \
+ *   embedding_model.default.model_name=text-embedding-v4 \
+ *   vector_store.default.backend=local
+ * </pre>
+ *
+ * <p>The service will run at http://localhost:8002 by default.
+ * You can override the base URL by setting the REME_API_BASE_URL environment variable.
+ */
+public class ReMeExample {
+
+    public static void main(String[] args) throws Exception {
+        // Get API keys
+        String dashscopeApiKey = ExampleUtils.getDashScopeApiKey();
+        String remeBaseUrl = getReMeBaseUrl();
+
+        ReMeLongTermMemory longTermMemory =
+                ReMeLongTermMemory.builder().userId("example_user").apiBaseUrl(remeBaseUrl).build();
+
+        // Create agent with STATIC_CONTROL mode
+        ReActAgent agent =
+                ReActAgent.builder()
+                        .name("Assistant")
+                        .model(
+                                DashScopeChatModel.builder()
+                                        .apiKey(dashscopeApiKey)
+                                        .modelName("qwen-plus")
+                                        .build())
+                        .longTermMemory(longTermMemory)
+                        .longTermMemoryMode(LongTermMemoryMode.STATIC_CONTROL)
+                        .build();
+
+        UserAgent userAgent = UserAgent.builder().name("User").build();
+
+        Msg msg = null;
+        while (true) {
+            msg = userAgent.call(msg).block();
+            if (msg.getTextContent().equals("exit")) {
+                break;
+            }
+            msg = agent.call(msg).block();
+        }
+    }
+
+    /**
+     * Gets ReMe API base URL from environment variable or uses default.
+     */
+    private static String getReMeBaseUrl() {
+        String baseUrl = System.getenv("REME_API_BASE_URL");
+        if (baseUrl == null || baseUrl.isEmpty()) {
+            return "http://localhost:8002";
+        }
+        return baseUrl;
+    }
+}

--- a/agentscope-examples/pom.xml
+++ b/agentscope-examples/pom.xml
@@ -74,7 +74,11 @@
                 <artifactId>agentscope-extensions-studio</artifactId>
                 <version>${revision}</version>
             </dependency>
-
+            <dependency>
+                <groupId>io.agentscope</groupId>
+                <artifactId>agentscope-extensions-reme</artifactId>
+                <version>${revision}</version>
+            </dependency>
             <dependency>
                 <groupId>io.agentscope</groupId>
                 <artifactId>agentscope-extensions-autocontext-memory</artifactId>

--- a/agentscope-extensions/agentscope-extensions-reme/pom.xml
+++ b/agentscope-extensions/agentscope-extensions-reme/pom.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2024-2025 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ You may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>io.agentscope</groupId>
+		<artifactId>agentscope-extensions</artifactId>
+		<version>${revision}</version>
+		<relativePath>../pom.xml</relativePath>
+	</parent>
+
+	<name>AgentScope Java - Extensions - ReMe</name>
+	<description>AgentScope Extensions - Long-Term-Memory ReMe</description>
+	<artifactId>agentscope-extensions-reme</artifactId>
+
+	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+	</properties>
+
+	<dependencies>
+		<dependency>
+			<groupId>io.agentscope</groupId>
+			<artifactId>agentscope-core</artifactId>
+			<version>${revision}</version>
+		</dependency>
+
+		<!-- OkHttp for HTTP client -->
+		<dependency>
+			<groupId>com.squareup.okhttp3</groupId>
+			<artifactId>okhttp</artifactId>
+		</dependency>
+	</dependencies>
+
+</project>

--- a/agentscope-extensions/agentscope-extensions-reme/src/main/java/io/agentscope/core/memory/reme/ReMeAddRequest.java
+++ b/agentscope-extensions/agentscope-extensions-reme/src/main/java/io/agentscope/core/memory/reme/ReMeAddRequest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2024-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.core.memory.reme;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+
+/**
+ * Request object for adding memories to ReMe API.
+ *
+ * <p>This request is sent to the ReMe API's {@code POST /summary_personal_memory} endpoint
+ * to record new memories. ReMe will process the trajectories and extract memorable information.
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class ReMeAddRequest {
+
+    /** Workspace identifier for memory organization. */
+    @JsonProperty("workspace_id")
+    private String workspaceId;
+
+    /** List of trajectories (conversation sequences) to process. */
+    private List<ReMeTrajectory> trajectories;
+
+    /** Default constructor for Jackson. */
+    public ReMeAddRequest() {}
+
+    /**
+     * Creates a new ReMeAddRequest with specified workspace ID and trajectories.
+     *
+     * @param workspaceId The workspace identifier
+     * @param trajectories The list of trajectories
+     */
+    public ReMeAddRequest(String workspaceId, List<ReMeTrajectory> trajectories) {
+        this.workspaceId = workspaceId;
+        this.trajectories = trajectories;
+    }
+
+    // Getters and Setters
+
+    public String getWorkspaceId() {
+        return workspaceId;
+    }
+
+    public void setWorkspaceId(String workspaceId) {
+        this.workspaceId = workspaceId;
+    }
+
+    public List<ReMeTrajectory> getTrajectories() {
+        return trajectories;
+    }
+
+    public void setTrajectories(List<ReMeTrajectory> trajectories) {
+        this.trajectories = trajectories;
+    }
+
+    /**
+     * Creates a new builder for ReMeAddRequest.
+     *
+     * @return A new builder instance
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /** Builder for ReMeAddRequest. */
+    public static class Builder {
+        private String workspaceId;
+        private List<ReMeTrajectory> trajectories;
+
+        public Builder workspaceId(String workspaceId) {
+            this.workspaceId = workspaceId;
+            return this;
+        }
+
+        public Builder trajectories(List<ReMeTrajectory> trajectories) {
+            this.trajectories = trajectories;
+            return this;
+        }
+
+        public ReMeAddRequest build() {
+            return new ReMeAddRequest(workspaceId, trajectories);
+        }
+    }
+}

--- a/agentscope-extensions/agentscope-extensions-reme/src/main/java/io/agentscope/core/memory/reme/ReMeAddResponse.java
+++ b/agentscope-extensions/agentscope-extensions-reme/src/main/java/io/agentscope/core/memory/reme/ReMeAddResponse.java
@@ -1,0 +1,314 @@
+/*
+ * Copyright 2024-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.core.memory.reme;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Response object from ReMe's add memory API.
+ *
+ * <p>This response is returned from the {@code POST /summary_personal_memory} endpoint
+ * after successfully adding memories. The actual response format is:
+ * <pre>{@code
+ * {
+ *   "answer": "",
+ *   "success": true,
+ *   "metadata": {
+ *     "memory_list": [...],
+ *     "deleted_memory_ids": [],
+ *     "update_result": {
+ *       "deleted_count": 0,
+ *       "inserted_count": 1
+ *     }
+ *   }
+ * }
+ * }</pre>
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class ReMeAddResponse {
+
+    /** The answer text (usually empty for add operations). */
+    private String answer;
+
+    /** Whether the operation was successful. */
+    private Boolean success;
+
+    /** Metadata containing additional information. */
+    private Metadata metadata;
+
+    /** Default constructor for Jackson. */
+    public ReMeAddResponse() {}
+
+    // Getters and Setters
+
+    public String getAnswer() {
+        return answer;
+    }
+
+    public void setAnswer(String answer) {
+        this.answer = answer;
+    }
+
+    public Boolean getSuccess() {
+        return success;
+    }
+
+    public void setSuccess(Boolean success) {
+        this.success = success;
+    }
+
+    public Metadata getMetadata() {
+        return metadata;
+    }
+
+    public void setMetadata(Metadata metadata) {
+        this.metadata = metadata;
+    }
+
+    @Override
+    public String toString() {
+        return "ReMeAddResponse{"
+                + "answer='"
+                + answer
+                + '\''
+                + ", success="
+                + success
+                + ", metadata="
+                + metadata
+                + '}';
+    }
+
+    /** Metadata object containing memory list and update results. */
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public static class Metadata {
+        @JsonProperty("memory_list")
+        private List<MemoryItem> memoryList;
+
+        @JsonProperty("deleted_memory_ids")
+        private List<String> deletedMemoryIds;
+
+        @JsonProperty("update_result")
+        private UpdateResult updateResult;
+
+        public List<MemoryItem> getMemoryList() {
+            return memoryList;
+        }
+
+        public void setMemoryList(List<MemoryItem> memoryList) {
+            this.memoryList = memoryList;
+        }
+
+        public List<String> getDeletedMemoryIds() {
+            return deletedMemoryIds;
+        }
+
+        public void setDeletedMemoryIds(List<String> deletedMemoryIds) {
+            this.deletedMemoryIds = deletedMemoryIds;
+        }
+
+        public UpdateResult getUpdateResult() {
+            return updateResult;
+        }
+
+        public void setUpdateResult(UpdateResult updateResult) {
+            this.updateResult = updateResult;
+        }
+
+        @Override
+        public String toString() {
+            return "Metadata{"
+                    + "memoryList="
+                    + (memoryList != null ? memoryList.size() + " items" : "null")
+                    + ", deletedMemoryIds="
+                    + (deletedMemoryIds != null ? deletedMemoryIds.size() + " items" : "null")
+                    + ", updateResult="
+                    + updateResult
+                    + '}';
+        }
+    }
+
+    /** Represents a single memory item in the response. */
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public static class MemoryItem {
+        @JsonProperty("workspace_id")
+        private String workspaceId;
+
+        @JsonProperty("memory_id")
+        private String memoryId;
+
+        @JsonProperty("memory_type")
+        private String memoryType;
+
+        @JsonProperty("when_to_use")
+        private String whenToUse;
+
+        private String content;
+
+        private Double score;
+
+        @JsonProperty("time_created")
+        private String timeCreated;
+
+        @JsonProperty("time_modified")
+        private String timeModified;
+
+        private String author;
+
+        private Map<String, Object> metadata;
+
+        private String target;
+
+        @JsonProperty("reflection_subject")
+        private String reflectionSubject;
+
+        // Getters and Setters
+
+        public String getWorkspaceId() {
+            return workspaceId;
+        }
+
+        public void setWorkspaceId(String workspaceId) {
+            this.workspaceId = workspaceId;
+        }
+
+        public String getMemoryId() {
+            return memoryId;
+        }
+
+        public void setMemoryId(String memoryId) {
+            this.memoryId = memoryId;
+        }
+
+        public String getMemoryType() {
+            return memoryType;
+        }
+
+        public void setMemoryType(String memoryType) {
+            this.memoryType = memoryType;
+        }
+
+        public String getWhenToUse() {
+            return whenToUse;
+        }
+
+        public void setWhenToUse(String whenToUse) {
+            this.whenToUse = whenToUse;
+        }
+
+        public String getContent() {
+            return content;
+        }
+
+        public void setContent(String content) {
+            this.content = content;
+        }
+
+        public Double getScore() {
+            return score;
+        }
+
+        public void setScore(Double score) {
+            this.score = score;
+        }
+
+        public String getTimeCreated() {
+            return timeCreated;
+        }
+
+        public void setTimeCreated(String timeCreated) {
+            this.timeCreated = timeCreated;
+        }
+
+        public String getTimeModified() {
+            return timeModified;
+        }
+
+        public void setTimeModified(String timeModified) {
+            this.timeModified = timeModified;
+        }
+
+        public String getAuthor() {
+            return author;
+        }
+
+        public void setAuthor(String author) {
+            this.author = author;
+        }
+
+        public Map<String, Object> getMetadata() {
+            return metadata;
+        }
+
+        public void setMetadata(Map<String, Object> metadata) {
+            this.metadata = metadata;
+        }
+
+        public String getTarget() {
+            return target;
+        }
+
+        public void setTarget(String target) {
+            this.target = target;
+        }
+
+        public String getReflectionSubject() {
+            return reflectionSubject;
+        }
+
+        public void setReflectionSubject(String reflectionSubject) {
+            this.reflectionSubject = reflectionSubject;
+        }
+    }
+
+    /** Update result information. */
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public static class UpdateResult {
+        @JsonProperty("deleted_count")
+        private Integer deletedCount;
+
+        @JsonProperty("inserted_count")
+        private Integer insertedCount;
+
+        public Integer getDeletedCount() {
+            return deletedCount;
+        }
+
+        public void setDeletedCount(Integer deletedCount) {
+            this.deletedCount = deletedCount;
+        }
+
+        public Integer getInsertedCount() {
+            return insertedCount;
+        }
+
+        public void setInsertedCount(Integer insertedCount) {
+            this.insertedCount = insertedCount;
+        }
+
+        @Override
+        public String toString() {
+            return "UpdateResult{"
+                    + "deletedCount="
+                    + deletedCount
+                    + ", insertedCount="
+                    + insertedCount
+                    + '}';
+        }
+    }
+}

--- a/agentscope-extensions/agentscope-extensions-reme/src/main/java/io/agentscope/core/memory/reme/ReMeClient.java
+++ b/agentscope-extensions/agentscope-extensions-reme/src/main/java/io/agentscope/core/memory/reme/ReMeClient.java
@@ -1,0 +1,178 @@
+/*
+ * Copyright 2024-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.core.memory.reme;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.time.Duration;
+import okhttp3.MediaType;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.Response;
+import okhttp3.ResponseBody;
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
+
+/**
+ * HTTP client for interacting with the ReMe API.
+ */
+public class ReMeClient {
+
+    private static final MediaType JSON = MediaType.parse("application/json; charset=utf-8");
+    private static final String SUMMARY_ENDPOINT = "/summary_personal_memory";
+    private static final String RETRIEVE_ENDPOINT = "/retrieve_personal_memory";
+
+    private final OkHttpClient httpClient;
+    private final String apiBaseUrl;
+    private final ObjectMapper objectMapper;
+
+    /**
+     * Creates a new ReMeClient with specified configuration.
+     *
+     * @param apiBaseUrl The base URL of the ReMe API (e.g., "http://localhost:8002")
+     */
+    public ReMeClient(String apiBaseUrl) {
+        this(apiBaseUrl, Duration.ofSeconds(60));
+    }
+
+    /**
+     * Creates a new ReMeClient with custom timeout.
+     *
+     * @param apiBaseUrl The base URL of the ReMe API
+     * @param timeout HTTP request timeout duration
+     */
+    public ReMeClient(String apiBaseUrl, Duration timeout) {
+        this.apiBaseUrl =
+                apiBaseUrl.endsWith("/")
+                        ? apiBaseUrl.substring(0, apiBaseUrl.length() - 1)
+                        : apiBaseUrl;
+        this.objectMapper = new ObjectMapper();
+        this.httpClient =
+                new OkHttpClient.Builder()
+                        .connectTimeout(Duration.ofSeconds(30))
+                        .readTimeout(timeout)
+                        .writeTimeout(Duration.ofSeconds(30))
+                        .build();
+    }
+
+    /**
+     * Executes a POST request to the ReMe API and parses the response.
+     *
+     * <p>This is a generic method that handles HTTP communication, JSON serialization,
+     * error handling, and response parsing for all POST endpoints.
+     *
+     * @param endpoint The API endpoint path (e.g., "/summary_personal_memory")
+     * @param request The request object to serialize as JSON
+     * @param responseType The class of the response type
+     * @param operationName A human-readable name for the operation (for error messages)
+     * @param <T> The request type
+     * @param <R> The response type
+     * @return A Mono emitting the parsed response
+     */
+    private <T, R> Mono<R> executePost(
+            String endpoint, T request, Class<R> responseType, String operationName) {
+        return Mono.fromCallable(
+                        () -> {
+                            // Serialize request to JSON
+                            String json = objectMapper.writeValueAsString(request);
+
+                            // Build HTTP request
+                            Request httpRequest =
+                                    new Request.Builder()
+                                            .url(apiBaseUrl + endpoint)
+                                            .addHeader("Content-Type", "application/json")
+                                            .post(RequestBody.create(json, JSON))
+                                            .build();
+
+                            // Execute request
+                            try (Response response = httpClient.newCall(httpRequest).execute()) {
+                                if (!response.isSuccessful()) {
+                                    String errorBody =
+                                            response.body() != null
+                                                    ? response.body().string()
+                                                    : "No error details";
+                                    throw new IOException(
+                                            "ReMe API "
+                                                    + operationName
+                                                    + " failed with status "
+                                                    + response.code()
+                                                    + ": "
+                                                    + errorBody);
+                                }
+
+                                // Parse and return response
+                                ResponseBody body = response.body();
+                                if (body == null) {
+                                    // Return empty response object if body is null
+                                    return objectMapper.readValue("{}", responseType);
+                                }
+                                String responseBody = body.string();
+                                if (responseBody == null || responseBody.trim().isEmpty()) {
+                                    // Return empty response object if body is empty
+                                    return objectMapper.readValue("{}", responseType);
+                                }
+                                return objectMapper.readValue(responseBody, responseType);
+                            }
+                        })
+                .subscribeOn(Schedulers.boundedElastic());
+    }
+
+    /**
+     * Adds memories to ReMe by sending trajectories for processing.
+     *
+     * <p>This method calls the {@code POST /summary_personal_memory} endpoint. ReMe will
+     * process the trajectories and extract memorable information.
+     *
+     * <p>The operation is performed asynchronously on the bounded elastic scheduler
+     * to avoid blocking the caller thread.
+     *
+     * @param request The add request containing trajectories and workspace ID
+     * @return A Mono emitting the response
+     */
+    public Mono<ReMeAddResponse> add(ReMeAddRequest request) {
+        return executePost(
+                SUMMARY_ENDPOINT, request, ReMeAddResponse.class, "summary_personal_memory");
+    }
+
+    /**
+     * Searches memories in ReMe using the provided query.
+     *
+     * <p>This method calls the {@code POST /retrieve_personal_memory} endpoint to find
+     * memories relevant to the query string.
+     *
+     * <p>The operation is performed asynchronously on the bounded elastic scheduler
+     * to avoid blocking the caller thread.
+     *
+     * @param request The search request containing query, workspace ID, and topK
+     * @return A Mono emitting the search response with relevant memories
+     */
+    public Mono<ReMeSearchResponse> search(ReMeSearchRequest request) {
+        return executePost(
+                RETRIEVE_ENDPOINT, request, ReMeSearchResponse.class, "retrieve_personal_memory");
+    }
+
+    /**
+     * Shuts down the HTTP client and releases resources.
+     *
+     * <p>This method should be called when the client is no longer needed.
+     * After calling this method, the client should not be used for further requests.
+     */
+    public void shutdown() {
+        httpClient.dispatcher().executorService().shutdown();
+        httpClient.connectionPool().evictAll();
+    }
+}

--- a/agentscope-extensions/agentscope-extensions-reme/src/main/java/io/agentscope/core/memory/reme/ReMeLongTermMemory.java
+++ b/agentscope-extensions/agentscope-extensions-reme/src/main/java/io/agentscope/core/memory/reme/ReMeLongTermMemory.java
@@ -1,0 +1,306 @@
+/*
+ * Copyright 2024-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.core.memory.reme;
+
+import io.agentscope.core.memory.LongTermMemory;
+import io.agentscope.core.message.Msg;
+import io.agentscope.core.message.MsgRole;
+import io.agentscope.core.message.ToolUseBlock;
+import java.time.Duration;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import reactor.core.publisher.Mono;
+
+/**
+ * Long-term memory implementation using ReMe as the backend.
+ *
+ * <p>This implementation integrates with ReMe, a memory layer for AI applications that
+ * provides persistent, searchable memory storage using LLM-powered memory extraction.
+ *
+ * <p><b>Key Features:</b>
+ * <ul>
+ *   <li>LLM-powered memory extraction and inference
+ *   <li>Workspace-based memory isolation
+ *   <li>Automatic memory summarization from conversation trajectories
+ *   <li>Reactive, non-blocking operations
+ * </ul>
+ *
+ * <p><b>Memory Isolation:</b>
+ * Memories are organized by userId (mapped to ReMe's workspace_id), enabling
+ * multi-tenant scenarios where different users maintain separate memory contexts.
+ *
+ * <p><b>Usage Example:</b>
+ * <pre>{@code
+ * // Create memory instance
+ * ReMeLongTermMemory memory = ReMeLongTermMemory.builder()
+ *     .userId("task_workspace")
+ *     .apiBaseUrl("http://localhost:8002")
+ *     .build();
+ *
+ * // Use in ReActAgent
+ * ReActAgent agent = ReActAgent.builder()
+ *     .name("Assistant")
+ *     .model(model)
+ *     .longTermMemory(memory)
+ *     .longTermMemoryMode(LongTermMemoryMode.BOTH)
+ *     .build();
+ * }</pre>
+ *
+ * @see LongTermMemory
+ * @see ReMeClient
+ */
+public class ReMeLongTermMemory implements LongTermMemory {
+
+    private final ReMeClient client;
+    private final String userId;
+
+    /**
+     * Private constructor - use Builder instead.
+     */
+    private ReMeLongTermMemory(Builder builder) {
+        // Validate required fields before creating ReMeClient
+        if (builder.userId == null || builder.userId.isEmpty()) {
+            throw new IllegalArgumentException("userId is required");
+        }
+        if (builder.apiBaseUrl == null || builder.apiBaseUrl.isEmpty()) {
+            throw new IllegalArgumentException("apiBaseUrl is required");
+        }
+
+        this.client = new ReMeClient(builder.apiBaseUrl, builder.timeout);
+        this.userId = builder.userId;
+    }
+
+    /**
+     * Records messages to long-term memory.
+     *
+     * <p>This method converts messages to ReMe trajectory format and sends them to
+     * the ReMe API for processing. ReMe will extract and store memorable information
+     * from the conversation.
+     *
+     * <p>Only USER and ASSISTANT messages are recorded. For ASSISTANT messages,
+     * only those without ToolUseBlock (pure assistant replies) are kept, filtering
+     * out tool call requests. TOOL and SYSTEM messages are also filtered out to keep
+     * the conversation history clean and focused on user-assistant interactions.
+     *
+     * <p>Messages containing compressed history markers (&lt;compressed_history&gt;) are
+     * filtered out to avoid storing redundant compressed information.
+     *
+     * <p>Null messages and messages with empty text content are filtered out before
+     * processing. Empty message lists are handled gracefully without error.
+     *
+     * @param msgs List of messages to record
+     * @return A Mono that completes when recording is finished
+     */
+    @Override
+    public Mono<Void> record(List<Msg> msgs) {
+        if (msgs == null || msgs.isEmpty()) {
+            return Mono.empty();
+        }
+
+        // Convert Msg list to ReMeMessage list
+        // Only keep USER and ASSISTANT messages (excluding ASSISTANT messages with ToolUseBlock)
+        List<ReMeMessage> remeMessages =
+                msgs.stream()
+                        .filter(Objects::nonNull)
+                        .filter(
+                                msg -> {
+                                    // Filter by role: only USER and ASSISTANT
+                                    MsgRole role = msg.getRole();
+                                    if (role != MsgRole.USER && role != MsgRole.ASSISTANT) {
+                                        return false;
+                                    }
+
+                                    // For ASSISTANT messages, exclude those with ToolUseBlock
+                                    // (tool call requests should not be recorded)
+                                    if (role == MsgRole.ASSISTANT
+                                            && msg.hasContentBlocks(ToolUseBlock.class)) {
+                                        return false;
+                                    }
+
+                                    // Check for non-empty text content
+                                    String textContent = msg.getTextContent();
+                                    if (textContent == null || textContent.isEmpty()) {
+                                        return false;
+                                    }
+
+                                    // Exclude messages with compressed history
+                                    if (textContent.contains("<compressed_history>")) {
+                                        return false;
+                                    }
+
+                                    return true;
+                                })
+                        .map(this::convertToReMeMessage)
+                        .filter(Objects::nonNull)
+                        .collect(Collectors.toList());
+
+        if (remeMessages.isEmpty()) {
+            return Mono.empty();
+        }
+
+        // Create trajectory with messages
+        ReMeTrajectory trajectory = ReMeTrajectory.builder().messages(remeMessages).build();
+
+        // Build request
+        // Note: userId is used as workspaceId for ReMe API
+        ReMeAddRequest request =
+                ReMeAddRequest.builder()
+                        .workspaceId(userId)
+                        .trajectories(List.of(trajectory))
+                        .build();
+
+        // Send to ReMe API
+        return client.add(request).then();
+    }
+
+    /**
+     * Converts a Msg to a ReMeMessage.
+     *
+     * <p>Role mapping:
+     * <ul>
+     *   <li>USER -> "user"</li>
+     *   <li>ASSISTANT -> "assistant" (only pure assistant replies without ToolUseBlock)</li>
+     * </ul>
+     *
+     * <p>Returns null for unsupported message types (TOOL, SYSTEM, or ASSISTANT with ToolUseBlock),
+     * which will be filtered out by the caller.
+     */
+    private ReMeMessage convertToReMeMessage(Msg msg) {
+        String role =
+                switch (msg.getRole()) {
+                    case USER -> "user";
+                    case ASSISTANT -> "assistant";
+                    default -> null; // Filter out unsupported message types
+                };
+
+        if (role == null) {
+            return null;
+        }
+
+        return ReMeMessage.builder().role(role).content(msg.getTextContent()).build();
+    }
+
+    /**
+     * Retrieves relevant memories based on the input message.
+     *
+     * <p>Uses the message content as a query to search for relevant memories in ReMe.
+     * Returns memory fragments as a newline-separated string, or empty string if no
+     * relevant memories are found.
+     *
+     * <p>Only memories from the configured workspace are returned.
+     *
+     * @param msg The message to use as a search query
+     * @return A Mono emitting the retrieved memory text (may be empty)
+     */
+    @Override
+    public Mono<String> retrieve(Msg msg) {
+        if (msg == null) {
+            return Mono.just("");
+        }
+
+        String query = msg.getTextContent();
+        if (query == null || query.isEmpty()) {
+            return Mono.just("");
+        }
+
+        // Build search request
+        // Note: userId is used as workspaceId for ReMe API
+        ReMeSearchRequest request =
+                ReMeSearchRequest.builder().workspaceId(userId).query(query).topK(5).build();
+
+        // Search and convert response to string
+        return client.search(request)
+                .map(
+                        response -> {
+                            // Use answer field if available, otherwise use memory_list
+                            if (response.getAnswer() != null && !response.getAnswer().isEmpty()) {
+                                return response.getAnswer();
+                            }
+
+                            List<String> memories = response.getMemories();
+                            if (memories == null || memories.isEmpty()) {
+                                return "";
+                            }
+
+                            return memories.stream()
+                                    .filter(Objects::nonNull)
+                                    .collect(Collectors.joining("\n"));
+                        })
+                .onErrorReturn("");
+    }
+
+    /**
+     * Creates a new builder for ReMeLongTermMemory.
+     *
+     * @return A new builder instance
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Builder for ReMeLongTermMemory.
+     */
+    public static class Builder {
+        private String userId;
+        private String apiBaseUrl;
+        private Duration timeout = Duration.ofSeconds(60);
+
+        /**
+         * Sets the userId.
+         *
+         * @param userId The userId
+         * @return This builder
+         */
+        public Builder userId(String userId) {
+            this.userId = userId;
+            return this;
+        }
+
+        /**
+         * Sets the ReMe API base URL.
+         *
+         * @param apiBaseUrl The base URL (e.g., "http://localhost:8002")
+         * @return This builder
+         */
+        public Builder apiBaseUrl(String apiBaseUrl) {
+            this.apiBaseUrl = apiBaseUrl;
+            return this;
+        }
+
+        /**
+         * Sets the HTTP request timeout.
+         *
+         * @param timeout The timeout duration
+         * @return This builder
+         */
+        public Builder timeout(Duration timeout) {
+            this.timeout = timeout;
+            return this;
+        }
+
+        /**
+         * Builds the ReMeLongTermMemory instance.
+         *
+         * @return A new ReMeLongTermMemory instance
+         * @throws IllegalArgumentException If required fields are missing
+         */
+        public ReMeLongTermMemory build() {
+            return new ReMeLongTermMemory(this);
+        }
+    }
+}

--- a/agentscope-extensions/agentscope-extensions-reme/src/main/java/io/agentscope/core/memory/reme/ReMeMessage.java
+++ b/agentscope-extensions/agentscope-extensions-reme/src/main/java/io/agentscope/core/memory/reme/ReMeMessage.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2024-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.core.memory.reme;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+/**
+ * Represents a message in the ReMe API format.
+ *
+ * <p>Messages are the primary input format for ReMe's memory recording. Each message
+ * has a role (user or assistant) and content.
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class ReMeMessage {
+
+    /** Role of the message sender, typically "user" or "assistant". */
+    private String role;
+
+    /** The actual text content of the message. */
+    private String content;
+
+    /** Default constructor for Jackson deserialization. */
+    public ReMeMessage() {}
+
+    /**
+     * Creates a new ReMeMessage with specified role and content.
+     *
+     * @param role The role (e.g., "user", "assistant")
+     * @param content The message content
+     */
+    public ReMeMessage(String role, String content) {
+        this.role = role;
+        this.content = content;
+    }
+
+    // Getters and Setters
+
+    public String getRole() {
+        return role;
+    }
+
+    public void setRole(String role) {
+        this.role = role;
+    }
+
+    public String getContent() {
+        return content;
+    }
+
+    public void setContent(String content) {
+        this.content = content;
+    }
+
+    /**
+     * Builder for creating ReMeMessage instances.
+     *
+     * @return A new builder instance
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /** Builder class for ReMeMessage. */
+    public static class Builder {
+        private String role;
+        private String content;
+
+        public Builder role(String role) {
+            this.role = role;
+            return this;
+        }
+
+        public Builder content(String content) {
+            this.content = content;
+            return this;
+        }
+
+        public ReMeMessage build() {
+            return new ReMeMessage(role, content);
+        }
+    }
+}

--- a/agentscope-extensions/agentscope-extensions-reme/src/main/java/io/agentscope/core/memory/reme/ReMeSearchRequest.java
+++ b/agentscope-extensions/agentscope-extensions-reme/src/main/java/io/agentscope/core/memory/reme/ReMeSearchRequest.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2024-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.core.memory.reme;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Request object for searching memories in ReMe API.
+ *
+ * <p>This request is sent to the ReMe API's {@code POST /retrieve_personal_memory} endpoint
+ * to retrieve relevant memories based on a query string.
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class ReMeSearchRequest {
+
+    /** Workspace identifier for memory organization. */
+    @JsonProperty("workspace_id")
+    private String workspaceId;
+
+    /** The search query string. */
+    private String query;
+
+    /** Maximum number of results to return. */
+    @JsonProperty("top_k")
+    private Integer topK;
+
+    /** Default constructor for Jackson. */
+    public ReMeSearchRequest() {
+        this.topK = 5; // Default value
+    }
+
+    /**
+     * Creates a new ReMeSearchRequest with specified workspace ID, query, and topK.
+     *
+     * @param workspaceId The workspace identifier
+     * @param query The search query
+     * @param topK Maximum number of results
+     */
+    public ReMeSearchRequest(String workspaceId, String query, Integer topK) {
+        this.workspaceId = workspaceId;
+        this.query = query;
+        this.topK = topK;
+    }
+
+    // Getters and Setters
+
+    public String getWorkspaceId() {
+        return workspaceId;
+    }
+
+    public void setWorkspaceId(String workspaceId) {
+        this.workspaceId = workspaceId;
+    }
+
+    public String getQuery() {
+        return query;
+    }
+
+    public void setQuery(String query) {
+        this.query = query;
+    }
+
+    public Integer getTopK() {
+        return topK;
+    }
+
+    public void setTopK(Integer topK) {
+        this.topK = topK;
+    }
+
+    /**
+     * Creates a new builder for ReMeSearchRequest.
+     *
+     * @return A new builder instance
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /** Builder for ReMeSearchRequest. */
+    public static class Builder {
+        private String workspaceId;
+        private String query;
+        private Integer topK = 5;
+
+        public Builder workspaceId(String workspaceId) {
+            this.workspaceId = workspaceId;
+            return this;
+        }
+
+        public Builder query(String query) {
+            this.query = query;
+            return this;
+        }
+
+        public Builder topK(Integer topK) {
+            this.topK = topK;
+            return this;
+        }
+
+        public ReMeSearchRequest build() {
+            return new ReMeSearchRequest(workspaceId, query, topK);
+        }
+    }
+}

--- a/agentscope-extensions/agentscope-extensions-reme/src/main/java/io/agentscope/core/memory/reme/ReMeSearchResponse.java
+++ b/agentscope-extensions/agentscope-extensions-reme/src/main/java/io/agentscope/core/memory/reme/ReMeSearchResponse.java
@@ -1,0 +1,273 @@
+/*
+ * Copyright 2024-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.core.memory.reme;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+/**
+ * Response object from ReMe's search memory API.
+ *
+ * <p>This response is returned from the {@code POST /retrieve_personal_memory} endpoint
+ * after performing a memory search. The actual response format is:
+ * <pre>{@code
+ * {
+ *   "answer": "string",
+ *   "success": true,
+ *   "metadata": {
+ *     "memory_list": [
+ *       {
+ *         "workspace_id": "...",
+ *         "memory_id": "...",
+ *         "content": "...",
+ *         ...
+ *       }
+ *     ]
+ *   }
+ * }
+ * }</pre>
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class ReMeSearchResponse {
+
+    /** The answer text containing retrieved memories. */
+    private String answer;
+
+    /** Whether the operation was successful. */
+    private Boolean success;
+
+    /** Metadata containing additional information. */
+    private Metadata metadata;
+
+    /** Default constructor for Jackson. */
+    public ReMeSearchResponse() {}
+
+    // Getters and Setters
+
+    public String getAnswer() {
+        return answer;
+    }
+
+    public void setAnswer(String answer) {
+        this.answer = answer;
+    }
+
+    public Boolean getSuccess() {
+        return success;
+    }
+
+    public void setSuccess(Boolean success) {
+        this.success = success;
+    }
+
+    public Metadata getMetadata() {
+        return metadata;
+    }
+
+    public void setMetadata(Metadata metadata) {
+        this.metadata = metadata;
+    }
+
+    /**
+     * Gets the list of memory fragments from metadata as strings.
+     *
+     * <p>This method extracts the content from each memory item for backward compatibility.
+     *
+     * @return List of memory content strings, or empty list if not available
+     */
+    public List<String> getMemories() {
+        if (metadata != null && metadata.getMemoryList() != null) {
+            return metadata.getMemoryList().stream()
+                    .map(MemoryItem::getContent)
+                    .filter(Objects::nonNull)
+                    .collect(Collectors.toList());
+        }
+        return List.of();
+    }
+
+    @Override
+    public String toString() {
+        return "ReMeSearchResponse{"
+                + "answer='"
+                + answer
+                + '\''
+                + ", success="
+                + success
+                + ", metadata="
+                + metadata
+                + '}';
+    }
+
+    /** Metadata object containing memory list. */
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public static class Metadata {
+        @JsonProperty("memory_list")
+        private List<MemoryItem> memoryList;
+
+        public List<MemoryItem> getMemoryList() {
+            return memoryList;
+        }
+
+        public void setMemoryList(List<MemoryItem> memoryList) {
+            this.memoryList = memoryList;
+        }
+
+        @Override
+        public String toString() {
+            return "Metadata{"
+                    + "memoryList="
+                    + (memoryList != null ? memoryList.size() + " items" : "null")
+                    + '}';
+        }
+    }
+
+    /** Represents a single memory item in the response. */
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public static class MemoryItem {
+        @JsonProperty("workspace_id")
+        private String workspaceId;
+
+        @JsonProperty("memory_id")
+        private String memoryId;
+
+        @JsonProperty("memory_type")
+        private String memoryType;
+
+        @JsonProperty("when_to_use")
+        private String whenToUse;
+
+        private String content;
+
+        private Double score;
+
+        @JsonProperty("time_created")
+        private String timeCreated;
+
+        @JsonProperty("time_modified")
+        private String timeModified;
+
+        private String author;
+
+        private Map<String, Object> metadata;
+
+        private String target;
+
+        @JsonProperty("reflection_subject")
+        private String reflectionSubject;
+
+        // Getters and Setters
+
+        public String getWorkspaceId() {
+            return workspaceId;
+        }
+
+        public void setWorkspaceId(String workspaceId) {
+            this.workspaceId = workspaceId;
+        }
+
+        public String getMemoryId() {
+            return memoryId;
+        }
+
+        public void setMemoryId(String memoryId) {
+            this.memoryId = memoryId;
+        }
+
+        public String getMemoryType() {
+            return memoryType;
+        }
+
+        public void setMemoryType(String memoryType) {
+            this.memoryType = memoryType;
+        }
+
+        public String getWhenToUse() {
+            return whenToUse;
+        }
+
+        public void setWhenToUse(String whenToUse) {
+            this.whenToUse = whenToUse;
+        }
+
+        public String getContent() {
+            return content;
+        }
+
+        public void setContent(String content) {
+            this.content = content;
+        }
+
+        public Double getScore() {
+            return score;
+        }
+
+        public void setScore(Double score) {
+            this.score = score;
+        }
+
+        public String getTimeCreated() {
+            return timeCreated;
+        }
+
+        public void setTimeCreated(String timeCreated) {
+            this.timeCreated = timeCreated;
+        }
+
+        public String getTimeModified() {
+            return timeModified;
+        }
+
+        public void setTimeModified(String timeModified) {
+            this.timeModified = timeModified;
+        }
+
+        public String getAuthor() {
+            return author;
+        }
+
+        public void setAuthor(String author) {
+            this.author = author;
+        }
+
+        public Map<String, Object> getMetadata() {
+            return metadata;
+        }
+
+        public void setMetadata(Map<String, Object> metadata) {
+            this.metadata = metadata;
+        }
+
+        public String getTarget() {
+            return target;
+        }
+
+        public void setTarget(String target) {
+            this.target = target;
+        }
+
+        public String getReflectionSubject() {
+            return reflectionSubject;
+        }
+
+        public void setReflectionSubject(String reflectionSubject) {
+            this.reflectionSubject = reflectionSubject;
+        }
+    }
+}

--- a/agentscope-extensions/agentscope-extensions-reme/src/main/java/io/agentscope/core/memory/reme/ReMeTrajectory.java
+++ b/agentscope-extensions/agentscope-extensions-reme/src/main/java/io/agentscope/core/memory/reme/ReMeTrajectory.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2024-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.core.memory.reme;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import java.util.List;
+
+/**
+ * Represents a trajectory (conversation sequence) in the ReMe API format.
+ *
+ * <p>A trajectory contains a list of messages that form a conversation sequence.
+ * This is used when recording memories to ReMe.
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class ReMeTrajectory {
+
+    /** List of messages in this trajectory. */
+    private List<ReMeMessage> messages;
+
+    /** Default constructor for Jackson deserialization. */
+    public ReMeTrajectory() {}
+
+    /**
+     * Creates a new ReMeTrajectory with specified messages.
+     *
+     * @param messages The list of messages
+     */
+    public ReMeTrajectory(List<ReMeMessage> messages) {
+        this.messages = messages;
+    }
+
+    // Getters and Setters
+
+    public List<ReMeMessage> getMessages() {
+        return messages;
+    }
+
+    public void setMessages(List<ReMeMessage> messages) {
+        this.messages = messages;
+    }
+
+    /**
+     * Builder for creating ReMeTrajectory instances.
+     *
+     * @return A new builder instance
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /** Builder class for ReMeTrajectory. */
+    public static class Builder {
+        private List<ReMeMessage> messages;
+
+        public Builder messages(List<ReMeMessage> messages) {
+            this.messages = messages;
+            return this;
+        }
+
+        public ReMeTrajectory build() {
+            return new ReMeTrajectory(messages);
+        }
+    }
+}

--- a/agentscope-extensions/agentscope-extensions-reme/src/test/java/io/agentscope/core/memory/reme/ReMeClientTest.java
+++ b/agentscope-extensions/agentscope-extensions-reme/src/test/java/io/agentscope/core/memory/reme/ReMeClientTest.java
@@ -1,0 +1,573 @@
+/*
+ * Copyright 2024-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.core.memory.reme;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.Duration;
+import java.util.List;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import reactor.test.StepVerifier;
+
+/** Unit tests for {@link ReMeClient}. */
+class ReMeClientTest {
+
+    private MockWebServer mockServer;
+    private ReMeClient client;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        mockServer = new MockWebServer();
+        mockServer.start();
+        String baseUrl = mockServer.url("/").toString();
+        // Remove trailing slash
+        if (baseUrl.endsWith("/")) {
+            baseUrl = baseUrl.substring(0, baseUrl.length() - 1);
+        }
+        client = new ReMeClient(baseUrl);
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        if (client != null) {
+            client.shutdown();
+        }
+        if (mockServer != null) {
+            mockServer.shutdown();
+        }
+    }
+
+    @Test
+    void testConstructorWithBaseUrl() {
+        String baseUrl = "http://localhost:8002";
+        ReMeClient client = new ReMeClient(baseUrl);
+        assertNotNull(client);
+        client.shutdown();
+    }
+
+    @Test
+    void testConstructorWithTrailingSlash() {
+        String baseUrl = "http://localhost:8002/";
+        ReMeClient client = new ReMeClient(baseUrl);
+        assertNotNull(client);
+        client.shutdown();
+    }
+
+    @Test
+    void testConstructorWithCustomTimeout() {
+        String baseUrl = "http://localhost:8002";
+        ReMeClient client = new ReMeClient(baseUrl, Duration.ofSeconds(30));
+        assertNotNull(client);
+        client.shutdown();
+    }
+
+    @Test
+    void testAddRequestSuccess() throws Exception {
+        // Mock successful response matching actual API format
+        String responseJson =
+                "{\"answer\":\"\",\"success\":true,\"metadata\":{\"memory_list\":[{"
+                    + "\"workspace_id\":\"task_workspace\",\"memory_id\":\"test_memory_id\",\"memory_type\":\"personal\",\"when_to_use\":\"coffee,"
+                    + " morning, work\",\"content\":\"user drinks coffee in the morning while"
+                    + " working\",\"score\":0.0,\"time_created\":\"2025-12-10"
+                    + " 10:30:43\",\"time_modified\":\"2025-12-10"
+                    + " 10:30:43\",\"author\":\"test-author\",\"metadata\":{\"keywords\":\"coffee,"
+                    + " morning, work\",\"time_info\":\"\",\"source_message\":\"I like to drink"
+                    + " coffee while working in the"
+                    + " morning\",\"observation_type\":\"personal_info_with_time\"},"
+                    + "\"target\":\"user\",\"reflection_subject\":\"\"}],\"deleted_memory_ids\":[],"
+                    + "\"update_result\":{\"deleted_count\":0,\"inserted_count\":1}}}";
+
+        mockServer.enqueue(new MockResponse().setBody(responseJson).setResponseCode(200));
+
+        // Create request
+        ReMeMessage message1 =
+                ReMeMessage.builder()
+                        .role("user")
+                        .content("I like to drink coffee while working in the morning")
+                        .build();
+        ReMeMessage message2 =
+                ReMeMessage.builder()
+                        .role("assistant")
+                        .content(
+                                "I understand, you prefer to start your workday with coffee to stay"
+                                        + " energized")
+                        .build();
+
+        ReMeTrajectory trajectory =
+                ReMeTrajectory.builder().messages(List.of(message1, message2)).build();
+
+        ReMeAddRequest request =
+                ReMeAddRequest.builder()
+                        .workspaceId("task_workspace")
+                        .trajectories(List.of(trajectory))
+                        .build();
+
+        // Execute and verify
+        StepVerifier.create(client.add(request))
+                .assertNext(
+                        response -> {
+                            assertNotNull(response);
+                            assertEquals(true, response.getSuccess());
+                            assertEquals("", response.getAnswer());
+                            assertNotNull(response.getMetadata());
+                            assertNotNull(response.getMetadata().getMemoryList());
+                            assertEquals(1, response.getMetadata().getMemoryList().size());
+                            ReMeAddResponse.MemoryItem memory =
+                                    response.getMetadata().getMemoryList().get(0);
+                            assertEquals("task_workspace", memory.getWorkspaceId());
+                            assertEquals(
+                                    "user drinks coffee in the morning while working",
+                                    memory.getContent());
+                            assertNotNull(response.getMetadata().getUpdateResult());
+                            assertEquals(
+                                    1, response.getMetadata().getUpdateResult().getInsertedCount());
+                        })
+                .verifyComplete();
+
+        // Verify request
+        RecordedRequest recordedRequest = mockServer.takeRequest();
+        assertEquals("POST", recordedRequest.getMethod());
+        assertEquals("/summary_personal_memory", recordedRequest.getPath());
+        assertTrue(recordedRequest.getHeader("Content-Type").contains("application/json"));
+
+        // Verify request body
+        String requestBody = recordedRequest.getBody().readUtf8();
+        assertTrue(requestBody.contains("\"workspace_id\":\"task_workspace\""));
+        assertTrue(requestBody.contains("\"trajectories\""));
+        assertTrue(requestBody.contains("\"role\":\"user\""));
+        assertTrue(requestBody.contains("\"content\":\"I like to drink coffee"));
+    }
+
+    @Test
+    void testAddRequestWithEmptyResponse() throws Exception {
+        // Mock empty response body (should return empty object)
+        mockServer.enqueue(new MockResponse().setBody("").setResponseCode(200));
+
+        ReMeMessage message = ReMeMessage.builder().role("user").content("Test").build();
+        ReMeTrajectory trajectory = ReMeTrajectory.builder().messages(List.of(message)).build();
+
+        ReMeAddRequest request =
+                ReMeAddRequest.builder()
+                        .workspaceId("test_workspace")
+                        .trajectories(List.of(trajectory))
+                        .build();
+
+        // Should handle empty response gracefully
+        StepVerifier.create(client.add(request))
+                .assertNext(response -> assertNotNull(response))
+                .verifyComplete();
+    }
+
+    @Test
+    void testAddRequestHttpError() {
+        mockServer.enqueue(
+                new MockResponse().setBody("{\"error\":\"Bad request\"}").setResponseCode(400));
+
+        ReMeMessage message = ReMeMessage.builder().role("user").content("Test").build();
+        ReMeTrajectory trajectory = ReMeTrajectory.builder().messages(List.of(message)).build();
+
+        ReMeAddRequest request =
+                ReMeAddRequest.builder()
+                        .workspaceId("test_workspace")
+                        .trajectories(List.of(trajectory))
+                        .build();
+
+        StepVerifier.create(client.add(request))
+                .expectErrorMatches(
+                        error ->
+                                error.getMessage().contains("failed with status 400")
+                                        && error.getMessage().contains("summary_personal_memory"))
+                .verify();
+    }
+
+    @Test
+    void testAddRequestInvalidJson() {
+        mockServer.enqueue(new MockResponse().setBody("invalid json").setResponseCode(200));
+
+        ReMeMessage message = ReMeMessage.builder().role("user").content("Test").build();
+        ReMeTrajectory trajectory = ReMeTrajectory.builder().messages(List.of(message)).build();
+
+        ReMeAddRequest request =
+                ReMeAddRequest.builder()
+                        .workspaceId("test_workspace")
+                        .trajectories(List.of(trajectory))
+                        .build();
+
+        StepVerifier.create(client.add(request))
+                .expectErrorMatches(
+                        error ->
+                                error.getMessage().contains("Failed to parse response")
+                                        || error
+                                                instanceof
+                                                com.fasterxml.jackson.core.JsonProcessingException)
+                .verify();
+    }
+
+    @Test
+    void testSearchRequestSuccess() throws Exception {
+        // Mock successful search response matching actual API format
+        String responseJson =
+                "{\"answer\":\"user drinks coffee in the morning while working\",\"success\":true,"
+                    + "\"metadata\":{\"memory_list\":[{\"workspace_id\":\"task_workspace\","
+                    + "\"memory_id\":\"test_memory_id\",\"memory_type\":\"personal\",\"when_to_use\":\"coffee,"
+                    + " morning, work\",\"content\":\"user drinks coffee in the morning while"
+                    + " working\",\"score\":0.048747035796754684,\"time_created\":\"2025-12-10"
+                    + " 10:30:43\",\"time_modified\":\"2025-12-10"
+                    + " 10:30:43\",\"author\":\"test-author\",\"metadata\":{\"keywords\":\"coffee,"
+                    + " morning, work\",\"time_info\":\"\",\"source_message\":\"I like to drink"
+                    + " coffee while working in the"
+                    + " morning\",\"observation_type\":\"personal_info_with_time\"},"
+                    + "\"target\":\"user\",\"reflection_subject\":\"\"}]}}";
+
+        mockServer.enqueue(new MockResponse().setBody(responseJson).setResponseCode(200));
+
+        // Create request
+        ReMeSearchRequest request =
+                ReMeSearchRequest.builder()
+                        .workspaceId("task_workspace")
+                        .query("What are the user's work habits?")
+                        .topK(5)
+                        .build();
+
+        // Execute and verify
+        StepVerifier.create(client.search(request))
+                .assertNext(
+                        response -> {
+                            assertNotNull(response);
+                            assertEquals(true, response.getSuccess());
+                            assertEquals(
+                                    "user drinks coffee in the morning while working",
+                                    response.getAnswer());
+                            assertNotNull(response.getMetadata());
+                            assertNotNull(response.getMetadata().getMemoryList());
+                            assertEquals(1, response.getMetadata().getMemoryList().size());
+                            ReMeSearchResponse.MemoryItem memory =
+                                    response.getMetadata().getMemoryList().get(0);
+                            assertEquals("task_workspace", memory.getWorkspaceId());
+                            assertEquals(
+                                    "user drinks coffee in the morning while working",
+                                    memory.getContent());
+                            // Test backward compatibility - getMemories() should extract content
+                            assertNotNull(response.getMemories());
+                            assertEquals(1, response.getMemories().size());
+                            assertEquals(
+                                    "user drinks coffee in the morning while working",
+                                    response.getMemories().get(0));
+                        })
+                .verifyComplete();
+
+        // Verify request
+        RecordedRequest recordedRequest = mockServer.takeRequest();
+        assertEquals("POST", recordedRequest.getMethod());
+        assertEquals("/retrieve_personal_memory", recordedRequest.getPath());
+        assertTrue(recordedRequest.getHeader("Content-Type").contains("application/json"));
+
+        // Verify request body
+        String requestBody = recordedRequest.getBody().readUtf8();
+        assertTrue(requestBody.contains("\"workspace_id\":\"task_workspace\""));
+        assertTrue(requestBody.contains("\"query\":\"What are the user's work habits?\""));
+        assertTrue(requestBody.contains("\"top_k\":5"));
+    }
+
+    @Test
+    void testSearchRequestEmptyResults() throws Exception {
+        String responseJson =
+                "{\"answer\":\"\",\"success\":true,\"metadata\":{\"memory_list\":[]}}";
+
+        mockServer.enqueue(new MockResponse().setBody(responseJson).setResponseCode(200));
+
+        ReMeSearchRequest request =
+                ReMeSearchRequest.builder()
+                        .workspaceId("test_workspace")
+                        .query("test query")
+                        .topK(5)
+                        .build();
+
+        StepVerifier.create(client.search(request))
+                .assertNext(
+                        response -> {
+                            assertNotNull(response);
+                            assertEquals(true, response.getSuccess());
+                            assertEquals("", response.getAnswer());
+                            assertNotNull(response.getMetadata());
+                            assertNotNull(response.getMetadata().getMemoryList());
+                            assertEquals(0, response.getMetadata().getMemoryList().size());
+                            assertEquals(0, response.getMemories().size());
+                        })
+                .verifyComplete();
+    }
+
+    @Test
+    void testSearchRequestWithDefaultTopK() throws Exception {
+        String responseJson =
+                "{\"answer\":\"Memory"
+                    + " 1\",\"success\":true,\"metadata\":{\"memory_list\":[{\"workspace_id\":\"test_workspace\",\"memory_id\":\"mem1\",\"content\":\"Memory"
+                    + " 1\"}]}}";
+
+        mockServer.enqueue(new MockResponse().setBody(responseJson).setResponseCode(200));
+
+        ReMeSearchRequest request =
+                ReMeSearchRequest.builder()
+                        .workspaceId("test_workspace")
+                        .query("test")
+                        .build(); // topK not set, should use default
+
+        StepVerifier.create(client.search(request))
+                .assertNext(
+                        response -> {
+                            assertNotNull(response);
+                            assertEquals(true, response.getSuccess());
+                            assertEquals("Memory 1", response.getAnswer());
+                        })
+                .verifyComplete();
+
+        // Verify default topK is used
+        RecordedRequest recordedRequest = mockServer.takeRequest();
+        String requestBody = recordedRequest.getBody().readUtf8();
+        assertTrue(requestBody.contains("\"top_k\":5")); // Default value
+    }
+
+    @Test
+    void testSearchRequestHttpError() {
+        mockServer.enqueue(
+                new MockResponse().setBody("{\"error\":\"Not found\"}").setResponseCode(404));
+
+        ReMeSearchRequest request =
+                ReMeSearchRequest.builder()
+                        .workspaceId("test_workspace")
+                        .query("test query")
+                        .topK(5)
+                        .build();
+
+        StepVerifier.create(client.search(request))
+                .expectErrorMatches(
+                        error ->
+                                error.getMessage().contains("failed with status 404")
+                                        && error.getMessage().contains("retrieve_personal_memory"))
+                .verify();
+    }
+
+    @Test
+    void testSearchRequestInvalidJson() {
+        mockServer.enqueue(new MockResponse().setBody("not valid json").setResponseCode(200));
+
+        ReMeSearchRequest request =
+                ReMeSearchRequest.builder().workspaceId("test_workspace").query("test").build();
+
+        StepVerifier.create(client.search(request))
+                .expectErrorMatches(
+                        error ->
+                                error.getMessage().contains("Failed to parse response")
+                                        || error
+                                                instanceof
+                                                com.fasterxml.jackson.core.JsonProcessingException)
+                .verify();
+    }
+
+    @Test
+    void testSearchRequestWithMultipleMemories() throws Exception {
+        String responseJson =
+                "{\"answer\":\"First memory fragment. Second memory fragment. Third memory"
+                    + " fragment\",\"success\":true,\"metadata\":{\"memory_list\":[{"
+                    + "\"workspace_id\":\"test_workspace\",\"memory_id\":\"mem1\",\"content\":\"First"
+                    + " memory fragment\",\"score\":0.9"
+                    + "},{\"workspace_id\":\"test_workspace\",\"memory_id\":\"mem2\",\"content\":\"Second"
+                    + " memory fragment\",\"score\":0.8"
+                    + "},{\"workspace_id\":\"test_workspace\",\"memory_id\":\"mem3\",\"content\":\"Third"
+                    + " memory fragment\",\"score\":0.7}]}}";
+
+        mockServer.enqueue(new MockResponse().setBody(responseJson).setResponseCode(200));
+
+        ReMeSearchRequest request =
+                ReMeSearchRequest.builder()
+                        .workspaceId("test_workspace")
+                        .query("test query")
+                        .topK(10)
+                        .build();
+
+        StepVerifier.create(client.search(request))
+                .assertNext(
+                        response -> {
+                            assertNotNull(response);
+                            assertEquals(true, response.getSuccess());
+                            assertNotNull(response.getMetadata());
+                            assertNotNull(response.getMetadata().getMemoryList());
+                            assertEquals(3, response.getMetadata().getMemoryList().size());
+                            // Test backward compatibility
+                            assertNotNull(response.getMemories());
+                            assertEquals(3, response.getMemories().size());
+                            assertEquals("First memory fragment", response.getMemories().get(0));
+                            assertEquals("Second memory fragment", response.getMemories().get(1));
+                            assertEquals("Third memory fragment", response.getMemories().get(2));
+                        })
+                .verifyComplete();
+    }
+
+    @Test
+    void testShutdown() {
+        ReMeClient client = new ReMeClient("http://localhost:8002");
+        // Should not throw exception
+        client.shutdown();
+    }
+
+    @Test
+    void testRequestBodySerialization() throws Exception {
+        mockServer.enqueue(
+                new MockResponse()
+                        .setBody(
+                                "{\"answer\":\"\",\"success\":true,\"metadata\":{\"memory_list\":[],\"deleted_memory_ids\":[],\"update_result\":{\"deleted_count\":0,\"inserted_count\":0}}}")
+                        .setResponseCode(200));
+
+        ReMeMessage message1 = ReMeMessage.builder().role("user").content("Test message 1").build();
+        ReMeMessage message2 =
+                ReMeMessage.builder().role("assistant").content("Test response 1").build();
+        ReMeMessage message3 = ReMeMessage.builder().role("user").content("Test message 2").build();
+
+        ReMeTrajectory trajectory =
+                ReMeTrajectory.builder().messages(List.of(message1, message2, message3)).build();
+
+        ReMeAddRequest request =
+                ReMeAddRequest.builder()
+                        .workspaceId("test_workspace")
+                        .trajectories(List.of(trajectory))
+                        .build();
+
+        StepVerifier.create(client.add(request))
+                .assertNext(response -> assertNotNull(response))
+                .verifyComplete();
+
+        // Verify request body contains expected fields
+        RecordedRequest recordedRequest = mockServer.takeRequest();
+        String requestBody = recordedRequest.getBody().readUtf8();
+        assertTrue(requestBody.contains("\"workspace_id\":\"test_workspace\""));
+        assertTrue(requestBody.contains("\"trajectories\""));
+        assertTrue(requestBody.contains("\"role\":\"user\""));
+        assertTrue(requestBody.contains("\"role\":\"assistant\""));
+        assertTrue(requestBody.contains("\"content\":\"Test message 1\""));
+        assertTrue(requestBody.contains("\"content\":\"Test response 1\""));
+        assertTrue(requestBody.contains("\"content\":\"Test message 2\""));
+    }
+
+    @Test
+    void testSearchRequestBodySerialization() throws Exception {
+        mockServer.enqueue(
+                new MockResponse()
+                        .setBody(
+                                "{\"answer\":\"Memory"
+                                    + " 1\",\"success\":true,\"metadata\":{\"memory_list\":[{\"workspace_id\":\"test_workspace\",\"memory_id\":\"mem1\",\"content\":\"Memory"
+                                    + " 1\"}]}}")
+                        .setResponseCode(200));
+
+        ReMeSearchRequest request =
+                ReMeSearchRequest.builder()
+                        .workspaceId("test_workspace")
+                        .query("What are the user preferences?")
+                        .topK(10)
+                        .build();
+
+        StepVerifier.create(client.search(request))
+                .assertNext(response -> assertNotNull(response))
+                .verifyComplete();
+
+        // Verify request body contains expected fields
+        RecordedRequest recordedRequest = mockServer.takeRequest();
+        String requestBody = recordedRequest.getBody().readUtf8();
+        assertTrue(requestBody.contains("\"workspace_id\":\"test_workspace\""));
+        assertTrue(requestBody.contains("\"query\":\"What are the user preferences?\""));
+        assertTrue(requestBody.contains("\"top_k\":10"));
+    }
+
+    @Test
+    void testHttpTimeout() {
+        // Create client with very short timeout
+        String baseUrl = mockServer.url("/").toString();
+        if (baseUrl.endsWith("/")) {
+            baseUrl = baseUrl.substring(0, baseUrl.length() - 1);
+        }
+        ReMeClient shortTimeoutClient = new ReMeClient(baseUrl, Duration.ofMillis(1));
+
+        // Enqueue delayed response
+        mockServer.enqueue(
+                new MockResponse()
+                        .setBody("{\"status\":\"success\"}")
+                        .setResponseCode(200)
+                        .setBodyDelay(1000, java.util.concurrent.TimeUnit.MILLISECONDS));
+
+        ReMeMessage message = ReMeMessage.builder().role("user").content("Test").build();
+        ReMeTrajectory trajectory = ReMeTrajectory.builder().messages(List.of(message)).build();
+
+        ReMeAddRequest request =
+                ReMeAddRequest.builder()
+                        .workspaceId("test_workspace")
+                        .trajectories(List.of(trajectory))
+                        .build();
+
+        // Should timeout
+        StepVerifier.create(shortTimeoutClient.add(request)).expectError().verify();
+
+        shortTimeoutClient.shutdown();
+    }
+
+    @Test
+    void testMultipleTrajectoriesInAddRequest() throws Exception {
+        String responseJson =
+                "{\"answer\":\"\",\"success\":true,\"metadata\":{\"memory_list\":[],\"deleted_memory_ids\":[],\"update_result\":{\"deleted_count\":0,\"inserted_count\":2}}}";
+
+        mockServer.enqueue(new MockResponse().setBody(responseJson).setResponseCode(200));
+
+        // Create multiple trajectories
+        ReMeMessage msg1 = ReMeMessage.builder().role("user").content("Message 1").build();
+        ReMeMessage msg2 = ReMeMessage.builder().role("assistant").content("Response 1").build();
+        ReMeTrajectory trajectory1 = ReMeTrajectory.builder().messages(List.of(msg1, msg2)).build();
+
+        ReMeMessage msg3 = ReMeMessage.builder().role("user").content("Message 2").build();
+        ReMeMessage msg4 = ReMeMessage.builder().role("assistant").content("Response 2").build();
+        ReMeTrajectory trajectory2 = ReMeTrajectory.builder().messages(List.of(msg3, msg4)).build();
+
+        ReMeAddRequest request =
+                ReMeAddRequest.builder()
+                        .workspaceId("test_workspace")
+                        .trajectories(List.of(trajectory1, trajectory2))
+                        .build();
+
+        StepVerifier.create(client.add(request))
+                .assertNext(
+                        response -> {
+                            assertNotNull(response);
+                            assertEquals(true, response.getSuccess());
+                            assertNotNull(response.getMetadata());
+                            assertNotNull(response.getMetadata().getUpdateResult());
+                            assertEquals(
+                                    2, response.getMetadata().getUpdateResult().getInsertedCount());
+                        })
+                .verifyComplete();
+
+        // Verify request contains both trajectories
+        RecordedRequest recordedRequest = mockServer.takeRequest();
+        String requestBody = recordedRequest.getBody().readUtf8();
+        assertTrue(requestBody.contains("\"trajectories\""));
+        // Should contain messages from both trajectories
+        assertTrue(requestBody.contains("\"content\":\"Message 1\""));
+        assertTrue(requestBody.contains("\"content\":\"Message 2\""));
+    }
+}

--- a/agentscope-extensions/agentscope-extensions-reme/src/test/java/io/agentscope/core/memory/reme/ReMeLongTermMemoryTest.java
+++ b/agentscope-extensions/agentscope-extensions-reme/src/test/java/io/agentscope/core/memory/reme/ReMeLongTermMemoryTest.java
@@ -1,0 +1,718 @@
+/*
+ * Copyright 2024-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.core.memory.reme;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.agentscope.core.message.Msg;
+import io.agentscope.core.message.MsgRole;
+import io.agentscope.core.message.TextBlock;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import reactor.test.StepVerifier;
+
+/** Unit tests for {@link ReMeLongTermMemory}. */
+class ReMeLongTermMemoryTest {
+
+    private MockWebServer mockServer;
+    private String baseUrl;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        mockServer = new MockWebServer();
+        mockServer.start();
+        baseUrl = mockServer.url("/").toString();
+        // Remove trailing slash
+        if (baseUrl.endsWith("/")) {
+            baseUrl = baseUrl.substring(0, baseUrl.length() - 1);
+        }
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        if (mockServer != null) {
+            mockServer.shutdown();
+        }
+    }
+
+    @Test
+    void testBuilderWithUserId() {
+        ReMeLongTermMemory memory =
+                ReMeLongTermMemory.builder().userId("task_workspace").apiBaseUrl(baseUrl).build();
+
+        assertNotNull(memory);
+    }
+
+    @Test
+    void testBuilderWithCustomTimeout() {
+        ReMeLongTermMemory memory =
+                ReMeLongTermMemory.builder()
+                        .userId("task_workspace")
+                        .apiBaseUrl(baseUrl)
+                        .timeout(Duration.ofSeconds(30))
+                        .build();
+
+        assertNotNull(memory);
+    }
+
+    @Test
+    void testBuilderRequiresUserId() {
+        IllegalArgumentException exception =
+                assertThrows(
+                        IllegalArgumentException.class,
+                        () -> ReMeLongTermMemory.builder().apiBaseUrl(baseUrl).build());
+
+        assertEquals("userId is required", exception.getMessage());
+    }
+
+    @Test
+    void testBuilderRequiresApiBaseUrl() {
+        IllegalArgumentException exception =
+                assertThrows(
+                        IllegalArgumentException.class,
+                        () -> ReMeLongTermMemory.builder().userId("task_workspace").build());
+
+        assertEquals("apiBaseUrl is required", exception.getMessage());
+    }
+
+    @Test
+    void testBuilderWithEmptyUserId() {
+        IllegalArgumentException exception =
+                assertThrows(
+                        IllegalArgumentException.class,
+                        () -> ReMeLongTermMemory.builder().userId("").apiBaseUrl(baseUrl).build());
+
+        assertEquals("userId is required", exception.getMessage());
+    }
+
+    @Test
+    void testBuilderWithEmptyApiBaseUrl() {
+        IllegalArgumentException exception =
+                assertThrows(
+                        IllegalArgumentException.class,
+                        () ->
+                                ReMeLongTermMemory.builder()
+                                        .userId("task_workspace")
+                                        .apiBaseUrl("")
+                                        .build());
+
+        assertEquals("apiBaseUrl is required", exception.getMessage());
+    }
+
+    @Test
+    void testRecordWithValidMessages() {
+        // Mock response with complete ReMeAddResponse structure
+        String responseJson =
+                "{\"answer\":\"\",\"success\":true,\"metadata\":{\"memory_list\":[{"
+                    + "\"workspace_id\":\"task_workspace\","
+                    + "\"memory_id\":\"688e9ef5904e4c8b8d60ef6ffff77c75\",\"memory_type\":\"personal\",\"when_to_use\":\"coffee,"
+                    + " morning, work\",\"content\":\"user drinks coffee in the morning while"
+                    + " working\",\"score\":0.048747035796754684,\"time_created\":\"2025-12-10"
+                    + " 10:30:43\",\"time_modified\":\"2025-12-10 10:30:43\","
+                    + "\"author\":\"qwen3-30b-a3b-thinking-2507\",\"metadata\":{\"keywords\":\"coffee,"
+                    + " morning, work\",\"time_info\":\"\",\"source_message\":\"I like to drink"
+                    + " coffee while working in the"
+                    + " morning\",\"observation_type\":\"personal_info_with_time\","
+                    + "\"match_event_flag\":\"0\",\"match_msg_flag\":\"0\"},\"target\":\"user\","
+                    + "\"reflection_subject\":\"\"}],\"deleted_memory_ids\":[],\"update_result\":{"
+                    + "\"deleted_count\":0,\"inserted_count\":1}}}";
+
+        mockServer.enqueue(new MockResponse().setBody(responseJson).setResponseCode(200));
+
+        ReMeLongTermMemory memory =
+                ReMeLongTermMemory.builder().userId("task_workspace").apiBaseUrl(baseUrl).build();
+
+        List<Msg> messages = new ArrayList<>();
+        messages.add(
+                Msg.builder()
+                        .role(MsgRole.USER)
+                        .content(
+                                TextBlock.builder()
+                                        .text("I like to drink coffee while working in the morning")
+                                        .build())
+                        .build());
+        messages.add(
+                Msg.builder()
+                        .role(MsgRole.ASSISTANT)
+                        .content(
+                                TextBlock.builder()
+                                        .text(
+                                                "I understand, you prefer to start your workday"
+                                                        + " with coffee to stay energized")
+                                        .build())
+                        .build());
+
+        StepVerifier.create(memory.record(messages)).verifyComplete();
+
+        // Verify response parsing by directly testing ReMeClient
+        ReMeClient client = new ReMeClient(baseUrl);
+        ReMeMessage remeMsg1 =
+                ReMeMessage.builder()
+                        .role("user")
+                        .content("I like to drink coffee while working in the morning")
+                        .build();
+        ReMeMessage remeMsg2 =
+                ReMeMessage.builder()
+                        .role("assistant")
+                        .content(
+                                "I understand, you prefer to start your workday with coffee to stay"
+                                        + " energized")
+                        .build();
+        ReMeTrajectory trajectory =
+                ReMeTrajectory.builder().messages(List.of(remeMsg1, remeMsg2)).build();
+        ReMeAddRequest addRequest =
+                ReMeAddRequest.builder()
+                        .workspaceId("task_workspace")
+                        .trajectories(List.of(trajectory))
+                        .build();
+
+        mockServer.enqueue(new MockResponse().setBody(responseJson).setResponseCode(200));
+
+        StepVerifier.create(client.add(addRequest))
+                .assertNext(
+                        response -> {
+                            // Verify top-level fields
+                            assertNotNull(response);
+                            assertEquals("", response.getAnswer());
+                            assertEquals(true, response.getSuccess());
+                            assertNotNull(response.getMetadata());
+
+                            // Verify metadata fields
+                            ReMeAddResponse.Metadata metadata = response.getMetadata();
+                            assertNotNull(metadata.getMemoryList());
+                            assertEquals(1, metadata.getMemoryList().size());
+                            assertNotNull(metadata.getDeletedMemoryIds());
+                            assertEquals(0, metadata.getDeletedMemoryIds().size());
+                            assertNotNull(metadata.getUpdateResult());
+
+                            // Verify update_result
+                            ReMeAddResponse.UpdateResult updateResult = metadata.getUpdateResult();
+                            assertEquals(0, updateResult.getDeletedCount());
+                            assertEquals(1, updateResult.getInsertedCount());
+
+                            // Verify memory_list item
+                            ReMeAddResponse.MemoryItem memoryItem = metadata.getMemoryList().get(0);
+                            assertEquals("task_workspace", memoryItem.getWorkspaceId());
+                            assertEquals(
+                                    "688e9ef5904e4c8b8d60ef6ffff77c75", memoryItem.getMemoryId());
+                            assertEquals("personal", memoryItem.getMemoryType());
+                            assertEquals("coffee, morning, work", memoryItem.getWhenToUse());
+                            assertEquals(
+                                    "user drinks coffee in the morning while working",
+                                    memoryItem.getContent());
+                            assertEquals(0.048747035796754684, memoryItem.getScore());
+                            assertEquals("2025-12-10 10:30:43", memoryItem.getTimeCreated());
+                            assertEquals("2025-12-10 10:30:43", memoryItem.getTimeModified());
+                            assertEquals("qwen3-30b-a3b-thinking-2507", memoryItem.getAuthor());
+                            assertEquals("user", memoryItem.getTarget());
+                            assertEquals("", memoryItem.getReflectionSubject());
+
+                            // Verify nested metadata
+                            assertNotNull(memoryItem.getMetadata());
+                            assertEquals(
+                                    "coffee, morning, work",
+                                    memoryItem.getMetadata().get("keywords"));
+                            assertEquals("", memoryItem.getMetadata().get("time_info"));
+                            assertEquals(
+                                    "I like to drink coffee while working in the morning",
+                                    memoryItem.getMetadata().get("source_message"));
+                            assertEquals(
+                                    "personal_info_with_time",
+                                    memoryItem.getMetadata().get("observation_type"));
+                            assertEquals("0", memoryItem.getMetadata().get("match_event_flag"));
+                            assertEquals("0", memoryItem.getMetadata().get("match_msg_flag"));
+                        })
+                .verifyComplete();
+
+        client.shutdown();
+    }
+
+    @Test
+    void testRecordWithNullMessages() {
+        ReMeLongTermMemory memory =
+                ReMeLongTermMemory.builder().userId("task_workspace").apiBaseUrl(baseUrl).build();
+
+        StepVerifier.create(memory.record(null)).verifyComplete();
+    }
+
+    @Test
+    void testRecordWithEmptyMessages() {
+        ReMeLongTermMemory memory =
+                ReMeLongTermMemory.builder().userId("task_workspace").apiBaseUrl(baseUrl).build();
+
+        StepVerifier.create(memory.record(new ArrayList<>())).verifyComplete();
+    }
+
+    @Test
+    void testRecordFiltersNullMessages() {
+        mockServer.enqueue(
+                new MockResponse()
+                        .setBody(
+                                "{\"answer\":\"\",\"success\":true,\"metadata\":{\"memory_list\":[],\"deleted_memory_ids\":[],\"update_result\":{\"deleted_count\":0,\"inserted_count\":1}}}")
+                        .setResponseCode(200));
+
+        ReMeLongTermMemory memory =
+                ReMeLongTermMemory.builder().userId("task_workspace").apiBaseUrl(baseUrl).build();
+
+        List<Msg> messages = new ArrayList<>();
+        messages.add(
+                Msg.builder()
+                        .role(MsgRole.USER)
+                        .content(TextBlock.builder().text("Valid message").build())
+                        .build());
+        messages.add(null);
+        messages.add(
+                Msg.builder()
+                        .role(MsgRole.ASSISTANT)
+                        .content(TextBlock.builder().text("Another valid").build())
+                        .build());
+
+        StepVerifier.create(memory.record(messages)).verifyComplete();
+    }
+
+    @Test
+    void testRecordFiltersEmptyContentMessages() {
+        mockServer.enqueue(
+                new MockResponse()
+                        .setBody(
+                                "{\"answer\":\"\",\"success\":true,\"metadata\":{\"memory_list\":[],\"deleted_memory_ids\":[],\"update_result\":{\"deleted_count\":0,\"inserted_count\":1}}}")
+                        .setResponseCode(200));
+
+        ReMeLongTermMemory memory =
+                ReMeLongTermMemory.builder().userId("task_workspace").apiBaseUrl(baseUrl).build();
+
+        List<Msg> messages = new ArrayList<>();
+        messages.add(
+                Msg.builder()
+                        .role(MsgRole.USER)
+                        .content(TextBlock.builder().text("Valid message").build())
+                        .build());
+        messages.add(
+                Msg.builder()
+                        .role(MsgRole.USER)
+                        .content(TextBlock.builder().text("").build())
+                        .build());
+
+        StepVerifier.create(memory.record(messages)).verifyComplete();
+    }
+
+    @Test
+    void testRecordWithOnlyInvalidMessages() {
+        ReMeLongTermMemory memory =
+                ReMeLongTermMemory.builder().userId("task_workspace").apiBaseUrl(baseUrl).build();
+
+        List<Msg> messages = new ArrayList<>();
+        messages.add(null);
+        messages.add(
+                Msg.builder()
+                        .role(MsgRole.USER)
+                        .content(TextBlock.builder().text("").build())
+                        .build());
+
+        // Should complete without making HTTP request
+        StepVerifier.create(memory.record(messages)).verifyComplete();
+    }
+
+    @Test
+    void testRetrieveWithValidQuery() {
+        // Mock response with complete ReMeSearchResponse structure
+        String responseJson =
+                "{\"answer\":\"user drinks coffee in the morning while working\",\"success\":true,"
+                    + "\"metadata\":{\"memory_list\":[{\"workspace_id\":\"task_workspace\","
+                    + "\"memory_id\":\"688e9ef5904e4c8b8d60ef6ffff77c75\",\"memory_type\":\"personal\",\"when_to_use\":\"coffee,"
+                    + " morning, work\",\"content\":\"user drinks coffee in the morning while"
+                    + " working\",\"score\":0.048747035796754684,\"time_created\":\"2025-12-10"
+                    + " 10:30:43\",\"time_modified\":\"2025-12-10 10:30:43\","
+                    + "\"author\":\"qwen3-30b-a3b-thinking-2507\",\"metadata\":{\"keywords\":\"coffee,"
+                    + " morning, work\",\"time_info\":\"\",\"source_message\":\"I like to drink"
+                    + " coffee while working in the"
+                    + " morning\",\"observation_type\":\"personal_info_with_time\","
+                    + "\"match_event_flag\":\"0\",\"match_msg_flag\":\"0\"},\"target\":\"user\","
+                    + "\"reflection_subject\":\"\"}]}}";
+
+        mockServer.enqueue(new MockResponse().setBody(responseJson).setResponseCode(200));
+
+        ReMeLongTermMemory memory =
+                ReMeLongTermMemory.builder().userId("task_workspace").apiBaseUrl(baseUrl).build();
+
+        Msg query =
+                Msg.builder()
+                        .role(MsgRole.USER)
+                        .content(TextBlock.builder().text("What are my work habits?").build())
+                        .build();
+
+        StepVerifier.create(memory.retrieve(query))
+                .assertNext(
+                        result -> {
+                            assertNotNull(result);
+                            // Should use answer field when available
+                            assertEquals("user drinks coffee in the morning while working", result);
+                        })
+                .verifyComplete();
+
+        // Verify response parsing by directly testing ReMeClient
+        ReMeClient client = new ReMeClient(baseUrl);
+        ReMeSearchRequest searchRequest =
+                ReMeSearchRequest.builder()
+                        .workspaceId("task_workspace")
+                        .query("What are my work habits?")
+                        .topK(5)
+                        .build();
+
+        mockServer.enqueue(new MockResponse().setBody(responseJson).setResponseCode(200));
+
+        StepVerifier.create(client.search(searchRequest))
+                .assertNext(
+                        response -> {
+                            // Verify top-level fields
+                            assertNotNull(response);
+                            assertEquals(
+                                    "user drinks coffee in the morning while working",
+                                    response.getAnswer());
+                            assertEquals(true, response.getSuccess());
+                            assertNotNull(response.getMetadata());
+
+                            // Verify metadata
+                            ReMeSearchResponse.Metadata metadata = response.getMetadata();
+                            assertNotNull(metadata.getMemoryList());
+                            assertEquals(1, metadata.getMemoryList().size());
+
+                            // Verify memory_list item
+                            ReMeSearchResponse.MemoryItem memoryItem =
+                                    metadata.getMemoryList().get(0);
+                            assertEquals("task_workspace", memoryItem.getWorkspaceId());
+                            assertEquals(
+                                    "688e9ef5904e4c8b8d60ef6ffff77c75", memoryItem.getMemoryId());
+                            assertEquals("personal", memoryItem.getMemoryType());
+                            assertEquals("coffee, morning, work", memoryItem.getWhenToUse());
+                            assertEquals(
+                                    "user drinks coffee in the morning while working",
+                                    memoryItem.getContent());
+                            assertEquals(0.048747035796754684, memoryItem.getScore());
+                            assertEquals("2025-12-10 10:30:43", memoryItem.getTimeCreated());
+                            assertEquals("2025-12-10 10:30:43", memoryItem.getTimeModified());
+                            assertEquals("qwen3-30b-a3b-thinking-2507", memoryItem.getAuthor());
+                            assertEquals("user", memoryItem.getTarget());
+                            assertEquals("", memoryItem.getReflectionSubject());
+
+                            // Verify nested metadata
+                            assertNotNull(memoryItem.getMetadata());
+                            assertEquals(
+                                    "coffee, morning, work",
+                                    memoryItem.getMetadata().get("keywords"));
+                            assertEquals("", memoryItem.getMetadata().get("time_info"));
+                            assertEquals(
+                                    "I like to drink coffee while working in the morning",
+                                    memoryItem.getMetadata().get("source_message"));
+                            assertEquals(
+                                    "personal_info_with_time",
+                                    memoryItem.getMetadata().get("observation_type"));
+                            assertEquals("0", memoryItem.getMetadata().get("match_event_flag"));
+                            assertEquals("0", memoryItem.getMetadata().get("match_msg_flag"));
+
+                            // Verify backward compatibility - getMemories() method
+                            List<String> memories = response.getMemories();
+                            assertNotNull(memories);
+                            assertEquals(1, memories.size());
+                            assertEquals(
+                                    "user drinks coffee in the morning while working",
+                                    memories.get(0));
+                        })
+                .verifyComplete();
+
+        client.shutdown();
+    }
+
+    @Test
+    void testRetrieveWithAnswerField() {
+        String responseJson =
+                "{\"answer\":\"User prefers coffee in the"
+                        + " morning\",\"success\":true,\"metadata\":{\"memory_list\":[]}}";
+
+        mockServer.enqueue(new MockResponse().setBody(responseJson).setResponseCode(200));
+
+        ReMeLongTermMemory memory =
+                ReMeLongTermMemory.builder().userId("task_workspace").apiBaseUrl(baseUrl).build();
+
+        Msg query =
+                Msg.builder()
+                        .role(MsgRole.USER)
+                        .content(TextBlock.builder().text("What are my preferences?").build())
+                        .build();
+
+        StepVerifier.create(memory.retrieve(query))
+                .assertNext(result -> assertEquals("User prefers coffee in the morning", result))
+                .verifyComplete();
+    }
+
+    @Test
+    void testRetrieveWithMemoryList() {
+        // Response with empty answer but memory_list
+        String responseJson =
+                "{\"answer\":\"\",\"success\":true,\"metadata\":{\"memory_list\":[{\"workspace_id\":\"task_workspace\",\"memory_id\":\"mem1\",\"content\":\"User"
+                    + " prefers dark"
+                    + " mode\",\"score\":0.95},{\"workspace_id\":\"task_workspace\",\"memory_id\":\"mem2\",\"content\":\"User"
+                    + " likes coffee\",\"score\":0.85}]}}";
+
+        mockServer.enqueue(new MockResponse().setBody(responseJson).setResponseCode(200));
+
+        ReMeLongTermMemory memory =
+                ReMeLongTermMemory.builder().userId("task_workspace").apiBaseUrl(baseUrl).build();
+
+        Msg query =
+                Msg.builder()
+                        .role(MsgRole.USER)
+                        .content(TextBlock.builder().text("What are my preferences?").build())
+                        .build();
+
+        StepVerifier.create(memory.retrieve(query))
+                .assertNext(
+                        result -> assertEquals("User prefers dark mode\nUser likes coffee", result))
+                .verifyComplete();
+    }
+
+    @Test
+    void testRetrieveWithNoResults() {
+        String responseJson =
+                "{\"answer\":\"\",\"success\":true,\"metadata\":{\"memory_list\":[]}}";
+
+        mockServer.enqueue(new MockResponse().setBody(responseJson).setResponseCode(200));
+
+        ReMeLongTermMemory memory =
+                ReMeLongTermMemory.builder().userId("task_workspace").apiBaseUrl(baseUrl).build();
+
+        Msg query =
+                Msg.builder()
+                        .role(MsgRole.USER)
+                        .content(TextBlock.builder().text("query").build())
+                        .build();
+
+        StepVerifier.create(memory.retrieve(query))
+                .assertNext(result -> assertEquals("", result))
+                .verifyComplete();
+    }
+
+    @Test
+    void testRetrieveWithNullMessage() {
+        ReMeLongTermMemory memory =
+                ReMeLongTermMemory.builder().userId("task_workspace").apiBaseUrl(baseUrl).build();
+
+        StepVerifier.create(memory.retrieve(null))
+                .assertNext(result -> assertEquals("", result))
+                .verifyComplete();
+    }
+
+    @Test
+    void testRetrieveWithEmptyQuery() {
+        ReMeLongTermMemory memory =
+                ReMeLongTermMemory.builder().userId("task_workspace").apiBaseUrl(baseUrl).build();
+
+        Msg query =
+                Msg.builder()
+                        .role(MsgRole.USER)
+                        .content(TextBlock.builder().text("").build())
+                        .build();
+
+        StepVerifier.create(memory.retrieve(query))
+                .assertNext(result -> assertEquals("", result))
+                .verifyComplete();
+    }
+
+    @Test
+    void testRetrieveWithNullQuery() {
+        ReMeLongTermMemory memory =
+                ReMeLongTermMemory.builder().userId("task_workspace").apiBaseUrl(baseUrl).build();
+
+        Msg query = Msg.builder().role(MsgRole.USER).build();
+
+        StepVerifier.create(memory.retrieve(query))
+                .assertNext(result -> assertEquals("", result))
+                .verifyComplete();
+    }
+
+    @Test
+    void testRetrieveWithHttpError() {
+        mockServer.enqueue(
+                new MockResponse().setBody("{\"error\":\"Not found\"}").setResponseCode(404));
+
+        ReMeLongTermMemory memory =
+                ReMeLongTermMemory.builder().userId("task_workspace").apiBaseUrl(baseUrl).build();
+
+        Msg query =
+                Msg.builder()
+                        .role(MsgRole.USER)
+                        .content(TextBlock.builder().text("query").build())
+                        .build();
+
+        // Should return empty string on error
+        StepVerifier.create(memory.retrieve(query))
+                .assertNext(result -> assertEquals("", result))
+                .verifyComplete();
+    }
+
+    @Test
+    void testRetrieveFiltersNullMemories() {
+        String responseJson =
+                "{\"answer\":\"\",\"success\":true,\"metadata\":{\"memory_list\":[{\"workspace_id\":\"task_workspace\",\"memory_id\":\"mem1\",\"content\":\"Valid"
+                    + " memory\",\"score\":0.95},{\"workspace_id\":\"task_workspace\",\"memory_id\":\"mem2\",\"content\":null,\"score\":0.85},{\"workspace_id\":\"task_workspace\",\"memory_id\":\"mem3\",\"content\":\"Another"
+                    + " valid\",\"score\":0.75}]}}";
+
+        mockServer.enqueue(new MockResponse().setBody(responseJson).setResponseCode(200));
+
+        ReMeLongTermMemory memory =
+                ReMeLongTermMemory.builder().userId("task_workspace").apiBaseUrl(baseUrl).build();
+
+        Msg query =
+                Msg.builder()
+                        .role(MsgRole.USER)
+                        .content(TextBlock.builder().text("query").build())
+                        .build();
+
+        StepVerifier.create(memory.retrieve(query))
+                .assertNext(result -> assertEquals("Valid memory\nAnother valid", result))
+                .verifyComplete();
+    }
+
+    @Test
+    void testRoleMapping() {
+        mockServer.enqueue(
+                new MockResponse()
+                        .setBody(
+                                "{\"answer\":\"\",\"success\":true,\"metadata\":{\"memory_list\":[],\"deleted_memory_ids\":[],\"update_result\":{\"deleted_count\":0,\"inserted_count\":1}}}")
+                        .setResponseCode(200));
+
+        ReMeLongTermMemory memory =
+                ReMeLongTermMemory.builder().userId("task_workspace").apiBaseUrl(baseUrl).build();
+
+        // Test USER role -> "user"
+        List<Msg> messages = new ArrayList<>();
+        messages.add(
+                Msg.builder()
+                        .role(MsgRole.USER)
+                        .content(TextBlock.builder().text("User message").build())
+                        .build());
+
+        // Test ASSISTANT role -> "assistant"
+        messages.add(
+                Msg.builder()
+                        .role(MsgRole.ASSISTANT)
+                        .content(TextBlock.builder().text("Assistant message").build())
+                        .build());
+
+        // Test SYSTEM role -> "user"
+        messages.add(
+                Msg.builder()
+                        .role(MsgRole.SYSTEM)
+                        .content(TextBlock.builder().text("System message").build())
+                        .build());
+
+        // Test TOOL role -> "assistant"
+        messages.add(
+                Msg.builder()
+                        .role(MsgRole.TOOL)
+                        .content(TextBlock.builder().text("Tool message").build())
+                        .build());
+
+        StepVerifier.create(memory.record(messages)).verifyComplete();
+
+        // Verify request body contains correct role mappings
+        okhttp3.mockwebserver.RecordedRequest recordedRequest;
+        try {
+            recordedRequest = mockServer.takeRequest();
+            String requestBody = recordedRequest.getBody().readUtf8();
+            // Should contain "user" role for USER and SYSTEM
+            assertTrue(requestBody.contains("\"role\":\"user\""));
+            // Should contain "assistant" role for ASSISTANT and TOOL
+            assertTrue(requestBody.contains("\"role\":\"assistant\""));
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    @Test
+    void testRecordRequestContainsWorkspaceId() {
+        mockServer.enqueue(
+                new MockResponse()
+                        .setBody(
+                                "{\"answer\":\"\",\"success\":true,\"metadata\":{\"memory_list\":[],\"deleted_memory_ids\":[],\"update_result\":{\"deleted_count\":0,\"inserted_count\":1}}}")
+                        .setResponseCode(200));
+
+        ReMeLongTermMemory memory =
+                ReMeLongTermMemory.builder().userId("test_workspace").apiBaseUrl(baseUrl).build();
+
+        List<Msg> messages = new ArrayList<>();
+        messages.add(
+                Msg.builder()
+                        .role(MsgRole.USER)
+                        .content(TextBlock.builder().text("Test message").build())
+                        .build());
+
+        StepVerifier.create(memory.record(messages)).verifyComplete();
+
+        // Verify request contains workspace_id
+        okhttp3.mockwebserver.RecordedRequest recordedRequest;
+        try {
+            recordedRequest = mockServer.takeRequest();
+            String requestBody = recordedRequest.getBody().readUtf8();
+            assertTrue(requestBody.contains("\"workspace_id\":\"test_workspace\""));
+            assertTrue(requestBody.contains("\"trajectories\""));
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    @Test
+    void testRetrieveRequestContainsWorkspaceId() {
+        String responseJson =
+                "{\"answer\":\"test answer\",\"success\":true,\"metadata\":{\"memory_list\":[]}}";
+
+        mockServer.enqueue(new MockResponse().setBody(responseJson).setResponseCode(200));
+
+        ReMeLongTermMemory memory =
+                ReMeLongTermMemory.builder().userId("test_workspace").apiBaseUrl(baseUrl).build();
+
+        Msg query =
+                Msg.builder()
+                        .role(MsgRole.USER)
+                        .content(TextBlock.builder().text("test query").build())
+                        .build();
+
+        StepVerifier.create(memory.retrieve(query))
+                .assertNext(result -> assertEquals("test answer", result))
+                .verifyComplete();
+
+        // Verify request contains workspace_id and query
+        okhttp3.mockwebserver.RecordedRequest recordedRequest;
+        try {
+            recordedRequest = mockServer.takeRequest();
+            String requestBody = recordedRequest.getBody().readUtf8();
+            assertTrue(requestBody.contains("\"workspace_id\":\"test_workspace\""));
+            assertTrue(requestBody.contains("\"query\":\"test query\""));
+            assertTrue(requestBody.contains("\"top_k\":5"));
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+    }
+}

--- a/agentscope-extensions/pom.xml
+++ b/agentscope-extensions/pom.xml
@@ -40,5 +40,6 @@
         <module>agentscope-extensions-scheduler/agentscope-extensions-scheduler</module>
         <module>agentscope-extensions-scheduler/agentscope-extensions-scheduler-xxl-job</module>
       	<module>agentscope-extensions-autocontext-memory</module>
+        <module>agentscope-extensions-reme</module>
     </modules>
 </project>

--- a/docs/en/task/memory.md
+++ b/docs/en/task/memory.md
@@ -94,3 +94,40 @@ Requires MEM0_API_KEY environment variable
 cd examples
 mvn exec:java -Dexec.mainClass="io.agentscope.examples.Mem0Example"
 ```
+
+### Using ReMe
+
+```java
+import io.agentscope.core.ReActAgent;
+import io.agentscope.core.memory.LongTermMemoryMode;
+import io.agentscope.core.memory.reme.ReMeLongTermMemory;
+
+ReMeLongTermMemory longTermMemory =
+        ReMeLongTermMemory.builder()
+                .userId("example_user")
+                .apiBaseUrl("http://localhost:8002")
+                .build();
+
+ReActAgent agent =
+        ReActAgent.builder()
+                .name("Assistant")
+                .model(
+                        DashScopeChatModel.builder()
+                                .apiKey(dashscopeApiKey)
+                                .modelName("qwen-plus")
+                                .build())
+                .longTermMemory(longTermMemory)
+                .longTermMemoryMode(LongTermMemoryMode.STATIC_CONTROL)
+                .build();
+```
+
+See the complete ReMe example:
+- `examples/advanced/src/main/java/io/agentscope/examples/advanced/ReMeExample.java`
+
+Run the example:
+
+Requires REME_API_BASE_URL environment variable (optional, defaults to `http://localhost:8002`)
+```bash
+cd examples/advanced
+mvn exec:java -Dexec.mainClass="io.agentscope.examples.advanced.ReMeExample"
+```

--- a/docs/zh/task/memory.md
+++ b/docs/zh/task/memory.md
@@ -94,3 +94,40 @@ ReActAgent agent =
 cd examples
 mvn exec:java -Dexec.mainClass="io.agentscope.examples.Mem0Example"
 ```
+
+### 使用 ReMe
+
+```java
+import io.agentscope.core.ReActAgent;
+import io.agentscope.core.memory.LongTermMemoryMode;
+import io.agentscope.core.memory.reme.ReMeLongTermMemory;
+
+ReMeLongTermMemory longTermMemory =
+        ReMeLongTermMemory.builder()
+                .userId("example_user")
+                .apiBaseUrl("http://localhost:8002")
+                .build();
+
+ReActAgent agent =
+        ReActAgent.builder()
+                .name("Assistant")
+                .model(
+                        DashScopeChatModel.builder()
+                                .apiKey(dashscopeApiKey)
+                                .modelName("qwen-plus")
+                                .build())
+                .longTermMemory(longTermMemory)
+                .longTermMemoryMode(LongTermMemoryMode.STATIC_CONTROL)
+                .build();
+```
+
+查看完整的 ReMe 示例：
+- `examples/advanced/src/main/java/io/agentscope/examples/advanced/ReMeExample.java`
+
+运行示例：
+
+需要配置 REME_API_BASE_URL 环境变量（可选，默认为 `http://localhost:8002`）
+```bash
+cd examples/advanced
+mvn exec:java -Dexec.mainClass="io.agentscope.examples.advanced.ReMeExample"
+```


### PR DESCRIPTION
This pull request introduces a new long-term memory backend integration for the AgentScope framework using ReMe, a memory layer for AI applications. The changes add support for ReMe in both the core extensions and the advanced example project, allowing agents to persist and retrieve memories using the ReMe API. The implementation includes a new Maven module, client, and memory classes, as well as an example demonstrating usage.

**ReMe Integration**

* Added a new Maven module `agentscope-extensions-reme` with its own `pom.xml` and dependencies, including OkHttp for HTTP communication.
* Implemented `ReMeClient` for interacting with the ReMe API, supporting memory addition and retrieval via asynchronous HTTP requests.
* Added `ReMeLongTermMemory` class implementing the `LongTermMemory` interface, enabling agents to record and retrieve memories using the ReMe backend, with filtering and conversion logic for messages.

**Project Configuration and Example Usage**

* Updated `pom.xml` files in both `agentscope-examples/advanced` and the root examples directory to include the new `agentscope-extensions-reme` dependency. [[1]](diffhunk://#diff-914386039cef5015f85cd46dc4c2e0141c6795b899ac86399e8fac32e47f7e60R58-R63) [[2]](diffhunk://#diff-8a73bc7a541635ac727c9b12071ae44c8d52d31b6cece4d4cec8be3f9c389ea2L77-R81)
* Added `ReMeExample.java` in the advanced examples to demonstrate how to use the new ReMe long-term memory integration in an agent, including environment setup instructions and a sample interactive loop.## AgentScope-Java Version

[The version of AgentScope-Java you are working on, e.g. 1.0.1, check your pom.xml dependency version or run `mvn dependency:tree | grep agentscope-parent:pom`(only mac/linux)]

## Description

[Please describe the background, purpose, changes made, and how to test this PR]

## Checklist

Please check the following items before code is ready to be reviewed.

- [ ]  Code has been formatted with `mvn spotless:apply`
- [ ]  All tests are passing (`mvn test`)
- [ ]  Javadoc comments are complete and follow project conventions
- [ ]  Related documentation has been updated (e.g. links, examples, etc.)
- [ ]  Code is ready for review
This pull request introduces a new extension module for AgentScope Java that adds support for long-term memory using the ReMe backend. It includes all necessary implementation, configuration, and example usage to integrate ReMe-based memory into AgentScope agents.

Key changes:

**New ReMe Extension Module:**

* Added a new Maven module `agentscope-extensions-reme` with its own `pom.xml`, declaring dependencies on `agentscope-core` and `okhttp` for HTTP communication.
* Implemented core request and response classes for interacting with the ReMe API, including `ReMeAddRequest` and `ReMeAddResponse`, supporting memory addition and response parsing. [[1]](diffhunk://#diff-4c224f39e53b88f6ac6302e3458ca34bdbc49f4ccbde9c5ffa836666d1d311a4R1-R98) [[2]](diffhunk://#diff-3170112fbef8c8f02d2084144d854dc091b093866e01df6868987f43cbe69252R1-R314)

**Integration and Example Usage:**

* Updated the main example projects (`agentscope-examples/pom.xml` and `agentscope-examples/advanced/pom.xml`) to include the new `agentscope-extensions-reme` dependency. [[1]](diffhunk://#diff-8a73bc7a541635ac727c9b12071ae44c8d52d31b6cece4d4cec8be3f9c389ea2L77-R81) [[2]](diffhunk://#diff-914386039cef5015f85cd46dc4c2e0141c6795b899ac86399e8fac32e47f7e60R58-R63)
* Added a new example class `ReMeExample.java` demonstrating how to configure and use ReMe-based long-term memory in an agent, including setup instructions and environment configuration.