### PR TITLE
fix(formatter): Fix the OpenAI streaming response chunk type detection logic

### DIFF
--- a/agentscope-core/src/main/java/io/agentscope/core/formatter/openai/dto/OpenAIResponse.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/formatter/openai/dto/OpenAIResponse.java
@@ -180,6 +180,7 @@ public class OpenAIResponse {
      *
      * <p>Detects streaming chunks by:
      * <ol>
+     *   <li>Object type not equals "chat.completion" (Not Streaming)</li>
      *   <li>Object type equals "chat.completion.chunk" (OpenAI standard)</li>
      *   <li>OR presence of delta field without message field (GLM and other OpenAI-compatible APIs)</li>
      * </ol>
@@ -187,6 +188,9 @@ public class OpenAIResponse {
      * @return true if this is a streaming chunk response
      */
     public boolean isChunk() {
+        if ("chat.completion".equals(object)) {
+            return false;
+        }
         return "chat.completion.chunk".equals(object)
                 || (choices != null
                         && choices.stream().anyMatch(choice -> choice.getDelta() != null));


### PR DESCRIPTION
fix(formatter): Fix the OpenAI streaming response chunk type detection logic

## AgentScope-Java Version
1.0.5

## Description
When using the OpenAI API with `stream = false`, the `"object"` field in the response is `"chat.completion"`.

## Checklist

Please check the following items before code is ready to be reviewed.

- [x]  Code has been formatted with `mvn spotless:apply`
- [x]  All tests are passing (`mvn test`)
- [x]  Javadoc comments are complete and follow project conventions
- [x]  Related documentation has been updated (e.g. links, examples, etc.)
- [x]  Code is ready for review
