### PR TITLE
ci: Improve windows ci stability

### DIFF
--- a/.github/workflows/maven-ci.yml
+++ b/.github/workflows/maven-ci.yml
@@ -99,6 +99,12 @@ jobs:
           mkdir -Path "~\.mvnd" -Force
           Expand-Archive -Path "mvnd.zip" -DestinationPath "mvnd" -FORCE
           Copy-Item -Path "mvnd\maven-mvnd-${{ env.MVND_VERSION }}-windows-amd64\*" -Destination "~\.mvnd\" -Recurse
+          Set-Content -Path "~\.mvnd\conf\mvnd.properties" -Value @"
+          # mvnd client timeout settings
+          mvnd.connectTimeout=120000
+          mvnd.socketConnectTimeout=30000
+          mvnd.cancelConnectTimeout=30000
+          "@ -Encoding Utf8 -Force
           Remove-Item -Path "mvnd", "mvnd.zip" -Recurse -Force
 
       - name: Build and Test with Coverage [Linux]


### PR DESCRIPTION
## AgentScope-Java Version

1.0.11

## Description

* Increment `mvnd` connect timeout to improve windows ci stability.

## Fix
Fix the follow recurring  windows ci mvnd problem.
```
Run & "~\.mvnd\bin\mvnd.cmd" -B clean verify
Mar 12, 2026 12:09:33 PM org.jline.utils.Log logr
WARNING: Unable to create a system terminal, creating a dumb terminal (enable debug logging for more information)
[main] WARNING org.jline - Unable to create a system terminal, creating a dumb terminal (enable debug logging for more information)
Error: Exception in thread "main" org.mvndaemon.mvnd.common.DaemonException$ConnectException: Timeout waiting to connect to the Maven daemon.
Daemon id: 6bcc0c5a
  log file: C:\Users\runneradmin\.m2\mvnd\registry\1.0.3\daemon-6bcc0c5a.log
----- Last  200 lines from daemon log file - C:\Users\runneradmin\.m2\mvnd\registry\1.0.3\daemon-6bcc0c5a.log -----

----- End of the daemon log file -----
  output: C:\Users\runneradmin\.m2\mvnd\registry\1.0.3\daemon-6bcc0c5a.out.log
----- Last  200 lines from daemon output - C:\Users\runneradmin\.m2\mvnd\registry\1.0.3\daemon-6bcc0c5a.out.log -----
Starting daemon process: id = 6bcc0c5a, workingDir = D:\a\agentscope-java\agentscope-java, daemonArgs: C:\hostedtoolcache\windows\Java_Temurin-Hotspot_jdk\17.0.18-8\x64\bin\java.exe -classpath C:\Users\runneradmin\.mvnd\mvn\boot\plexus-classworlds-2.9.0.jar -javaagent:C:\Users\runneradmin\.mvnd\mvn\lib\mvnd\mvnd-agent-1.0.3.jar -Dmvnd.home=C:\Users\runneradmin\.mvnd -Dmaven.home=C:\Users\runneradmin\.mvnd\mvn -Dmaven.conf=C:\Users\runneradmin\.mvnd\mvn\conf -Dclassworlds.conf=C:\Users\runneradmin\.mvnd\bin\mvnd-daemon.conf -Dorg.slf4j.simpleLogger.logFile=C:\Users\runneradmin\.m2\mvnd\registry\1.0.3\daemon-6bcc0c5a.log -Dmvnd.java.home=C:\hostedtoolcache\windows\Java_Temurin-Hotspot_jdk\17.0.18-8\x64 -Dmvnd.id=6bcc0c5a -Dmvnd.daemonStorage=C:\Users\runneradmin\.m2\mvnd\registry\1.0.3 -Dmvnd.registry=C:\Users\runneradmin\.m2\mvnd\registry\1.0.3\registry.bin -Dmvnd.socketFamily=inet -Dmvnd.home=C:\Users\runneradmin\.mvnd -Djdk.java.options=--add-opens java.base/java.io=ALL-UNNAMED --add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.util=ALL-UNNAMED --add-opens java.base/sun.net.www.protocol.jar=ALL-UNNAMED --add-opens java.base/sun.nio.fs=ALL-UNNAMED -Dmvnd.noDaemon=false -Dmvnd.debug=false -Dmvnd.debug.address=8000 -Dmvnd.idleTimeout=3h -Dmvnd.keepAlive=100ms -Dmvnd.extClasspath= -Dmvnd.coreExtensions= -Dmvnd.enableAssertions=false -Dmvnd.expirationCheckDelay=10s -Dmvnd.duplicateDaemonGracePeriod=10s -Dmvnd.socketFamily=inet org.codehaus.plexus.classworlds.launcher.LauncherNOTE: Picked up JDK_JAVA_OPTIONS: --add-opens java.base/java.io=ALL-UNNAMED --add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.util=ALL-UNNAMED --add-opens java.base/sun.net.www.protocol.jar=ALL-UNNAMED --add-opens java.base/sun.nio.fs=ALL-UNNAMED
----- End of the daemon output -----

	at org.mvndaemon.mvnd.client.DaemonConnector.startDaemon(DaemonConnector.java:332)
	at org.mvndaemon.mvnd.client.DaemonConnector.connect(DaemonConnector.java:123)
	at org.mvndaemon.mvnd.client.DefaultClient.execute(DefaultClient.java:353)
	at org.mvndaemon.mvnd.client.DefaultClient.main(DefaultClient.java:171)
	at java.base@22.0.2/java.lang.invoke.LambdaForm$DMH/sa346b79c.invokeStaticInit(LambdaForm$DMH)
```

## Checklist

Please check the following items before code is ready to be reviewed.

- [x]  Code has been formatted with `mvn spotless:apply`
- [x]  All tests are passing (`mvn test`)
- [x]  Javadoc comments are complete and follow project conventions
- [x]  Related documentation has been updated (e.g. links, examples, etc.)
- [x]  Code is ready for review
