### PR TITLE
fix(rag): remove needless content validation in QueryHistoryEntry constructor

### DIFF
--- a/agentscope-extensions/agentscope-extensions-rag-bailian/src/main/java/io/agentscope/core/rag/integration/bailian/QueryHistoryEntry.java
+++ b/agentscope-extensions/agentscope-extensions-rag-bailian/src/main/java/io/agentscope/core/rag/integration/bailian/QueryHistoryEntry.java
@@ -36,9 +36,6 @@ public class QueryHistoryEntry {
         if (role == null || (!role.equals("user") && !role.equals("assistant"))) {
             throw new IllegalArgumentException("Role must be 'user' or 'assistant'");
         }
-        if (content == null || content.isEmpty()) {
-            throw new IllegalArgumentException("Content cannot be null or empty");
-        }
         this.role = role;
         this.content = content;
     }

--- a/agentscope-extensions/agentscope-extensions-rag-bailian/src/test/java/io/agentscope/core/rag/integration/bailian/QueryHistoryEntryTest.java
+++ b/agentscope-extensions/agentscope-extensions-rag-bailian/src/test/java/io/agentscope/core/rag/integration/bailian/QueryHistoryEntryTest.java
@@ -16,6 +16,7 @@
 package io.agentscope.core.rag.integration.bailian;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.junit.jupiter.api.Test;
@@ -56,11 +57,15 @@ class QueryHistoryEntryTest {
 
     @Test
     void testNullContent() {
-        assertThrows(IllegalArgumentException.class, () -> new QueryHistoryEntry("user", null));
+        QueryHistoryEntry entry = new QueryHistoryEntry("user", null);
+        assertEquals("user", entry.getRole());
+        assertNull(entry.getContent());
     }
 
     @Test
     void testEmptyContent() {
-        assertThrows(IllegalArgumentException.class, () -> new QueryHistoryEntry("user", ""));
+        QueryHistoryEntry entry = new QueryHistoryEntry("user", "");
+        assertEquals("user", entry.getRole());
+        assertEquals("", entry.getContent());
     }
 }


### PR DESCRIPTION
## AgentScope-Java Version

1.0.4

## Description

When running BailianRAGExample, an error occurs due to unnecessary exception being thrown. The subsequent filter step already filters out empty content - this exception can be safely removed.

## Checklist

Please check the following items before code is ready to be reviewed.

- [x]  Code has been formatted with `mvn spotless:apply`
- [x]  All tests are passing (`mvn test`)
- [x]  Javadoc comments are complete and follow project conventions
- [x]  Related documentation has been updated (e.g. links, examples, etc.)
- [x]  Code is ready for review
