### PR TITLE
fix(examples): prevent duplicate message output by specifying streamOptions

### DIFF
--- a/agentscope-examples/quickstart/src/main/java/io/agentscope/examples/quickstart/ExampleUtils.java
+++ b/agentscope-examples/quickstart/src/main/java/io/agentscope/examples/quickstart/ExampleUtils.java
@@ -16,6 +16,8 @@
 package io.agentscope.examples.quickstart;
 
 import io.agentscope.core.agent.Agent;
+import io.agentscope.core.agent.EventType;
+import io.agentscope.core.agent.StreamOptions;
 import io.agentscope.core.message.ContentBlock;
 import io.agentscope.core.message.Msg;
 import io.agentscope.core.message.MsgRole;
@@ -160,7 +162,14 @@ public class ExampleUtils {
                     AtomicReference<String> lastThinkingContent = new AtomicReference<>("");
                     AtomicReference<String> lastTextContent = new AtomicReference<>("");
 
-                    agent.stream(userMsg)
+                    StreamOptions streamOptions =
+                            StreamOptions.builder()
+                                    .eventTypes(EventType.REASONING, EventType.TOOL_RESULT)
+                                    .incremental(true)
+                                    .includeReasoningResult(false)
+                                    .build();
+
+                    agent.stream(userMsg, streamOptions)
                             .doOnNext(
                                     event -> {
                                         Msg msg = event.getMessage();


### PR DESCRIPTION
## AgentScope-Java Version

1.0.7-SNAPSHOT

## Description

Previously, `ExampleUtils` invoked the Agent `stream` method without specifying `StreamOptions` and`EventType`, which caused all event types to be emitted by default.
This resulted in duplicate message outputs in certain examples, such as `ToolCallingExample`.

For example:
```text
=== Chat Started ===
Type 'exit' to quit

You> 今天是几号
Agent> Text: 我将使用search函数来获取今天的日期，但是请注意，这个功能可能不会直接返回当前的日期。通常我们通过其他方式如系统时间等来获取当天的日期。这里我会尝试搜索 "今天的日期" 以演示如何使用search工具。搜索 "今天的日期" 得到的结果并没有直接提供今天的具体日期，这是因为搜索工具返回的是模拟的搜索结果列表，并不包含实际的日期信息。为了获取当前确切的日期，通常我们会查看设备上的日历或时钟，或者使用能够访问系统时间的功能。

如果您需要知道具体的日期，您可以查看所在设备右下角（或设置区域）显示的日期，或者告诉我您所在的时区，我可以尝试通过其他方式帮助您获取正确的日期。您想要继续吗？如果需要，也请告知您的时区。搜索 "今天的日期" 得到的结果并没有直接提供今天的具体日期，这是因为搜索工具返回的是模拟的搜索结果列表，并不包含实际的日期信息。为了获取当前确切的日期，通常我们会查看设备上的日历或时钟，或者使用能够访问系统时间的功能。

如果您需要知道具体的日期，您可以查看所在设备右下角（或设置区域）显示的日期，或者告诉我您所在的时区，我可以尝试通过其他方式帮助您获取正确的日期。您想要继续吗？如果需要，也请告知您的时区。搜索 "今天的日期" 得到的结果并没有直接提供今天的具体日期，这是因为搜索工具返回的是模拟的搜索结果列表，并不包含实际的日期信息。为了获取当前确切的日期，通常我们会查看设备上的日历或时钟，或者使用能够访问系统时间的功能。

如果您需要知道具体的日期，您可以查看所在设备右下角（或设置区域）显示的日期，或者告诉我您所在的时区，我可以尝试通过其他方式帮助您获取正确的日期。您想要继续吗？如果需要，也请告知您的时区。
```

This PR adds explicit `StreamOptions` configuration to the `stream` call in `ExampleUtils` and restricts the emitted `EventType`s, preventing duplicate message output.

## Checklist

Please check the following items before code is ready to be reviewed.

- [x]  Code has been formatted with `mvn spotless:apply`
- [x]  All tests are passing (`mvn test`)
- [x]  Javadoc comments are complete and follow project conventions
- [x]  Related documentation has been updated (e.g. links, examples, etc.)
- [x]  Code is ready for review
