### PR TITLE
feat(e2e-test): add support for Qwen 3.5 series models

### DIFF
--- a/agentscope-core/src/test/java/io/agentscope/core/e2e/ProviderFactory.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/e2e/ProviderFactory.java
@@ -96,6 +96,14 @@ public class ProviderFactory {
         providers.add(new DashScopeCompatibleProvider.Qwen3VlPlusOpenAI());
         providers.add(new DashScopeCompatibleProvider.Qwen3VlPlusMultiAgentOpenAI());
 
+        // DashScope Compatible providers (Qwen3.5)
+        providers.add(new DashScopeCompatibleProvider.Qwen35PlusOpenAI());
+        providers.add(new DashScopeCompatibleProvider.Qwen35PlusMultiAgentOpenAI());
+        providers.add(new DashScopeCompatibleProvider.Qwen35FlashOpenAI());
+        providers.add(new DashScopeCompatibleProvider.Qwen35FlashMultiAgentOpenAI());
+        providers.add(new DashScopeCompatibleProvider.Qwen35_397bA17bOpenAI());
+        providers.add(new DashScopeCompatibleProvider.Qwen35_397bA17bMultiAgentOpenAI());
+
         // DashScope Native providers
         providers.add(new DashScopeProvider.QwenPlusDashScope());
         providers.add(new DashScopeProvider.QwenPlusMultiAgentDashScope());
@@ -103,6 +111,12 @@ public class ProviderFactory {
         providers.add(new DashScopeProvider.QwenPlusThinkingMultiAgentDashScope());
         providers.add(new DashScopeProvider.Qwen3VlPlusDashScope());
         providers.add(new DashScopeProvider.Qwen3VlPlusMultiAgentDashScope());
+        providers.add(new DashScopeProvider.Qwen35PlusDashScope());
+        providers.add(new DashScopeProvider.Qwen35PlusMultiAgentDashScope());
+        providers.add(new DashScopeProvider.Qwen35FlashDashScope());
+        providers.add(new DashScopeProvider.Qwen35FlashMultiAgentDashScope());
+        providers.add(new DashScopeProvider.Qwen35_397bA17bDashScope());
+        providers.add(new DashScopeProvider.Qwen35_397bA17bMultiAgentDashScope());
 
         // Gemini providers
         providers.add(new GeminiProvider.Gemini25FlashGemini());

--- a/agentscope-core/src/test/java/io/agentscope/core/e2e/providers/DashScopeCompatibleProvider.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/e2e/providers/DashScopeCompatibleProvider.java
@@ -182,4 +182,115 @@ public class DashScopeCompatibleProvider extends BaseModelProvider {
             return "OpenAI to DashScope (Multi-Agent)";
         }
     }
+
+    /** Qwen3.5-Plus - Native multimodal model (image, video). */
+    @ModelCapabilities({
+        ModelCapability.BASIC,
+        ModelCapability.TOOL_CALLING,
+        ModelCapability.IMAGE,
+        ModelCapability.VIDEO
+    })
+    public static class Qwen35PlusOpenAI extends DashScopeCompatibleProvider {
+        public Qwen35PlusOpenAI() {
+            super("qwen3.5-plus", false);
+        }
+
+        @Override
+        public String getProviderName() {
+            return "OpenAI to DashScope";
+        }
+    }
+
+    /** Qwen3.5-Plus with multi-agent formatter. */
+    @ModelCapabilities({
+        ModelCapability.BASIC,
+        ModelCapability.TOOL_CALLING,
+        ModelCapability.IMAGE,
+        ModelCapability.VIDEO,
+        ModelCapability.MULTI_AGENT_FORMATTER
+    })
+    public static class Qwen35PlusMultiAgentOpenAI extends DashScopeCompatibleProvider {
+        public Qwen35PlusMultiAgentOpenAI() {
+            super("qwen3.5-plus", true);
+        }
+
+        @Override
+        public String getProviderName() {
+            return "OpenAI to DashScope (Multi-Agent)";
+        }
+    }
+
+    /** Qwen3.5-Flash - Native multimodal model (image, video). */
+    @ModelCapabilities({
+        ModelCapability.BASIC,
+        ModelCapability.TOOL_CALLING,
+        ModelCapability.IMAGE,
+        ModelCapability.VIDEO
+    })
+    public static class Qwen35FlashOpenAI extends DashScopeCompatibleProvider {
+        public Qwen35FlashOpenAI() {
+            super("qwen3.5-flash", false);
+        }
+
+        @Override
+        public String getProviderName() {
+            return "OpenAI to DashScope";
+        }
+    }
+
+    /** Qwen3.5-Flash with multi-agent formatter. */
+    @ModelCapabilities({
+        ModelCapability.BASIC,
+        ModelCapability.TOOL_CALLING,
+        ModelCapability.IMAGE,
+        ModelCapability.VIDEO,
+        ModelCapability.MULTI_AGENT_FORMATTER
+    })
+    public static class Qwen35FlashMultiAgentOpenAI extends DashScopeCompatibleProvider {
+        public Qwen35FlashMultiAgentOpenAI() {
+            super("qwen3.5-flash", true);
+        }
+
+        @Override
+        public String getProviderName() {
+            return "OpenAI to DashScope (Multi-Agent)";
+        }
+    }
+
+    /** Qwen3.5-397B-A17B - Native multimodal MoE model (image, video). */
+    @ModelCapabilities({
+        ModelCapability.BASIC,
+        ModelCapability.TOOL_CALLING,
+        ModelCapability.IMAGE,
+        ModelCapability.VIDEO
+    })
+    public static class Qwen35_397bA17bOpenAI extends DashScopeCompatibleProvider {
+        public Qwen35_397bA17bOpenAI() {
+            super("qwen3.5-397b-a17b", false);
+        }
+
+        @Override
+        public String getProviderName() {
+            return "OpenAI to DashScope";
+        }
+    }
+
+    /** Qwen3.5-397B-A17B with multi-agent formatter. */
+    @ModelCapabilities({
+        ModelCapability.BASIC,
+        ModelCapability.TOOL_CALLING,
+        ModelCapability.IMAGE,
+        ModelCapability.VIDEO,
+        ModelCapability.MULTI_AGENT_FORMATTER
+    })
+    public static class Qwen35_397bA17bMultiAgentOpenAI extends DashScopeCompatibleProvider {
+        public Qwen35_397bA17bMultiAgentOpenAI() {
+            super("qwen3.5-397b-a17b", true);
+        }
+
+        @Override
+        public String getProviderName() {
+            return "OpenAI to DashScope (Multi-Agent)";
+        }
+    }
 }

--- a/agentscope-core/src/test/java/io/agentscope/core/e2e/providers/DashScopeProvider.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/e2e/providers/DashScopeProvider.java
@@ -222,4 +222,127 @@ public class DashScopeProvider extends BaseModelProvider {
             return "DashScope (Multi-Agent)";
         }
     }
+
+    /**
+     * Qwen3.5-Plus - Native multimodal model (image, video).
+     */
+    @ModelCapabilities({
+        ModelCapability.BASIC,
+        ModelCapability.TOOL_CALLING,
+        ModelCapability.IMAGE,
+        ModelCapability.VIDEO
+    })
+    public static class Qwen35PlusDashScope extends DashScopeProvider {
+        public Qwen35PlusDashScope() {
+            super("qwen3.5-plus", false);
+        }
+
+        @Override
+        public String getProviderName() {
+            return "DashScope";
+        }
+    }
+
+    /**
+     * Qwen3.5-Plus with multi-agent formatter.
+     */
+    @ModelCapabilities({
+        ModelCapability.BASIC,
+        ModelCapability.TOOL_CALLING,
+        ModelCapability.IMAGE,
+        ModelCapability.VIDEO,
+        ModelCapability.MULTI_AGENT_FORMATTER
+    })
+    public static class Qwen35PlusMultiAgentDashScope extends DashScopeProvider {
+        public Qwen35PlusMultiAgentDashScope() {
+            super("qwen3.5-plus", true);
+        }
+
+        @Override
+        public String getProviderName() {
+            return "DashScope (Multi-Agent)";
+        }
+    }
+
+    /**
+     * Qwen3.5-Flash - Native multimodal model (image, video).
+     */
+    @ModelCapabilities({
+        ModelCapability.BASIC,
+        ModelCapability.TOOL_CALLING,
+        ModelCapability.IMAGE,
+        ModelCapability.VIDEO
+    })
+    public static class Qwen35FlashDashScope extends DashScopeProvider {
+        public Qwen35FlashDashScope() {
+            super("qwen3.5-flash", false);
+        }
+
+        @Override
+        public String getProviderName() {
+            return "DashScope";
+        }
+    }
+
+    /**
+     * Qwen3.5-Flash with multi-agent formatter.
+     */
+    @ModelCapabilities({
+        ModelCapability.BASIC,
+        ModelCapability.TOOL_CALLING,
+        ModelCapability.IMAGE,
+        ModelCapability.VIDEO,
+        ModelCapability.MULTI_AGENT_FORMATTER
+    })
+    public static class Qwen35FlashMultiAgentDashScope extends DashScopeProvider {
+        public Qwen35FlashMultiAgentDashScope() {
+            super("qwen3.5-flash", true);
+        }
+
+        @Override
+        public String getProviderName() {
+            return "DashScope (Multi-Agent)";
+        }
+    }
+
+    /**
+     * Qwen3.5-397B-A17B - Native multimodal MoE model (image, video).
+     */
+    @ModelCapabilities({
+        ModelCapability.BASIC,
+        ModelCapability.TOOL_CALLING,
+        ModelCapability.IMAGE,
+        ModelCapability.VIDEO
+    })
+    public static class Qwen35_397bA17bDashScope extends DashScopeProvider {
+        public Qwen35_397bA17bDashScope() {
+            super("qwen3.5-397b-a17b", false);
+        }
+
+        @Override
+        public String getProviderName() {
+            return "DashScope";
+        }
+    }
+
+    /**
+     * Qwen3.5-397B-A17B with multi-agent formatter.
+     */
+    @ModelCapabilities({
+        ModelCapability.BASIC,
+        ModelCapability.TOOL_CALLING,
+        ModelCapability.IMAGE,
+        ModelCapability.VIDEO,
+        ModelCapability.MULTI_AGENT_FORMATTER
+    })
+    public static class Qwen35_397bA17bMultiAgentDashScope extends DashScopeProvider {
+        public Qwen35_397bA17bMultiAgentDashScope() {
+            super("qwen3.5-397b-a17b", true);
+        }
+
+        @Override
+        public String getProviderName() {
+            return "DashScope (Multi-Agent)";
+        }
+    }
 }


### PR DESCRIPTION
## AgentScope-Java Version

1.0.11

## Description

- Add Qwen3.5-Plus, Qwen3.5-Flash, and Qwen3.5-397B-A17B models to DashScopeCompatibleProvider

## Checklist

Please check the following items before code is ready to be reviewed.

- [x]  Code has been formatted with `mvn spotless:apply`
- [x]  All tests are passing (`mvn test`)
- [x]  Javadoc comments are complete and follow project conventions
- [x]  Related documentation has been updated (e.g. links, examples, etc.)
- [x]  Code is ready for review
