### PR TITLE
refactor(core): add timeouts to block() and use Objects utilities

### DIFF
--- a/agentscope-core/src/main/java/io/agentscope/core/pipeline/MsgHub.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/pipeline/MsgHub.java
@@ -18,9 +18,11 @@ package io.agentscope.core.pipeline;
 import io.agentscope.core.agent.Agent;
 import io.agentscope.core.agent.AgentBase;
 import io.agentscope.core.message.Msg;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 import java.util.UUID;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.stream.Collectors;
@@ -100,6 +102,7 @@ import reactor.core.publisher.Mono;
 public class MsgHub implements AutoCloseable {
 
     private static final Logger log = LoggerFactory.getLogger(MsgHub.class);
+    private static final Duration CLOSE_TIMEOUT = Duration.ofSeconds(10);
 
     private final String name;
     private final List<AgentBase> participants;
@@ -113,7 +116,7 @@ public class MsgHub implements AutoCloseable {
      * @param builder Builder instance
      */
     private MsgHub(Builder builder) {
-        this.name = builder.name != null ? builder.name : UUID.randomUUID().toString();
+        this.name = Objects.requireNonNullElse(builder.name, UUID.randomUUID().toString());
         this.participants = new CopyOnWriteArrayList<>(builder.participants);
         this.announcement = builder.announcement;
         this.enableAutoBroadcast = builder.enableAutoBroadcast;
@@ -195,10 +198,11 @@ public class MsgHub implements AutoCloseable {
     /**
      * Close the MsgHub and cleanup resources.
      * This is the AutoCloseable implementation for try-with-resources support.
+     * Waits up to 10 seconds for exit to complete.
      */
     @Override
     public void close() {
-        exit().block();
+        exit().block(CLOSE_TIMEOUT);
     }
 
     /**

--- a/agentscope-core/src/main/java/io/agentscope/core/rag/KnowledgeRetrievalTools.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/rag/KnowledgeRetrievalTools.java
@@ -22,7 +22,9 @@ import io.agentscope.core.rag.model.Document;
 import io.agentscope.core.rag.model.RetrieveConfig;
 import io.agentscope.core.tool.Tool;
 import io.agentscope.core.tool.ToolParam;
+import java.time.Duration;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * Knowledge retrieval tools for Agentic RAG mode.
@@ -51,19 +53,19 @@ import java.util.List;
  */
 public class KnowledgeRetrievalTools {
 
+    private static final int DEFAULT_RETRIEVE_LIMIT = 5;
+    private static final Duration RETRIEVE_TIMEOUT = Duration.ofSeconds(60);
+
     private final Knowledge knowledge;
 
     /**
      * Creates a new KnowledgeRetrievalTools instance.
      *
      * @param knowledge the knowledge base to retrieve from
-     * @throws IllegalArgumentException if knowledgeBase is null
+     * @throws NullPointerException if knowledge is null
      */
     public KnowledgeRetrievalTools(Knowledge knowledge) {
-        if (knowledge == null) {
-            throw new IllegalArgumentException("Knowledge base cannot be null");
-        }
-        this.knowledge = knowledge;
+        this.knowledge = Objects.requireNonNull(knowledge, "knowledge");
     }
 
     /**
@@ -108,10 +110,7 @@ public class KnowledgeRetrievalTools {
                     Integer limit,
             Agent agent) {
 
-        // Set default value
-        if (limit == null) {
-            limit = 5;
-        }
+        int effectiveLimit = Objects.requireNonNullElse(limit, DEFAULT_RETRIEVE_LIMIT);
 
         // Extract conversation history from agent if available
         List<Msg> conversationHistory = null;
@@ -122,7 +121,7 @@ public class KnowledgeRetrievalTools {
         // Build retrieval config with conversation history
         RetrieveConfig config =
                 RetrieveConfig.builder()
-                        .limit(limit)
+                        .limit(effectiveLimit)
                         .scoreThreshold(0.5)
                         .conversationHistory(conversationHistory)
                         .build();
@@ -131,7 +130,7 @@ public class KnowledgeRetrievalTools {
                 .retrieve(query, config)
                 .map(this::formatDocumentsForTool)
                 .onErrorReturn("Failed to retrieve knowledge for query: " + query)
-                .block(); // Convert to synchronous call to match Tool interface
+                .block(RETRIEVE_TIMEOUT);
     }
 
     /**

--- a/agentscope-core/src/main/java/io/agentscope/core/tool/Toolkit.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/tool/Toolkit.java
@@ -25,6 +25,7 @@ import io.agentscope.core.tool.subagent.SubAgentConfig;
 import io.agentscope.core.tool.subagent.SubAgentProvider;
 import io.agentscope.core.tool.subagent.SubAgentTool;
 import java.lang.reflect.Method;
+import java.time.Duration;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -935,7 +936,7 @@ public class Toolkit {
                                 disableTools,
                                 groupName,
                                 presetParameters)
-                        .block();
+                        .block(Duration.ofSeconds(30));
             } else if (subAgentProvider != null) {
                 SubAgentTool subAgentTool = new SubAgentTool(subAgentProvider, subAgentConfig);
                 toolkit.registerAgentTool(subAgentTool, groupName, extendedModel, null, null);

--- a/agentscope-core/src/main/java/io/agentscope/core/tool/mcp/McpAsyncClientWrapper.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/tool/mcp/McpAsyncClientWrapper.java
@@ -17,6 +17,7 @@ package io.agentscope.core.tool.mcp;
 
 import io.modelcontextprotocol.client.McpAsyncClient;
 import io.modelcontextprotocol.spec.McpSchema;
+import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import org.slf4j.Logger;
@@ -167,7 +168,7 @@ public class McpAsyncClientWrapper extends McpClientWrapper {
                 client.closeGracefully()
                         .doOnSuccess(v -> logger.debug("MCP client '{}' closed", name))
                         .doOnError(e -> logger.error("Error closing MCP client '{}'", name, e))
-                        .block();
+                        .block(Duration.ofSeconds(10));
             } catch (Exception e) {
                 logger.error("Exception during MCP client close", e);
                 client.close();


### PR DESCRIPTION
## Description

Adds explicit timeouts to all `block()` calls in core to avoid indefinite blocking, and uses `Objects.requireNonNull` / `Objects.requireNonNullElse` where appropriate for consistency with project style.

**Changes:**
- **KnowledgeRetrievalTools:** Constants `DEFAULT_RETRIEVE_LIMIT` (5) and `RETRIEVE_TIMEOUT` (60s); `Objects.requireNonNull(knowledge)` in constructor; `Objects.requireNonNullElse(limit, DEFAULT_RETRIEVE_LIMIT)`; `block(RETRIEVE_TIMEOUT)` for retrieval.
- **MsgHub:** `CLOSE_TIMEOUT` (10s) for `exit().block()` in `close()`; `Objects.requireNonNullElse(builder.name, ...)` in constructor.
- **McpAsyncClientWrapper:** 10s timeout when closing the MCP client in `close()`.
- **Toolkit:** 30s timeout when registering MCP client in builder.

**Testing:** `mvn spotless:apply` and `mvn test` (or `mvn verify`) pass.