### PR TITLE
fix issue #1160

### DIFF
--- a/agentscope-core/src/main/java/io/agentscope/core/ReActAgent.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/ReActAgent.java
@@ -1120,6 +1120,7 @@ public class ReActAgent extends StructuredOutputCapableAgent {
         // Long-term memory configuration
         private LongTermMemory longTermMemory;
         private LongTermMemoryMode longTermMemoryMode = LongTermMemoryMode.BOTH;
+        private boolean longTermMemoryAsyncRecord = false;
 
         // State persistence configuration
         private StatePersistence statePersistence;
@@ -1419,6 +1420,29 @@ public class ReActAgent extends StructuredOutputCapableAgent {
         }
 
         /**
+         * Sets whether long-term memory recording should be performed asynchronously.
+         *
+         * <p>When enabled, the framework will record memories to long-term storage
+         * in a fire-and-forget manner, without blocking the agent's main execution flow.
+         * This improves response latency but means memory persistence is not guaranteed
+         * before the agent returns its response.
+         *
+         * <p>When disabled (default), the framework waits for the recording operation
+         * to complete before returning the agent's response. This ensures memory
+         * persistence is finalized but may increase response latency.
+         *
+         * <p>Note: This setting only affects the static control mode (STATIC_CONTROL, BOTH).
+         * Agent-controlled recording through tools is always synchronous.
+         *
+         * @param asyncRecord Whether to record memories asynchronously
+         * @return This builder instance for method chaining
+         */
+        public Builder longTermMemoryAsyncRecord(boolean asyncRecord) {
+            this.longTermMemoryAsyncRecord = asyncRecord;
+            return this;
+        }
+
+        /**
          * Sets the state persistence configuration.
          *
          * <p>Use this to control which components' state is managed by the agent during
@@ -1591,7 +1615,8 @@ public class ReActAgent extends StructuredOutputCapableAgent {
             if (longTermMemoryMode == LongTermMemoryMode.STATIC_CONTROL
                     || longTermMemoryMode == LongTermMemoryMode.BOTH) {
                 StaticLongTermMemoryHook hook =
-                        new StaticLongTermMemoryHook(longTermMemory, memory);
+                        new StaticLongTermMemoryHook(
+                                longTermMemory, memory, longTermMemoryAsyncRecord);
                 hooks.add(hook);
             }
         }

--- a/agentscope-core/src/main/java/io/agentscope/core/memory/StaticLongTermMemoryHook.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/memory/StaticLongTermMemoryHook.java
@@ -76,15 +76,29 @@ public class StaticLongTermMemoryHook implements Hook {
 
     private final LongTermMemory longTermMemory;
     private final Memory memory;
+    private final boolean asyncRecord;
 
     /**
-     * Creates a new StaticLongTermMemoryHook.
+     * Creates a new StaticLongTermMemoryHook with synchronous recording.
      *
      * @param longTermMemory The long-term memory instance for persistent storage
      * @param memory The agent's memory for accessing conversation history
      * @throws IllegalArgumentException if longTermMemory or memory is null
      */
     public StaticLongTermMemoryHook(LongTermMemory longTermMemory, Memory memory) {
+        this(longTermMemory, memory, false);
+    }
+
+    /**
+     * Creates a new StaticLongTermMemoryHook.
+     *
+     * @param longTermMemory The long-term memory instance for persistent storage
+     * @param memory The agent's memory for accessing conversation history
+     * @param asyncRecord Whether to record memories asynchronously (fire-and-forget)
+     * @throws IllegalArgumentException if longTermMemory or memory is null
+     */
+    public StaticLongTermMemoryHook(
+            LongTermMemory longTermMemory, Memory memory, boolean asyncRecord) {
         if (longTermMemory == null) {
             throw new IllegalArgumentException("Long-term memory cannot be null");
         }
@@ -93,6 +107,7 @@ public class StaticLongTermMemoryHook implements Hook {
         }
         this.longTermMemory = longTermMemory;
         this.memory = memory;
+        this.asyncRecord = asyncRecord;
     }
 
     @Override
@@ -180,6 +195,10 @@ public class StaticLongTermMemoryHook implements Hook {
      * the long-term memory backend (e.g., Mem0) to extract memorable information from
      * the entire conversation context.
      *
+     * <p>When {@code asyncRecord} is enabled, the recording is performed in a
+     * fire-and-forget manner that does not block the agent's response. Otherwise,
+     * the recording completes before returning the event.
+     *
      * @param event the PostCallEvent
      * @return Mono containing the unmodified event
      */
@@ -191,16 +210,31 @@ public class StaticLongTermMemoryHook implements Hook {
         }
 
         // Record to long-term memory
-        return longTermMemory
-                .record(allMessages)
-                .thenReturn(event)
-                .onErrorResume(
-                        error -> {
-                            // Log error but don't interrupt the flow
-                            log.warn(
-                                    "Failed to record to long-term memory: {}", error.getMessage());
-                            return Mono.just(event);
-                        });
+        if (asyncRecord) {
+            // Fire-and-forget: do not block the agent's response
+            longTermMemory
+                    .record(allMessages)
+                    .subscribe(
+                            unused -> {},
+                            error ->
+                                    log.warn(
+                                            "Failed to asynchronously record to long-term memory:"
+                                                    + " {}",
+                                            error.getMessage()));
+            return Mono.just(event);
+        } else {
+            return longTermMemory
+                    .record(allMessages)
+                    .thenReturn(event)
+                    .onErrorResume(
+                            error -> {
+                                // Log error but don't interrupt the flow
+                                log.warn(
+                                        "Failed to record to long-term memory: {}",
+                                        error.getMessage());
+                                return Mono.just(event);
+                            });
+        }
     }
 
     /**

--- a/agentscope-core/src/main/java/io/agentscope/core/memory/StaticLongTermMemoryHook.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/memory/StaticLongTermMemoryHook.java
@@ -29,6 +29,7 @@ import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
 
 /**
  * Static Long-Term Memory Hook for automatic memory management.
@@ -211,16 +212,20 @@ public class StaticLongTermMemoryHook implements Hook {
 
         // Record to long-term memory
         if (asyncRecord) {
-            // Fire-and-forget: do not block the agent's response
+            // Fire-and-forget: schedule on boundedElastic so the agent's
+            // response is not blocked. subscribe() is intentional here —
+            // the record pipeline runs independently of the event chain.
             longTermMemory
                     .record(allMessages)
-                    .subscribe(
-                            unused -> {},
-                            error ->
-                                    log.warn(
-                                            "Failed to asynchronously record to long-term memory:"
-                                                    + " {}",
-                                            error.getMessage()));
+                    .subscribeOn(Schedulers.boundedElastic())
+                    .onErrorResume(
+                            error -> {
+                                log.warn(
+                                        "Failed to asynchronously record to long-term memory: {}",
+                                        error.getMessage());
+                                return Mono.empty();
+                            })
+                    .subscribe();
             return Mono.just(event);
         } else {
             return longTermMemory

--- a/agentscope-core/src/main/java/io/agentscope/core/memory/StaticLongTermMemoryHook.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/memory/StaticLongTermMemoryHook.java
@@ -29,6 +29,7 @@ import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Scheduler;
 import reactor.core.scheduler.Schedulers;
 
 /**
@@ -74,6 +75,12 @@ import reactor.core.scheduler.Schedulers;
 public class StaticLongTermMemoryHook implements Hook {
 
     private static final Logger log = LoggerFactory.getLogger(StaticLongTermMemoryHook.class);
+    // Dedicated async scheduler for long-term memory recording:
+    // - max 1 concurrent workers
+    // - max 3 queued tasks (new tasks are rejected when saturated)
+    // This avoids unbounded queuing on the global boundedElastic scheduler.
+    private static final Scheduler ASYNC_RECORD_SCHEDULER =
+            Schedulers.newBoundedElastic(1, 3, "long-term-memory-record");
 
     private final LongTermMemory longTermMemory;
     private final Memory memory;
@@ -197,8 +204,14 @@ public class StaticLongTermMemoryHook implements Hook {
      * the entire conversation context.
      *
      * <p>When {@code asyncRecord} is enabled, the recording is performed in a
-     * fire-and-forget manner that does not block the agent's response. Otherwise,
-     * the recording completes before returning the event.
+     * fire-and-forget manner that does not block the agent's response. Async recording
+     * uses a bounded scheduler (1 workers, queue size 3). When saturated, new record
+     * tasks are dropped and logged.
+     *
+     * <p><b>Trade-offs:</b> This async path intentionally decouples recording from the
+     * main event chain. The returned subscription is not retained in this mode, so
+     * in-flight record tasks are not explicitly cancelled by this class.
+     * Otherwise, the recording completes before returning the event.
      *
      * @param event the PostCallEvent
      * @return Mono containing the unmodified event
@@ -212,21 +225,25 @@ public class StaticLongTermMemoryHook implements Hook {
 
         // Record to long-term memory
         if (asyncRecord) {
-            // Fire-and-forget: schedule on boundedElastic so the agent's
-            // response is not blocked. subscribe() is intentional here —
-            // the record pipeline runs independently of the event chain.
-            longTermMemory
-                    .record(allMessages)
-                    .subscribeOn(Schedulers.boundedElastic())
-                    .onErrorResume(
-                            error -> {
-                                log.warn(
-                                        "Failed to asynchronously record to long-term memory: {}",
-                                        error.getMessage());
-                                return Mono.empty();
-                            })
-                    .subscribe();
-            return Mono.just(event);
+            // Fire-and-forget: schedule on a dedicated bounded scheduler so the agent's
+            // response is not blocked while still limiting backlog growth.
+            return Mono.deferContextual(
+                    ctxView -> {
+                        longTermMemory
+                                .record(allMessages)
+                                .subscribeOn(ASYNC_RECORD_SCHEDULER)
+                                .contextWrite(context -> context.putAll(ctxView))
+                                .onErrorResume(
+                                        error -> {
+                                            log.warn(
+                                                    "Failed to asynchronously record to long-term"
+                                                            + " memory: {}",
+                                                    error.getMessage());
+                                            return Mono.empty();
+                                        })
+                                .subscribe();
+                        return Mono.just(event);
+                    });
         } else {
             return longTermMemory
                     .record(allMessages)

--- a/agentscope-core/src/test/java/io/agentscope/core/agent/ReActAgentLongTermMemoryConfigTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/agent/ReActAgentLongTermMemoryConfigTest.java
@@ -1,0 +1,258 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.core.agent;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.agentscope.core.ReActAgent;
+import io.agentscope.core.memory.InMemoryMemory;
+import io.agentscope.core.memory.LongTermMemory;
+import io.agentscope.core.memory.LongTermMemoryMode;
+import io.agentscope.core.memory.StaticLongTermMemoryHook;
+import io.agentscope.core.message.Msg;
+import io.agentscope.core.message.MsgRole;
+import io.agentscope.core.message.TextBlock;
+import io.agentscope.core.model.ChatResponse;
+import io.agentscope.core.model.GenerateOptions;
+import io.agentscope.core.model.Model;
+import io.agentscope.core.model.ToolSchema;
+import io.agentscope.core.tool.Toolkit;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+/**
+ * Unit tests for ReActAgent's long-term memory configuration,
+ * including the {@code longTermMemoryAsyncRecord} builder option
+ * and its integration with {@link StaticLongTermMemoryHook}.
+ */
+@Tag("unit")
+@DisplayName("ReActAgent Long-Term Memory Configuration Tests")
+class ReActAgentLongTermMemoryConfigTest {
+
+    private Model mockModel;
+
+    @org.junit.jupiter.api.BeforeEach
+    void setUp() {
+        mockModel =
+                new Model() {
+                    @Override
+                    public Flux<ChatResponse> stream(
+                            List<Msg> messages, List<ToolSchema> tools, GenerateOptions options) {
+                        ChatResponse response =
+                                ChatResponse.builder()
+                                        .content(
+                                                List.of(
+                                                        TextBlock.builder()
+                                                                .text("Test response")
+                                                                .build()))
+                                        .build();
+                        return Flux.just(response);
+                    }
+
+                    @Override
+                    public String getModelName() {
+                        return "mock-model";
+                    }
+                };
+    }
+
+    @Test
+    @DisplayName("Should build agent with longTermMemoryAsyncRecord(true)")
+    void testAsyncRecordTrue() {
+        CountingLongTermMemory countingMemory = new CountingLongTermMemory();
+
+        ReActAgent agent =
+                ReActAgent.builder()
+                        .name("TestAgent")
+                        .model(mockModel)
+                        .toolkit(new Toolkit())
+                        .memory(new InMemoryMemory())
+                        .longTermMemory(countingMemory)
+                        .longTermMemoryMode(LongTermMemoryMode.STATIC_CONTROL)
+                        .longTermMemoryAsyncRecord(true)
+                        .build();
+
+        assertNotNull(agent);
+        assertEquals("TestAgent", agent.getName());
+    }
+
+    @Test
+    @DisplayName("Should build agent with longTermMemoryAsyncRecord(false) - default")
+    void testAsyncRecordFalse() {
+        CountingLongTermMemory countingMemory = new CountingLongTermMemory();
+
+        ReActAgent agent =
+                ReActAgent.builder()
+                        .name("TestAgent")
+                        .model(mockModel)
+                        .toolkit(new Toolkit())
+                        .memory(new InMemoryMemory())
+                        .longTermMemory(countingMemory)
+                        .longTermMemoryMode(LongTermMemoryMode.STATIC_CONTROL)
+                        .longTermMemoryAsyncRecord(false)
+                        .build();
+
+        assertNotNull(agent);
+    }
+
+    @Test
+    @DisplayName("Should work with BOTH mode and asyncRecord enabled")
+    void testBothModeWithAsyncRecord() {
+        CountingLongTermMemory countingMemory = new CountingLongTermMemory();
+
+        ReActAgent agent =
+                ReActAgent.builder()
+                        .name("TestAgent")
+                        .model(mockModel)
+                        .toolkit(new Toolkit())
+                        .memory(new InMemoryMemory())
+                        .longTermMemory(countingMemory)
+                        .longTermMemoryMode(LongTermMemoryMode.BOTH)
+                        .longTermMemoryAsyncRecord(true)
+                        .build();
+
+        assertNotNull(agent);
+        // In BOTH mode, memory tools should be registered
+        // Tool names use underscore convention from method names
+        boolean hasRecordTool =
+                agent.getToolkit().getToolNames().stream()
+                        .anyMatch(name -> name.contains("record"));
+        boolean hasRetrieveTool =
+                agent.getToolkit().getToolNames().stream()
+                        .anyMatch(name -> name.contains("retrieve"));
+        assertTrue(hasRecordTool, "record tool should be registered in BOTH mode");
+        assertTrue(hasRetrieveTool, "retrieve tool should be registered in BOTH mode");
+    }
+
+    @Test
+    @DisplayName("Async record should complete without blocking and call onSuccess")
+    void testAsyncRecordDoesNotBlock() throws InterruptedException {
+        CountDownLatch recordLatch = new CountDownLatch(1);
+        AtomicBoolean onSuccessCalled = new AtomicBoolean(false);
+
+        LongTermMemory asyncMemory =
+                new LongTermMemory() {
+                    @Override
+                    public Mono<Void> record(List<Msg> msgs) {
+                        return Mono.fromRunnable(
+                                        () -> {
+                                            onSuccessCalled.set(true);
+                                            recordLatch.countDown();
+                                        })
+                                .then();
+                    }
+
+                    @Override
+                    public Mono<String> retrieve(Msg msg) {
+                        return Mono.just("");
+                    }
+                };
+
+        StaticLongTermMemoryHook asyncHook =
+                new StaticLongTermMemoryHook(asyncMemory, new InMemoryMemory(), true);
+
+        // Simulate PostCallEvent scenario
+        InMemoryMemory agentMemory = new InMemoryMemory();
+        agentMemory.addMessage(
+                Msg.builder()
+                        .role(MsgRole.USER)
+                        .content(TextBlock.builder().text("Hello").build())
+                        .build());
+        agentMemory.addMessage(
+                Msg.builder()
+                        .role(MsgRole.ASSISTANT)
+                        .content(TextBlock.builder().text("Hi there").build())
+                        .build());
+
+        StaticLongTermMemoryHook hookWithAccess =
+                new StaticLongTermMemoryHook(asyncMemory, agentMemory, true);
+
+        io.agentscope.core.hook.PostCallEvent event =
+                new io.agentscope.core.hook.PostCallEvent(
+                        createMockAgent(),
+                        Msg.builder()
+                                .role(MsgRole.ASSISTANT)
+                                .content(TextBlock.builder().text("Reply").build())
+                                .build());
+
+        // Execute hook - should return immediately
+        Mono<io.agentscope.core.hook.PostCallEvent> resultMono = hookWithAccess.onEvent(event);
+        io.agentscope.core.hook.PostCallEvent result = resultMono.block();
+
+        assertNotNull(result);
+
+        // Wait for async record to complete
+        assertTrue(
+                recordLatch.await(1, TimeUnit.SECONDS), "Async record should have been scheduled");
+        assertTrue(
+                onSuccessCalled.get(),
+                "The onSuccess lambda (unused -> {}) should have been invoked");
+    }
+
+    private Agent createMockAgent() {
+        return new AgentBase("MockAgent") {
+            @Override
+            protected Mono<Msg> doCall(List<Msg> msgs) {
+                return Mono.just(msgs.get(0));
+            }
+
+            @Override
+            protected Mono<Void> doObserve(Msg msg) {
+                return Mono.empty();
+            }
+
+            @Override
+            protected Mono<Msg> handleInterrupt(
+                    io.agentscope.core.interruption.InterruptContext context, Msg... originalArgs) {
+                return Mono.just(
+                        Msg.builder()
+                                .name(getName())
+                                .role(MsgRole.ASSISTANT)
+                                .content(TextBlock.builder().text("Interrupted").build())
+                                .build());
+            }
+        };
+    }
+
+    /** Simple LongTermMemory implementation that counts record calls. */
+    private static class CountingLongTermMemory implements LongTermMemory {
+        private int recordCount = 0;
+
+        @Override
+        public Mono<Void> record(List<Msg> msgs) {
+            recordCount++;
+            return Mono.empty();
+        }
+
+        @Override
+        public Mono<String> retrieve(Msg msg) {
+            return Mono.just("");
+        }
+
+        public int getRecordCount() {
+            return recordCount;
+        }
+    }
+}

--- a/agentscope-core/src/test/java/io/agentscope/core/memory/StaticLongTermMemoryHookTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/memory/StaticLongTermMemoryHookTest.java
@@ -38,6 +38,8 @@ import io.agentscope.core.message.MsgRole;
 import io.agentscope.core.message.TextBlock;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -250,5 +252,90 @@ class StaticLongTermMemoryHookTest {
         PostCallEvent event = new PostCallEvent(mockAgent, replyMsg);
 
         StepVerifier.create(hook.onEvent(event)).expectNext(event).verifyComplete();
+    }
+
+    @Test
+    void testOnEventWithPostCallEventAsyncRecord() throws InterruptedException {
+        List<Msg> allMessages = new ArrayList<>();
+        allMessages.add(
+                Msg.builder()
+                        .role(MsgRole.USER)
+                        .content(TextBlock.builder().text("User message").build())
+                        .build());
+        allMessages.add(
+                Msg.builder()
+                        .role(MsgRole.ASSISTANT)
+                        .content(TextBlock.builder().text("Assistant reply").build())
+                        .build());
+
+        CountDownLatch latch = new CountDownLatch(1);
+
+        when(mockMemory.getMessages()).thenReturn(allMessages);
+        when(mockLongTermMemory.record(anyList()))
+                .thenAnswer(
+                        invocation -> {
+                            latch.countDown();
+                            return Mono.empty();
+                        });
+
+        StaticLongTermMemoryHook asyncHook =
+                new StaticLongTermMemoryHook(mockLongTermMemory, mockMemory, true);
+
+        Msg replyMsg =
+                Msg.builder()
+                        .role(MsgRole.ASSISTANT)
+                        .content(TextBlock.builder().text("Reply").build())
+                        .build();
+        PostCallEvent event = new PostCallEvent(mockAgent, replyMsg);
+
+        // Should return immediately without waiting for record
+        StepVerifier.create(asyncHook.onEvent(event)).expectNext(event).verifyComplete();
+
+        // Verify record was still called (async)
+        assertTrue(latch.await(1, TimeUnit.SECONDS), "Async record should have been called");
+        ArgumentCaptor<List<Msg>> captor = ArgumentCaptor.forClass(List.class);
+        verify(mockLongTermMemory, times(1)).record(captor.capture());
+        assertEquals(2, captor.getValue().size());
+    }
+
+    @Test
+    void testOnEventWithPostCallEventAsyncRecordError() throws InterruptedException {
+        List<Msg> messages = List.of(Msg.builder().role(MsgRole.USER).build());
+        CountDownLatch latch = new CountDownLatch(1);
+
+        when(mockMemory.getMessages()).thenReturn(messages);
+        when(mockLongTermMemory.record(anyList()))
+                .thenAnswer(
+                        invocation -> {
+                            latch.countDown();
+                            return Mono.error(new RuntimeException("Async record error"));
+                        });
+
+        StaticLongTermMemoryHook asyncHook =
+                new StaticLongTermMemoryHook(mockLongTermMemory, mockMemory, true);
+
+        Msg replyMsg = Msg.builder().role(MsgRole.ASSISTANT).build();
+        PostCallEvent event = new PostCallEvent(mockAgent, replyMsg);
+
+        // Should still return the event (error is logged, not thrown)
+        StepVerifier.create(asyncHook.onEvent(event)).expectNext(event).verifyComplete();
+
+        // Verify record was attempted
+        assertTrue(latch.await(1, TimeUnit.SECONDS), "Async record should have been called");
+    }
+
+    @Test
+    void testOnEventWithPostCallEventAsyncRecordEmptyMemory() {
+        when(mockMemory.getMessages()).thenReturn(new ArrayList<>());
+
+        StaticLongTermMemoryHook asyncHook =
+                new StaticLongTermMemoryHook(mockLongTermMemory, mockMemory, true);
+
+        Msg replyMsg = Msg.builder().role(MsgRole.ASSISTANT).build();
+        PostCallEvent event = new PostCallEvent(mockAgent, replyMsg);
+
+        StepVerifier.create(asyncHook.onEvent(event)).expectNext(event).verifyComplete();
+
+        verify(mockLongTermMemory, never()).record(anyList());
     }
 }


### PR DESCRIPTION
## AgentScope-Java Version

io.agentscope:agentscope-parent:pom:1.0.12-SNAPSHOT

## Description

LongTermMemory will block the agent when the LLM stops responding. This commit enables the framework to record long term memory asynchronously.

Added `longTermMemoryAsyncRecord` option to `ReActAgent.Builder` to support fire-and-forget long-term memory recording in `STATIC_CONTROL` / `BOTH` mode.

When enabled, the `StaticLongTermMemoryHook` performs `record()` asynchronously without blocking the agent's response, reducing latency in `STATIC_CONTROL` mode. Agent-controlled recording (`AGENT_CONTROL`) remains synchronous.

## Checklist

Please check the following items before code is ready to be reviewed.

- `ReActAgent.Builder` — new `longTermMemoryAsyncRecord(boolean)` setter
- `StaticLongTermMemoryHook` — overloaded constructor accepting `asyncRecord` flag; `handlePostCall()` splits sync/async paths
- `StaticLongTermMemoryHookTest` — added 3 async recording test cases


- [X]  Code has been formatted with `mvn spotless:apply`
- [X]  All tests are passing (`mvn test`)
- [X]  Javadoc comments are complete and follow project conventions
- [X]  Related documentation has been updated (e.g. links, examples, etc.)
- [X]  Code is ready for review
