### PR TITLE
fix: current round summary

### DIFF
--- a/agentscope-extensions/agentscope-extensions-autocontext-memory/src/main/java/io/agentscope/core/memory/autocontext/AutoContextMemory.java
+++ b/agentscope-extensions/agentscope-extensions-autocontext-memory/src/main/java/io/agentscope/core/memory/autocontext/AutoContextMemory.java
@@ -336,11 +336,8 @@ public class AutoContextMemory extends StateModuleBase implements Memory, Contex
                                             .filter(text -> text != null)
                                             .collect(java.util.stream.Collectors.joining("\n"));
 
-                            if (outputText.length() > 500) {
-                                toolInfo.append("  Result: ")
-                                        .append(outputText.substring(0, 500))
-                                        .append("...\n");
-                            } else {
+                            // Append full result - LLM will intelligently compress it
+                            if (!outputText.isEmpty()) {
                                 toolInfo.append("  Result: ").append(outputText).append("\n");
                             }
                         }


### PR DESCRIPTION
This pull request makes a targeted change to how tool results are appended in the `mergeAndCompressCurrentRoundMessages` method. Instead of truncating long results, the full output is now included, relying on the LLM to compress it as needed.

- Tool result handling:
  * [`AutoContextMemory.java`](diffhunk://#diff-122d812e4a4112a8ba1e8702c54c400ecd624c7e1e717accd6993594347df230L339-R340): Modified the logic in `mergeAndCompressCurrentRoundMessages` to append the full tool result output instead of truncating it to 500 characters. This allows the LLM to perform intelligent compression on the complete result.移除了对输出文本长度的限制，改为在非空情况下直接追加完整结果。

Change-Id: I73268cb06cbe38e5dc656ebd0e46135d0b30a910
Co-developed-by: Aone Copilot <noreply@alibaba-inc.com>

## AgentScope-Java Version

[The version of AgentScope-Java you are working on, e.g. 1.0.1, check your pom.xml dependency version or run `mvn dependency:tree | grep agentscope-parent:pom`(only mac/linux)]

## Description

[Please describe the background, purpose, changes made, and how to test this PR]

## Checklist

Please check the following items before code is ready to be reviewed.

- [ ]  Code has been formatted with `mvn spotless:apply`
- [ ]  All tests are passing (`mvn test`)
- [ ]  Javadoc comments are complete and follow project conventions
- [ ]  Related documentation has been updated (e.g. links, examples, etc.)
- [ ]  Code is ready for review
