### PR TITLE
feat(mcp): 添加elicitation功能支持

### DIFF
--- a/agentscope-core/src/main/java/io/agentscope/core/tool/mcp/McpClientBuilder.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/tool/mcp/McpClientBuilder.java
@@ -384,7 +384,8 @@ public class McpClientBuilder {
                                     "AgentScope Java Framework",
                                     "1.0.10-SNAPSHOT");
 
-                    McpSchema.ClientCapabilities clientCapabilities = buildCapabilities(asyncElicitationHandler != null);
+                    McpSchema.ClientCapabilities clientCapabilities =
+                            buildCapabilities(asyncElicitationHandler != null);
 
                     var clientBuilder =
                             McpClient.async(transport)
@@ -419,7 +420,8 @@ public class McpClientBuilder {
                 new McpSchema.Implementation(
                         "agentscope-java", "AgentScope Java Framework", "1.0.10-SNAPSHOT");
 
-        McpSchema.ClientCapabilities clientCapabilities = buildCapabilities(syncElicitationHandler != null);
+        McpSchema.ClientCapabilities clientCapabilities =
+                buildCapabilities(syncElicitationHandler != null);
 
         var clientBuilder =
                 McpClient.sync(transport)

--- a/agentscope-core/src/main/java/io/agentscope/core/tool/mcp/McpClientBuilder.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/tool/mcp/McpClientBuilder.java
@@ -25,6 +25,8 @@ import io.modelcontextprotocol.client.transport.StdioClientTransport;
 import io.modelcontextprotocol.json.McpJsonMapper;
 import io.modelcontextprotocol.spec.McpClientTransport;
 import io.modelcontextprotocol.spec.McpSchema;
+import io.modelcontextprotocol.spec.McpSchema.ElicitRequest;
+import io.modelcontextprotocol.spec.McpSchema.ElicitResult;
 import java.net.URI;
 import java.net.URLDecoder;
 import java.net.URLEncoder;
@@ -37,6 +39,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 import reactor.core.publisher.Mono;
 
@@ -45,33 +48,33 @@ import reactor.core.publisher.Mono;
  *
  * <p>Supports three transport types:
  * <ul>
- *   <li>StdIO - for local process communication</li>
- *   <li>SSE - for HTTP Server-Sent Events (stateful)</li>
- *   <li>StreamableHTTP - for HTTP streaming (stateless)</li>
+ * <li>StdIO - for local process communication</li>
+ * <li>SSE - for HTTP Server-Sent Events (stateful)</li>
+ * <li>StreamableHTTP - for HTTP streaming (stateless)</li>
  * </ul>
  *
  * <p>Example usage:
  * <pre>{@code
  * // StdIO transport
  * McpClientWrapper client = McpClientBuilder.create("git-mcp")
- *     .stdioTransport("python", "-m", "mcp_server_git")
- *     .buildAsync()
- *     .block();
+ *         .stdioTransport("python", "-m", "mcp_server_git")
+ *         .buildAsync()
+ *         .block();
  *
  * // SSE transport with headers and query parameters
  * McpClientWrapper client = McpClientBuilder.create("remote-mcp")
- *     .sseTransport("https://mcp.example.com/sse")
- *     .header("Authorization", "Bearer " + token)
- *     .queryParam("queryKey", "queryValue")
- *     .timeout(Duration.ofSeconds(60))
- *     .buildAsync()
- *     .block();
+ *         .sseTransport("https://mcp.example.com/sse")
+ *         .header("Authorization", "Bearer " + token)
+ *         .queryParam("queryKey", "queryValue")
+ *         .timeout(Duration.ofSeconds(60))
+ *         .buildAsync()
+ *         .block();
  *
  * // HTTP transport with multiple query parameters
  * McpClientWrapper client = McpClientBuilder.create("http-mcp")
- *     .streamableHttpTransport("https://mcp.example.com/http")
- *     .queryParams(Map.of("token", "abc123", "env", "prod"))
- *     .buildSync();
+ *         .streamableHttpTransport("https://mcp.example.com/http")
+ *         .queryParams(Map.of("token", "abc123", "env", "prod"))
+ *         .buildSync();
  * }</pre>
  */
 public class McpClientBuilder {
@@ -83,6 +86,8 @@ public class McpClientBuilder {
     private TransportConfig transportConfig;
     private Duration requestTimeout = DEFAULT_REQUEST_TIMEOUT;
     private Duration initializationTimeout = DEFAULT_INIT_TIMEOUT;
+    private Function<ElicitRequest, Mono<ElicitResult>> asyncElicitationHandler;
+    private Function<ElicitRequest, ElicitResult> syncElicitationHandler;
 
     private McpClientBuilder(String name) {
         this.name = name;
@@ -105,7 +110,7 @@ public class McpClientBuilder {
      * Configures StdIO transport for local process communication.
      *
      * @param command the executable command
-     * @param args command arguments
+     * @param args    command arguments
      * @return this builder
      */
     public McpClientBuilder stdioTransport(String command, String... args) {
@@ -117,8 +122,8 @@ public class McpClientBuilder {
      * Configures StdIO transport with environment variables.
      *
      * @param command the executable command
-     * @param args command arguments list
-     * @param env environment variables
+     * @param args    command arguments list
+     * @param env     environment variables
      * @return this builder
      */
     public McpClientBuilder stdioTransport(
@@ -145,11 +150,11 @@ public class McpClientBuilder {
      * <p>Example usage for HTTP/2:
      * <pre>{@code
      * McpClientWrapper client = McpClientBuilder.create("mcp")
-     *     .sseTransport("https://example.com/sse")
+     *         .sseTransport("https://example.com/sse")
      *     .customizeSseClient(clientBuilder ->
      *         clientBuilder.version(java.net.http.HttpClient.Version.HTTP_2))
-     *     .buildAsync()
-     *     .block();
+     *         .buildAsync()
+     *         .block();
      * }</pre>
      *
      * @param customizer consumer to customize the HttpClient.Builder
@@ -174,17 +179,21 @@ public class McpClientBuilder {
     }
 
     /**
-     * Customizes the HTTP client for StreamableHTTP transport (only applicable after calling streamableHttpTransport).
-     * This allows advanced HTTP client configuration like HTTP/2, custom timeouts, SSL settings, etc.
+     * Customizes the HTTP client for StreamableHTTP transport (only applicable
+     * after calling streamableHttpTransport).
+     * This allows advanced HTTP client configuration like HTTP/2, custom timeouts,
+     * SSL settings, etc.
      *
-     * <p>Example usage for HTTP/2:
+     * <p>
+     * Example usage for HTTP/2:
+     *
      * <pre>{@code
      * McpClientWrapper client = McpClientBuilder.create("mcp")
-     *     .streamableHttpTransport("https://example.com/http")
-     *     .customizeStreamableHttpClient(clientBuilder ->
-     *         clientBuilder.version(java.net.http.HttpClient.Version.HTTP_2))
-     *     .buildAsync()
-     *     .block();
+     *         .streamableHttpTransport("https://example.com/http")
+     *         .customizeStreamableHttpClient(
+     *                 clientBuilder -> clientBuilder.version(java.net.http.HttpClient.Version.HTTP_2))
+     *         .buildAsync()
+     *         .block();
      * }</pre>
      *
      * @param customizer consumer to customize the HttpClient.Builder
@@ -200,7 +209,7 @@ public class McpClientBuilder {
     /**
      * Adds an HTTP header (only applicable for HTTP transports).
      *
-     * @param key header name
+     * @param key   header name
      * @param value header value
      * @return this builder
      */
@@ -227,11 +236,12 @@ public class McpClientBuilder {
     /**
      * Adds a query parameter to the URL (only applicable for HTTP transports).
      *
-     * <p>Query parameters added via this method will be merged with any existing
+     * <p>
+     * Query parameters added via this method will be merged with any existing
      * query parameters in the URL. If the same parameter key exists in both the URL
      * and the added parameters, the added parameter will take precedence.
      *
-     * @param key query parameter name
+     * @param key   query parameter name
      * @param value query parameter value
      * @return this builder
      */
@@ -245,7 +255,8 @@ public class McpClientBuilder {
     /**
      * Sets multiple query parameters (only applicable for HTTP transports).
      *
-     * <p>This method replaces any previously added query parameters.
+     * <p>
+     * This method replaces any previously added query parameters.
      * Query parameters in the original URL are still preserved and merged.
      *
      * @param queryParams map of query parameter name-value pairs
@@ -281,6 +292,79 @@ public class McpClientBuilder {
     }
 
     /**
+     * Registers an asynchronous elicitation handler for processing elicit requests
+     * from the server.
+     *
+     * <p>
+     * When an elicitation handler is registered, the client will automatically
+     * enable
+     * the elicitation capability in ClientCapabilities.
+     *
+     * <p>
+     * This method is for use with {@link #buildAsync()}. The handler returns a
+     * {@link Mono}
+     * for asynchronous processing.
+     *
+     * <p>
+     * Example usage:
+     *
+     * <pre>{@code
+     * McpClientWrapper client = McpClientBuilder.create("mcp")
+     *     .stdioTransport("python", "-m", "mcp_server")
+     *     .asyncElicitation(request -> {
+     *         // Handle elicitation request asynchronously
+     *         return Mono.just(ElicitResult.builder()...build());
+     *     })
+     *     .buildAsync()
+     *     .block();
+     * }
+     * </pre>
+     *
+     * @param handler function to handle elicit requests asynchronously
+     * @return this builder
+     */
+    public McpClientBuilder asyncElicitation(Function<ElicitRequest, Mono<ElicitResult>> handler) {
+        this.asyncElicitationHandler = handler;
+        return this;
+    }
+
+    /**
+     * Registers a synchronous elicitation handler for processing elicit requests
+     * from the server.
+     *
+     * <p>
+     * When an elicitation handler is registered, the client will automatically
+     * enable
+     * the elicitation capability in ClientCapabilities.
+     *
+     * <p>
+     * This method is for use with {@link #buildSync()}. The handler returns an
+     * {@link ElicitResult}
+     * directly for synchronous processing.
+     *
+     * <p>
+     * Example usage:
+     *
+     * <pre>{@code
+     * McpClientWrapper client = McpClientBuilder.create("mcp")
+     *     .stdioTransport("python", "-m", "mcp_server")
+     *     .syncElicitation(request -> {
+     *         // Handle elicitation request synchronously
+     *         return ElicitResult.builder()...build();
+     *     })
+     *     .buildSync();
+     * }
+     * </pre>
+     *
+     * @param handler function to handle elicit requests synchronously
+     * @return this builder
+     */
+    public McpClientBuilder syncElicitation(Function<ElicitRequest, ElicitResult> handler) {
+        this.syncElicitationHandler = handler;
+        return this;
+    }
+
+    /**
      * Builds an asynchronous MCP client wrapper.
      *
      * @return Mono emitting the async client wrapper
@@ -296,18 +380,29 @@ public class McpClientBuilder {
 
                     McpSchema.Implementation clientInfo =
                             new McpSchema.Implementation(
-                                    "agentscope-java", "AgentScope Java Framework", "1.0.10-SNAPSHOT");
+                                    "agentscope-java",
+                                    "AgentScope Java Framework",
+                                    "1.0.10-SNAPSHOT");
 
-                    McpSchema.ClientCapabilities clientCapabilities =
-                            McpSchema.ClientCapabilities.builder().build();
+                    McpSchema.ClientCapabilities.Builder capabilitiesBuilder =
+                            McpSchema.ClientCapabilities.builder();
+                    if (asyncElicitationHandler != null) {
+                        capabilitiesBuilder.elicitation();
+                    }
+                    McpSchema.ClientCapabilities clientCapabilities = capabilitiesBuilder.build();
 
-                    McpAsyncClient mcpClient =
+                    var clientBuilder =
                             McpClient.async(transport)
                                     .requestTimeout(requestTimeout)
                                     .initializationTimeout(initializationTimeout)
                                     .clientInfo(clientInfo)
-                                    .capabilities(clientCapabilities)
-                                    .build();
+                                    .capabilities(clientCapabilities);
+
+                    if (asyncElicitationHandler != null) {
+                        clientBuilder = clientBuilder.elicitation(asyncElicitationHandler);
+                    }
+
+                    McpAsyncClient mcpClient = clientBuilder.build();
 
                     return new McpAsyncClientWrapper(name, mcpClient);
                 });
@@ -329,16 +424,25 @@ public class McpClientBuilder {
                 new McpSchema.Implementation(
                         "agentscope-java", "AgentScope Java Framework", "1.0.10-SNAPSHOT");
 
-        McpSchema.ClientCapabilities clientCapabilities =
-                McpSchema.ClientCapabilities.builder().build();
+        McpSchema.ClientCapabilities.Builder capabilitiesBuilder =
+                McpSchema.ClientCapabilities.builder();
+        if (syncElicitationHandler != null) {
+            capabilitiesBuilder.elicitation();
+        }
+        McpSchema.ClientCapabilities clientCapabilities = capabilitiesBuilder.build();
 
-        McpSyncClient mcpClient =
+        var clientBuilder =
                 McpClient.sync(transport)
                         .requestTimeout(requestTimeout)
                         .initializationTimeout(initializationTimeout)
                         .clientInfo(clientInfo)
-                        .capabilities(clientCapabilities)
-                        .build();
+                        .capabilities(clientCapabilities);
+
+        if (syncElicitationHandler != null) {
+            clientBuilder = clientBuilder.elicitation(syncElicitationHandler);
+        }
+
+        McpSyncClient mcpClient = clientBuilder.build();
 
         return new McpSyncClientWrapper(name, mcpClient);
     }
@@ -416,8 +520,10 @@ public class McpClientBuilder {
         }
 
         /**
-         * Extracts the endpoint path from URL, merging with additional query parameters.
-         * Query parameters from the original URL are merged with additionally configured parameters.
+         * Extracts the endpoint path from URL, merging with additional query
+         * parameters.
+         * Query parameters from the original URL are merged with additionally
+         * configured parameters.
          * Additional parameters take precedence over URL parameters with the same key.
          *
          * @return endpoint path with query parameters (e.g., "/api/sse?token=abc")

--- a/agentscope-core/src/main/java/io/agentscope/core/tool/mcp/McpClientBuilder.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/tool/mcp/McpClientBuilder.java
@@ -384,12 +384,7 @@ public class McpClientBuilder {
                                     "AgentScope Java Framework",
                                     "1.0.10-SNAPSHOT");
 
-                    McpSchema.ClientCapabilities.Builder capabilitiesBuilder =
-                            McpSchema.ClientCapabilities.builder();
-                    if (asyncElicitationHandler != null) {
-                        capabilitiesBuilder.elicitation();
-                    }
-                    McpSchema.ClientCapabilities clientCapabilities = capabilitiesBuilder.build();
+                    McpSchema.ClientCapabilities clientCapabilities = buildCapabilities(asyncElicitationHandler != null);
 
                     var clientBuilder =
                             McpClient.async(transport)
@@ -424,12 +419,7 @@ public class McpClientBuilder {
                 new McpSchema.Implementation(
                         "agentscope-java", "AgentScope Java Framework", "1.0.10-SNAPSHOT");
 
-        McpSchema.ClientCapabilities.Builder capabilitiesBuilder =
-                McpSchema.ClientCapabilities.builder();
-        if (syncElicitationHandler != null) {
-            capabilitiesBuilder.elicitation();
-        }
-        McpSchema.ClientCapabilities clientCapabilities = capabilitiesBuilder.build();
+        McpSchema.ClientCapabilities clientCapabilities = buildCapabilities(syncElicitationHandler != null);
 
         var clientBuilder =
                 McpClient.sync(transport)
@@ -445,6 +435,20 @@ public class McpClientBuilder {
         McpSyncClient mcpClient = clientBuilder.build();
 
         return new McpSyncClientWrapper(name, mcpClient);
+    }
+
+    /**
+     * Builds client capabilities
+     * @param withElicitation whether to include elicitation capability
+     * @return client capabilities
+     */
+    private McpSchema.ClientCapabilities buildCapabilities(boolean withElicitation) {
+        McpSchema.ClientCapabilities.Builder capabilitiesBuilder =
+                McpSchema.ClientCapabilities.builder();
+        if (withElicitation) {
+            capabilitiesBuilder.elicitation();
+        }
+        return capabilitiesBuilder.build();
     }
 
     // ==================== Internal Transport Configuration Classes ====================

--- a/agentscope-core/src/test/java/io/agentscope/core/VersionTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/VersionTest.java
@@ -30,7 +30,8 @@ class VersionTest {
         // Verify version constant is set
         Assertions.assertNotNull(Version.VERSION, "VERSION constant should not be null");
         Assertions.assertFalse(Version.VERSION.isEmpty(), "VERSION constant should not be empty");
-        Assertions.assertEquals("1.0.10-SNAPSHOT", Version.VERSION, "VERSION should match current version");
+        Assertions.assertEquals(
+                "1.0.10-SNAPSHOT", Version.VERSION, "VERSION should match current version");
     }
 
     @Test

--- a/agentscope-core/src/test/java/io/agentscope/core/tool/mcp/McpClientBuilderTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/tool/mcp/McpClientBuilderTest.java
@@ -452,8 +452,10 @@ class McpClientBuilderTest {
     // ==================== extractEndpoint Tests ====================
 
     /**
-     * Helper method to invoke the extractEndpoint method in HttpTransportConfig using reflection.
-     * Creates a builder with the specified URL and query params, then extracts the endpoint.
+     * Helper method to invoke the extractEndpoint method in HttpTransportConfig
+     * using reflection.
+     * Creates a builder with the specified URL and query params, then extracts the
+     * endpoint.
      */
     private String invokeExtractEndpoint(String url, Map<String, String> queryParams)
             throws Exception {
@@ -673,7 +675,8 @@ class McpClientBuilderTest {
         assertNotNull(wrapper);
     }
 
-    // ==================== extractEndpoint with Query Params Tests ====================
+    // ==================== extractEndpoint with Query Params Tests
+    // ====================
 
     @Test
     void testExtractEndpoint_NoAdditionalParams() throws Exception {
@@ -820,7 +823,8 @@ class McpClientBuilderTest {
         McpClientBuilder builder =
                 McpClientBuilder.create("client").stdioTransport("python", "server.py");
 
-        // Should not throw because the method simply returns without calling addQueryParam
+        // Should not throw because the method simply returns without calling
+        // addQueryParam
         assertNotNull(builder.queryParam(null, "value"));
         assertNotNull(builder.queryParam("key", null));
     }
@@ -831,7 +835,8 @@ class McpClientBuilderTest {
         McpClientBuilder builder =
                 McpClientBuilder.create("client").stdioTransport("python", "server.py");
 
-        // Should not throw because the method simply returns without calling setQueryParams
+        // Should not throw because the method simply returns without calling
+        // setQueryParams
         assertNotNull(builder.queryParams(null));
     }
 
@@ -1005,7 +1010,8 @@ class McpClientBuilderTest {
 
     @Test
     void testCustomizeSseClient_OnStdioTransport_ShouldBeIgnored() {
-        // Customizing SSE client on stdio transport should not cause errors (just ignored)
+        // Customizing SSE client on stdio transport should not cause errors (just
+        // ignored)
         McpClientBuilder builder =
                 McpClientBuilder.create("stdio-client")
                         .stdioTransport("python", "-m", "mcp_server_time")
@@ -1020,7 +1026,8 @@ class McpClientBuilderTest {
 
     @Test
     void testCustomizeSseClient_OnStreamableHttpTransport_ShouldBeIgnored() {
-        // Customizing SSE client on streamable http transport should not cause errors (just
+        // Customizing SSE client on streamable http transport should not cause errors
+        // (just
         // ignored)
         McpClientBuilder builder =
                 McpClientBuilder.create("http-client")
@@ -1073,7 +1080,8 @@ class McpClientBuilderTest {
 
     @Test
     void testCustomizeStreamableHttpClient_OnStdioTransport_ShouldBeIgnored() {
-        // Customizing streamable http client on stdio transport should not cause errors (just
+        // Customizing streamable http client on stdio transport should not cause errors
+        // (just
         // ignored)
         McpClientBuilder builder =
                 McpClientBuilder.create("stdio-client")
@@ -1089,7 +1097,8 @@ class McpClientBuilderTest {
 
     @Test
     void testCustomizeStreamableHttpClient_OnSseTransport_ShouldBeIgnored() {
-        // Customizing streamable http client on SSE transport should not cause errors (just
+        // Customizing streamable http client on SSE transport should not cause errors
+        // (just
         // ignored)
         McpClientBuilder builder =
                 McpClientBuilder.create("sse-client")
@@ -1184,5 +1193,108 @@ class McpClientBuilderTest {
         assertNotNull(wrapper);
         assertEquals("all-features-client", wrapper.getName());
         assertFalse(wrapper.isInitialized());
+    }
+
+    // ==================== Elicitation Tests ====================
+
+    @Test
+    void testAsyncElicitation_WithHandler() {
+        // Test that asyncElicitation method can be called and builder is returned
+        McpClientBuilder builder =
+                McpClientBuilder.create("async-elicit-client")
+                        .stdioTransport("echo", "test")
+                        .asyncElicitation(request -> reactor.core.publisher.Mono.empty());
+
+        assertNotNull(builder);
+        McpClientWrapper wrapper = builder.buildAsync().block();
+        assertNotNull(wrapper);
+        assertTrue(wrapper instanceof McpAsyncClientWrapper);
+    }
+
+    @Test
+    void testSyncElicitation_WithHandler() {
+        // Test that syncElicitation method can be called and builder is returned
+        McpClientBuilder builder =
+                McpClientBuilder.create("sync-elicit-client")
+                        .stdioTransport("echo", "test")
+                        .syncElicitation(request -> null);
+
+        assertNotNull(builder);
+        McpClientWrapper wrapper = builder.buildSync();
+        assertNotNull(wrapper);
+        assertTrue(wrapper instanceof McpSyncClientWrapper);
+    }
+
+    @Test
+    void testAsyncElicitation_WithoutHandler() {
+        // Test that building without elicitation handler works normally
+        McpClientBuilder builder =
+                McpClientBuilder.create("no-elicit-async").stdioTransport("echo", "test");
+
+        McpClientWrapper wrapper = builder.buildAsync().block();
+        assertNotNull(wrapper);
+        assertTrue(wrapper instanceof McpAsyncClientWrapper);
+    }
+
+    @Test
+    void testSyncElicitation_WithoutHandler() {
+        // Test that building without elicitation handler works normally
+        McpClientBuilder builder =
+                McpClientBuilder.create("no-elicit-sync").stdioTransport("echo", "test");
+
+        McpClientWrapper wrapper = builder.buildSync();
+        assertNotNull(wrapper);
+        assertTrue(wrapper instanceof McpSyncClientWrapper);
+    }
+
+    @Test
+    void testAsyncElicitation_FluentApi() {
+        // Test fluent API with asyncElicitation
+        McpClientBuilder builder =
+                McpClientBuilder.create("fluent-async-elicit")
+                        .sseTransport("https://mcp.example.com/sse")
+                        .header("Authorization", "Bearer token")
+                        .asyncElicitation(request -> reactor.core.publisher.Mono.empty())
+                        .timeout(Duration.ofSeconds(60));
+
+        assertNotNull(builder);
+        McpClientWrapper wrapper = builder.buildAsync().block();
+        assertNotNull(wrapper);
+    }
+
+    @Test
+    void testSyncElicitation_FluentApi() {
+        // Test fluent API with syncElicitation
+        McpClientBuilder builder =
+                McpClientBuilder.create("fluent-sync-elicit")
+                        .streamableHttpTransport("https://mcp.example.com/http")
+                        .queryParam("token", "abc123")
+                        .syncElicitation(request -> null)
+                        .timeout(Duration.ofSeconds(90));
+
+        assertNotNull(builder);
+        McpClientWrapper wrapper = builder.buildSync();
+        assertNotNull(wrapper);
+    }
+
+    @Test
+    void testElicitation_BothHandlersSet() {
+        // Test that setting both handlers doesn't cause issues
+        // Only the appropriate one will be used based on build method
+        McpClientBuilder builder =
+                McpClientBuilder.create("both-handlers")
+                        .stdioTransport("echo", "test")
+                        .asyncElicitation(request -> reactor.core.publisher.Mono.empty())
+                        .syncElicitation(request -> null);
+
+        // Build async - should use async handler
+        McpClientWrapper asyncWrapper = builder.buildAsync().block();
+        assertNotNull(asyncWrapper);
+        assertTrue(asyncWrapper instanceof McpAsyncClientWrapper);
+
+        // Build sync - should use sync handler
+        McpClientWrapper syncWrapper = builder.buildSync();
+        assertNotNull(syncWrapper);
+        assertTrue(syncWrapper instanceof McpSyncClientWrapper);
     }
 }

--- a/docs/en/task/mcp.md
+++ b/docs/en/task/mcp.md
@@ -239,6 +239,45 @@ McpClientWrapper syncClient = McpClientBuilder.create("sync-mcp")
         .buildSync();
 ```
 
+### elicitation 支持
+
+The elicitation feature in MCP enables interactive information collection during the invocation of MCP server-side tools.
+
+Asynchronous client example
+```java
+McpClientWrapper client = McpClientBuilder.create("mcp-async")
+.stdioTransport("python", "-m", "mcp_server")
+.asyncElicitation(request -> {
+// 处理 elicitation 请求
+System.out.println("Received elicit request: " + request.message());
+        // 返回 Mono<ElicitResult>
+        return Mono.just(
+            ElicitResult.builder()
+                .action(ElicitResult.Action.ACCEPT)
+                .data(Map.of("response", "user input"))
+                .build()
+        );
+    })
+    .buildAsync()
+    .block();
+```
+
+Synchronous client example
+```java
+McpClientWrapper client = McpClientBuilder.create("mcp-sync")
+.stdioTransport("python", "-m", "mcp_server")
+.syncElicitation(request -> {
+// 处理 elicitation 请求
+System.out.println("Received elicit request: " + request.message());
+        // 直接返回 ElicitResult
+        return ElicitResult.builder()
+            .action(ElicitResult.Action.ACCEPT)
+            .data(Map.of("response", "user input"))
+            .build();
+    })
+    .buildSync();
+```
+
 ## Managing MCP Clients
 
 ### List Tools from MCP Server

--- a/docs/en/task/mcp.md
+++ b/docs/en/task/mcp.md
@@ -248,9 +248,9 @@ Asynchronous client example
 McpClientWrapper client = McpClientBuilder.create("mcp-async")
 .stdioTransport("python", "-m", "mcp_server")
 .asyncElicitation(request -> {
-// 处理 elicitation 请求
+// Handle elicitation request
 System.out.println("Received elicit request: " + request.message());
-        // 返回 Mono<ElicitResult>
+        // Return Mono<ElicitResult>
         return Mono.just(
             ElicitResult.builder()
                 .action(ElicitResult.Action.ACCEPT)
@@ -267,9 +267,9 @@ Synchronous client example
 McpClientWrapper client = McpClientBuilder.create("mcp-sync")
 .stdioTransport("python", "-m", "mcp_server")
 .syncElicitation(request -> {
-// 处理 elicitation 请求
+// Handle elicitation request
 System.out.println("Received elicit request: " + request.message());
-        // 直接返回 ElicitResult
+        // return ElicitResult directly
         return ElicitResult.builder()
             .action(ElicitResult.Action.ACCEPT)
             .data(Map.of("response", "user input"))

--- a/docs/en/task/mcp.md
+++ b/docs/en/task/mcp.md
@@ -239,7 +239,7 @@ McpClientWrapper syncClient = McpClientBuilder.create("sync-mcp")
         .buildSync();
 ```
 
-### elicitation 支持
+### elicitation support
 
 The elicitation feature in MCP enables interactive information collection during the invocation of MCP server-side tools.
 

--- a/docs/zh/task/mcp.md
+++ b/docs/zh/task/mcp.md
@@ -239,6 +239,45 @@ McpClientWrapper syncClient = McpClientBuilder.create("sync-mcp")
         .buildSync();
 ```
 
+### elicitation 支持
+
+MCP中的 elicitation 功能允许调用 MCP 服务端工具过程中，实现交互式信息补充收集。
+
+异步客户端示例
+```java
+McpClientWrapper client = McpClientBuilder.create("mcp-async")
+.stdioTransport("python", "-m", "mcp_server")
+.asyncElicitation(request -> {
+// 处理 elicitation 请求
+System.out.println("Received elicit request: " + request.message());
+        // 返回 Mono<ElicitResult>
+        return Mono.just(
+            ElicitResult.builder()
+                .action(ElicitResult.Action.ACCEPT)
+                .data(Map.of("response", "user input"))
+                .build()
+        );
+    })
+    .buildAsync()
+    .block();
+```
+
+同步客户端示例
+```java
+McpClientWrapper client = McpClientBuilder.create("mcp-sync")
+.stdioTransport("python", "-m", "mcp_server")
+.syncElicitation(request -> {
+// 处理 elicitation 请求
+System.out.println("Received elicit request: " + request.message());
+        // 直接返回 ElicitResult
+        return ElicitResult.builder()
+            .action(ElicitResult.Action.ACCEPT)
+            .data(Map.of("response", "user input"))
+            .build();
+    })
+    .buildSync();
+```
+
 ## 管理 MCP 客户端
 
 ### 列出 MCP 服务器的工具


### PR DESCRIPTION
#797 
- 在McpClientBuilder中添加asyncElicitation和syncElicitation方法
- 更新文档说明elicitation特性和使用示例
- 添加完整的单元测试验证elicitation功能

## AgentScope-Java Version

<revision>1.0.10-SNAPSHOT</revision>

## Description

为 McpClientBuilder 添加了 MCP 官方 SDK 定义的 elicitation 功能支持。

### 核心变更
修改了 McpClientBuilder.java:

新增导入
io.modelcontextprotocol.spec.McpSchema.ElicitRequest
io.modelcontextprotocol.spec.McpSchema.ElicitResult
java.util.function.Function

新增字段
asyncElicitationHandler: 用于异步客户端的 elicitation handler
syncElicitationHandler: 用于同步客户端的 elicitation handler

新增方法
asyncElicitation(Function<ElicitRequest, Mono> handler): 注册异步 elicitation handler
syncElicitation(Function<ElicitRequest, ElicitResult> handler): 注册同步 elicitation handler

修改 buildAsync() 方法
当 asyncElicitationHandler 不为 null 时,在 ClientCapabilities.builder() 中调用 .elicitation()
当 asyncElicitationHandler 不为 null 时,在 McpClient.async() builder 中调用 .elicitation(asyncElicitationHandler)

修改 buildSync() 方法
当 syncElicitationHandler 不为 null 时,在 ClientCapabilities.builder() 中调用 .elicitation()
当 syncElicitationHandler 不为 null 时,在 McpClient.sync() builder 中调用 .elicitation(syncElicitationHandler)

新增单元测试 McpClientBuilderTest 类中相关测试方法
测试命令 
```
mvn test -pl agentscope-core -Dtest='McpClientBuilderTest#test*Elicitation*'
```

更新了中英两版 mcp.md 文件，添加了使用示例。


