### PR TITLE
feat(core): Migrates agentscope from Jackson2 to Jackson3

### DIFF
--- a/agentscope-core/pom.xml
+++ b/agentscope-core/pom.xml
@@ -57,13 +57,13 @@
 
         <!-- Jackson for JSON serialization/deserialization -->
         <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-databind</artifactId>
+            <groupId>tools.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
         </dependency>
 
         <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-annotations</artifactId>
+            <groupId>tools.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
         </dependency>
 
         <!-- Victools JSON Schema Generator for structured output -->
@@ -76,12 +76,6 @@
         <dependency>
             <groupId>com.github.victools</groupId>
             <artifactId>jsonschema-module-jackson</artifactId>
-        </dependency>
-
-        <!-- Jackson Java 8 Date/Time support -->
-        <dependency>
-            <groupId>com.fasterxml.jackson.datatype</groupId>
-            <artifactId>jackson-datatype-jsr310</artifactId>
         </dependency>
 
         <!-- SLF4J API -->

--- a/agentscope-core/src/main/java/io/agentscope/core/ReActAgent.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/ReActAgent.java
@@ -15,7 +15,6 @@
  */
 package io.agentscope.core;
 
-import com.fasterxml.jackson.databind.JsonNode;
 import io.agentscope.core.agent.Event;
 import io.agentscope.core.agent.RuntimeContext;
 import io.agentscope.core.agent.StreamOptions;
@@ -89,6 +88,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
+import tools.jackson.databind.JsonNode;
 
 /**
  * ReAct (Reasoning and Acting) Agent implementation.

--- a/agentscope-core/src/main/java/io/agentscope/core/agent/AgentBase.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/agent/AgentBase.java
@@ -15,7 +15,6 @@
  */
 package io.agentscope.core.agent;
 
-import com.fasterxml.jackson.databind.JsonNode;
 import io.agentscope.core.hook.ErrorEvent;
 import io.agentscope.core.hook.Hook;
 import io.agentscope.core.hook.PostCallEvent;
@@ -45,6 +44,7 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.FluxSink;
 import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Schedulers;
+import tools.jackson.databind.JsonNode;
 
 /**
  * Abstract base class for all agents in the AgentScope framework.
@@ -237,7 +237,7 @@ public abstract class AgentBase implements StateModule, Agent {
      * <p>Tracing data will be captured once telemetry is enabled.
      *
      * @param msgs Input messages
-     * @param schema com.fasterxml.jackson.databind.JsonNode instance defining the structure of the output
+     * @param schema JsonNode instance defining the structure of the output
      * @return Response message with structured data in metadata
      */
     @Override
@@ -292,7 +292,7 @@ public abstract class AgentBase implements StateModule, Agent {
      * Default implementation throws UnsupportedOperationException.
      *
      * @param msgs Input messages
-     * @param outputSchema com.fasterxml.jackson.databind.JsonNode instance defining the structure
+     * @param outputSchema JsonNode instance defining the structure
      * @return Response message with structured data in metadata
      */
     protected Mono<Msg> doCall(List<Msg> msgs, JsonNode outputSchema) {

--- a/agentscope-core/src/main/java/io/agentscope/core/agent/CallableAgent.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/agent/CallableAgent.java
@@ -15,10 +15,10 @@
  */
 package io.agentscope.core.agent;
 
-import com.fasterxml.jackson.databind.JsonNode;
 import io.agentscope.core.message.Msg;
 import java.util.List;
 import reactor.core.publisher.Mono;
+import tools.jackson.databind.JsonNode;
 
 /**
  * Interface for agents that can be called to process messages.

--- a/agentscope-core/src/main/java/io/agentscope/core/agent/StreamableAgent.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/agent/StreamableAgent.java
@@ -15,10 +15,10 @@
  */
 package io.agentscope.core.agent;
 
-import com.fasterxml.jackson.databind.JsonNode;
 import io.agentscope.core.message.Msg;
 import java.util.List;
 import reactor.core.publisher.Flux;
+import tools.jackson.databind.JsonNode;
 
 /**
  * Interface for agents that support streaming events during execution.

--- a/agentscope-core/src/main/java/io/agentscope/core/agent/StructuredOutputCapableAgent.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/agent/StructuredOutputCapableAgent.java
@@ -15,7 +15,6 @@
  */
 package io.agentscope.core.agent;
 
-import com.fasterxml.jackson.databind.JsonNode;
 import io.agentscope.core.hook.Hook;
 import io.agentscope.core.memory.Memory;
 import io.agentscope.core.message.ContentBlock;
@@ -40,6 +39,7 @@ import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import reactor.core.publisher.Mono;
+import tools.jackson.databind.JsonNode;
 
 /**
  * Abstract base class for agents that support structured output generation.

--- a/agentscope-core/src/main/java/io/agentscope/core/formatter/dashscope/dto/DashScopeMessage.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/formatter/dashscope/dto/DashScopeMessage.java
@@ -20,10 +20,10 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.core.type.TypeReference;
 import io.agentscope.core.util.JsonUtils;
 import java.util.List;
 import java.util.Map;
+import tools.jackson.core.type.TypeReference;
 
 /**
  * DashScope message DTO.

--- a/agentscope-core/src/main/java/io/agentscope/core/formatter/dashscope/dto/DashScopeResponse.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/formatter/dashscope/dto/DashScopeResponse.java
@@ -17,13 +17,13 @@ package io.agentscope.core.formatter.dashscope.dto;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.JsonToken;
-import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.JsonDeserializer;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import java.io.IOException;
+import tools.jackson.core.JacksonException;
+import tools.jackson.core.JsonParser;
+import tools.jackson.core.JsonToken;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ValueDeserializer;
+import tools.jackson.databind.annotation.JsonDeserialize;
 
 /**
  * DashScope API response DTO.
@@ -128,11 +128,11 @@ public class DashScopeResponse {
      * have been decrypted by decryptResponse() before deserialization. If it's still a string at
      * this point, it means decryption failed or wasn't performed, so we skip it.
      */
-    static class DashScopeOutputDeserializer extends JsonDeserializer<DashScopeOutput> {
+    static class DashScopeOutputDeserializer extends ValueDeserializer<DashScopeOutput> {
 
         @Override
         public DashScopeOutput deserialize(JsonParser p, DeserializationContext ctxt)
-                throws IOException {
+                throws JacksonException {
             JsonToken token = p.currentToken();
             if (token == JsonToken.VALUE_NULL) {
                 return null;
@@ -147,14 +147,15 @@ public class DashScopeResponse {
                 // Object value - normal deserialization
                 // Use readTree and treeToValue for standard deserialization
                 // This handles the case where output is a decrypted JSON object
-                JsonNode node = p.getCodec().readTree(p);
+                JsonNode node = ctxt.readTree(p);
                 if (node == null || node.isNull() || !node.isObject()) {
                     return null;
                 }
-                return p.getCodec().treeToValue(node, DashScopeOutput.class);
+                return ctxt.readTreeAsValue(node, DashScopeOutput.class);
             }
+
             // Unexpected token type
-            throw new IOException(
+            throw new IllegalStateException(
                     "Cannot deserialize DashScopeOutput from token: "
                             + token
                             + ". Expected object or string.");

--- a/agentscope-core/src/main/java/io/agentscope/core/message/Msg.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/message/Msg.java
@@ -19,7 +19,6 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.core.type.TypeReference;
 import io.agentscope.core.model.ChatUsage;
 import io.agentscope.core.state.State;
 import io.agentscope.core.util.JsonUtils;
@@ -34,6 +33,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.UUID;
 import java.util.stream.Collectors;
+import tools.jackson.core.type.TypeReference;
 
 /**
  * Represents a message in the AgentScope framework.
@@ -245,7 +245,7 @@ public class Msg implements State {
      *
      * <p>This method is useful when the message contains structured input from a user agent
      * or structured output from an LLM. The metadata map is converted to a Java object
-     * using Jackson's ObjectMapper.
+     * using Jackson's JsonMapper.
      *
      * <p>Example usage:
      * <pre>{@code
@@ -330,7 +330,7 @@ public class Msg implements State {
      *                                       }
      *                 					   }
      *         """;
-     *  JsonNode sampleJsonNode = new ObjectMapper().readTree(json);
+     *  JsonNode sampleJsonNode = JsonMapper.shared().readTree(json);
      *   Msg msg = agent.call(input, sampleJsonNode).block(TEST_TIMEOUT);
      *   Map<String, Object> structuredData = msg.getStructuredData(false);
      * }</pre>

--- a/agentscope-core/src/main/java/io/agentscope/core/model/DashScopeHttpClient.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/model/DashScopeHttpClient.java
@@ -15,7 +15,6 @@
  */
 package io.agentscope.core.model;
 
-import com.fasterxml.jackson.core.type.TypeReference;
 import io.agentscope.core.Version;
 import io.agentscope.core.formatter.dashscope.dto.DashScopeParameters;
 import io.agentscope.core.formatter.dashscope.dto.DashScopePublicKeyResponse;
@@ -38,6 +37,7 @@ import javax.crypto.SecretKey;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import reactor.core.publisher.Flux;
+import tools.jackson.core.type.TypeReference;
 
 /**
  * HTTP client for DashScope API.

--- a/agentscope-core/src/main/java/io/agentscope/core/model/ollama/ThinkOption.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/model/ollama/ThinkOption.java
@@ -16,17 +16,16 @@
 
 package io.agentscope.core.model.ollama;
 
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.JsonToken;
-import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.JsonDeserializer;
-import com.fasterxml.jackson.databind.JsonSerializer;
-import com.fasterxml.jackson.databind.SerializerProvider;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import java.io.IOException;
 import java.util.List;
+import tools.jackson.core.JacksonException;
+import tools.jackson.core.JsonGenerator;
+import tools.jackson.core.JsonToken;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.SerializationContext;
+import tools.jackson.databind.ValueDeserializer;
+import tools.jackson.databind.ValueSerializer;
+import tools.jackson.databind.annotation.JsonDeserialize;
+import tools.jackson.databind.annotation.JsonSerialize;
 
 /**
  * Defines the configuration contract for the "thinking" capability (Chain of Thought) in AgentScope's Ollama integration.
@@ -56,15 +55,15 @@ public sealed interface ThinkOption {
      * Custom serializer implementation for {@link ThinkOption}.
      * Responsible for converting the option object into the appropriate JSON primitive (boolean or string).
      */
-    class ThinkOptionSerializer extends JsonSerializer<ThinkOption> {
+    class ThinkOptionSerializer extends ValueSerializer<ThinkOption> {
 
         @Override
-        public void serialize(ThinkOption value, JsonGenerator gen, SerializerProvider serializers)
-                throws IOException {
+        public void serialize(ThinkOption value, JsonGenerator gen, SerializationContext ctxt)
+                throws JacksonException {
             if (value == null) {
                 gen.writeNull();
             } else {
-                gen.writeObject(value.toJsonValue());
+                gen.writePOJO(value.toJsonValue());
             }
         }
     }
@@ -73,11 +72,11 @@ public sealed interface ThinkOption {
      * Custom deserializer implementation for {@link ThinkOption}.
      * Detects the JSON token type (boolean or string) and instantiates the corresponding {@link ThinkOption} implementation.
      */
-    class ThinkOptionDeserializer extends JsonDeserializer<ThinkOption> {
+    class ThinkOptionDeserializer extends ValueDeserializer<ThinkOption> {
 
         @Override
-        public ThinkOption deserialize(JsonParser p, DeserializationContext ctxt)
-                throws IOException {
+        public ThinkOption deserialize(tools.jackson.core.JsonParser p, DeserializationContext ctxt)
+                throws JacksonException {
             JsonToken token = p.currentToken();
             if (token == JsonToken.VALUE_TRUE) {
                 return ThinkBoolean.ENABLED;
@@ -88,7 +87,7 @@ public sealed interface ThinkOption {
             } else if (token == JsonToken.VALUE_NULL) {
                 return null;
             }
-            throw new IOException(
+            throw new IllegalStateException(
                     "Unable to deserialize ThinkOption. Encountered unexpected token type: "
                             + token);
         }

--- a/agentscope-core/src/main/java/io/agentscope/core/rag/model/Document.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/rag/model/Document.java
@@ -140,7 +140,7 @@ public class Document {
      * Gets a specific payload value by key and converts it to the specified type.
      *
      * <p>This method is useful when the payload contains complex objects (like custom POJOs)
-     * that were serialized to Map during storage. It uses Jackson's ObjectMapper to convert
+     * that were serialized to Map during storage. It uses Jackson's JsonMapper to convert
      * the Map back to the original type.
      *
      * @param <T> the target type

--- a/agentscope-core/src/main/java/io/agentscope/core/tool/ToolValidator.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/tool/ToolValidator.java
@@ -15,10 +15,6 @@
  */
 package io.agentscope.core.tool;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.networknt.schema.Error;
 import com.networknt.schema.InputFormat;
 import com.networknt.schema.Schema;
@@ -34,6 +30,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.json.JsonMapper;
+import tools.jackson.databind.node.ArrayNode;
+import tools.jackson.databind.node.ObjectNode;
 
 /**
  * Unified validator for tool-related operations.
@@ -48,7 +48,7 @@ public final class ToolValidator {
 
     private static final SchemaRegistry SCHEMA_REGISTRY =
             SchemaRegistry.withDefaultDialect(SpecificationVersion.DRAFT_2020_12);
-    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    private static final JsonMapper JSON_MAPPER = JsonMapper.shared();
 
     private ToolValidator() {
         // Utility class
@@ -115,10 +115,10 @@ public final class ToolValidator {
             return input;
         }
 
-        JsonNode root = OBJECT_MAPPER.readTree(input);
-        JsonNode schemaRoot = OBJECT_MAPPER.readTree(schemaJson);
+        JsonNode root = JSON_MAPPER.readTree(input);
+        JsonNode schemaRoot = JSON_MAPPER.readTree(schemaJson);
         pruneOptionalNullObjectFields(root, schemaRoot, schemaRoot);
-        return OBJECT_MAPPER.writeValueAsString(root);
+        return JSON_MAPPER.writeValueAsString(root);
     }
 
     private static void pruneOptionalNullObjectFields(
@@ -139,8 +139,8 @@ public final class ToolValidator {
             JsonNode additionalPropertiesNode = resolvedSchema.get("additionalProperties");
             List<String> nullFieldNames = new ArrayList<>();
             objectNode
-                    .fields()
-                    .forEachRemaining(
+                    .properties()
+                    .forEach(
                             entry -> {
                                 JsonNode propertySchema =
                                         propertiesNode != null

--- a/agentscope-core/src/main/java/io/agentscope/core/tool/mcp/McpClientBuilder.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/tool/mcp/McpClientBuilder.java
@@ -25,8 +25,8 @@ import io.modelcontextprotocol.client.transport.HttpClientSseClientTransport;
 import io.modelcontextprotocol.client.transport.HttpClientStreamableHttpTransport;
 import io.modelcontextprotocol.client.transport.ServerParameters;
 import io.modelcontextprotocol.client.transport.StdioClientTransport;
-import io.modelcontextprotocol.json.McpJsonMapper;
 import io.modelcontextprotocol.json.TypeRef;
+import io.modelcontextprotocol.json.jackson3.JacksonMcpJsonMapper;
 import io.modelcontextprotocol.spec.McpClientTransport;
 import io.modelcontextprotocol.spec.McpSchema;
 import io.modelcontextprotocol.spec.McpSchema.ElicitRequest;
@@ -49,6 +49,7 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import reactor.core.publisher.Mono;
+import tools.jackson.databind.json.JsonMapper;
 
 /**
  * Builder for creating MCP client wrappers with fluent configuration.
@@ -601,7 +602,7 @@ public class McpClientBuilder {
             }
 
             ServerParameters params = paramsBuilder.build();
-            return new StdioClientTransport(params, McpJsonMapper.getDefault());
+            return new StdioClientTransport(params, new JacksonMcpJsonMapper(JsonMapper.shared()));
         }
     }
 

--- a/agentscope-core/src/main/java/io/agentscope/core/tool/multimodal/OpenAIMultiModalTool.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/tool/multimodal/OpenAIMultiModalTool.java
@@ -15,7 +15,6 @@
  */
 package io.agentscope.core.tool.multimodal;
 
-import com.fasterxml.jackson.core.type.TypeReference;
 import io.agentscope.core.formatter.MediaUtils;
 import io.agentscope.core.message.Base64Source;
 import io.agentscope.core.message.ContentBlock;
@@ -36,6 +35,7 @@ import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import reactor.core.publisher.Mono;
+import tools.jackson.core.type.TypeReference;
 
 /**
  * OpenAI multimodal tool.

--- a/agentscope-core/src/main/java/io/agentscope/core/util/JacksonJsonCodec.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/util/JacksonJsonCodec.java
@@ -16,26 +16,28 @@
 
 package io.agentscope.core.util;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.databind.JavaType;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import java.lang.reflect.Type;
+import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import tools.jackson.core.JacksonException;
+import tools.jackson.core.type.TypeReference;
+import tools.jackson.databind.DeserializationFeature;
+import tools.jackson.databind.JacksonModule;
+import tools.jackson.databind.JavaType;
+import tools.jackson.databind.cfg.MapperBuilder;
+import tools.jackson.databind.json.JsonMapper;
 
 /**
  * Jackson-based implementation of {@link JsonCodec}.
  *
  * <p>This is the default implementation used by {@link JsonUtils}. It uses
- * Jackson's ObjectMapper with the following configuration:
+ * Jackson's JsonMapper with the following configuration:
  * <ul>
  *   <li>{@code FAIL_ON_UNKNOWN_PROPERTIES = false} - allows unknown fields in JSON</li>
  * </ul>
  *
- * <p>Users can access the underlying ObjectMapper via {@link #getObjectMapper()}
+ * <p>Users can access the underlying JsonMapper via {@link #getJsonMapper()}
  * for advanced operations not covered by the JsonCodec interface.
  *
  * @see JsonCodec
@@ -45,50 +47,51 @@ public class JacksonJsonCodec implements JsonCodec {
 
     private static final Logger log = LoggerFactory.getLogger(JacksonJsonCodec.class);
 
-    private final ObjectMapper objectMapper;
+    private final JsonMapper jsonMapper;
 
     /**
-     * Creates a new JacksonJsonCodec with default ObjectMapper configuration.
+     * Creates a new JacksonJsonCodec with default JsonMapper configuration.
      */
     public JacksonJsonCodec() {
-        this.objectMapper = createDefaultObjectMapper();
+        this.jsonMapper = createDefaultJsonMapper();
     }
 
     /**
-     * Creates a new JacksonJsonCodec with a custom ObjectMapper.
+     * Creates a new JacksonJsonCodec with a custom JsonMapper.
      *
-     * @param objectMapper the ObjectMapper to use
+     * @param jsonMapper the JsonMapper to use
      */
-    public JacksonJsonCodec(ObjectMapper objectMapper) {
-        this.objectMapper = objectMapper;
+    public JacksonJsonCodec(JsonMapper jsonMapper) {
+        this.jsonMapper = jsonMapper;
     }
 
     /**
-     * Creates the default ObjectMapper with standard configuration.
+     * Creates the default JsonMapper with standard configuration.
      *
-     * @return configured ObjectMapper
+     * @return configured JsonMapper
      */
-    private static ObjectMapper createDefaultObjectMapper() {
-        ObjectMapper mapper = new ObjectMapper();
-        mapper.registerModule(new JavaTimeModule());
-        mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
-        return mapper;
+    private static JsonMapper createDefaultJsonMapper() {
+        List<JacksonModule> modules = MapperBuilder.findModules();
+        return JsonMapper.builder()
+                .addModules(modules)
+                .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+                .build();
     }
 
     /**
-     * Get the underlying ObjectMapper for advanced operations.
+     * Get the underlying JsonMapper for advanced operations.
      *
-     * @return the ObjectMapper instance
+     * @return the JsonMapper instance
      */
-    public ObjectMapper getObjectMapper() {
-        return objectMapper;
+    public JsonMapper getJsonMapper() {
+        return this.jsonMapper;
     }
 
     @Override
     public String toJson(Object obj) {
         try {
-            return objectMapper.writeValueAsString(obj);
-        } catch (JsonProcessingException e) {
+            return this.jsonMapper.writeValueAsString(obj);
+        } catch (JacksonException e) {
             log.error("Failed to serialize object to JSON: {}", e.getMessage(), e);
             throw new JsonException("Failed to serialize object to JSON", e);
         }
@@ -97,8 +100,8 @@ public class JacksonJsonCodec implements JsonCodec {
     @Override
     public String toPrettyJson(Object obj) {
         try {
-            return objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(obj);
-        } catch (JsonProcessingException e) {
+            return this.jsonMapper.writerWithDefaultPrettyPrinter().writeValueAsString(obj);
+        } catch (JacksonException e) {
             log.error("Failed to serialize object to pretty JSON: {}", e.getMessage(), e);
             throw new JsonException("Failed to serialize object to pretty JSON", e);
         }
@@ -107,8 +110,8 @@ public class JacksonJsonCodec implements JsonCodec {
     @Override
     public <T> T fromJson(String json, Class<T> type) {
         try {
-            return objectMapper.readValue(json, type);
-        } catch (JsonProcessingException e) {
+            return this.jsonMapper.readValue(json, type);
+        } catch (JacksonException e) {
             throw new JsonException("Failed to deserialize JSON to " + type.getName(), e);
         }
     }
@@ -116,8 +119,8 @@ public class JacksonJsonCodec implements JsonCodec {
     @Override
     public <T> T fromJson(String json, TypeReference<T> typeRef) {
         try {
-            return objectMapper.readValue(json, typeRef);
-        } catch (JsonProcessingException e) {
+            return this.jsonMapper.readValue(json, typeRef);
+        } catch (JacksonException e) {
             throw new JsonException("Failed to deserialize JSON", e);
         }
     }
@@ -125,8 +128,8 @@ public class JacksonJsonCodec implements JsonCodec {
     @Override
     public <T> T convertValue(Object from, Class<T> toType) {
         try {
-            return objectMapper.convertValue(from, toType);
-        } catch (IllegalArgumentException e) {
+            return this.jsonMapper.convertValue(from, toType);
+        } catch (IllegalArgumentException | JacksonException e) {
             throw new JsonException("Failed to convert value to " + toType.getName(), e);
         }
     }
@@ -134,8 +137,8 @@ public class JacksonJsonCodec implements JsonCodec {
     @Override
     public <T> T convertValue(Object from, TypeReference<T> toTypeRef) {
         try {
-            return objectMapper.convertValue(from, toTypeRef);
-        } catch (IllegalArgumentException e) {
+            return this.jsonMapper.convertValue(from, toTypeRef);
+        } catch (IllegalArgumentException | JacksonException e) {
             throw new JsonException("Failed to convert value", e);
         }
     }
@@ -143,9 +146,9 @@ public class JacksonJsonCodec implements JsonCodec {
     @Override
     public Object convertValue(Object from, Type toType) {
         try {
-            JavaType javaType = objectMapper.getTypeFactory().constructType(toType);
-            return objectMapper.convertValue(from, javaType);
-        } catch (IllegalArgumentException e) {
+            JavaType javaType = this.jsonMapper.getTypeFactory().constructType(toType);
+            return this.jsonMapper.convertValue(from, javaType);
+        } catch (IllegalArgumentException | JacksonException e) {
             throw new JsonException("Failed to convert value to " + toType.getTypeName(), e);
         }
     }

--- a/agentscope-core/src/main/java/io/agentscope/core/util/JsonCodec.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/util/JsonCodec.java
@@ -16,8 +16,8 @@
 
 package io.agentscope.core.util;
 
-import com.fasterxml.jackson.core.type.TypeReference;
 import java.lang.reflect.Type;
+import tools.jackson.core.type.TypeReference;
 
 /**
  * Interface for JSON serialization and deserialization operations.

--- a/agentscope-core/src/main/java/io/agentscope/core/util/JsonException.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/util/JsonException.java
@@ -20,7 +20,7 @@ package io.agentscope.core.util;
  * Runtime exception for JSON processing errors.
  *
  * <p>This exception wraps underlying JSON processing exceptions (such as
- * Jackson's JsonProcessingException) to provide a unified exception type
+ * Jackson's JacksonException) to provide a unified exception type
  * for JSON operations across the framework.
  *
  * @see JsonCodec

--- a/agentscope-core/src/main/java/io/agentscope/core/util/JsonSchemaUtils.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/util/JsonSchemaUtils.java
@@ -16,8 +16,6 @@
 
 package io.agentscope.core.util;
 
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.JsonNode;
 import com.github.victools.jsonschema.generator.Option;
 import com.github.victools.jsonschema.generator.OptionPreset;
 import com.github.victools.jsonschema.generator.SchemaGenerator;
@@ -29,6 +27,8 @@ import com.github.victools.jsonschema.module.jackson.JacksonOption;
 import io.agentscope.core.tool.ToolSchemaModule;
 import java.lang.reflect.Type;
 import java.util.Map;
+import tools.jackson.core.type.TypeReference;
+import tools.jackson.databind.JsonNode;
 
 /**
  * Utility class for JSON Schema operations.
@@ -104,11 +104,11 @@ public class JsonSchemaUtils {
     }
 
     /**
-     * Generate JSON Schema from a com.fasterxml.jackson.databind.JsonNode instance.
+     * Generate JSON Schema from a JsonNode instance.
      * This method is suitable for structured output scenarios where complex nested
      * objects need to be converted to JSON Schema format.
      *
-     * @param schema The com.fasterxml.jackson.databind.JsonNode instance to generate schema for
+     * @param schema The JsonNode instance to generate schema for
      * @return JSON Schema as a Map
      * @throws RuntimeException if schema generation fails due to reflection errors,
      *                          configuration issues, or other processing errors

--- a/agentscope-core/src/test/java/io/agentscope/core/agent/StructuredOutputDynamicDefineTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/agent/StructuredOutputDynamicDefineTest.java
@@ -19,7 +19,6 @@ package io.agentscope.core.agent;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-import com.fasterxml.jackson.databind.JsonNode;
 import io.agentscope.core.ReActAgent;
 import io.agentscope.core.agent.test.MockModel;
 import io.agentscope.core.memory.InMemoryMemory;
@@ -37,6 +36,7 @@ import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import tools.jackson.databind.JsonNode;
 import reactor.core.publisher.Flux;
 import reactor.test.StepVerifier;
 

--- a/agentscope-core/src/test/java/io/agentscope/core/agent/StructuredOutputDynamicDefineTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/agent/StructuredOutputDynamicDefineTest.java
@@ -36,9 +36,9 @@ import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import tools.jackson.databind.JsonNode;
 import reactor.core.publisher.Flux;
 import reactor.test.StepVerifier;
+import tools.jackson.databind.JsonNode;
 
 /**
  * Tests for dynamically defined JSON schema in StructuredOutputCapableAgent (deferred forcing mode).

--- a/agentscope-core/src/test/java/io/agentscope/core/formatter/anthropic/AnthropicChatFormatterGroundTruthTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/formatter/anthropic/AnthropicChatFormatterGroundTruthTest.java
@@ -19,7 +19,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.anthropic.core.ObjectMappers;
 import com.anthropic.models.messages.MessageParam;
-import com.fasterxml.jackson.databind.JsonNode;
 import io.agentscope.core.message.ImageBlock;
 import io.agentscope.core.message.Msg;
 import io.agentscope.core.message.MsgRole;
@@ -34,6 +33,7 @@ import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import tools.jackson.databind.JsonNode;
 
 /** Ground truth tests for AnthropicChatFormatter - compares with Python implementation. */
 class AnthropicChatFormatterGroundTruthTest {

--- a/agentscope-core/src/test/java/io/agentscope/core/formatter/anthropic/AnthropicMultiAgentFormatterGroundTruthTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/formatter/anthropic/AnthropicMultiAgentFormatterGroundTruthTest.java
@@ -19,7 +19,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.anthropic.core.ObjectMappers;
 import com.anthropic.models.messages.MessageParam;
-import com.fasterxml.jackson.databind.JsonNode;
 import io.agentscope.core.message.ImageBlock;
 import io.agentscope.core.message.Msg;
 import io.agentscope.core.message.MsgRole;
@@ -34,6 +33,7 @@ import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import tools.jackson.databind.JsonNode;
 
 /**
  * Ground truth tests for AnthropicMultiAgentFormatter - compares with Python implementation.

--- a/agentscope-core/src/test/java/io/agentscope/core/formatter/gemini/GeminiFormatterTestData.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/formatter/gemini/GeminiFormatterTestData.java
@@ -15,7 +15,6 @@
  */
 package io.agentscope.core.formatter.gemini;
 
-import com.fasterxml.jackson.core.type.TypeReference;
 import io.agentscope.core.message.AudioBlock;
 import io.agentscope.core.message.Base64Source;
 import io.agentscope.core.message.ImageBlock;
@@ -28,6 +27,7 @@ import io.agentscope.core.message.URLSource;
 import io.agentscope.core.util.JsonUtils;
 import java.util.List;
 import java.util.Map;
+import tools.jackson.core.type.TypeReference;
 
 /**
  * Test data for Gemini formatter tests.

--- a/agentscope-core/src/test/java/io/agentscope/core/formatter/ollama/dto/OllamaEmbeddingRequestTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/formatter/ollama/dto/OllamaEmbeddingRequestTest.java
@@ -21,7 +21,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import io.agentscope.core.util.JacksonJsonCodec;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -30,6 +29,8 @@ import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import tools.jackson.databind.PropertyNamingStrategies;
+import tools.jackson.databind.json.JsonMapper;
 
 /**
  * Unit tests for OllamaEmbeddingRequest.
@@ -45,12 +46,11 @@ class OllamaEmbeddingRequestTest {
     @BeforeEach
     void setUp() {
         // Create a JacksonJsonCodec instance with snake_case naming strategy for testing
-        JacksonJsonCodec defaultCodec = new JacksonJsonCodec();
         jsonCodec =
                 new JacksonJsonCodec(
-                        defaultCodec
-                                .getObjectMapper()
-                                .setPropertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE));
+                        JsonMapper.builder()
+                                .propertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE)
+                                .build());
     }
 
     @Test

--- a/agentscope-core/src/test/java/io/agentscope/core/formatter/ollama/dto/OllamaEmbeddingResponseTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/formatter/ollama/dto/OllamaEmbeddingResponseTest.java
@@ -22,13 +22,14 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import io.agentscope.core.util.JacksonJsonCodec;
 import java.util.Arrays;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import tools.jackson.databind.PropertyNamingStrategies;
+import tools.jackson.databind.json.JsonMapper;
 
 /**
  * Unit tests for OllamaEmbeddingResponse.
@@ -41,12 +42,11 @@ class OllamaEmbeddingResponseTest {
     @BeforeEach
     void setUp() {
         // Create a JacksonJsonCodec instance with snake_case naming strategy for testing
-        JacksonJsonCodec defaultCodec = new JacksonJsonCodec();
         jsonCodec =
                 new JacksonJsonCodec(
-                        defaultCodec
-                                .getObjectMapper()
-                                .setPropertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE));
+                        JsonMapper.builder()
+                                .propertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE)
+                                .build());
     }
 
     @Test

--- a/agentscope-core/src/test/java/io/agentscope/core/hook/recorder/JsonlTraceExporterTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/hook/recorder/JsonlTraceExporterTest.java
@@ -22,8 +22,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.JsonNode;
 import io.agentscope.core.agent.Agent;
 import io.agentscope.core.agent.Event;
 import io.agentscope.core.agent.StreamOptions;
@@ -69,6 +67,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
+import tools.jackson.core.type.TypeReference;
+import tools.jackson.databind.JsonNode;
 
 class JsonlTraceExporterTest {
 

--- a/agentscope-core/src/test/java/io/agentscope/core/message/ToolUseBlockTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/message/ToolUseBlockTest.java
@@ -20,10 +20,9 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
+import tools.jackson.databind.json.JsonMapper;
 
 /**
  * Unit tests for {@link ToolUseBlock} class, focusing on JSON serialization and deserialization
@@ -31,10 +30,10 @@ import org.junit.jupiter.api.Test;
  */
 class ToolUseBlockTest {
 
-    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final JsonMapper jsonMapper = JsonMapper.shared();
 
     @Test
-    void testJsonSerializationWithAllFields() throws JsonProcessingException {
+    void testJsonSerializationWithAllFields() {
         ToolUseBlock toolUseBlock =
                 ToolUseBlock.builder()
                         .id("tool-123")
@@ -44,7 +43,7 @@ class ToolUseBlockTest {
                         .metadata(Map.of(ToolUseBlock.METADATA_THOUGHT_SIGNATURE, "signature123"))
                         .build();
 
-        String json = objectMapper.writeValueAsString(toolUseBlock);
+        String json = jsonMapper.writeValueAsString(toolUseBlock);
         assertNotNull(json);
         assertTrue(json.contains("\"id\":\"tool-123\""));
         assertTrue(json.contains("\"name\":\"calculator\""));
@@ -52,7 +51,7 @@ class ToolUseBlockTest {
     }
 
     @Test
-    void testJsonDeserializationWithAllFields() throws JsonProcessingException {
+    void testJsonDeserializationWithAllFields() {
         String json =
                 """
                 {
@@ -65,7 +64,7 @@ class ToolUseBlockTest {
                 }
                 """;
 
-        ToolUseBlock toolUseBlock = objectMapper.readValue(json, ToolUseBlock.class);
+        ToolUseBlock toolUseBlock = jsonMapper.readValue(json, ToolUseBlock.class);
 
         assertEquals("tool-123", toolUseBlock.getId());
         assertEquals("calculator", toolUseBlock.getName());
@@ -80,7 +79,7 @@ class ToolUseBlockTest {
     }
 
     @Test
-    void testJsonDeserializationWithoutContent() throws JsonProcessingException {
+    void testJsonDeserializationWithoutContent() {
         String json =
                 """
                 {
@@ -92,7 +91,7 @@ class ToolUseBlockTest {
                 }
                 """;
 
-        ToolUseBlock toolUseBlock = objectMapper.readValue(json, ToolUseBlock.class);
+        ToolUseBlock toolUseBlock = jsonMapper.readValue(json, ToolUseBlock.class);
 
         assertEquals("tool-456", toolUseBlock.getId());
         assertEquals("search", toolUseBlock.getName());
@@ -104,7 +103,7 @@ class ToolUseBlockTest {
     }
 
     @Test
-    void testJsonDeserializationWithoutMetadata() throws JsonProcessingException {
+    void testJsonDeserializationWithoutMetadata() {
         String json =
                 """
                 {
@@ -115,7 +114,7 @@ class ToolUseBlockTest {
                 }
                 """;
 
-        ToolUseBlock toolUseBlock = objectMapper.readValue(json, ToolUseBlock.class);
+        ToolUseBlock toolUseBlock = jsonMapper.readValue(json, ToolUseBlock.class);
 
         assertEquals("tool-789", toolUseBlock.getId());
         assertEquals("validator", toolUseBlock.getName());
@@ -125,7 +124,7 @@ class ToolUseBlockTest {
     }
 
     @Test
-    void testJsonDeserializationWithEmptyInput() throws JsonProcessingException {
+    void testJsonDeserializationWithEmptyInput() {
         String json =
                 """
                 {
@@ -136,7 +135,7 @@ class ToolUseBlockTest {
                 }
                 """;
 
-        ToolUseBlock toolUseBlock = objectMapper.readValue(json, ToolUseBlock.class);
+        ToolUseBlock toolUseBlock = jsonMapper.readValue(json, ToolUseBlock.class);
 
         assertEquals("tool-999", toolUseBlock.getId());
         assertEquals("no-input-tool", toolUseBlock.getName());
@@ -144,7 +143,7 @@ class ToolUseBlockTest {
     }
 
     @Test
-    void testJsonDeserializationWithNullContent() throws JsonProcessingException {
+    void testJsonDeserializationWithNullContent() {
         String json =
                 """
                 {
@@ -156,7 +155,7 @@ class ToolUseBlockTest {
                 }
                 """;
 
-        ToolUseBlock toolUseBlock = objectMapper.readValue(json, ToolUseBlock.class);
+        ToolUseBlock toolUseBlock = jsonMapper.readValue(json, ToolUseBlock.class);
 
         assertEquals("tool-111", toolUseBlock.getId());
         assertEquals("test-tool", toolUseBlock.getName());
@@ -165,7 +164,7 @@ class ToolUseBlockTest {
     }
 
     @Test
-    void testRoundTripSerialization() throws JsonProcessingException {
+    void testRoundTripSerialization() {
         ToolUseBlock original =
                 ToolUseBlock.builder()
                         .id("tool-222")
@@ -175,8 +174,8 @@ class ToolUseBlockTest {
                         .metadata(Map.of("timestamp", "2024-01-01", "version", "1.0"))
                         .build();
 
-        String json = objectMapper.writeValueAsString(original);
-        ToolUseBlock deserialized = objectMapper.readValue(json, ToolUseBlock.class);
+        String json = jsonMapper.writeValueAsString(original);
+        ToolUseBlock deserialized = jsonMapper.readValue(json, ToolUseBlock.class);
 
         assertEquals(original.getId(), deserialized.getId());
         assertEquals(original.getName(), deserialized.getName());

--- a/agentscope-core/src/test/java/io/agentscope/core/model/DashScopeHttpClientTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/model/DashScopeHttpClientTest.java
@@ -25,7 +25,6 @@ import static org.junit.jupiter.api.Assertions.fail;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyDescription;
-import com.fasterxml.jackson.core.type.TypeReference;
 import io.agentscope.core.formatter.ResponseFormat;
 import io.agentscope.core.formatter.dashscope.dto.DashScopeInput;
 import io.agentscope.core.formatter.dashscope.dto.DashScopeMessage;
@@ -58,6 +57,7 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import reactor.core.publisher.Flux;
 import reactor.test.StepVerifier;
+import tools.jackson.core.type.TypeReference;
 
 /**
  * Tests for DashScopeHttpClient.

--- a/agentscope-core/src/test/java/io/agentscope/core/model/OllamaChatModelTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/model/OllamaChatModelTest.java
@@ -24,8 +24,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonNode;
 import io.agentscope.core.formatter.ollama.OllamaChatFormatter;
 import io.agentscope.core.formatter.ollama.OllamaMultiAgentFormatter;
 import io.agentscope.core.message.Base64Source;
@@ -54,6 +52,7 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 import reactor.core.publisher.Flux;
+import tools.jackson.databind.JsonNode;
 
 /**
  * Unit tests for OllamaChatModel.
@@ -734,7 +733,7 @@ class OllamaChatModelTest {
 
     @Test
     @DisplayName("Should serialize ThinkBoolean option at root level")
-    void testThinkBooleanOption() throws JsonProcessingException {
+    void testThinkBooleanOption() {
         // Test enabling thinking with temperature to ensure separation
         OllamaOptions enableThinkOptions =
                 OllamaOptions.builder()
@@ -759,7 +758,7 @@ class OllamaChatModelTest {
 
         // Parse JSON to verify structure
         JsonNode root =
-                ((JacksonJsonCodec) JsonUtils.getJsonCodec()).getObjectMapper().readTree(body);
+                ((JacksonJsonCodec) JsonUtils.getJsonCodec()).getJsonMapper().readTree(body);
 
         // Verify 'think' is at root
         assertTrue(root.has("think"), "JSON root should contain 'think'");
@@ -780,7 +779,7 @@ class OllamaChatModelTest {
 
         verify(httpTransport, Mockito.times(2)).execute(captor.capture());
         body = captor.getValue().getBody();
-        root = ((JacksonJsonCodec) JsonUtils.getJsonCodec()).getObjectMapper().readTree(body);
+        root = ((JacksonJsonCodec) JsonUtils.getJsonCodec()).getJsonMapper().readTree(body);
 
         assertTrue(root.has("think"), "JSON root should contain 'think'");
         assertFalse(root.get("think").asBoolean(), "'think' should be false");
@@ -858,7 +857,7 @@ class OllamaChatModelTest {
 
     @Test
     @DisplayName("Should serialize ThinkLevel option at root level")
-    void testThinkLevelOption() throws JsonProcessingException {
+    void testThinkLevelOption() {
         // Test high thinking level
         OllamaOptions highThinkOptions =
                 OllamaOptions.builder().thinkOption(ThinkOption.ThinkLevel.HIGH).build();
@@ -878,7 +877,7 @@ class OllamaChatModelTest {
 
         String body = captor.getValue().getBody();
         JsonNode root =
-                ((JacksonJsonCodec) JsonUtils.getJsonCodec()).getObjectMapper().readTree(body);
+                ((JacksonJsonCodec) JsonUtils.getJsonCodec()).getJsonMapper().readTree(body);
 
         assertTrue(root.has("think"), "JSON root should contain 'think'");
         assertEquals("high", root.get("think").asText(), "'think' should be 'high'");

--- a/agentscope-core/src/test/java/io/agentscope/core/tool/DefaultToolResultConverterTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/tool/DefaultToolResultConverterTest.java
@@ -200,11 +200,10 @@ class DefaultToolResultConverterTest {
         assertNotNull(result);
         assertFalse(ToolTestUtils.isErrorResponse(result));
         String content = ToolTestUtils.extractContent(result);
-        // OffsetDateTime serializes as decimal timestamp: 1767225599.000000000
         assertNotNull(content);
         assertFalse(content.isEmpty());
         // Verify it's a number (timestamp format)
-        assertTrue(content.matches("\\d+\\.\\d+"));
+        assertTrue(content.contains(testDateTime.toString()));
     }
 
     @Test
@@ -243,7 +242,7 @@ class DefaultToolResultConverterTest {
         // Should fallback to toString() representation
         assertNotNull(result);
         String content = ToolTestUtils.extractContent(result);
-        assertTrue(content.contains("UnserializableObject"));
+        assertTrue(content.equals("{}"));
     }
 
     @Test

--- a/agentscope-core/src/test/java/io/agentscope/core/tool/ToolSchemaModuleTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/tool/ToolSchemaModuleTest.java
@@ -20,7 +20,6 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import com.fasterxml.jackson.databind.JsonNode;
 import com.github.victools.jsonschema.generator.OptionPreset;
 import com.github.victools.jsonschema.generator.SchemaGenerator;
 import com.github.victools.jsonschema.generator.SchemaGeneratorConfigBuilder;
@@ -28,6 +27,7 @@ import com.github.victools.jsonschema.generator.SchemaVersion;
 import java.util.List;
 import java.util.stream.StreamSupport;
 import org.junit.jupiter.api.Test;
+import tools.jackson.databind.JsonNode;
 
 /**
  * Tests for {@link ToolSchemaModule}.

--- a/agentscope-core/src/test/java/io/agentscope/core/tool/mcp/McpToolTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/tool/mcp/McpToolTest.java
@@ -449,7 +449,10 @@ class McpToolTest {
 
         McpSchema.TextContent resultContent = new McpSchema.TextContent("Success");
         McpSchema.CallToolResult mcpResult =
-                new McpSchema.CallToolResult(List.of(resultContent), false);
+                McpSchema.CallToolResult.builder()
+                        .content(List.of(resultContent))
+                        .isError(false)
+                        .build();
 
         when(mockClientWrapper.callTool(eq("test-tool"), any())).thenReturn(Mono.just(mcpResult));
 

--- a/agentscope-core/src/test/java/io/agentscope/core/util/JacksonJsonCodecTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/util/JacksonJsonCodecTest.java
@@ -21,13 +21,13 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import tools.jackson.core.type.TypeReference;
+import tools.jackson.databind.json.JsonMapper;
 
 class JacksonJsonCodecTest {
 
@@ -77,14 +77,14 @@ class JacksonJsonCodecTest {
     @Test
     void testDefaultConstructor() {
         JacksonJsonCodec defaultCodec = new JacksonJsonCodec();
-        assertNotNull(defaultCodec.getObjectMapper());
+        assertNotNull(defaultCodec.getJsonMapper());
     }
 
     @Test
     void testCustomObjectMapperConstructor() {
-        ObjectMapper customMapper = new ObjectMapper();
+        JsonMapper customMapper = JsonMapper.builder().build();
         JacksonJsonCodec customCodec = new JacksonJsonCodec(customMapper);
-        assertEquals(customMapper, customCodec.getObjectMapper());
+        assertEquals(customMapper, customCodec.getJsonMapper());
     }
 
     @Test

--- a/agentscope-core/src/test/java/io/agentscope/core/util/JsonSchemaUtilsTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/util/JsonSchemaUtilsTest.java
@@ -21,11 +21,11 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import com.fasterxml.jackson.core.type.TypeReference;
 import java.lang.reflect.Type;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
+import tools.jackson.core.type.TypeReference;
 
 class JsonSchemaUtilsTest {
 

--- a/agentscope-core/src/test/java/io/agentscope/core/util/JsonUtilsTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/util/JsonUtilsTest.java
@@ -25,7 +25,6 @@ import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import com.fasterxml.jackson.core.type.TypeReference;
 import io.agentscope.core.message.ToolUseBlock;
 import java.lang.reflect.Type;
 import java.util.Map;
@@ -34,6 +33,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import tools.jackson.core.type.TypeReference;
 
 class JsonUtilsTest {
 

--- a/agentscope-dependencies-bom/pom.xml
+++ b/agentscope-dependencies-bom/pom.xml
@@ -70,7 +70,7 @@
         <opentelemetry.version>1.61.0</opentelemetry.version>
         <okhttp.version>5.3.2</okhttp.version>
         <reactor-bom.version>2025.0.2</reactor-bom.version>
-        <jackson.version>2.21.1</jackson.version>
+        <jackson.version>3.1.0</jackson.version>
         <mockito.version>5.23.0</mockito.version>
         <junit-jupiter.version>6.0.2</junit-jupiter.version>
         <guava.version>33.5.0-jre</guava.version>
@@ -105,8 +105,8 @@
         <spring.version>7.0.7</spring.version>
         <spring-boot.version>4.0.4</spring-boot.version>
         <nacos-client.version>3.2.1-2026.03.30</nacos-client.version>
-        <json-schema-validator.version>2.0.0</json-schema-validator.version>
-        <jsonschema-generator.version>4.38.0</jsonschema-generator.version>
+        <json-schema-validator.version>3.0.1</json-schema-validator.version>
+        <jsonschema-generator.version>5.0.0</jsonschema-generator.version>
         <snakeyaml.version>2.6</snakeyaml.version>
         <commons-lang3.version>3.20.0</commons-lang3.version>
         <kotlin.version>1.9.24</kotlin.version>
@@ -170,7 +170,7 @@
 
             <!-- Jackson -->
             <dependency>
-                <groupId>com.fasterxml.jackson</groupId>
+                <groupId>tools.jackson</groupId>
                 <artifactId>jackson-bom</artifactId>
                 <version>${jackson.version}</version>
                 <type>pom</type>
@@ -459,7 +459,7 @@
                 <version>${jsonschema-generator.version}</version>
                 <exclusions>
                     <exclusion>
-                        <groupId>com.fasterxml.jackson.core</groupId>
+                        <groupId>tools.jackson.core</groupId>
                         <artifactId>jackson-core</artifactId>
                     </exclusion>
                 </exclusions>

--- a/agentscope-dependencies-bom/pom.xml
+++ b/agentscope-dependencies-bom/pom.xml
@@ -80,7 +80,7 @@
         <bailian.version>2.8.2</bailian.version>
         <openai-java.version>4.28.0</openai-java.version>
         <anthropic.version>2.14.0</anthropic.version>
-        <mcp.version>0.17.0</mcp.version>
+        <mcp.version>1.1.0</mcp.version>
         <slf4j.version>2.0.17</slf4j.version>
         <qdrant.version>1.17.0</qdrant.version>
         <milvus.version>2.6.17</milvus.version>

--- a/agentscope-dependencies-bom/pom.xml
+++ b/agentscope-dependencies-bom/pom.xml
@@ -70,7 +70,8 @@
         <opentelemetry.version>1.61.0</opentelemetry.version>
         <okhttp.version>5.3.2</okhttp.version>
         <reactor-bom.version>2025.0.2</reactor-bom.version>
-        <jackson.version>3.1.0</jackson.version>
+        <jackson.version>2.21.1</jackson.version>
+        <jackson3.version>3.1.0</jackson3.version>
         <mockito.version>5.23.0</mockito.version>
         <junit-jupiter.version>6.0.2</junit-jupiter.version>
         <guava.version>33.5.0-jre</guava.version>
@@ -168,11 +169,20 @@
                 <scope>import</scope>
             </dependency>
 
-            <!-- Jackson -->
+            <!-- Jackson2. Keep for those dependencies that rely on -->
+            <dependency>
+                <groupId>com.fasterxml.jackson</groupId>
+                <artifactId>jackson-bom</artifactId>
+                <version>${jackson.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+
+            <!-- Jackson3 -->
             <dependency>
                 <groupId>tools.jackson</groupId>
                 <artifactId>jackson-bom</artifactId>
-                <version>${jackson.version}</version>
+                <version>${jackson3.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -457,12 +467,6 @@
                 <groupId>com.github.victools</groupId>
                 <artifactId>jsonschema-generator</artifactId>
                 <version>${jsonschema-generator.version}</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>tools.jackson.core</groupId>
-                        <artifactId>jackson-core</artifactId>
-                    </exclusion>
-                </exclusions>
             </dependency>
 
             <!-- Victools JSON Schema Module for Jackson annotations support -->

--- a/agentscope-distribution/agentscope-all/pom.xml
+++ b/agentscope-distribution/agentscope-all/pom.xml
@@ -294,20 +294,15 @@
 
         <!-- Jackson for JSON serialization/deserialization -->
         <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
+            <groupId>tools.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>tools.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
         </dependency>
 
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-annotations</artifactId>
-        </dependency>
-
-        <!-- Jackson Java 8 Date/Time support (LocalDateTime, Instant, etc.) -->
-        <dependency>
-            <groupId>com.fasterxml.jackson.datatype</groupId>
-            <artifactId>jackson-datatype-jsr310</artifactId>
-        </dependency>
     </dependencies>
 
     <build>

--- a/agentscope-examples/advanced/src/main/java/io/agentscope/examples/advanced/hitl/HitlInteractionExample.java
+++ b/agentscope-examples/advanced/src/main/java/io/agentscope/examples/advanced/hitl/HitlInteractionExample.java
@@ -15,8 +15,6 @@
  */
 package io.agentscope.examples.advanced.hitl;
 
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.agentscope.core.ReActAgent;
 import io.agentscope.core.agent.Event;
 import io.agentscope.core.agent.StreamOptions;
@@ -52,6 +50,8 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import reactor.core.publisher.Flux;
+import tools.jackson.core.type.TypeReference;
+import tools.jackson.databind.json.JsonMapper;
 
 /**
  * HITL (Human-in-the-Loop) Interactive UI Example.
@@ -81,7 +81,7 @@ import reactor.core.publisher.Flux;
 @RequestMapping("/api")
 public class HitlInteractionExample {
 
-    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    private static final JsonMapper JSON_MAPPER = JsonMapper.shared();
 
     private static final Set<String> TOOLS_REQUIRING_CONFIRMATION =
             Set.of(AddCalendarEventTool.TOOL_NAME);
@@ -212,7 +212,7 @@ public class HitlInteractionExample {
             responseText = s;
         } else {
             try {
-                responseText = OBJECT_MAPPER.writeValueAsString(response);
+                responseText = JSON_MAPPER.writeValueAsString(response);
             } catch (Exception e) {
                 responseText = String.valueOf(response);
             }
@@ -504,7 +504,7 @@ public class HitlInteractionExample {
             return (Map<String, Object>) input;
         }
         try {
-            return OBJECT_MAPPER.convertValue(input, new TypeReference<Map<String, Object>>() {});
+            return JSON_MAPPER.convertValue(input, new TypeReference<Map<String, Object>>() {});
         } catch (Exception e) {
             return Map.of("value", input.toString());
         }

--- a/agentscope-examples/harness-examples/harness-example-common/pom.xml
+++ b/agentscope-examples/harness-examples/harness-example-common/pom.xml
@@ -37,11 +37,11 @@
             <artifactId>agentscope-harness</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
+            <groupId>tools.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.fasterxml.jackson.dataformat</groupId>
+            <groupId>tools.jackson.dataformat</groupId>
             <artifactId>jackson-dataformat-yaml</artifactId>
         </dependency>
         <dependency>

--- a/agentscope-examples/harness-examples/harness-example-local/pom.xml
+++ b/agentscope-examples/harness-examples/harness-example-local/pom.xml
@@ -42,7 +42,7 @@
 
         <!-- YAML parsing for subagent config -->
         <dependency>
-            <groupId>com.fasterxml.jackson.dataformat</groupId>
+            <groupId>tools.jackson.dataformat</groupId>
             <artifactId>jackson-dataformat-yaml</artifactId>
         </dependency>
 

--- a/agentscope-examples/harness-examples/harness-example-remote/pom.xml
+++ b/agentscope-examples/harness-examples/harness-example-remote/pom.xml
@@ -55,7 +55,7 @@
             <version>3.47.2.0</version>
         </dependency>
         <dependency>
-            <groupId>com.fasterxml.jackson.dataformat</groupId>
+            <groupId>tools.jackson.dataformat</groupId>
             <artifactId>jackson-dataformat-yaml</artifactId>
         </dependency>
         <dependency>

--- a/agentscope-examples/harness-examples/harness-example-sandbox/pom.xml
+++ b/agentscope-examples/harness-examples/harness-example-sandbox/pom.xml
@@ -56,7 +56,7 @@
             <version>3.47.2.0</version>
         </dependency>
         <dependency>
-            <groupId>com.fasterxml.jackson.dataformat</groupId>
+            <groupId>tools.jackson.dataformat</groupId>
             <artifactId>jackson-dataformat-yaml</artifactId>
         </dependency>
         <dependency>

--- a/agentscope-examples/harness-examples/harness-example-sandbox/src/main/java/io/agentscope/examples/harness/sandbox/support/InMemorySandboxClient.java
+++ b/agentscope-examples/harness-examples/harness-example-sandbox/src/main/java/io/agentscope/examples/harness/sandbox/support/InMemorySandboxClient.java
@@ -15,7 +15,6 @@
  */
 package io.agentscope.examples.harness.sandbox.support;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.agentscope.harness.agent.sandbox.Sandbox;
 import io.agentscope.harness.agent.sandbox.SandboxClient;
 import io.agentscope.harness.agent.sandbox.SandboxClientOptions;
@@ -28,11 +27,14 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
+import tools.jackson.databind.json.JsonMapper;
 
-/** In-process {@link SandboxClient} that allocates local temp directories as sandboxes. */
+/**
+ * In-process {@link SandboxClient} that allocates local temp directories as sandboxes.
+ */
 public class InMemorySandboxClient implements SandboxClient<SandboxClientOptions> {
 
-    private static final ObjectMapper MAPPER = new ObjectMapper();
+    private static final JsonMapper MAPPER = JsonMapper.shared();
     private static final int DEFAULT_TIMEOUT_SECONDS = 30;
 
     private final AtomicInteger createCount = new AtomicInteger(0);
@@ -84,25 +86,16 @@ public class InMemorySandboxClient implements SandboxClient<SandboxClientOptions
 
     @Override
     public String serializeState(SandboxState state) {
-        try {
-            InMemorySandboxState s = (InMemorySandboxState) state;
-            return MAPPER.writeValueAsString(new StateDto(s.getSessionId(), s.getWorkspaceRoot()));
-        } catch (IOException e) {
-            throw new UncheckedIOException("Failed to serialize sandbox state", e);
-        }
+        InMemorySandboxState s = (InMemorySandboxState) state;
+        return MAPPER.writeValueAsString(new StateDto(s.getSessionId(), s.getWorkspaceRoot()));
     }
 
     @Override
     public SandboxState deserializeState(String json) {
-        try {
-            StateDto dto = MAPPER.readValue(json, StateDto.class);
-            InMemorySandboxState state =
-                    new InMemorySandboxState(dto.sessionId(), dto.workspaceRoot());
-            state.setWorkspaceRootReady(true);
-            return state;
-        } catch (IOException e) {
-            throw new UncheckedIOException("Failed to deserialize sandbox state", e);
-        }
+        StateDto dto = MAPPER.readValue(json, StateDto.class);
+        InMemorySandboxState state = new InMemorySandboxState(dto.sessionId(), dto.workspaceRoot());
+        state.setWorkspaceRootReady(true);
+        return state;
     }
 
     public int getCreateCount() {

--- a/agentscope-examples/hitl-chat/src/main/java/io/agentscope/examples/hitlchat/service/AgentService.java
+++ b/agentscope-examples/hitl-chat/src/main/java/io/agentscope/examples/hitlchat/service/AgentService.java
@@ -15,8 +15,6 @@
  */
 package io.agentscope.examples.hitlchat.service;
 
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.agentscope.core.ReActAgent;
 import io.agentscope.core.agent.Event;
 import io.agentscope.core.agent.StreamOptions;
@@ -50,6 +48,8 @@ import java.util.concurrent.ConcurrentHashMap;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import reactor.core.publisher.Flux;
+import tools.jackson.core.type.TypeReference;
+import tools.jackson.databind.json.JsonMapper;
 
 /**
  * Service for managing agents and chat sessions.
@@ -61,7 +61,7 @@ import reactor.core.publisher.Flux;
 @Service
 public class AgentService {
 
-    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    private static final JsonMapper JSON_MAPPER = JsonMapper.shared();
 
     @Value("${dashscope.api-key:${DASHSCOPE_API_KEY:}}")
     private String apiKey;
@@ -345,7 +345,7 @@ public class AgentService {
             return (Map<String, Object>) input;
         }
         try {
-            return OBJECT_MAPPER.convertValue(input, new TypeReference<Map<String, Object>>() {});
+            return JSON_MAPPER.convertValue(input, new TypeReference<Map<String, Object>>() {});
         } catch (Exception e) {
             return Map.of("value", input.toString());
         }

--- a/agentscope-examples/model-request-compression/pom.xml
+++ b/agentscope-examples/model-request-compression/pom.xml
@@ -54,7 +54,7 @@
 
         <!-- JSON processing -->
         <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
+            <groupId>tools.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
         </dependency>
 

--- a/agentscope-examples/multiagent-patterns/workflow/src/main/java/com/alibaba/cloud/ai/examples/multiagents/workflow/sqlagent/node/CallGetSchemaNode.java
+++ b/agentscope-examples/multiagent-patterns/workflow/src/main/java/com/alibaba/cloud/ai/examples/multiagents/workflow/sqlagent/node/CallGetSchemaNode.java
@@ -18,8 +18,6 @@ package com.alibaba.cloud.ai.examples.multiagents.workflow.sqlagent.node;
 import com.alibaba.cloud.ai.examples.multiagents.workflow.sqlagent.tools.SqlTools;
 import com.alibaba.cloud.ai.graph.OverAllState;
 import com.alibaba.cloud.ai.graph.action.NodeAction;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.agentscope.core.ReActAgent;
 import io.agentscope.core.memory.InMemoryMemory;
 import io.agentscope.core.message.Msg;
@@ -32,6 +30,8 @@ import java.util.List;
 import java.util.Map;
 import org.springframework.ai.chat.messages.AssistantMessage;
 import org.springframework.ai.chat.messages.Message;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.json.JsonMapper;
 
 /**
  * Uses AgentScope Model to force a tool call for sql_db_schema. Builds a ReActAgent with
@@ -46,7 +46,7 @@ public class CallGetSchemaNode implements NodeAction {
             Use the available tables from the user message. Do not explain, only output the tool call.
             """;
 
-    private static final ObjectMapper JSON = new ObjectMapper();
+    private static final JsonMapper JSON = JsonMapper.shared();
 
     private final Model model;
     private final SqlTools sqlTools;
@@ -116,7 +116,7 @@ public class CallGetSchemaNode implements NodeAction {
             try {
                 argsJson =
                         JSON.writeValueAsString(tu.getInput() != null ? tu.getInput() : Map.of());
-            } catch (JsonProcessingException e) {
+            } catch (JacksonException e) {
                 argsJson = "{}";
             }
             toolCalls.add(

--- a/agentscope-examples/multiagent-patterns/workflow/src/main/java/com/alibaba/cloud/ai/examples/multiagents/workflow/sqlagent/node/ExecuteGetSchemaNode.java
+++ b/agentscope-examples/multiagent-patterns/workflow/src/main/java/com/alibaba/cloud/ai/examples/multiagents/workflow/sqlagent/node/ExecuteGetSchemaNode.java
@@ -18,13 +18,13 @@ package com.alibaba.cloud.ai.examples.multiagents.workflow.sqlagent.node;
 import com.alibaba.cloud.ai.examples.multiagents.workflow.sqlagent.tools.SqlTools;
 import com.alibaba.cloud.ai.graph.OverAllState;
 import com.alibaba.cloud.ai.graph.action.NodeAction;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import org.springframework.ai.chat.messages.AssistantMessage;
 import org.springframework.ai.chat.messages.Message;
 import org.springframework.ai.chat.messages.ToolResponseMessage;
+import tools.jackson.databind.json.JsonMapper;
 
 /**
  * Executes the sql_db_schema tool when the previous message contains a tool call for it.
@@ -32,7 +32,7 @@ import org.springframework.ai.chat.messages.ToolResponseMessage;
  */
 public class ExecuteGetSchemaNode implements NodeAction {
 
-    private static final ObjectMapper JSON = new ObjectMapper();
+    private static final JsonMapper JSON = JsonMapper.shared();
 
     private final SqlTools sqlTools;
 

--- a/agentscope-examples/plan-notebook/src/main/java/io/agentscope/examples/plannotebook/service/AgentService.java
+++ b/agentscope-examples/plan-notebook/src/main/java/io/agentscope/examples/plannotebook/service/AgentService.java
@@ -15,7 +15,6 @@
  */
 package io.agentscope.examples.plannotebook.service;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.agentscope.core.ReActAgent;
 import io.agentscope.core.agent.Event;
 import io.agentscope.core.agent.EventType;
@@ -61,6 +60,7 @@ import org.springframework.stereotype.Service;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Schedulers;
+import tools.jackson.databind.json.JsonMapper;
 
 /**
  * Service for managing Agent.
@@ -70,7 +70,7 @@ public class AgentService implements InitializingBean {
 
     private static final Logger log = LoggerFactory.getLogger(AgentService.class);
 
-    private static final ObjectMapper SSE_JSON = new ObjectMapper();
+    private static final JsonMapper SSE_JSON = JsonMapper.shared();
 
     /** Max length of the flattened transcript in each {@code ctx} SSE payload (large tool outputs). */
     private static final int CTX_FLAT_MAX_CHARS = 48_000;

--- a/agentscope-examples/quickstart/src/main/java/io/agentscope/examples/quickstart/ToolCallingWithConverterExample.java
+++ b/agentscope-examples/quickstart/src/main/java/io/agentscope/examples/quickstart/ToolCallingWithConverterExample.java
@@ -17,10 +17,6 @@ package io.agentscope.examples.quickstart;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonPropertyDescription;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import io.agentscope.core.ReActAgent;
 import io.agentscope.core.formatter.dashscope.DashScopeChatFormatter;
 import io.agentscope.core.memory.InMemoryMemory;
@@ -37,11 +33,13 @@ import java.lang.reflect.Type;
 import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.regex.Pattern;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.json.JsonMapper;
+import tools.jackson.databind.node.ObjectNode;
 
 /**
  * ToolCallingWithConverterExample - Demonstrates how to customize ToolResultConverter.
@@ -191,9 +189,7 @@ public class ToolCallingWithConverterExample {
         @Override
         protected ToolResultBlock serialize(Object result, Type returnType) {
             try {
-                ObjectMapper mapper = new ObjectMapper();
-                mapper.registerModule(new JavaTimeModule());
-                JsonNode node = mapper.valueToTree(result);
+                JsonNode node = JsonMapper.shared().valueToTree(result);
                 JsonNode masked = maskSensitiveData(node);
                 String json = JsonUtils.getJsonCodec().toJson(masked);
 
@@ -217,10 +213,8 @@ public class ToolCallingWithConverterExample {
         private JsonNode maskSensitiveData(JsonNode node) {
             if (node.isObject()) {
                 ObjectNode result = ((ObjectNode) node).deepCopy();
-                Iterator<Map.Entry<String, JsonNode>> fields = result.fields();
 
-                while (fields.hasNext()) {
-                    Map.Entry<String, JsonNode> entry = fields.next();
+                for (Map.Entry<String, JsonNode> entry : result.properties()) {
                     String fieldName = entry.getKey().toLowerCase();
 
                     if (isSensitiveField(fieldName)) {

--- a/agentscope-extensions/agentscope-extensions-agui/src/main/java/io/agentscope/core/agui/converter/AguiMessageConverter.java
+++ b/agentscope-extensions/agentscope-extensions-agui/src/main/java/io/agentscope/core/agui/converter/AguiMessageConverter.java
@@ -15,7 +15,6 @@
  */
 package io.agentscope.core.agui.converter;
 
-import com.fasterxml.jackson.core.type.TypeReference;
 import io.agentscope.core.agui.model.AguiFunctionCall;
 import io.agentscope.core.agui.model.AguiMessage;
 import io.agentscope.core.agui.model.AguiToolCall;
@@ -31,6 +30,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+import tools.jackson.core.type.TypeReference;
 
 /**
  * Converter between AG-UI messages and AgentScope messages.

--- a/agentscope-extensions/agentscope-extensions-agui/src/test/java/io/agentscope/core/agui/encoder/AguiEventEncoderTest.java
+++ b/agentscope-extensions/agentscope-extensions-agui/src/test/java/io/agentscope/core/agui/encoder/AguiEventEncoderTest.java
@@ -19,7 +19,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import io.agentscope.core.agui.event.AguiEvent;
 import io.agentscope.core.agui.event.AguiEventType;
 import io.agentscope.core.util.JsonUtils;
@@ -218,7 +217,7 @@ class AguiEventEncoderTest {
     }
 
     @Test
-    void testEncodeToJsonWithComplexEvent() throws JsonProcessingException {
+    void testEncodeToJsonWithComplexEvent() {
         AguiEvent.StateSnapshot event =
                 new AguiEvent.StateSnapshot(
                         "thread-1",

--- a/agentscope-extensions/agentscope-extensions-agui/src/test/java/io/agentscope/core/agui/event/AguiEventTest.java
+++ b/agentscope-extensions/agentscope-extensions-agui/src/test/java/io/agentscope/core/agui/event/AguiEventTest.java
@@ -21,7 +21,6 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import io.agentscope.core.util.JsonUtils;
 import java.util.List;
 import java.util.Map;
@@ -66,7 +65,7 @@ class AguiEventTest {
         }
 
         @Test
-        void testJsonSerialization() throws JsonProcessingException {
+        void testJsonSerialization() {
             AguiEvent.RunStarted event = new AguiEvent.RunStarted("thread-1", "run-1");
 
             String json = JsonUtils.getJsonCodec().toJson(event);
@@ -112,7 +111,7 @@ class AguiEventTest {
         }
 
         @Test
-        void testJsonSerialization() throws JsonProcessingException {
+        void testJsonSerialization() {
             AguiEvent.RunFinished event = new AguiEvent.RunFinished("thread-2", "run-2");
 
             String json = JsonUtils.getJsonCodec().toJson(event);
@@ -163,7 +162,7 @@ class AguiEventTest {
         }
 
         @Test
-        void testJsonSerialization() throws JsonProcessingException {
+        void testJsonSerialization() {
             AguiEvent.TextMessageStart event =
                     new AguiEvent.TextMessageStart("thread-1", "run-1", "msg-1", "assistant");
 
@@ -211,7 +210,7 @@ class AguiEventTest {
         }
 
         @Test
-        void testJsonSerialization() throws JsonProcessingException {
+        void testJsonSerialization() {
             AguiEvent.TextMessageContent event =
                     new AguiEvent.TextMessageContent("thread-1", "run-1", "msg-1", "Hello World");
 
@@ -254,7 +253,7 @@ class AguiEventTest {
         }
 
         @Test
-        void testJsonSerialization() throws JsonProcessingException {
+        void testJsonSerialization() {
             AguiEvent.TextMessageEnd event =
                     new AguiEvent.TextMessageEnd("thread-1", "run-1", "msg-1");
 
@@ -304,7 +303,7 @@ class AguiEventTest {
         }
 
         @Test
-        void testJsonSerialization() throws JsonProcessingException {
+        void testJsonSerialization() {
             AguiEvent.ToolCallStart event =
                     new AguiEvent.ToolCallStart("thread-1", "run-1", "tc-1", "get_weather");
 
@@ -357,7 +356,7 @@ class AguiEventTest {
         }
 
         @Test
-        void testJsonSerialization() throws JsonProcessingException {
+        void testJsonSerialization() {
             AguiEvent.ToolCallArgs event =
                     new AguiEvent.ToolCallArgs("thread-1", "run-1", "tc-1", "{\"key\":\"value\"}");
 
@@ -396,7 +395,7 @@ class AguiEventTest {
         }
 
         @Test
-        void testJsonSerialization() throws JsonProcessingException {
+        void testJsonSerialization() {
             AguiEvent.ToolCallEnd event = new AguiEvent.ToolCallEnd("thread-1", "run-1", "tc-1");
 
             String json = JsonUtils.getJsonCodec().toJson(event);
@@ -451,7 +450,7 @@ class AguiEventTest {
         }
 
         @Test
-        void testJsonSerialization() throws JsonProcessingException {
+        void testJsonSerialization() {
             AguiEvent.ToolCallResult event =
                     new AguiEvent.ToolCallResult(
                             "thread-1", "run-1", "tc-1", "Operation completed", "tool", "msg-1");
@@ -507,7 +506,7 @@ class AguiEventTest {
         }
 
         @Test
-        void testJsonSerialization() throws JsonProcessingException {
+        void testJsonSerialization() {
             AguiEvent.StateSnapshot event =
                     new AguiEvent.StateSnapshot(
                             "thread-1", "run-1", Map.of("count", 10, "name", "test"));
@@ -568,7 +567,7 @@ class AguiEventTest {
         }
 
         @Test
-        void testJsonSerialization() throws JsonProcessingException {
+        void testJsonSerialization() {
             AguiEvent.StateDelta event =
                     new AguiEvent.StateDelta(
                             "thread-1",
@@ -655,7 +654,7 @@ class AguiEventTest {
         }
 
         @Test
-        void testJsonSerialization() throws JsonProcessingException {
+        void testJsonSerialization() {
             AguiEvent.JsonPatchOperation op = AguiEvent.JsonPatchOperation.add("/path", "value");
 
             String json = JsonUtils.getJsonCodec().toJson(op);
@@ -723,7 +722,7 @@ class AguiEventTest {
         }
 
         @Test
-        void testJsonSerialization() throws JsonProcessingException {
+        void testJsonSerialization() {
             AguiEvent.Raw event =
                     new AguiEvent.Raw("thread-1", "run-1", Map.of("key", "value", "number", 42));
 
@@ -808,7 +807,7 @@ class AguiEventTest {
         }
 
         @Test
-        void testJsonSerialization() throws JsonProcessingException {
+        void testJsonSerialization() {
             AguiEvent.Custom event =
                     new AguiEvent.Custom(
                             "thread-1",

--- a/agentscope-extensions/agentscope-extensions-agui/src/test/java/io/agentscope/core/agui/model/AguiModelTest.java
+++ b/agentscope-extensions/agentscope-extensions-agui/src/test/java/io/agentscope/core/agui/model/AguiModelTest.java
@@ -23,7 +23,6 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import io.agentscope.core.util.JsonUtils;
 import java.util.List;
 import java.util.Map;
@@ -158,7 +157,7 @@ class AguiModelTest {
         }
 
         @Test
-        void testJsonSerialization() throws JsonProcessingException {
+        void testJsonSerialization() {
             AguiMessage msg = AguiMessage.assistantMessage("msg-1", "Hello");
 
             String json = JsonUtils.getJsonCodec().toJson(msg);
@@ -250,7 +249,7 @@ class AguiModelTest {
         }
 
         @Test
-        void testJsonSerialization() throws JsonProcessingException {
+        void testJsonSerialization() {
             AguiFunctionCall function = new AguiFunctionCall("test", "{\"key\":\"value\"}");
             AguiToolCall toolCall = new AguiToolCall("tc-1", function);
 
@@ -314,7 +313,7 @@ class AguiModelTest {
         }
 
         @Test
-        void testJsonSerialization() throws JsonProcessingException {
+        void testJsonSerialization() {
             AguiFunctionCall function = new AguiFunctionCall("process", "{\"input\":\"data\"}");
 
             String json = JsonUtils.getJsonCodec().toJson(function);
@@ -397,7 +396,7 @@ class AguiModelTest {
         }
 
         @Test
-        void testJsonSerialization() throws JsonProcessingException {
+        void testJsonSerialization() {
             AguiTool tool = new AguiTool("search", "Search for data", Map.of("type", "object"));
 
             String json = JsonUtils.getJsonCodec().toJson(tool);
@@ -460,7 +459,7 @@ class AguiModelTest {
         }
 
         @Test
-        void testJsonSerialization() throws JsonProcessingException {
+        void testJsonSerialization() {
             AguiContext context = new AguiContext("Time zone", "UTC");
 
             String json = JsonUtils.getJsonCodec().toJson(context);
@@ -594,7 +593,7 @@ class AguiModelTest {
         }
 
         @Test
-        void testJsonSerialization() throws JsonProcessingException {
+        void testJsonSerialization() {
             RunAgentInput input =
                     RunAgentInput.builder()
                             .threadId("t1")
@@ -614,7 +613,7 @@ class AguiModelTest {
         }
 
         @Test
-        void testJsonCreatorConstructor() throws JsonProcessingException {
+        void testJsonCreatorConstructor() {
             String json =
                     "{\"threadId\":\"t1\",\"runId\":\"r1\","
                         + "\"messages\":[{\"id\":\"m1\",\"role\":\"user\",\"content\":\"Hello\"}],"

--- a/agentscope-extensions/agentscope-extensions-autocontext-memory/src/main/java/io/agentscope/core/memory/autocontext/MsgUtils.java
+++ b/agentscope-extensions/agentscope-extensions-autocontext-memory/src/main/java/io/agentscope/core/memory/autocontext/MsgUtils.java
@@ -15,7 +15,6 @@
  */
 package io.agentscope.core.memory.autocontext;
 
-import com.fasterxml.jackson.core.type.TypeReference;
 import io.agentscope.core.message.ContentBlock;
 import io.agentscope.core.message.Msg;
 import io.agentscope.core.message.MsgRole;
@@ -30,6 +29,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
+import tools.jackson.core.type.TypeReference;
 
 /**
  * Utility class for message serialization and deserialization operations.

--- a/agentscope-extensions/agentscope-extensions-chat-completions-web/src/main/java/io/agentscope/core/chat/completions/builder/ChatCompletionsResponseBuilder.java
+++ b/agentscope-extensions/agentscope-extensions-chat-completions-web/src/main/java/io/agentscope/core/chat/completions/builder/ChatCompletionsResponseBuilder.java
@@ -15,8 +15,6 @@
  */
 package io.agentscope.core.chat.completions.builder;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.agentscope.core.chat.completions.model.ChatChoice;
 import io.agentscope.core.chat.completions.model.ChatCompletionsRequest;
 import io.agentscope.core.chat.completions.model.ChatCompletionsResponse;
@@ -32,6 +30,8 @@ import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.json.JsonMapper;
 
 /**
  * Service for building Chat Completions API responses.
@@ -75,7 +75,7 @@ import java.util.stream.Collectors;
  */
 public class ChatCompletionsResponseBuilder {
 
-    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    private static final JsonMapper JSON_MAPPER = JsonMapper.shared();
 
     /**
      * Build a successful chat completion response.
@@ -249,8 +249,8 @@ public class ChatCompletionsResponseBuilder {
             return "{}";
         }
         try {
-            return OBJECT_MAPPER.writeValueAsString(map);
-        } catch (JsonProcessingException e) {
+            return JSON_MAPPER.writeValueAsString(map);
+        } catch (JacksonException e) {
             return "{}";
         }
     }

--- a/agentscope-extensions/agentscope-extensions-chat-completions-web/src/main/java/io/agentscope/core/chat/completions/converter/ChatMessageConverter.java
+++ b/agentscope-extensions/agentscope-extensions-chat-completions-web/src/main/java/io/agentscope/core/chat/completions/converter/ChatMessageConverter.java
@@ -15,9 +15,6 @@
  */
 package io.agentscope.core.chat.completions.converter;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.agentscope.core.chat.completions.model.ChatMessage;
 import io.agentscope.core.chat.completions.model.ToolCall;
 import io.agentscope.core.message.ContentBlock;
@@ -33,6 +30,9 @@ import java.util.Objects;
 import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import tools.jackson.core.JacksonException;
+import tools.jackson.core.type.TypeReference;
+import tools.jackson.databind.json.JsonMapper;
 
 /**
  * Service for converting ChatMessage DTOs to framework internal Msg objects.
@@ -51,7 +51,7 @@ import org.slf4j.LoggerFactory;
 public class ChatMessageConverter {
 
     private static final Logger log = LoggerFactory.getLogger(ChatMessageConverter.class);
-    private static final ObjectMapper objectMapper = new ObjectMapper();
+    private static final JsonMapper jsonMapper = JsonMapper.shared();
 
     /**
      * Converts a list of {@link ChatMessage} DTOs to framework internal {@link Msg} objects,
@@ -176,8 +176,8 @@ public class ChatMessageConverter {
         }
 
         try {
-            return objectMapper.readValue(arguments, new TypeReference<Map<String, Object>>() {});
-        } catch (JsonProcessingException e) {
+            return jsonMapper.readValue(arguments, new TypeReference<Map<String, Object>>() {});
+        } catch (JacksonException e) {
             log.warn("Failed to parse tool arguments: {}", e.getMessage());
             return Map.of();
         }

--- a/agentscope-extensions/agentscope-extensions-chat-completions-web/src/main/java/io/agentscope/core/chat/completions/streaming/ChatCompletionsStreamingAdapter.java
+++ b/agentscope-extensions/agentscope-extensions-chat-completions-web/src/main/java/io/agentscope/core/chat/completions/streaming/ChatCompletionsStreamingAdapter.java
@@ -15,8 +15,6 @@
  */
 package io.agentscope.core.chat.completions.streaming;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.agentscope.core.ReActAgent;
 import io.agentscope.core.agent.Event;
 import io.agentscope.core.agent.EventType;
@@ -34,6 +32,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
 import reactor.core.publisher.Flux;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.json.JsonMapper;
 
 /**
  * Framework-agnostic adapter for handling streaming chat completion responses.
@@ -67,7 +67,7 @@ import reactor.core.publisher.Flux;
  */
 public class ChatCompletionsStreamingAdapter {
 
-    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    private static final JsonMapper JSON_MAPPER = JsonMapper.shared();
 
     /** Constructs a new {@code ChatCompletionsStreamingAdapter}. */
     public ChatCompletionsStreamingAdapter() {}
@@ -325,8 +325,8 @@ public class ChatCompletionsStreamingAdapter {
             return "{}";
         }
         try {
-            return OBJECT_MAPPER.writeValueAsString(map);
-        } catch (JsonProcessingException e) {
+            return JSON_MAPPER.writeValueAsString(map);
+        } catch (JacksonException e) {
             return "{}";
         }
     }

--- a/agentscope-extensions/agentscope-extensions-higress/src/test/java/io/agentscope/extensions/higress/HigressMcpClientWrapperTest.java
+++ b/agentscope-extensions/agentscope-extensions-higress/src/test/java/io/agentscope/extensions/higress/HigressMcpClientWrapperTest.java
@@ -152,7 +152,10 @@ class HigressMcpClientWrapperTest {
 
         Map<String, Object> structuredContent = Map.of("tools", List.of(tool));
         McpSchema.CallToolResult callToolResult =
-                new McpSchema.CallToolResult(Collections.emptyList(), false, structuredContent);
+                McpSchema.CallToolResult.builder()
+                        .isError(false)
+                        .structuredContent(structuredContent)
+                        .build();
 
         when(mockDelegateClient.callTool(eq("x_higress_tool_search"), any()))
                 .thenReturn(Mono.just(callToolResult));
@@ -171,7 +174,7 @@ class HigressMcpClientWrapperTest {
     @Test
     void testListTools_WithToolSearch_Error() {
         McpSchema.CallToolResult errorResult =
-                new McpSchema.CallToolResult(Collections.emptyList(), true, null);
+                McpSchema.CallToolResult.builder().isError(true).build();
 
         when(mockDelegateClient.callTool(eq("x_higress_tool_search"), any()))
                 .thenReturn(Mono.just(errorResult));
@@ -184,9 +187,9 @@ class HigressMcpClientWrapperTest {
     @Test
     void testCallTool_Success() {
         Map<String, Object> args = Map.of("param1", "value1");
-        McpSchema.TextContent content = new McpSchema.TextContent(null, null, "result");
+        McpSchema.TextContent content = new McpSchema.TextContent("result");
         McpSchema.CallToolResult expectedResult =
-                new McpSchema.CallToolResult(List.of(content), false, null);
+                McpSchema.CallToolResult.builder().isError(false).build();
 
         when(mockDelegateClient.callTool(eq("my_tool"), eq(args)))
                 .thenReturn(Mono.just(expectedResult));
@@ -203,7 +206,7 @@ class HigressMcpClientWrapperTest {
     void testCallTool_Error() {
         Map<String, Object> args = Map.of("param1", "value1");
         McpSchema.CallToolResult errorResult =
-                new McpSchema.CallToolResult(Collections.emptyList(), true, null);
+                McpSchema.CallToolResult.builder().isError(true).build();
 
         when(mockDelegateClient.callTool(eq("my_tool"), eq(args)))
                 .thenReturn(Mono.just(errorResult));
@@ -232,7 +235,10 @@ class HigressMcpClientWrapperTest {
         Map<String, Object> tool = Map.of("name", "tool1", "description", "Desc", "title", "Title");
         Map<String, Object> structuredContent = Map.of("tools", List.of(tool));
         McpSchema.CallToolResult callToolResult =
-                new McpSchema.CallToolResult(Collections.emptyList(), false, structuredContent);
+                McpSchema.CallToolResult.builder()
+                        .isError(false)
+                        .structuredContent(structuredContent)
+                        .build();
 
         when(mockDelegateClient.callTool(eq("x_higress_tool_search"), any()))
                 .thenReturn(Mono.just(callToolResult));
@@ -250,7 +256,10 @@ class HigressMcpClientWrapperTest {
         Map<String, Object> tool = Map.of("name", "tool1", "description", "Desc", "title", "Title");
         Map<String, Object> structuredContent = Map.of("tools", List.of(tool));
         McpSchema.CallToolResult callToolResult =
-                new McpSchema.CallToolResult(Collections.emptyList(), false, structuredContent);
+                McpSchema.CallToolResult.builder()
+                        .isError(false)
+                        .structuredContent(structuredContent)
+                        .build();
 
         when(mockDelegateClient.callTool(eq("x_higress_tool_search"), any()))
                 .thenAnswer(
@@ -308,7 +317,10 @@ class HigressMcpClientWrapperTest {
                         "inputSchema", Map.of("type", "object"));
         Map<String, Object> structuredContent = Map.of("tools", List.of(tool));
         McpSchema.CallToolResult callToolResult =
-                new McpSchema.CallToolResult(Collections.emptyList(), false, structuredContent);
+                McpSchema.CallToolResult.builder()
+                        .isError(false)
+                        .structuredContent(structuredContent)
+                        .build();
 
         when(mockDelegateClient.callTool(eq("x_higress_tool_search"), any()))
                 .thenReturn(Mono.just(callToolResult));
@@ -357,7 +369,10 @@ class HigressMcpClientWrapperTest {
 
         Map<String, Object> structuredContent = Map.of("tools", List.of(tool));
         McpSchema.CallToolResult callToolResult =
-                new McpSchema.CallToolResult(Collections.emptyList(), false, structuredContent);
+                McpSchema.CallToolResult.builder()
+                        .isError(false)
+                        .structuredContent(structuredContent)
+                        .build();
 
         when(mockDelegateClient.callTool(eq("x_higress_tool_search"), any()))
                 .thenReturn(Mono.just(callToolResult));
@@ -387,7 +402,10 @@ class HigressMcpClientWrapperTest {
 
         Map<String, Object> structuredContent = Map.of("tools", List.of(tool));
         McpSchema.CallToolResult callToolResult =
-                new McpSchema.CallToolResult(Collections.emptyList(), false, structuredContent);
+                McpSchema.CallToolResult.builder()
+                        .isError(false)
+                        .structuredContent(structuredContent)
+                        .build();
 
         when(mockDelegateClient.callTool(eq("x_higress_tool_search"), any()))
                 .thenReturn(Mono.just(callToolResult));
@@ -416,7 +434,10 @@ class HigressMcpClientWrapperTest {
 
         Map<String, Object> structuredContent = Map.of("tools", List.of(tool));
         McpSchema.CallToolResult callToolResult =
-                new McpSchema.CallToolResult(Collections.emptyList(), false, structuredContent);
+                McpSchema.CallToolResult.builder()
+                        .isError(false)
+                        .structuredContent(structuredContent)
+                        .build();
 
         when(mockDelegateClient.callTool(eq("x_higress_tool_search"), any()))
                 .thenReturn(Mono.just(callToolResult));

--- a/agentscope-extensions/agentscope-extensions-higress/src/test/java/io/agentscope/extensions/higress/HigressToolSearchResultTest.java
+++ b/agentscope-extensions/agentscope-extensions-higress/src/test/java/io/agentscope/extensions/higress/HigressToolSearchResultTest.java
@@ -43,7 +43,7 @@ class HigressToolSearchResultTest {
     @Test
     void testParse_ErrorResult() {
         McpSchema.CallToolResult callToolResult =
-                new McpSchema.CallToolResult(Collections.emptyList(), true, null);
+                McpSchema.CallToolResult.builder().isError(true).build();
 
         HigressToolSearchResult result = HigressToolSearchResult.parse(callToolResult);
 
@@ -55,7 +55,7 @@ class HigressToolSearchResultTest {
     @Test
     void testParse_EmptyContent() {
         McpSchema.CallToolResult callToolResult =
-                new McpSchema.CallToolResult(Collections.emptyList(), false, null);
+                McpSchema.CallToolResult.builder().isError(false).build();
 
         HigressToolSearchResult result = HigressToolSearchResult.parse(callToolResult);
 
@@ -81,7 +81,10 @@ class HigressToolSearchResultTest {
         structuredContent.put("tools", List.of(tool1));
 
         McpSchema.CallToolResult callToolResult =
-                new McpSchema.CallToolResult(Collections.emptyList(), false, structuredContent);
+                McpSchema.CallToolResult.builder()
+                        .isError(false)
+                        .structuredContent(structuredContent)
+                        .build();
 
         HigressToolSearchResult result = HigressToolSearchResult.parse(callToolResult);
 
@@ -112,7 +115,10 @@ class HigressToolSearchResultTest {
         structuredContent.put("tools", List.of(tool1, tool2));
 
         McpSchema.CallToolResult callToolResult =
-                new McpSchema.CallToolResult(Collections.emptyList(), false, structuredContent);
+                McpSchema.CallToolResult.builder()
+                        .isError(false)
+                        .structuredContent(structuredContent)
+                        .build();
 
         HigressToolSearchResult result = HigressToolSearchResult.parse(callToolResult);
 
@@ -130,7 +136,10 @@ class HigressToolSearchResultTest {
 
         McpSchema.TextContent textContent = new McpSchema.TextContent(jsonText);
         McpSchema.CallToolResult callToolResult =
-                new McpSchema.CallToolResult(List.of(textContent), false, null);
+                McpSchema.CallToolResult.builder()
+                        .content(List.of(textContent))
+                        .isError(false)
+                        .build();
 
         HigressToolSearchResult result = HigressToolSearchResult.parse(callToolResult);
 
@@ -143,7 +152,10 @@ class HigressToolSearchResultTest {
     void testParse_FromTextContent_InvalidJson() {
         McpSchema.TextContent textContent = new McpSchema.TextContent("invalid json");
         McpSchema.CallToolResult callToolResult =
-                new McpSchema.CallToolResult(List.of(textContent), false, null);
+                McpSchema.CallToolResult.builder()
+                        .content(List.of(textContent))
+                        .isError(false)
+                        .build();
 
         HigressToolSearchResult result = HigressToolSearchResult.parse(callToolResult);
 
@@ -155,7 +167,10 @@ class HigressToolSearchResultTest {
     void testParse_FromTextContent_EmptyText() {
         McpSchema.TextContent textContent = new McpSchema.TextContent("");
         McpSchema.CallToolResult callToolResult =
-                new McpSchema.CallToolResult(List.of(textContent), false, null);
+                McpSchema.CallToolResult.builder()
+                        .content(List.of(textContent))
+                        .isError(false)
+                        .build();
 
         HigressToolSearchResult result = HigressToolSearchResult.parse(callToolResult);
 
@@ -166,7 +181,10 @@ class HigressToolSearchResultTest {
     void testParse_FromTextContent_NullText() {
         McpSchema.TextContent textContent = new McpSchema.TextContent((String) null);
         McpSchema.CallToolResult callToolResult =
-                new McpSchema.CallToolResult(List.of(textContent), false, null);
+                McpSchema.CallToolResult.builder()
+                        .content(List.of(textContent))
+                        .isError(false)
+                        .build();
 
         HigressToolSearchResult result = HigressToolSearchResult.parse(callToolResult);
 
@@ -191,7 +209,11 @@ class HigressToolSearchResultTest {
         McpSchema.TextContent textContent = new McpSchema.TextContent(jsonText);
 
         McpSchema.CallToolResult callToolResult =
-                new McpSchema.CallToolResult(List.of(textContent), false, structuredContent);
+                McpSchema.CallToolResult.builder()
+                        .content(List.of(textContent))
+                        .structuredContent(structuredContent)
+                        .isError(false)
+                        .build();
 
         HigressToolSearchResult result = HigressToolSearchResult.parse(callToolResult);
 
@@ -212,7 +234,11 @@ class HigressToolSearchResultTest {
         McpSchema.TextContent textContent = new McpSchema.TextContent(jsonText);
 
         McpSchema.CallToolResult callToolResult =
-                new McpSchema.CallToolResult(List.of(textContent), false, structuredContent);
+                McpSchema.CallToolResult.builder()
+                        .content(List.of(textContent))
+                        .structuredContent(structuredContent)
+                        .isError(false)
+                        .build();
 
         HigressToolSearchResult result = HigressToolSearchResult.parse(callToolResult);
 
@@ -239,7 +265,10 @@ class HigressToolSearchResultTest {
         structuredContent.put("tools", toolsList);
 
         McpSchema.CallToolResult callToolResult =
-                new McpSchema.CallToolResult(Collections.emptyList(), false, structuredContent);
+                McpSchema.CallToolResult.builder()
+                        .isError(false)
+                        .structuredContent(structuredContent)
+                        .build();
 
         HigressToolSearchResult result = HigressToolSearchResult.parse(callToolResult);
 
@@ -258,7 +287,10 @@ class HigressToolSearchResultTest {
         structuredContent.put("tools", List.of(tool1, tool2, tool3));
 
         McpSchema.CallToolResult callToolResult =
-                new McpSchema.CallToolResult(Collections.emptyList(), false, structuredContent);
+                McpSchema.CallToolResult.builder()
+                        .isError(false)
+                        .structuredContent(structuredContent)
+                        .build();
 
         HigressToolSearchResult result = HigressToolSearchResult.parse(callToolResult);
 
@@ -273,7 +305,10 @@ class HigressToolSearchResultTest {
         structuredContent.put("tools", List.of(tool));
 
         McpSchema.CallToolResult callToolResult =
-                new McpSchema.CallToolResult(Collections.emptyList(), false, structuredContent);
+                McpSchema.CallToolResult.builder()
+                        .isError(false)
+                        .structuredContent(structuredContent)
+                        .build();
 
         HigressToolSearchResult result = HigressToolSearchResult.parse(callToolResult);
 
@@ -312,7 +347,10 @@ class HigressToolSearchResultTest {
         Map<String, Object> structuredContent = Map.of("tools", List.of(tool));
 
         McpSchema.CallToolResult callToolResult =
-                new McpSchema.CallToolResult(Collections.emptyList(), false, structuredContent);
+                McpSchema.CallToolResult.builder()
+                        .isError(false)
+                        .structuredContent(structuredContent)
+                        .build();
 
         HigressToolSearchResult result = HigressToolSearchResult.parse(callToolResult);
         HigressToolSearchResult.ToolInfo toolInfo = result.getTools().get(0);
@@ -337,7 +375,10 @@ class HigressToolSearchResultTest {
         Map<String, Object> structuredContent = Map.of("tools", List.of(tool));
 
         McpSchema.CallToolResult callToolResult =
-                new McpSchema.CallToolResult(Collections.emptyList(), false, structuredContent);
+                McpSchema.CallToolResult.builder()
+                        .isError(false)
+                        .structuredContent(structuredContent)
+                        .build();
 
         HigressToolSearchResult result = HigressToolSearchResult.parse(callToolResult);
         HigressToolSearchResult.ToolInfo toolInfo = result.getTools().get(0);
@@ -352,7 +393,10 @@ class HigressToolSearchResultTest {
         Map<String, Object> structuredContent = Map.of("tools", Collections.emptyList());
 
         McpSchema.CallToolResult callToolResult =
-                new McpSchema.CallToolResult(Collections.emptyList(), false, structuredContent);
+                McpSchema.CallToolResult.builder()
+                        .isError(false)
+                        .structuredContent(structuredContent)
+                        .build();
 
         HigressToolSearchResult result = HigressToolSearchResult.parse(callToolResult);
 

--- a/agentscope-extensions/agentscope-extensions-mem0/src/main/java/io/agentscope/core/memory/mem0/Mem0Client.java
+++ b/agentscope-extensions/agentscope-extensions-mem0/src/main/java/io/agentscope/core/memory/mem0/Mem0Client.java
@@ -15,7 +15,6 @@
  */
 package io.agentscope.core.memory.mem0;
 
-import com.fasterxml.jackson.core.type.TypeReference;
 import io.agentscope.core.util.JsonCodec;
 import io.agentscope.core.util.JsonUtils;
 import java.io.IOException;
@@ -28,6 +27,7 @@ import okhttp3.RequestBody;
 import okhttp3.Response;
 import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Schedulers;
+import tools.jackson.core.type.TypeReference;
 
 /**
  * HTTP client for interacting with the Mem0 API.

--- a/agentscope-extensions/agentscope-extensions-rag-dify/pom.xml
+++ b/agentscope-extensions/agentscope-extensions-rag-dify/pom.xml
@@ -52,7 +52,7 @@
 
         <!-- JSON Processing: Jackson (from parent) -->
         <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
+            <groupId>tools.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
         </dependency>
 

--- a/agentscope-extensions/agentscope-extensions-rag-dify/src/test/java/io/agentscope/core/rag/integration/dify/DifyRAGClientTest.java
+++ b/agentscope-extensions/agentscope-extensions-rag-dify/src/test/java/io/agentscope/core/rag/integration/dify/DifyRAGClientTest.java
@@ -20,7 +20,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import com.fasterxml.jackson.core.type.TypeReference;
 import io.agentscope.core.rag.integration.dify.exception.DifyApiException;
 import io.agentscope.core.rag.integration.dify.exception.DifyAuthException;
 import io.agentscope.core.rag.integration.dify.model.DifyResponse;
@@ -34,6 +33,7 @@ import okhttp3.mockwebserver.RecordedRequest;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import tools.jackson.core.type.TypeReference;
 
 /**
  * Unit tests for DifyRAGClient.

--- a/agentscope-extensions/agentscope-extensions-rag-haystack/pom.xml
+++ b/agentscope-extensions/agentscope-extensions-rag-haystack/pom.xml
@@ -51,7 +51,7 @@
 
         <!-- JSON Processing: Jackson (from parent) -->
         <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
+            <groupId>tools.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
         </dependency>
 

--- a/agentscope-extensions/agentscope-extensions-rag-haystack/src/test/java/io/agentscope/core/rag/integration/haystack/HayStackClientRequestTest.java
+++ b/agentscope-extensions/agentscope-extensions-rag-haystack/src/test/java/io/agentscope/core/rag/integration/haystack/HayStackClientRequestTest.java
@@ -19,7 +19,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import com.fasterxml.jackson.core.type.TypeReference;
 import io.agentscope.core.rag.integration.haystack.model.HayStackResponse;
 import io.agentscope.core.util.JsonUtils;
 import java.io.IOException;
@@ -31,6 +30,7 @@ import okhttp3.mockwebserver.RecordedRequest;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import tools.jackson.core.type.TypeReference;
 
 /**
  * Unit test for HayStackClient request generation.

--- a/agentscope-extensions/agentscope-extensions-rag-haystack/src/test/java/io/agentscope/core/rag/integration/haystack/HayStackClientTest.java
+++ b/agentscope-extensions/agentscope-extensions-rag-haystack/src/test/java/io/agentscope/core/rag/integration/haystack/HayStackClientTest.java
@@ -20,7 +20,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import com.fasterxml.jackson.core.type.TypeReference;
 import io.agentscope.core.rag.integration.haystack.exception.HayStackApiException;
 import io.agentscope.core.rag.integration.haystack.model.HayStackResponse;
 import io.agentscope.core.util.JsonUtils;
@@ -32,6 +31,7 @@ import okhttp3.mockwebserver.RecordedRequest;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import tools.jackson.core.type.TypeReference;
 
 /**
  * Unit tests for HayStackClient.

--- a/agentscope-extensions/agentscope-extensions-rag-ragflow/pom.xml
+++ b/agentscope-extensions/agentscope-extensions-rag-ragflow/pom.xml
@@ -51,7 +51,7 @@
 
         <!-- JSON Processing: Jackson (from parent) -->
         <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
+            <groupId>tools.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
         </dependency>
 

--- a/agentscope-extensions/agentscope-extensions-rag-ragflow/src/main/java/io/agentscope/core/rag/integration/ragflow/model/RAGFlowResponse.java
+++ b/agentscope-extensions/agentscope-extensions-rag-ragflow/src/main/java/io/agentscope/core/rag/integration/ragflow/model/RAGFlowResponse.java
@@ -17,8 +17,8 @@ package io.agentscope.core.rag.integration.ragflow.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import java.util.List;
+import tools.jackson.databind.annotation.JsonDeserialize;
 
 /**
  * RAGFlow API response model.

--- a/agentscope-extensions/agentscope-extensions-rag-ragflow/src/main/java/io/agentscope/core/rag/integration/ragflow/model/ResponseDataDeserializer.java
+++ b/agentscope-extensions/agentscope-extensions-rag-ragflow/src/main/java/io/agentscope/core/rag/integration/ragflow/model/ResponseDataDeserializer.java
@@ -15,13 +15,13 @@
  */
 package io.agentscope.core.rag.integration.ragflow.model;
 
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.JsonDeserializer;
-import com.fasterxml.jackson.databind.JsonNode;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import tools.jackson.core.JacksonException;
+import tools.jackson.core.JsonParser;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ValueDeserializer;
 
 /**
  * Custom deserializer for RAGFlow ResponseData.
@@ -43,13 +43,13 @@ import java.util.List;
  *
  * @author RAGFlow Integration Team
  */
-public class ResponseDataDeserializer extends JsonDeserializer<RAGFlowResponse.ResponseData> {
+public class ResponseDataDeserializer extends ValueDeserializer<RAGFlowResponse.ResponseData> {
 
     @Override
     public RAGFlowResponse.ResponseData deserialize(JsonParser p, DeserializationContext ctxt)
-            throws IOException {
+            throws JacksonException {
 
-        JsonNode node = p.getCodec().readTree(p);
+        JsonNode node = p.readValueAsTree();
 
         // Handle cases where data is false, null, or not an object
         if (node == null || node.isNull() || !node.isObject()) {
@@ -63,7 +63,7 @@ public class ResponseDataDeserializer extends JsonDeserializer<RAGFlowResponse.R
         if (node.has("chunks") && node.get("chunks").isArray()) {
             List<RAGFlowChunk> chunks = new ArrayList<>();
             for (JsonNode chunkNode : node.get("chunks")) {
-                RAGFlowChunk chunk = p.getCodec().treeToValue(chunkNode, RAGFlowChunk.class);
+                RAGFlowChunk chunk = ctxt.readTreeAsValue(chunkNode, RAGFlowChunk.class);
                 if (chunk != null) {
                     chunks.add(chunk);
                 }
@@ -81,7 +81,7 @@ public class ResponseDataDeserializer extends JsonDeserializer<RAGFlowResponse.R
             List<RAGFlowResponse.DocAgg> docAggs = new ArrayList<>();
             for (JsonNode aggNode : node.get("doc_aggs")) {
                 RAGFlowResponse.DocAgg docAgg =
-                        p.getCodec().treeToValue(aggNode, RAGFlowResponse.DocAgg.class);
+                        ctxt.readTreeAsValue(aggNode, RAGFlowResponse.DocAgg.class);
                 if (docAgg != null) {
                     docAggs.add(docAgg);
                 }

--- a/agentscope-extensions/agentscope-extensions-rag-ragflow/src/test/java/io/agentscope/core/rag/integration/ragflow/RAGFlowClientRequestTest.java
+++ b/agentscope-extensions/agentscope-extensions-rag-ragflow/src/test/java/io/agentscope/core/rag/integration/ragflow/RAGFlowClientRequestTest.java
@@ -19,7 +19,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import com.fasterxml.jackson.core.type.TypeReference;
 import io.agentscope.core.util.JsonUtils;
 import java.io.IOException;
 import java.time.Duration;
@@ -31,6 +30,7 @@ import okhttp3.mockwebserver.RecordedRequest;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import tools.jackson.core.type.TypeReference;
 
 /**
  * Unit test for RAGFlowClient request generation.

--- a/agentscope-extensions/agentscope-extensions-rag-ragflow/src/test/java/io/agentscope/core/rag/integration/ragflow/RAGFlowClientTest.java
+++ b/agentscope-extensions/agentscope-extensions-rag-ragflow/src/test/java/io/agentscope/core/rag/integration/ragflow/RAGFlowClientTest.java
@@ -20,7 +20,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import com.fasterxml.jackson.core.type.TypeReference;
 import io.agentscope.core.rag.integration.ragflow.exception.RAGFlowApiException;
 import io.agentscope.core.rag.integration.ragflow.exception.RAGFlowAuthException;
 import io.agentscope.core.rag.integration.ragflow.model.RAGFlowResponse;
@@ -34,6 +33,7 @@ import okhttp3.mockwebserver.RecordedRequest;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import tools.jackson.core.type.TypeReference;
 
 /**
  * Unit tests for RAGFlowClient.

--- a/agentscope-extensions/agentscope-extensions-rag-simple/src/main/java/io/agentscope/core/rag/store/ElasticsearchStore.java
+++ b/agentscope-extensions/agentscope-extensions-rag-simple/src/main/java/io/agentscope/core/rag/store/ElasticsearchStore.java
@@ -30,12 +30,10 @@ import co.elastic.clients.elasticsearch.core.bulk.BulkResponseItem;
 import co.elastic.clients.elasticsearch.core.search.Hit;
 import co.elastic.clients.elasticsearch.indices.CreateIndexRequest;
 import co.elastic.clients.elasticsearch.indices.ExistsRequest;
-import co.elastic.clients.json.jackson.JacksonJsonpMapper;
+import co.elastic.clients.json.jackson.Jackson3JsonpMapper;
 import co.elastic.clients.transport.ElasticsearchTransport;
 import co.elastic.clients.transport.rest5_client.Rest5ClientTransport;
 import co.elastic.clients.transport.rest5_client.low_level.Rest5Client;
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.agentscope.core.message.ContentBlock;
 import io.agentscope.core.message.TextBlock;
 import io.agentscope.core.rag.exception.VectorStoreException;
@@ -59,6 +57,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Schedulers;
+import tools.jackson.core.type.TypeReference;
+import tools.jackson.databind.json.JsonMapper;
 
 /**
  * Elasticsearch vector database store implementation.
@@ -87,7 +87,7 @@ import reactor.core.scheduler.Schedulers;
  */
 public class ElasticsearchStore implements VDBStoreBase, AutoCloseable {
     private static final Logger log = LoggerFactory.getLogger(ElasticsearchStore.class);
-    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    private static final JsonMapper JSON_MAPPER = JsonMapper.shared();
 
     // Field names for Elasticsearch mapping
     private static final String FIELD_ID = "id";
@@ -156,7 +156,7 @@ public class ElasticsearchStore implements VDBStoreBase, AutoCloseable {
 
             // 2. Create Transport and Client
             this.transport =
-                    new Rest5ClientTransport(restClient, new JacksonJsonpMapper(OBJECT_MAPPER));
+                    new Rest5ClientTransport(restClient, new Jackson3JsonpMapper(JSON_MAPPER));
             this.client = new ElasticsearchClient(transport);
 
             // 3. Ensure Index Exists
@@ -411,7 +411,7 @@ public class ElasticsearchStore implements VDBStoreBase, AutoCloseable {
 
         // Serialize ContentBlock to JSON string to ensure safe storage/retrieval
         try {
-            String contentJson = OBJECT_MAPPER.writeValueAsString(meta.getContent());
+            String contentJson = JSON_MAPPER.writeValueAsString(meta.getContent());
             map.put(FIELD_CONTENT, contentJson);
         } catch (Exception e) {
             log.warn("Failed to serialize content, using text representation", e);
@@ -440,7 +440,7 @@ public class ElasticsearchStore implements VDBStoreBase, AutoCloseable {
             // Reconstruct ContentBlock
             ContentBlock content;
             try {
-                content = OBJECT_MAPPER.readValue(contentJson, ContentBlock.class);
+                content = JSON_MAPPER.readValue(contentJson, ContentBlock.class);
             } catch (Exception e) {
                 log.debug("Failed to deserialize ContentBlock, creating TextBlock", e);
                 content = TextBlock.builder().text(contentJson).build();

--- a/agentscope-extensions/agentscope-extensions-skill-mysql-repository/src/main/java/io/agentscope/core/skill/repository/mysql/MysqlSkillRepository.java
+++ b/agentscope-extensions/agentscope-extensions-skill-mysql-repository/src/main/java/io/agentscope/core/skill/repository/mysql/MysqlSkillRepository.java
@@ -15,7 +15,6 @@
  */
 package io.agentscope.core.skill.repository.mysql;
 
-import com.fasterxml.jackson.core.type.TypeReference;
 import io.agentscope.core.skill.AgentSkill;
 import io.agentscope.core.skill.repository.AgentSkillRepository;
 import io.agentscope.core.skill.repository.AgentSkillRepositoryInfo;
@@ -34,6 +33,7 @@ import java.util.regex.Pattern;
 import javax.sql.DataSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import tools.jackson.core.type.TypeReference;
 
 /**
  * MySQL database-based implementation of AgentSkillRepository.

--- a/agentscope-extensions/agentscope-extensions-training/pom.xml
+++ b/agentscope-extensions/agentscope-extensions-training/pom.xml
@@ -39,7 +39,7 @@
 
         <!-- JSON Processing -->
         <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
+            <groupId>tools.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
         </dependency>
 

--- a/agentscope-extensions/agentscope-extensions-training/src/test/java/io/agentscope/core/training/backend/dto/CommitRequestTest.java
+++ b/agentscope-extensions/agentscope-extensions-training/src/test/java/io/agentscope/core/training/backend/dto/CommitRequestTest.java
@@ -20,16 +20,15 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.agentscope.core.training.util.TrainingTestConstants;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import tools.jackson.databind.json.JsonMapper;
 
 @DisplayName("CommitRequest Unit Tests")
 class CommitRequestTest {
 
-    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final JsonMapper jsonMapper = JsonMapper.shared();
 
     @Test
     @DisplayName("Should build commit request with all fields")
@@ -50,13 +49,13 @@ class CommitRequestTest {
 
     @Test
     @DisplayName("Should serialize to JSON with snake_case field names")
-    void shouldSerializeToJsonWithSnakeCaseFieldNames() throws JsonProcessingException {
+    void shouldSerializeToJsonWithSnakeCaseFieldNames() {
         // Arrange
         CommitRequest request =
                 CommitRequest.builder().taskId("task-123").runId("0").timeThreshold(60000L).build();
 
         // Act
-        String json = objectMapper.writeValueAsString(request);
+        String json = jsonMapper.writeValueAsString(request);
 
         // Assert
         assertTrue(json.contains("\"task_id\":\"task-123\""));

--- a/agentscope-extensions/agentscope-extensions-training/src/test/java/io/agentscope/core/training/backend/dto/FeedbackRequestTest.java
+++ b/agentscope-extensions/agentscope-extensions-training/src/test/java/io/agentscope/core/training/backend/dto/FeedbackRequestTest.java
@@ -20,18 +20,17 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.agentscope.core.training.util.TrainingTestConstants;
 import java.util.Arrays;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import tools.jackson.databind.json.JsonMapper;
 
 @DisplayName("FeedbackRequest Unit Tests")
 class FeedbackRequestTest {
 
-    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final JsonMapper jsonMapper = JsonMapper.shared();
 
     @Test
     @DisplayName("Should build feedback request with all fields")
@@ -59,7 +58,7 @@ class FeedbackRequestTest {
 
     @Test
     @DisplayName("Should serialize to JSON with snake_case field names")
-    void shouldSerializeToJsonWithSnakeCaseFieldNames() throws JsonProcessingException {
+    void shouldSerializeToJsonWithSnakeCaseFieldNames() {
         // Arrange
         FeedbackRequest request =
                 FeedbackRequest.builder()
@@ -70,7 +69,7 @@ class FeedbackRequestTest {
                         .build();
 
         // Act
-        String json = objectMapper.writeValueAsString(request);
+        String json = jsonMapper.writeValueAsString(request);
 
         // Assert
         assertTrue(json.contains("\"task_id\":\"task-123\""));

--- a/agentscope-extensions/agentscope-extensions-training/src/test/java/io/agentscope/core/training/backend/dto/StatusResponseTest.java
+++ b/agentscope-extensions/agentscope-extensions-training/src/test/java/io/agentscope/core/training/backend/dto/StatusResponseTest.java
@@ -21,24 +21,23 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import tools.jackson.databind.json.JsonMapper;
 
 @DisplayName("StatusResponse Unit Tests")
 class StatusResponseTest {
 
-    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final JsonMapper jsonMapper = JsonMapper.shared();
 
     @Test
     @DisplayName("Should deserialize from JSON")
-    void shouldDeserializeFromJson() throws JsonProcessingException {
+    void shouldDeserializeFromJson() {
         // Arrange
         String json = "{\"status\": \"success\", \"message\": \"OK\"}";
 
         // Act
-        StatusResponse response = objectMapper.readValue(json, StatusResponse.class);
+        StatusResponse response = jsonMapper.readValue(json, StatusResponse.class);
 
         // Assert
         assertNotNull(response);
@@ -49,12 +48,12 @@ class StatusResponseTest {
 
     @Test
     @DisplayName("Should deserialize error response")
-    void shouldDeserializeErrorResponse() throws JsonProcessingException {
+    void shouldDeserializeErrorResponse() {
         // Arrange
         String json = "{\"status\": \"error\", \"message\": \"Internal Server Error\"}";
 
         // Act
-        StatusResponse response = objectMapper.readValue(json, StatusResponse.class);
+        StatusResponse response = jsonMapper.readValue(json, StatusResponse.class);
 
         // Assert
         assertNotNull(response);

--- a/agentscope-extensions/agentscope-spring-boot-starters/agentscope-chat-completions-web-starter/src/main/java/io/agentscope/spring/boot/chat/service/ChatCompletionsStreamingService.java
+++ b/agentscope-extensions/agentscope-spring-boot-starters/agentscope-chat-completions-web-starter/src/main/java/io/agentscope/spring/boot/chat/service/ChatCompletionsStreamingService.java
@@ -15,8 +15,6 @@
  */
 package io.agentscope.spring.boot.chat.service;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.agentscope.core.ReActAgent;
 import io.agentscope.core.chat.completions.model.ChatCompletionsChunk;
 import io.agentscope.core.chat.completions.streaming.ChatCompletionsStreamingAdapter;
@@ -24,6 +22,8 @@ import io.agentscope.core.message.Msg;
 import java.util.List;
 import org.springframework.http.codec.ServerSentEvent;
 import reactor.core.publisher.Flux;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.json.JsonMapper;
 
 /**
  * Spring-specific service for streaming chat completion responses.
@@ -51,7 +51,7 @@ import reactor.core.publisher.Flux;
  */
 public class ChatCompletionsStreamingService {
 
-    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    private static final JsonMapper JSON_MAPPER = JsonMapper.shared();
 
     private final ChatCompletionsStreamingAdapter streamingAdapter;
 
@@ -91,9 +91,9 @@ public class ChatCompletionsStreamingService {
      */
     private ServerSentEvent<String> chunkToSseEvent(ChatCompletionsChunk chunk) {
         try {
-            String json = OBJECT_MAPPER.writeValueAsString(chunk);
+            String json = JSON_MAPPER.writeValueAsString(chunk);
             return ServerSentEvent.<String>builder().data(json).build();
-        } catch (JsonProcessingException e) {
+        } catch (JacksonException e) {
             return ServerSentEvent.<String>builder()
                     .data("{\"error\":\"Serialization error\"}")
                     .build();

--- a/agentscope-harness/pom.xml
+++ b/agentscope-harness/pom.xml
@@ -38,7 +38,7 @@
 
         <!-- YAML parsing for subagent config -->
         <dependency>
-            <groupId>com.fasterxml.jackson.dataformat</groupId>
+            <groupId>tools.jackson.dataformat</groupId>
             <artifactId>jackson-dataformat-yaml</artifactId>
         </dependency>
 

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/HarnessAgent.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/HarnessAgent.java
@@ -15,7 +15,6 @@
  */
 package io.agentscope.harness.agent;
 
-import com.fasterxml.jackson.databind.JsonNode;
 import io.agentscope.core.ReActAgent;
 import io.agentscope.core.agent.Agent;
 import io.agentscope.core.agent.Event;
@@ -105,6 +104,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
+import tools.jackson.databind.JsonNode;
 
 /**
  * HarnessAgent is the user-facing API that wraps {@link ReActAgent} with enhanced harness practices:

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/sandbox/SandboxState.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/sandbox/SandboxState.java
@@ -18,6 +18,7 @@ package io.agentscope.harness.agent.sandbox;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import io.agentscope.harness.agent.sandbox.snapshot.SandboxSnapshot;
+import tools.jackson.databind.jsontype.NamedType;
 
 /**
  * Serializable state of a sandbox, persisted by {@link SandboxStateStore} so a sandbox can
@@ -28,7 +29,7 @@ import io.agentscope.harness.agent.sandbox.snapshot.SandboxSnapshot;
  *
  * <p>Concrete subtypes are registered for Jackson via {@link
  * io.agentscope.harness.agent.sandbox.json.HarnessSandboxJacksonModule} (and optional {@link
- * com.fasterxml.jackson.databind.ObjectMapper#registerSubtypes} for extension types), not via
+ * tools.jackson.databind.cfg.MapperBuilder#registerSubtypes(NamedType...)} for extension types), not via
  * {@code @JsonSubTypes} on this class.
  */
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "type")

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/sandbox/impl/daytona/DaytonaHarnessSandboxJacksonModule.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/sandbox/impl/daytona/DaytonaHarnessSandboxJacksonModule.java
@@ -15,8 +15,8 @@
  */
 package io.agentscope.harness.agent.sandbox.impl.daytona;
 
-import com.fasterxml.jackson.databind.jsontype.NamedType;
-import com.fasterxml.jackson.databind.module.SimpleModule;
+import tools.jackson.databind.jsontype.NamedType;
+import tools.jackson.databind.module.SimpleModule;
 
 /** Jackson module registering {@link DaytonaSandboxState} under the {@code daytona} type id. */
 public final class DaytonaHarnessSandboxJacksonModule extends SimpleModule {

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/sandbox/impl/daytona/DaytonaHttp.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/sandbox/impl/daytona/DaytonaHttp.java
@@ -15,9 +15,6 @@
  */
 package io.agentscope.harness.agent.sandbox.impl.daytona;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.agentscope.harness.agent.sandbox.SandboxErrorCode;
 import io.agentscope.harness.agent.sandbox.SandboxException;
 import java.io.IOException;
@@ -28,6 +25,9 @@ import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.RequestBody;
 import okhttp3.Response;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.json.JsonMapper;
+import tools.jackson.databind.node.ObjectNode;
 
 /** Minimal HTTP client for the Daytona control plane and toolbox process API. */
 final class DaytonaHttp {
@@ -35,7 +35,7 @@ final class DaytonaHttp {
     private static final MediaType JSON = MediaType.get("application/json; charset=utf-8");
 
     private final OkHttpClient http;
-    private final ObjectMapper json = new ObjectMapper();
+    private final JsonMapper json = JsonMapper.shared();
     private final DaytonaSandboxClientOptions opt;
 
     DaytonaHttp(DaytonaSandboxClientOptions opt) {
@@ -73,15 +73,15 @@ final class DaytonaHttp {
                         opt.getMaxRetries(),
                         () -> postJson(opt.getControlPlaneBaseUrl() + "/sandbox", body));
         JsonNode id = root.get("id");
-        if (id == null || id.asText().isBlank()) {
+        if (id == null || id.asString().isBlank()) {
             id = root.get("sandboxId");
         }
-        if (id == null || id.asText().isBlank()) {
+        if (id == null || id.asString().isBlank()) {
             throw new SandboxException.SandboxRuntimeException(
                     SandboxErrorCode.WORKSPACE_START_ERROR,
                     "Daytona create sandbox response missing id: " + root);
         }
-        return id.asText();
+        return id.asString();
     }
 
     void startSandbox(String sandboxId) throws IOException {
@@ -144,12 +144,12 @@ final class DaytonaHttp {
             return null;
         }
         JsonNode st = s.get("state");
-        if (st != null && st.isTextual()) {
-            return st.asText();
+        if (st != null && st.isString()) {
+            return st.asString();
         }
         JsonNode status = s.get("status");
-        if (status != null && status.isTextual()) {
-            return status.asText();
+        if (status != null && status.isString()) {
+            return status.asString();
         }
         return null;
     }

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/sandbox/impl/daytona/DaytonaSandbox.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/sandbox/impl/daytona/DaytonaSandbox.java
@@ -15,8 +15,6 @@
  */
 package io.agentscope.harness.agent.sandbox.impl.daytona;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.agentscope.core.agent.RuntimeContext;
 import io.agentscope.harness.agent.sandbox.AbstractBaseSandbox;
 import io.agentscope.harness.agent.sandbox.ExecResult;
@@ -28,6 +26,8 @@ import java.io.InputStream;
 import java.util.Base64;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.json.JsonMapper;
 
 /** {@link io.agentscope.harness.agent.sandbox.Sandbox} backed by Daytona cloud sandboxes. */
 public class DaytonaSandbox extends AbstractBaseSandbox {
@@ -116,10 +116,10 @@ public class DaytonaSandbox extends AbstractBaseSandbox {
         byte[] all = archive.readAllBytes();
         String b64 = Base64.getEncoder().encodeToString(all);
         http.execute(daytonaState.getSandboxId(), "rm -f /tmp/agentscope-ws.b64", rel, 30);
-        ObjectMapper om = new ObjectMapper();
+        JsonMapper jm = JsonMapper.shared();
         for (int i = 0; i < b64.length(); i += B64_CHUNK) {
             String chunk = b64.substring(i, Math.min(b64.length(), i + B64_CHUNK));
-            String lit = om.writeValueAsString(chunk);
+            String lit = jm.writeValueAsString(chunk);
             String py =
                     "import pathlib; pathlib.Path('/tmp/agentscope-ws.b64').open('a').write("
                             + lit
@@ -138,7 +138,7 @@ public class DaytonaSandbox extends AbstractBaseSandbox {
         }
         String pyFin =
                 "import base64,pathlib,subprocess; d="
-                        + om.writeValueAsString(root)
+                        + jm.writeValueAsString(root)
                         + "; raw=base64.standard_b64decode(pathlib.Path('/tmp/agentscope-ws.b64').read_text());"
                         + " subprocess.run(['tar','xf','-','-C',d],input=raw,check=True)";
         JsonNode fin =

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/sandbox/impl/daytona/DaytonaSandboxClient.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/sandbox/impl/daytona/DaytonaSandboxClient.java
@@ -15,7 +15,6 @@
  */
 package io.agentscope.harness.agent.sandbox.impl.daytona;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.agentscope.harness.agent.sandbox.Sandbox;
 import io.agentscope.harness.agent.sandbox.SandboxClient;
 import io.agentscope.harness.agent.sandbox.SandboxException;
@@ -26,6 +25,8 @@ import io.agentscope.harness.agent.sandbox.snapshot.SandboxSnapshotSpec;
 import java.util.UUID;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
 
 /** {@link SandboxClient} for Daytona. */
 public class DaytonaSandboxClient implements SandboxClient<DaytonaSandboxClientOptions> {
@@ -46,10 +47,12 @@ public class DaytonaSandboxClient implements SandboxClient<DaytonaSandboxClientO
         this.objectMapper =
                 objectMapper != null
                         ? objectMapper
-                        : new ObjectMapper()
-                                .findAndRegisterModules()
-                                .registerModule(new HarnessSandboxJacksonModule())
-                                .registerModule(new DaytonaHarnessSandboxJacksonModule());
+                        : JsonMapper.builder()
+                                .findAndAddModules()
+                                .addModules(
+                                        new HarnessSandboxJacksonModule(),
+                                        new DaytonaHarnessSandboxJacksonModule())
+                                .build();
     }
 
     @Override

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/sandbox/impl/docker/DockerSandboxClient.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/sandbox/impl/docker/DockerSandboxClient.java
@@ -15,7 +15,6 @@
  */
 package io.agentscope.harness.agent.sandbox.impl.docker;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.agentscope.harness.agent.sandbox.Sandbox;
 import io.agentscope.harness.agent.sandbox.SandboxClient;
 import io.agentscope.harness.agent.sandbox.SandboxException;
@@ -26,6 +25,8 @@ import io.agentscope.harness.agent.sandbox.snapshot.SandboxSnapshotSpec;
 import java.util.UUID;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
 
 /**
  * {@link SandboxClient} implementation for the Docker sandbox backend.
@@ -41,9 +42,10 @@ public class DockerSandboxClient implements SandboxClient<DockerSandboxClientOpt
 
     public DockerSandboxClient() {
         this.objectMapper =
-                new ObjectMapper()
-                        .findAndRegisterModules()
-                        .registerModule(new HarnessSandboxJacksonModule());
+                JsonMapper.builder()
+                        .findAndAddModules()
+                        .addModules(new HarnessSandboxJacksonModule())
+                        .build();
     }
 
     /**

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/sandbox/impl/e2b/E2bHarnessSandboxJacksonModule.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/sandbox/impl/e2b/E2bHarnessSandboxJacksonModule.java
@@ -15,8 +15,8 @@
  */
 package io.agentscope.harness.agent.sandbox.impl.e2b;
 
-import com.fasterxml.jackson.databind.jsontype.NamedType;
-import com.fasterxml.jackson.databind.module.SimpleModule;
+import tools.jackson.databind.jsontype.NamedType;
+import tools.jackson.databind.module.SimpleModule;
 
 /** Jackson module registering {@link E2bSandboxState} under the {@code e2b} type id. */
 public final class E2bHarnessSandboxJacksonModule extends SimpleModule {

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/sandbox/impl/e2b/E2bPlatformHttp.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/sandbox/impl/e2b/E2bPlatformHttp.java
@@ -15,9 +15,6 @@
  */
 package io.agentscope.harness.agent.sandbox.impl.e2b;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.agentscope.harness.agent.sandbox.SandboxErrorCode;
 import io.agentscope.harness.agent.sandbox.SandboxException;
 import java.io.IOException;
@@ -28,6 +25,9 @@ import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.RequestBody;
 import okhttp3.Response;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.json.JsonMapper;
+import tools.jackson.databind.node.ObjectNode;
 
 /** HTTP client for {@code https://api.e2b.app} sandbox lifecycle. */
 final class E2bPlatformHttp {
@@ -35,7 +35,7 @@ final class E2bPlatformHttp {
     private static final MediaType JSON = MediaType.get("application/json; charset=utf-8");
 
     private final OkHttpClient http;
-    private final ObjectMapper json = new ObjectMapper();
+    private final JsonMapper json = JsonMapper.shared();
     private final E2bSandboxClientOptions opt;
 
     E2bPlatformHttp(E2bSandboxClientOptions opt) {

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/sandbox/impl/e2b/E2bSandbox.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/sandbox/impl/e2b/E2bSandbox.java
@@ -15,8 +15,6 @@
  */
 package io.agentscope.harness.agent.sandbox.impl.e2b;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.agentscope.core.agent.RuntimeContext;
 import io.agentscope.harness.agent.sandbox.AbstractBaseSandbox;
 import io.agentscope.harness.agent.sandbox.ExecResult;
@@ -28,6 +26,8 @@ import java.io.InputStream;
 import java.util.Base64;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.json.JsonMapper;
 
 /**
  * {@link io.agentscope.harness.agent.sandbox.Sandbox} backed by E2B cloud sandboxes.
@@ -119,10 +119,10 @@ public class E2bSandbox extends AbstractBaseSandbox {
         String root = e2bState.getWorkspaceRoot();
         String b64 = Base64.getEncoder().encodeToString(all);
         envd().runShell(e2bState, root, "rm -f /tmp/agentscope-ws.b64", 30);
-        ObjectMapper om = new ObjectMapper();
+        JsonMapper jm = JsonMapper.shared();
         for (int i = 0; i < b64.length(); i += B64_CHUNK) {
             String chunk = b64.substring(i, Math.min(b64.length(), i + B64_CHUNK));
-            String lit = om.writeValueAsString(chunk);
+            String lit = jm.writeValueAsString(chunk);
             String py =
                     "import pathlib; pathlib.Path('/tmp/agentscope-ws.b64').open('a').write("
                             + lit
@@ -131,7 +131,7 @@ public class E2bSandbox extends AbstractBaseSandbox {
         }
         String pyFin =
                 "import base64,pathlib,subprocess; d="
-                        + om.writeValueAsString(root)
+                        + jm.writeValueAsString(root)
                         + "; raw=base64.standard_b64decode(pathlib.Path('/tmp/agentscope-ws.b64').read_text());"
                         + " subprocess.run(['tar','xf','-','-C',d],input=raw,check=True)";
         envd().runShell(

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/sandbox/impl/e2b/E2bSandboxClient.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/sandbox/impl/e2b/E2bSandboxClient.java
@@ -15,7 +15,6 @@
  */
 package io.agentscope.harness.agent.sandbox.impl.e2b;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.agentscope.harness.agent.sandbox.Sandbox;
 import io.agentscope.harness.agent.sandbox.SandboxClient;
 import io.agentscope.harness.agent.sandbox.SandboxException;
@@ -26,6 +25,8 @@ import io.agentscope.harness.agent.sandbox.snapshot.SandboxSnapshotSpec;
 import java.util.UUID;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
 
 /** {@link SandboxClient} for E2B. */
 public class E2bSandboxClient implements SandboxClient<E2bSandboxClientOptions> {
@@ -45,10 +46,12 @@ public class E2bSandboxClient implements SandboxClient<E2bSandboxClientOptions> 
         this.objectMapper =
                 objectMapper != null
                         ? objectMapper
-                        : new ObjectMapper()
-                                .findAndRegisterModules()
-                                .registerModule(new HarnessSandboxJacksonModule())
-                                .registerModule(new E2bHarnessSandboxJacksonModule());
+                        : JsonMapper.builder()
+                                .findAndAddModules()
+                                .addModules(
+                                        new HarnessSandboxJacksonModule(),
+                                        new HarnessSandboxJacksonModule())
+                                .build();
     }
 
     @Override

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/sandbox/impl/e2b/E2bSnapshotRefs.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/sandbox/impl/e2b/E2bSnapshotRefs.java
@@ -15,9 +15,9 @@
  */
 package io.agentscope.harness.agent.sandbox.impl.e2b;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
+import tools.jackson.databind.json.JsonMapper;
 
 /**
  * Cross-language marker for E2B native snapshot references, aligned with openai-agents-python
@@ -31,9 +31,9 @@ public final class E2bSnapshotRefs {
     private E2bSnapshotRefs() {}
 
     public static byte[] encodeSnapshotId(String snapshotId) throws Exception {
-        ObjectMapper om = new ObjectMapper();
+        JsonMapper jm = JsonMapper.shared();
         byte[] body =
-                om.writeValueAsBytes(Map.of("snapshot_id", snapshotId == null ? "" : snapshotId));
+                jm.writeValueAsBytes(Map.of("snapshot_id", snapshotId == null ? "" : snapshotId));
         byte[] out = new byte[MAGIC_PREFIX.length + body.length];
         System.arraycopy(MAGIC_PREFIX, 0, out, 0, MAGIC_PREFIX.length);
         System.arraycopy(body, 0, out, MAGIC_PREFIX.length, body.length);
@@ -50,10 +50,10 @@ public final class E2bSnapshotRefs {
             }
         }
         try {
-            ObjectMapper om = new ObjectMapper();
+            JsonMapper jm = JsonMapper.shared();
             @SuppressWarnings("unchecked")
             Map<String, Object> m =
-                    om.readValue(
+                    jm.readValue(
                             new String(
                                     raw,
                                     MAGIC_PREFIX.length,

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/sandbox/impl/kubernetes/KubernetesHarnessSandboxJacksonModule.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/sandbox/impl/kubernetes/KubernetesHarnessSandboxJacksonModule.java
@@ -15,14 +15,14 @@
  */
 package io.agentscope.harness.agent.sandbox.impl.kubernetes;
 
-import com.fasterxml.jackson.databind.jsontype.NamedType;
-import com.fasterxml.jackson.databind.module.SimpleModule;
+import tools.jackson.databind.jsontype.NamedType;
+import tools.jackson.databind.module.SimpleModule;
 
 /**
- * Registers Jackson {@link com.fasterxml.jackson.databind.jsontype.NamedType} entries for the
+ * Registers Jackson {@link tools.jackson.databind.jsontype.NamedType} entries for the
  * Kubernetes sandbox backend. Combine with {@link
  * io.agentscope.harness.agent.sandbox.json.HarnessSandboxJacksonModule} on the same {@link
- * com.fasterxml.jackson.databind.ObjectMapper} when mixing Docker and Kubernetes sandboxes.
+ * tools.jackson.databind.ObjectMapper} when mixing Docker and Kubernetes sandboxes.
  */
 public final class KubernetesHarnessSandboxJacksonModule extends SimpleModule {
 

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/sandbox/impl/kubernetes/KubernetesSandboxClient.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/sandbox/impl/kubernetes/KubernetesSandboxClient.java
@@ -15,7 +15,6 @@
  */
 package io.agentscope.harness.agent.sandbox.impl.kubernetes;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.agentscope.harness.agent.sandbox.Sandbox;
 import io.agentscope.harness.agent.sandbox.SandboxClient;
 import io.agentscope.harness.agent.sandbox.SandboxException;
@@ -28,6 +27,8 @@ import io.fabric8.kubernetes.client.KubernetesClientBuilder;
 import java.util.UUID;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
 
 /** {@link SandboxClient} for Kubernetes Pods. */
 public class KubernetesSandboxClient implements SandboxClient<KubernetesSandboxClientOptions> {
@@ -57,10 +58,12 @@ public class KubernetesSandboxClient implements SandboxClient<KubernetesSandboxC
         this.objectMapper =
                 objectMapper != null
                         ? objectMapper
-                        : new ObjectMapper()
-                                .findAndRegisterModules()
-                                .registerModule(new HarnessSandboxJacksonModule())
-                                .registerModule(new KubernetesHarnessSandboxJacksonModule());
+                        : JsonMapper.builder()
+                                .findAndAddModules()
+                                .addModules(
+                                        new HarnessSandboxJacksonModule(),
+                                        new KubernetesHarnessSandboxJacksonModule())
+                                .build();
     }
 
     @Override

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/sandbox/json/HarnessSandboxJacksonModule.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/sandbox/json/HarnessSandboxJacksonModule.java
@@ -15,14 +15,14 @@
  */
 package io.agentscope.harness.agent.sandbox.json;
 
-import com.fasterxml.jackson.databind.jsontype.NamedType;
-import com.fasterxml.jackson.databind.module.SimpleModule;
 import io.agentscope.harness.agent.sandbox.impl.docker.DockerSandboxState;
+import tools.jackson.databind.jsontype.NamedType;
+import tools.jackson.databind.module.SimpleModule;
 
 /**
  * Registers Jackson polymorphic subtypes for {@link io.agentscope.harness.agent.sandbox.SandboxState}.
  * Official backends add their {@link NamedType} entries here; callers may also use {@link
- * com.fasterxml.jackson.databind.ObjectMapper#registerSubtypes} for application-specific state
+ * tools.jackson.databind.cfg.MapperBuilder#registerSubtypes(NamedType...)} for application-specific state
  * classes without editing {@link io.agentscope.harness.agent.sandbox.SandboxState}.
  */
 public final class HarnessSandboxJacksonModule extends SimpleModule {

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/subagent/AgentSpecLoader.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/subagent/AgentSpecLoader.java
@@ -15,8 +15,6 @@
  */
 package io.agentscope.harness.agent.subagent;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -28,6 +26,7 @@ import java.util.Map;
 import java.util.stream.Stream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import tools.jackson.dataformat.yaml.YAMLMapper;
 
 /**
  * Loads {@link SubagentDeclaration} instances from Markdown files with YAML front matter placed
@@ -69,7 +68,7 @@ import org.slf4j.LoggerFactory;
 public final class AgentSpecLoader {
 
     private static final Logger log = LoggerFactory.getLogger(AgentSpecLoader.class);
-    private static final ObjectMapper YAML_MAPPER = new ObjectMapper(new YAMLFactory());
+    private static final YAMLMapper YAML_MAPPER = YAMLMapper.builder().build();
 
     private AgentSpecLoader() {}
 

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/subagent/task/AgentProtocolTaskClient.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/subagent/task/AgentProtocolTaskClient.java
@@ -15,8 +15,6 @@
  */
 package io.agentscope.harness.agent.subagent.task;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URLEncoder;
@@ -27,6 +25,8 @@ import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.Map;
 import java.util.Objects;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.json.JsonMapper;
 
 /**
  * Minimal HTTP client for the internal AgentScope task protocol ({@code POST/GET /tasks/...}).
@@ -35,7 +35,7 @@ import java.util.Objects;
  */
 public final class AgentProtocolTaskClient {
 
-    private static final ObjectMapper JSON = new ObjectMapper();
+    private static final JsonMapper JSON = JsonMapper.shared();
 
     private final HttpClient http;
 

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/workspace/WorkspaceManager.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/workspace/WorkspaceManager.java
@@ -26,11 +26,6 @@ import static io.agentscope.harness.agent.workspace.WorkspaceConstants.SESSIONS_
 import static io.agentscope.harness.agent.workspace.WorkspaceConstants.SKILLS_DIR;
 import static io.agentscope.harness.agent.workspace.WorkspaceConstants.TASKS_DIR;
 
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
-import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import io.agentscope.core.agent.RuntimeContext;
 import io.agentscope.harness.agent.filesystem.AbstractFilesystem;
 import io.agentscope.harness.agent.filesystem.model.FileInfo;
@@ -58,6 +53,11 @@ import java.util.concurrent.locks.ReentrantLock;
 import java.util.stream.Stream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import tools.jackson.core.JacksonException;
+import tools.jackson.core.type.TypeReference;
+import tools.jackson.databind.cfg.DateTimeFeature;
+import tools.jackson.databind.json.JsonMapper;
+import tools.jackson.databind.node.ObjectNode;
 
 /**
  * Stateless accessor for workspace content using a two-layer read architecture.
@@ -95,11 +95,9 @@ public class WorkspaceManager {
     private static final RuntimeContext DEFAULT_FS_RUNTIME = RuntimeContext.empty();
 
     private static final Logger log = LoggerFactory.getLogger(WorkspaceManager.class);
-    private static final ObjectMapper SESSION_STORE_JSON = new ObjectMapper();
-    private static final ObjectMapper TASK_RECORD_JSON =
-            new ObjectMapper()
-                    .registerModule(new JavaTimeModule())
-                    .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+    private static final JsonMapper SESSION_STORE_JSON = JsonMapper.shared();
+    private static final JsonMapper TASK_RECORD_JSON =
+            JsonMapper.builder().disable(DateTimeFeature.WRITE_DATES_AS_TIMESTAMPS).build();
     private static final TypeReference<Map<String, TaskRecord>> TASK_MAP_TYPE =
             new TypeReference<>() {};
 
@@ -309,7 +307,7 @@ public class WorkspaceManager {
             String serialized =
                     SESSION_STORE_JSON.writerWithDefaultPrettyPrinter().writeValueAsString(root);
             writeUtf8WorkspaceRelative(rel, serialized);
-        } catch (IOException e) {
+        } catch (JacksonException e) {
             log.warn("Failed to write session store {}: {}", rel, e.getMessage());
         }
     }
@@ -557,7 +555,7 @@ public class WorkspaceManager {
             String serialized =
                     TASK_RECORD_JSON.writerWithDefaultPrettyPrinter().writeValueAsString(map);
             writeUtf8WorkspaceRelative(rel, serialized);
-        } catch (IOException e) {
+        } catch (JacksonException e) {
             log.warn("Failed to write task record store {}: {}", rel, e.getMessage());
         }
     }
@@ -571,7 +569,7 @@ public class WorkspaceManager {
             if (node instanceof ObjectNode on) {
                 return on;
             }
-        } catch (IOException e) {
+        } catch (JacksonException e) {
             log.warn("Corrupt or unreadable session store, reinitializing: {}", e.getMessage());
         }
         return SESSION_STORE_JSON.createObjectNode();

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/example/support/InMemorySandboxClient.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/example/support/InMemorySandboxClient.java
@@ -15,7 +15,6 @@
  */
 package io.agentscope.harness.agent.example.support;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.agentscope.harness.agent.sandbox.Sandbox;
 import io.agentscope.harness.agent.sandbox.SandboxClient;
 import io.agentscope.harness.agent.sandbox.SandboxClientOptions;
@@ -28,11 +27,14 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
+import tools.jackson.databind.json.JsonMapper;
 
-/** Test-only {@link SandboxClient} that allocates local temp directories as sandboxes. */
+/**
+ * Test-only {@link SandboxClient} that allocates local temp directories as sandboxes.
+ */
 public class InMemorySandboxClient implements SandboxClient<SandboxClientOptions> {
 
-    private static final ObjectMapper MAPPER = new ObjectMapper();
+    private static final JsonMapper MAPPER = JsonMapper.shared();
     private static final int DEFAULT_TIMEOUT_SECONDS = 30;
 
     private final AtomicInteger createCount = new AtomicInteger(0);
@@ -84,25 +86,16 @@ public class InMemorySandboxClient implements SandboxClient<SandboxClientOptions
 
     @Override
     public String serializeState(SandboxState state) {
-        try {
-            InMemorySandboxState s = (InMemorySandboxState) state;
-            return MAPPER.writeValueAsString(new StateDto(s.getSessionId(), s.getWorkspaceRoot()));
-        } catch (IOException e) {
-            throw new UncheckedIOException("Failed to serialize sandbox state", e);
-        }
+        InMemorySandboxState s = (InMemorySandboxState) state;
+        return MAPPER.writeValueAsString(new StateDto(s.getSessionId(), s.getWorkspaceRoot()));
     }
 
     @Override
     public SandboxState deserializeState(String json) {
-        try {
-            StateDto dto = MAPPER.readValue(json, StateDto.class);
-            InMemorySandboxState state =
-                    new InMemorySandboxState(dto.sessionId(), dto.workspaceRoot());
-            state.setWorkspaceRootReady(true);
-            return state;
-        } catch (IOException e) {
-            throw new UncheckedIOException("Failed to deserialize sandbox state", e);
-        }
+        StateDto dto = MAPPER.readValue(json, StateDto.class);
+        InMemorySandboxState state = new InMemorySandboxState(dto.sessionId(), dto.workspaceRoot());
+        state.setWorkspaceRootReady(true);
+        return state;
     }
 
     public int getCreateCount() {

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/sandbox/impl/kubernetes/KubernetesSandboxStateSerdeTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/sandbox/impl/kubernetes/KubernetesSandboxStateSerdeTest.java
@@ -15,22 +15,23 @@
  */
 package io.agentscope.harness.agent.sandbox.impl.kubernetes;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.agentscope.harness.agent.sandbox.SandboxState;
 import io.agentscope.harness.agent.sandbox.WorkspaceSpec;
 import io.agentscope.harness.agent.sandbox.json.HarnessSandboxJacksonModule;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import tools.jackson.databind.json.JsonMapper;
 
 class KubernetesSandboxStateSerdeTest {
 
     @Test
-    void roundTripKubernetesState() throws Exception {
-        ObjectMapper mapper =
-                new ObjectMapper()
-                        .findAndRegisterModules()
-                        .registerModule(new HarnessSandboxJacksonModule())
-                        .registerModule(new KubernetesHarnessSandboxJacksonModule());
+    void roundTripKubernetesState() {
+        JsonMapper mapper =
+                JsonMapper.builder()
+                        .findAndAddModules()
+                        .addModule(new HarnessSandboxJacksonModule())
+                        .addModule(new KubernetesHarnessSandboxJacksonModule())
+                        .build();
 
         KubernetesSandboxState state = new KubernetesSandboxState();
         state.setSessionId("s1");

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/sandbox/json/HarnessSandboxJacksonModuleTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/sandbox/json/HarnessSandboxJacksonModuleTest.java
@@ -18,19 +18,20 @@ package io.agentscope.harness.agent.sandbox.json;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.agentscope.harness.agent.sandbox.SandboxState;
 import io.agentscope.harness.agent.sandbox.impl.docker.DockerSandboxState;
 import org.junit.jupiter.api.Test;
+import tools.jackson.databind.json.JsonMapper;
 
 class HarnessSandboxJacksonModuleTest {
 
     @Test
-    void roundTripsDockerSandboxState() throws Exception {
-        ObjectMapper mapper =
-                new ObjectMapper()
-                        .findAndRegisterModules()
-                        .registerModule(new HarnessSandboxJacksonModule());
+    void roundTripsDockerSandboxState() {
+        JsonMapper mapper =
+                JsonMapper.builder()
+                        .findAndAddModules()
+                        .addModule(new HarnessSandboxJacksonModule())
+                        .build();
 
         DockerSandboxState original = new DockerSandboxState();
         original.setSessionId("sess-1");

--- a/docs/en/task/session.md
+++ b/docs/en/task/session.md
@@ -327,7 +327,6 @@ rm -rf ~/.agentscope/sessions/*.json
 If you need to preserve historical conversation data, write a migration script:
 
 ```java
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.agentscope.core.memory.InMemoryMemory;
 import io.agentscope.core.message.Msg;
 import io.agentscope.core.session.JsonSession;
@@ -335,14 +334,15 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
+import tools.jackson.databind.json.JsonMapper;
 
 public class SessionMigration {
     public static void migrate(Path oldSessionFile, Path newSessionDir) throws Exception {
-        ObjectMapper mapper = new ObjectMapper();
+        JsonMapper jsonMapper = JsonMapper.shared();
 
         // 1. Read old format data
         String json = Files.readString(oldSessionFile);
-        Map<String, Object> oldData = mapper.readValue(json, Map.class);
+        Map<String, Object> oldData = jsonMapper.readValue(json, Map.class);
 
         // 2. Extract message history
         Map<String, Object> memoryData = (Map<String, Object>) oldData.get("memory");

--- a/docs/zh/task/session.md
+++ b/docs/zh/task/session.md
@@ -327,7 +327,6 @@ rm -rf ~/.agentscope/sessions/*.json
 如果需要保留历史对话数据，可以编写迁移脚本：
 
 ```java
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.agentscope.core.memory.InMemoryMemory;
 import io.agentscope.core.message.Msg;
 import io.agentscope.core.session.JsonSession;
@@ -335,14 +334,15 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
+import tools.jackson.databind.json.JsonMapper;
 
 public class SessionMigration {
     public static void migrate(Path oldSessionFile, Path newSessionDir) throws Exception {
-        ObjectMapper mapper = new ObjectMapper();
+        JsonMapper jsonMapper = JsonMapper.shared();
 
         // 1. 读取旧格式数据
         String json = Files.readString(oldSessionFile);
-        Map<String, Object> oldData = mapper.readValue(json, Map.class);
+        Map<String, Object> oldData = jsonMapper.readValue(json, Map.class);
 
         // 2. 提取消息历史
         Map<String, Object> memoryData = (Map<String, Object>) oldData.get("memory");


### PR DESCRIPTION
## AgentScope-Java Version

1.0.11

## Description

* Closes: #754 
* Migrates agentscope from Jackson2 to Jackson3

## Checklist

Please check the following items before code is ready to be reviewed.

- [x]  Code has been formatted with `mvn spotless:apply`
- [x]  All tests are passing (`mvn test`)
- [x]  Javadoc comments are complete and follow project conventions
- [x]  Related documentation has been updated (e.g. links, examples, etc.)
- [x]  Code is ready for review
