### PR TITLE
feat: add reasoningEffort field support in OpenAIChatFormatter

### DIFF
--- a/agentscope-core/src/main/java/io/agentscope/core/formatter/openai/OpenAIChatFormatter.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/formatter/openai/OpenAIChatFormatter.java
@@ -73,6 +73,12 @@ public class OpenAIChatFormatter extends OpenAIBaseFormatter {
         if (temperature != null) {
             request.setTemperature(temperature);
         }
+        // Apply reasoning effort
+        String reasoningEffort =
+                getOptionOrDefault(options, defaultOptions, GenerateOptions::getReasoningEffort);
+        if (reasoningEffort != null) {
+            request.setReasoningEffort(reasoningEffort);
+        }
 
         // Apply top_p
         Double topP = getOptionOrDefault(options, defaultOptions, GenerateOptions::getTopP);

--- a/agentscope-core/src/test/java/io/agentscope/core/formatter/openai/OpenAIChatFormatterTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/formatter/openai/OpenAIChatFormatterTest.java
@@ -395,6 +395,46 @@ class OpenAIChatFormatterTest {
         }
 
         @Test
+        @DisplayName("Should apply reasoningEffort from GenerateOptions field")
+        void testApplyReasoningEffortFromField() {
+            OpenAIRequest request = OpenAIRequest.builder().model("o1").messages(List.of()).build();
+
+            GenerateOptions options = GenerateOptions.builder().reasoningEffort("high").build();
+
+            formatter.applyOptions(request, options, null);
+
+            assertEquals("high", request.getReasoningEffort());
+        }
+
+        @Test
+        @DisplayName("Should apply reasoningEffort with default options")
+        void testApplyReasoningEffortWithDefault() {
+            OpenAIRequest request = OpenAIRequest.builder().model("o1").messages(List.of()).build();
+
+            GenerateOptions defaultOptions =
+                    GenerateOptions.builder().reasoningEffort("low").build();
+            GenerateOptions options = GenerateOptions.builder().reasoningEffort("high").build();
+
+            formatter.applyOptions(request, options, defaultOptions);
+
+            // Options should override defaultOptions
+            assertEquals("high", request.getReasoningEffort());
+        }
+
+        @Test
+        @DisplayName("Should apply reasoningEffort from default when options is null")
+        void testApplyReasoningEffortFromDefaultOnly() {
+            OpenAIRequest request = OpenAIRequest.builder().model("o1").messages(List.of()).build();
+
+            GenerateOptions defaultOptions =
+                    GenerateOptions.builder().reasoningEffort("medium").build();
+
+            formatter.applyOptions(request, null, defaultOptions);
+
+            assertEquals("medium", request.getReasoningEffort());
+        }
+
+        @Test
         @DisplayName("Should apply include_reasoning parameter")
         void testApplyIncludeReasoning() {
             OpenAIRequest request =


### PR DESCRIPTION
 ## AgentScope-Java Version

  0.9.0-SNAPSHOT

  ## Description

  ### Background
  Issue #98 requested support for OpenAI's thinking block/reasoning mode. While the response parsing was already implemented, the request building was missing direct handling of the `reasoningEffort` field from `GenerateOptions`.

  ### Changes
  - Added direct `reasoningEffort` parameter handling in `OpenAIChatFormatter.applyOptions()`
  - Added 3 unit tests to verify the new functionality:
    - `testApplyReasoningEffortFromField` - test direct field usage
    - `testApplyReasoningEffortWithDefault` - test with default options
    - `testApplyReasoningEffortFromDefaultOnly` - test default-only scenario

  ### How to Test
  ```bash
  # Run unit tests
  mvn test -Dtest=OpenAIChatFormatterTest

  # Test with real API (requires OPENROUTER_API_KEY)
  curl https://openrouter.ai/api/v1/chat/completions \
    -H "Authorization: Bearer $OPENROUTER_API_KEY" \
    -d '{"model":"openai/o3-mini","reasoning_effort":"low","messages":[{"role":"user","content":"2+2=?"}],"max_tokens":500}'

  Checklist

  - Code has been formatted with mvn spotless:apply
  - All tests are passing (mvn test)
  - Javadoc comments are complete and follow project conventions
  - Related documentation has been updated (e.g. links, examples, etc.)
  - Code is ready for review

  Closes #98
  ```
