### PR TITLE
chore(dependency): Exclude lombok to compatible with jdk25

### DIFF
--- a/agentscope-core/pom.xml
+++ b/agentscope-core/pom.xml
@@ -100,6 +100,10 @@
                     <artifactId>slf4j-simple</artifactId>
                     <groupId>org.slf4j</groupId>
                 </exclusion>
+                <exclusion>
+                    <artifactId>lombok</artifactId>
+                    <groupId>org.projectlombok</groupId>
+                </exclusion>
             </exclusions>
         </dependency>
 

--- a/agentscope-extensions/agentscope-extensions-rag-simple/pom.xml
+++ b/agentscope-extensions/agentscope-extensions-rag-simple/pom.xml
@@ -45,6 +45,10 @@
                     <artifactId>slf4j-simple</artifactId>
                     <groupId>org.slf4j</groupId>
                 </exclusion>
+                <exclusion>
+                    <artifactId>lombok</artifactId>
+                    <groupId>org.projectlombok</groupId>
+                </exclusion>
             </exclusions>
         </dependency>
 


### PR DESCRIPTION
## AgentScope-Java Version

1.0.8

## Description

* Exclude lombok to compatible with jdk25.
* When use the low level lombok and jdk25 will cause the error as the follow, btw, lombok should not be passed on. 
```java
java: java.lang.ExceptionInInitializerError
com.sun.tools.javac.code.TypeTag :: UNKNOWN
java: java.lang.ExceptionInInitializerError
```

## Checklist

Please check the following items before code is ready to be reviewed.

- [x]  Code has been formatted with `mvn spotless:apply`
- [x]  All tests are passing (`mvn test`)
- [x]  Javadoc comments are complete and follow project conventions
- [x]  Related documentation has been updated (e.g. links, examples, etc.)
- [x]  Code is ready for review
