### PR TITLE
fix(rag): Exclude jackson3 from elasticsearch-java9

### DIFF
--- a/agentscope-dependencies-bom/pom.xml
+++ b/agentscope-dependencies-bom/pom.xml
@@ -432,6 +432,12 @@
                 <groupId>com.github.victools</groupId>
                 <artifactId>jsonschema-generator</artifactId>
                 <version>${jsonschema-generator.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>com.fasterxml.jackson.core</groupId>
+                        <artifactId>jackson-core</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
 
             <!-- Victools JSON Schema Module for Jackson annotations support -->


### PR DESCRIPTION
## AgentScope-Java Version

1.0.9

## Title

fix(agentscope-all): Exclude `jackson-core` from `jsonschema-generator`

## Description

Fixes: #728 

## Root Cause
The `jackson-core` dependency conflict caused `java.lang.NoSuchMethodError` error when calling `reactor.core.publisher.FluxCreate.SerializedFluxSink#next`. However, this error was not handled, leading to system hang. 
The following error:
```java
"java.lang.NoSuchMethodError: 'void com.fasterxml.jackson.core.base.ParserMinimalBase.<init>(com.fasterxml.jackson.core.StreamReadConstraints)'"
```

## Checklist

Please check the following items before code is ready to be reviewed.

- [x]  Code has been formatted with `mvn spotless:apply`
- [x]  All tests are passing (`mvn test`)
- [x]  Javadoc comments are complete and follow project conventions
- [x]  Related documentation has been updated (e.g. links, examples, etc.)
- [x]  Code is ready for review
