### PR TITLE
fix: make the maxSubtasks parameter of PlanNotebook effective 

### DIFF
--- a/agentscope-core/src/main/java/io/agentscope/core/plan/PlanNotebook.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/plan/PlanNotebook.java
@@ -951,7 +951,7 @@ public class PlanNotebook implements StateModule {
      *     applicable
      */
     public Mono<Msg> getCurrentHint() {
-        String hintContent = planToHint.generateHint(currentPlan, needUserConfirm);
+        String hintContent = planToHint.generateHint(currentPlan, this);
         if (hintContent != null && !hintContent.isEmpty()) {
             return Mono.just(
                     Msg.builder()
@@ -979,6 +979,15 @@ public class PlanNotebook implements StateModule {
      */
     public boolean isNeedUserConfirm() {
         return needUserConfirm;
+    }
+
+    /**
+     * Gets the maximum number of subtasks allowed per plan.
+     *
+     * @return maximum number of subtasks
+     */
+    public Integer getMaxSubtasks() {
+        return maxSubtasks;
     }
 
     private Mono<Void> triggerPlanChangeHooks() {

--- a/agentscope-core/src/main/java/io/agentscope/core/plan/hint/PlanToHint.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/plan/hint/PlanToHint.java
@@ -15,6 +15,7 @@
  */
 package io.agentscope.core.plan.hint;
 
+import io.agentscope.core.plan.PlanNotebook;
 import io.agentscope.core.plan.model.Plan;
 
 /**
@@ -32,15 +33,15 @@ public interface PlanToHint {
      * @return The generated hint message, or null if no hint is applicable
      */
     default String generateHint(Plan plan) {
-        return generateHint(plan, true);
+        return generateHint(plan, PlanNotebook.builder().needUserConfirm(true).build());
     }
 
     /**
-     * Generate a hint message based on the current plan state with confirmation control.
+     * Generate a hint message based on the current plan state with planNoteBook control.
      *
      * @param plan The current plan (can be null if no plan exists)
-     * @param needUserConfirm Whether to include the "wait for user confirmation" rule in hints
+     * @param planNotebook related planNoteBook configuration
      * @return The generated hint message, or null if no hint is applicable
      */
-    String generateHint(Plan plan, boolean needUserConfirm);
+    String generateHint(Plan plan, PlanNotebook planNotebook);
 }

--- a/agentscope-core/src/test/java/io/agentscope/core/plan/hint/DefaultPlanToHintTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/plan/hint/DefaultPlanToHintTest.java
@@ -20,6 +20,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import io.agentscope.core.plan.PlanNotebook;
 import io.agentscope.core.plan.model.Plan;
 import io.agentscope.core.plan.model.SubTask;
 import io.agentscope.core.plan.model.SubTaskState;
@@ -244,7 +245,9 @@ class DefaultPlanToHintTest {
 
     @Test
     void testNoPlanHint_WithUserConfirmation() {
-        String hint = hintGenerator.generateHint(null, true);
+        String hint =
+                hintGenerator.generateHint(
+                        null, PlanNotebook.builder().needUserConfirm(true).build());
 
         assertNotNull(hint);
         assertTrue(hint.startsWith("<system-hint>"));
@@ -254,7 +257,9 @@ class DefaultPlanToHintTest {
 
     @Test
     void testNoPlanHint_WithoutUserConfirmation() {
-        String hint = hintGenerator.generateHint(null, false);
+        String hint =
+                hintGenerator.generateHint(
+                        null, PlanNotebook.builder().needUserConfirm(false).build());
 
         assertNotNull(hint);
         assertTrue(hint.startsWith("<system-hint>"));
@@ -265,10 +270,23 @@ class DefaultPlanToHintTest {
     }
 
     @Test
+    void testNoPlanHint_WithMaxSubtasks() {
+        String hint =
+                hintGenerator.generateHint(null, PlanNotebook.builder().maxSubtasks(5).build());
+
+        assertNotNull(hint);
+        assertTrue(hint.startsWith("<system-hint>"));
+        assertTrue(hint.endsWith("</system-hint>"));
+        assertTrue(hint.contains("Subtask Limit"));
+    }
+
+    @Test
     void testDefaultMethodDelegatesToOverload() {
         // Test that the default method generateHint(plan) calls generateHint(plan, true)
         String hintDefault = hintGenerator.generateHint(null);
-        String hintWithConfirm = hintGenerator.generateHint(null, true);
+        String hintWithConfirm =
+                hintGenerator.generateHint(
+                        null, PlanNotebook.builder().needUserConfirm(true).build());
 
         assertEquals(hintDefault, hintWithConfirm);
     }
@@ -281,7 +299,9 @@ class DefaultPlanToHintTest {
                                 createSubTask("Task1", SubTaskState.TODO),
                                 createSubTask("Task2", SubTaskState.TODO)));
 
-        String hint = hintGenerator.generateHint(plan, true);
+        String hint =
+                hintGenerator.generateHint(
+                        plan, PlanNotebook.builder().needUserConfirm(true).build());
 
         assertNotNull(hint);
         assertTrue(hint.contains("The current plan"));
@@ -298,7 +318,9 @@ class DefaultPlanToHintTest {
                                 createSubTask("Task1", SubTaskState.TODO),
                                 createSubTask("Task2", SubTaskState.TODO)));
 
-        String hint = hintGenerator.generateHint(plan, false);
+        String hint =
+                hintGenerator.generateHint(
+                        plan, PlanNotebook.builder().needUserConfirm(false).build());
 
         assertNotNull(hint);
         assertTrue(hint.contains("Mark the first subtask as 'in_progress'"));
@@ -312,7 +334,9 @@ class DefaultPlanToHintTest {
         SubTask task2 = createSubTask("Task2", SubTaskState.TODO);
         Plan plan = createPlan(List.of(task1, task2));
 
-        String hint = hintGenerator.generateHint(plan, true);
+        String hint =
+                hintGenerator.generateHint(
+                        plan, PlanNotebook.builder().needUserConfirm(true).build());
 
         assertNotNull(hint);
         assertTrue(hint.contains("Now the subtask at index 0"));
@@ -327,7 +351,9 @@ class DefaultPlanToHintTest {
         SubTask task2 = createSubTask("Task2", SubTaskState.TODO);
         Plan plan = createPlan(List.of(task1, task2));
 
-        String hint = hintGenerator.generateHint(plan, false);
+        String hint =
+                hintGenerator.generateHint(
+                        plan, PlanNotebook.builder().needUserConfirm(false).build());
 
         assertNotNull(hint);
         assertTrue(hint.contains("Now the subtask at index 0"));
@@ -340,7 +366,9 @@ class DefaultPlanToHintTest {
         SubTask task2 = createSubTask("Task2", SubTaskState.TODO);
         Plan plan = createPlan(List.of(task1, task2));
 
-        String hint = hintGenerator.generateHint(plan, true);
+        String hint =
+                hintGenerator.generateHint(
+                        plan, PlanNotebook.builder().needUserConfirm(true).build());
 
         assertNotNull(hint);
         assertTrue(hint.contains("The first 1 subtasks are done"));
@@ -356,7 +384,9 @@ class DefaultPlanToHintTest {
                                 createSubTask("Task1", SubTaskState.DONE),
                                 createSubTask("Task2", SubTaskState.DONE)));
 
-        String hint = hintGenerator.generateHint(plan, true);
+        String hint =
+                hintGenerator.generateHint(
+                        plan, PlanNotebook.builder().needUserConfirm(true).build());
 
         assertNotNull(hint);
         assertTrue(hint.contains("All the subtasks are done"));
@@ -373,7 +403,9 @@ class DefaultPlanToHintTest {
                                 createSubTask("Task1", SubTaskState.DONE),
                                 createSubTask("Task2", SubTaskState.DONE)));
 
-        String hint = hintGenerator.generateHint(plan, false);
+        String hint =
+                hintGenerator.generateHint(
+                        plan, PlanNotebook.builder().needUserConfirm(false).build());
 
         assertNotNull(hint);
         assertTrue(hint.contains("All the subtasks are done"));


### PR DESCRIPTION
## AgentScope-Java Version

[The version of AgentScope-Java you are working on, e.g. 1.0.7, check your pom.xml dependency version or run `mvn dependency:tree | grep agentscope-parent:pom`(only mac/linux)]

## Description

make the maxSubtasks parameter of PlanNotebook effective.

## Checklist

Please check the following items before code is ready to be reviewed.

- [ ]  Code has been formatted with `mvn spotless:apply`
- [ ]  All tests are passing (`mvn test`)
- [ ]  Javadoc comments are complete and follow project conventions
- [ ]  Related documentation has been updated (e.g. links, examples, etc.)
- [ ]  Code is ready for review
