### PR TITLE
feat(session): Improve mysql session sql

### DIFF
--- a/agentscope-extensions/agentscope-extensions-session-mysql/src/main/java/io/agentscope/core/session/mysql/MysqlSession.java
+++ b/agentscope-extensions/agentscope-extensions-session-mysql/src/main/java/io/agentscope/core/session/mysql/MysqlSession.java
@@ -699,9 +699,11 @@ public class MysqlSession implements Session {
      * Clear all sessions from the database (for testing or cleanup).
      *
      * @return Number of rows deleted
+     * @deprecated Use {@link #truncateAllSessions()} instead
      */
+    @Deprecated
     public int clearAllSessions() {
-        String clearSql = "TRUNCATE TABLE " + getFullTableName();
+        String clearSql = "DELETE FROM " + getFullTableName();
 
         try (Connection conn = dataSource.getConnection();
                 PreparedStatement stmt = conn.prepareStatement(clearSql)) {
@@ -710,6 +712,31 @@ public class MysqlSession implements Session {
 
         } catch (SQLException e) {
             throw new RuntimeException("Failed to clear sessions", e);
+        }
+    }
+
+    /**
+     * Truncate session table from the database (for testing or cleanup).
+     * <p>
+     * This method clears all session records by executing a TRUNCATE TABLE statement on the
+     * sessions table. TRUNCATE is faster than DELETE as it resets the table without logging
+     * individual row deletions and reclaims storage space immediately.
+     *
+     * <p>
+     * <strong>Note:</strong> The TRUNCATE operation requires DROP privileges in MySQL.
+     *
+     * @return typically 0 if successful
+     */
+    public int truncateAllSessions() {
+        String clearSql = "TRUNCATE TABLE " + getFullTableName();
+
+        try (Connection conn = dataSource.getConnection();
+                PreparedStatement stmt = conn.prepareStatement(clearSql)) {
+
+            return stmt.executeUpdate();
+
+        } catch (SQLException e) {
+            throw new RuntimeException("Failed to truncate sessions", e);
         }
     }
 

--- a/agentscope-extensions/agentscope-extensions-session-mysql/src/test/java/io/agentscope/core/session/mysql/MysqlSessionTest.java
+++ b/agentscope-extensions/agentscope-extensions-session-mysql/src/test/java/io/agentscope/core/session/mysql/MysqlSessionTest.java
@@ -376,6 +376,18 @@ public class MysqlSessionTest {
     }
 
     @Test
+    @DisplayName("Should truncate session table")
+    void testTruncateAllSessions() throws SQLException {
+        when(mockStatement.execute()).thenReturn(true);
+        when(mockStatement.executeUpdate()).thenReturn(0);
+
+        MysqlSession session = new MysqlSession(mockDataSource, true);
+        int success = session.truncateAllSessions();
+
+        assertEquals(0, success);
+    }
+
+    @Test
     @DisplayName("Should not close DataSource when closing session")
     void testClose() throws SQLException {
         when(mockStatement.execute()).thenReturn(true);


### PR DESCRIPTION
## AgentScope-Java Version

1.0.11

## Description

- Closes: #991 
- Closes: #992 
- Use DATETIME instead of TIMESTAMP for mysql field
- Use TRUNCATE instead of DELETE from table

## Checklist

Please check the following items before code is ready to be reviewed.

- [x]  Code has been formatted with `mvn spotless:apply`
- [x]  All tests are passing (`mvn test`)
- [x]  Javadoc comments are complete and follow project conventions
- [x]  Related documentation has been updated (e.g. links, examples, etc.)
- [x]  Code is ready for review
