### PR TITLE
fix(core): mirror summary thinking into reasoning events

### DIFF
--- a/agentscope-core/src/main/java/io/agentscope/core/ReActAgent.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/ReActAgent.java
@@ -936,45 +936,21 @@ public class ReActAgent extends StructuredOutputCapableAgent {
     }
 
     private Mono<Void> notifyReasoningChunk(Msg chunkMsg, ReasoningContext context) {
-        ContentBlock content = chunkMsg.getFirstContentBlock();
+        return notifyReasoningChunk(chunkMsg, context, null);
+    }
 
-        ContentBlock accumulatedContent = null;
-        if (content instanceof TextBlock) {
-            accumulatedContent = TextBlock.builder().text(context.getAccumulatedText()).build();
-        } else if (content instanceof ThinkingBlock) {
-            accumulatedContent =
-                    ThinkingBlock.builder().thinking(context.getAccumulatedThinking()).build();
-        } else if (content instanceof ToolUseBlock tub) {
-            // Support streaming ToolUseBlock events
-            ToolUseBlock accumulated = context.getAccumulatedToolCall(tub.getId());
-            if (accumulated != null) {
-                accumulatedContent = accumulated;
-            } else {
-                // If no accumulated data, use the current chunk directly
-                accumulatedContent = tub;
-            }
+    private Mono<Void> notifyReasoningChunk(
+            Msg chunkMsg, ReasoningContext context, GenerateOptions generateOptions) {
+        ContentBlock accumulatedContent = resolveAccumulatedReasoningContent(chunkMsg, context);
+        if (accumulatedContent == null) {
+            return Mono.empty();
         }
 
-        if (accumulatedContent != null) {
-            Msg accumulated =
-                    Msg.builder()
-                            .id(chunkMsg.getId())
-                            .name(chunkMsg.getName())
-                            .role(chunkMsg.getRole())
-                            .content(accumulatedContent)
-                            .build();
-            if (context.getChatUsage() != null) {
-                accumulated
-                        .getMetadata()
-                        .put(MessageMetadataKeys.CHAT_USAGE, context.getChatUsage());
-            }
-            ReasoningChunkEvent event =
-                    new ReasoningChunkEvent(
-                            this, model.getModelName(), null, chunkMsg, accumulated);
-            return Flux.fromIterable(getSortedHooks()).flatMap(hook -> hook.onEvent(event)).then();
-        }
-
-        return Mono.empty();
+        Msg accumulated = buildAccumulatedChunkMessage(chunkMsg, accumulatedContent, context);
+        ReasoningChunkEvent event =
+                new ReasoningChunkEvent(
+                        this, model.getModelName(), generateOptions, chunkMsg, accumulated);
+        return Flux.fromIterable(getSortedHooks()).flatMap(hook -> hook.onEvent(event)).then();
     }
 
     // ==================== Summary Hook Notification Methods ====================
@@ -994,34 +970,66 @@ public class ReActAgent extends StructuredOutputCapableAgent {
             Msg chunkMsg, ReasoningContext context, GenerateOptions generateOptions) {
         ContentBlock content = chunkMsg.getFirstContentBlock();
 
-        ContentBlock accumulatedContent = null;
+        ContentBlock accumulatedContent = resolveAccumulatedSummaryContent(chunkMsg, context);
+        if (accumulatedContent == null) {
+            return Mono.empty();
+        }
+
+        Msg accumulated = buildAccumulatedChunkMessage(chunkMsg, accumulatedContent, context);
+        SummaryChunkEvent event =
+                new SummaryChunkEvent(
+                        this, model.getModelName(), generateOptions, chunkMsg, accumulated);
+        Mono<Void> summaryNotification =
+                Flux.fromIterable(getSortedHooks()).flatMap(hook -> hook.onEvent(event)).then();
+
+        if (content instanceof ThinkingBlock) {
+            return notifyReasoningChunk(chunkMsg, context, generateOptions)
+                    .then(summaryNotification);
+        }
+
+        return summaryNotification;
+    }
+
+    private Msg buildAccumulatedChunkMessage(
+            Msg chunkMsg, ContentBlock accumulatedContent, ReasoningContext context) {
+        Msg accumulated =
+                Msg.builder()
+                        .id(chunkMsg.getId())
+                        .name(chunkMsg.getName())
+                        .role(chunkMsg.getRole())
+                        .content(accumulatedContent)
+                        .build();
+        if (context.getChatUsage() != null) {
+            accumulated.getMetadata().put(MessageMetadataKeys.CHAT_USAGE, context.getChatUsage());
+        }
+        return accumulated;
+    }
+
+    private ContentBlock resolveAccumulatedReasoningContent(
+            Msg chunkMsg, ReasoningContext context) {
+        ContentBlock content = chunkMsg.getFirstContentBlock();
         if (content instanceof TextBlock) {
-            accumulatedContent = TextBlock.builder().text(context.getAccumulatedText()).build();
-        } else if (content instanceof ThinkingBlock) {
-            accumulatedContent =
-                    ThinkingBlock.builder().thinking(context.getAccumulatedThinking()).build();
+            return TextBlock.builder().text(context.getAccumulatedText()).build();
         }
-
-        if (accumulatedContent != null) {
-            Msg accumulated =
-                    Msg.builder()
-                            .id(chunkMsg.getId())
-                            .name(chunkMsg.getName())
-                            .role(chunkMsg.getRole())
-                            .content(accumulatedContent)
-                            .build();
-            if (context.getChatUsage() != null) {
-                accumulated
-                        .getMetadata()
-                        .put(MessageMetadataKeys.CHAT_USAGE, context.getChatUsage());
-            }
-            SummaryChunkEvent event =
-                    new SummaryChunkEvent(
-                            this, model.getModelName(), generateOptions, chunkMsg, accumulated);
-            return Flux.fromIterable(getSortedHooks()).flatMap(hook -> hook.onEvent(event)).then();
+        if (content instanceof ThinkingBlock) {
+            return ThinkingBlock.builder().thinking(context.getAccumulatedThinking()).build();
         }
+        if (content instanceof ToolUseBlock tub) {
+            ToolUseBlock accumulated = context.getAccumulatedToolCall(tub.getId());
+            return accumulated != null ? accumulated : tub;
+        }
+        return null;
+    }
 
-        return Mono.empty();
+    private ContentBlock resolveAccumulatedSummaryContent(Msg chunkMsg, ReasoningContext context) {
+        ContentBlock content = chunkMsg.getFirstContentBlock();
+        if (content instanceof TextBlock) {
+            return TextBlock.builder().text(context.getAccumulatedText()).build();
+        }
+        if (content instanceof ThinkingBlock) {
+            return ThinkingBlock.builder().thinking(context.getAccumulatedThinking()).build();
+        }
+        return null;
     }
 
     @Override

--- a/agentscope-core/src/test/java/io/agentscope/core/agent/ReActAgentSummaryThinkingHookTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/agent/ReActAgentSummaryThinkingHookTest.java
@@ -1,0 +1,248 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.core.agent;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.agentscope.core.ReActAgent;
+import io.agentscope.core.agent.test.MockModel;
+import io.agentscope.core.agent.test.MockToolkit;
+import io.agentscope.core.agent.test.TestConstants;
+import io.agentscope.core.agent.test.TestUtils;
+import io.agentscope.core.hook.Hook;
+import io.agentscope.core.hook.HookEvent;
+import io.agentscope.core.hook.ReasoningChunkEvent;
+import io.agentscope.core.hook.SummaryChunkEvent;
+import io.agentscope.core.memory.InMemoryMemory;
+import io.agentscope.core.message.GenerateReason;
+import io.agentscope.core.message.Msg;
+import io.agentscope.core.message.TextBlock;
+import io.agentscope.core.message.ThinkingBlock;
+import io.agentscope.core.message.ToolUseBlock;
+import io.agentscope.core.model.ChatResponse;
+import io.agentscope.core.util.JsonUtils;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.CopyOnWriteArrayList;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Mono;
+
+/** Regression tests for summary-stream thinking hook events. */
+@DisplayName("ReActAgent Summary Thinking Hook Tests")
+class ReActAgentSummaryThinkingHookTest {
+
+    @Test
+    @DisplayName("Should emit ReasoningChunkEvent for summary thinking chunks")
+    void testSummaryThinkingChunksAlsoEmitReasoningEvents() {
+        CopyOnWriteArrayList<String> reasoningChunks = new CopyOnWriteArrayList<>();
+        CopyOnWriteArrayList<String> summaryThinkingChunks = new CopyOnWriteArrayList<>();
+        CopyOnWriteArrayList<String> summaryTextChunks = new CopyOnWriteArrayList<>();
+
+        Hook captureHook =
+                new Hook() {
+                    @Override
+                    public <T extends HookEvent> Mono<T> onEvent(T event) {
+                        if (event instanceof ReasoningChunkEvent reasoningEvent) {
+                            ThinkingBlock block =
+                                    reasoningEvent
+                                            .getIncrementalChunk()
+                                            .getFirstContentBlock(ThinkingBlock.class);
+                            if (block != null) {
+                                reasoningChunks.add(block.getThinking());
+                            }
+                        }
+                        if (event instanceof SummaryChunkEvent summaryEvent) {
+                            ThinkingBlock thinkingBlock =
+                                    summaryEvent
+                                            .getIncrementalChunk()
+                                            .getFirstContentBlock(ThinkingBlock.class);
+                            if (thinkingBlock != null) {
+                                summaryThinkingChunks.add(thinkingBlock.getThinking());
+                            }
+                            TextBlock textBlock =
+                                    summaryEvent
+                                            .getIncrementalChunk()
+                                            .getFirstContentBlock(TextBlock.class);
+                            if (textBlock != null && !textBlock.getText().isEmpty()) {
+                                summaryTextChunks.add(textBlock.getText());
+                            }
+                        }
+                        return Mono.just(event);
+                    }
+                };
+
+        ReActAgent agent = createAgentForSummaryThinkingHooks(captureHook);
+        Msg response =
+                agent.call(TestUtils.createUserMessage("User", "Need a concise answer"))
+                        .block(Duration.ofMillis(TestConstants.DEFAULT_TEST_TIMEOUT_MS));
+
+        assertEquals(GenerateReason.MAX_ITERATIONS, response.getGenerateReason());
+        assertEquals(List.of("I should ", "summarize carefully."), reasoningChunks);
+        assertEquals(List.of("I should ", "summarize carefully."), summaryThinkingChunks);
+        assertEquals(List.of("Final concise answer."), summaryTextChunks);
+    }
+
+    @Test
+    @DisplayName("Should accumulate summary thinking content in mirrored reasoning events")
+    void testSummaryThinkingReasoningEventsUseAccumulatedThinking() {
+        CopyOnWriteArrayList<String> accumulatedThinking = new CopyOnWriteArrayList<>();
+
+        Hook captureHook =
+                new Hook() {
+                    @Override
+                    public <T extends HookEvent> Mono<T> onEvent(T event) {
+                        if (event instanceof ReasoningChunkEvent reasoningEvent) {
+                            ThinkingBlock block =
+                                    reasoningEvent
+                                            .getAccumulated()
+                                            .getFirstContentBlock(ThinkingBlock.class);
+                            if (block != null) {
+                                accumulatedThinking.add(block.getThinking());
+                            }
+                        }
+                        return Mono.just(event);
+                    }
+                };
+
+        ReActAgent agent = createAgentForSummaryThinkingHooks(captureHook);
+        agent.call(TestUtils.createUserMessage("User", "Need a concise answer"))
+                .block(Duration.ofMillis(TestConstants.DEFAULT_TEST_TIMEOUT_MS));
+
+        assertEquals(List.of("I should ", "I should summarize carefully."), accumulatedThinking);
+    }
+
+    @Test
+    @DisplayName("Should emit mirrored reasoning event before summary event for summary thinking")
+    void testSummaryThinkingReasoningEventOrder() {
+        CopyOnWriteArrayList<String> eventOrder = new CopyOnWriteArrayList<>();
+
+        Hook captureHook =
+                new Hook() {
+                    @Override
+                    public <T extends HookEvent> Mono<T> onEvent(T event) {
+                        if (event instanceof ReasoningChunkEvent reasoningEvent) {
+                            ThinkingBlock block =
+                                    reasoningEvent
+                                            .getIncrementalChunk()
+                                            .getFirstContentBlock(ThinkingBlock.class);
+                            if (block != null) {
+                                eventOrder.add("reasoning:" + block.getThinking());
+                            }
+                        }
+                        if (event instanceof SummaryChunkEvent summaryEvent) {
+                            ThinkingBlock thinkingBlock =
+                                    summaryEvent
+                                            .getIncrementalChunk()
+                                            .getFirstContentBlock(ThinkingBlock.class);
+                            if (thinkingBlock != null) {
+                                eventOrder.add("summary-thinking:" + thinkingBlock.getThinking());
+                            }
+                            TextBlock textBlock =
+                                    summaryEvent
+                                            .getIncrementalChunk()
+                                            .getFirstContentBlock(TextBlock.class);
+                            if (textBlock != null && !textBlock.getText().isEmpty()) {
+                                eventOrder.add("summary-text:" + textBlock.getText());
+                            }
+                        }
+                        return Mono.just(event);
+                    }
+                };
+
+        ReActAgent agent = createAgentForSummaryThinkingHooks(captureHook);
+        agent.call(TestUtils.createUserMessage("User", "Need a concise answer"))
+                .block(Duration.ofMillis(TestConstants.DEFAULT_TEST_TIMEOUT_MS));
+
+        assertFalse(eventOrder.isEmpty());
+        assertEquals(
+                List.of(
+                        "reasoning:I should ",
+                        "summary-thinking:I should ",
+                        "reasoning:summarize carefully.",
+                        "summary-thinking:summarize carefully.",
+                        "summary-text:Final concise answer."),
+                eventOrder);
+        assertTrue(
+                eventOrder.stream()
+                        .noneMatch(item -> item.startsWith("reasoning:Final concise answer.")));
+    }
+
+    private ReActAgent createAgentForSummaryThinkingHooks(Hook captureHook) {
+        MockModel model =
+                new MockModel(
+                        messages -> {
+                            if (messages.stream()
+                                    .anyMatch(
+                                            msg ->
+                                                    msg.getTextContent()
+                                                            .contains("maximum iterations"))) {
+                                return List.of(
+                                        createThinkingResponse("I should "),
+                                        createThinkingResponse("summarize carefully."),
+                                        createTextResponse("Final concise answer."));
+                            }
+                            return List.of(
+                                    createToolCallResponse(
+                                            TestConstants.TEST_TOOL_NAME,
+                                            "summary_tool_call",
+                                            TestUtils.createToolArguments()));
+                        });
+
+        return ReActAgent.builder()
+                .name(TestConstants.TEST_REACT_AGENT_NAME)
+                .sysPrompt(TestConstants.DEFAULT_SYS_PROMPT)
+                .model(model)
+                .toolkit(new MockToolkit())
+                .memory(new InMemoryMemory())
+                .hook(captureHook)
+                .maxIters(1)
+                .build();
+    }
+
+    private ChatResponse createThinkingResponse(String thinking) {
+        return ChatResponse.builder()
+                .id("msg_" + UUID.randomUUID())
+                .content(List.of(ThinkingBlock.builder().thinking(thinking).build()))
+                .build();
+    }
+
+    private ChatResponse createTextResponse(String text) {
+        return ChatResponse.builder()
+                .id("msg_" + UUID.randomUUID())
+                .content(List.of(TextBlock.builder().text(text).build()))
+                .build();
+    }
+
+    private ChatResponse createToolCallResponse(
+            String toolName, String toolCallId, Map<String, Object> arguments) {
+        return ChatResponse.builder()
+                .id("msg_" + UUID.randomUUID())
+                .content(
+                        List.of(
+                                ToolUseBlock.builder()
+                                        .name(toolName)
+                                        .id(toolCallId)
+                                        .input(arguments)
+                                        .content(JsonUtils.getJsonCodec().toJson(arguments))
+                                        .build()))
+                .build();
+    }
+}


### PR DESCRIPTION
## Summary
- mirror summary-phase `ThinkingBlock` chunks into `ReasoningChunkEvent`
- keep the existing `SummaryChunkEvent` behavior for summary streaming intact
- add regression tests for summary thinking delivery, accumulated reasoning content, and hook event order

## Why this fix
`ReActAgent` uses a dedicated summary streaming path after max-iteration fallback. In that path, a streamed `ThinkingBlock` currently only triggers `SummaryChunkEvent`, even though the same provider/model behavior is exposed as `ReasoningChunkEvent` in normal reasoning streams.

That breaks the hook abstraction for clients that render reasoning exclusively from `ReasoningChunkEvent`, especially with models like `qwen3.5-plus` that may place thinking deltas inside the summary stream.

This patch keeps summary hooks working as before, while also mirroring summary-phase thinking chunks into `ReasoningChunkEvent` with accumulated thinking content.

Fixes #1152.

## Validation
- `mvn -pl :agentscope-core -am spotless:apply`
- `mvn -pl :agentscope-core -am "-Dtest=ReActAgentSummaryThinkingHookTest" test`
- `mvn -pl :agentscope-core -am "-Dtest=ReActAgentTest,ReActAgentThinkingCumulativeTest,ReActAgentSummaryThinkingHookTest" test`