### PR TITLE
fix(AgentBase): Optimize AgentBase's lock management to resolve concurrency conflicts.

### DIFF
--- a/agentscope-core/src/main/java/io/agentscope/core/agent/AgentBase.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/agent/AgentBase.java
@@ -160,24 +160,29 @@ public abstract class AgentBase implements StateModule, Agent {
      */
     @Override
     public final Mono<Msg> call(List<Msg> msgs) {
-        if (!running.compareAndSet(false, true) && checkRunning) {
-            return Mono.error(
-                    new IllegalStateException(
-                            "Agent is still running, please wait for it to finish"));
-        }
-        resetInterruptFlag();
-
-        return TracerRegistry.get()
-                .callAgent(
-                        this,
-                        msgs,
-                        () ->
-                                notifyPreCall(msgs)
-                                        .flatMap(this::doCall)
-                                        .flatMap(this::notifyPostCall)
-                                        .onErrorResume(
-                                                createErrorHandler(msgs.toArray(new Msg[0]))))
-                .doFinally(signalType -> running.set(false));
+        return Mono.using(
+                () -> {
+                    if (checkRunning && !running.compareAndSet(false, true)) {
+                        throw new IllegalStateException(
+                                "Agent is still running, please wait for it to finish");
+                    }
+                    resetInterruptFlag();
+                    return this;
+                },
+                resource ->
+                        TracerRegistry.get()
+                                .callAgent(
+                                        this,
+                                        msgs,
+                                        () ->
+                                                notifyPreCall(msgs)
+                                                        .flatMap(this::doCall)
+                                                        .flatMap(this::notifyPostCall)
+                                                        .onErrorResume(
+                                                                createErrorHandler(
+                                                                        msgs.toArray(new Msg[0])))),
+                resource -> running.set(false),
+                true);
     }
 
     /**
@@ -191,24 +196,33 @@ public abstract class AgentBase implements StateModule, Agent {
      */
     @Override
     public final Mono<Msg> call(List<Msg> msgs, Class<?> structuredOutputClass) {
-        if (!running.compareAndSet(false, true) && checkRunning) {
-            return Mono.error(
-                    new IllegalStateException(
-                            "Agent is still running, please wait for it to finish"));
-        }
-        resetInterruptFlag();
-
-        return TracerRegistry.get()
-                .callAgent(
-                        this,
-                        msgs,
-                        () ->
-                                notifyPreCall(msgs)
-                                        .flatMap(m -> doCall(m, structuredOutputClass))
-                                        .flatMap(this::notifyPostCall)
-                                        .onErrorResume(
-                                                createErrorHandler(msgs.toArray(new Msg[0]))))
-                .doFinally(signalType -> running.set(false));
+        return Mono.using(
+                () -> {
+                    if (checkRunning && !running.compareAndSet(false, true)) {
+                        throw new IllegalStateException(
+                                "Agent is still running, please wait for it to finish");
+                    }
+                    resetInterruptFlag();
+                    return this;
+                },
+                resource ->
+                        TracerRegistry.get()
+                                .callAgent(
+                                        this,
+                                        msgs,
+                                        () ->
+                                                notifyPreCall(msgs)
+                                                        .flatMap(
+                                                                m ->
+                                                                        doCall(
+                                                                                m,
+                                                                                structuredOutputClass))
+                                                        .flatMap(this::notifyPostCall)
+                                                        .onErrorResume(
+                                                                createErrorHandler(
+                                                                        msgs.toArray(new Msg[0])))),
+                resource -> running.set(false),
+                true);
     }
 
     /**
@@ -222,24 +236,29 @@ public abstract class AgentBase implements StateModule, Agent {
      */
     @Override
     public final Mono<Msg> call(List<Msg> msgs, JsonNode schema) {
-        if (!running.compareAndSet(false, true) && checkRunning) {
-            return Mono.error(
-                    new IllegalStateException(
-                            "Agent is still running, please wait for it to finish"));
-        }
-        resetInterruptFlag();
-
-        return TracerRegistry.get()
-                .callAgent(
-                        this,
-                        msgs,
-                        () ->
-                                notifyPreCall(msgs)
-                                        .flatMap(m -> doCall(m, schema))
-                                        .flatMap(this::notifyPostCall)
-                                        .onErrorResume(
-                                                createErrorHandler(msgs.toArray(new Msg[0]))))
-                .doFinally(signalType -> running.set(false));
+        return Mono.using(
+                () -> {
+                    if (checkRunning && !running.compareAndSet(false, true)) {
+                        throw new IllegalStateException(
+                                "Agent is still running, please wait for it to finish");
+                    }
+                    resetInterruptFlag();
+                    return this;
+                },
+                resource ->
+                        TracerRegistry.get()
+                                .callAgent(
+                                        this,
+                                        msgs,
+                                        () ->
+                                                notifyPreCall(msgs)
+                                                        .flatMap(m -> doCall(m, schema))
+                                                        .flatMap(this::notifyPostCall)
+                                                        .onErrorResume(
+                                                                createErrorHandler(
+                                                                        msgs.toArray(new Msg[0])))),
+                resource -> running.set(false),
+                true);
     }
 
     /**

--- a/agentscope-core/src/test/java/io/agentscope/core/agent/ReActAgentStructuredOutputTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/agent/ReActAgentStructuredOutputTest.java
@@ -21,6 +21,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import io.agentscope.core.ReActAgent;
 import io.agentscope.core.agent.test.MockModel;
+import io.agentscope.core.agent.test.TestConstants;
 import io.agentscope.core.memory.InMemoryMemory;
 import io.agentscope.core.memory.Memory;
 import io.agentscope.core.message.Msg;
@@ -32,10 +33,12 @@ import io.agentscope.core.model.ChatResponse;
 import io.agentscope.core.model.ChatUsage;
 import io.agentscope.core.tool.Toolkit;
 import io.agentscope.core.util.JsonUtils;
+import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import reactor.core.scheduler.Schedulers;
 
 class ReActAgentStructuredOutputTest {
 
@@ -529,5 +532,94 @@ class ReActAgentStructuredOutputTest {
                 "Let me analyze the weather data for San Francisco...",
                 thinking.getThinking(),
                 "Thinking content should be preserved");
+    }
+
+    @Test
+    void testConcurrencyConflictStructuredOutput() {
+        Memory memory = new InMemoryMemory();
+        Map<String, Object> toolInput =
+                Map.of(
+                        "response",
+                        Map.of(
+                                "location", "San Francisco",
+                                "temperature", "72°F",
+                                "condition", "Sunny"));
+
+        MockModel mockModel =
+                new MockModel(
+                        msgs -> {
+                            boolean hasToolResults =
+                                    msgs.stream().anyMatch(m -> m.getRole() == MsgRole.TOOL);
+                            if (!hasToolResults) {
+                                return List.of(
+                                        ChatResponse.builder()
+                                                .id("msg_1")
+                                                .content(
+                                                        List.of(
+                                                                ToolUseBlock.builder()
+                                                                        .id("call_123")
+                                                                        .name("generate_response")
+                                                                        .input(toolInput)
+                                                                        .content(
+                                                                                JsonUtils
+                                                                                        .getJsonCodec()
+                                                                                        .toJson(
+                                                                                                toolInput))
+                                                                        .build()))
+                                                .usage(new ChatUsage(10, 20, 30))
+                                                .build());
+                            } else {
+                                return List.of(
+                                        ChatResponse.builder()
+                                                .id("msg_2")
+                                                .content(
+                                                        List.of(
+                                                                TextBlock.builder()
+                                                                        .text("Done")
+                                                                        .build()))
+                                                .usage(new ChatUsage(5, 10, 15))
+                                                .build());
+                            }
+                        });
+
+        ReActAgent agent =
+                ReActAgent.builder()
+                        .name("weather-agent")
+                        .sysPrompt("You are a weather assistant")
+                        .model(mockModel)
+                        .toolkit(toolkit)
+                        .memory(memory)
+                        .build();
+
+        Msg inputMsg =
+                Msg.builder()
+                        .name("user")
+                        .role(MsgRole.USER)
+                        .content(
+                                TextBlock.builder()
+                                        .text("What's the weather in San Francisco?")
+                                        .build())
+                        .build();
+
+        Msg responseMsg =
+                agent.call(inputMsg, WeatherResponse.class)
+                        .subscribeOn(Schedulers.boundedElastic())
+                        .block(Duration.ofMillis(TestConstants.DEFAULT_TEST_TIMEOUT_MS));
+
+        Msg response2 =
+                agent.call(inputMsg, WeatherResponse.class)
+                        .block(Duration.ofMillis(TestConstants.DEFAULT_TEST_TIMEOUT_MS));
+
+        assertNotNull(responseMsg);
+        WeatherResponse result = responseMsg.getStructuredData(WeatherResponse.class);
+        assertNotNull(result);
+        assertEquals("San Francisco", result.location);
+        assertEquals("72°F", result.temperature);
+        assertEquals("Sunny", result.condition);
+
+        assertNotNull(response2);
+        // no IllegalStateException throw
+        WeatherResponse result2 = response2.getStructuredData(WeatherResponse.class);
+        assertNotNull(result2);
     }
 }


### PR DESCRIPTION
## AgentScope-Java Version

[The version of AgentScope-Java you are working on, e.g. 1.0.8, check your pom.xml dependency version or run `mvn dependency:tree | grep agentscope-parent:pom`(only mac/linux)]

## Description
Ref Issue #732 

Replace the doFinally structure with Mono.using and set the eager parameter to true. This ensures that the state bit is forcibly reset before the onComplete or onError signals reach the downstream subscriber, thereby eliminating the race condition.

## Checklist

Please check the following items before code is ready to be reviewed.

- [x]  Code has been formatted with `mvn spotless:apply`
- [x]  All tests are passing (`mvn test`)
- [x]  Javadoc comments are complete and follow project conventions
- [x]  Related documentation has been updated (e.g. links, examples, etc.)
- [x]  Code is ready for review
