### PR TITLE
fix(core):Include all messages in conversation history for OpenAI formatter

### DIFF
--- a/agentscope-core/src/main/java/io/agentscope/core/formatter/openai/OpenAIConversationMerger.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/formatter/openai/OpenAIConversationMerger.java
@@ -83,38 +83,16 @@ public class OpenAIConversationMerger {
         StringBuilder textBuffer = new StringBuilder();
         textBuffer.append(conversationHistoryPrompt);
         textBuffer.append(HISTORY_START_TAG).append("\n");
-
-        // Process all messages EXCEPT the last one as history
-        int lastIndex = msgs.size() - 1;
-
-        // Append history messages
-        if (lastIndex > 0) {
-            for (int i = 0; i < lastIndex; i++) {
-                processMessage(
-                        msgs.get(i),
-                        roleFormatter,
-                        toolResultConverter,
-                        textBuffer,
-                        allParts,
-                        true);
-            }
+        // Include prefix only if there is history (multi-turn context)
+        // For single-turn user queries,
+        // omitting the prefix makes it look like a standard chat request.
+        boolean includePrefix = msgs.size() > 1;
+        // Process all messages as history (similar to DashScopeConversationMerger)
+        for (Msg msg : msgs) {
+            processMessage(
+                    msg, roleFormatter, toolResultConverter, textBuffer, allParts, includePrefix);
         }
         textBuffer.append(HISTORY_END_TAG).append("\n");
-
-        // Process the last message (current turn)
-        if (lastIndex >= 0) {
-            // Include prefix only if there is history (multi-turn context)
-            // or if it's explicitly needed. For single-turn user queries,
-            // omitting the prefix makes it look like a standard chat request.
-            boolean includePrefix = lastIndex > 0;
-            processMessage(
-                    msgs.get(lastIndex),
-                    roleFormatter,
-                    toolResultConverter,
-                    textBuffer,
-                    allParts,
-                    includePrefix);
-        }
 
         // Flush remaining text
         if (textBuffer.length() > 0) {


### PR DESCRIPTION


## AgentScope-Java Version
main

## Description

When using `agent.call()` without parameters, the OpenAIConversationMerger was 
excluding the last message from the history and treating it as the current turn. 
This caused the LLM to misunderstand the conversation context because the 
message sequence was incomplete.
<img width="986" height="540" alt="1654" src="https://github.com/user-attachments/assets/d25a0811-1b7a-4242-bf39-96ee95ffb716" />


The lastMessage:3号:[3号发言]过，我不知道 
is not in history,
Agent 2 is confused. It thinks it is Agent 3.

Modified `OpenAIConversationMerger.mergeToUserMessage()` to merge ALL messages 
into the conversation history (similar to `DashScopeConversationMerger`), 
instead of separating the last message as the current turn.
Always, For single-turn user queries,  omitting the prefix makes it look like a standard chat request.

## Checklist

Please check the following items before code is ready to be reviewed.

- [ ]  Code has been formatted with `mvn spotless:apply`
- [ ]  All tests are passing (`mvn test`)
- [ ]  Javadoc comments are complete and follow project conventions
- [ ]  Related documentation has been updated (e.g. links, examples, etc.)
- [ ]  Code is ready for review
