### PR TITLE
fix(dify): correct reranking_model JSON key in DifyRAG retrieval request

### DIFF
--- a/agentscope-extensions/agentscope-extensions-rag-dify/src/main/java/io/agentscope/core/rag/integration/dify/DifyRAGClient.java
+++ b/agentscope-extensions/agentscope-extensions-rag-dify/src/main/java/io/agentscope/core/rag/integration/dify/DifyRAGClient.java
@@ -158,19 +158,19 @@ public class DifyRAGClient {
                         retrievalModel.put("reranking_enable", true);
 
                         if (config.getRerankConfig() != null) {
-                            Map<String, Object> rerankingMode = new HashMap<>();
+                            Map<String, Object> rerankingModel = new HashMap<>();
                             if (config.getRerankConfig().getProviderName() != null) {
-                                rerankingMode.put(
+                                rerankingModel.put(
                                         "reranking_provider_name",
                                         config.getRerankConfig().getProviderName());
                             }
                             if (config.getRerankConfig().getModelName() != null) {
-                                rerankingMode.put(
+                                rerankingModel.put(
                                         "reranking_model_name",
                                         config.getRerankConfig().getModelName());
                             }
-                            if (!rerankingMode.isEmpty()) {
-                                retrievalModel.put("reranking_mode", rerankingMode);
+                            if (!rerankingModel.isEmpty()) {
+                                retrievalModel.put("reranking_model", rerankingModel);
                             }
                         }
                     } else {

--- a/agentscope-extensions/agentscope-extensions-rag-dify/src/test/java/io/agentscope/core/rag/integration/dify/DifyRAGClientTest.java
+++ b/agentscope-extensions/agentscope-extensions-rag-dify/src/test/java/io/agentscope/core/rag/integration/dify/DifyRAGClientTest.java
@@ -246,11 +246,11 @@ class DifyRAGClientTest {
         assertEquals(true, retrievalModel.get("reranking_enable"));
 
         @SuppressWarnings("unchecked")
-        Map<String, Object> rerankingMode =
-                (Map<String, Object>) retrievalModel.get("reranking_mode");
-        assertNotNull(rerankingMode);
-        assertEquals("cohere", rerankingMode.get("reranking_provider_name"));
-        assertEquals("rerank-english-v2.0", rerankingMode.get("reranking_model_name"));
+        Map<String, Object> rerankingModel =
+                (Map<String, Object>) retrievalModel.get("reranking_model");
+        assertNotNull(rerankingModel);
+        assertEquals("cohere", rerankingModel.get("reranking_provider_name"));
+        assertEquals("rerank-english-v2.0", rerankingModel.get("reranking_model_name"));
     }
 
     @Test


### PR DESCRIPTION
## 📝 变更说明

修复了 DifyRAGClient 中检索请求的 JSON key 错误。

## 🎯 主要变更

- 修正了 `retrievalModel.put("reranking_mode", rerankingMode)` 为 `retrievalModel.put("reranking_model", rerankingModel)`
- 将变量名从 `rerankingMode` 重命名为 `rerankingModel` 以保持一致性
- 同步更新了测试文件中的相关代码

## 🐛 问题描述

Dify API 期望使用 `reranking_model` 作为 reranking 配置的 JSON key，但代码中错误地使用了 `reranking_mode`。

## ✅ 测试

- [x] 所有单元测试通过 (24 tests, 0 failures)
- [x] 代码通过 Spotless 检查
- [x] 本地构建成功
- [x] 已添加/更新测试用例

## 📋 修改文件

- `agentscope-extensions/agentscope-extensions-rag-dify/src/main/java/io/agentscope/core/rag/integration/dify/DifyRAGClient.java`
- `agentscope-extensions/agentscope-extensions-rag-dify/src/test/java/io/agentscope/core/rag/integration/dify/DifyRAGClientTest.java`

## 🔗 相关信息

**API 参考示例**:
```json
{
  "retrieval_model": {
    "reranking_enable": true,
    "reranking_model": {
      "reranking_provider_name": "langgenius/siliconflow/siliconflow",
      "reranking_model_name": "netease-youdao/bce-reranker-base_v1"
    }
  }
}
```

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)