### PR TITLE
fix: handle Map type in getChatUsage() after deserialization

### DIFF
--- a/agentscope-core/src/main/java/io/agentscope/core/message/Msg.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/message/Msg.java
@@ -421,11 +421,12 @@ public class Msg implements State {
         if (usage instanceof Map) {
             @SuppressWarnings("unchecked")
             Map<String, Object> map = (Map<String, Object>) usage;
-            ChatUsage chatUsage = ChatUsage.builder()
-                    .inputTokens(toInt(map.get("inputTokens")))
-                    .outputTokens(toInt(map.get("outputTokens")))
-                    .time(toDouble(map.get("time")))
-                    .build();
+            ChatUsage chatUsage =
+                    ChatUsage.builder()
+                            .inputTokens(toInt(map.get("inputTokens")))
+                            .outputTokens(toInt(map.get("outputTokens")))
+                            .time(toDouble(map.get("time")))
+                            .build();
             metadata.put(MessageMetadataKeys.CHAT_USAGE, chatUsage);
             return chatUsage;
         }

--- a/agentscope-core/src/main/java/io/agentscope/core/message/Msg.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/message/Msg.java
@@ -415,7 +415,35 @@ public class Msg implements State {
             return null;
         }
         Object usage = metadata.get(MessageMetadataKeys.CHAT_USAGE);
-        return usage instanceof ChatUsage ? (ChatUsage) usage : null;
+        if (usage instanceof ChatUsage) {
+            return (ChatUsage) usage;
+        }
+        if (usage instanceof Map) {
+            @SuppressWarnings("unchecked")
+            Map<String, Object> map = (Map<String, Object>) usage;
+            ChatUsage chatUsage = ChatUsage.builder()
+                    .inputTokens(toInt(map.get("inputTokens")))
+                    .outputTokens(toInt(map.get("outputTokens")))
+                    .time(toDouble(map.get("time")))
+                    .build();
+            metadata.put(MessageMetadataKeys.CHAT_USAGE, chatUsage);
+            return chatUsage;
+        }
+        return null;
+    }
+
+    private static int toInt(Object value) {
+        if (value instanceof Number) {
+            return ((Number) value).intValue();
+        }
+        return 0;
+    }
+
+    private static double toDouble(Object value) {
+        if (value instanceof Number) {
+            return ((Number) value).doubleValue();
+        }
+        return 0.0;
     }
 
     /**


### PR DESCRIPTION
## Summary

`getChatUsage()` returns null when `_chat_usage` metadata is a Map (after session persistence/reload) instead of a ChatUsage object.

## Why this matters

When messages are persisted via `agent.loadFrom()` and reloaded, JSON deserialization converts the `_chat_usage` metadata value to a `Map<String, Object>` instead of a `ChatUsage` instance. The existing `instanceof ChatUsage` check fails, returning null even though the token usage data exists in the metadata.

## Changes

`agentscope-core/src/main/java/io/agentscope/core/message/Msg.java`:

- Added Map handling in `getChatUsage()` (line 413): when the metadata value is a Map, extract `inputTokens`, `outputTokens`, and `time` fields, build a ChatUsage via the builder, and cache it back in metadata for subsequent calls
- Added `toInt()` and `toDouble()` helper methods for safe numeric conversion from deserialized values (handles Integer, Long, Double from JSON)

## Testing

- When `_chat_usage` is a ChatUsage object: unchanged behavior
- When `_chat_usage` is a Map (post-deserialization): converts to ChatUsage and returns it
- When `_chat_usage` is null or absent: returns null (unchanged)
- The converted ChatUsage is cached back in metadata so the conversion only happens once

Fixes #1115

This contribution was developed with AI assistance (Claude Code).