### PR TITLE
Fix: preserve LLM metadata (_chat_usage) in StructuredOutputHook

### DIFF
--- a/agentscope-core/src/main/java/io/agentscope/core/agent/StructuredOutputHook.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/agent/StructuredOutputHook.java
@@ -145,6 +145,29 @@ public class StructuredOutputHook implements Hook {
 
         boolean hasCall = !msg.getContentBlocks(ToolUseBlock.class).isEmpty();
 
+        // Capture metadata from reasoning message (including _chat_usage)
+        // This ensures metadata is preserved even when generate_response is called
+        if (hasCall) {
+            ChatUsage usage = msg.getChatUsage();
+            if (usage != null) {
+                // Aggregate usage from all reasoning rounds
+                if (this.aggregatedUsage == null) {
+                    this.aggregatedUsage = usage;
+                } else {
+                    this.aggregatedUsage = ChatUsage.builder()
+                            .inputTokens(this.aggregatedUsage.getInputTokens() + usage.getInputTokens())
+                            .outputTokens(this.aggregatedUsage.getOutputTokens() + usage.getOutputTokens())
+                            .time(this.aggregatedUsage.getTime() + usage.getTime())
+                            .build();
+                }
+            }
+            // Capture ThinkingBlock (keep the last one)
+            ThinkingBlock thinking = msg.getFirstContentBlock(ThinkingBlock.class);
+            if (thinking != null) {
+                this.aggregatedThinking = thinking;
+            }
+        }
+
         if (!hasCall && retryCount < MAX_RETRIES) {
             retryCount++;
             log.debug(


### PR DESCRIPTION
## Description
This PR fixes the metadata loss issue in StructuredOutputHook where LLM call metadata (such as _chat_usage containing token usage information) was lost during the structured output generation flow.

## Root Cause
In handlePostReasoning(), when the model called generate_response tool, the reasoning message metadata was not being captured. This caused the final ASSISTANT message to lose metadata fields like _chat_usage.

## Solution
Modified handlePostReasoning() to capture and aggregate ChatUsage and ThinkingBlock from the reasoning message when tools are called. This ensures metadata is properly propagated through the entire structured output flow.

## Changes
- agentscope-core/src/main/java/io/agentscope/core/agent/StructuredOutputHook.java: Added metadata capture logic in handlePostReasoning() to aggregate ChatUsage and ThinkingBlock from reasoning messages.

## Testing
The fix ensures that:
1. Memory path: The final message saved to session/memory preserves metadata
2. API return path: The Msg returned by agent.call() preserves metadata
3. When both reasoning and response messages contain metadata, they are properly merged instead of overwritten.