### PR TITLE
fix: make dimensions parameter optional in OpenAITextEmbedding (#1095)

### DIFF
--- a/agentscope-extensions/agentscope-extensions-rag-simple/src/main/java/io/agentscope/core/embedding/openai/OpenAITextEmbedding.java
+++ b/agentscope-extensions/agentscope-extensions-rag-simple/src/main/java/io/agentscope/core/embedding/openai/OpenAITextEmbedding.java
@@ -49,7 +49,7 @@ public class OpenAITextEmbedding implements EmbeddingModel {
 
     private final String apiKey;
     private final String modelName;
-    private final int dimensions;
+    private final Integer dimensions;
     private final ExecutionConfig defaultExecutionConfig;
 
     private final String baseUrl;
@@ -66,7 +66,7 @@ public class OpenAITextEmbedding implements EmbeddingModel {
     public OpenAITextEmbedding(
             String apiKey,
             String modelName,
-            int dimensions,
+            Integer dimensions,
             ExecutionConfig defaultExecutionConfig,
             String baseUrl) {
         this.apiKey = apiKey;
@@ -132,15 +132,16 @@ public class OpenAITextEmbedding implements EmbeddingModel {
 
                                         OpenAIClient client = clientBuilder.build();
 
-                                        EmbeddingCreateParams createParams =
-                                                EmbeddingCreateParams.builder()
-                                                        .model(modelName)
-                                                        .dimensions(dimensions)
-                                                        .encodingFormat(
-                                                                EmbeddingCreateParams.EncodingFormat
-                                                                        .FLOAT)
-                                                        .inputOfArrayOfStrings(List.of(text))
-                                                        .build();
+                                        EmbeddingCreateParams.Builder paramsBuilder = EmbeddingCreateParams.builder()
+                                                .model(modelName)
+                                                .encodingFormat(EmbeddingCreateParams.EncodingFormat.FLOAT)
+                                                .inputOfArrayOfStrings(List.of(text));
+
+                                        if (dimensions != null && dimensions > 0) {
+                                            paramsBuilder.dimensions(dimensions);
+                                        }
+
+                                        EmbeddingCreateParams createParams = paramsBuilder.build();
 
                                         log.debug(
                                                 "OpenAI embedding call: model={},"
@@ -182,12 +183,9 @@ public class OpenAITextEmbedding implements EmbeddingModel {
                                                         embeddingValues);
 
                                         // Validate dimension
-                                        if (embeddingArray.length != dimensions) {
-                                            log.warn(
-                                                    "Embedding dimension mismatch: expected={},"
-                                                            + " actual={}",
-                                                    dimensions,
-                                                    embeddingArray.length);
+                                        if (dimensions != null && embeddingArray.length != dimensions) {
+                                            log.warn("Embedding dimension mismatch: expected={}, actual={}",
+                                                    dimensions, embeddingArray.length);
                                         }
 
                                         return embeddingArray;
@@ -225,7 +223,7 @@ public class OpenAITextEmbedding implements EmbeddingModel {
 
     @Override
     public int getDimensions() {
-        return dimensions;
+        return dimensions != null ? dimensions : 0;
     }
 
     /**
@@ -234,7 +232,7 @@ public class OpenAITextEmbedding implements EmbeddingModel {
     public static class Builder {
         private String apiKey;
         private String modelName;
-        private int dimensions = 1536;
+        private Integer dimensions;
         private ExecutionConfig defaultExecutionConfig;
         private String baseUrl;
 
@@ -266,7 +264,7 @@ public class OpenAITextEmbedding implements EmbeddingModel {
          * @param dimensions the dimension
          * @return this builder instance
          */
-        public Builder dimensions(int dimensions) {
+        public Builder dimensions(Integer dimensions) {
             this.dimensions = dimensions;
             return this;
         }
@@ -311,8 +309,8 @@ public class OpenAITextEmbedding implements EmbeddingModel {
                 throw new IllegalStateException(
                         "modelName is required and cannot be null or empty");
             }
-            if (dimensions <= 0) {
-                throw new IllegalStateException("dimensions must be positive, got: " + dimensions);
+            if (dimensions != null && dimensions <= 0) {
+                throw new IllegalStateException("dimensions must be positive if provided, got: " + dimensions);
             }
 
             ExecutionConfig effectiveConfig =

--- a/agentscope-extensions/agentscope-extensions-rag-simple/src/main/java/io/agentscope/core/embedding/openai/OpenAITextEmbedding.java
+++ b/agentscope-extensions/agentscope-extensions-rag-simple/src/main/java/io/agentscope/core/embedding/openai/OpenAITextEmbedding.java
@@ -132,10 +132,13 @@ public class OpenAITextEmbedding implements EmbeddingModel {
 
                                         OpenAIClient client = clientBuilder.build();
 
-                                        EmbeddingCreateParams.Builder paramsBuilder = EmbeddingCreateParams.builder()
-                                                .model(modelName)
-                                                .encodingFormat(EmbeddingCreateParams.EncodingFormat.FLOAT)
-                                                .inputOfArrayOfStrings(List.of(text));
+                                        EmbeddingCreateParams.Builder paramsBuilder =
+                                                EmbeddingCreateParams.builder()
+                                                        .model(modelName)
+                                                        .encodingFormat(
+                                                                EmbeddingCreateParams.EncodingFormat
+                                                                        .FLOAT)
+                                                        .inputOfArrayOfStrings(List.of(text));
 
                                         if (dimensions != null && dimensions > 0) {
                                             paramsBuilder.dimensions(dimensions);
@@ -183,9 +186,13 @@ public class OpenAITextEmbedding implements EmbeddingModel {
                                                         embeddingValues);
 
                                         // Validate dimension
-                                        if (dimensions != null && embeddingArray.length != dimensions) {
-                                            log.warn("Embedding dimension mismatch: expected={}, actual={}",
-                                                    dimensions, embeddingArray.length);
+                                        if (dimensions != null
+                                                && embeddingArray.length != dimensions) {
+                                            log.warn(
+                                                    "Embedding dimension mismatch: expected={},"
+                                                            + " actual={}",
+                                                    dimensions,
+                                                    embeddingArray.length);
                                         }
 
                                         return embeddingArray;
@@ -310,7 +317,8 @@ public class OpenAITextEmbedding implements EmbeddingModel {
                         "modelName is required and cannot be null or empty");
             }
             if (dimensions != null && dimensions <= 0) {
-                throw new IllegalStateException("dimensions must be positive if provided, got: " + dimensions);
+                throw new IllegalStateException(
+                        "dimensions must be positive if provided, got: " + dimensions);
             }
 
             ExecutionConfig effectiveConfig =

--- a/agentscope-extensions/agentscope-extensions-rag-simple/src/test/java/io/agentscope/core/embedding/openai/OpenAITextEmbeddingTest.java
+++ b/agentscope-extensions/agentscope-extensions-rag-simple/src/test/java/io/agentscope/core/embedding/openai/OpenAITextEmbeddingTest.java
@@ -260,4 +260,19 @@ class OpenAITextEmbeddingTest {
                                 .dimensions(-1)
                                 .build());
     }
+
+    @Test
+    @DisplayName("Should support optional dimensions in builder")
+    void testOptionalDimensions() {
+        OpenAITextEmbedding model =
+                OpenAITextEmbedding.builder()
+                        .apiKey(TEST_API_KEY)
+                        .modelName(TEST_MODEL_NAME)
+                        .build();
+
+        assertNotNull(model);
+        assertEquals(TEST_MODEL_NAME, model.getModelName());
+
+        assertEquals(0, model.getDimensions());
+    }
 }


### PR DESCRIPTION
## AgentScope-Java Version
1.0.12-SNAPSHOT

## Description
Background & Purpose:
Currently, `OpenAITextEmbedding` enforces a mandatory `dimensions` parameter. This causes 400 Bad Request errors when using open-source embedding models (like BAAI/bge) through the OpenAI-compatible API, as these models do not support the Matryoshka representation parameter.

Changes:
- Changed `dimensions` type from `int` to `Integer` in `OpenAITextEmbedding` and its `Builder`.
- Removed the hardcoded default value of `1536` to make it optional.
- Updated the request builder logic to only include the `dimensions` field in the API payload if it is explicitly provided.
- Added null checks in `embed()`, `getDimensions()`, and validation logic to ensure stability.

How to test:
Initialize `OpenAITextEmbedding` without calling `.dimensions()`. Verify that the outgoing JSON request to the embedding endpoint does not contain the `dimensions` key.

## Checklist
- [x] Code has been formatted with mvn spotless:apply
- [x] All tests are passing (mvn test)
- [x] Javadoc comments are complete and follow project conventions
- [x] Code is ready for review