### PR TITLE
fix(tool): prevent SubAgent name collisions for unsupported characters via deterministic hashing

### DIFF
--- a/agentscope-core/src/main/java/io/agentscope/core/tool/subagent/SubAgentTool.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/tool/subagent/SubAgentTool.java
@@ -420,12 +420,13 @@ public class SubAgentTool implements AgentTool {
      * @return A sanitized, safe-to-use tool name.
      */
     private String sanitizeName(String prefix, String originalName) {
-        // Keep the underline, replace other illegal characters with underscores uniformly,
+        // Keep the underscore, replace other illegal characters with underscores uniformly,
         // merge consecutive underscores, and remove the first and last underscores
         String safePart =
                 originalName
                         .toLowerCase()
                         .replaceAll("[^a-z0-9_-]+", "_")
+                        .replaceAll("_+", "_")
                         .replaceAll("^_+|_+$", "");
 
         if (safePart.isEmpty()) {
@@ -444,9 +445,10 @@ public class SubAgentTool implements AgentTool {
             String suffix = "_" + shortHash;
 
             logger.warn(
-                    "Agent name '{}' contains non-ASCII characters or is too long. Appended hash"
-                            + " '{}' to prevent collisions. Recommended to configure an explicit"
-                            + " English 'toolName' via SubAgentConfig.",
+                    "Agent name '{}' contains unsupported characters or is too long. Appended hash"
+                        + " '{}' to prevent collisions. Only alphanumeric characters, underscores,"
+                        + " and hyphens are supported in generated names. Recommended to configure"
+                        + " an explicit English 'toolName' via SubAgentConfig.",
                     originalName,
                     shortHash);
 

--- a/agentscope-core/src/main/java/io/agentscope/core/tool/subagent/SubAgentTool.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/tool/subagent/SubAgentTool.java
@@ -31,6 +31,7 @@ import io.agentscope.core.util.JsonUtils;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.UUID;
 import org.slf4j.Logger;
@@ -422,9 +423,8 @@ public class SubAgentTool implements AgentTool {
     private String sanitizeName(String prefix, String originalName) {
         // Keep the underscore, replace other illegal characters with underscores uniformly,
         // merge consecutive underscores, and remove the first and last underscores
-        String safePart =
-                originalName
-                        .toLowerCase()
+        String lowerOriginal = originalName.toLowerCase(Locale.ROOT);
+        String safePart = lowerOriginal
                         .replaceAll("[^a-z0-9_-]+", "_")
                         .replaceAll("_+", "_")
                         .replaceAll("^_+|_+$", "");
@@ -434,9 +434,9 @@ public class SubAgentTool implements AgentTool {
         }
 
         String resolvedName = prefix + safePart;
-        boolean isPureEnglish = originalName.toLowerCase().matches("^[a-z0-9_-]+$");
+        boolean isInformationLost = lowerOriginal.matches("^[a-z0-9_\\-\\s]+$");
 
-        boolean needsHash = !isPureEnglish || resolvedName.length() > 64;
+        boolean needsHash = !isInformationLost || resolvedName.length() > 64;
 
         if (needsHash) {
             // Generate deterministic hash

--- a/agentscope-core/src/main/java/io/agentscope/core/tool/subagent/SubAgentTool.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/tool/subagent/SubAgentTool.java
@@ -28,6 +28,7 @@ import io.agentscope.core.tool.AgentTool;
 import io.agentscope.core.tool.ToolCallParam;
 import io.agentscope.core.tool.ToolEmitter;
 import io.agentscope.core.util.JsonUtils;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -388,24 +389,89 @@ public class SubAgentTool implements AgentTool {
     /**
      * Resolves the tool name from config or derives it from the agent.
      *
-     * <p>Priority: config.toolName > derived from agent name. When deriving from agent name, the
-     * name is converted to lowercase and prefixed with "call_" (e.g., "ResearchAgent" becomes
-     * "call_researchagent").
+     * <p>Priority: explicit config.toolName > derived from agent name.
+     * If derived from the agent name, the name will be sanitized to comply with strict LLM API constraints
+     * (e.g., ^[a-zA-Z0-9_-]{1,64}$). For non-English characters (like Chinese) or excessively long names,
+     * a deterministic short hash of the original name is appended to prevent naming collisions.
      *
      * @param agent The agent to derive name from if not configured
      * @param config The configuration that may override the name
      * @return The resolved tool name
      */
     private String resolveToolName(Agent agent, SubAgentConfig config) {
-        if (config.getToolName() != null && !config.getToolName().isEmpty()) {
-            return config.getToolName();
+        if (config.getToolName() != null && !config.getToolName().trim().isEmpty()) {
+            return config.getToolName().trim();
         }
-        // Generate from agent name: "ResearchAgent" -> "call_researchagent"
-        String agentName = agent.getName();
-        if (agentName == null || agentName.isEmpty()) {
+
+        if (agent.getName() == null || agent.getName().trim().isEmpty()) {
             return "call_agent";
         }
-        return "call_" + agentName.toLowerCase().replaceAll("[^a-z0-9]", "_");
+
+        return sanitizeName("call_", agent.getName().trim());
+    }
+
+    /**
+     * Helper method for {@link #resolveToolName(Agent, SubAgentConfig)}.
+     * Extracts valid characters, lazily computes a deterministic hash
+     * if necessary, and strictly enforces length limits via safe truncation.
+     *
+     * @param prefix The prefix to prepend to the tool name (e.g., "call_").
+     * @param originalName The original name of the agent.
+     * @return A sanitized, safe-to-use tool name.
+     */
+    private String sanitizeName(String prefix, String originalName) {
+        // Keep the underline, replace other illegal characters with underscores uniformly,
+        // merge consecutive underscores, and remove the first and last underscores
+        String safePart =
+                originalName
+                        .toLowerCase()
+                        .replaceAll("[^a-z0-9_-]+", "_")
+                        .replaceAll("^_+|_+$", "");
+
+        if (safePart.isEmpty()) {
+            safePart = "agent";
+        }
+
+        String resolvedName = prefix + safePart;
+        boolean isPureEnglish = originalName.toLowerCase().matches("^[a-z0-9_-]+$");
+
+        boolean needsHash = !isPureEnglish || resolvedName.length() > 64;
+
+        if (needsHash) {
+            // Generate deterministic hash
+            UUID uuid = UUID.nameUUIDFromBytes(originalName.getBytes(StandardCharsets.UTF_8));
+            String shortHash = uuid.toString().replace("-", "").substring(0, 8);
+            String suffix = "_" + shortHash;
+
+            logger.warn(
+                    "Agent name '{}' contains non-ASCII characters or is too long. Appended hash"
+                            + " '{}' to prevent collisions. Recommended to configure an explicit"
+                            + " English 'toolName' via SubAgentConfig.",
+                    originalName,
+                    shortHash);
+
+            resolvedName = prefix + safePart + suffix;
+
+            if (resolvedName.length() > 64) {
+                int allowedSafePartLen = 64 - prefix.length() - suffix.length();
+                if (allowedSafePartLen > 0) {
+                    // replaceAll("_+$", "") strips any trailing underscores created by the cut,
+                    // preventing double underscores when the suffix is appended.
+                    safePart = safePart.substring(0, allowedSafePartLen).replaceAll("_+$", "");
+                    resolvedName = prefix + safePart + suffix;
+                } else {
+                    // If prefix + suffix alone exceeds or equals 64 characters,
+                    // discard the safePart entirely and forcefully truncate the prefix + hash
+                    // combination.
+                    resolvedName =
+                            (prefix + shortHash)
+                                    .substring(
+                                            0, Math.min(64, prefix.length() + shortHash.length()));
+                }
+            }
+        }
+
+        return resolvedName;
     }
 
     /**

--- a/agentscope-core/src/main/java/io/agentscope/core/tool/subagent/SubAgentTool.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/tool/subagent/SubAgentTool.java
@@ -424,7 +424,8 @@ public class SubAgentTool implements AgentTool {
         // Keep the underscore, replace other illegal characters with underscores uniformly,
         // merge consecutive underscores, and remove the first and last underscores
         String lowerOriginal = originalName.toLowerCase(Locale.ROOT);
-        String safePart = lowerOriginal
+        String safePart =
+                lowerOriginal
                         .replaceAll("[^a-z0-9_-]+", "_")
                         .replaceAll("_+", "_")
                         .replaceAll("^_+|_+$", "");

--- a/agentscope-core/src/test/java/io/agentscope/core/tool/subagent/SubAgentToolTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/tool/subagent/SubAgentToolTest.java
@@ -71,7 +71,7 @@ class SubAgentToolTest {
 
         SubAgentTool tool = new SubAgentTool(() -> mockAgent, null);
 
-        assertEquals("call_research_agent", tool.getName());
+        assertTrue(tool.getName().startsWith("call_research_agent"));
     }
 
     @Test
@@ -426,6 +426,57 @@ class SubAgentToolTest {
 
         // Verify stream was called with custom options
         verify(mockAgent).stream(any(List.class), any(StreamOptions.class));
+    }
+
+    @Test
+    @DisplayName("Should generate deterministic hash for Chinese names to avoid collision")
+    void testToolNameGenerationWithChinese() {
+        Agent mathTeacher = createMockAgent("数学老师", "处理数学问题");
+        Agent chineseTeacher = createMockAgent("语文老师", "处理语文问题");
+
+        SubAgentTool mathTool = new SubAgentTool(() -> mathTeacher, null);
+        SubAgentTool chineseTool = new SubAgentTool(() -> chineseTeacher, null);
+
+        String mathToolName = mathTool.getName();
+        String chineseToolName = chineseTool.getName();
+
+        assertTrue(mathToolName.startsWith("call_agent_"));
+        assertTrue(chineseToolName.startsWith("call_agent_"));
+
+        // "call_agent_".length(11) + 8 (hash) = 19
+        assertEquals(19, mathToolName.length());
+
+        assertFalse(mathToolName.equals(chineseToolName), "Names should not collide due to hash");
+
+        Agent mathTeacherAgain = createMockAgent("数学老师", "处理数学问题");
+        SubAgentTool mathToolAgain = new SubAgentTool(() -> mathTeacherAgain, null);
+        assertEquals(
+                mathToolName,
+                mathToolAgain.getName(),
+                "Hash should be deterministic for the same name");
+    }
+
+    @Test
+    @DisplayName("Should truncate safely when generated tool name exceeds 64 characters")
+    void testToolNameGenerationTruncation() {
+        // An extremely lengthy English name
+        String incrediblyLongName =
+                "Very Long Agent Name That Simply Keeps Going On And On Without Any End In Sight"
+                        + " Because We Need To Test Limits";
+        Agent longNameAgent = createMockAgent(incrediblyLongName, "Test truncation");
+
+        SubAgentTool tool = new SubAgentTool(() -> longNameAgent, null);
+        String generatedName = tool.getName();
+
+        assertTrue(generatedName.length() <= 64);
+
+        assertTrue(generatedName.startsWith("call_"));
+
+        assertTrue(
+                generatedName.matches(".*_[0-9a-f]{8}$"),
+                "Truncated name must end with an underscore and an 8-character hash");
+
+        assertFalse(generatedName.contains("__"));
     }
 
     // Helper methods


### PR DESCRIPTION
## Description

Close #1140 

This PR resolves tool name collision issues for SubAgents containing unsupported characters (e.g., spaces, non-English text). It introduces deterministic hashing and safe truncation, ensuring all automatically generated tool names are strictly unique and fully compliant with LLM API length constraints

## Checklist

Please check the following items before code is ready to be reviewed.

- [ ]  Code has been formatted with `mvn spotless:apply`
- [ ]  All tests are passing (`mvn test`)
- [ ]  Javadoc comments are complete and follow project conventions
- [ ]  Related documentation has been updated (e.g. links, examples, etc.)
- [ ]  Code is ready for review
