### PR TITLE
fix(core): use @JsonProperty on Event.isLast() to preserve JSON key

### DIFF
--- a/agentscope-core/src/main/java/io/agentscope/core/agent/Event.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/agent/Event.java
@@ -132,6 +132,7 @@ public class Event {
      *
      * @return true if this is the last chunk, false if more chunks will follow
      */
+    @JsonProperty("isLast")
     public boolean isLast() {
         return isLast;
     }

--- a/agentscope-core/src/test/java/io/agentscope/core/agent/EventTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/agent/EventTest.java
@@ -24,6 +24,7 @@ import io.agentscope.core.message.ContentBlock;
 import io.agentscope.core.message.Msg;
 import io.agentscope.core.message.MsgRole;
 import io.agentscope.core.message.TextBlock;
+import io.agentscope.core.util.JsonUtils;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 
@@ -232,5 +233,30 @@ class EventTest {
         // All events should have the same message ID
         assertEquals(event1.getMessageId(), event2.getMessageId());
         assertEquals(event2.getMessageId(), event3.getMessageId());
+    }
+
+    @Test
+    void testEventJsonSerializationIsLastFieldName() {
+        Msg msg =
+                Msg.builder()
+                        .name("assistant")
+                        .role(MsgRole.ASSISTANT)
+                        .content(List.of(TextBlock.builder().text("Test").build()))
+                        .build();
+
+        Event event = new Event(EventType.REASONING, msg, false);
+        String json = JsonUtils.getJsonCodec().toJson(event);
+
+        // BUG: Jackson serializes boolean field "isLast" as "last" because
+        // the getter isLast() follows JavaBeans convention for boolean (is-prefix stripped).
+        // The @JsonProperty("isLast") on the constructor only affects deserialization.
+        assertTrue(
+                json.contains("\"isLast\""), "JSON should contain 'isLast' key, but got: " + json);
+        assertFalse(
+                json.contains("\"last\""), "JSON should NOT contain 'last' key, but got: " + json);
+
+        // Verify round-trip: deserialize back should preserve isLast value
+        Event deserialized = JsonUtils.getJsonCodec().fromJson(json, Event.class);
+        assertEquals(event.isLast(), deserialized.isLast());
     }
 }


### PR DESCRIPTION
## AgentScope-Java Version

1.0.10

## Description

fix(core): use @JsonProperty on Event.isLast() to preserve JSON key

## Checklist

Please check the following items before code is ready to be reviewed.

- [x]  Code has been formatted with `mvn spotless:apply`
- [x]  All tests are passing (`mvn test`)
- [x]  Javadoc comments are complete and follow project conventions
- [x]  Related documentation has been updated (e.g. links, examples, etc.)
- [x]  Code is ready for review
