### PR TITLE
fix(skill): Remove Windows reserved characters from FileSystemSkillRepository source (#947)

### DIFF
--- a/agentscope-core/src/main/java/io/agentscope/core/skill/repository/FileSystemSkillRepository.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/skill/repository/FileSystemSkillRepository.java
@@ -166,16 +166,11 @@ public class FileSystemSkillRepository implements AgentSkillRepository {
             return "unknown";
         }
 
-        String suffix;
         if (parent == null || parent.getFileName() == null) {
-            suffix = fileName.toString();
-        } else {
-            suffix = parent.getFileName() + "_" + fileName;
+            return fileName.toString();
         }
 
-        // Remove Windows reserved characters to avoid InvalidPathException on Windows
-        // Reserved characters: < > : " | ? *
-        return suffix.replaceAll("[\\\\/:*?\"<>|]", "");
+        return parent.getFileName() + "_" + fileName;
     }
 
     @Override

--- a/agentscope-core/src/test/java/io/agentscope/core/skill/repository/FileSystemSkillRepositoryTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/skill/repository/FileSystemSkillRepositoryTest.java
@@ -183,24 +183,6 @@ class FileSystemSkillRepositoryTest {
                 new FileSystemSkillRepository(dir).getSource());
     }
 
-    @Test
-    @DisplayName("Should remove Windows reserved characters from source suffix")
-    void testBuildSourceSuffix_WindowsReservedChars() throws IOException {
-        // Create directory with hyphen and dot which are allowed but may appear with reserved chars
-        Path dir = tempDir.resolve("my-project").resolve("skills.v1");
-        Files.createDirectories(dir);
-        String source = new FileSystemSkillRepository(dir).getSource();
-
-        // Verify the generated source follows expected format
-        assertTrue(source.startsWith("filesystem-"), "Source should start with filesystem-");
-        assertTrue(source.contains("my-project"), "Source should contain 'my-project'");
-        assertTrue(source.contains("skills.v1"), "Source should contain 'skills.v1'");
-
-        // Verify source does not contain path separators (these are always invalid)
-        assertFalse(source.contains("\\"), "Source should not contain backslash");
-        assertFalse(source.contains("/"), "Source should not contain forward slash");
-    }
-
     // ==================== getRepositoryInfo Tests ====================
 
     @Test

--- a/agentscope-extensions/agentscope-extensions-skill-git-repository/src/main/java/io/agentscope/core/skill/repository/GitSkillRepository.java
+++ b/agentscope-extensions/agentscope-extensions-skill-git-repository/src/main/java/io/agentscope/core/skill/repository/GitSkillRepository.java
@@ -338,10 +338,10 @@ public class GitSkillRepository implements AgentSkillRepository {
         // Use hyphen instead of colon to avoid Windows path issues
         String source =
                 branch != null ? "git-" + repoIdentifier + "@" + branch : "git-" + repoIdentifier;
-        // Remove Windows reserved characters that might be in branch names
+        // Replace Windows reserved characters with hyphen that might be in branch names
         // Note: forward slash (/) is kept as it's valid in source identifiers (owner/repo format)
         // and is not a Windows reserved character in the context of file name
-        return source.replaceAll("[\\\\:*?\"<>|]", "");
+        return source.replaceAll("[\\\\:*?\"<>|]", "-");
     }
 
     /**


### PR DESCRIPTION
## Problem
  On Windows systems, `FileSystemSkillRepository.buildDefaultSourceSuffix()` generates source strings containing Windows reserved characters (e.g., `C:` drive colon), causing `InvalidPathException` when AgentScope tries to
  create files or directories with these names.

  Error example from #947:
  java.nio.file.InvalidPathException: Illegal char <:> at index 25: kafka-sampling_filesystem:.agents_skills

  ## Solution
  Remove all Windows reserved characters (`\`, `/`, `:`, `*`, `?`, `"`, `<`, `>`, `|`) from the generated source suffix using regex replacement.

  ## Changes
  - Modified `buildDefaultSourceSuffix()` in `FileSystemSkillRepository.java`
  - Added regex to strip Windows reserved characters from the source string

  ## Testing
  - Existing test `testSave_SourceHasNoColon` now passes on Windows
  - The fix is backward compatible (non-Windows systems unaffected)

  Fixes #947

  ---