### PR TITLE
fix: remove race condition in shutdown state transition

### DIFF
--- a/agentscope-core/src/main/java/io/agentscope/core/shutdown/GracefulShutdownManager.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/shutdown/GracefulShutdownManager.java
@@ -167,6 +167,7 @@ public final class GracefulShutdownManager {
         }
         activeRequestsByAgentId.remove(agent.getAgentId());
         sessionBindings.remove(agent.getAgentId());
+        updateTerminatedIfNoRequests();
     }
 
     private Optional<ActiveRequestContext> getActiveRequestByAgent(Agent agent) {
@@ -262,9 +263,6 @@ public final class GracefulShutdownManager {
                 }
             }
         }
-
-        // Always check if we can transition to TERMINATED (no active requests)
-        updateTerminatedIfNoRequests();
     }
 
     private void updateTerminatedIfNoRequests() {
@@ -284,6 +282,7 @@ public final class GracefulShutdownManager {
      * @return true if TERMINATED was reached, false if timed out
      */
     public boolean awaitTermination(Duration timeout) {
+        updateTerminatedIfNoRequests();
         long deadline =
                 timeout != null ? System.currentTimeMillis() + timeout.toMillis() : Long.MAX_VALUE;
         synchronized (terminationLock) {


### PR DESCRIPTION
## Summary

- Fix a race condition in `GracefulShutdownManager` where the monitor thread (with `initialDelay=0`) calls `updateTerminatedIfNoRequests()` on every tick, which can advance the state from `SHUTTING_DOWN` to `TERMINATED` before `performGracefulShutdown()` even returns. This causes `performShutdownTransition` test to fail flakily.
- Move `updateTerminatedIfNoRequests()` from the monitor thread to two deterministic call sites: `unregisterRequest()` (when the last request completes) and `awaitTermination()` entry (for the "no active requests at shutdown time" edge case).

## Root Cause

The monitor thread was responsible for both timeout enforcement (its intended job) and state transition (an overreach). Since it runs with `initialDelay=0`, it could execute `updateTerminatedIfNoRequests()` before `performGracefulShutdown()` returned to the caller, making the `SHUTTING_DOWN` state unobservable.

## Test plan

- [x] `GracefulShutdownTest` (59 tests) all pass, including the previously flaky `performShutdownTransition`
- [x] No other files changed, minimal blast radius

Made with [Cursor](https://cursor.com)