### PR TITLE
fix(skill): remove FileSystemSkillRepository empty directory validation

### DIFF
--- a/agentscope-core/src/main/java/io/agentscope/core/skill/repository/FileSystemSkillRepository.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/skill/repository/FileSystemSkillRepository.java
@@ -97,18 +97,6 @@ public class FileSystemSkillRepository implements AgentSkillRepository {
                     "Base directory is not a directory: " + this.baseDir);
         }
 
-        // Validate directory is not empty (must contain at least one subdirectory)
-        try (Stream<Path> entries = Files.list(this.baseDir)) {
-            boolean hasSubdirectory = entries.anyMatch(Files::isDirectory);
-            if (!hasSubdirectory) {
-                throw new IllegalArgumentException(
-                        "Base directory is empty (no skill subdirectories found): " + this.baseDir);
-            }
-        } catch (IOException e) {
-            throw new IllegalArgumentException(
-                    "Failed to validate base directory: " + this.baseDir, e);
-        }
-
         logger.info("FileSystemSkillRepository initialized with base directory: {}", this.baseDir);
     }
 

--- a/agentscope-core/src/test/java/io/agentscope/core/skill/repository/FileSystemSkillRepositoryTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/skill/repository/FileSystemSkillRepositoryTest.java
@@ -103,11 +103,33 @@ class FileSystemSkillRepositoryTest {
     }
 
     @Test
-    @DisplayName("Should throw exception when base directory is empty")
+    @DisplayName("Should not throw exception when base directory is empty")
     void testConstructor_EmptyBaseDir() throws IOException {
         Path emptyDir = tempDir.resolve("empty");
         Files.createDirectories(emptyDir);
-        assertThrows(IllegalArgumentException.class, () -> new FileSystemSkillRepository(emptyDir));
+        FileSystemSkillRepository fileSystemSkillRepository =
+                new FileSystemSkillRepository(emptyDir);
+        assertNotNull(fileSystemSkillRepository);
+    }
+
+    @Test
+    @DisplayName("Should transform relative path to absolute in constructor")
+    void testConstructor_RelativePath() throws IOException {
+        Path relativePath = Path.of("relative-skills");
+        Files.createDirectories(relativePath);
+
+        try {
+            FileSystemSkillRepository fileSystemSkillRepository =
+                    new FileSystemSkillRepository(relativePath);
+            assertNotNull(fileSystemSkillRepository);
+            assertEquals(
+                    relativePath.toAbsolutePath().normalize().toString(),
+                    fileSystemSkillRepository.getRepositoryInfo().getLocation());
+        } finally {
+            if (Files.exists(relativePath)) {
+                Files.delete(relativePath);
+            }
+        }
     }
 
     // ==================== getAllSkillNames Tests ====================


### PR DESCRIPTION
## AgentScope-Java Version

1.0..5-SNAPSHOT

## Description

Remove the non-empty validation for the baseDir in the constructor of FileSystemSkillRepository to ensure that saving skills to an empty folder works properly.

## Checklist

Please check the following items before code is ready to be reviewed.

- [x]  Code has been formatted with `mvn spotless:apply`
- [x]  All tests are passing (`mvn test`)
- [x]  Javadoc comments are complete and follow project conventions
- [x]  Related documentation has been updated (e.g. links, examples, etc.)
- [x]  Code is ready for review
