### PR TITLE
fix(extensions-agui): convert SUMMARY events to AG-UI messages (#1029)

### DIFF
--- a/agentscope-extensions/agentscope-extensions-agui/src/main/java/io/agentscope/core/agui/adapter/AguiAgentAdapter.java
+++ b/agentscope-extensions/agentscope-extensions-agui/src/main/java/io/agentscope/core/agui/adapter/AguiAgentAdapter.java
@@ -325,14 +325,14 @@ public class AguiAgentAdapter {
         StringBuilder sb = new StringBuilder();
         for (ContentBlock output : toolResult.getOutput()) {
             if (output instanceof TextBlock textBlock) {
-                if (sb.length() > 0) {
+                if (!sb.isEmpty()) {
                     sb.append("\n");
                 }
                 sb.append(textBlock.getText());
             }
         }
 
-        return sb.length() > 0 ? sb.toString() : null;
+        return !sb.isEmpty() ? sb.toString() : null;
     }
 
     /**

--- a/agentscope-extensions/agentscope-extensions-agui/src/main/java/io/agentscope/core/agui/adapter/AguiAgentAdapter.java
+++ b/agentscope-extensions/agentscope-extensions-agui/src/main/java/io/agentscope/core/agui/adapter/AguiAgentAdapter.java
@@ -47,8 +47,9 @@ import reactor.core.publisher.Flux;
  *
  * <p><b>Event Mapping:</b>
  * <ul>
- *   <li>AgentScope REASONING events → AG-UI TEXT_MESSAGE_* events (for TextBlock)</li>
- *   <li>AgentScope REASONING events → AG-UI REASONING_* events (for ThinkingBlock, when enabled)</li>
+ *   <li>AgentScope REASONING/SUMMARY events → AG-UI TEXT_MESSAGE_* events (for TextBlock)</li>
+ *   <li>AgentScope REASONING/SUMMARY events → AG-UI REASONING_* events (for
+ *       ThinkingBlock, when enabled)</li>
  *   <li>AgentScope TOOL_RESULT events → AG-UI TOOL_CALL_END events</li>
  *   <li>ToolUseBlock content → AG-UI TOOL_CALL_START events</li>
  * </ul>
@@ -136,8 +137,8 @@ public class AguiAgentAdapter {
         Msg msg = event.getMessage();
         EventType type = event.getType();
 
-        if (type == EventType.REASONING) {
-            // Handle reasoning events - convert to text messages and tool calls
+        if (type == EventType.REASONING || type == EventType.SUMMARY) {
+            // Handle reasoning/summary events - convert to text messages and tool calls
             for (ContentBlock block : msg.getContent()) {
                 if (block instanceof TextBlock textBlock) {
                     String text = textBlock.getText();

--- a/agentscope-extensions/agentscope-extensions-agui/src/test/java/io/agentscope/core/agui/adapter/AguiAgentAdapterTest.java
+++ b/agentscope-extensions/agentscope-extensions-agui/src/test/java/io/agentscope/core/agui/adapter/AguiAgentAdapterTest.java
@@ -172,6 +172,114 @@ class AguiAgentAdapterTest {
     }
 
     @Test
+    void testRunWithSummaryEventUsesTextMessages() {
+        Msg summaryChunk =
+                Msg.builder()
+                        .id("msg-summary")
+                        .role(MsgRole.ASSISTANT)
+                        .content(
+                                TextBlock.builder()
+                                        .text("Here is the conversation summary.")
+                                        .build())
+                        .build();
+
+        Msg summaryFinal =
+                Msg.builder()
+                        .id("msg-summary")
+                        .role(MsgRole.ASSISTANT)
+                        .content(
+                                TextBlock.builder()
+                                        .text("Here is the conversation summary.")
+                                        .build())
+                        .build();
+
+        Event summaryChunkEvent = new Event(EventType.SUMMARY, summaryChunk, false);
+        Event summaryFinalEvent = new Event(EventType.SUMMARY, summaryFinal, true);
+
+        when(mockAgent.stream(anyList(), any(StreamOptions.class)))
+                .thenReturn(Flux.just(summaryChunkEvent, summaryFinalEvent));
+
+        RunAgentInput input =
+                RunAgentInput.builder()
+                        .threadId("thread-1")
+                        .runId("run-1")
+                        .messages(List.of(AguiMessage.userMessage("msg-1", "Hello")))
+                        .build();
+
+        List<AguiEvent> events = adapter.run(input).collectList().block();
+
+        assertNotNull(events);
+
+        AguiEvent.TextMessageContent summaryContent =
+                events.stream()
+                        .filter(e -> e instanceof AguiEvent.TextMessageContent)
+                        .map(e -> (AguiEvent.TextMessageContent) e)
+                        .findFirst()
+                        .orElse(null);
+
+        assertNotNull(summaryContent, "Should convert SUMMARY to TextMessageContent");
+        assertEquals("msg-summary", summaryContent.messageId());
+        assertEquals("Here is the conversation summary.", summaryContent.delta());
+
+        long textEndCount =
+                events.stream().filter(e -> e instanceof AguiEvent.TextMessageEnd).count();
+        assertEquals(1, textEndCount, "Should close the summary text message exactly once");
+    }
+
+    @Test
+    void testRunWithStreamingSummaryEvents() {
+        Msg summaryChunk1 =
+                Msg.builder()
+                        .id("msg-summary")
+                        .role(MsgRole.ASSISTANT)
+                        .content(TextBlock.builder().text("First part. ").build())
+                        .build();
+
+        Msg summaryChunk2 =
+                Msg.builder()
+                        .id("msg-summary")
+                        .role(MsgRole.ASSISTANT)
+                        .content(TextBlock.builder().text("Second part.").build())
+                        .build();
+
+        Msg summaryFinal =
+                Msg.builder()
+                        .id("msg-summary")
+                        .role(MsgRole.ASSISTANT)
+                        .content(TextBlock.builder().text("First part. Second part.").build())
+                        .build();
+
+        Event event1 = new Event(EventType.SUMMARY, summaryChunk1, false);
+        Event event2 = new Event(EventType.SUMMARY, summaryChunk2, false);
+        Event event3 = new Event(EventType.SUMMARY, summaryFinal, true);
+
+        when(mockAgent.stream(anyList(), any(StreamOptions.class)))
+                .thenReturn(Flux.just(event1, event2, event3));
+
+        RunAgentInput input =
+                RunAgentInput.builder()
+                        .threadId("thread-1")
+                        .runId("run-1")
+                        .messages(List.of(AguiMessage.userMessage("msg-1", "Hello")))
+                        .build();
+
+        List<AguiEvent> events = adapter.run(input).collectList().block();
+
+        assertNotNull(events);
+
+        long contentCount =
+                events.stream().filter(e -> e instanceof AguiEvent.TextMessageContent).count();
+        assertEquals(2, contentCount, "Should stream summary chunks as text deltas");
+
+        long startCount =
+                events.stream().filter(e -> e instanceof AguiEvent.TextMessageStart).count();
+        assertEquals(1, startCount, "Should only start the summary message once");
+
+        long endCount = events.stream().filter(e -> e instanceof AguiEvent.TextMessageEnd).count();
+        assertEquals(1, endCount, "Should only end the summary message once");
+    }
+
+    @Test
     void testRunWithToolCallEvent() {
         Msg toolCallMsg =
                 Msg.builder()


### PR DESCRIPTION

## Description

Fixes #1029.

When a ReAct agent reaches `maxIters`, AgentScope emits a `SUMMARY` event as a fallback response.
Before this change, `extensions-agui` only converted `REASONING` events into AG-UI text events, so the client only received `RUN_FINISHED` and could not see the summary content.

This PR updates the AG-UI adapter to also convert `EventType.SUMMARY` using the existing text-message mapping path.
As a result, when the agent stops because it exceeds `maxIters`, the frontend can still receive the final summary content through AG-UI events.

Changes included:
- Handle `EventType.SUMMARY` in the AG-UI adapter
- Reuse the existing text/reasoning event conversion flow
- Add regression tests for normal summary and streaming summary cases

How to verify:
- Configure an agent with `maxIters=1`
- Send a request that requires at least one tool call before producing the final answer
- Before the fix:
  - the AG-UI stream ends after `TOOL_CALL_RESULT` with `RUN_FINISHED`
  - no assistant summary text is delivered
- After the fix:
  - the AG-UI stream includes `TEXT_MESSAGE_START / TEXT_MESSAGE_CONTENT / TEXT_MESSAGE_END`
  - the summary content is visible to the client

## Checklist

- [x] Code has been formatted
- [x] All tests are passing 
- [x] Javadoc comments are complete and follow project conventions
- [x] Code is ready for review