### PR TITLE
change response parsing，support v1.1 format

### DIFF
--- a/agentscope-extensions/agentscope-extensions-mem0/src/main/java/io/agentscope/core/memory/mem0/Mem0Client.java
+++ b/agentscope-extensions/agentscope-extensions-mem0/src/main/java/io/agentscope/core/memory/mem0/Mem0Client.java
@@ -227,14 +227,17 @@ public class Mem0Client {
      * memories relevant to the query string. Results are ordered by relevance score
      * (highest first).
      *
-     * <p>The v2 API returns a direct array of results, which this method wraps
-     * into a Mem0SearchResponse object for consistency with the existing API.
+     * <p>Automatically compatible with two Mem0 API response formats:
+     * <ul>
+     *   <li><b>format v1.1</b> — response is a JSON object with a {@code results} field
+     *       (e.g. {@code {"results": [...]}}), deserialized directly into
+     *       {@link Mem0SearchResponse}.</li>
+     *   <li><b>format v1.0</b> — response is a direct JSON array (e.g. {@code [...]}),
+     *       parsed as a list of results and wrapped into a {@link Mem0SearchResponse}.</li>
+     * </ul>
      *
      * <p>The metadata filters (agent_id, user_id, run_id) in the request ensure
      * that only memories from the specified context are returned.
-     *
-     * <p>The operation is performed asynchronously on the bounded elastic scheduler
-     * to avoid blocking the caller thread.
      *
      * @param request The search request containing query and filters
      * @return A Mono emitting the search response with relevant memories


### PR DESCRIPTION
This pull request updates the `search` method in `Mem0Client.java` to improve compatibility with different Mem0 API response formats. The method now detects whether the response is a JSON array or a wrapped object and parses it accordingly, ensuring consistent handling of both platform and self-hosted Mem0 endpoints.

**Improved response format handling:**

* Updated the `search` method in `Mem0Client.java` to support both direct JSON array responses and wrapped object responses by checking the response format at runtime and parsing appropriately. This ensures compatibility with both platform and self-hosted Mem0 endpoints.Change-Id: I584de6958cacd4c9a29b4cdc04cfcd79bcee6750

## AgentScope-Java Version

[The version of AgentScope-Java you are working on, e.g. 1.0.9, check your pom.xml dependency version or run `mvn dependency:tree | grep agentscope-parent:pom`(only mac/linux)]

## Description

[Please describe the background, purpose, changes made, and how to test this PR]

## Checklist

Please check the following items before code is ready to be reviewed.

- [ ]  Code has been formatted with `mvn spotless:apply`
- [ ]  All tests are passing (`mvn test`)
- [ ]  Javadoc comments are complete and follow project conventions
- [ ]  Related documentation has been updated (e.g. links, examples, etc.)
- [ ]  Code is ready for review
