### PR TITLE
fix(skill): skillBox prompt should merge into system prompts

### DIFF
--- a/agentscope-core/src/main/java/io/agentscope/core/skill/SkillHook.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/skill/SkillHook.java
@@ -18,6 +18,7 @@ package io.agentscope.core.skill;
 import io.agentscope.core.hook.Hook;
 import io.agentscope.core.hook.HookEvent;
 import io.agentscope.core.hook.PreReasoningEvent;
+import io.agentscope.core.message.ContentBlock;
 import io.agentscope.core.message.Msg;
 import io.agentscope.core.message.MsgRole;
 import io.agentscope.core.message.TextBlock;
@@ -41,15 +42,18 @@ public class SkillHook implements Hook {
                 List<Msg> inputMessages = preReasoningEvent.getInputMessages();
                 int systemIndex = findFirstSystemMessageIndex(inputMessages);
                 if (systemIndex >= 0) {
-                    // Merge skill prompt into existing system message
+                    // Merge skill prompt into existing system message in-place (structural)
                     Msg existingSystem = inputMessages.get(systemIndex);
-                    String existingText = existingSystem.getTextContent();
-                    String mergedText = skillPrompt + "\n\n" + existingText;
+                    List<ContentBlock> mergedContent = new ArrayList<>(existingSystem.getContent());
+                    mergedContent.add(TextBlock.builder().text(skillPrompt).build());
                     Msg mergedMsg =
                             Msg.builder()
+                                    .id(existingSystem.getId())
                                     .role(MsgRole.SYSTEM)
                                     .name(existingSystem.getName())
-                                    .content(TextBlock.builder().text(mergedText).build())
+                                    .content(mergedContent)
+                                    .metadata(existingSystem.getMetadata())
+                                    .timestamp(existingSystem.getTimestamp())
                                     .build();
                     List<Msg> newMessages = new ArrayList<>(inputMessages);
                     newMessages.set(systemIndex, mergedMsg);

--- a/agentscope-core/src/test/java/io/agentscope/core/skill/SkillHookTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/skill/SkillHookTest.java
@@ -345,22 +345,26 @@ class SkillHookTest {
                         .count();
         assertEquals(1, systemCount, "There should be exactly one SYSTEM message");
 
-        // Verify the SYSTEM message contains both skill prompt and original system instruction
+        // Verify the merged SYSTEM message is at index 0
         Msg systemMsg = result.getInputMessages().get(0);
         assertEquals(MsgRole.SYSTEM, systemMsg.getRole());
-        assertTrue(
-                systemMsg.getTextContent().contains("test_skill"),
-                "SYSTEM message should contain skill prompt");
-        assertTrue(
-                systemMsg.getTextContent().contains("System instruction"),
-                "SYSTEM message should contain original system instruction");
 
-        // Verify skill prompt comes before original system instruction
-        int skillIndex = systemMsg.getTextContent().indexOf("test_skill");
-        int sysIndex = systemMsg.getTextContent().indexOf("System instruction");
+        // Verify structural merge: content blocks are preserved, not flattened
+        // First content block should be the original system instruction TextBlock,
+        // second should be the skill prompt TextBlock
+        assertEquals(
+                2,
+                systemMsg.getContent().size(),
+                "Merged SYSTEM message should have 2 content blocks (structural merge)");
+        assertInstanceOf(TextBlock.class, systemMsg.getContent().get(0));
+        assertInstanceOf(TextBlock.class, systemMsg.getContent().get(1));
+        assertEquals(
+                "System instruction",
+                ((TextBlock) systemMsg.getContent().get(0)).getText(),
+                "First content block should be the original system instruction");
         assertTrue(
-                skillIndex < sysIndex,
-                "Skill prompt should be prepended before original system instruction");
+                ((TextBlock) systemMsg.getContent().get(1)).getText().contains("test_skill"),
+                "Second content block should be the skill prompt");
 
         // Verify other messages are preserved
         assertEquals("User query", result.getInputMessages().get(1).getTextContent());


### PR DESCRIPTION
## AgentScope-Java Version

[The version of AgentScope-Java you are working on, e.g. 1.0.9, check your pom.xml dependency version or run `mvn dependency:tree | grep agentscope-parent:pom`(only mac/linux)]

## Description

fix & close #845 

## Checklist

Please check the following items before code is ready to be reviewed.

- [x]  Code has been formatted with `mvn spotless:apply`
- [x]  All tests are passing (`mvn test`)
- [x]  Javadoc comments are complete and follow project conventions
- [x]  Related documentation has been updated (e.g. links, examples, etc.)
- [x]  Code is ready for review
