### PR TITLE
feat(model): Support DashScope model preserve_thinking option

### DIFF
--- a/agentscope-core/src/main/java/io/agentscope/core/formatter/dashscope/dto/DashScopeParameters.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/formatter/dashscope/dto/DashScopeParameters.java
@@ -60,6 +60,12 @@ public class DashScopeParameters {
     @JsonProperty("enable_thinking")
     private Boolean enableThinking;
 
+    /**
+     *  Whether to stitch the reasoning_content of the assistant message in the conversation history to the model input.
+     */
+    @JsonProperty("preserve_thinking")
+    private Boolean preserveThinking;
+
     /** Token budget for thinking. */
     @JsonProperty("thinking_budget")
     private Integer thinkingBudget;
@@ -175,6 +181,14 @@ public class DashScopeParameters {
 
     public void setEnableThinking(Boolean enableThinking) {
         this.enableThinking = enableThinking;
+    }
+
+    public Boolean getPreserveThinking() {
+        return preserveThinking;
+    }
+
+    public void setPreserveThinking(Boolean preserveThinking) {
+        this.preserveThinking = preserveThinking;
     }
 
     public Integer getThinkingBudget() {
@@ -317,6 +331,11 @@ public class DashScopeParameters {
 
         public Builder enableThinking(Boolean enableThinking) {
             params.setEnableThinking(enableThinking);
+            return this;
+        }
+
+        public Builder preserveThinking(Boolean preserveThinking) {
+            params.setPreserveThinking(preserveThinking);
             return this;
         }
 

--- a/agentscope-core/src/main/java/io/agentscope/core/formatter/dashscope/dto/DashScopeParameters.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/formatter/dashscope/dto/DashScopeParameters.java
@@ -60,9 +60,7 @@ public class DashScopeParameters {
     @JsonProperty("enable_thinking")
     private Boolean enableThinking;
 
-    /**
-     *  Whether to stitch the reasoning_content of the assistant message in the conversation history to the model input.
-     */
+    /** Whether to append the reasoning_content to the model input. */
     @JsonProperty("preserve_thinking")
     private Boolean preserveThinking;
 

--- a/agentscope-core/src/main/java/io/agentscope/core/model/DashScopeChatModel.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/model/DashScopeChatModel.java
@@ -56,6 +56,7 @@ public class DashScopeChatModel extends ChatModelBase {
     private final String modelName;
     private final boolean stream;
     private final Boolean enableThinking; // nullable
+    private final Boolean preserveThinking; // nullable
     private final Boolean enableSearch; // nullable
     private final EndpointType endpointType;
     private final GenerateOptions defaultOptions;
@@ -81,7 +82,9 @@ public class DashScopeChatModel extends ChatModelBase {
      * @param httpTransport custom HTTP transport (null for default from factory)
      * @param publicKeyId the RSA public key ID for encryption (null to disable encryption)
      * @param publicKey the RSA public key for encryption (Base64-encoded, null to disable encryption)
+     * @deprecated Use {@link #builder()} instead.
      */
+    @Deprecated(since = "1.1.0", forRemoval = true)
     public DashScopeChatModel(
             String apiKey,
             String modelName,
@@ -124,12 +127,61 @@ public class DashScopeChatModel extends ChatModelBase {
      * @param httpTransport custom HTTP transport (null for default from factory)
      * @param publicKeyId the RSA public key ID for encryption (null to disable encryption)
      * @param publicKey the RSA public key for encryption (Base64-encoded, null to disable encryption)
+     * @deprecated Use {@link #builder()} instead.
      */
+    @Deprecated(since = "1.1.0", forRemoval = true)
     public DashScopeChatModel(
             String apiKey,
             String modelName,
             boolean stream,
             Boolean enableThinking,
+            Boolean enableSearch,
+            EndpointType endpointType,
+            GenerateOptions defaultOptions,
+            String baseUrl,
+            Formatter<DashScopeMessage, DashScopeResponse, DashScopeRequest> formatter,
+            HttpTransport httpTransport,
+            String publicKeyId,
+            String publicKey) {
+        this(
+                apiKey,
+                modelName,
+                stream,
+                enableThinking,
+                null,
+                enableSearch,
+                null,
+                defaultOptions,
+                baseUrl,
+                formatter,
+                httpTransport,
+                publicKeyId,
+                publicKey);
+    }
+
+    /**
+     * Creates a new DashScope chat model instance with explicit API type.
+     *
+     * @param apiKey the API key for DashScope authentication
+     * @param modelName the model name (e.g., "qwen-max", "qwen-vl-plus")
+     * @param stream whether streaming should be enabled (ignored if enableThinking is true)
+     * @param enableThinking whether thinking mode should be enabled (null for disabled)
+     * @param preserveThinking whether to append reasoning_content (null for disabled)
+     * @param enableSearch whether search enhancement should be enabled (null for disabled)
+     * @param endpointType the endpoint type to use (null for AUTO detection)
+     * @param defaultOptions default generation options (null for defaults)
+     * @param baseUrl custom base URL for DashScope API (null for default)
+     * @param formatter the message formatter to use (null for default DashScope formatter)
+     * @param httpTransport custom HTTP transport (null for default from factory)
+     * @param publicKeyId the RSA public key ID for encryption (null to disable encryption)
+     * @param publicKey the RSA public key for encryption (Base64-encoded, null to disable encryption)
+     */
+    protected DashScopeChatModel(
+            String apiKey,
+            String modelName,
+            boolean stream,
+            Boolean enableThinking,
+            Boolean preserveThinking,
             Boolean enableSearch,
             EndpointType endpointType,
             GenerateOptions defaultOptions,
@@ -147,6 +199,7 @@ public class DashScopeChatModel extends ChatModelBase {
         }
         this.stream = enableThinking != null && enableThinking ? true : stream;
         this.enableThinking = enableThinking;
+        this.preserveThinking = preserveThinking;
         this.enableSearch = enableSearch;
         this.endpointType = endpointType != null ? endpointType : EndpointType.AUTO;
         this.defaultOptions =
@@ -337,6 +390,10 @@ public class DashScopeChatModel extends ChatModelBase {
             request.getParameters().setThinkingBudget(options.getThinkingBudget());
         }
 
+        if (Boolean.TRUE.equals(enableThinking) && preserveThinking != null) {
+            request.getParameters().setPreserveThinking(preserveThinking);
+        }
+
         // Model-specific settings for search mode
         if (enableSearch != null) {
             // Explicitly assign value for search mode
@@ -359,6 +416,7 @@ public class DashScopeChatModel extends ChatModelBase {
         private String modelName;
         private boolean stream = true;
         private Boolean enableThinking;
+        private Boolean preserveThinking;
         private Boolean enableSearch;
         private EndpointType endpointType;
         private GenerateOptions defaultOptions = null;
@@ -417,6 +475,19 @@ public class DashScopeChatModel extends ChatModelBase {
          */
         public Builder enableThinking(Boolean enableThinking) {
             this.enableThinking = enableThinking;
+            return this;
+        }
+
+        /**
+         * Sets whether to append the reasoning_content of the assistant message in the conversation history to the model input.
+         *
+         * <p>When enabled, this reasoning_content will be appended to the model input.
+         *
+         * @param preserveThinking true to append reasoning_content, false to disable, null for default (disabled)
+         * @return this builder instance
+         */
+        public Builder preserveThinking(Boolean preserveThinking) {
+            this.preserveThinking = preserveThinking;
             return this;
         }
 
@@ -575,6 +646,7 @@ public class DashScopeChatModel extends ChatModelBase {
                     modelName,
                     stream,
                     enableThinking,
+                    preserveThinking,
                     enableSearch,
                     endpointType,
                     effectiveOptions,

--- a/agentscope-core/src/test/java/io/agentscope/core/formatter/dashscope/dto/DashScopeDtoSerializationTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/formatter/dashscope/dto/DashScopeDtoSerializationTest.java
@@ -342,6 +342,7 @@ class DashScopeDtoSerializationTest {
                         .topP(0.95)
                         .maxTokens(2048)
                         .enableThinking(true)
+                        .preserveThinking(true)
                         .thinkingBudget(500)
                         .seed(42)
                         .frequencyPenalty(0.5)
@@ -354,6 +355,7 @@ class DashScopeDtoSerializationTest {
         assertEquals(0.95, params.getTopP());
         assertEquals(2048, params.getMaxTokens());
         assertTrue(params.getEnableThinking());
+        assertTrue(params.getPreserveThinking());
         assertEquals(500, params.getThinkingBudget());
         assertEquals(42, params.getSeed());
         assertEquals(0.5, params.getFrequencyPenalty());

--- a/agentscope-core/src/test/java/io/agentscope/core/model/DashScopeChatModelTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/model/DashScopeChatModelTest.java
@@ -24,6 +24,8 @@ import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.agentscope.core.formatter.dashscope.DashScopeChatFormatter;
 import io.agentscope.core.formatter.dashscope.DashScopeMultiAgentFormatter;
 import io.agentscope.core.formatter.dashscope.dto.DashScopeParameters;
@@ -67,10 +69,13 @@ class DashScopeChatModelTest {
 
     private DashScopeChatModel model;
     private String mockApiKey;
+    private ObjectMapper objectMapper;
     private MockWebServer mockServer;
 
     @BeforeEach
     void setUp() throws IOException {
+        objectMapper = new ObjectMapper();
+
         mockApiKey = ModelTestUtils.createMockApiKey();
 
         mockServer = new MockWebServer();
@@ -243,6 +248,8 @@ class DashScopeChatModelTest {
                         null,
                         null,
                         null,
+                        null,
+                        null,
                         null);
 
         assertNotNull(model, "Model from overloaded constructor should be created");
@@ -257,6 +264,7 @@ class DashScopeChatModelTest {
                         mockApiKey,
                         "qwen3.5-plus",
                         true,
+                        null,
                         null,
                         null,
                         EndpointType.MULTIMODAL,
@@ -971,6 +979,194 @@ class DashScopeChatModelTest {
         assertFalse(
                 body.contains("\"cache_control\""),
                 "Request body should NOT contain cache_control when disabled: " + body);
+
+        mockServer.shutdown();
+    }
+
+    @Test
+    @DisplayName(
+            "Should set preserve_thinking to true in the request when preserveThinking option is"
+                    + " enabled")
+    void testPreserveThinkingEnabled() throws Exception {
+        MockWebServer mockServer = new MockWebServer();
+        mockServer.start();
+
+        mockServer.enqueue(
+                new MockResponse()
+                        .setResponseCode(200)
+                        .setBody(
+                                """
+                                        {
+                                            "request_id": "test",
+                                            "output": {
+                                                "choices": []
+                                            }
+                                        }
+                                """)
+                        .setHeader("Content-Type", "application/json"));
+
+        DashScopeChatModel chatModel =
+                DashScopeChatModel.builder()
+                        .apiKey(mockApiKey)
+                        .modelName("qwen-plus")
+                        .enableThinking(true)
+                        .preserveThinking(true)
+                        .baseUrl(mockServer.url("/").toString().replaceAll("/$", ""))
+                        .httpTransport(OkHttpTransport.builder().build())
+                        .build();
+
+        chatModel
+                .doStream(
+                        List.of(
+                                Msg.builder()
+                                        .role(MsgRole.SYSTEM)
+                                        .content(
+                                                TextBlock.builder()
+                                                        .text("You are helpful.")
+                                                        .build())
+                                        .build(),
+                                Msg.builder()
+                                        .role(MsgRole.USER)
+                                        .content(TextBlock.builder().text("Hello").build())
+                                        .build()),
+                        List.of(),
+                        GenerateOptions.builder().build())
+                .blockLast();
+
+        RecordedRequest recorded = mockServer.takeRequest();
+        String body = recorded.getBody().readUtf8();
+        JsonNode jsonNode = objectMapper.readTree(body).get("parameters");
+        assertTrue(
+                jsonNode.get("enable_thinking").asBoolean(),
+                "Request body should set enable_thinking to true: " + body);
+        assertTrue(
+                jsonNode.get("preserve_thinking").asBoolean(),
+                "Request body should set preserve_thinking to true: " + body);
+
+        mockServer.shutdown();
+    }
+
+    @Test
+    @DisplayName(
+            "Should set preserve_thinking to false in the request when preserveThinking option is"
+                    + " disabled")
+    void testPreserveThinkingDisabled() throws Exception {
+        MockWebServer mockServer = new MockWebServer();
+        mockServer.start();
+
+        mockServer.enqueue(
+                new MockResponse()
+                        .setResponseCode(200)
+                        .setBody(
+                                """
+                                        {
+                                            "request_id": "test",
+                                            "output": {
+                                                "choices": []
+                                            }
+                                        }
+                                """)
+                        .setHeader("Content-Type", "application/json"));
+
+        DashScopeChatModel chatModel =
+                DashScopeChatModel.builder()
+                        .apiKey(mockApiKey)
+                        .modelName("qwen-plus")
+                        .enableThinking(true)
+                        .preserveThinking(false)
+                        .baseUrl(mockServer.url("/").toString().replaceAll("/$", ""))
+                        .httpTransport(OkHttpTransport.builder().build())
+                        .build();
+
+        chatModel
+                .doStream(
+                        List.of(
+                                Msg.builder()
+                                        .role(MsgRole.SYSTEM)
+                                        .content(
+                                                TextBlock.builder()
+                                                        .text("You are helpful.")
+                                                        .build())
+                                        .build(),
+                                Msg.builder()
+                                        .role(MsgRole.USER)
+                                        .content(TextBlock.builder().text("Hello").build())
+                                        .build()),
+                        List.of(),
+                        GenerateOptions.builder().build())
+                .blockLast();
+
+        RecordedRequest recorded = mockServer.takeRequest();
+        String body = recorded.getBody().readUtf8();
+        JsonNode jsonNode = objectMapper.readTree(body).get("parameters");
+        assertTrue(
+                jsonNode.get("enable_thinking").asBoolean(),
+                "Request body should set enable_thinking to true: " + body);
+        assertFalse(
+                jsonNode.get("preserve_thinking").asBoolean(),
+                "Request body should set preserve_thinking to false: " + body);
+
+        mockServer.shutdown();
+    }
+
+    @Test
+    @DisplayName(
+            "Should not apply preserve_thinking to request when enableThinking option is disabled")
+    void testPreserveThinkingWhenEnableThinkingDisabled() throws Exception {
+        MockWebServer mockServer = new MockWebServer();
+        mockServer.start();
+
+        mockServer.enqueue(
+                new MockResponse()
+                        .setResponseCode(200)
+                        .setBody(
+                                """
+                                        {
+                                            "request_id": "test",
+                                            "output": {
+                                                "choices": []
+                                            }
+                                        }
+                                """)
+                        .setHeader("Content-Type", "application/json"));
+
+        DashScopeChatModel chatModel =
+                DashScopeChatModel.builder()
+                        .apiKey(mockApiKey)
+                        .modelName("qwen-plus")
+                        .enableThinking(false)
+                        .preserveThinking(true)
+                        .baseUrl(mockServer.url("/").toString().replaceAll("/$", ""))
+                        .httpTransport(OkHttpTransport.builder().build())
+                        .build();
+
+        chatModel
+                .doStream(
+                        List.of(
+                                Msg.builder()
+                                        .role(MsgRole.SYSTEM)
+                                        .content(
+                                                TextBlock.builder()
+                                                        .text("You are helpful.")
+                                                        .build())
+                                        .build(),
+                                Msg.builder()
+                                        .role(MsgRole.USER)
+                                        .content(TextBlock.builder().text("Hello").build())
+                                        .build()),
+                        List.of(),
+                        GenerateOptions.builder().build())
+                .blockLast();
+
+        RecordedRequest recorded = mockServer.takeRequest();
+        String body = recorded.getBody().readUtf8();
+        JsonNode jsonNode = objectMapper.readTree(body).get("parameters");
+        assertFalse(
+                jsonNode.get("enable_thinking").asBoolean(),
+                "Request body should set enable_thinking to false: " + body);
+        assertNull(
+                jsonNode.get("preserve_thinking"),
+                "Request body should not apply preserve_thinking: " + body);
 
         mockServer.shutdown();
     }

--- a/agentscope-extensions/agentscope-extensions-rag-simple/src/main/java/io/agentscope/core/rag/store/MilvusStore.java
+++ b/agentscope-extensions/agentscope-extensions-rag-simple/src/main/java/io/agentscope/core/rag/store/MilvusStore.java
@@ -195,22 +195,6 @@ public class MilvusStore implements VDBStoreBase, AutoCloseable {
         }
     }
 
-    /**
-     * Creates a new MilvusStore with minimal configuration.
-     *
-     * @param uri the Milvus server URI (e.g., "http://localhost:19530")
-     * @param collectionName the name of the collection to use
-     * @param dimensions the dimension of vectors that will be stored
-     * @return a new MilvusStore instance
-     * @throws VectorStoreException if initialization fails
-     * @deprecated Use {@link MilvusStore#builder()} instead
-     */
-    @Deprecated(since = "1.0.11", forRemoval = true)
-    public static MilvusStore create(String uri, String collectionName, int dimensions)
-            throws VectorStoreException {
-        return builder().uri(uri).collectionName(collectionName).dimensions(dimensions).build();
-    }
-
     @Override
     public Mono<Void> add(List<Document> documents) {
         if (documents == null) {


### PR DESCRIPTION
## AgentScope-Java Version

1.0.12

## Description

* Support DashScope Model `preserve_thinking` option.
* Delete deprecated method for `MilvusStore`.

## Checklist

Please check the following items before code is ready to be reviewed.

- [x]  Code has been formatted with `mvn spotless:apply`
- [x]  All tests are passing (`mvn test`)
- [x]  Javadoc comments are complete and follow project conventions
- [x]  Related documentation has been updated (e.g. links, examples, etc.)
- [x]  Code is ready for review
