### PR TITLE
fix: sanitize tool call arguments JSON on interrupted streaming to prevent 400 errors

### DIFF
--- a/agentscope-core/src/main/java/io/agentscope/core/agent/accumulator/ToolCallsAccumulator.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/agent/accumulator/ToolCallsAccumulator.java
@@ -86,6 +86,7 @@ public class ToolCallsAccumulator implements ContentAccumulator<ToolUseBlock> {
         ToolUseBlock build() {
             Map<String, Object> finalArgs = new HashMap<>(args);
             String rawContentStr = this.rawContent.toString();
+            boolean rawContentParsed = false;
 
             // If no parsed arguments but has raw JSON content, try to parse
             if (finalArgs.isEmpty() && rawContentStr.length() > 0) {
@@ -95,19 +96,44 @@ public class ToolCallsAccumulator implements ContentAccumulator<ToolUseBlock> {
                             JsonUtils.getJsonCodec().fromJson(rawContentStr, Map.class);
                     if (parsed != null) {
                         finalArgs.putAll(parsed);
+                        rawContentParsed = true;
                     }
                 } catch (Exception ignored) {
                     // Parsing failed, keep empty args
                 }
             }
 
+            // Use raw content only if it was successfully parsed or args were
+            // already populated (meaning the content matches the parsed input).
+            // Otherwise fall back to "{}" to avoid sending malformed JSON
+            // (e.g. when streaming was interrupted mid-arguments).
+            String contentStr;
+            if (rawContentStr.isEmpty()) {
+                contentStr = "{}";
+            } else if (!finalArgs.isEmpty() || rawContentParsed) {
+                contentStr = rawContentStr;
+            } else if (isValidJson(rawContentStr)) {
+                contentStr = rawContentStr;
+            } else {
+                contentStr = "{}";
+            }
+
             return ToolUseBlock.builder()
                     .id(toolId != null ? toolId : generateId())
                     .name(name)
                     .input(finalArgs)
-                    .content(rawContentStr.isEmpty() ? "{}" : rawContentStr)
+                    .content(contentStr)
                     .metadata(metadata.isEmpty() ? null : metadata)
                     .build();
+        }
+
+        private boolean isValidJson(String str) {
+            try {
+                JsonUtils.getJsonCodec().fromJson(str, Object.class);
+                return true;
+            } catch (Exception e) {
+                return false;
+            }
         }
 
         private boolean isPlaceholder(String name) {

--- a/agentscope-core/src/main/java/io/agentscope/core/agent/accumulator/ToolCallsAccumulator.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/agent/accumulator/ToolCallsAccumulator.java
@@ -86,7 +86,6 @@ public class ToolCallsAccumulator implements ContentAccumulator<ToolUseBlock> {
         ToolUseBlock build() {
             Map<String, Object> finalArgs = new HashMap<>(args);
             String rawContentStr = this.rawContent.toString();
-            boolean rawContentParsed = false;
 
             // If no parsed arguments but has raw JSON content, try to parse
             if (finalArgs.isEmpty() && rawContentStr.length() > 0) {
@@ -96,23 +95,19 @@ public class ToolCallsAccumulator implements ContentAccumulator<ToolUseBlock> {
                             JsonUtils.getJsonCodec().fromJson(rawContentStr, Map.class);
                     if (parsed != null) {
                         finalArgs.putAll(parsed);
-                        rawContentParsed = true;
                     }
                 } catch (Exception ignored) {
                     // Parsing failed, keep empty args
                 }
             }
 
-            // Use raw content only if it was successfully parsed or args were
-            // already populated (meaning the content matches the parsed input).
-            // Otherwise fall back to "{}" to avoid sending malformed JSON
+            // Always validate rawContent is a legal JSON object before using it
+            // as content. This prevents persisting malformed JSON fragments
             // (e.g. when streaming was interrupted mid-arguments).
             String contentStr;
             if (rawContentStr.isEmpty()) {
                 contentStr = "{}";
-            } else if (!finalArgs.isEmpty() || rawContentParsed) {
-                contentStr = rawContentStr;
-            } else if (isValidJson(rawContentStr)) {
+            } else if (JsonUtils.isValidJsonObject(rawContentStr)) {
                 contentStr = rawContentStr;
             } else {
                 contentStr = "{}";
@@ -125,15 +120,6 @@ public class ToolCallsAccumulator implements ContentAccumulator<ToolUseBlock> {
                     .content(contentStr)
                     .metadata(metadata.isEmpty() ? null : metadata)
                     .build();
-        }
-
-        private boolean isValidJson(String str) {
-            try {
-                JsonUtils.getJsonCodec().fromJson(str, Object.class);
-                return true;
-            } catch (Exception e) {
-                return false;
-            }
         }
 
         private boolean isPlaceholder(String name) {

--- a/agentscope-core/src/main/java/io/agentscope/core/formatter/dashscope/DashScopeToolsHelper.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/formatter/dashscope/DashScopeToolsHelper.java
@@ -236,7 +236,7 @@ public class DashScopeToolsHelper {
                 continue;
             }
 
-            String argsJson = resolveArgsJson(toolUse);
+            String argsJson = JsonUtils.resolveToolCallArgsJson(toolUse);
 
             DashScopeFunction function = DashScopeFunction.of(toolUse.getName(), argsJson);
             DashScopeToolCall toolCall =
@@ -319,38 +319,5 @@ public class DashScopeToolsHelper {
         }
 
         return result.isEmpty() ? null : result;
-    }
-
-    /**
-     * Resolve the arguments JSON string from a ToolUseBlock, with validation
-     * to prevent sending malformed JSON (e.g. from interrupted streaming).
-     */
-    private String resolveArgsJson(ToolUseBlock toolUse) {
-        String content = toolUse.getContent();
-        if (content != null && !content.isEmpty()) {
-            if (isValidJson(content)) {
-                return content;
-            }
-            log.warn(
-                    "Invalid JSON in tool call content for '{}', falling back to input"
-                            + " serialization",
-                    toolUse.getName());
-        }
-
-        try {
-            return JsonUtils.getJsonCodec().toJson(toolUse.getInput());
-        } catch (Exception e) {
-            log.warn("Failed to serialize tool call arguments: {}", e.getMessage());
-            return "{}";
-        }
-    }
-
-    private boolean isValidJson(String str) {
-        try {
-            JsonUtils.getJsonCodec().fromJson(str, Object.class);
-            return true;
-        } catch (Exception e) {
-            return false;
-        }
     }
 }

--- a/agentscope-core/src/main/java/io/agentscope/core/formatter/dashscope/DashScopeToolsHelper.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/formatter/dashscope/DashScopeToolsHelper.java
@@ -236,19 +236,7 @@ public class DashScopeToolsHelper {
                 continue;
             }
 
-            // Prioritize using content field (raw arguments string), fallback to input map
-            // serialization
-            String argsJson;
-            if (toolUse.getContent() != null && !toolUse.getContent().isEmpty()) {
-                argsJson = toolUse.getContent();
-            } else {
-                try {
-                    argsJson = JsonUtils.getJsonCodec().toJson(toolUse.getInput());
-                } catch (Exception e) {
-                    log.warn("Failed to serialize tool call arguments: {}", e.getMessage());
-                    argsJson = "{}";
-                }
-            }
+            String argsJson = resolveArgsJson(toolUse);
 
             DashScopeFunction function = DashScopeFunction.of(toolUse.getName(), argsJson);
             DashScopeToolCall toolCall =
@@ -331,5 +319,38 @@ public class DashScopeToolsHelper {
         }
 
         return result.isEmpty() ? null : result;
+    }
+
+    /**
+     * Resolve the arguments JSON string from a ToolUseBlock, with validation
+     * to prevent sending malformed JSON (e.g. from interrupted streaming).
+     */
+    private String resolveArgsJson(ToolUseBlock toolUse) {
+        String content = toolUse.getContent();
+        if (content != null && !content.isEmpty()) {
+            if (isValidJson(content)) {
+                return content;
+            }
+            log.warn(
+                    "Invalid JSON in tool call content for '{}', falling back to input"
+                            + " serialization",
+                    toolUse.getName());
+        }
+
+        try {
+            return JsonUtils.getJsonCodec().toJson(toolUse.getInput());
+        } catch (Exception e) {
+            log.warn("Failed to serialize tool call arguments: {}", e.getMessage());
+            return "{}";
+        }
+    }
+
+    private boolean isValidJson(String str) {
+        try {
+            JsonUtils.getJsonCodec().fromJson(str, Object.class);
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
     }
 }

--- a/agentscope-core/src/main/java/io/agentscope/core/formatter/openai/OpenAIMessageConverter.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/formatter/openai/OpenAIMessageConverter.java
@@ -330,23 +330,7 @@ public class OpenAIMessageConverter {
                     continue;
                 }
 
-                // Prioritize using content field (raw arguments string), fallback to input map
-                // serialization
-                String argsJson;
-                if (toolUse.getContent() != null && !toolUse.getContent().isEmpty()) {
-                    argsJson = toolUse.getContent();
-                } else {
-                    try {
-                        argsJson = JsonUtils.getJsonCodec().toJson(toolUse.getInput());
-                    } catch (Exception e) {
-                        String errorMsg =
-                                e.getMessage() != null
-                                        ? e.getMessage()
-                                        : e.getClass().getSimpleName();
-                        log.warn("Failed to serialize tool call arguments: {}", errorMsg);
-                        argsJson = "{}";
-                    }
-                }
+                String argsJson = resolveArgsJson(toolUse);
 
                 // Add thought signature if present in metadata (required for Gemini)
                 String signature = null;
@@ -490,6 +474,41 @@ public class OpenAIMessageConverter {
         Object cacheFlag = msg.getMetadata().get(MessageMetadataKeys.CACHE_CONTROL);
         if (Boolean.TRUE.equals(cacheFlag)) {
             result.setCacheControl(OpenAIBaseFormatter.getEphemeralCacheControl());
+        }
+    }
+
+    /**
+     * Resolve the arguments JSON string from a ToolUseBlock, with validation
+     * to prevent sending malformed JSON (e.g. from interrupted streaming).
+     */
+    private String resolveArgsJson(ToolUseBlock toolUse) {
+        String content = toolUse.getContent();
+        if (content != null && !content.isEmpty()) {
+            if (isValidJson(content)) {
+                return content;
+            }
+            log.warn(
+                    "Invalid JSON in tool call content for '{}', falling back to input"
+                            + " serialization",
+                    toolUse.getName());
+        }
+
+        try {
+            return JsonUtils.getJsonCodec().toJson(toolUse.getInput());
+        } catch (Exception e) {
+            String errorMsg =
+                    e.getMessage() != null ? e.getMessage() : e.getClass().getSimpleName();
+            log.warn("Failed to serialize tool call arguments: {}", errorMsg);
+            return "{}";
+        }
+    }
+
+    private boolean isValidJson(String str) {
+        try {
+            JsonUtils.getJsonCodec().fromJson(str, Object.class);
+            return true;
+        } catch (Exception e) {
+            return false;
         }
     }
 }

--- a/agentscope-core/src/main/java/io/agentscope/core/formatter/openai/OpenAIMessageConverter.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/formatter/openai/OpenAIMessageConverter.java
@@ -330,7 +330,7 @@ public class OpenAIMessageConverter {
                     continue;
                 }
 
-                String argsJson = resolveArgsJson(toolUse);
+                String argsJson = JsonUtils.resolveToolCallArgsJson(toolUse);
 
                 // Add thought signature if present in metadata (required for Gemini)
                 String signature = null;
@@ -474,41 +474,6 @@ public class OpenAIMessageConverter {
         Object cacheFlag = msg.getMetadata().get(MessageMetadataKeys.CACHE_CONTROL);
         if (Boolean.TRUE.equals(cacheFlag)) {
             result.setCacheControl(OpenAIBaseFormatter.getEphemeralCacheControl());
-        }
-    }
-
-    /**
-     * Resolve the arguments JSON string from a ToolUseBlock, with validation
-     * to prevent sending malformed JSON (e.g. from interrupted streaming).
-     */
-    private String resolveArgsJson(ToolUseBlock toolUse) {
-        String content = toolUse.getContent();
-        if (content != null && !content.isEmpty()) {
-            if (isValidJson(content)) {
-                return content;
-            }
-            log.warn(
-                    "Invalid JSON in tool call content for '{}', falling back to input"
-                            + " serialization",
-                    toolUse.getName());
-        }
-
-        try {
-            return JsonUtils.getJsonCodec().toJson(toolUse.getInput());
-        } catch (Exception e) {
-            String errorMsg =
-                    e.getMessage() != null ? e.getMessage() : e.getClass().getSimpleName();
-            log.warn("Failed to serialize tool call arguments: {}", errorMsg);
-            return "{}";
-        }
-    }
-
-    private boolean isValidJson(String str) {
-        try {
-            JsonUtils.getJsonCodec().fromJson(str, Object.class);
-            return true;
-        } catch (Exception e) {
-            return false;
         }
     }
 }

--- a/agentscope-core/src/main/java/io/agentscope/core/util/JsonUtils.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/util/JsonUtils.java
@@ -106,8 +106,8 @@ public final class JsonUtils {
             return false;
         }
         try {
-            codec.fromJson(str, Map.class);
-            return true;
+            Map<String, Object> parsed = codec.fromJson(str, Map.class);
+            return parsed != null;
         } catch (Exception e) {
             return false;
         }

--- a/agentscope-core/src/main/java/io/agentscope/core/util/JsonUtils.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/util/JsonUtils.java
@@ -16,6 +16,11 @@
 
 package io.agentscope.core.util;
 
+import io.agentscope.core.message.ToolUseBlock;
+import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 /**
  * Utility class for accessing the global {@link JsonCodec} instance.
  *
@@ -42,6 +47,8 @@ package io.agentscope.core.util;
  * @see JacksonJsonCodec
  */
 public final class JsonUtils {
+
+    private static final Logger log = LoggerFactory.getLogger(JsonUtils.class);
 
     private static volatile JsonCodec codec = new JacksonJsonCodec();
 
@@ -81,5 +88,65 @@ public final class JsonUtils {
      */
     public static void resetToDefault() {
         codec = new JacksonJsonCodec();
+    }
+
+    /**
+     * Check whether the given string is a valid JSON object (i.e. starts with '{' and
+     * can be parsed into a {@link Map}).
+     *
+     * <p>Tool call {@code arguments} must be JSON objects, so plain JSON values like
+     * {@code null}, arrays, or strings are rejected.
+     *
+     * @param str the string to validate
+     * @return {@code true} if {@code str} is a non-null, parseable JSON object
+     */
+    @SuppressWarnings("unchecked")
+    public static boolean isValidJsonObject(String str) {
+        if (str == null || str.isEmpty()) {
+            return false;
+        }
+        try {
+            codec.fromJson(str, Map.class);
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    /**
+     * Resolve the arguments JSON string from a {@link ToolUseBlock}, ensuring the
+     * result is always a valid JSON object.
+     *
+     * <p>Resolution order:
+     * <ol>
+     *   <li>Use {@link ToolUseBlock#getContent()} if it is a valid JSON object</li>
+     *   <li>Serialize {@link ToolUseBlock#getInput()} via {@link JsonCodec#toJson}</li>
+     *   <li>Fall back to {@code "{}"}</li>
+     * </ol>
+     *
+     * <p>This prevents sending malformed JSON (e.g. from interrupted streaming) as
+     * tool call arguments, which would cause model APIs to reject the request.
+     *
+     * @param toolUse the tool use block
+     * @return a valid JSON object string representing the tool call arguments
+     */
+    public static String resolveToolCallArgsJson(ToolUseBlock toolUse) {
+        String content = toolUse.getContent();
+        if (content != null && !content.isEmpty()) {
+            if (isValidJsonObject(content)) {
+                return content;
+            }
+            log.warn(
+                    "Invalid JSON in tool call content for '{}', falling back to input"
+                            + " serialization",
+                    toolUse.getName());
+        }
+
+        try {
+            return codec.toJson(toolUse.getInput());
+        } catch (Exception e) {
+            log.warn("Failed to serialize tool call arguments: {}", e.getMessage());
+            return "{}";
+        }
     }
 }

--- a/agentscope-core/src/test/java/io/agentscope/core/agent/accumulator/ToolCallsAccumulatorTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/agent/accumulator/ToolCallsAccumulatorTest.java
@@ -323,4 +323,93 @@ class ToolCallsAccumulatorTest {
         List<ToolUseBlock> allCalls = accumulator.getAllAccumulatedToolCalls();
         assertEquals(2, allCalls.size());
     }
+
+    @Test
+    @DisplayName("Should produce valid JSON content when streaming is interrupted mid-arguments")
+    void testInterruptedStreamingProducesValidJsonContent() {
+        // Simulate streaming that gets interrupted mid-arguments:
+        // Model was outputting {"query": "hello wor... but got cut off
+        ToolUseBlock chunk1 =
+                ToolUseBlock.builder()
+                        .id("call_1")
+                        .name("search")
+                        .content("{\"query\": \"hello wor")
+                        .build();
+
+        accumulator.add(chunk1);
+
+        List<ToolUseBlock> result = accumulator.buildAllToolCalls();
+        assertEquals(1, result.size());
+
+        ToolUseBlock toolCall = result.get(0);
+        // Content should fall back to "{}" since the raw content is invalid JSON
+        assertEquals("{}", toolCall.getContent());
+        // Input should be empty since parsing failed
+        assertTrue(toolCall.getInput().isEmpty());
+    }
+
+    @Test
+    @DisplayName("Should produce valid JSON content when multiple chunks are interrupted")
+    void testInterruptedMultiChunkStreamingProducesValidJsonContent() {
+        // First chunk starts the arguments
+        ToolUseBlock chunk1 =
+                ToolUseBlock.builder()
+                        .id("call_1")
+                        .name("get_weather")
+                        .content("{\"city\":")
+                        .build();
+
+        // Second chunk is a partial value — streaming interrupted here
+        ToolUseBlock chunk2 =
+                ToolUseBlock.builder().id("call_1").name("__fragment__").content("\"Bei").build();
+
+        accumulator.add(chunk1);
+        accumulator.add(chunk2);
+
+        List<ToolUseBlock> result = accumulator.buildAllToolCalls();
+        assertEquals(1, result.size());
+
+        ToolUseBlock toolCall = result.get(0);
+        assertEquals("{}", toolCall.getContent());
+        assertTrue(toolCall.getInput().isEmpty());
+    }
+
+    @Test
+    @DisplayName("Should handle non-object JSON content like arrays or null")
+    void testNonObjectJsonContentFallsBackToEmpty() {
+        ToolUseBlock chunk =
+                ToolUseBlock.builder().id("call_1").name("tool").content("[1, 2, 3]").build();
+
+        accumulator.add(chunk);
+
+        List<ToolUseBlock> result = accumulator.buildAllToolCalls();
+        assertEquals(1, result.size());
+        // Arrays are not valid JSON objects for tool call arguments
+        assertEquals("{}", result.get(0).getContent());
+    }
+
+    @Test
+    @DisplayName("Should preserve valid content even when input was populated via merge")
+    void testValidContentPreservedWithMergedInput() {
+        // First chunk: input populated via parsed args
+        Map<String, Object> args = new HashMap<>();
+        args.put("city", "Tokyo");
+        ToolUseBlock chunk1 =
+                ToolUseBlock.builder()
+                        .id("call_1")
+                        .name("weather")
+                        .input(args)
+                        .content("{\"city\": \"Tokyo\"}")
+                        .build();
+
+        accumulator.add(chunk1);
+
+        List<ToolUseBlock> result = accumulator.buildAllToolCalls();
+        assertEquals(1, result.size());
+
+        ToolUseBlock toolCall = result.get(0);
+        // Valid JSON content should be preserved
+        assertEquals("{\"city\": \"Tokyo\"}", toolCall.getContent());
+        assertEquals("Tokyo", toolCall.getInput().get("city"));
+    }
 }

--- a/agentscope-core/src/test/java/io/agentscope/core/formatter/dashscope/DashScopeToolsHelperComprehensiveTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/formatter/dashscope/DashScopeToolsHelperComprehensiveTest.java
@@ -317,6 +317,46 @@ class DashScopeToolsHelperComprehensiveTest {
     }
 
     @Test
+    void testConvertToolCallsWithInvalidJsonContent() {
+        // Simulate interrupted streaming: content is incomplete JSON
+        ToolUseBlock block =
+                ToolUseBlock.builder()
+                        .id("call_broken")
+                        .name("search")
+                        .input(Map.of("query", "test"))
+                        .content("{\"query\": \"hel")
+                        .build();
+
+        List<DashScopeToolCall> result = helper.convertToolCalls(List.of(block));
+
+        assertEquals(1, result.size());
+        String argsJson = result.get(0).getFunction().getArguments();
+        // Should fall back to input serialization, not the broken content
+        assertTrue(argsJson.contains("query"));
+        assertTrue(argsJson.contains("test"));
+    }
+
+    @Test
+    void testConvertToolCallsWithNonObjectJsonContent() {
+        // Content is valid JSON but not an object (array)
+        ToolUseBlock block =
+                ToolUseBlock.builder()
+                        .id("call_array")
+                        .name("tool")
+                        .input(Map.of("key", "value"))
+                        .content("[1, 2, 3]")
+                        .build();
+
+        List<DashScopeToolCall> result = helper.convertToolCalls(List.of(block));
+
+        assertEquals(1, result.size());
+        String argsJson = result.get(0).getFunction().getArguments();
+        // Should fall back to input since content is not a JSON object
+        assertTrue(argsJson.contains("key"));
+        assertTrue(argsJson.contains("value"));
+    }
+
+    @Test
     void testConvertToolCallsWithComplexArgs() {
         Map<String, Object> complexArgs = new HashMap<>();
         complexArgs.put("string", "value");

--- a/agentscope-core/src/test/java/io/agentscope/core/formatter/openai/OpenAIMessageConverterTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/formatter/openai/OpenAIMessageConverterTest.java
@@ -531,6 +531,54 @@ class OpenAIMessageConverterTest {
             assertTrue(args.contains("city"));
             assertTrue(args.contains("Shanghai"));
         }
+
+        @Test
+        @DisplayName(
+                "Should fallback to input when content is invalid JSON (interrupted streaming)")
+        void testToolCallFallbackWhenContentIsInvalidJson() {
+            ToolUseBlock toolBlock =
+                    ToolUseBlock.builder()
+                            .id("call_broken")
+                            .name("search")
+                            .input(Map.of("query", "hello"))
+                            .content("{\"query\": \"hel")
+                            .build();
+
+            Msg msg = Msg.builder().role(MsgRole.ASSISTANT).content(List.of(toolBlock)).build();
+
+            OpenAIMessage result = converter.convertToMessage(msg, false);
+
+            assertNotNull(result);
+            assertNotNull(result.getToolCalls());
+            assertEquals(1, result.getToolCalls().size());
+            String args = result.getToolCalls().get(0).getFunction().getArguments();
+            // Should fall back to input serialization
+            assertTrue(args.contains("query"));
+            assertTrue(args.contains("hello"));
+        }
+
+        @Test
+        @DisplayName("Should fallback to input when content is non-object JSON like array")
+        void testToolCallFallbackWhenContentIsNonObjectJson() {
+            ToolUseBlock toolBlock =
+                    ToolUseBlock.builder()
+                            .id("call_array")
+                            .name("tool")
+                            .input(Map.of("key", "value"))
+                            .content("[1, 2, 3]")
+                            .build();
+
+            Msg msg = Msg.builder().role(MsgRole.ASSISTANT).content(List.of(toolBlock)).build();
+
+            OpenAIMessage result = converter.convertToMessage(msg, false);
+
+            assertNotNull(result);
+            assertNotNull(result.getToolCalls());
+            assertEquals(1, result.getToolCalls().size());
+            String args = result.getToolCalls().get(0).getFunction().getArguments();
+            assertTrue(args.contains("key"));
+            assertTrue(args.contains("value"));
+        }
     }
 
     @Nested

--- a/agentscope-core/src/test/java/io/agentscope/core/util/JsonUtilsTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/util/JsonUtilsTest.java
@@ -17,17 +17,22 @@
 package io.agentscope.core.util;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.fasterxml.jackson.core.type.TypeReference;
+import io.agentscope.core.message.ToolUseBlock;
 import java.lang.reflect.Type;
 import java.util.Map;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 class JsonUtilsTest {
@@ -114,6 +119,138 @@ class JsonUtilsTest {
         String result = codec.toJson(new Object());
 
         assertEquals("custom_json", result);
+    }
+
+    @Nested
+    @DisplayName("isValidJsonObject Tests")
+    class IsValidJsonObjectTests {
+
+        @Test
+        @DisplayName("Should accept valid JSON object")
+        void testValidJsonObject() {
+            assertTrue(JsonUtils.isValidJsonObject("{\"key\":\"value\"}"));
+            assertTrue(JsonUtils.isValidJsonObject("{}"));
+            assertTrue(JsonUtils.isValidJsonObject("{\"a\":1,\"b\":true}"));
+        }
+
+        @Test
+        @DisplayName("Should reject incomplete JSON")
+        void testIncompleteJson() {
+            assertFalse(JsonUtils.isValidJsonObject("{\"query\":\"hel"));
+            assertFalse(JsonUtils.isValidJsonObject("{\"key\":"));
+            assertFalse(JsonUtils.isValidJsonObject("{"));
+        }
+
+        @Test
+        @DisplayName("Should reject non-object JSON values")
+        void testNonObjectJsonValues() {
+            assertFalse(JsonUtils.isValidJsonObject("null"));
+            assertFalse(JsonUtils.isValidJsonObject("[1,2,3]"));
+            assertFalse(JsonUtils.isValidJsonObject("\"just a string\""));
+            assertFalse(JsonUtils.isValidJsonObject("42"));
+            assertFalse(JsonUtils.isValidJsonObject("true"));
+        }
+
+        @Test
+        @DisplayName("Should reject null and empty")
+        void testNullAndEmpty() {
+            assertFalse(JsonUtils.isValidJsonObject(null));
+            assertFalse(JsonUtils.isValidJsonObject(""));
+        }
+    }
+
+    @Nested
+    @DisplayName("resolveToolCallArgsJson Tests")
+    class ResolveToolCallArgsJsonTests {
+
+        @Test
+        @DisplayName("Should return valid content when present")
+        void testValidContent() {
+            ToolUseBlock block =
+                    ToolUseBlock.builder()
+                            .id("call_1")
+                            .name("tool")
+                            .input(Map.of("fallback", "value"))
+                            .content("{\"key\":\"value\"}")
+                            .build();
+
+            assertEquals("{\"key\":\"value\"}", JsonUtils.resolveToolCallArgsJson(block));
+        }
+
+        @Test
+        @DisplayName("Should fall back to input when content is invalid JSON")
+        void testInvalidContentFallsBackToInput() {
+            ToolUseBlock block =
+                    ToolUseBlock.builder()
+                            .id("call_1")
+                            .name("tool")
+                            .input(Map.of("city", "Beijing"))
+                            .content("{\"query\":\"hel")
+                            .build();
+
+            String result = JsonUtils.resolveToolCallArgsJson(block);
+            assertTrue(result.contains("city"));
+            assertTrue(result.contains("Beijing"));
+        }
+
+        @Test
+        @DisplayName("Should fall back to input when content is null")
+        void testNullContentFallsBackToInput() {
+            ToolUseBlock block =
+                    ToolUseBlock.builder()
+                            .id("call_1")
+                            .name("tool")
+                            .input(Map.of("key", "value"))
+                            .content(null)
+                            .build();
+
+            String result = JsonUtils.resolveToolCallArgsJson(block);
+            assertTrue(result.contains("key"));
+        }
+
+        @Test
+        @DisplayName("Should fall back to input when content is empty")
+        void testEmptyContentFallsBackToInput() {
+            ToolUseBlock block =
+                    ToolUseBlock.builder()
+                            .id("call_1")
+                            .name("tool")
+                            .input(Map.of("key", "value"))
+                            .content("")
+                            .build();
+
+            String result = JsonUtils.resolveToolCallArgsJson(block);
+            assertTrue(result.contains("key"));
+        }
+
+        @Test
+        @DisplayName("Should reject non-object JSON content like arrays")
+        void testNonObjectJsonContentFallsBackToInput() {
+            ToolUseBlock block =
+                    ToolUseBlock.builder()
+                            .id("call_1")
+                            .name("tool")
+                            .input(Map.of("key", "value"))
+                            .content("[1,2,3]")
+                            .build();
+
+            String result = JsonUtils.resolveToolCallArgsJson(block);
+            assertTrue(result.contains("key"));
+        }
+
+        @Test
+        @DisplayName("Should return {} when both content and input are empty")
+        void testEmptyContentAndInput() {
+            ToolUseBlock block =
+                    ToolUseBlock.builder()
+                            .id("call_1")
+                            .name("tool")
+                            .input(Map.of())
+                            .content("")
+                            .build();
+
+            assertEquals("{}", JsonUtils.resolveToolCallArgsJson(block));
+        }
     }
 
     private static class CustomJsonCodec implements JsonCodec {


### PR DESCRIPTION
## Summary

- When streaming tool call responses are interrupted mid-arguments, the partially accumulated JSON (e.g. `{"query": "hello wor`) was saved to memory and sent as-is in subsequent API requests, causing DashScope (百炼) to reject with HTTP 400 due to invalid JSON in tool call arguments.
- This fix adds JSON validation at two layers: (1) `ToolCallsAccumulator.build()` now falls back to `"{}"` when raw content is not valid JSON, and (2) both `DashScopeToolsHelper` and `OpenAIMessageConverter` validate content before using it as arguments, falling back to serializing the `input` map.

Fixes #1147

## Test plan

- [ ] Verify streaming tool call completes normally (no regression)
- [ ] Simulate interrupt during streaming tool call and verify the saved message contains valid JSON arguments (`"{}"` instead of broken JSON)
- [ ] After interrupt, verify next model request succeeds without 400 error
- [ ] Test with DashScope API (qwen3.5/qwen3.6) specifically


Made with [Cursor](https://cursor.com)