### PR TITLE
feat(gemini): add baseUrl builder support

### DIFF
--- a/agentscope-core/src/main/java/io/agentscope/core/model/GeminiChatModel.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/model/GeminiChatModel.java
@@ -108,12 +108,7 @@ public class GeminiChatModel extends ChatModelBase {
         this.project = project;
         this.location = location;
         this.vertexAI = vertexAI;
-        this.httpOptions =
-                baseUrl == null
-                        ? httpOptions
-                        : (httpOptions == null
-                                ? HttpOptions.builder().baseUrl(baseUrl).build()
-                                : httpOptions.toBuilder().baseUrl(baseUrl).build());
+        this.httpOptions = resolveHttpOptions(baseUrl, httpOptions);
         this.credentials = credentials;
         this.clientOptions = clientOptions;
         this.defaultOptions =
@@ -154,7 +149,11 @@ public class GeminiChatModel extends ChatModelBase {
     }
 
     /**
-     * Creates a new Gemini chat model instance with the default Gemini API endpoint.
+     * Creates a new Gemini chat model instance using the default endpoint configuration.
+     *
+     * <p>This overload passes {@code null} for {@code baseUrl}, allowing the SDK to use its
+     * default endpoint behavior for either Gemini API or Vertex AI, depending on the provided
+     * configuration.
      *
      * @param apiKey         the API key for authentication (for Gemini API)
      * @param modelName      the model name to use (e.g., "gemini-2.0-flash",
@@ -196,6 +195,16 @@ public class GeminiChatModel extends ChatModelBase {
                 clientOptions,
                 defaultOptions,
                 formatter);
+    }
+
+    private static HttpOptions resolveHttpOptions(String baseUrl, HttpOptions httpOptions) {
+        if (baseUrl == null) {
+            return httpOptions;
+        }
+        if (httpOptions == null) {
+            return HttpOptions.builder().baseUrl(baseUrl).build();
+        }
+        return httpOptions.toBuilder().baseUrl(baseUrl).build();
     }
 
     /**

--- a/agentscope-core/src/main/java/io/agentscope/core/model/GeminiChatModel.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/model/GeminiChatModel.java
@@ -74,6 +74,7 @@ public class GeminiChatModel extends ChatModelBase {
      * Creates a new Gemini chat model instance.
      *
      * @param apiKey         the API key for authentication (for Gemini API)
+     * @param baseUrl        the custom base URL for Gemini API (null for default)
      * @param modelName      the model name to use (e.g., "gemini-2.0-flash",
      *                       "gemini-1.5-pro")
      * @param streamEnabled  whether streaming should be enabled
@@ -90,6 +91,7 @@ public class GeminiChatModel extends ChatModelBase {
      */
     public GeminiChatModel(
             String apiKey,
+            String baseUrl,
             String modelName,
             boolean streamEnabled,
             String project,
@@ -106,7 +108,12 @@ public class GeminiChatModel extends ChatModelBase {
         this.project = project;
         this.location = location;
         this.vertexAI = vertexAI;
-        this.httpOptions = httpOptions;
+        this.httpOptions =
+                baseUrl == null
+                        ? httpOptions
+                        : (httpOptions == null
+                                ? HttpOptions.builder().baseUrl(baseUrl).build()
+                                : httpOptions.toBuilder().baseUrl(baseUrl).build());
         this.credentials = credentials;
         this.clientOptions = clientOptions;
         this.defaultOptions =
@@ -136,8 +143,8 @@ public class GeminiChatModel extends ChatModelBase {
         }
 
         // Configure HTTP and client options
-        if (httpOptions != null) {
-            clientBuilder.httpOptions(httpOptions);
+        if (this.httpOptions != null) {
+            clientBuilder.httpOptions(this.httpOptions);
         }
         if (clientOptions != null) {
             clientBuilder.clientOptions(clientOptions);
@@ -281,6 +288,7 @@ public class GeminiChatModel extends ChatModelBase {
      */
     public static class Builder {
         private String apiKey;
+        private String baseUrl;
         private String modelName = "gemini-2.5-flash";
         private boolean streamEnabled = true;
         private String project;
@@ -301,6 +309,17 @@ public class GeminiChatModel extends ChatModelBase {
          */
         public Builder apiKey(String apiKey) {
             this.apiKey = apiKey;
+            return this;
+        }
+
+        /**
+         * Sets the custom base URL (for Gemini API).
+         *
+         * @param baseUrl the custom Gemini API base URL
+         * @return this builder
+         */
+        public Builder baseUrl(String baseUrl) {
+            this.baseUrl = baseUrl;
             return this;
         }
 
@@ -424,6 +443,7 @@ public class GeminiChatModel extends ChatModelBase {
         public GeminiChatModel build() {
             return new GeminiChatModel(
                     apiKey,
+                    baseUrl,
                     modelName,
                     streamEnabled,
                     project,

--- a/agentscope-core/src/main/java/io/agentscope/core/model/GeminiChatModel.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/model/GeminiChatModel.java
@@ -154,6 +154,51 @@ public class GeminiChatModel extends ChatModelBase {
     }
 
     /**
+     * Creates a new Gemini chat model instance with the default Gemini API endpoint.
+     *
+     * @param apiKey         the API key for authentication (for Gemini API)
+     * @param modelName      the model name to use (e.g., "gemini-2.0-flash",
+     *                       "gemini-1.5-pro")
+     * @param streamEnabled  whether streaming should be enabled
+     * @param project        the Google Cloud project ID (for Vertex AI)
+     * @param location       the Google Cloud location (for Vertex AI, e.g.,
+     *                       "us-central1")
+     * @param vertexAI       whether to use Vertex AI APIs (null for auto-detection)
+     * @param httpOptions    HTTP options for the client
+     * @param credentials    Google credentials (for Vertex AI)
+     * @param clientOptions  client options for the API client
+     * @param defaultOptions default generation options
+     * @param formatter      the message formatter to use (null for default Gemini
+     *                       formatter)
+     */
+    public GeminiChatModel(
+            String apiKey,
+            String modelName,
+            boolean streamEnabled,
+            String project,
+            String location,
+            Boolean vertexAI,
+            HttpOptions httpOptions,
+            GoogleCredentials credentials,
+            ClientOptions clientOptions,
+            GenerateOptions defaultOptions,
+            Formatter<Content, GenerateContentResponse, GenerateContentConfig.Builder> formatter) {
+        this(
+                apiKey,
+                null,
+                modelName,
+                streamEnabled,
+                project,
+                location,
+                vertexAI,
+                httpOptions,
+                credentials,
+                clientOptions,
+                defaultOptions,
+                formatter);
+    }
+
+    /**
      * Stream chat completion responses from Gemini's API.
      *
      * <p>

--- a/agentscope-core/src/test/java/io/agentscope/core/model/GeminiChatModelTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/model/GeminiChatModelTest.java
@@ -314,7 +314,7 @@ class GeminiChatModelTest {
                         .build();
 
         assertNotNull(model);
-        assertEquals(baseUrl, getHttpOptions(model).baseUrl().orElse(null));
+        assertEquals(baseUrl, getHttpOptions(model).baseUrl().orElseThrow());
     }
 
     @Test
@@ -339,9 +339,9 @@ class GeminiChatModelTest {
         assertNotNull(effectiveHttpOptions);
         assertEquals(
                 "https://override-gemini-endpoint.example",
-                effectiveHttpOptions.baseUrl().orElse(null));
-        assertEquals("v1beta", effectiveHttpOptions.apiVersion().orElse(null));
-        assertEquals(3210, effectiveHttpOptions.timeout().orElse(null));
+                effectiveHttpOptions.baseUrl().orElseThrow());
+        assertEquals("v1beta", effectiveHttpOptions.apiVersion().orElseThrow());
+        assertEquals(3210, effectiveHttpOptions.timeout().orElseThrow());
     }
 
     @Test

--- a/agentscope-core/src/test/java/io/agentscope/core/model/GeminiChatModelTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/model/GeminiChatModelTest.java
@@ -23,6 +23,7 @@ import com.google.genai.types.HttpOptions;
 import io.agentscope.core.formatter.gemini.GeminiChatFormatter;
 import io.agentscope.core.formatter.gemini.GeminiMultiAgentFormatter;
 import io.agentscope.core.model.test.ModelTestUtils;
+import java.lang.reflect.Field;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -301,6 +302,49 @@ class GeminiChatModelTest {
     }
 
     @Test
+    @DisplayName("Should configure custom base URL")
+    void testBaseUrlConfiguration() throws Exception {
+        String baseUrl = "https://custom-gemini-endpoint.example";
+
+        GeminiChatModel model =
+                GeminiChatModel.builder()
+                        .apiKey(mockApiKey)
+                        .modelName("gemini-2.0-flash")
+                        .baseUrl(baseUrl)
+                        .build();
+
+        assertNotNull(model);
+        assertEquals(baseUrl, getHttpOptions(model).baseUrl().orElse(null));
+    }
+
+    @Test
+    @DisplayName("Should override HTTP options base URL while preserving other settings")
+    void testBaseUrlOverridesHttpOptionsBaseUrl() throws Exception {
+        HttpOptions httpOptions =
+                HttpOptions.builder()
+                        .baseUrl("https://original-gemini-endpoint.example")
+                        .apiVersion("v1beta")
+                        .timeout(3210)
+                        .build();
+
+        GeminiChatModel model =
+                GeminiChatModel.builder()
+                        .apiKey(mockApiKey)
+                        .modelName("gemini-2.0-flash")
+                        .httpOptions(httpOptions)
+                        .baseUrl("https://override-gemini-endpoint.example")
+                        .build();
+
+        HttpOptions effectiveHttpOptions = getHttpOptions(model);
+        assertNotNull(effectiveHttpOptions);
+        assertEquals(
+                "https://override-gemini-endpoint.example",
+                effectiveHttpOptions.baseUrl().orElse(null));
+        assertEquals("v1beta", effectiveHttpOptions.apiVersion().orElse(null));
+        assertEquals(3210, effectiveHttpOptions.timeout().orElse(null));
+    }
+
+    @Test
     @DisplayName("Should handle all generation options")
     void testAllGenerateOptions() {
         GenerateOptions fullOptions =
@@ -453,5 +497,11 @@ class GeminiChatModelTest {
 
         assertNotNull(model);
         // Should use default GeminiChatFormatter
+    }
+
+    private static HttpOptions getHttpOptions(GeminiChatModel model) throws Exception {
+        Field httpOptionsField = GeminiChatModel.class.getDeclaredField("httpOptions");
+        httpOptionsField.setAccessible(true);
+        return (HttpOptions) httpOptionsField.get(model);
     }
 }

--- a/docs/en/task/model.md
+++ b/docs/en/task/model.md
@@ -136,6 +136,7 @@ Google's Gemini series models, supporting both Gemini API and Vertex AI.
 GeminiChatModel model = GeminiChatModel.builder()
         .apiKey(System.getenv("GEMINI_API_KEY"))
         .modelName("gemini-2.5-flash")  // Default
+        .baseUrl("https://your-gateway.example")  // Optional
         .build();
 ```
 
@@ -156,12 +157,15 @@ GeminiChatModel model = GeminiChatModel.builder()
 | Option | Description |
 |--------|-------------|
 | `apiKey` | Gemini API key |
+| `baseUrl` | Custom Gemini API endpoint (optional) |
 | `modelName` | Model name, default `gemini-2.5-flash` |
 | `project` | GCP project ID (Vertex AI) |
 | `location` | GCP region (Vertex AI) |
 | `vertexAI` | Whether to use Vertex AI |
 | `credentials` | GCP credentials (Vertex AI) |
 | `streamEnabled` | Enable streaming, default `true` |
+
+For endpoint override, use `baseUrl(...)`. For more advanced transport or proxy setup, continue to use `httpOptions(...)` or `clientOptions(...)`.
 
 ## Ollama
 

--- a/docs/zh/task/model.md
+++ b/docs/zh/task/model.md
@@ -133,6 +133,7 @@ Google 的 Gemini 系列模型，支持 Gemini API 和 Vertex AI。
 GeminiChatModel model = GeminiChatModel.builder()
         .apiKey(System.getenv("GEMINI_API_KEY"))
         .modelName("gemini-2.5-flash")  // 默认值
+        .baseUrl("https://your-gateway.example")  // 可选
         .build();
 ```
 
@@ -153,12 +154,15 @@ GeminiChatModel model = GeminiChatModel.builder()
 | 配置项 | 说明 |
 |--------|------|
 | `apiKey` | Gemini API 密钥 |
+| `baseUrl` | 自定义 Gemini API 端点（可选） |
 | `modelName` | 模型名称，默认 `gemini-2.5-flash` |
 | `project` | GCP 项目 ID（Vertex AI） |
 | `location` | GCP 区域（Vertex AI） |
 | `vertexAI` | 是否使用 Vertex AI |
 | `credentials` | GCP 凭证（Vertex AI） |
 | `streamEnabled` | 是否启用流式输出，默认 `true` |
+
+如需覆盖请求端点，可使用 `baseUrl(...)`。更高级的传输层或代理配置，仍建议通过 `httpOptions(...)` 或 `clientOptions(...)` 处理。
 
 ## Ollama
 


### PR DESCRIPTION
## AgentScope-Java Version

1.0.12-SNAPSHOT

## Description

### Background

Issue #1127 requests a simpler way to configure a custom `baseUrl` for Gemini.

The underlying Google GenAI SDK already supports endpoint override through `HttpOptions`, but AgentScope-Java currently exposes that only through the lower-level `httpOptions(...)` builder method. As a result, Gemini is less ergonomic than the other model builders when users need to target a custom gateway, private endpoint, or mock server.

### Purpose

Add a first-class `baseUrl` builder entrypoint for Gemini so custom endpoints can be configured more easily and consistently.

### Changes Made

- Added `GeminiChatModel.Builder.baseUrl(String)`
- Mapped builder-level `baseUrl` to the effective Google GenAI `HttpOptions`
- Preserved existing `httpOptions(...)` settings when both `httpOptions(...)` and `baseUrl(...)` are provided
- Updated Gemini documentation examples in both English and Chinese docs
- Added unit coverage for `baseUrl(...)` and the merge behavior with existing `httpOptions(...)`

### Why this approach

This change is intentionally kept narrow and focused on the builder ergonomics requested in #1127.

The Google GenAI SDK already models endpoint override through `HttpOptions`, so this PR adds a convenient high-level entrypoint without changing the underlying transport model. Advanced transport or proxy-related configuration remains available through the existing lower-level configuration methods.

### How to Test

- Build a `GeminiChatModel` with `.baseUrl(https://example.test)` and verify construction succeeds
- Build a model with both `.httpOptions(...)` and `.baseUrl(...)` and verify the custom base URL is applied without losing the other HTTP settings
- Run `mvn -pl agentscope-core -Dtest=GeminiChatModelTest test`
- Run `mvn -pl agentscope-core test`
- Run `mvn -pl agentscope-core spotless:check`

## Checklist

- [x] Code has been formatted with `mvn spotless:apply`
- [x] All tests are passing (`mvn test` for the affected module)
- [x] Javadoc comments are complete and follow project conventions
- [x] Related documentation has been updated
- [x] Code is ready for review

Closes #1127