### PR TITLE
fix(Tool): use mergeSequential to preserve tool call order in paralle…

### DIFF
--- a/agentscope-core/src/main/java/io/agentscope/core/tool/ToolExecutor.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/tool/ToolExecutor.java
@@ -249,7 +249,7 @@ class ToolExecutor {
 
         // Parallel or sequential execution
         if (parallel) {
-            return Flux.merge(monos).collectList();
+            return Flux.mergeSequential(monos).collectList();
         }
         return Flux.concat(monos).collectList();
     }


### PR DESCRIPTION
## AgentScope-Java Version
1.0.7

## Description

The current implementation of parallel tool execution uses `Flux.merge(monos)`. While `Flux.merge` executes tasks concurrently, it emits results as soon as they complete, without preserving the source order.

This creates a critical bug in `ReActAgent.java` (or the relevant calling logic), where tool calls and results are paired by index:
```
// Logic assuming strict ordering
IntStream.range(0, toolCalls.size())
    .mapToObj(i -> Map.entry(toolCalls.get(i), results.get(i)))
    .toList()
```

Impact: If a later tool finishes before an earlier tool, the results become misaligned with the original `toolCalls` list, causing the agent to process the wrong result for a given action.

Changes Made
Replaced `Flux.merge(monos)` with `Flux.mergeSequential(monos)`.

```
// Before: Unordered (Race condition risk)
return Flux.merge(monos).collectList();

// After: Ordered + Parallel
return Flux.mergeSequential(monos).collectList();
```

## Checklist

Please check the following items before code is ready to be reviewed.

- [ ]  Code has been formatted with `mvn spotless:apply`
- [ ]  All tests are passing (`mvn test`)
- [ ]  Javadoc comments are complete and follow project conventions
- [ ]  Related documentation has been updated (e.g. links, examples, etc.)
- [ ]  Code is ready for review
