### PR TITLE
fix: handle tool execution timeout/error causing IllegalStateExceptio…

### DIFF
--- a/agentscope-core/src/main/java/io/agentscope/core/ReActAgent.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/ReActAgent.java
@@ -252,9 +252,55 @@ public class ReActAgent extends StructuredOutputCapableAgent {
             return executeIteration(0);
         }
 
-        // Has pending tools -> validate and add tool results
+        // Has pending tools -> check if user provided tool results
+        List<ToolResultBlock> providedResults = msgs == null ? List.of() :
+                msgs.stream()
+                        .flatMap(m -> m.getContentBlocks(ToolResultBlock.class).stream())
+                        .toList();
+
+        if (providedResults.isEmpty()) {
+            // User didn't provide tool results - auto-generate error results for pending calls
+            // This handles cases where previous tool execution failed without writing results to memory
+            log.warn("Pending tool calls detected without results, auto-generating error results. Pending IDs: {}", pendingIds);
+            generateAndAddErrorToolResults(pendingIds);
+            // Add user message to memory and continue normal processing
+            addToMemory(msgs);
+            return executeIteration(0);
+        }
+
+        // User provided tool results -> validate and add
         validateAndAddToolResults(msgs, pendingIds);
         return hasPendingToolUse() ? acting(0) : executeIteration(0);
+    }
+
+    /**
+     * Generate error tool results for pending tool calls and add them to memory.
+     * This is used to recover from situations where tool execution failed without
+     * properly writing results to memory.
+     *
+     * @param pendingIds The set of pending tool use IDs
+     */
+    private void generateAndAddErrorToolResults(Set<String> pendingIds) {
+        Msg lastAssistant = findLastAssistantMsg();
+        if (lastAssistant == null) {
+            return;
+        }
+
+        List<ToolUseBlock> pendingToolCalls = lastAssistant.getContentBlocks(ToolUseBlock.class).stream()
+                .filter(toolUse -> pendingIds.contains(toolUse.getId()))
+                .toList();
+
+        for (ToolUseBlock toolCall : pendingToolCalls) {
+            ToolResultBlock errorResult = ToolResultBlock.builder()
+                    .id(toolCall.getId())
+                    .output(List.of(TextBlock.builder()
+                            .text("[ERROR] Previous tool execution failed or was interrupted. Tool: " + toolCall.getName())
+                            .build()))
+                    .build();
+            Msg toolResultMsg = ToolResultMessageBuilder.buildToolResultMsg(errorResult, toolCall, getName());
+            memory.addMessage(toolResultMsg);
+            log.info("Auto-generated error result for pending tool call: {} ({})", toolCall.getName(), toolCall.getId());
+        }
     }
 
     /**
@@ -592,6 +638,10 @@ public class ReActAgent extends StructuredOutputCapableAgent {
     /**
      * Execute tool calls and return paired results.
      *
+     * <p>If tool execution fails (timeout, error, etc.), this method generates error tool results
+     * for all pending tool calls instead of propagating the error. This ensures the agent can
+     * continue processing and the model receives proper error feedback.
+     *
      * @param toolCalls The list of tool calls (potentially modified by PreActingEvent hooks)
      * @return Mono containing list of (ToolUseBlock, ToolResultBlock) pairs
      */
@@ -602,7 +652,24 @@ public class ReActAgent extends StructuredOutputCapableAgent {
                         results ->
                                 IntStream.range(0, toolCalls.size())
                                         .mapToObj(i -> Map.entry(toolCalls.get(i), results.get(i)))
-                                        .toList());
+                                        .toList())
+                .onErrorResume(error -> {
+                    // Generate error tool results for all pending tool calls
+                    log.error("Tool execution failed, generating error results for {} tool calls: {}",
+                            toolCalls.size(), error.getMessage());
+                    List<Map.Entry<ToolUseBlock, ToolResultBlock>> errorResults = toolCalls.stream()
+                            .map(toolCall -> {
+                                ToolResultBlock errorResult = ToolResultBlock.builder()
+                                        .id(toolCall.getId())
+                                        .output(List.of(TextBlock.builder()
+                                                .text("[ERROR] Tool execution failed: " + error.getMessage())
+                                                .build()))
+                                        .build();
+                                return Map.entry(toolCall, errorResult);
+                            })
+                            .toList();
+                    return Mono.just(errorResults);
+                });
     }
 
     /**


### PR DESCRIPTION
…n (#951)

ReActAgent throws IllegalStateException when tool calls timeout or fail, because no tool result is written to memory, leaving orphaned pending tool call states that crash the agent on subsequent requests.

Root cause:
- Tool execution timeout/error propagates without writing results to memory
- Pending tool call state remains, blocking subsequent doCall() invocations
- validateAndAddToolResults() throws when user message has no tool results

Changes:
- doCall(): detect pending tool calls without user-provided results and auto-generate error results to clear the pending state
- executeToolCalls(): add onErrorResume to catch tool execution failures and generate error tool results instead of propagating exceptions
- Add generateAndAddErrorToolResults() helper to create error results for orphaned pending tool calls

This ensures the agent recovers gracefully from tool failures instead of crashing, and the model receives proper error feedback to continue processing.

Closes #951

## AgentScope-Java Version

[The version of AgentScope-Java you are working on, e.g. 1.0.9, check your pom.xml dependency version or run `mvn dependency:tree | grep agentscope-parent:pom`(only mac/linux)]

## Description

[Please describe the background, purpose, changes made, and how to test this PR]

## Checklist

Please check the following items before code is ready to be reviewed.

- [ ]  Code has been formatted with `mvn spotless:apply`
- [ ]  All tests are passing (`mvn test`)
- [ ]  Javadoc comments are complete and follow project conventions
- [ ]  Related documentation has been updated (e.g. links, examples, etc.)
- [ ]  Code is ready for review
