### PR TITLE
feat: add qwen3.6 model family to multimodal API endpoint routing

### DIFF
--- a/agentscope-core/src/main/java/io/agentscope/core/model/DashScopeHttpClient.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/model/DashScopeHttpClient.java
@@ -331,6 +331,7 @@ public class DashScopeHttpClient {
      *       <li>Models containing "-vl" → multimodal API</li>
      *       <li>Models containing "-asr" → multimodal API</li>
      *       <li>Models starting with "qwen3.5" → multimodal API</li>
+     *       <li>Models starting with "qwen3.6" → multimodal API</li>
      *       <li>All other models → text generation API</li>
      *     </ul>
      *   </li>
@@ -370,6 +371,7 @@ public class DashScopeHttpClient {
      *   <li>Models containing "-vl" (e.g., qwen-vl-plus, qwen3-vl-max)</li>
      *   <li>Models containing "-asr" (e.g., qwen3-asr-flash)</li>
      *   <li>Models starting with "qwen3.5" (e.g., qwen3.5-plus, qwen3.5-flash)</li>
+     *   <li>Models starting with "qwen3.6" (e.g., qwen3.6-plus, qwen3.6-flash)</li>
      * </ul>
      *
      * @param modelName the model name
@@ -383,7 +385,8 @@ public class DashScopeHttpClient {
         return lowerModelName.startsWith("qvq")
                 || lowerModelName.contains("-vl")
                 || lowerModelName.contains("-asr")
-                || lowerModelName.startsWith("qwen3.5");
+                || lowerModelName.startsWith("qwen3.5")
+                || lowerModelName.startsWith("qwen3.6");
     }
 
     /**

--- a/agentscope-core/src/test/java/io/agentscope/core/model/DashScopeHttpClientTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/model/DashScopeHttpClientTest.java
@@ -170,6 +170,9 @@ class DashScopeHttpClientTest {
         assertEquals(
                 DashScopeHttpClient.MULTIMODAL_GENERATION_ENDPOINT,
                 client.selectEndpoint("qwen3.5-plus", EndpointType.AUTO));
+        assertEquals(
+                DashScopeHttpClient.MULTIMODAL_GENERATION_ENDPOINT,
+                client.selectEndpoint("qwen3.6-plus", EndpointType.AUTO));
     }
 
     @Test
@@ -182,6 +185,7 @@ class DashScopeHttpClientTest {
         assertFalse(client.requiresMultimodalApi("qwen-plus", EndpointType.AUTO));
         assertTrue(client.requiresMultimodalApi("qwen-vl-plus", EndpointType.AUTO));
         assertTrue(client.requiresMultimodalApi("qwen3.5-plus", EndpointType.AUTO));
+        assertTrue(client.requiresMultimodalApi("qwen3.6-plus", EndpointType.AUTO));
     }
 
     @Test
@@ -193,6 +197,16 @@ class DashScopeHttpClientTest {
         assertTrue(DashScopeHttpClient.isMultimodalModel("qwen3.5-397b-a17b"));
         // qwen-3.5-plus (with hyphen before 3.5) does not match
         assertFalse(DashScopeHttpClient.isMultimodalModel("qwen-3.5-plus"));
+    }
+
+    @Test
+    void testIsMultimodalModelIncludesQwen36Family() {
+        // Qwen 3.6 family uses multimodal API (prefix-based matching)
+        assertTrue(DashScopeHttpClient.isMultimodalModel("qwen3.6-plus"));
+        assertTrue(DashScopeHttpClient.isMultimodalModel("qwen3.6-flash"));
+        assertTrue(DashScopeHttpClient.isMultimodalModel("Qwen3.6-Plus"));
+        // qwen-3.6-plus (with hyphen before 3.6) does not match
+        assertFalse(DashScopeHttpClient.isMultimodalModel("qwen-3.6-plus"));
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Add `qwen3.6` prefix matching to `DashScopeHttpClient.isMultimodalModel()` so that qwen3.6 models (e.g., `qwen3.6-plus`, `qwen3.6-flash`) are correctly routed to the multimodal-generation API endpoint.
- Without this fix, qwen3.6 models are sent to the text-generation endpoint, causing a `url error` from DashScope API.
- Updated Javadoc and added unit tests for the new model family.

## Test plan
- [x] Added `testIsMultimodalModelIncludesQwen36Family` test for `isMultimodalModel` with qwen3.6 variants (including case-insensitivity and negative case)
- [x] Added qwen3.6 assertions to `testSelectEndpointWithAutoFallsBackToModelNameDetection`
- [x] Added qwen3.6 assertion to `testRequiresMultimodalApiWithEndpointType`
- [x] All existing `DashScopeHttpClientTest` tests pass


Made with [Cursor](https://cursor.com)