### PR TITLE
feat(stream): add option to filter acting chunks from streaming output

### DIFF
--- a/agentscope-core/src/main/java/io/agentscope/core/agent/StreamOptions.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/agent/StreamOptions.java
@@ -81,6 +81,14 @@ public class StreamOptions {
     private final boolean includeReasoningResult;
 
     /**
+     * Whether to include the incremental chunks from tool execution during streaming.
+     * <p>
+     * If false, intermediate acting chunk emissions should be filtered out by the stream
+     * implementation.
+     */
+    private final boolean includeActingChunk;
+
+    /**
      * Private constructor called by the builder.
      *
      * @param builder The builder containing configuration values
@@ -90,6 +98,7 @@ public class StreamOptions {
         this.incremental = builder.incremental;
         this.includeReasoningChunk = builder.includeReasoningChunk;
         this.includeReasoningResult = builder.includeReasoningResult;
+        this.includeActingChunk = builder.includeActingChunk;
     }
 
     /**
@@ -156,6 +165,17 @@ public class StreamOptions {
     }
 
     /**
+     * Whether acting (tool execution) chunk emissions should be included.
+     *
+     * <p>Acting chunks are the incremental outputs from tool execution via ToolEmitter.</p>
+     *
+     * @return true if acting chunks should be included
+     */
+    public boolean isIncludeActingChunk() {
+        return includeActingChunk;
+    }
+
+    /**
      * Check if a specific event type should be streamed.
      *
      * @param type The event type to check
@@ -186,6 +206,7 @@ public class StreamOptions {
         // Defaults are "true" to preserve existing behavior.
         private boolean includeReasoningChunk = true;
         private boolean includeReasoningResult = true;
+        private boolean includeActingChunk = true;
 
         /**
          * Set which event types to stream.
@@ -243,6 +264,20 @@ public class StreamOptions {
          */
         public Builder includeReasoningResult(boolean includeReasoningResult) {
             this.includeReasoningResult = includeReasoningResult;
+            return this;
+        }
+
+        /**
+         * Include or exclude tool execution chunk emissions.
+         *
+         * <p>When {@link EventType#TOOL_RESULT} is enabled, tools may emit intermediate chunks via
+         * ToolEmitter. Set to false to hide these and only receive the final tool result.</p>
+         *
+         * @param includeActingChunk true to include chunk emissions, false to filter them out
+         * @return this builder
+         */
+        public Builder includeActingChunk(boolean includeActingChunk) {
+            this.includeActingChunk = includeActingChunk;
             return this;
         }
 

--- a/agentscope-core/src/main/java/io/agentscope/core/agent/StreamingHook.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/agent/StreamingHook.java
@@ -90,7 +90,7 @@ class StreamingHook implements Hook {
         } else if (event instanceof ActingChunkEvent) {
             ActingChunkEvent e = (ActingChunkEvent) event;
             // Intermediate tool chunk
-            if (options.shouldStream(EventType.TOOL_RESULT)) {
+            if (options.shouldStream(EventType.TOOL_RESULT) && options.isIncludeActingChunk()) {
                 Msg toolMsg = createToolMessage(e.getChunk());
                 emitEvent(EventType.TOOL_RESULT, toolMsg, false);
             }

--- a/agentscope-core/src/test/java/io/agentscope/core/agent/StreamOptionsTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/agent/StreamOptionsTest.java
@@ -197,4 +197,55 @@ class StreamOptionsTest {
         assertFalse(options.shouldIncludeReasoningEmission(true)); // chunk filtered
         assertFalse(options.shouldIncludeReasoningEmission(false)); // result filtered
     }
+
+    @Test
+    void testActingChunk_DefaultsTrue() {
+        StreamOptions options = StreamOptions.builder().eventTypes(EventType.TOOL_RESULT).build();
+
+        assertTrue(options.isIncludeActingChunk());
+    }
+
+    @Test
+    void testActingChunk_SetToFalse() {
+        StreamOptions options =
+                StreamOptions.builder()
+                        .eventTypes(EventType.TOOL_RESULT)
+                        .includeActingChunk(false)
+                        .build();
+
+        assertFalse(options.isIncludeActingChunk());
+    }
+
+    @Test
+    void testActingChunk_SetToTrue() {
+        StreamOptions options =
+                StreamOptions.builder()
+                        .eventTypes(EventType.TOOL_RESULT)
+                        .includeActingChunk(true)
+                        .build();
+
+        assertTrue(options.isIncludeActingChunk());
+    }
+
+    @Test
+    void testActingChunk_CombinedWithReasoningFlags() {
+        StreamOptions options =
+                StreamOptions.builder()
+                        .eventTypes(EventType.ALL)
+                        .includeReasoningChunk(false)
+                        .includeReasoningResult(true)
+                        .includeActingChunk(false)
+                        .build();
+
+        assertFalse(options.isIncludeReasoningChunk());
+        assertTrue(options.isIncludeReasoningResult());
+        assertFalse(options.isIncludeActingChunk());
+    }
+
+    @Test
+    void testDefaults_IncludesActingChunk() {
+        StreamOptions options = StreamOptions.defaults();
+
+        assertTrue(options.isIncludeActingChunk());
+    }
 }


### PR DESCRIPTION
Change-Id: Ic9f7c11aaee4bfe5975d7c92377146d791b513fa

## AgentScope-Java Version

[The version of AgentScope-Java you are working on, e.g. 1.0.6, check your pom.xml dependency version or run `mvn dependency:tree | grep agentscope-parent:pom`(only mac/linux)]

## Description

[Please describe the background, purpose, changes made, and how to test this PR]

## Checklist

Please check the following items before code is ready to be reviewed.

- [ ]  Code has been formatted with `mvn spotless:apply`
- [ ]  All tests are passing (`mvn test`)
- [ ]  Javadoc comments are complete and follow project conventions
- [ ]  Related documentation has been updated (e.g. links, examples, etc.)
- [ ]  Code is ready for review
