### PR TITLE
feat(nacos-prompt): migrate NacosPromptListener to Nacos 3.2.0 AiService API with version/label support

### DIFF
--- a/agentscope-dependencies-bom/pom.xml
+++ b/agentscope-dependencies-bom/pom.xml
@@ -103,7 +103,7 @@
         <quartz.version>2.5.2</quartz.version>
         <spring.version>7.0.3</spring.version>
         <spring-boot.version>4.0.3</spring-boot.version>
-        <nacos-client.version>3.1.1</nacos-client.version>
+        <nacos-client.version>3.2.0-BETA</nacos-client.version>
         <json-schema-validator.version>3.0.0</json-schema-validator.version>
         <jsonschema-generator.version>4.38.0</jsonschema-generator.version>
         <snakeyaml.version>2.6</snakeyaml.version>

--- a/agentscope-extensions/agentscope-extensions-nacos/agentscope-extensions-nacos-prompt/src/main/java/io/agentscope/core/nacos/prompt/NacosPromptListener.java
+++ b/agentscope-extensions/agentscope-extensions-nacos/agentscope-extensions-nacos-prompt/src/main/java/io/agentscope/core/nacos/prompt/NacosPromptListener.java
@@ -16,16 +16,13 @@
 
 package io.agentscope.core.nacos.prompt;
 
-import com.alibaba.nacos.api.config.ConfigService;
-import com.alibaba.nacos.api.config.listener.Listener;
+import com.alibaba.nacos.api.ai.AiService;
+import com.alibaba.nacos.api.ai.listener.AbstractNacosPromptListener;
+import com.alibaba.nacos.api.ai.listener.NacosPromptEvent;
+import com.alibaba.nacos.api.ai.model.prompt.Prompt;
 import com.alibaba.nacos.api.exception.NacosException;
-import com.alibaba.nacos.common.utils.JacksonUtils;
-import com.fasterxml.jackson.databind.JsonNode;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.Executor;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -33,18 +30,41 @@ public class NacosPromptListener {
 
     private static final Logger log = LoggerFactory.getLogger(NacosPromptListener.class);
 
-    private static final String PROMPT_KEY_SUFFIX = ".json";
-    private static final String FIELD_TEMPLATE = "template";
-    private static final String FIELD_PROMPT_KEY = "promptKey";
-    private static final String DEFAULT_GROUP = "nacos-ai-prompt";
-    private static final Pattern PLACEHOLDER_PATTERN = Pattern.compile("\\{\\{(.+?)\\}\\}");
+    private static final Prompt EMPTY_SENTINEL = new Prompt("", "", "");
 
-    private final ConfigService configService;
+    private final AiService aiService;
 
-    private final Map<String, String> prompts;
+    private final Map<String, Prompt> prompts;
 
-    public NacosPromptListener(ConfigService configService) {
-        this.configService = configService;
+    private final AbstractNacosPromptListener internalListener =
+            new AbstractNacosPromptListener() {
+                @Override
+                public void onEvent(NacosPromptEvent event) {
+                    if (event == null) {
+                        return;
+                    }
+                    String key = event.getPromptKey();
+                    Prompt prompt = event.getPrompt();
+                    if (key == null || key.isEmpty()) {
+                        log.warn("Received prompt event with null or empty promptKey");
+                        return;
+                    }
+                    if (prompt != null && prompt.getTemplate() != null) {
+                        prompts.put(key, prompt);
+                        log.info(
+                                "Prompt updated for key: {}, version: {}",
+                                key,
+                                prompt.getVersion());
+                    } else {
+                        log.warn(
+                                "Received prompt event with null prompt or template for key: {}",
+                                key);
+                    }
+                }
+            };
+
+    public NacosPromptListener(AiService aiService) {
+        this.aiService = aiService;
         this.prompts = new ConcurrentHashMap<>(10);
     }
 
@@ -57,7 +77,8 @@ public class NacosPromptListener {
     }
 
     /**
-     * Get prompt template with optional default value
+     * Get prompt template with optional default value.
+     *
      * @param promptKey the prompt key
      * @param args the template variables for rendering
      * @param defaultValue the default value to use if prompt not found in Nacos
@@ -66,142 +87,73 @@ public class NacosPromptListener {
      */
     public String getPrompt(String promptKey, Map<String, String> args, String defaultValue)
             throws NacosException {
-        // Use computeIfAbsent to ensure atomic check-and-load operation
-        String template =
-                prompts.computeIfAbsent(
-                        promptKey,
-                        key -> {
-                            try {
-                                return getPromptFromNacosAndListener(key);
-                            } catch (NacosException e) {
-                                log.error("Failed to load prompt from Nacos for key: {}", key, e);
-                                return "";
-                            }
-                        });
-
-        // Use default value if template is empty
-        if (template == null || template.isEmpty()) {
-            if (defaultValue != null) {
-                log.info("Using default value for prompt key: {}", promptKey);
-                template = defaultValue;
-            } else {
-                return "";
-            }
-        }
-
-        // Render template with args if provided
-        if (args != null && !args.isEmpty()) {
-            return renderTemplate(template, args);
-        }
-        return template;
-    }
-
-    private String getPromptFromNacosAndListener(String promptKey) throws NacosException {
-        String promptDataId = promptKey + PROMPT_KEY_SUFFIX;
-        String promptStr =
-                configService.getConfigAndSignListener(
-                        promptDataId, DEFAULT_GROUP, 5000, this.promptListener);
-
-        JsonNode node;
-        try {
-            node = JacksonUtils.toObj(promptStr, JsonNode.class);
-        } catch (Exception e) {
-            log.warn("Failed to parse prompt config JSON for key: {}", promptKey, e);
-            return "";
-        }
-
-        if (node == null || !node.has(FIELD_PROMPT_KEY) || !node.has(FIELD_TEMPLATE)) {
-            log.warn("Invalid prompt config for key: {}, missing required fields", promptKey);
-            return "";
-        }
-
-        JsonNode templateNode = node.get(FIELD_TEMPLATE);
-        if (templateNode == null || templateNode.isNull()) {
-            log.warn("Template field is null for prompt key: {}", promptKey);
-            return "";
-        }
-
-        String promptTemplate = templateNode.asText();
-        log.info("Loaded prompt template for key: {}", promptKey);
-        return promptTemplate;
+        return getPrompt(promptKey, null, null, args, defaultValue);
     }
 
     /**
-     * Render template by replacing {{variableName}} with values from args.
-     * Uses single-pass regex replacement for better performance.
-     * Unmatched placeholders are preserved as-is.
+     * Get prompt template with version/label targeting and optional default value.
      *
-     * @param template the template string with {{}} placeholders
-     * @param args the variable map for replacement
-     * @return rendered string
+     * @param promptKey the prompt key
+     * @param version target prompt version (e.g. "1.0.0"), mutually exclusive with label
+     * @param label target prompt label (e.g. "prod"), mutually exclusive with version
+     * @param args the template variables for rendering
+     * @param defaultValue the default value to use if prompt not found in Nacos
+     * @return rendered prompt string or default value
+     * @throws NacosException if Nacos service error occurs
      */
-    private String renderTemplate(String template, Map<String, String> args) {
-        if (template == null || template.isEmpty()) {
-            return template;
+    public String getPrompt(
+            String promptKey,
+            String version,
+            String label,
+            Map<String, String> args,
+            String defaultValue)
+            throws NacosException {
+
+        Prompt prompt = prompts.get(promptKey);
+        if (prompt == null) {
+            try {
+                prompt = subscribeAndLoad(promptKey, version, label);
+            } catch (NacosException e) {
+                log.error("Failed to load prompt from Nacos for key: {}", promptKey, e);
+                if (defaultValue != null) {
+                    log.info("Using default value for prompt key: {}", promptKey);
+                    return renderDefault(defaultValue, args);
+                }
+                throw e;
+            }
+            prompts.putIfAbsent(promptKey, prompt);
+            prompt = prompts.get(promptKey);
         }
 
-        Matcher matcher = PLACEHOLDER_PATTERN.matcher(template);
-        StringBuilder sb = new StringBuilder();
-        while (matcher.find()) {
-            String key = matcher.group(1);
-            if (args.containsKey(key)) {
-                String value = args.get(key) != null ? args.get(key) : "";
-                matcher.appendReplacement(sb, Matcher.quoteReplacement(value));
+        if (prompt == EMPTY_SENTINEL
+                || prompt.getTemplate() == null
+                || prompt.getTemplate().isEmpty()) {
+            if (defaultValue != null) {
+                log.info("Using default value for prompt key: {}", promptKey);
+                return renderDefault(defaultValue, args);
             }
+            return "";
         }
-        matcher.appendTail(sb);
-        return sb.toString();
+
+        return prompt.render(args);
     }
 
-    private final Listener promptListener =
-            new Listener() {
-                @Override
-                public Executor getExecutor() {
-                    return null;
-                }
+    private Prompt subscribeAndLoad(String promptKey, String version, String label)
+            throws NacosException {
+        Prompt prompt = aiService.subscribePrompt(promptKey, version, label, internalListener);
+        if (prompt != null) {
+            log.info("Loaded prompt for key: {}, version: {}", promptKey, prompt.getVersion());
+            return prompt;
+        }
+        log.warn("Prompt not found in Nacos for key: {}", promptKey);
+        return EMPTY_SENTINEL;
+    }
 
-                @Override
-                public void receiveConfigInfo(String configInfo) {
-                    try {
-                        JsonNode node = JacksonUtils.toObj(configInfo, JsonNode.class);
-                        if (node == null || !node.has(FIELD_PROMPT_KEY)) {
-                            log.warn("Received invalid prompt config, missing promptKey field");
-                            return;
-                        }
-
-                        JsonNode promptKeyNode = node.get(FIELD_PROMPT_KEY);
-                        if (promptKeyNode == null || promptKeyNode.isNull()) {
-                            log.warn("PromptKey field is null in configuration");
-                            return;
-                        }
-
-                        String promptKey = promptKeyNode.asText();
-
-                        if (!node.has(FIELD_TEMPLATE)) {
-                            log.warn(
-                                    "No template field found in configuration for key: {}",
-                                    promptKey);
-                            return;
-                        }
-
-                        JsonNode templateNode = node.get(FIELD_TEMPLATE);
-                        if (templateNode == null || templateNode.isNull()) {
-                            log.warn(
-                                    "Template field is null in configuration for key: {}",
-                                    promptKey);
-                            return;
-                        }
-
-                        String newTemplate = templateNode.asText();
-                        prompts.put(promptKey, newTemplate);
-                        log.info("Prompt template updated for key: {}", promptKey);
-
-                    } catch (Exception e) {
-                        log.error(
-                                "Failed to parse prompt configuration from config: {}",
-                                configInfo,
-                                e);
-                    }
-                }
-            };
+    private String renderDefault(String defaultValue, Map<String, String> args) {
+        if (args == null || args.isEmpty()) {
+            return defaultValue;
+        }
+        Prompt fallback = new Prompt(null, null, defaultValue);
+        return fallback.render(args);
+    }
 }

--- a/agentscope-extensions/agentscope-extensions-nacos/agentscope-extensions-nacos-prompt/src/test/java/io/agentscope/core/nacos/prompt/NacosPromptListenerTest.java
+++ b/agentscope-extensions/agentscope-extensions-nacos/agentscope-extensions-nacos-prompt/src/test/java/io/agentscope/core/nacos/prompt/NacosPromptListenerTest.java
@@ -17,16 +17,19 @@
 package io.agentscope.core.nacos.prompt;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import com.alibaba.nacos.api.config.ConfigService;
-import com.alibaba.nacos.api.config.listener.Listener;
+import com.alibaba.nacos.api.ai.AiService;
+import com.alibaba.nacos.api.ai.listener.AbstractNacosPromptListener;
+import com.alibaba.nacos.api.ai.listener.NacosPromptEvent;
+import com.alibaba.nacos.api.ai.model.prompt.Prompt;
 import com.alibaba.nacos.api.exception.NacosException;
 import java.lang.reflect.Field;
 import java.util.HashMap;
@@ -45,19 +48,13 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 class NacosPromptListenerTest {
 
-    private static final String VALID_CONFIG =
-            "{\"promptKey\":\"test-agent\",\"template\":\"You are {{role}} in {{department}}\"}";
-    private static final String VALID_CONFIG_NO_VARS =
-            "{\"promptKey\":\"simple\",\"template\":\"You are a helpful assistant\"}";
-    private static final String DEFAULT_GROUP = "nacos-ai-prompt";
-
-    @Mock private ConfigService configService;
+    @Mock private AiService aiService;
 
     private NacosPromptListener listener;
 
     @BeforeEach
     void setUp() {
-        listener = new NacosPromptListener(configService);
+        listener = new NacosPromptListener(aiService);
     }
 
     @Nested
@@ -67,9 +64,9 @@ class NacosPromptListenerTest {
         @Test
         @DisplayName("should load prompt from Nacos and return rendered template")
         void shouldLoadAndRenderPrompt() throws NacosException {
-            when(configService.getConfigAndSignListener(
-                            eq("test-agent.json"), eq(DEFAULT_GROUP), anyLong(), any()))
-                    .thenReturn(VALID_CONFIG);
+            Prompt prompt = new Prompt("test-agent", "1.0.0", "You are {{role}} in {{department}}");
+            when(aiService.subscribePrompt(eq("test-agent"), isNull(), isNull(), any()))
+                    .thenReturn(prompt);
 
             Map<String, String> args = Map.of("role", "AI Assistant", "department", "Engineering");
             String result = listener.getPrompt("test-agent", args);
@@ -80,9 +77,9 @@ class NacosPromptListenerTest {
         @Test
         @DisplayName("should load prompt without variable rendering when args is null")
         void shouldLoadPromptWithoutArgs() throws NacosException {
-            when(configService.getConfigAndSignListener(
-                            eq("simple.json"), eq(DEFAULT_GROUP), anyLong(), any()))
-                    .thenReturn(VALID_CONFIG_NO_VARS);
+            Prompt prompt = new Prompt("simple", "1.0.0", "You are a helpful assistant");
+            when(aiService.subscribePrompt(eq("simple"), isNull(), isNull(), any()))
+                    .thenReturn(prompt);
 
             String result = listener.getPrompt("simple");
 
@@ -92,9 +89,9 @@ class NacosPromptListenerTest {
         @Test
         @DisplayName("should load prompt without variable rendering when args is empty")
         void shouldLoadPromptWithEmptyArgs() throws NacosException {
-            when(configService.getConfigAndSignListener(
-                            eq("simple.json"), eq(DEFAULT_GROUP), anyLong(), any()))
-                    .thenReturn(VALID_CONFIG_NO_VARS);
+            Prompt prompt = new Prompt("simple", "1.0.0", "You are a helpful assistant");
+            when(aiService.subscribePrompt(eq("simple"), isNull(), isNull(), any()))
+                    .thenReturn(prompt);
 
             String result = listener.getPrompt("simple", Map.of());
 
@@ -102,51 +99,79 @@ class NacosPromptListenerTest {
         }
 
         @Test
-        @DisplayName("should return empty string when prompt config is invalid JSON")
-        void shouldReturnEmptyForInvalidJson() throws NacosException {
-            when(configService.getConfigAndSignListener(
-                            eq("bad.json"), eq(DEFAULT_GROUP), anyLong(), any()))
-                    .thenReturn("not valid json");
+        @DisplayName("should return empty string when prompt is not found in Nacos")
+        void shouldReturnEmptyForMissingPrompt() throws NacosException {
+            when(aiService.subscribePrompt(eq("missing"), isNull(), isNull(), any()))
+                    .thenReturn(null);
 
-            String result = listener.getPrompt("bad");
-
-            assertTrue(result.isEmpty());
-        }
-
-        @Test
-        @DisplayName("should return empty string when config missing promptKey field")
-        void shouldReturnEmptyForMissingPromptKey() throws NacosException {
-            when(configService.getConfigAndSignListener(
-                            eq("no-key.json"), eq(DEFAULT_GROUP), anyLong(), any()))
-                    .thenReturn("{\"template\":\"some text\"}");
-
-            String result = listener.getPrompt("no-key");
+            String result = listener.getPrompt("missing");
 
             assertTrue(result.isEmpty());
         }
 
         @Test
-        @DisplayName("should return empty string when config missing template field")
-        void shouldReturnEmptyForMissingTemplate() throws NacosException {
-            when(configService.getConfigAndSignListener(
-                            eq("no-tpl.json"), eq(DEFAULT_GROUP), anyLong(), any()))
-                    .thenReturn("{\"promptKey\":\"no-tpl\"}");
-
-            String result = listener.getPrompt("no-tpl");
-
-            assertTrue(result.isEmpty());
-        }
-
-        @Test
-        @DisplayName("should return empty string when template field is null")
+        @DisplayName("should return empty string when prompt template is null")
         void shouldReturnEmptyForNullTemplate() throws NacosException {
-            when(configService.getConfigAndSignListener(
-                            eq("null-tpl.json"), eq(DEFAULT_GROUP), anyLong(), any()))
-                    .thenReturn("{\"promptKey\":\"null-tpl\",\"template\":null}");
+            Prompt prompt = new Prompt("null-tpl", "1.0.0", null);
+            when(aiService.subscribePrompt(eq("null-tpl"), isNull(), isNull(), any()))
+                    .thenReturn(prompt);
 
             String result = listener.getPrompt("null-tpl");
 
             assertTrue(result.isEmpty());
+        }
+
+        @Test
+        @DisplayName("should return empty string when prompt template is empty string")
+        void shouldReturnEmptyForEmptyTemplate() throws NacosException {
+            Prompt prompt = new Prompt("empty-tpl", "1.0.0", "");
+            when(aiService.subscribePrompt(eq("empty-tpl"), isNull(), isNull(), any()))
+                    .thenReturn(prompt);
+
+            String result = listener.getPrompt("empty-tpl");
+
+            assertTrue(result.isEmpty());
+        }
+
+        @Test
+        @DisplayName("should fallback to default when prompt template is empty string")
+        void shouldFallbackWhenEmptyTemplate() throws NacosException {
+            Prompt prompt = new Prompt("empty-tpl", "1.0.0", "");
+            when(aiService.subscribePrompt(eq("empty-tpl"), isNull(), isNull(), any()))
+                    .thenReturn(prompt);
+
+            String result = listener.getPrompt("empty-tpl", null, "Default for empty");
+
+            assertEquals("Default for empty", result);
+        }
+    }
+
+    @Nested
+    @DisplayName("getPrompt - version and label")
+    class VersionAndLabelTests {
+
+        @Test
+        @DisplayName("should load prompt with specific version")
+        void shouldLoadPromptByVersion() throws NacosException {
+            Prompt prompt = new Prompt("versioned", "2.0.0", "Version 2 template");
+            when(aiService.subscribePrompt(eq("versioned"), eq("2.0.0"), isNull(), any()))
+                    .thenReturn(prompt);
+
+            String result = listener.getPrompt("versioned", "2.0.0", null, null, null);
+
+            assertEquals("Version 2 template", result);
+        }
+
+        @Test
+        @DisplayName("should load prompt with specific label")
+        void shouldLoadPromptByLabel() throws NacosException {
+            Prompt prompt = new Prompt("labeled", "1.0.0", "Production template");
+            when(aiService.subscribePrompt(eq("labeled"), isNull(), eq("prod"), any()))
+                    .thenReturn(prompt);
+
+            String result = listener.getPrompt("labeled", null, "prod", null, null);
+
+            assertEquals("Production template", result);
         }
     }
 
@@ -155,11 +180,10 @@ class NacosPromptListenerTest {
     class DefaultValueTests {
 
         @Test
-        @DisplayName("should use default value when Nacos returns empty config")
+        @DisplayName("should use default value when Nacos returns null prompt")
         void shouldFallbackToDefaultValue() throws NacosException {
-            when(configService.getConfigAndSignListener(
-                            eq("missing.json"), eq(DEFAULT_GROUP), anyLong(), any()))
-                    .thenReturn("{\"promptKey\":\"missing\"}");
+            when(aiService.subscribePrompt(eq("missing"), isNull(), isNull(), any()))
+                    .thenReturn(null);
 
             String result = listener.getPrompt("missing", null, "I am a fallback assistant");
 
@@ -169,9 +193,8 @@ class NacosPromptListenerTest {
         @Test
         @DisplayName("should render default value with args")
         void shouldRenderDefaultValueWithArgs() throws NacosException {
-            when(configService.getConfigAndSignListener(
-                            eq("missing.json"), eq(DEFAULT_GROUP), anyLong(), any()))
-                    .thenReturn("{\"promptKey\":\"missing\"}");
+            when(aiService.subscribePrompt(eq("missing"), isNull(), isNull(), any()))
+                    .thenReturn(null);
 
             Map<String, String> args = Map.of("name", "Bob");
             String result = listener.getPrompt("missing", args, "Hello {{name}}");
@@ -182,9 +205,8 @@ class NacosPromptListenerTest {
         @Test
         @DisplayName("should return empty string when no default value and Nacos empty")
         void shouldReturnEmptyWhenNoDefaultAndNacosEmpty() throws NacosException {
-            when(configService.getConfigAndSignListener(
-                            eq("missing.json"), eq(DEFAULT_GROUP), anyLong(), any()))
-                    .thenReturn("{\"promptKey\":\"missing\"}");
+            when(aiService.subscribePrompt(eq("missing"), isNull(), isNull(), any()))
+                    .thenReturn(null);
 
             String result = listener.getPrompt("missing", null, null);
 
@@ -194,9 +216,9 @@ class NacosPromptListenerTest {
         @Test
         @DisplayName("should use Nacos value over default value when both available")
         void shouldPreferNacosOverDefault() throws NacosException {
-            when(configService.getConfigAndSignListener(
-                            eq("test-agent.json"), eq(DEFAULT_GROUP), anyLong(), any()))
-                    .thenReturn(VALID_CONFIG);
+            Prompt prompt = new Prompt("test-agent", "1.0.0", "You are {{role}} in {{department}}");
+            when(aiService.subscribePrompt(eq("test-agent"), isNull(), isNull(), any()))
+                    .thenReturn(prompt);
 
             String result =
                     listener.getPrompt(
@@ -210,13 +232,21 @@ class NacosPromptListenerTest {
         @Test
         @DisplayName("should use default value when NacosException occurs during loading")
         void shouldFallbackOnNacosException() throws NacosException {
-            when(configService.getConfigAndSignListener(
-                            eq("error.json"), eq(DEFAULT_GROUP), anyLong(), any()))
+            when(aiService.subscribePrompt(eq("error"), isNull(), isNull(), any()))
                     .thenThrow(new NacosException(500, "Nacos server error"));
 
             String result = listener.getPrompt("error", null, "Fallback on error");
 
             assertEquals("Fallback on error", result);
+        }
+
+        @Test
+        @DisplayName("should throw NacosException when no default value provided")
+        void shouldThrowWhenNoDefaultAndNacosException() throws NacosException {
+            when(aiService.subscribePrompt(eq("error"), isNull(), isNull(), any()))
+                    .thenThrow(new NacosException(500, "Nacos server error"));
+
+            assertThrows(NacosException.class, () -> listener.getPrompt("error"));
         }
     }
 
@@ -227,12 +257,11 @@ class NacosPromptListenerTest {
         @Test
         @DisplayName("should replace multiple variables in template")
         void shouldReplaceMultipleVariables() throws NacosException {
-            String config =
-                    "{\"promptKey\":\"multi\",\"template\":\"{{greeting}} I am {{name}}, working at"
-                            + " {{company}}\"}";
-            when(configService.getConfigAndSignListener(
-                            eq("multi.json"), eq(DEFAULT_GROUP), anyLong(), any()))
-                    .thenReturn(config);
+            Prompt prompt =
+                    new Prompt(
+                            "multi", "1.0.0", "{{greeting}} I am {{name}}, working at {{company}}");
+            when(aiService.subscribePrompt(eq("multi"), isNull(), isNull(), any()))
+                    .thenReturn(prompt);
 
             Map<String, String> args = new HashMap<>();
             args.put("greeting", "Hello!");
@@ -247,12 +276,9 @@ class NacosPromptListenerTest {
         @Test
         @DisplayName("should leave unmatched placeholders as-is")
         void shouldLeaveUnmatchedPlaceholders() throws NacosException {
-            String config =
-                    "{\"promptKey\":\"partial\","
-                            + "\"template\":\"Hello {{name}}, your role is {{role}}\"}";
-            when(configService.getConfigAndSignListener(
-                            eq("partial.json"), eq(DEFAULT_GROUP), anyLong(), any()))
-                    .thenReturn(config);
+            Prompt prompt = new Prompt("partial", "1.0.0", "Hello {{name}}, your role is {{role}}");
+            when(aiService.subscribePrompt(eq("partial"), isNull(), isNull(), any()))
+                    .thenReturn(prompt);
 
             Map<String, String> args = Map.of("name", "Alice");
             String result = listener.getPrompt("partial", args);
@@ -263,10 +289,9 @@ class NacosPromptListenerTest {
         @Test
         @DisplayName("should handle null value in args by replacing with empty string")
         void shouldHandleNullArgValue() throws NacosException {
-            String config = "{\"promptKey\":\"nullval\"," + "\"template\":\"Hello {{name}}\"}";
-            when(configService.getConfigAndSignListener(
-                            eq("nullval.json"), eq(DEFAULT_GROUP), anyLong(), any()))
-                    .thenReturn(config);
+            Prompt prompt = new Prompt("nullval", "1.0.0", "Hello {{name}}");
+            when(aiService.subscribePrompt(eq("nullval"), isNull(), isNull(), any()))
+                    .thenReturn(prompt);
 
             Map<String, String> args = new HashMap<>();
             args.put("name", null);
@@ -283,38 +308,32 @@ class NacosPromptListenerTest {
         @Test
         @DisplayName("should only call Nacos once for the same key (cache hit)")
         void shouldCachePromptAfterFirstLoad() throws NacosException {
-            when(configService.getConfigAndSignListener(
-                            eq("cached.json"), eq(DEFAULT_GROUP), anyLong(), any()))
-                    .thenReturn(VALID_CONFIG_NO_VARS);
+            Prompt prompt = new Prompt("cached", "1.0.0", "You are a helpful assistant");
+            when(aiService.subscribePrompt(eq("cached"), isNull(), isNull(), any()))
+                    .thenReturn(prompt);
 
             listener.getPrompt("cached");
             listener.getPrompt("cached");
             listener.getPrompt("cached");
 
-            verify(configService, times(1))
-                    .getConfigAndSignListener(
-                            eq("cached.json"), eq(DEFAULT_GROUP), anyLong(), any());
+            verify(aiService, times(1)).subscribePrompt(eq("cached"), isNull(), isNull(), any());
         }
 
         @Test
         @DisplayName("should call Nacos separately for different keys")
         void shouldLoadDifferentKeysIndependently() throws NacosException {
-            when(configService.getConfigAndSignListener(
-                            eq("key-a.json"), eq(DEFAULT_GROUP), anyLong(), any()))
-                    .thenReturn("{\"promptKey\":\"key-a\",\"template\":\"Template A\"}");
-            when(configService.getConfigAndSignListener(
-                            eq("key-b.json"), eq(DEFAULT_GROUP), anyLong(), any()))
-                    .thenReturn("{\"promptKey\":\"key-b\",\"template\":\"Template B\"}");
+            Prompt promptA = new Prompt("key-a", "1.0.0", "Template A");
+            Prompt promptB = new Prompt("key-b", "1.0.0", "Template B");
+            when(aiService.subscribePrompt(eq("key-a"), isNull(), isNull(), any()))
+                    .thenReturn(promptA);
+            when(aiService.subscribePrompt(eq("key-b"), isNull(), isNull(), any()))
+                    .thenReturn(promptB);
 
             assertEquals("Template A", listener.getPrompt("key-a"));
             assertEquals("Template B", listener.getPrompt("key-b"));
 
-            verify(configService, times(1))
-                    .getConfigAndSignListener(
-                            eq("key-a.json"), eq(DEFAULT_GROUP), anyLong(), any());
-            verify(configService, times(1))
-                    .getConfigAndSignListener(
-                            eq("key-b.json"), eq(DEFAULT_GROUP), anyLong(), any());
+            verify(aiService, times(1)).subscribePrompt(eq("key-a"), isNull(), isNull(), any());
+            verify(aiService, times(1)).subscribePrompt(eq("key-b"), isNull(), isNull(), any());
         }
     }
 
@@ -323,81 +342,106 @@ class NacosPromptListenerTest {
     class ListenerCallbackTests {
 
         @Test
-        @DisplayName("should update cached prompt when listener receives new config")
+        @DisplayName("should update cached prompt when listener receives new prompt")
         void shouldUpdateCacheOnListenerCallback() throws Exception {
-            when(configService.getConfigAndSignListener(
-                            eq("updatable.json"), eq(DEFAULT_GROUP), anyLong(), any()))
-                    .thenReturn(
-                            "{\"promptKey\":\"updatable\","
-                                    + "\"template\":\"Original template\"}");
+            Prompt original = new Prompt("updatable", "1.0.0", "Original template");
+            when(aiService.subscribePrompt(eq("updatable"), isNull(), isNull(), any()))
+                    .thenReturn(original);
 
-            // First load
             assertEquals("Original template", listener.getPrompt("updatable"));
 
-            // Simulate listener callback with updated config
-            Listener nacosListener = getPromptListener();
-            nacosListener.receiveConfigInfo(
-                    "{\"promptKey\":\"updatable\"," + "\"template\":\"Updated template\"}");
+            // Capture the listener registered with aiService
+            AbstractNacosPromptListener nacosListener = getInternalListener();
 
-            // Should return updated template
+            // Simulate prompt update event
+            Prompt updated = new Prompt("updatable", "2.0.0", "Updated template");
+            nacosListener.onEvent(new NacosPromptEvent("updatable", updated));
+
             assertEquals("Updated template", listener.getPrompt("updatable"));
         }
 
         @Test
-        @DisplayName("should not crash when listener receives invalid JSON")
-        void shouldHandleInvalidJsonInCallback() throws Exception {
-            when(configService.getConfigAndSignListener(
-                            eq("stable.json"), eq(DEFAULT_GROUP), anyLong(), any()))
-                    .thenReturn("{\"promptKey\":\"stable\"," + "\"template\":\"Stable template\"}");
+        @DisplayName("should not crash when listener receives event with null prompt")
+        void shouldHandleNullPromptInCallback() throws Exception {
+            Prompt original = new Prompt("stable", "1.0.0", "Stable template");
+            when(aiService.subscribePrompt(eq("stable"), isNull(), isNull(), any()))
+                    .thenReturn(original);
 
-            // First load
             assertEquals("Stable template", listener.getPrompt("stable"));
 
-            // Simulate listener callback with invalid JSON - should not throw
-            Listener nacosListener = getPromptListener();
-            nacosListener.receiveConfigInfo("not valid json");
+            AbstractNacosPromptListener nacosListener = getInternalListener();
+            nacosListener.onEvent(new NacosPromptEvent("stable", null));
 
-            // Should still return original template
             assertEquals("Stable template", listener.getPrompt("stable"));
         }
 
         @Test
-        @DisplayName("should ignore callback when missing promptKey field")
-        void shouldIgnoreCallbackMissingPromptKey() throws Exception {
-            when(configService.getConfigAndSignListener(
-                            eq("safe.json"), eq(DEFAULT_GROUP), anyLong(), any()))
-                    .thenReturn("{\"promptKey\":\"safe\"," + "\"template\":\"Safe template\"}");
+        @DisplayName("should ignore callback with null event")
+        void shouldIgnoreNullEvent() throws Exception {
+            Prompt original = new Prompt("safe", "1.0.0", "Safe template");
+            when(aiService.subscribePrompt(eq("safe"), isNull(), isNull(), any()))
+                    .thenReturn(original);
 
             assertEquals("Safe template", listener.getPrompt("safe"));
 
-            Listener nacosListener = getPromptListener();
-            nacosListener.receiveConfigInfo("{\"template\":\"No key here\"}");
+            AbstractNacosPromptListener nacosListener = getInternalListener();
+            nacosListener.onEvent(null);
 
             assertEquals("Safe template", listener.getPrompt("safe"));
         }
 
         @Test
-        @DisplayName("should ignore callback when template field is missing")
-        void shouldIgnoreCallbackMissingTemplate() throws Exception {
-            when(configService.getConfigAndSignListener(
-                            eq("keep.json"), eq(DEFAULT_GROUP), anyLong(), any()))
-                    .thenReturn("{\"promptKey\":\"keep\"," + "\"template\":\"Keep this\"}");
+        @DisplayName("should ignore callback when promptKey is empty")
+        void shouldIgnoreCallbackEmptyPromptKey() throws Exception {
+            Prompt original = new Prompt("keep", "1.0.0", "Keep this");
+            when(aiService.subscribePrompt(eq("keep"), isNull(), isNull(), any()))
+                    .thenReturn(original);
 
             assertEquals("Keep this", listener.getPrompt("keep"));
 
-            Listener nacosListener = getPromptListener();
-            nacosListener.receiveConfigInfo("{\"promptKey\":\"keep\"}");
+            AbstractNacosPromptListener nacosListener = getInternalListener();
+            Prompt rogue = new Prompt("", "1.0.0", "Should not be stored");
+            nacosListener.onEvent(new NacosPromptEvent("", rogue));
 
             assertEquals("Keep this", listener.getPrompt("keep"));
         }
 
-        /**
-         * Access the private promptListener field via reflection.
-         */
-        private Listener getPromptListener() throws Exception {
-            Field field = NacosPromptListener.class.getDeclaredField("promptListener");
+        @Test
+        @DisplayName("should ignore callback when promptKey is null")
+        void shouldIgnoreCallbackNullPromptKey() throws Exception {
+            Prompt original = new Prompt("keep2", "1.0.0", "Keep this too");
+            when(aiService.subscribePrompt(eq("keep2"), isNull(), isNull(), any()))
+                    .thenReturn(original);
+
+            assertEquals("Keep this too", listener.getPrompt("keep2"));
+
+            AbstractNacosPromptListener nacosListener = getInternalListener();
+            Prompt rogue = new Prompt(null, "1.0.0", "Should not be stored");
+            nacosListener.onEvent(new NacosPromptEvent(null, rogue));
+
+            assertEquals("Keep this too", listener.getPrompt("keep2"));
+        }
+
+        @Test
+        @DisplayName("should ignore callback when prompt has null template")
+        void shouldIgnoreCallbackNullTemplate() throws Exception {
+            Prompt original = new Prompt("keep3", "1.0.0", "Original");
+            when(aiService.subscribePrompt(eq("keep3"), isNull(), isNull(), any()))
+                    .thenReturn(original);
+
+            assertEquals("Original", listener.getPrompt("keep3"));
+
+            AbstractNacosPromptListener nacosListener = getInternalListener();
+            Prompt bad = new Prompt("keep3", "2.0.0", null);
+            nacosListener.onEvent(new NacosPromptEvent("keep3", bad));
+
+            assertEquals("Original", listener.getPrompt("keep3"));
+        }
+
+        private AbstractNacosPromptListener getInternalListener() throws Exception {
+            Field field = NacosPromptListener.class.getDeclaredField("internalListener");
             field.setAccessible(true);
-            return (Listener) field.get(listener);
+            return (AbstractNacosPromptListener) field.get(listener);
         }
     }
 }

--- a/agentscope-extensions/agentscope-spring-boot-starters/agentscope-nacos-spring-boot-starter/src/main/java/io/agentscope/spring/boot/nacos/AgentscopeNacosPromptAutoConfiguration.java
+++ b/agentscope-extensions/agentscope-spring-boot-starters/agentscope-nacos-spring-boot-starter/src/main/java/io/agentscope/spring/boot/nacos/AgentscopeNacosPromptAutoConfiguration.java
@@ -16,8 +16,8 @@
 
 package io.agentscope.spring.boot.nacos;
 
-import com.alibaba.nacos.api.config.ConfigFactory;
-import com.alibaba.nacos.api.config.ConfigService;
+import com.alibaba.nacos.api.ai.AiFactory;
+import com.alibaba.nacos.api.ai.AiService;
 import com.alibaba.nacos.api.exception.NacosException;
 import io.agentscope.core.nacos.prompt.NacosPromptListener;
 import io.agentscope.spring.boot.AgentscopeAutoConfiguration;
@@ -57,22 +57,20 @@ import org.springframework.context.annotation.Bean;
         matchIfMissing = true)
 public class AgentscopeNacosPromptAutoConfiguration {
 
-    @Bean(name = "agentscopePromptConfigService")
-    @ConditionalOnMissingBean(name = "agentscopePromptConfigService")
-    public ConfigService agentscopePromptConfigService(
+    @Bean(name = "agentscopePromptAiService")
+    @ConditionalOnMissingBean(name = "agentscopePromptAiService")
+    public AiService agentscopePromptAiService(
             AgentScopeNacosProperties nacosProperties,
             AgentScopeNacosPromptProperties promptNacosProperties)
             throws NacosException {
-        // Start from the global Nacos configuration (with defaults)
         Properties result = nacosProperties.getNacosProperties();
-        // Only overlay explicitly configured prompt-specific fields (no defaults)
         result.putAll(promptNacosProperties.getExplicitNacosProperties());
-        return ConfigFactory.createConfigService(result);
+        return AiFactory.createAiService(result);
     }
 
     @Bean
     @ConditionalOnMissingBean(NacosPromptListener.class)
-    public NacosPromptListener nacosPromptListener(ConfigService agentscopePromptConfigService) {
-        return new NacosPromptListener(agentscopePromptConfigService);
+    public NacosPromptListener nacosPromptListener(AiService agentscopePromptAiService) {
+        return new NacosPromptListener(agentscopePromptAiService);
     }
 }

--- a/agentscope-extensions/agentscope-spring-boot-starters/agentscope-nacos-spring-boot-starter/src/main/java/io/agentscope/spring/boot/nacos/AgentscopeNacosReActAgentAutoConfiguration.java
+++ b/agentscope-extensions/agentscope-spring-boot-starters/agentscope-nacos-spring-boot-starter/src/main/java/io/agentscope/spring/boot/nacos/AgentscopeNacosReActAgentAutoConfiguration.java
@@ -45,7 +45,7 @@ import org.springframework.context.annotation.Scope;
  * <p>This configuration is responsible only for wiring the Agent from existing building blocks
  * (model, memory, toolkit, Nacos prompt infrastructure). It is separated from
  * {@code AgentscopeNacosPromptAutoConfiguration}, which focuses on Nacos prompt-related
- * components such as {@code ConfigService} and {@code NacosPromptListener}.
+ * components such as {@code AiService} and {@code NacosPromptListener}.
  */
 @AutoConfiguration
 @AutoConfigureBefore(AgentscopeAutoConfiguration.class)
@@ -82,7 +82,11 @@ public class AgentscopeNacosReActAgentAutoConfiguration {
             try {
                 sysPrompt =
                         nacosPromptListener.getPrompt(
-                                promptKey, nacosPromptProperties.getVariables(), defaultSysPrompt);
+                                promptKey,
+                                nacosPromptProperties.getVersion(),
+                                nacosPromptProperties.getLabel(),
+                                nacosPromptProperties.getVariables(),
+                                defaultSysPrompt);
             } catch (NacosException e) {
                 log.warn(
                         "Failed to load sys prompt from Nacos for key: {}, fallback to default"

--- a/agentscope-extensions/agentscope-spring-boot-starters/agentscope-nacos-spring-boot-starter/src/main/java/io/agentscope/spring/boot/nacos/properties/AgentScopeNacosPromptProperties.java
+++ b/agentscope-extensions/agentscope-spring-boot-starters/agentscope-nacos-spring-boot-starter/src/main/java/io/agentscope/spring/boot/nacos/properties/AgentScopeNacosPromptProperties.java
@@ -43,6 +43,8 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
  *     prompt:
  *       enabled: true
  *       sys-prompt-key: agent-main
+ *       version: "1.0.0"
+ *       label: "prod"
  *       variables:
  *         env: prod
  *         app: order-service
@@ -58,9 +60,20 @@ public class AgentScopeNacosPromptProperties extends BaseNacosProperties {
 
     /**
      * The promptKey used to locate the system prompt in Nacos.
-     * <p>The actual Nacos dataId will typically be {@code promptKey + ".json"}.
      */
     private String sysPromptKey;
+
+    /**
+     * Target prompt version (e.g. "1.0.0"). Mutually exclusive with {@link #label}.
+     * When both are null, the latest version is used.
+     */
+    private String version;
+
+    /**
+     * Target prompt label (e.g. "prod", "staging"). Mutually exclusive with {@link #version}.
+     * When both are null, the latest version is used.
+     */
+    private String label;
 
     /**
      * Template variables used to render the Nacos prompt with {{}} placeholders.
@@ -81,6 +94,22 @@ public class AgentScopeNacosPromptProperties extends BaseNacosProperties {
 
     public void setSysPromptKey(String sysPromptKey) {
         this.sysPromptKey = sysPromptKey;
+    }
+
+    public String getVersion() {
+        return version;
+    }
+
+    public void setVersion(String version) {
+        this.version = version;
+    }
+
+    public String getLabel() {
+        return label;
+    }
+
+    public void setLabel(String label) {
+        this.label = label;
     }
 
     public Map<String, String> getVariables() {

--- a/agentscope-extensions/agentscope-spring-boot-starters/agentscope-nacos-spring-boot-starter/src/test/java/io/agentscope/spring/boot/nacos/AgentscopeNacosPromptAutoConfigurationTest.java
+++ b/agentscope-extensions/agentscope-spring-boot-starters/agentscope-nacos-spring-boot-starter/src/test/java/io/agentscope/spring/boot/nacos/AgentscopeNacosPromptAutoConfigurationTest.java
@@ -21,8 +21,8 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 
 import com.alibaba.nacos.api.PropertyKeyConst;
-import com.alibaba.nacos.api.config.ConfigFactory;
-import com.alibaba.nacos.api.config.ConfigService;
+import com.alibaba.nacos.api.ai.AiFactory;
+import com.alibaba.nacos.api.ai.AiService;
 import io.agentscope.core.nacos.prompt.NacosPromptListener;
 import io.agentscope.spring.boot.nacos.properties.AgentScopeNacosPromptProperties;
 import io.agentscope.spring.boot.nacos.properties.AgentScopeNacosProperties;
@@ -38,24 +38,24 @@ import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 /**
  * Unit tests for {@link AgentscopeNacosPromptAutoConfiguration}.
  *
- * <p>Verifies that ConfigService and NacosPromptListener beans are correctly created,
+ * <p>Verifies that AiService and NacosPromptListener beans are correctly created,
  * conditional on properties and classpath conditions.
  */
 class AgentscopeNacosPromptAutoConfigurationTest {
 
-    private ConfigService mockConfigService;
+    private AiService mockAiService;
 
     @BeforeEach
     void setUp() {
-        mockConfigService = mock(ConfigService.class);
+        mockAiService = mock(AiService.class);
     }
 
     @Test
-    @DisplayName("should create ConfigService and NacosPromptListener when enabled")
+    @DisplayName("should create AiService and NacosPromptListener when enabled")
     void shouldCreateBeansWhenEnabled() {
-        try (MockedStatic<ConfigFactory> mocked = Mockito.mockStatic(ConfigFactory.class)) {
-            mocked.when(() -> ConfigFactory.createConfigService(any(java.util.Properties.class)))
-                    .thenReturn(mockConfigService);
+        try (MockedStatic<AiFactory> mocked = Mockito.mockStatic(AiFactory.class)) {
+            mocked.when(() -> AiFactory.createAiService(any(java.util.Properties.class)))
+                    .thenReturn(mockAiService);
 
             new ApplicationContextRunner()
                     .withConfiguration(
@@ -70,7 +70,7 @@ class AgentscopeNacosPromptAutoConfigurationTest {
                                 assertThat(context)
                                         .hasSingleBean(AgentScopeNacosPromptProperties.class);
                                 assertThat(context).hasSingleBean(AgentscopeProperties.class);
-                                assertThat(context).hasSingleBean(ConfigService.class);
+                                assertThat(context).hasSingleBean(AiService.class);
                                 assertThat(context).hasSingleBean(NacosPromptListener.class);
                             });
         }
@@ -85,17 +85,17 @@ class AgentscopeNacosPromptAutoConfigurationTest {
                 .withPropertyValues("agentscope.nacos.prompt.enabled=false")
                 .run(
                         context -> {
-                            assertThat(context).doesNotHaveBean(ConfigService.class);
+                            assertThat(context).doesNotHaveBean(AiService.class);
                             assertThat(context).doesNotHaveBean(NacosPromptListener.class);
                         });
     }
 
     @Test
-    @DisplayName("should bind prompt properties correctly")
+    @DisplayName("should bind prompt properties correctly including version and label")
     void shouldBindProperties() {
-        try (MockedStatic<ConfigFactory> mocked = Mockito.mockStatic(ConfigFactory.class)) {
-            mocked.when(() -> ConfigFactory.createConfigService(any(java.util.Properties.class)))
-                    .thenReturn(mockConfigService);
+        try (MockedStatic<AiFactory> mocked = Mockito.mockStatic(AiFactory.class)) {
+            mocked.when(() -> AiFactory.createAiService(any(java.util.Properties.class)))
+                    .thenReturn(mockAiService);
 
             new ApplicationContextRunner()
                     .withConfiguration(
@@ -104,6 +104,8 @@ class AgentscopeNacosPromptAutoConfigurationTest {
                             "agentscope.nacos.server-addr=10.0.0.1:8848",
                             "agentscope.nacos.prompt.enabled=true",
                             "agentscope.nacos.prompt.sys-prompt-key=my-agent",
+                            "agentscope.nacos.prompt.version=2.0.0",
+                            "agentscope.nacos.prompt.label=prod",
                             "agentscope.nacos.prompt.variables.role=Helper",
                             "agentscope.nacos.prompt.variables.env=prod")
                     .run(
@@ -112,6 +114,8 @@ class AgentscopeNacosPromptAutoConfigurationTest {
                                         context.getBean(AgentScopeNacosPromptProperties.class);
                                 assertThat(props.isEnabled()).isTrue();
                                 assertThat(props.getSysPromptKey()).isEqualTo("my-agent");
+                                assertThat(props.getVersion()).isEqualTo("2.0.0");
+                                assertThat(props.getLabel()).isEqualTo("prod");
                                 assertThat(props.getVariables())
                                         .containsEntry("role", "Helper")
                                         .containsEntry("env", "prod");
@@ -122,11 +126,11 @@ class AgentscopeNacosPromptAutoConfigurationTest {
     @Test
     @DisplayName("should not replace existing NacosPromptListener bean")
     void shouldNotReplaceExistingBean() {
-        NacosPromptListener customListener = new NacosPromptListener(mockConfigService);
+        NacosPromptListener customListener = new NacosPromptListener(mockAiService);
 
-        try (MockedStatic<ConfigFactory> mocked = Mockito.mockStatic(ConfigFactory.class)) {
-            mocked.when(() -> ConfigFactory.createConfigService(any(java.util.Properties.class)))
-                    .thenReturn(mockConfigService);
+        try (MockedStatic<AiFactory> mocked = Mockito.mockStatic(AiFactory.class)) {
+            mocked.when(() -> AiFactory.createAiService(any(java.util.Properties.class)))
+                    .thenReturn(mockAiService);
 
             new ApplicationContextRunner()
                     .withConfiguration(
@@ -147,9 +151,9 @@ class AgentscopeNacosPromptAutoConfigurationTest {
     @Test
     @DisplayName("should use prompt-specific Nacos config when both global and prompt config set")
     void shouldUsePromptSpecificNacosConfig() {
-        try (MockedStatic<ConfigFactory> mocked = Mockito.mockStatic(ConfigFactory.class)) {
-            mocked.when(() -> ConfigFactory.createConfigService(any(java.util.Properties.class)))
-                    .thenReturn(mockConfigService);
+        try (MockedStatic<AiFactory> mocked = Mockito.mockStatic(AiFactory.class)) {
+            mocked.when(() -> AiFactory.createAiService(any(java.util.Properties.class)))
+                    .thenReturn(mockAiService);
 
             new ApplicationContextRunner()
                     .withConfiguration(
@@ -179,14 +183,14 @@ class AgentscopeNacosPromptAutoConfigurationTest {
     @Test
     @DisplayName("should not overwrite global server-addr when prompt server-addr is not set")
     void shouldNotOverwriteGlobalServerAddrWhenPromptNotSet() {
-        try (MockedStatic<ConfigFactory> mocked = Mockito.mockStatic(ConfigFactory.class)) {
+        try (MockedStatic<AiFactory> mocked = Mockito.mockStatic(AiFactory.class)) {
             java.util.concurrent.atomic.AtomicReference<java.util.Properties> capturedProps =
                     new java.util.concurrent.atomic.AtomicReference<>();
-            mocked.when(() -> ConfigFactory.createConfigService(any(java.util.Properties.class)))
+            mocked.when(() -> AiFactory.createAiService(any(java.util.Properties.class)))
                     .thenAnswer(
                             invocation -> {
                                 capturedProps.set(invocation.getArgument(0));
-                                return mockConfigService;
+                                return mockAiService;
                             });
 
             new ApplicationContextRunner()

--- a/agentscope-extensions/agentscope-spring-boot-starters/agentscope-nacos-spring-boot-starter/src/test/java/io/agentscope/spring/boot/nacos/AgentscopeNacosReActAgentAutoConfigurationTest.java
+++ b/agentscope-extensions/agentscope-spring-boot-starters/agentscope-nacos-spring-boot-starter/src/test/java/io/agentscope/spring/boot/nacos/AgentscopeNacosReActAgentAutoConfigurationTest.java
@@ -18,12 +18,13 @@ package io.agentscope.spring.boot.nacos;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import com.alibaba.nacos.api.config.ConfigService;
+import com.alibaba.nacos.api.ai.AiService;
+import com.alibaba.nacos.api.ai.model.prompt.Prompt;
 import io.agentscope.core.ReActAgent;
 import io.agentscope.core.memory.Memory;
 import io.agentscope.core.model.Model;
@@ -46,14 +47,14 @@ class AgentscopeNacosReActAgentAutoConfigurationTest {
     private Model mockModel;
     private Memory mockMemory;
     private Toolkit mockToolkit;
-    private ConfigService mockConfigService;
+    private AiService mockAiService;
 
     @BeforeEach
     void setUp() {
         mockModel = mock(Model.class);
         mockMemory = mock(Memory.class);
         mockToolkit = mock(Toolkit.class);
-        mockConfigService = mock(ConfigService.class);
+        mockAiService = mock(AiService.class);
     }
 
     private ApplicationContextRunner contextRunner() {
@@ -63,19 +64,15 @@ class AgentscopeNacosReActAgentAutoConfigurationTest {
                 .withBean(Model.class, () -> mockModel)
                 .withBean(Memory.class, () -> mockMemory)
                 .withBean(Toolkit.class, () -> mockToolkit)
-                .withBean(
-                        NacosPromptListener.class,
-                        () -> new NacosPromptListener(mockConfigService));
+                .withBean(NacosPromptListener.class, () -> new NacosPromptListener(mockAiService));
     }
 
     @Test
     @DisplayName("should create ReActAgent with Nacos prompt when config is available")
     void shouldCreateAgentWithNacosPrompt() throws Exception {
-        String nacosConfig =
-                "{\"promptKey\":\"test-agent\"," + "\"template\":\"You are {{role}} in {{dept}}\"}";
-        when(mockConfigService.getConfigAndSignListener(
-                        eq("test-agent.json"), eq("nacos-ai-prompt"), anyLong(), any()))
-                .thenReturn(nacosConfig);
+        Prompt prompt = new Prompt("test-agent", "1.0.0", "You are {{role}} in {{dept}}");
+        when(mockAiService.subscribePrompt(eq("test-agent"), isNull(), isNull(), any()))
+                .thenReturn(prompt);
 
         contextRunner()
                 .withPropertyValues(
@@ -97,12 +94,56 @@ class AgentscopeNacosReActAgentAutoConfigurationTest {
     }
 
     @Test
+    @DisplayName("should create ReActAgent with versioned Nacos prompt")
+    void shouldCreateAgentWithVersionedPrompt() throws Exception {
+        Prompt prompt = new Prompt("test-agent", "2.0.0", "V2: You are {{role}}");
+        when(mockAiService.subscribePrompt(eq("test-agent"), eq("2.0.0"), isNull(), any()))
+                .thenReturn(prompt);
+
+        contextRunner()
+                .withPropertyValues(
+                        "agentscope.agent.name=VersionBot",
+                        "agentscope.agent.sys-prompt=Default prompt",
+                        "agentscope.nacos.prompt.enabled=true",
+                        "agentscope.nacos.prompt.sys-prompt-key=test-agent",
+                        "agentscope.nacos.prompt.version=2.0.0",
+                        "agentscope.nacos.prompt.variables.role=Assistant")
+                .run(
+                        context -> {
+                            assertThat(context).hasSingleBean(ReActAgent.class);
+                            ReActAgent agent = context.getBean(ReActAgent.class);
+                            assertThat(agent.getSysPrompt()).isEqualTo("V2: You are Assistant");
+                        });
+    }
+
+    @Test
+    @DisplayName("should create ReActAgent with labeled Nacos prompt")
+    void shouldCreateAgentWithLabeledPrompt() throws Exception {
+        Prompt prompt = new Prompt("test-agent", "1.0.0", "Prod: You are {{role}}");
+        when(mockAiService.subscribePrompt(eq("test-agent"), isNull(), eq("prod"), any()))
+                .thenReturn(prompt);
+
+        contextRunner()
+                .withPropertyValues(
+                        "agentscope.agent.name=LabelBot",
+                        "agentscope.agent.sys-prompt=Default prompt",
+                        "agentscope.nacos.prompt.enabled=true",
+                        "agentscope.nacos.prompt.sys-prompt-key=test-agent",
+                        "agentscope.nacos.prompt.label=prod",
+                        "agentscope.nacos.prompt.variables.role=Assistant")
+                .run(
+                        context -> {
+                            assertThat(context).hasSingleBean(ReActAgent.class);
+                            ReActAgent agent = context.getBean(ReActAgent.class);
+                            assertThat(agent.getSysPrompt()).isEqualTo("Prod: You are Assistant");
+                        });
+    }
+
+    @Test
     @DisplayName("should fallback to YAML prompt when Nacos config is missing")
     void shouldFallbackToYamlPrompt() throws Exception {
-        // Nacos returns config without template field -> empty prompt -> fallback
-        when(mockConfigService.getConfigAndSignListener(
-                        eq("missing.json"), eq("nacos-ai-prompt"), anyLong(), any()))
-                .thenReturn("{\"promptKey\":\"missing\"}");
+        when(mockAiService.subscribePrompt(eq("missing"), isNull(), isNull(), any()))
+                .thenReturn(null);
 
         contextRunner()
                 .withPropertyValues(

--- a/agentscope-extensions/agentscope-spring-boot-starters/agentscope-nacos-spring-boot-starter/src/test/java/io/agentscope/spring/boot/nacos/properties/AgentScopeNacosPromptPropertiesTest.java
+++ b/agentscope-extensions/agentscope-spring-boot-starters/agentscope-nacos-spring-boot-starter/src/test/java/io/agentscope/spring/boot/nacos/properties/AgentScopeNacosPromptPropertiesTest.java
@@ -59,6 +59,20 @@ class AgentScopeNacosPromptPropertiesTest {
             assertNotNull(props.getVariables());
             assertTrue(props.getVariables().isEmpty());
         }
+
+        @Test
+        @DisplayName("should have null version by default")
+        void shouldHaveNullVersionByDefault() {
+            AgentScopeNacosPromptProperties props = new AgentScopeNacosPromptProperties();
+            assertNull(props.getVersion());
+        }
+
+        @Test
+        @DisplayName("should have null label by default")
+        void shouldHaveNullLabelByDefault() {
+            AgentScopeNacosPromptProperties props = new AgentScopeNacosPromptProperties();
+            assertNull(props.getLabel());
+        }
     }
 
     @Nested
@@ -93,6 +107,22 @@ class AgentScopeNacosPromptPropertiesTest {
             AgentScopeNacosPromptProperties props = new AgentScopeNacosPromptProperties();
             props.setEnabled(false);
             assertEquals(false, props.isEnabled());
+        }
+
+        @Test
+        @DisplayName("should set and get version")
+        void shouldSetAndGetVersion() {
+            AgentScopeNacosPromptProperties props = new AgentScopeNacosPromptProperties();
+            props.setVersion("2.0.0");
+            assertEquals("2.0.0", props.getVersion());
+        }
+
+        @Test
+        @DisplayName("should set and get label")
+        void shouldSetAndGetLabel() {
+            AgentScopeNacosPromptProperties props = new AgentScopeNacosPromptProperties();
+            props.setLabel("prod");
+            assertEquals("prod", props.getLabel());
         }
     }
 


### PR DESCRIPTION
## AgentScope-Java Version

1.0.9

## Description

- NacosPromptListener: replace ConfigService with AiService, use Prompt.render() for template rendering, subscribe via AbstractNacosPromptListener for hot updates, fix ConcurrentHashMap recursive update bug (computeIfAbsent -> get/putIfAbsent)
- AgentscopeNacosPromptAutoConfiguration: replace ConfigFactory with AiFactory for bean creation
- AgentscopeNacosReActAgentAutoConfiguration: pass version/label params to NacosPromptListener.getPrompt()
- AgentScopeNacosPromptProperties: add version and label fields
- Bump nacos-client from 3.1.1 to 3.2.0-BETA
- Update all unit tests to match new API

## Checklist

Please check the following items before code is ready to be reviewed.

- [x]  Code has been formatted with `mvn spotless:apply`
- [x]  All tests are passing (`mvn test`)
- [x]  Javadoc comments are complete and follow project conventions
- [x]  Related documentation has been updated (e.g. links, examples, etc.)
- [x]  Code is ready for review
