### PR TITLE
fix(a2a): jakarta.servlet.http.HttpServletRequest is not compatible with webflux, use @RequestHeader make spring autoAdjust

### DIFF
--- a/agentscope-extensions/agentscope-spring-boot-starters/agentscope-a2a-spring-boot-starter/src/main/java/io/agentscope/spring/boot/a2a/controller/A2aJsonRpcController.java
+++ b/agentscope-extensions/agentscope-spring-boot-starters/agentscope-a2a-spring-boot-starter/src/main/java/io/agentscope/spring/boot/a2a/controller/A2aJsonRpcController.java
@@ -21,13 +21,17 @@ import io.a2a.spec.TransportProtocol;
 import io.a2a.util.Utils;
 import io.agentscope.core.a2a.server.AgentScopeA2aServer;
 import io.agentscope.core.a2a.server.transport.jsonrpc.JsonRpcTransportWrapper;
-import org.springframework.http.MediaType;
-import org.springframework.http.codec.ServerSentEvent;
-import org.springframework.web.bind.annotation.*;
-import reactor.core.publisher.Flux;
-
 import java.util.Map;
 import java.util.logging.Logger;
+import org.springframework.http.MediaType;
+import org.springframework.http.codec.ServerSentEvent;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.RestController;
+import reactor.core.publisher.Flux;
 
 @RestController
 @RequestMapping("/")
@@ -48,7 +52,8 @@ public class A2aJsonRpcController {
             consumes = MediaType.APPLICATION_JSON_VALUE,
             produces = {MediaType.APPLICATION_JSON_VALUE, MediaType.TEXT_EVENT_STREAM_VALUE})
     @ResponseBody
-    public Object handleRequest(@RequestBody String body, @RequestHeader Map<String, String> header) {
+    public Object handleRequest(
+            @RequestBody String body, @RequestHeader Map<String, String> header) {
         Object result = getJsonRpcHandler().handleRequest(body, header, Map.of());
         if (result instanceof Flux<?> fluxResult) {
             return fluxResult

--- a/agentscope-extensions/agentscope-spring-boot-starters/agentscope-a2a-spring-boot-starter/src/test/java/io/agentscope/spring/boot/a2a/controller/A2aJsonRpcControllerTest.java
+++ b/agentscope-extensions/agentscope-spring-boot-starters/agentscope-a2a-spring-boot-starter/src/test/java/io/agentscope/spring/boot/a2a/controller/A2aJsonRpcControllerTest.java
@@ -29,12 +29,8 @@ import io.a2a.spec.SendStreamingMessageResponse;
 import io.a2a.spec.TransportProtocol;
 import io.agentscope.core.a2a.server.AgentScopeA2aServer;
 import io.agentscope.core.a2a.server.transport.jsonrpc.JsonRpcTransportWrapper;
-import jakarta.servlet.http.HttpServletRequest;
 import java.util.Collections;
-import java.util.Enumeration;
-import java.util.HashMap;
 import java.util.Map;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -143,8 +139,8 @@ class A2aJsonRpcControllerTest {
             String responseBody = "{\"result\": \"success\"}";
 
             // Mock headers
-            Map<String, String> header = Map.of("Content-Type", "application/json",
-                    "Authorization", "Bearer token");
+            Map<String, String> header =
+                    Map.of("Content-Type", "application/json", "Authorization", "Bearer token");
 
             when(jsonRpcTransportWrapper.handleRequest(anyString(), anyMap(), anyMap()))
                     .thenReturn(responseBody);


### PR DESCRIPTION
## AgentScope-Java Version

main branch

## Description

jakarta.servlet.http.HttpServletRequest is not compatible with webflux, use @RequestHeader make spring autoAdjust

## Checklist

Please check the following items before code is ready to be reviewed.

- [x]  Code has been formatted with `mvn spotless:apply`
- [x]  All tests are passing (`mvn test`)
- [x]  Javadoc comments are complete and follow project conventions
- [x]  Related documentation has been updated (e.g. links, examples, etc.)
- [x]  Code is ready for review
