### PR TITLE
fix(mcp): preserve $defs and definitions fields in JsonSchema conversion 

### DIFF
--- a/agentscope-core/src/main/java/io/agentscope/core/tool/mcp/McpTool.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/tool/mcp/McpTool.java
@@ -240,6 +240,15 @@ public class McpTool implements AgentTool {
             parameters.put("additionalProperties", inputSchema.additionalProperties());
         }
 
+        // Preserve $defs and definitions for $ref resolution
+        if (inputSchema.defs() != null && !inputSchema.defs().isEmpty()) {
+            parameters.put("$defs", new HashMap<>(inputSchema.defs()));
+        }
+
+        if (inputSchema.definitions() != null && !inputSchema.definitions().isEmpty()) {
+            parameters.put("definitions", new HashMap<>(inputSchema.definitions()));
+        }
+
         return parameters;
     }
 }

--- a/agentscope-core/src/test/java/io/agentscope/core/tool/mcp/McpToolTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/tool/mcp/McpToolTest.java
@@ -562,4 +562,214 @@ class McpToolTest {
         assertTrue(resultRequired.contains("param1"));
         assertTrue(resultRequired.contains("param2"));
     }
+
+    // ==================== Issue #893: $defs Support Tests ====================
+
+    @Test
+    void testConvertMcpSchemaToParameters_WithDefs() {
+        // Create Material definition in $defs
+        Map<String, Object> materialDef = new HashMap<>();
+        materialDef.put("type", "object");
+        materialDef.put(
+                "properties",
+                Map.of("key", Map.of("type", "string"), "value", Map.of("type", "string")));
+
+        Map<String, Object> defs = new HashMap<>();
+        defs.put("Material", materialDef);
+
+        // Create properties with $ref reference
+        Map<String, Object> materialProperty = new HashMap<>();
+        materialProperty.put("type", "object");
+        materialProperty.put(
+                "properties",
+                Map.of(
+                        "searchMaterialList",
+                        Map.of("type", "array", "items", Map.of("$ref", "#/$defs/Material"))));
+
+        Map<String, Object> properties = new HashMap<>();
+        properties.put("request", materialProperty);
+
+        // Create MCP JsonSchema with defs
+        McpSchema.JsonSchema schema =
+                new McpSchema.JsonSchema(
+                        "object", properties, List.of("request"), null, defs, null);
+
+        Map<String, Object> result = McpTool.convertMcpSchemaToParameters(schema, null);
+
+        assertNotNull(result);
+        assertEquals("object", result.get("type"));
+
+        // Verify $defs field is correctly copied
+        assertTrue(result.containsKey("$defs"), "$defs should be present in converted schema");
+        Map<?, ?> resultDefs = (Map<?, ?>) result.get("$defs");
+        assertTrue(
+                resultDefs.containsKey("Material"),
+                "Material definition should be present in $defs");
+    }
+
+    @Test
+    void testConvertMcpSchemaToParameters_WithDefinitions() {
+        // Create Material definition in definitions (legacy JSON Schema)
+        Map<String, Object> materialDef = new HashMap<>();
+        materialDef.put("type", "object");
+        materialDef.put("properties", Map.of("key", Map.of("type", "string")));
+
+        Map<String, Object> definitions = new HashMap<>();
+        definitions.put("Material", materialDef);
+
+        McpSchema.JsonSchema schema =
+                new McpSchema.JsonSchema(
+                        "object", new HashMap<>(), new ArrayList<>(), null, null, definitions);
+
+        Map<String, Object> result = McpTool.convertMcpSchemaToParameters(schema, null);
+
+        assertNotNull(result);
+
+        // Verify definitions field is correctly copied
+        assertTrue(
+                result.containsKey("definitions"),
+                "definitions should be present in converted schema");
+        Map<?, ?> resultDefinitions = (Map<?, ?>) result.get("definitions");
+        assertTrue(
+                resultDefinitions.containsKey("Material"),
+                "Material definition should be present in definitions");
+    }
+
+    @Test
+    void testConvertMcpSchemaToParameters_WithBothDefsAndDefinitions() {
+        Map<String, Object> defs = new HashMap<>();
+        defs.put("NewType", Map.of("type", "string"));
+
+        Map<String, Object> definitions = new HashMap<>();
+        definitions.put("OldType", Map.of("type", "integer"));
+
+        McpSchema.JsonSchema schema =
+                new McpSchema.JsonSchema(
+                        "object", new HashMap<>(), new ArrayList<>(), null, defs, definitions);
+
+        Map<String, Object> result = McpTool.convertMcpSchemaToParameters(schema, null);
+
+        assertNotNull(result);
+        assertTrue(result.containsKey("$defs"), "$defs should be present");
+        assertTrue(result.containsKey("definitions"), "definitions should be present");
+    }
+
+    @Test
+    void testConvertMcpSchemaToParameters_WithEmptyDefsAndDefinitions() {
+        // Empty maps should not be added to result
+        McpSchema.JsonSchema schema =
+                new McpSchema.JsonSchema(
+                        "object",
+                        new HashMap<>(),
+                        new ArrayList<>(),
+                        null,
+                        new HashMap<>(),
+                        new HashMap<>());
+
+        Map<String, Object> result = McpTool.convertMcpSchemaToParameters(schema, null);
+
+        assertNotNull(result);
+        assertFalse(result.containsKey("$defs"), "Empty $defs should not be present");
+        assertFalse(result.containsKey("definitions"), "Empty definitions should not be present");
+    }
+
+    @Test
+    void testConvertMcpSchemaToParameters_DefsWithMultipleDefinitions() {
+        // Test $defs with multiple type definitions
+        Map<String, Object> defs = new HashMap<>();
+        defs.put(
+                "Material",
+                Map.of("type", "object", "properties", Map.of("id", Map.of("type", "string"))));
+        defs.put("Category", Map.of("type", "string", "enum", List.of("A", "B", "C")));
+
+        Map<String, Object> properties = new HashMap<>();
+        properties.put(
+                "items", Map.of("type", "array", "items", Map.of("$ref", "#/$defs/Material")));
+        properties.put("category", Map.of("$ref", "#/$defs/Category"));
+
+        McpSchema.JsonSchema schema =
+                new McpSchema.JsonSchema("object", properties, List.of("items"), null, defs, null);
+
+        Map<String, Object> result = McpTool.convertMcpSchemaToParameters(schema, null);
+
+        assertNotNull(result);
+        assertTrue(result.containsKey("$defs"));
+        Map<?, ?> resultDefs = (Map<?, ?>) result.get("$defs");
+        assertEquals(2, resultDefs.size(), "Should have 2 definitions");
+        assertTrue(resultDefs.containsKey("Material"));
+        assertTrue(resultDefs.containsKey("Category"));
+    }
+
+    @Test
+    void testConvertMcpSchemaToParameters_DefsWithExcludeParams() {
+        // Test that $defs is preserved even when excludeParams is used
+        Map<String, Object> defs = new HashMap<>();
+        defs.put("ItemType", Map.of("type", "string"));
+
+        Map<String, Object> properties = new HashMap<>();
+        properties.put("name", Map.of("type", "string"));
+        properties.put("hidden", Map.of("type", "string"));
+
+        McpSchema.JsonSchema schema =
+                new McpSchema.JsonSchema(
+                        "object", properties, List.of("name", "hidden"), null, defs, null);
+
+        Map<String, Object> result = McpTool.convertMcpSchemaToParameters(schema, Set.of("hidden"));
+
+        assertNotNull(result);
+        assertTrue(result.containsKey("$defs"), "$defs should be preserved with excludeParams");
+        assertFalse(
+                ((Map<?, ?>) result.get("properties")).containsKey("hidden"),
+                "hidden property should be excluded");
+    }
+
+    @Test
+    void testConvertMcpSchemaToParameters_WithNullDefsAndDefinitions() {
+        // When defs and definitions are null, they should not be added to result
+        Map<String, Object> properties = new HashMap<>();
+        properties.put("name", Map.of("type", "string"));
+
+        McpSchema.JsonSchema schema =
+                new McpSchema.JsonSchema("object", properties, List.of("name"), null, null, null);
+
+        Map<String, Object> result = McpTool.convertMcpSchemaToParameters(schema, null);
+
+        assertNotNull(result);
+        assertFalse(result.containsKey("$defs"), "null $defs should not be present");
+        assertFalse(result.containsKey("definitions"), "null definitions should not be present");
+    }
+
+    @Test
+    void testConvertMcpSchemaToParameters_OnlyDefsNull() {
+        // Test when only definitions is present, defs is null
+        Map<String, Object> definitions = new HashMap<>();
+        definitions.put("OldType", Map.of("type", "integer"));
+
+        McpSchema.JsonSchema schema =
+                new McpSchema.JsonSchema(
+                        "object", new HashMap<>(), new ArrayList<>(), null, null, definitions);
+
+        Map<String, Object> result = McpTool.convertMcpSchemaToParameters(schema, null);
+
+        assertNotNull(result);
+        assertFalse(result.containsKey("$defs"), "null $defs should not be present");
+        assertTrue(result.containsKey("definitions"), "definitions should be present");
+    }
+
+    @Test
+    void testConvertMcpSchemaToParameters_OnlyDefinitionsNull() {
+        // Test when only defs is present, definitions is null
+        Map<String, Object> defs = new HashMap<>();
+        defs.put("NewType", Map.of("type", "string"));
+
+        McpSchema.JsonSchema schema =
+                new McpSchema.JsonSchema(
+                        "object", new HashMap<>(), new ArrayList<>(), null, defs, null);
+
+        Map<String, Object> result = McpTool.convertMcpSchemaToParameters(schema, null);
+
+        assertNotNull(result);
+        assertTrue(result.containsKey("$defs"), "$defs should be present");
+        assertFalse(result.containsKey("definitions"), "null definitions should not be present");
+    }
 }


### PR DESCRIPTION
 ---                                                                                                 
  AgentScope-Java Version
                                                                                                      
  1.0.10-SNAPSHOT                                           

  Description

  Background

  When MCP (Model Context Protocol) tools return JSON Schema with $ref references, the referenced type
   definitions are stored in $defs (JSON Schema 2020-12) or definitions (legacy JSON Schema) fields.
  These definitions are essential for resolving $ref references.

  Problem

  The McpTool.convertMcpSchemaToParameters() method was only copying type, properties, required, and
  additionalProperties fields from the MCP JsonSchema. The $defs and definitions fields were being
  dropped during conversion, causing $ref references to become invalid.

  Solution

  Added logic to preserve $defs and definitions fields when converting MCP schema to AgentScope
  parameters:

  // Preserve $defs and definitions for $ref resolution
  if (inputSchema.defs() != null && !inputSchema.defs().isEmpty()) {
      parameters.put("$defs", new HashMap<>(inputSchema.defs()));
  }

  if (inputSchema.definitions() != null && !inputSchema.definitions().isEmpty()) {
      parameters.put("definitions", new HashMap<>(inputSchema.definitions()));
  }

  Changes

  - McpTool.java: Added handling for $defs and definitions fields in convertMcpSchemaToParameters()
  - McpToolTest.java: Added 3 test cases:
    - testConvertMcpSchemaToParameters_WithDefs: Tests $defs preservation
    - testConvertMcpSchemaToParameters_WithDefinitions: Tests definitions preservation
    - testConvertMcpSchemaToParameters_WithBothDefsAndDefinitions: Tests both fields together

  How to Test

  mvn test -pl agentscope-core -Dtest=McpToolTest

  Fixes #893

  Checklist

  - Code has been formatted with mvn spotless:apply
  - All tests are passing (mvn test)
  - Javadoc comments are complete and follow project conventions
  - Related documentation has been updated (e.g. links, examples, etc.)
  - Code is ready for review

  ---