### PR TITLE
fix(anthropic): tolerate proxy responses without message ids

### DIFF
--- a/agentscope-core/src/main/java/io/agentscope/core/formatter/anthropic/AnthropicResponseParser.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/formatter/anthropic/AnthropicResponseParser.java
@@ -94,7 +94,11 @@ public class AnthropicResponseParser {
                         .time(Duration.between(startTime, Instant.now()).toMillis() / 1000.0)
                         .build();
 
-        return ChatResponse.builder().id(message.id()).content(contentBlocks).usage(usage).build();
+        return ChatResponse.builder()
+                .id(safeMessageId(message))
+                .content(contentBlocks)
+                .usage(usage)
+                .build();
     }
 
     /**
@@ -125,7 +129,7 @@ public class AnthropicResponseParser {
 
         // Message start
         if (event.isMessageStart()) {
-            messageId = event.asMessageStart().message().id();
+            messageId = safeMessageId(event.asMessageStart().message());
         }
 
         // Content block delta - text
@@ -187,6 +191,35 @@ public class AnthropicResponseParser {
         }
 
         return ChatResponse.builder().id(messageId).content(contentBlocks).usage(usage).build();
+    }
+
+    /**
+     * Read Anthropic message id without requiring the strict SDK accessor to succeed.
+     *
+     * <p>Some proxy services strip the `id` field from the payload. In that case the SDK's
+     * `message.id()` accessor throws, but the parser should still be able to produce a
+     * ChatResponse and let the ChatResponse builder generate a fallback id.
+     */
+    private static String safeMessageId(Message message) {
+        if (message == null) {
+            return null;
+        }
+
+        try {
+            var rawId = message._id();
+            if (rawId != null && !rawId.isMissing()) {
+                return rawId.asString().orElse(null);
+            }
+        } catch (Exception e) {
+            log.debug("Failed to read Anthropic raw message id: {}", e.getMessage());
+        }
+
+        try {
+            return message.id();
+        } catch (Exception e) {
+            log.debug("Anthropic message id is missing, falling back to generated ChatResponse id");
+            return null;
+        }
     }
 
     /**

--- a/agentscope-core/src/test/java/io/agentscope/core/formatter/anthropic/AnthropicChatFormatterTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/formatter/anthropic/AnthropicChatFormatterTest.java
@@ -152,6 +152,61 @@ class AnthropicChatFormatterTest extends AnthropicFormatterTestBase {
     }
 
     @Test
+    void testParseResponseUsesRawJsonFieldIdWhenStrictAccessorThrows() {
+        Message message = mock(Message.class);
+        Usage usage = mock(Usage.class);
+        ContentBlock contentBlock = mock(ContentBlock.class);
+        var textBlock = mockTextBlock();
+
+        when(message.id()).thenThrow(new IllegalStateException("id is not set"));
+        when(message._id()).thenReturn(com.anthropic.core.JsonField.of("msg_formatter_raw_only"));
+        when(message.content()).thenReturn(List.of(contentBlock));
+        when(message.usage()).thenReturn(usage);
+        when(usage.inputTokens()).thenReturn(12L);
+        when(usage.outputTokens()).thenReturn(6L);
+        when(contentBlock.text()).thenReturn(Optional.of(textBlock));
+        when(contentBlock.toolUse()).thenReturn(Optional.empty());
+        when(contentBlock.thinking()).thenReturn(Optional.empty());
+        when(textBlock.text()).thenReturn("Response through formatter");
+
+        ChatResponse response = formatter.parseResponse(message, Instant.now());
+
+        assertNotNull(response);
+        assertEquals("msg_formatter_raw_only", response.getId());
+        assertEquals(1, response.getContent().size());
+        assertEquals(12, response.getUsage().getInputTokens());
+        assertEquals(6, response.getUsage().getOutputTokens());
+    }
+
+    @Test
+    void testParseResponseWithoutIdFallsBackToGeneratedId() {
+        Message message = mock(Message.class);
+        Usage usage = mock(Usage.class);
+        ContentBlock contentBlock = mock(ContentBlock.class);
+        var textBlock = mockTextBlock();
+
+        when(message.id()).thenThrow(new IllegalStateException("id is not set"));
+        when(message._id()).thenReturn(com.anthropic.core.JsonField.ofNullable(null));
+        when(message.content()).thenReturn(List.of(contentBlock));
+        when(message.usage()).thenReturn(usage);
+        when(usage.inputTokens()).thenReturn(8L);
+        when(usage.outputTokens()).thenReturn(4L);
+        when(contentBlock.text()).thenReturn(Optional.of(textBlock));
+        when(contentBlock.toolUse()).thenReturn(Optional.empty());
+        when(contentBlock.thinking()).thenReturn(Optional.empty());
+        when(textBlock.text()).thenReturn("Response without id");
+
+        ChatResponse response = formatter.parseResponse(message, Instant.now());
+
+        assertNotNull(response);
+        assertNotNull(response.getId());
+        assertTrue(!response.getId().isEmpty());
+        assertEquals(1, response.getContent().size());
+        assertEquals(8, response.getUsage().getInputTokens());
+        assertEquals(4, response.getUsage().getOutputTokens());
+    }
+
+    @Test
     void testParseResponseWithInvalidType() {
         // Pass non-Message object should throw exception
         String invalidResponse = "not a message";

--- a/agentscope-core/src/test/java/io/agentscope/core/formatter/anthropic/AnthropicResponseParserTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/formatter/anthropic/AnthropicResponseParserTest.java
@@ -105,6 +105,57 @@ class AnthropicResponseParserTest extends AnthropicFormatterTestBase {
     }
 
     @Test
+    void testParseMessageUsesRawJsonFieldIdWhenStrictAccessorThrows() {
+        Message message = mock(Message.class);
+        Usage usage = mock(Usage.class);
+        ContentBlock contentBlock = mock(ContentBlock.class);
+        var textBlock = mockTextBlock();
+
+        when(message.id()).thenThrow(new IllegalStateException("id is not set"));
+        when(message._id()).thenReturn(com.anthropic.core.JsonField.of("msg_raw_only"));
+        when(message.content()).thenReturn(List.of(contentBlock));
+        when(message.usage()).thenReturn(usage);
+        when(usage.inputTokens()).thenReturn(10L);
+        when(usage.outputTokens()).thenReturn(5L);
+        when(contentBlock.text()).thenReturn(Optional.of(textBlock));
+        when(contentBlock.toolUse()).thenReturn(Optional.empty());
+        when(contentBlock.thinking()).thenReturn(Optional.empty());
+        when(textBlock.text()).thenReturn("proxy-safe");
+
+        ChatResponse response = AnthropicResponseParser.parseMessage(message, Instant.now());
+
+        assertNotNull(response);
+        assertEquals("msg_raw_only", response.getId());
+        assertEquals(1, response.getContent().size());
+    }
+
+    @Test
+    void testParseMessageWithoutIdFallsBackToGeneratedId() {
+        Message message = mock(Message.class);
+        Usage usage = mock(Usage.class);
+        ContentBlock contentBlock = mock(ContentBlock.class);
+        var textBlock = mockTextBlock();
+
+        when(message.id()).thenThrow(new IllegalStateException("id is not set"));
+        when(message._id()).thenReturn(com.anthropic.core.JsonField.ofNullable(null));
+        when(message.content()).thenReturn(List.of(contentBlock));
+        when(message.usage()).thenReturn(usage);
+        when(usage.inputTokens()).thenReturn(10L);
+        when(usage.outputTokens()).thenReturn(5L);
+        when(contentBlock.text()).thenReturn(Optional.of(textBlock));
+        when(contentBlock.toolUse()).thenReturn(Optional.empty());
+        when(contentBlock.thinking()).thenReturn(Optional.empty());
+        when(textBlock.text()).thenReturn("proxy-without-id");
+
+        ChatResponse response = AnthropicResponseParser.parseMessage(message, Instant.now());
+
+        assertNotNull(response);
+        assertNotNull(response.getId());
+        assertFalse(response.getId().isEmpty());
+        assertEquals(1, response.getContent().size());
+    }
+
+    @Test
     void testParseMessageWithToolUseBlock() {
         // Create mock Message with tool use content
         // Note: We use null input to avoid Kotlin reflection issues with JsonValue mocking
@@ -293,6 +344,27 @@ class AnthropicResponseParserTest extends AnthropicFormatterTestBase {
     }
 
     @Test
+    void testParseStreamEventsMessageStartWithoutIdStillCompletes() {
+        RawMessageStreamEvent event = mock(RawMessageStreamEvent.class);
+        RawMessageStartEvent messageStartEvent = mock(RawMessageStartEvent.class);
+        Message message = mock(Message.class);
+
+        when(event.isMessageStart()).thenReturn(true);
+        when(event.asMessageStart()).thenReturn(messageStartEvent);
+        when(messageStartEvent.message()).thenReturn(message);
+        when(message.id()).thenThrow(new IllegalStateException("id is not set"));
+        when(message._id()).thenReturn(com.anthropic.core.JsonField.ofNullable(null));
+        when(event.isContentBlockDelta()).thenReturn(false);
+        when(event.isContentBlockStart()).thenReturn(false);
+        when(event.isMessageDelta()).thenReturn(false);
+
+        Flux<ChatResponse> responseFlux =
+                AnthropicResponseParser.parseStreamEvents(Flux.just(event), Instant.now());
+
+        StepVerifier.create(responseFlux).verifyComplete();
+    }
+
+    @Test
     void testParseStreamEventMessageStart() throws Exception {
         // Test MessageStart event - should set message ID but have empty content
         RawMessageStreamEvent event = mock(RawMessageStreamEvent.class);
@@ -314,6 +386,52 @@ class AnthropicResponseParserTest extends AnthropicFormatterTestBase {
         assertNotNull(response);
         assertEquals("msg_stream_123", response.getId());
         assertTrue(response.getContent().isEmpty()); // MessageStart has no content
+    }
+
+    @Test
+    void testParseStreamEventMessageStartUsesRawJsonFieldIdWhenStrictAccessorThrows()
+            throws Exception {
+        RawMessageStreamEvent event = mock(RawMessageStreamEvent.class);
+        RawMessageStartEvent messageStart = mock(RawMessageStartEvent.class);
+        Message message = mock(Message.class);
+
+        when(event.isMessageStart()).thenReturn(true);
+        when(event.asMessageStart()).thenReturn(messageStart);
+        when(messageStart.message()).thenReturn(message);
+        when(message.id()).thenThrow(new IllegalStateException("id is not set"));
+        when(message._id()).thenReturn(com.anthropic.core.JsonField.of("msg_stream_raw_only"));
+        when(event.isContentBlockDelta()).thenReturn(false);
+        when(event.isContentBlockStart()).thenReturn(false);
+        when(event.isMessageDelta()).thenReturn(false);
+
+        ChatResponse response = invokeParseStreamEvent(event, Instant.now());
+
+        assertNotNull(response);
+        assertEquals("msg_stream_raw_only", response.getId());
+        assertTrue(response.getContent().isEmpty());
+    }
+
+    @Test
+    void testParseStreamEventMessageStartWithoutIdFallsBackToGeneratedId() throws Exception {
+        RawMessageStreamEvent event = mock(RawMessageStreamEvent.class);
+        RawMessageStartEvent messageStart = mock(RawMessageStartEvent.class);
+        Message message = mock(Message.class);
+
+        when(event.isMessageStart()).thenReturn(true);
+        when(event.asMessageStart()).thenReturn(messageStart);
+        when(messageStart.message()).thenReturn(message);
+        when(message.id()).thenThrow(new IllegalStateException("id is not set"));
+        when(message._id()).thenReturn(com.anthropic.core.JsonField.ofNullable(null));
+        when(event.isContentBlockDelta()).thenReturn(false);
+        when(event.isContentBlockStart()).thenReturn(false);
+        when(event.isMessageDelta()).thenReturn(false);
+
+        ChatResponse response = invokeParseStreamEvent(event, Instant.now());
+
+        assertNotNull(response);
+        assertNotNull(response.getId());
+        assertFalse(response.getId().isEmpty());
+        assertTrue(response.getContent().isEmpty());
     }
 
     @Test


### PR DESCRIPTION
## Summary
- tolerate Anthropic proxy responses that omit the top-level `id` field
- reuse the SDK raw `_id()` field when available and fall back gracefully when it is missing
- add parser- and formatter-level regression coverage for both non-streaming and message-start streaming paths

## Root cause
`AnthropicResponseParser` called `message.id()` directly in both the non-streaming parse path and the streaming message-start path. Some proxy services strip the top-level `id` field, and the Anthropic SDK throws before AgentScope can build a `ChatResponse`.

## Fix
- add a safe message-id reader that prefers the SDK raw `_id()` field
- fall back to a generated `ChatResponse` id when the payload really has no `id`
- cover raw-id reuse and missing-id fallback in parser and formatter tests

## Validation
- `mvn -pl :agentscope-core -am spotless:apply`
- `mvn -pl :agentscope-core -am "-Dtest=AnthropicResponseParserTest,AnthropicChatFormatterTest" test`