### PR TITLE
(feat-351) add oltp headers

### DIFF
--- a/agentscope-extensions/agentscope-extensions-studio/src/main/java/io/agentscope/core/studio/StudioConfig.java
+++ b/agentscope-extensions/agentscope-extensions-studio/src/main/java/io/agentscope/core/studio/StudioConfig.java
@@ -16,6 +16,9 @@
 package io.agentscope.core.studio;
 
 import java.time.Duration;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.UUID;
 
 /**
@@ -48,6 +51,7 @@ public class StudioConfig {
     private final int reconnectAttempts;
     private final Duration reconnectDelay;
     private final Duration reconnectMaxDelay;
+    private final Map<String, String> otlpHeaders;
 
     private StudioConfig(Builder builder) {
         this.studioUrl = builder.studioUrl;
@@ -59,6 +63,7 @@ public class StudioConfig {
         this.reconnectAttempts = builder.reconnectAttempts;
         this.reconnectDelay = builder.reconnectDelay;
         this.reconnectMaxDelay = builder.reconnectMaxDelay;
+        this.otlpHeaders = Collections.unmodifiableMap(new HashMap<>(builder.otlpHeaders));
     }
 
     public static Builder builder() {
@@ -146,6 +151,18 @@ public class StudioConfig {
         return reconnectMaxDelay;
     }
 
+    /**
+     * Gets the OTLP headers for authentication.
+     *
+     * <p>These headers are included in OTLP HTTP requests to the tracing endpoint.
+     * Useful for authentication with systems like Langfuse that require custom headers.
+     *
+     * @return an unmodifiable map of header names to values (default: empty map)
+     */
+    public Map<String, String> getOtlpHeaders() {
+        return otlpHeaders;
+    }
+
     public static class Builder {
         private String studioUrl = "http://localhost:3000";
         private String tracingUrl;
@@ -156,6 +173,7 @@ public class StudioConfig {
         private int reconnectAttempts = 3;
         private Duration reconnectDelay = Duration.ofSeconds(1);
         private Duration reconnectMaxDelay = Duration.ofSeconds(5);
+        private Map<String, String> otlpHeaders = new HashMap<>();
 
         public Builder studioUrl(String studioUrl) {
             this.studioUrl = studioUrl;
@@ -199,6 +217,44 @@ public class StudioConfig {
 
         public Builder reconnectMaxDelay(Duration reconnectMaxDelay) {
             this.reconnectMaxDelay = reconnectMaxDelay;
+            return this;
+        }
+
+        /**
+         * Adds a single OTLP header for authentication.
+         *
+         * <p>This header will be included in OTLP HTTP requests to the tracing endpoint.
+         * Useful for systems like Langfuse that require authentication headers.
+         *
+         * <p>Example for Langfuse:
+         * <pre>{@code
+         * StudioConfig config = StudioConfig.builder()
+         *     .studioUrl("https://cloud.langfuse.com")
+         *     .tracingUrl("https://cloud.langfuse.com/api/public/otel/v1/traces")
+         *     .addOtlpHeader("Authorization", "Basic " + base64Credentials)
+         *     .build();
+         * }</pre>
+         *
+         * @param key   The header name (e.g., "Authorization")
+         * @param value The header value (e.g., "Basic dXNlcjpwYXNz")
+         * @return This builder
+         */
+        public Builder addOtlpHeader(String key, String value) {
+            this.otlpHeaders.put(key, value);
+            return this;
+        }
+
+        /**
+         * Sets all OTLP headers for authentication.
+         *
+         * <p>These headers will be included in OTLP HTTP requests to the tracing endpoint.
+         * This method replaces any previously added headers.
+         *
+         * @param headers Map of header names to values
+         * @return This builder
+         */
+        public Builder otlpHeaders(Map<String, String> headers) {
+            this.otlpHeaders = new HashMap<>(headers);
             return this;
         }
 

--- a/agentscope-extensions/agentscope-extensions-studio/src/main/java/io/agentscope/core/studio/StudioManager.java
+++ b/agentscope-extensions/agentscope-extensions-studio/src/main/java/io/agentscope/core/studio/StudioManager.java
@@ -198,6 +198,45 @@ public class StudioManager {
         }
 
         /**
+         * Adds a single OTLP header for authentication.
+         *
+         * <p>This header will be included in OTLP HTTP requests to the tracing endpoint.
+         * Useful for systems like Langfuse that require authentication headers.
+         *
+         * <p>Example for Langfuse:
+         * <pre>{@code
+         * StudioManager.init()
+         *     .studioUrl("https://cloud.langfuse.com")
+         *     .tracingUrl("https://cloud.langfuse.com/api/public/otel/v1/traces")
+         *     .addOtlpHeader("Authorization", "Basic " + base64Credentials)
+         *     .initialize()
+         *     .block();
+         * }</pre>
+         *
+         * @param key   The header name (e.g., "Authorization")
+         * @param value The header value (e.g., "Basic dXNlcjpwYXNz")
+         * @return This builder
+         */
+        public Builder addOtlpHeader(String key, String value) {
+            configBuilder.addOtlpHeader(key, value);
+            return this;
+        }
+
+        /**
+         * Sets all OTLP headers for authentication.
+         *
+         * <p>These headers will be included in OTLP HTTP requests to the tracing endpoint.
+         * This method replaces any previously added headers.
+         *
+         * @param headers Map of header names to values
+         * @return This builder
+         */
+        public Builder otlpHeaders(java.util.Map<String, String> headers) {
+            configBuilder.otlpHeaders(headers);
+            return this;
+        }
+
+        /**
          * Initializes Studio integration.
          *
          * <p>This method:
@@ -255,7 +294,10 @@ public class StudioManager {
                                     traceEndpoint = config.getTracingUrl();
                                 }
                                 TracerRegistry.register(
-                                        TelemetryTracer.builder().endpoint(traceEndpoint).build());
+                                        TelemetryTracer.builder()
+                                                .endpoint(traceEndpoint)
+                                                .headers(config.getOtlpHeaders())
+                                                .build());
                             })
                     .doOnError(e -> logger.error("Failed to initialize Studio", e))
                     .onErrorResume(

--- a/agentscope-extensions/agentscope-extensions-studio/src/test/java/io/agentscope/core/studio/StudioConfigTest.java
+++ b/agentscope-extensions/agentscope-extensions-studio/src/test/java/io/agentscope/core/studio/StudioConfigTest.java
@@ -20,6 +20,8 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -128,5 +130,145 @@ class StudioConfigTest {
 
         assertEquals(Duration.ofHours(1), config2.getReconnectDelay());
         assertEquals(Duration.ofHours(24), config2.getReconnectMaxDelay());
+    }
+
+    @Test
+    @DisplayName("Builder with addOtlpHeader should create config with single header")
+    void testBuilderWithAddOtlpHeader() {
+        StudioConfig config =
+                StudioConfig.builder()
+                        .studioUrl("http://localhost:3000")
+                        .project("TestProject")
+                        .runName("test_run")
+                        .addOtlpHeader("Authorization", "Basic dGVzdDp0ZXN0")
+                        .build();
+
+        assertNotNull(config.getOtlpHeaders());
+        assertEquals(1, config.getOtlpHeaders().size());
+        assertEquals("Basic dGVzdDp0ZXN0", config.getOtlpHeaders().get("Authorization"));
+    }
+
+    @Test
+    @DisplayName("Builder with multiple addOtlpHeader calls should accumulate headers")
+    void testBuilderWithMultipleAddOtlpHeaders() {
+        StudioConfig config =
+                StudioConfig.builder()
+                        .studioUrl("http://localhost:3000")
+                        .project("TestProject")
+                        .runName("test_run")
+                        .addOtlpHeader("Authorization", "Basic dGVzdDp0ZXN0")
+                        .addOtlpHeader("X-Custom-Header", "custom-value")
+                        .addOtlpHeader("X-Trace-Id", "trace-123")
+                        .build();
+
+        assertNotNull(config.getOtlpHeaders());
+        assertEquals(3, config.getOtlpHeaders().size());
+        assertEquals("Basic dGVzdDp0ZXN0", config.getOtlpHeaders().get("Authorization"));
+        assertEquals("custom-value", config.getOtlpHeaders().get("X-Custom-Header"));
+        assertEquals("trace-123", config.getOtlpHeaders().get("X-Trace-Id"));
+    }
+
+    @Test
+    @DisplayName("Builder with otlpHeaders map should create config with all headers")
+    void testBuilderWithOtlpHeadersMap() {
+        Map<String, String> headers = new HashMap<>();
+        headers.put("Authorization", "Bearer token123");
+        headers.put("X-Api-Key", "api-key-value");
+
+        StudioConfig config =
+                StudioConfig.builder()
+                        .studioUrl("http://localhost:3000")
+                        .project("TestProject")
+                        .runName("test_run")
+                        .otlpHeaders(headers)
+                        .build();
+
+        assertNotNull(config.getOtlpHeaders());
+        assertEquals(2, config.getOtlpHeaders().size());
+        assertEquals("Bearer token123", config.getOtlpHeaders().get("Authorization"));
+        assertEquals("api-key-value", config.getOtlpHeaders().get("X-Api-Key"));
+    }
+
+    @Test
+    @DisplayName("Default config should have empty OTLP headers")
+    void testDefaultOtlpHeadersEmpty() {
+        StudioConfig config =
+                StudioConfig.builder()
+                        .studioUrl("http://localhost:3000")
+                        .project("TestProject")
+                        .runName("test_run")
+                        .build();
+
+        assertNotNull(config.getOtlpHeaders());
+        assertTrue(config.getOtlpHeaders().isEmpty());
+    }
+
+    @Test
+    @DisplayName("OTLP headers should be immutable after build")
+    void testOtlpHeadersImmutability() {
+        StudioConfig config =
+                StudioConfig.builder()
+                        .studioUrl("http://localhost:3000")
+                        .project("TestProject")
+                        .runName("test_run")
+                        .addOtlpHeader("Authorization", "Basic dGVzdDp0ZXN0")
+                        .build();
+
+        Map<String, String> headers = config.getOtlpHeaders();
+
+        try {
+            headers.put("X-New-Header", "should-fail");
+            // If we reach here, the map is mutable (which is wrong)
+            assertTrue(false, "Headers map should be immutable");
+        } catch (UnsupportedOperationException e) {
+            // Expected behavior - map is immutable
+            assertTrue(true);
+        }
+    }
+
+    @Test
+    @DisplayName("Combining otlpHeaders and addOtlpHeader should work correctly")
+    void testCombiningHeaderMethods() {
+        Map<String, String> initialHeaders = new HashMap<>();
+        initialHeaders.put("X-Initial", "initial-value");
+
+        StudioConfig config =
+                StudioConfig.builder()
+                        .studioUrl("http://localhost:3000")
+                        .project("TestProject")
+                        .runName("test_run")
+                        .otlpHeaders(initialHeaders)
+                        .addOtlpHeader("X-Additional", "additional-value")
+                        .build();
+
+        assertNotNull(config.getOtlpHeaders());
+        assertEquals(2, config.getOtlpHeaders().size());
+        assertEquals("initial-value", config.getOtlpHeaders().get("X-Initial"));
+        assertEquals("additional-value", config.getOtlpHeaders().get("X-Additional"));
+    }
+
+    @Test
+    @DisplayName("Langfuse-style authentication should work correctly")
+    void testLangfuseStyleAuthentication() {
+        String publicKey = "pk-lf-test";
+        String secretKey = "sk-lf-test";
+        String base64Credentials =
+                java.util.Base64.getEncoder()
+                        .encodeToString((publicKey + ":" + secretKey).getBytes());
+
+        StudioConfig config =
+                StudioConfig.builder()
+                        .studioUrl("https://cloud.langfuse.com")
+                        .tracingUrl("https://cloud.langfuse.com/api/public/otel/v1/traces")
+                        .project("LangfuseProject")
+                        .runName("langfuse_run")
+                        .addOtlpHeader("Authorization", "Basic " + base64Credentials)
+                        .build();
+
+        assertNotNull(config.getOtlpHeaders());
+        assertEquals(1, config.getOtlpHeaders().size());
+        assertTrue(config.getOtlpHeaders().get("Authorization").startsWith("Basic "));
+        assertEquals(
+                "https://cloud.langfuse.com/api/public/otel/v1/traces", config.getTracingUrl());
     }
 }

--- a/agentscope-extensions/agentscope-extensions-studio/src/test/java/io/agentscope/core/studio/StudioManagerTest.java
+++ b/agentscope-extensions/agentscope-extensions-studio/src/test/java/io/agentscope/core/studio/StudioManagerTest.java
@@ -19,6 +19,8 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
+import java.util.HashMap;
+import java.util.Map;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -124,5 +126,75 @@ class StudioManagerTest {
 
         assertNull(StudioManager.getClient());
         assertFalse(StudioManager.isInitialized());
+    }
+
+    @Test
+    @DisplayName("Builder should support addOtlpHeader method")
+    void testBuilderAddOtlpHeader() {
+        StudioManager.Builder builder =
+                StudioManager.init()
+                        .studioUrl("http://localhost:3000")
+                        .project("TestProject")
+                        .runName("test_run")
+                        .addOtlpHeader("Authorization", "Basic dGVzdDp0ZXN0");
+
+        assertNotNull(builder);
+    }
+
+    @Test
+    @DisplayName("Builder should support otlpHeaders method with map")
+    void testBuilderOtlpHeadersMap() {
+        Map<String, String> headers = new HashMap<>();
+        headers.put("Authorization", "Bearer token123");
+        headers.put("X-Api-Key", "api-key-value");
+
+        StudioManager.Builder builder =
+                StudioManager.init()
+                        .studioUrl("http://localhost:3000")
+                        .project("TestProject")
+                        .runName("test_run")
+                        .otlpHeaders(headers);
+
+        assertNotNull(builder);
+    }
+
+    @Test
+    @DisplayName("Builder should support combining header methods with other configuration")
+    void testBuilderCombiningHeadersWithOtherConfig() {
+        Map<String, String> headers = new HashMap<>();
+        headers.put("X-Initial", "initial");
+
+        StudioManager.Builder builder =
+                StudioManager.init()
+                        .studioUrl("https://cloud.langfuse.com")
+                        .tracingUrl("https://cloud.langfuse.com/api/public/otel/v1/traces")
+                        .project("LangfuseProject")
+                        .runName("langfuse_run")
+                        .maxRetries(5)
+                        .reconnectAttempts(3)
+                        .otlpHeaders(headers)
+                        .addOtlpHeader("Authorization", "Basic credentials");
+
+        assertNotNull(builder);
+    }
+
+    @Test
+    @DisplayName("Builder should support Langfuse-style configuration")
+    void testBuilderLangfuseConfiguration() {
+        String publicKey = "pk-lf-test";
+        String secretKey = "sk-lf-test";
+        String base64Credentials =
+                java.util.Base64.getEncoder()
+                        .encodeToString((publicKey + ":" + secretKey).getBytes());
+
+        StudioManager.Builder builder =
+                StudioManager.init()
+                        .studioUrl("https://cloud.langfuse.com")
+                        .tracingUrl("https://cloud.langfuse.com/api/public/otel/v1/traces")
+                        .project("LangfuseProject")
+                        .runName("langfuse_run")
+                        .addOtlpHeader("Authorization", "Basic " + base64Credentials);
+
+        assertNotNull(builder);
     }
 }


### PR DESCRIPTION
feat(studio): add OTLP headers support for authentication

Add support for configuring OTLP headers in agentscope-extensions-studio
to enable authentication with external tracing systems like Langfuse.

Changes:
- Add otlpHeaders field to StudioConfig with getter method
- Add addOtlpHeader() and otlpHeaders() builder methods to StudioConfig
- Add corresponding methods to StudioManager.Builder for convenience
- Pass configured headers to TelemetryTracer during initialization
- Add comprehensive test cases for header configuration

This closes #351 by allowing users to configure authentication headers
when reporting trace data via OTLP to systems requiring authentication.

Example usage for Langfuse:
```java
StudioManager.init()
    .studioUrl("https://cloud.langfuse.com")
    .tracingUrl("https://cloud.langfuse.com/api/public/otel/v1/traces")
    .addOtlpHeader("Authorization", "Basic " + base64Credentials)
    .initialize()
    .block();