### PR TITLE
fix(rag): Missing the dimension parameter for embedding

### DIFF
--- a/agentscope-extensions/agentscope-extensions-rag-simple/src/main/java/io/agentscope/core/embedding/EmbeddingModel.java
+++ b/agentscope-extensions/agentscope-extensions-rag-simple/src/main/java/io/agentscope/core/embedding/EmbeddingModel.java
@@ -57,6 +57,7 @@ public interface EmbeddingModel {
 
     /**
      * Get the dimension of embedding vectors produced by this model.
+     * The default value is 1024 if not specified.
      *
      * @return the dimension of embedding vectors
      */

--- a/agentscope-extensions/agentscope-extensions-rag-simple/src/main/java/io/agentscope/core/embedding/dashscope/DashScopeMultiModalEmbedding.java
+++ b/agentscope-extensions/agentscope-extensions-rag-simple/src/main/java/io/agentscope/core/embedding/dashscope/DashScopeMultiModalEmbedding.java
@@ -30,6 +30,7 @@ import io.agentscope.core.message.ImageBlock;
 import io.agentscope.core.message.TextBlock;
 import io.agentscope.core.model.ExecutionConfig;
 import java.util.List;
+import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import reactor.core.publisher.Mono;
@@ -202,6 +203,7 @@ public class DashScopeMultiModalEmbedding implements EmbeddingModel {
         return MultiModalEmbeddingParam.builder()
                 .apiKey(apiKey)
                 .model(modelName)
+                .parameters(Map.of("dimension", dimensions))
                 .contents(List.of(MultiModalEmbeddingItemText.builder().text(text).build()))
                 .build();
     }
@@ -216,6 +218,7 @@ public class DashScopeMultiModalEmbedding implements EmbeddingModel {
         return MultiModalEmbeddingParam.builder()
                 .apiKey(apiKey)
                 .model(modelName)
+                .parameters(Map.of("dimension", dimensions))
                 .contents(List.of(MultiModalEmbeddingItemImage.builder().image(imageUrl).build()))
                 .build();
     }
@@ -305,7 +308,7 @@ public class DashScopeMultiModalEmbedding implements EmbeddingModel {
     public static class Builder {
         private String apiKey;
         private String modelName;
-        private int dimensions;
+        private int dimensions = 1024;
         private ExecutionConfig defaultExecutionConfig;
         private String baseUrl;
 

--- a/agentscope-extensions/agentscope-extensions-rag-simple/src/main/java/io/agentscope/core/embedding/dashscope/DashScopeTextEmbedding.java
+++ b/agentscope-extensions/agentscope-extensions-rag-simple/src/main/java/io/agentscope/core/embedding/dashscope/DashScopeTextEmbedding.java
@@ -119,6 +119,7 @@ public class DashScopeTextEmbedding implements EmbeddingModel {
                                                 TextEmbeddingParam.builder()
                                                         .apiKey(apiKey)
                                                         .model(modelName)
+                                                        .dimension(dimensions)
                                                         .texts(List.of(text))
                                                         .build();
 
@@ -216,7 +217,7 @@ public class DashScopeTextEmbedding implements EmbeddingModel {
     public static class Builder {
         private String apiKey;
         private String modelName;
-        private int dimensions;
+        private int dimensions = 1024;
         private ExecutionConfig defaultExecutionConfig;
         private String baseUrl;
 


### PR DESCRIPTION
## AgentScope-Java Version

1.0.3-SNAPSHOT

## Description

- Add the dimension parameter for embedding.
- Set the default value of the dimension parameter to 1024 if not specified.

## Checklist

Please check the following items before code is ready to be reviewed.

- [x]  Code has been formatted with `mvn spotless:apply`
- [x]  All tests are passing (`mvn test`)
- [x]  Javadoc comments are complete and follow project conventions
- [x]  Related documentation has been updated (e.g. links, examples, etc.)
- [x]  Code is ready for review
