### PR TITLE
fix(core): Missing ToolUseBlock handling after Hooks PostReasoningEvent and PreActingEvent

### DIFF
--- a/agentscope-core/src/main/java/io/agentscope/core/message/Msg.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/message/Msg.java
@@ -399,6 +399,15 @@ public class Msg {
         return usage instanceof ChatUsage ? (ChatUsage) usage : null;
     }
 
+    /**
+     * Returns a builder pre-populated with the current Msg for mutation.
+     */
+    @Transient
+    @JsonIgnore
+    public Builder mutate() {
+        return new Builder(this);
+    }
+
     public static class Builder {
 
         private String id;
@@ -418,6 +427,20 @@ public class Msg {
          */
         public Builder() {
             randomId();
+        }
+
+        /**
+         * Creates a new builder for mutation.
+         *
+         * @param msg The message to mutate
+         */
+        public Builder(Msg msg) {
+            this.id = msg.id;
+            this.name = msg.name;
+            this.role = msg.role;
+            this.content = msg.content;
+            this.metadata = msg.metadata;
+            this.timestamp = msg.timestamp;
         }
 
         /**

--- a/agentscope-core/src/test/java/io/agentscope/core/message/MsgTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/message/MsgTest.java
@@ -19,6 +19,9 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 
@@ -204,5 +207,28 @@ class MsgTest {
         assertEquals("Hello World", msg.getTextContent());
         assertTrue(msg.getFirstContentBlock() instanceof TextBlock);
         assertEquals("Hello World", ((TextBlock) msg.getFirstContentBlock()).getText());
+    }
+
+    @Test
+    void testMutate() {
+        String timestamp =
+                DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSS")
+                        .withZone(ZoneId.systemDefault())
+                        .format(Instant.now());
+        TextBlock textBlock = TextBlock.builder().text("Hello, world!").build();
+        Msg msg =
+                Msg.builder()
+                        .name("user")
+                        .role(MsgRole.USER)
+                        .content(textBlock)
+                        .metadata(Map.of("k", "v"))
+                        .timestamp(timestamp)
+                        .build();
+        Msg mutateMsg = msg.mutate().build();
+        assertEquals(msg.getName(), mutateMsg.getName());
+        assertEquals(msg.getRole(), mutateMsg.getRole());
+        assertEquals(msg.getContent(), mutateMsg.getContent());
+        assertEquals(msg.getMetadata(), mutateMsg.getMetadata());
+        assertEquals(msg.getTimestamp(), mutateMsg.getTimestamp());
     }
 }


### PR DESCRIPTION
## AgentScope-Java Version

1.0.5-SNAPSHOT

## Description

* Fixes: #396 

## Checklist

Please check the following items before code is ready to be reviewed.

- [x]  Code has been formatted with `mvn spotless:apply`
- [x]  All tests are passing (`mvn test`)
- [x]  Javadoc comments are complete and follow project conventions
- [x]  Related documentation has been updated (e.g. links, examples, etc.)
- [ ]  Code is ready for review