### PR TITLE
fix(core): sanitize interrupted tool call arguments

### DIFF
--- a/agentscope-core/src/main/java/io/agentscope/core/agent/accumulator/ToolCallsAccumulator.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/agent/accumulator/ToolCallsAccumulator.java
@@ -17,7 +17,7 @@ package io.agentscope.core.agent.accumulator;
 
 import io.agentscope.core.message.ContentBlock;
 import io.agentscope.core.message.ToolUseBlock;
-import io.agentscope.core.util.JsonUtils;
+import io.agentscope.core.util.ToolCallJsonUtils;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -87,25 +87,18 @@ public class ToolCallsAccumulator implements ContentAccumulator<ToolUseBlock> {
             Map<String, Object> finalArgs = new HashMap<>(args);
             String rawContentStr = this.rawContent.toString();
 
-            // If no parsed arguments but has raw JSON content, try to parse
-            if (finalArgs.isEmpty() && rawContentStr.length() > 0) {
-                try {
-                    @SuppressWarnings("unchecked")
-                    Map<String, Object> parsed =
-                            JsonUtils.getJsonCodec().fromJson(rawContentStr, Map.class);
-                    if (parsed != null) {
-                        finalArgs.putAll(parsed);
-                    }
-                } catch (Exception ignored) {
-                    // Parsing failed, keep empty args
-                }
+            if (finalArgs.isEmpty()) {
+                finalArgs.putAll(ToolCallJsonUtils.parseJsonObjectOrEmpty(rawContentStr));
             }
+
+            String sanitizedContent =
+                    ToolCallJsonUtils.sanitizeArgumentsJson(rawContentStr, finalArgs);
 
             return ToolUseBlock.builder()
                     .id(toolId != null ? toolId : generateId())
                     .name(name)
                     .input(finalArgs)
-                    .content(rawContentStr.isEmpty() ? "{}" : rawContentStr)
+                    .content(sanitizedContent)
                     .metadata(metadata.isEmpty() ? null : metadata)
                     .build();
         }

--- a/agentscope-core/src/main/java/io/agentscope/core/formatter/dashscope/DashScopeToolsHelper.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/formatter/dashscope/DashScopeToolsHelper.java
@@ -24,7 +24,7 @@ import io.agentscope.core.message.ToolUseBlock;
 import io.agentscope.core.model.GenerateOptions;
 import io.agentscope.core.model.ToolChoice;
 import io.agentscope.core.model.ToolSchema;
-import io.agentscope.core.util.JsonUtils;
+import io.agentscope.core.util.ToolCallJsonUtils;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -236,19 +236,9 @@ public class DashScopeToolsHelper {
                 continue;
             }
 
-            // Prioritize using content field (raw arguments string), fallback to input map
-            // serialization
-            String argsJson;
-            if (toolUse.getContent() != null && !toolUse.getContent().isEmpty()) {
-                argsJson = toolUse.getContent();
-            } else {
-                try {
-                    argsJson = JsonUtils.getJsonCodec().toJson(toolUse.getInput());
-                } catch (Exception e) {
-                    log.warn("Failed to serialize tool call arguments: {}", e.getMessage());
-                    argsJson = "{}";
-                }
-            }
+            String argsJson =
+                    ToolCallJsonUtils.sanitizeArgumentsJson(
+                            toolUse.getContent(), toolUse.getInput());
 
             DashScopeFunction function = DashScopeFunction.of(toolUse.getName(), argsJson);
             DashScopeToolCall toolCall =

--- a/agentscope-core/src/main/java/io/agentscope/core/formatter/openai/OpenAIMessageConverter.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/formatter/openai/OpenAIMessageConverter.java
@@ -34,7 +34,7 @@ import io.agentscope.core.message.ToolResultBlock;
 import io.agentscope.core.message.ToolUseBlock;
 import io.agentscope.core.message.URLSource;
 import io.agentscope.core.message.VideoBlock;
-import io.agentscope.core.util.JsonUtils;
+import io.agentscope.core.util.ToolCallJsonUtils;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Function;
@@ -330,23 +330,9 @@ public class OpenAIMessageConverter {
                     continue;
                 }
 
-                // Prioritize using content field (raw arguments string), fallback to input map
-                // serialization
-                String argsJson;
-                if (toolUse.getContent() != null && !toolUse.getContent().isEmpty()) {
-                    argsJson = toolUse.getContent();
-                } else {
-                    try {
-                        argsJson = JsonUtils.getJsonCodec().toJson(toolUse.getInput());
-                    } catch (Exception e) {
-                        String errorMsg =
-                                e.getMessage() != null
-                                        ? e.getMessage()
-                                        : e.getClass().getSimpleName();
-                        log.warn("Failed to serialize tool call arguments: {}", errorMsg);
-                        argsJson = "{}";
-                    }
-                }
+                String argsJson =
+                        ToolCallJsonUtils.sanitizeArgumentsJson(
+                                toolUse.getContent(), toolUse.getInput());
 
                 // Add thought signature if present in metadata (required for Gemini)
                 String signature = null;

--- a/agentscope-core/src/main/java/io/agentscope/core/util/ToolCallJsonUtils.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/util/ToolCallJsonUtils.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.core.util;
+
+import java.util.Collections;
+import java.util.Map;
+
+/** Utility helpers for normalizing tool-call arguments stored as JSON strings. */
+public final class ToolCallJsonUtils {
+
+    private ToolCallJsonUtils() {}
+
+    /**
+     * Parse a raw JSON object string into a map.
+     *
+     * @param rawJson raw JSON object string
+     * @return parsed map, or empty map when the payload is blank or invalid
+     */
+    public static Map<String, Object> parseJsonObjectOrEmpty(String rawJson) {
+        if (rawJson == null || rawJson.isBlank()) {
+            return Collections.emptyMap();
+        }
+
+        try {
+            @SuppressWarnings("unchecked")
+            Map<String, Object> parsed = JsonUtils.getJsonCodec().fromJson(rawJson, Map.class);
+            return parsed != null ? parsed : Collections.emptyMap();
+        } catch (Exception ignored) {
+            return Collections.emptyMap();
+        }
+    }
+
+    /**
+     * Return a provider-safe JSON object string for tool call arguments.
+     *
+     * <p>Valid raw JSON is preserved as-is. Invalid or partial JSON falls back to serializing the
+     * structured input map, and ultimately to an empty JSON object.
+     *
+     * @param rawJson raw tool-call content accumulated from streaming chunks
+     * @param input structured tool-call input map
+     * @return safe JSON object string for downstream provider formatters
+     */
+    public static String sanitizeArgumentsJson(String rawJson, Map<String, Object> input) {
+        if (isValidJsonObject(rawJson)) {
+            return rawJson;
+        }
+        return serializeInputOrEmpty(input);
+    }
+
+    /**
+     * Check whether a raw tool-call payload is a valid JSON object.
+     *
+     * @param rawJson raw tool-call content
+     * @return true when the payload parses as a JSON object
+     */
+    public static boolean isValidJsonObject(String rawJson) {
+        return !parseJsonObjectOrEmpty(rawJson).isEmpty()
+                || (rawJson != null && "{}".equals(rawJson.trim()));
+    }
+
+    private static String serializeInputOrEmpty(Map<String, Object> input) {
+        if (input == null || input.isEmpty()) {
+            return "{}";
+        }
+
+        try {
+            return JsonUtils.getJsonCodec().toJson(input);
+        } catch (Exception ignored) {
+            return "{}";
+        }
+    }
+}

--- a/agentscope-core/src/test/java/io/agentscope/core/agent/accumulator/ToolCallsAccumulatorTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/agent/accumulator/ToolCallsAccumulatorTest.java
@@ -180,6 +180,45 @@ class ToolCallsAccumulatorTest {
     }
 
     @Test
+    @DisplayName("Should replace incomplete raw JSON with empty object when interrupted")
+    void testBuildSanitizesIncompleteRawContent() {
+        ToolUseBlock interruptedChunk =
+                ToolUseBlock.builder()
+                        .id("call_incomplete")
+                        .name("search")
+                        .content("{\"query\":\"hello wor")
+                        .build();
+
+        accumulator.add(interruptedChunk);
+
+        ToolUseBlock toolCall = accumulator.buildAllToolCalls().get(0);
+
+        assertEquals("{}", toolCall.getContent());
+        assertTrue(toolCall.getInput().isEmpty());
+    }
+
+    @Test
+    @DisplayName("Should serialize structured input when raw JSON fragments are invalid")
+    void testBuildFallsBackToStructuredInputWhenRawContentInvalid() {
+        ToolUseBlock interruptedChunk =
+                ToolUseBlock.builder()
+                        .id("call_structured")
+                        .name("search")
+                        .input(Map.of("query", "hello world", "page", 2))
+                        .content("{\"query\":\"hello wor")
+                        .build();
+
+        accumulator.add(interruptedChunk);
+
+        ToolUseBlock toolCall = accumulator.buildAllToolCalls().get(0);
+
+        assertEquals("hello world", toolCall.getInput().get("query"));
+        assertEquals(2, toolCall.getInput().get("page"));
+        assertTrue(toolCall.getContent().contains("hello world"));
+        assertTrue(toolCall.getContent().contains("page"));
+    }
+
+    @Test
     @DisplayName("Should get accumulated tool call by ID")
     void testGetAccumulatedToolCallById() {
         ToolUseBlock call1 =

--- a/agentscope-core/src/test/java/io/agentscope/core/formatter/dashscope/DashScopeToolsHelperComprehensiveTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/formatter/dashscope/DashScopeToolsHelperComprehensiveTest.java
@@ -340,6 +340,38 @@ class DashScopeToolsHelperComprehensiveTest {
         assertTrue(argsJson.contains("value"));
     }
 
+    @Test
+    void testConvertToolCallsFallsBackToStructuredInputWhenContentInvalid() {
+        ToolUseBlock block =
+                ToolUseBlock.builder()
+                        .id("call_invalid_json")
+                        .name("search")
+                        .input(Map.of("query", "hello world"))
+                        .content("{\"query\":\"hello wor")
+                        .build();
+
+        List<DashScopeToolCall> result = helper.convertToolCalls(List.of(block));
+
+        assertEquals(1, result.size());
+        assertEquals("search", result.get(0).getFunction().getName());
+        assertEquals("{\"query\":\"hello world\"}", result.get(0).getFunction().getArguments());
+    }
+
+    @Test
+    void testConvertToolCallsFallsBackToEmptyObjectWhenContentInvalidAndInputMissing() {
+        ToolUseBlock block =
+                ToolUseBlock.builder()
+                        .id("call_invalid_empty")
+                        .name("search")
+                        .content("{\"query\":\"hello wor")
+                        .build();
+
+        List<DashScopeToolCall> result = helper.convertToolCalls(List.of(block));
+
+        assertEquals(1, result.size());
+        assertEquals("{}", result.get(0).getFunction().getArguments());
+    }
+
     // ==================== convertToolChoice Tests ====================
 
     @Test

--- a/agentscope-core/src/test/java/io/agentscope/core/formatter/openai/OpenAIMessageConverterTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/formatter/openai/OpenAIMessageConverterTest.java
@@ -531,6 +531,50 @@ class OpenAIMessageConverterTest {
             assertTrue(args.contains("city"));
             assertTrue(args.contains("Shanghai"));
         }
+
+        @Test
+        @DisplayName("Should fallback to input map serialization when content is invalid JSON")
+        void testToolCallFallbackToInputMapWhenContentInvalid() {
+            ToolUseBlock toolBlock =
+                    ToolUseBlock.builder()
+                            .id("call_invalid_content_test")
+                            .name("get_weather")
+                            .input(Map.of("city", "Beijing"))
+                            .content("{\"city\":\"Beiji")
+                            .build();
+
+            Msg msg = Msg.builder().role(MsgRole.ASSISTANT).content(List.of(toolBlock)).build();
+
+            OpenAIMessage result = converter.convertToMessage(msg, false);
+
+            assertNotNull(result);
+            assertNotNull(result.getToolCalls());
+            assertEquals(1, result.getToolCalls().size());
+            assertEquals(
+                    "{\"city\":\"Beijing\"}",
+                    result.getToolCalls().get(0).getFunction().getArguments());
+        }
+
+        @Test
+        @DisplayName(
+                "Should fallback to empty object when content is invalid JSON and input is absent")
+        void testToolCallFallbackToEmptyObjectWhenContentInvalidAndInputAbsent() {
+            ToolUseBlock toolBlock =
+                    ToolUseBlock.builder()
+                            .id("call_invalid_content_empty")
+                            .name("get_weather")
+                            .content("{\"city\":\"Beiji")
+                            .build();
+
+            Msg msg = Msg.builder().role(MsgRole.ASSISTANT).content(List.of(toolBlock)).build();
+
+            OpenAIMessage result = converter.convertToMessage(msg, false);
+
+            assertNotNull(result);
+            assertNotNull(result.getToolCalls());
+            assertEquals(1, result.getToolCalls().size());
+            assertEquals("{}", result.getToolCalls().get(0).getFunction().getArguments());
+        }
     }
 
     @Nested

--- a/agentscope-core/src/test/java/io/agentscope/core/util/ToolCallJsonUtilsTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/util/ToolCallJsonUtilsTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.core.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/** Unit tests for {@link ToolCallJsonUtils}. */
+@DisplayName("ToolCallJsonUtils Tests")
+class ToolCallJsonUtilsTest {
+
+    @Test
+    @DisplayName("Should parse valid JSON object payloads")
+    void testParseJsonObjectOrEmptyWithValidObject() {
+        Map<String, Object> parsed =
+                ToolCallJsonUtils.parseJsonObjectOrEmpty("{\"query\":\"hello\",\"page\":2}");
+
+        assertEquals("hello", parsed.get("query"));
+        assertEquals(2, parsed.get("page"));
+    }
+
+    @Test
+    @DisplayName("Should return empty map for invalid JSON object payloads")
+    void testParseJsonObjectOrEmptyWithInvalidObject() {
+        Map<String, Object> parsed = ToolCallJsonUtils.parseJsonObjectOrEmpty("{\"query\":\"hello");
+
+        assertTrue(parsed.isEmpty());
+    }
+
+    @Test
+    @DisplayName("Should recognize valid JSON objects")
+    void testIsValidJsonObject() {
+        assertTrue(ToolCallJsonUtils.isValidJsonObject("{\"query\":\"hello\"}"));
+        assertTrue(ToolCallJsonUtils.isValidJsonObject("{}"));
+        assertFalse(ToolCallJsonUtils.isValidJsonObject("{\"query\":\"hello"));
+        assertFalse(ToolCallJsonUtils.isValidJsonObject("[]"));
+    }
+
+    @Test
+    @DisplayName("Should preserve valid raw JSON arguments")
+    void testSanitizeArgumentsJsonPreservesValidContent() {
+        String sanitized =
+                ToolCallJsonUtils.sanitizeArgumentsJson(
+                        "{\"query\":\"hello\"}", Map.of("query", "ignored"));
+
+        assertEquals("{\"query\":\"hello\"}", sanitized);
+    }
+
+    @Test
+    @DisplayName("Should fallback to structured input when raw JSON is invalid")
+    void testSanitizeArgumentsJsonFallsBackToStructuredInput() {
+        String sanitized =
+                ToolCallJsonUtils.sanitizeArgumentsJson(
+                        "{\"query\":\"hello", Map.of("query", "hello", "page", 2));
+
+        assertTrue(sanitized.contains("hello"));
+        assertTrue(sanitized.contains("page"));
+    }
+
+    @Test
+    @DisplayName("Should fallback to empty object when both raw JSON and input are missing")
+    void testSanitizeArgumentsJsonFallsBackToEmptyObject() {
+        String sanitized = ToolCallJsonUtils.sanitizeArgumentsJson("{\"query\":\"hello", Map.of());
+
+        assertEquals("{}", sanitized);
+    }
+}


### PR DESCRIPTION
## Summary
- sanitize interrupted streaming tool-call argument payloads before they are persisted into memory
- add a shared JSON normalization helper used by the accumulator and provider converters
- add regression tests for accumulator recovery plus DashScope/OpenAI formatter fallback behavior

## Why this fix
When a streaming tool call is interrupted mid-JSON, AgentScope can persist a partial `ToolUseBlock.content` string into memory. On the next request, the DashScope/OpenAI formatter path reuses that invalid JSON as tool-call arguments, which can trigger provider-side 400 errors.

This patch fixes the bug at two layers:
- `ToolCallsAccumulator` now normalizes incomplete raw argument fragments to either serialized structured input or `{}` before the message is finalized
- `DashScopeToolsHelper` and `OpenAIMessageConverter` now defensively sanitize historical `ToolUseBlock.content` before sending it back to providers

Fixes #1147.

## Validation
- `mvn -pl :agentscope-core -am spotless:apply`
- `mvn -pl :agentscope-core -am "-Dtest=ToolCallsAccumulatorTest,DashScopeToolsHelperComprehensiveTest,OpenAIMessageConverterTest,ToolCallJsonUtilsTest" test`