### PR TITLE
修复OpenAIChatModel流式响应失效问题

### DIFF
--- a/agentscope-core/src/main/java/io/agentscope/core/model/OpenAIChatModel.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/model/OpenAIChatModel.java
@@ -199,7 +199,7 @@ public class OpenAIChatModel extends ChatModelBase {
     public static class Builder {
         private String apiKey;
         private String modelName;
-        private Boolean stream;
+        private boolean stream = true;
         private GenerateOptions defaultOptions;
         private String baseUrl;
         private String endpointPath;


### PR DESCRIPTION
## AgentScope-Java Version
1.0.10-SNAPSHOT

## Description
issue: #884 

在 OpenAIChatModel.Builder中，stream字段默认为 null（位于 OpenAIChatModel.java:202）：
```java
private Boolean stream;
```
因此，当使用最简配置（如 issue 中的示例）时，构造器生成的 effectiveOptions中的 stream也为 null（OpenAIChatModel.Builder.effectiveOptions即 OpenAIChatModel.configuredOptions）

<img width="250" height="500" alt="image" src="https://github.com/user-attachments/assets/02bd1713-e9bb-4dfa-8140-97ed7f4bfd4d" />

调用 ReactAgent.stream(msg)时，ReactAgent.steam实际执行的是 AgentBase.steam（AgentBase.java:659-662），传入的 options是 StreamableAgent.steam（StreamableAgent:74-76）所给的默认 StreamOptions.defaults()，即为空。因此，options.stream和 configuredOptions.stream都是 null，合并后的 effectiveOptions.stream也是 null。

在兜底逻辑中，stream被判断为 false（OpenAIChatModel.java:107-108）：
```java
        boolean stream =
                        effectiveOptions.getStream() != null ? effectiveOptions.getStream() : false;
```
最终，实际调用的是 call方法请求非流式模型，导致流式响应失效。
```java
        // Make the API call
        if (stream) {
            // Streaming mode
            return client.stream(apiKey, baseUrl, request, effectiveOptions)
                    .map(response -> formatter.parseResponse(response, start))
                    .filter(Objects::nonNull);
        } else {
            // Non-streaming mode: make a single call and return as Flux
            return Flux.defer(
                            () -> {
                                try {
                                    OpenAIResponse response =
                                            client.call(apiKey, baseUrl, request, effectiveOptions);
                                    ChatResponse chatResponse =
                                            formatter.parseResponse(response, start);
                                    return Flux.just(chatResponse);
                                } catch (Exception e) {
                                    return Flux.error(
                                            new ModelException(
                                                    "Failed to call OpenAI API: " + e.getMessage(),
                                                    e,
                                                    modelName,
                                                    "openai"));
                                }
                            })
                    .subscribeOn(Schedulers.boundedElastic());
        }
```

### Repair plan
其他 ChatModel或者在方法参数中传递 stream（调用时写死 true和 false），或者作为构造参数传入。由于此处 Builder中有 stream参数，因此模仿 DashScopeChatModel将默认 stream设置为 true以修复此 issue。

### Tips
在修复前的版本中，可以通过 defaultOptions指定 stream为 true临时处理该问题。