### PR TITLE
fix(model): auto-generate ChatResponse.id when LLM doesn't provide it

### DIFF
--- a/agentscope-core/src/main/java/io/agentscope/core/model/ChatResponse.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/model/ChatResponse.java
@@ -18,6 +18,7 @@ package io.agentscope.core.model;
 import io.agentscope.core.message.ContentBlock;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 
 /**
  * Represents a chat completion response from a language model.
@@ -176,11 +177,20 @@ public class ChatResponse {
 
         /**
          * Builds a new ChatResponse instance with the set values.
+         * <p>
+         * If no id was set (or is empty/blank), a random UUID will be generated
+         * automatically. This ensures compatibility with LLM providers (like Ollama)
+         * that don't return an id field in their API responses.
          *
          * @return a new ChatResponse instance
          */
         public ChatResponse build() {
-            return new ChatResponse(id, content, usage, metadata, finishReason);
+            // Auto-generate id if not set, empty, or blank (for providers like Ollama)
+            String responseId = this.id;
+            if (responseId == null || responseId.trim().isEmpty()) {
+                responseId = UUID.randomUUID().toString();
+            }
+            return new ChatResponse(responseId, content, usage, metadata, finishReason);
         }
     }
 }

--- a/agentscope-core/src/test/java/io/agentscope/core/formatter/anthropic/AnthropicResponseParserTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/formatter/anthropic/AnthropicResponseParserTest.java
@@ -16,6 +16,7 @@
 package io.agentscope.core.formatter.anthropic;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -324,7 +325,8 @@ class AnthropicResponseParserTest extends AnthropicFormatterTestBase {
         ChatResponse response = invokeParseStreamEvent(event, startTime);
 
         assertNotNull(response);
-        assertNull(response.getId());
+        assertNotNull(response.getId()); // Builder auto-generates UUID when id is null
+        assertFalse(response.getId().isEmpty());
         assertTrue(response.getContent().isEmpty());
         assertNull(response.getUsage());
     }


### PR DESCRIPTION
AgentScope-Java Version                                                      
                                                                               
  1.0.9-SNAPSHOT                                                               
                                                                               
  Description                                                                  
                                                                               
  This PR fixes Issue #708 where OllamaChatModel fails with the AGUI protocol  
  due to missing id field in Ollama API responses.                             
                                                                               
  Problem                                                                      
                                                                               
  Ollama API doesn't return an id field in its chat completion responses,      
  unlike other LLM providers (OpenAI, Anthropic, DashScope). This causes the   
  AGUI protocol and other components that depend on ChatResponse.getId() to    
  fail with NullPointerException: "messageId cannot be null".                  
                                                                               
  Root Cause Chain:                                                            
  Ollama API → no id field                                                     
      ↓                                                                        
  OllamaResponseParser → ChatResponse.id = null                                
      ↓                                                                        
  Msg.id = null                                                                
      ↓                                                                        
  Event.getMessage().getId() = null                                            
      ↓                                                                        
  AguiEvent.TextMessageStart → NullPointerException                            
                                                                               
  Solution                                                                     
                                                                               
  Modified ChatResponse.Builder.build() to automatically generate a UUID when  
  id is null or empty. This provides a unified solution that:                  
                                                                               
  1. Fixes the Ollama issue - Ollama responses now get auto-generated IDs      
  2. Benefits all parsers - Any future provider without an id field is handled 
  automatically                                                                
  3. Maintains backward compatibility - Providers that return an id keep their 
  original value                                                               
  4. Follows single responsibility principle - The Builder ensures valid object
   state                                                                       
                                                                               
  Changes                                                                      
                                                                               
  Modified Files:                                                              
  - ChatResponse.java - Modified build() method to auto-generate UUID when id  
  is null or empty                                                             
  - AnthropicResponseParserTest.java - Updated test assertion to verify        
  auto-generated IDs                                                           
                                                                               
  Code Change:                                                                 
  public ChatResponse build() {                                                
      // Auto-generate id if not set or empty (for providers like Ollama)      
      String responseId = this.id;                                             
      if (responseId == null || responseId.isEmpty()) {                        
          responseId = UUID.randomUUID().toString();                           
      }                                                                        
      return new ChatResponse(responseId, content, usage, metadata,            
  finishReason);                                                               
  }                                                                            
                                                                               
  Testing                                                                      
                                                                               
  Manual Testing:                                                              
  - Created reproduction test using OllamaChatModel with AGUI protocol         
  - Verified that all events now contain valid messageId values                
  - Tested with Ollama model qwen2.5:0.5b running locally                      
                                                                               
  Automated Testing:                                                           
  - All existing tests pass (3289 tests, 0 failures, 118 skipped)              
  - Updated AnthropicResponseParserTest to reflect new behavior                
                                                                               
  Checklist                                                                    
                                                                               
  - Code has been formatted with mvn spotless:apply                            
  - All tests are passing (mvn test)                                           
  - Javadoc comments are complete and follow project conventions               
  - Related documentation has been updated (e.g. links, examples, etc.)        
  - Code is ready for review   