### PR TITLE
refactor(hook): change PreCallEvent related comments from read-only to modifiable, aligning with PreReasoningEvent

### DIFF
--- a/agentscope-core/src/main/java/io/agentscope/core/hook/Hook.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/hook/Hook.java
@@ -124,12 +124,12 @@ public interface Hook {
      *   <li>{@link PostReasoningEvent} - Modify reasoning results</li>
      *   <li>{@link PreActingEvent} - Modify tool parameters before execution</li>
      *   <li>{@link PostActingEvent} - Modify tool results</li>
+     *   <li>{@link PreCallEvent} - Modify messages before agent starts</li>
      *   <li>{@link PostCallEvent} - Modify final agent response</li>
      * </ul>
      *
      * <p><b>Notification Events:</b> Events without setters are read-only:
      * <ul>
-     *   <li>{@link PreCallEvent} - Notified when agent starts</li>
      *   <li>{@link ReasoningChunkEvent} - Streaming reasoning chunks</li>
      *   <li>{@link ActingChunkEvent} - Streaming tool execution chunks</li>
      *   <li>{@link ErrorEvent} - Errors during execution</li>

--- a/agentscope-core/src/main/java/io/agentscope/core/hook/PreCallEvent.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/hook/PreCallEvent.java
@@ -29,7 +29,7 @@ import java.util.Objects;
  * <p><b>Context:</b>
  * <ul>
  *   <li>{@link #getAgent()} - The agent instance</li>
- *   <li>{@link #getMemory()} - Agent's memory (includes input messages already added)</li>
+ *   <li>{@link #getMemory()} - Agent's existing memory or conversation history prior to processing this call</li>
  *   <li>{@link #getInputMessages()} - Messages input to the agent (modifiable)</li>
  * </ul>
  *
@@ -38,7 +38,7 @@ import java.util.Objects;
  *   <li>Log the start of agent execution</li>
  *   <li>Initialize execution-specific resources</li>
  *   <li>Track agent invocation metrics</li>
- * <li>Filter or modify input messages before agent processing</li>
+ *   <li>Filter or modify input messages before agent processing</li>
  * </ul>
  */
 public final class PreCallEvent extends HookEvent {

--- a/agentscope-core/src/main/java/io/agentscope/core/hook/PreCallEvent.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/hook/PreCallEvent.java
@@ -17,17 +17,20 @@ package io.agentscope.core.hook;
 
 import io.agentscope.core.agent.Agent;
 import io.agentscope.core.message.Msg;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * Event fired before agent starts processing.
  *
- * <p><b>Modifiable:</b> No (notification-only)
+ * <p><b>Modifiable:</b> Yes - {@link #setInputMessages(List)}
  *
  * <p><b>Context:</b>
  * <ul>
  *   <li>{@link #getAgent()} - The agent instance</li>
  *   <li>{@link #getMemory()} - Agent's memory (includes input messages already added)</li>
+ *   <li>{@link #getInputMessages()} - Messages input to the agent (modifiable)</li>
  * </ul>
  *
  * <p><b>Use Cases:</b>
@@ -35,6 +38,7 @@ import java.util.List;
  *   <li>Log the start of agent execution</li>
  *   <li>Initialize execution-specific resources</li>
  *   <li>Track agent invocation metrics</li>
+ * <li>Filter or modify input messages before agent processing</li>
  * </ul>
  */
 public final class PreCallEvent extends HookEvent {
@@ -45,18 +49,32 @@ public final class PreCallEvent extends HookEvent {
      * Constructor for PreCallEvent.
      *
      * @param agent The agent instance (must not be null)
-     * @throws NullPointerException if agent is null
+     * @param inputMessages The messages input to the agent (must not be null)
+     * @throws NullPointerException if agent or inputMessages is null
      */
     public PreCallEvent(Agent agent, List<Msg> inputMessages) {
         super(HookEventType.PRE_CALL, agent);
-        this.inputMessages = inputMessages;
+        this.inputMessages =
+                new ArrayList<>(
+                        Objects.requireNonNull(inputMessages, "inputMessages cannot be null"));
     }
 
+    /**
+     * Get the input messages for the agent call.
+     *
+     * @return The input messages
+     */
     public List<Msg> getInputMessages() {
         return inputMessages;
     }
 
+    /**
+     * Modify the input messages for the agent call.
+     *
+     * @param inputMessages The new message list (must not be null)
+     * @throws NullPointerException if inputMessages is null
+     */
     public void setInputMessages(List<Msg> inputMessages) {
-        this.inputMessages = inputMessages;
+        this.inputMessages = Objects.requireNonNull(inputMessages, "inputMessages cannot be null");
     }
 }

--- a/agentscope-core/src/test/java/io/agentscope/core/hook/HookEventTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/hook/HookEventTest.java
@@ -30,6 +30,7 @@ import io.agentscope.core.message.ToolResultBlock;
 import io.agentscope.core.message.ToolUseBlock;
 import io.agentscope.core.model.GenerateOptions;
 import io.agentscope.core.tool.Toolkit;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
@@ -102,7 +103,7 @@ class HookEventTest {
         @Test
         @DisplayName("Should create and access event")
         void testCreationAndAccess() {
-            PreCallEvent event = new PreCallEvent(testAgent, null);
+            PreCallEvent event = new PreCallEvent(testAgent, new ArrayList<>());
 
             assertEquals(HookEventType.PRE_CALL, event.getType());
             assertEquals(testAgent, event.getAgent());


### PR DESCRIPTION
## Description

This PR updates PreCallEvent to be modifiable (revising the previous read-only comments), and aligns its inputMessages handling with PreReasoningEvent.

## Checklist

Please check the following items before code is ready to be reviewed.

- [ ]  Code has been formatted with `mvn spotless:apply`
- [ ]  All tests are passing (`mvn test`)
- [ ]  Javadoc comments are complete and follow project conventions
- [ ]  Related documentation has been updated (e.g. links, examples, etc.)
- [ ]  Code is ready for review
