### PR TITLE
fix(structured-output): preserve ChatUsage after memory compression

### DIFF
--- a/agentscope-core/src/test/java/io/agentscope/core/agent/ReActAgentStructuredOutputTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/agent/ReActAgentStructuredOutputTest.java
@@ -340,4 +340,94 @@ class ReActAgentStructuredOutputTest {
                 memoryMessages.stream().filter(m -> m.getRole() == MsgRole.USER).count(),
                 "Should only have the original user message, no new ones added");
     }
+
+    @Test
+    void testStructuredOutputPreservesChatUsage() {
+        Memory memory = new InMemoryMemory();
+
+        // Create a mock model that returns tool call with ChatUsage
+        Map<String, Object> toolInput =
+                Map.of(
+                        "response",
+                        Map.of(
+                                "location",
+                                "San Francisco",
+                                "temperature",
+                                "72°F",
+                                "condition",
+                                "Sunny"));
+
+        MockModel mockModel =
+                new MockModel(
+                        msgs -> {
+                            boolean hasToolResults =
+                                    msgs.stream().anyMatch(m -> m.getRole() == MsgRole.TOOL);
+
+                            if (!hasToolResults) {
+                                // First call: return tool use with usage
+                                return List.of(
+                                        ChatResponse.builder()
+                                                .id("msg_1")
+                                                .content(
+                                                        List.of(
+                                                                ToolUseBlock.builder()
+                                                                        .id("call_123")
+                                                                        .name("generate_response")
+                                                                        .input(toolInput)
+                                                                        .content(
+                                                                                JsonUtils
+                                                                                        .getJsonCodec()
+                                                                                        .toJson(
+                                                                                                toolInput))
+                                                                        .build()))
+                                                .usage(new ChatUsage(100, 50, 1.5))
+                                                .build());
+                            } else {
+                                return List.of(
+                                        ChatResponse.builder()
+                                                .id("msg_2")
+                                                .content(
+                                                        List.of(
+                                                                TextBlock.builder()
+                                                                        .text("Done")
+                                                                        .build()))
+                                                .usage(new ChatUsage(10, 5, 0.1))
+                                                .build());
+                            }
+                        });
+
+        ReActAgent agent =
+                ReActAgent.builder()
+                        .name("weather-agent")
+                        .sysPrompt("You are a weather assistant")
+                        .model(mockModel)
+                        .toolkit(toolkit)
+                        .memory(memory)
+                        .build();
+
+        Msg inputMsg =
+                Msg.builder()
+                        .name("user")
+                        .role(MsgRole.USER)
+                        .content(
+                                TextBlock.builder()
+                                        .text("What's the weather in San Francisco?")
+                                        .build())
+                        .build();
+
+        Msg responseMsg = agent.call(inputMsg, WeatherResponse.class).block();
+        assertNotNull(responseMsg);
+
+        // Verify structured output
+        WeatherResponse result = responseMsg.getStructuredData(WeatherResponse.class);
+        assertNotNull(result);
+        assertEquals("San Francisco", result.location);
+
+        // Verify ChatUsage is preserved after memory compression
+        ChatUsage usage = responseMsg.getChatUsage();
+        assertNotNull(usage, "ChatUsage should be preserved after structured output compression");
+        assertEquals(100, usage.getInputTokens(), "Input tokens should be preserved");
+        assertEquals(50, usage.getOutputTokens(), "Output tokens should be preserved");
+        assertEquals(1.5, usage.getTime(), 0.01, "Time should be preserved");
+    }
 }


### PR DESCRIPTION
Change-Id: Ic62165dd6126430bef585f140107d5921fa9999a

## AgentScope-Java Version

[The version of AgentScope-Java you are working on, e.g. 1.0.6, check your pom.xml dependency version or run `mvn dependency:tree | grep agentscope-parent:pom`(only mac/linux)]

## Description

[Please describe the background, purpose, changes made, and how to test this PR]

## Checklist

Please check the following items before code is ready to be reviewed.

- [ ]  Code has been formatted with `mvn spotless:apply`
- [ ]  All tests are passing (`mvn test`)
- [ ]  Javadoc comments are complete and follow project conventions
- [ ]  Related documentation has been updated (e.g. links, examples, etc.)
- [ ]  Code is ready for review
