### PR TITLE
fix(ToolMethodInvoker): Re-throw ToolSuspendException

### DIFF
--- a/agentscope-core/src/main/java/io/agentscope/core/tool/ToolMethodInvoker.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/tool/ToolMethodInvoker.java
@@ -336,11 +336,25 @@ class ToolMethodInvoker {
     /**
      * Handle invocation errors with informative messages.
      *
+     * <p>Special handling for {@link ToolSuspendException}: if found in the exception chain,
+     * it will be re-thrown to allow proper suspension handling by {@link ToolExecutor}.
+     *
      * @param e the exception
      * @return ToolResultBlock with error message
+     * @throws ToolSuspendException if found in the exception chain
      */
     private ToolResultBlock handleInvocationError(Exception e) {
+        // Check if the exception itself is ToolSuspendException
+        if (e instanceof ToolSuspendException) {
+            throw (ToolSuspendException) e;
+        }
+
         Throwable cause = e.getCause();
+        // Check for ToolSuspendException in the exception chain
+        if (cause instanceof ToolSuspendException) {
+            throw (ToolSuspendException) cause;
+        }
+
         String errorMsg =
                 cause != null
                         ? ExceptionUtils.getErrorMessage(cause)


### PR DESCRIPTION
## AgentScope-Java Version

[The version of AgentScope-Java you are working on, e.g. 1.0.8, check your pom.xml dependency version or run `mvn dependency:tree | grep agentscope-parent:pom`(only mac/linux)]

Related Issues
Ref [#717](https://github.com/agentscope-ai/agentscope-java/issues/717)

## Description
Modify `handleInvocationError` to re-throw `ToolSuspendException`

## Checklist

Please check the following items before code is ready to be reviewed.

- [x]  Code has been formatted with `mvn spotless:apply`
- [x]  All tests are passing (`mvn test`)
- [x]  Javadoc comments are complete and follow project conventions
- [x]  Related documentation has been updated (e.g. links, examples, etc.)
- [x]  Code is ready for review