### PR TITLE
feat(agent): Support stream(List<Msg>, StreamOptions, JsonNode) for dynamic structured output during streaming

### DIFF
--- a/agentscope-core/src/main/java/io/agentscope/core/agent/AgentBase.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/agent/AgentBase.java
@@ -675,8 +675,16 @@ public abstract class AgentBase implements StateModule, Agent {
         return createEventStream(options, () -> call(msgs, structuredModel));
     }
 
+    /**
+     * Stream with multiple input messages using a JSON schema.
+     *
+     * @param msgs Input messages
+     * @param options Stream configuration options
+     * @param schema JSON schema defining the structure of the response
+     * @return Flux of events emitted during execution
+     */
     @Override
-    public Flux<Event> stream(List<Msg> msgs, StreamOptions options, JsonNode schema) {
+    public final Flux<Event> stream(List<Msg> msgs, StreamOptions options, JsonNode schema) {
         return createEventStream(options, () -> call(msgs, schema));
     }
 

--- a/agentscope-core/src/main/java/io/agentscope/core/agent/StreamableAgent.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/agent/StreamableAgent.java
@@ -100,7 +100,7 @@ public interface StreamableAgent {
     }
 
     /**
-     * Stream execution events for a single message with JSON scheme support.
+     * Stream execution events for a single message with JSON schema support.
      *
      * @param msg Input message
      * @param options Stream configuration options
@@ -141,7 +141,7 @@ public interface StreamableAgent {
     Flux<Event> stream(List<Msg> msgs, StreamOptions options, Class<?> structuredModel);
 
     /**
-     * Stream execution events with JSON scheme support.
+     * Stream execution events with JSON schema support.
      *
      * @param msgs Input messages
      * @param options Stream configuration options

--- a/agentscope-core/src/test/java/io/agentscope/core/agent/StructuredOutputDynamicDefineTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/agent/StructuredOutputDynamicDefineTest.java
@@ -41,7 +41,7 @@ import reactor.core.publisher.Flux;
 import reactor.test.StepVerifier;
 
 /**
- * Tests for dynamic define json schema in StructuredOutputCapableAgent (deferred forcing mode).
+ * Tests for dynamically defined JSON schema in StructuredOutputCapableAgent (deferred forcing mode).
  */
 public class StructuredOutputDynamicDefineTest {
 
@@ -114,7 +114,7 @@ public class StructuredOutputDynamicDefineTest {
     }
 
     @Test
-    @DisplayName("Stream execution events with JSON scheme structured support")
+    @DisplayName("Stream execution events with JSON schema structured support")
     void testDynamicComplexNestedStructureStreamingMode() {
         Memory memory = new InMemoryMemory();
         MockModel mockModel = getMockModel();


### PR DESCRIPTION
## AgentScope-Java Version

1.0.11

## Description

* Closes: #929 
* Support stream(List<Msg>, StreamOptions, JsonNode) for dynamic structured output during streaming

## Checklist

Please check the following items before code is ready to be reviewed.

- [x]  Code has been formatted with `mvn spotless:apply`
- [x]  All tests are passing (`mvn test`)
- [x]  Javadoc comments are complete and follow project conventions
- [x]  Related documentation has been updated (e.g. links, examples, etc.)
- [x]  Code is ready for review
