### PR TITLE
fix(mem0): build v2-compatible search filters for mixed entity IDs

### DIFF
--- a/agentscope-extensions/agentscope-extensions-mem0/src/main/java/io/agentscope/core/memory/mem0/Mem0LongTermMemory.java
+++ b/agentscope-extensions/agentscope-extensions-mem0/src/main/java/io/agentscope/core/memory/mem0/Mem0LongTermMemory.java
@@ -17,6 +17,8 @@ package io.agentscope.core.memory.mem0;
 
 import io.agentscope.core.memory.LongTermMemory;
 import io.agentscope.core.message.Msg;
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -226,30 +228,60 @@ public class Mem0LongTermMemory implements LongTermMemory {
     /**
      * Builds a search request with the given query.
      *
-     * <p>The search request includes:
-     * <ul>
-     *   <li>Standard filters: userId, agentId, runId (added by builder convenience methods)</li>
-     *   <li>Custom metadata filters: merged into filters via builder.getFilters()</li>
-     * </ul>
+     * <p>Mem0 v2 filter syntax only allows logical operators (AND/OR/NOT) and a fixed set of
+     * top-level fields. Custom metadata must be nested under the "metadata" field, and multiple
+     * entity identifiers (user/agent/run) should be treated as OR conditions rather than implicit
+     * AND.
      *
      * @param query The search query string
      * @return A configured Mem0SearchRequest for v2 API
      */
     private Mem0SearchRequest buildSearchRequest(String query) {
-        Mem0SearchRequest.Builder builder =
-                Mem0SearchRequest.builder()
-                        .query(query)
-                        .userId(userId)
-                        .agentId(agentId)
-                        .runId(runId)
-                        .topK(5);
+        Mem0SearchRequest request =
+                Mem0SearchRequest.builder().query(query).userId(userId).topK(5).build();
+        request.setFilters(buildSearchFilters());
+        return request;
+    }
 
-        // Merge custom metadata into filters if present
-        if (metadata != null && !metadata.isEmpty()) {
-            builder.getFilters().putAll(metadata);
+    private Map<String, Object> buildSearchFilters() {
+        List<Map<String, Object>> entityFilters = new ArrayList<>();
+        addEntityFilter(entityFilters, "user_id", userId);
+        addEntityFilter(entityFilters, "agent_id", agentId);
+        addEntityFilter(entityFilters, "run_id", runId);
+
+        Map<String, Object> entityExpression = null;
+        if (entityFilters.size() == 1) {
+            entityExpression = entityFilters.get(0);
+        } else if (!entityFilters.isEmpty()) {
+            entityExpression = Map.of("OR", entityFilters);
         }
 
-        return builder.build();
+        Map<String, Object> metadataExpression =
+                (metadata == null || metadata.isEmpty()) ? null : Map.of("metadata", metadata);
+
+        if (entityExpression != null && metadataExpression != null) {
+            List<Map<String, Object>> andExpressions = new ArrayList<>();
+            andExpressions.add(entityExpression);
+            andExpressions.add(metadataExpression);
+            return Map.of("AND", andExpressions);
+        }
+
+        if (entityExpression != null) {
+            return entityExpression;
+        }
+
+        if (metadataExpression != null) {
+            return metadataExpression;
+        }
+
+        return new HashMap<>();
+    }
+
+    private void addEntityFilter(
+            List<Map<String, Object>> entityFilters, String key, String value) {
+        if (value != null) {
+            entityFilters.add(Map.of(key, value));
+        }
     }
 
     /**

--- a/agentscope-extensions/agentscope-extensions-mem0/src/test/java/io/agentscope/core/memory/mem0/Mem0LongTermMemoryTest.java
+++ b/agentscope-extensions/agentscope-extensions-mem0/src/test/java/io/agentscope/core/memory/mem0/Mem0LongTermMemoryTest.java
@@ -16,17 +16,23 @@
 package io.agentscope.core.memory.mem0;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.fasterxml.jackson.core.type.TypeReference;
 import io.agentscope.core.message.Msg;
 import io.agentscope.core.message.MsgRole;
 import io.agentscope.core.message.TextBlock;
+import io.agentscope.core.util.JsonUtils;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -291,6 +297,92 @@ class Mem0LongTermMemoryTest {
         StepVerifier.create(memory.retrieve(query))
                 .assertNext(result -> assertEquals("", result))
                 .verifyComplete();
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void testRetrieveUsesOrForMultipleEntityFilters() throws Exception {
+        mockServer.enqueue(new MockResponse().setBody("[]").setResponseCode(200));
+
+        Mem0LongTermMemory memory =
+                Mem0LongTermMemory.builder()
+                        .userId("user123")
+                        .agentName("agent123")
+                        .apiBaseUrl(baseUrl)
+                        .build();
+
+        Msg query =
+                Msg.builder()
+                        .role(MsgRole.USER)
+                        .content(TextBlock.builder().text("query").build())
+                        .build();
+
+        StepVerifier.create(memory.retrieve(query))
+                .assertNext(result -> assertEquals("", result))
+                .verifyComplete();
+
+        RecordedRequest request = mockServer.takeRequest();
+        Map<String, Object> payload =
+                JsonUtils.getJsonCodec()
+                        .fromJson(
+                                request.getBody().readUtf8(),
+                                new TypeReference<Map<String, Object>>() {});
+        Map<String, Object> filters = (Map<String, Object>) payload.get("filters");
+
+        assertNotNull(filters);
+        assertTrue(filters.containsKey("OR"));
+        assertFalse(filters.containsKey("user_id"));
+        assertFalse(filters.containsKey("agent_id"));
+
+        List<Map<String, Object>> orFilters = (List<Map<String, Object>>) filters.get("OR");
+        assertEquals(2, orFilters.size());
+        assertEquals("user123", orFilters.get(0).get("user_id"));
+        assertEquals("agent123", orFilters.get(1).get("agent_id"));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void testRetrieveNestsMetadataUnderMetadataFilterField() throws Exception {
+        mockServer.enqueue(new MockResponse().setBody("[]").setResponseCode(200));
+
+        Mem0LongTermMemory memory =
+                Mem0LongTermMemory.builder()
+                        .userId("user123")
+                        .agentName("agent123")
+                        .metadata(Map.of("system", "bifrost-agent", "type", "diagnosis"))
+                        .apiBaseUrl(baseUrl)
+                        .build();
+
+        Msg query =
+                Msg.builder()
+                        .role(MsgRole.USER)
+                        .content(TextBlock.builder().text("query").build())
+                        .build();
+
+        StepVerifier.create(memory.retrieve(query))
+                .assertNext(result -> assertEquals("", result))
+                .verifyComplete();
+
+        RecordedRequest request = mockServer.takeRequest();
+        Map<String, Object> payload =
+                JsonUtils.getJsonCodec()
+                        .fromJson(
+                                request.getBody().readUtf8(),
+                                new TypeReference<Map<String, Object>>() {});
+        Map<String, Object> filters = (Map<String, Object>) payload.get("filters");
+
+        assertNotNull(filters);
+        assertTrue(filters.containsKey("AND"));
+        assertFalse(filters.containsKey("system"));
+
+        List<Map<String, Object>> andFilters = (List<Map<String, Object>>) filters.get("AND");
+        assertEquals(2, andFilters.size());
+        Map<String, Object> metadataFilter = andFilters.get(1);
+        assertTrue(metadataFilter.containsKey("metadata"));
+
+        Map<String, Object> metadata = (Map<String, Object>) metadataFilter.get("metadata");
+        assertEquals("bifrost-agent", metadata.get("system"));
+        assertEquals("diagnosis", metadata.get("type"));
     }
 
     @Test


### PR DESCRIPTION
## Summary
Fixes #823 by generating Mem0 search filters that match v2 syntax and expected matching semantics:

- Use **OR** when multiple entity IDs are present (`user_id`, `agent_id`, `run_id`) instead of implicit top-level AND.
- Nest custom metadata under the supported `metadata` field (instead of flattening metadata keys at filter root).
- Combine entity expression and metadata expression with **AND** to preserve retrieval narrowing by metadata.

## Why
Issue #823 reported two problems in current request building:
1. `user_id` + `agent_id` were serialized as sibling filter keys (implicit AND), which can miss records when memory belongs to only one entity dimension.
2. Custom metadata keys were flattened into the top-level filter object, which is incompatible with Mem0 v2 filter syntax (allowed roots are logical operators + known fields).

## Implementation notes
- Updated `Mem0LongTermMemory.buildSearchRequest` to build filters through a dedicated helper:
  - Entity filters -> single clause or `OR` expression.
  - Metadata -> `{ "metadata": { ... } }`.
  - Final filter -> `AND(entityExpr, metadataExpr)` when both exist.
- Kept changes scoped to Mem0 long-term memory request construction to minimize blast radius.

## Tests
Added request-shape assertions in `Mem0LongTermMemoryTest`:
- `testRetrieveUsesOrForMultipleEntityFilters`
- `testRetrieveNestsMetadataUnderMetadataFilterField`

Validation performed:
- New tests fail against old implementation (verified locally).
- Full targeted suite passes after fix:

```bash
mvn -pl agentscope-extensions/agentscope-extensions-mem0 -am \
  -DskipITs -DskipIntegrationTests \
  test -Dtest=Mem0LongTermMemoryTest,Mem0SearchRequestTest,Mem0ClientTest
```

Result: `Tests run: 74, Failures: 0, Errors: 0, Skipped: 0`
