### PR TITLE
refactor(tool): Add the missing `@ToolParam` annotations to `RoutingByToolCallsExample`.

### DIFF
--- a/agentscope-examples/advanced/src/main/java/io/agentscope/examples/advanced/RoutingByToolCallsExample.java
+++ b/agentscope-examples/advanced/src/main/java/io/agentscope/examples/advanced/RoutingByToolCallsExample.java
@@ -24,6 +24,7 @@ import io.agentscope.core.message.TextBlock;
 import io.agentscope.core.model.DashScopeChatModel;
 import io.agentscope.core.model.GenerateOptions;
 import io.agentscope.core.tool.Tool;
+import io.agentscope.core.tool.ToolParam;
 import io.agentscope.core.tool.Toolkit;
 import io.agentscope.examples.advanced.util.MsgUtils;
 
@@ -85,7 +86,9 @@ public class RoutingByToolCallsExample {
         @Tool(
                 name = "generate_Python_code",
                 description = "Generate Python code based on the demand")
-        public Msg generatePython(String demand) {
+        public Msg generatePython(
+                @ToolParam(name = "demand", description = "The demand for the Python code")
+                        String demand) {
             System.out.println("I am PythonAgent,now generating Python code for demand: " + demand);
             String apiKey = ExampleUtils.getDashScopeApiKey();
             ReActAgent agent =
@@ -124,7 +127,9 @@ public class RoutingByToolCallsExample {
          * @param demand The demand for the poem.
          */
         @Tool(name = "generate_poem", description = "Generate a poem based on the demand")
-        public Msg generatePoem(String demand) {
+        public Msg generatePoem(
+                @ToolParam(name = "demand", description = "The demand for the poem")
+                        String demand) {
             System.out.println("I am PoemAgent,now generating a poem for demand: " + demand);
             String apiKey = ExampleUtils.getDashScopeApiKey();
             ReActAgent agent =


### PR DESCRIPTION
## AgentScope-Java Version

1.0.7-SNAPSHOT

## Description

Because the tool methods lack the `@ToolParam` annotation, the required parameters are not passed when the tools are invoked.

- Add the `@ToolParam` annotation to the `demand` parameter of the `generatePython` method  
- Add the `@ToolParam` annotation to the `demand` parameter of the `generatePoem` method  
- Clearly specify parameter names and descriptions to improve the metadata accuracy of the tool methods  
- Enhance code readability for easier annotation-driven processing and future extension

## Checklist

Please check the following items before code is ready to be reviewed.

- [x]  Code has been formatted with `mvn spotless:apply`
- [x]  All tests are passing (`mvn test`)
- [x]  Javadoc comments are complete and follow project conventions
- [x]  Related documentation has been updated (e.g. links, examples, etc.)
- [x]  Code is ready for review
