### PR TITLE
fix(core): enable pending tool recovery by default

### DIFF
--- a/agentscope-core/src/main/java/io/agentscope/core/ReActAgent.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/ReActAgent.java
@@ -291,9 +291,8 @@ public class ReActAgent extends StructuredOutputCapableAgent {
         // patched during PreCallEvent. If we still reach here, the hook was disabled
         // and the user did not provide tool results — this is an unrecoverable state.
         throw new IllegalStateException(
-                "Pending tool calls exist without results. "
-                        + "Enable PendingToolRecoveryHook or provide tool results. "
-                        + "Pending IDs: "
+                "Pending tool calls exist without results. Provide tool results or re-enable"
+                        + " PendingToolRecoveryHook if it was disabled. Pending IDs: "
                         + pendingIds);
     }
 
@@ -1115,7 +1114,7 @@ public class ReActAgent extends StructuredOutputCapableAgent {
         private PlanNotebook planNotebook;
         private SkillBox skillBox;
         private ToolExecutionContext toolExecutionContext;
-        private boolean enablePendingToolRecovery = false;
+        private boolean enablePendingToolRecovery = true;
 
         // Long-term memory configuration
         private LongTermMemory longTermMemory;
@@ -1257,7 +1256,7 @@ public class ReActAgent extends StructuredOutputCapableAgent {
         /**
          * Enables or disables automatic recovery from orphaned pending tool calls.
          *
-         * <p>When enabled , a {@link PendingToolRecoveryHook} is automatically
+         * <p>This recovery is enabled by default. When enabled, a {@link PendingToolRecoveryHook}
          * registered to detect and patch orphaned pending tool calls with synthetic error
          * results before agent processing begins. This prevents {@link IllegalStateException}
          * when tool execution fails, times out, or is interrupted.

--- a/agentscope-core/src/test/java/io/agentscope/core/session/ReActAgentSessionPendingToolRecoveryTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/session/ReActAgentSessionPendingToolRecoveryTest.java
@@ -1,0 +1,191 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.core.session;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.agentscope.core.ReActAgent;
+import io.agentscope.core.agent.test.MockModel;
+import io.agentscope.core.hook.Hook;
+import io.agentscope.core.hook.PostReasoningEvent;
+import io.agentscope.core.memory.InMemoryMemory;
+import io.agentscope.core.message.Msg;
+import io.agentscope.core.message.MsgRole;
+import io.agentscope.core.message.TextBlock;
+import io.agentscope.core.message.ToolResultBlock;
+import io.agentscope.core.message.ToolUseBlock;
+import io.agentscope.core.tool.Toolkit;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class ReActAgentSessionPendingToolRecoveryTest {
+
+    private static final Duration TEST_TIMEOUT = Duration.ofSeconds(5);
+
+    @Test
+    void shouldRecoverPendingToolCallsAfterSessionRestoreByDefault(@TempDir Path tempDir) {
+        String pendingToolId = "pending-tool-1";
+
+        ReActAgent initialAgent =
+                ReActAgent.builder()
+                        .name("session-agent")
+                        .model(MockModel.withToolCall("missing_tool", pendingToolId, Map.of()))
+                        .toolkit(new Toolkit())
+                        .memory(new InMemoryMemory())
+                        .checkRunning(false)
+                        .hook(createPostReasoningStopHook())
+                        .build();
+
+        SessionManager.forSessionId("recover-default")
+                .withSession(new JsonSession(tempDir))
+                .addComponent(initialAgent)
+                .saveIfExists();
+
+        Msg firstResult = initialAgent.call(createUserMsg("first")).block(TEST_TIMEOUT);
+        assertNotNull(firstResult);
+        assertTrue(firstResult.hasContentBlocks(ToolUseBlock.class));
+
+        SessionManager.forSessionId("recover-default")
+                .withSession(new JsonSession(tempDir))
+                .addComponent(initialAgent)
+                .saveSession();
+
+        InMemoryMemory restoredMemory = new InMemoryMemory();
+        MockModel recoveredModel = new MockModel("Recovered after session restore");
+        ReActAgent restoredAgent =
+                ReActAgent.builder()
+                        .name("session-agent")
+                        .model(recoveredModel)
+                        .toolkit(new Toolkit())
+                        .memory(restoredMemory)
+                        .checkRunning(false)
+                        .build();
+
+        SessionManager.forSessionId("recover-default")
+                .withSession(new JsonSession(tempDir))
+                .addComponent(restoredAgent)
+                .loadIfExists();
+
+        Msg result = restoredAgent.call(createUserMsg("resume")).block(TEST_TIMEOUT);
+        assertNotNull(result);
+        assertEquals("Recovered after session restore", extractFirstText(result));
+        assertTrue(
+                containsErrorToolResult(restoredMemory.getMessages(), pendingToolId),
+                "Recovered memory should contain an auto-generated error tool result for the"
+                        + " restored pending tool call");
+        assertTrue(
+                modelSawToolResult(recoveredModel.getLastMessages(), pendingToolId),
+                "Recovered model input should include the synthesized tool result before"
+                        + " continuing");
+    }
+
+    @Test
+    void shouldStillThrowWhenPendingToolRecoveryIsExplicitlyDisabled(@TempDir Path tempDir) {
+        String pendingToolId = "pending-tool-2";
+
+        ReActAgent initialAgent =
+                ReActAgent.builder()
+                        .name("session-agent-disabled")
+                        .model(MockModel.withToolCall("missing_tool", pendingToolId, Map.of()))
+                        .toolkit(new Toolkit())
+                        .memory(new InMemoryMemory())
+                        .checkRunning(false)
+                        .hook(createPostReasoningStopHook())
+                        .build();
+
+        initialAgent.call(createUserMsg("first")).block(TEST_TIMEOUT);
+
+        SessionManager.forSessionId("recover-disabled")
+                .withSession(new JsonSession(tempDir))
+                .addComponent(initialAgent)
+                .saveSession();
+
+        ReActAgent restoredAgent =
+                ReActAgent.builder()
+                        .name("session-agent-disabled")
+                        .model(new MockModel("Should not reach model"))
+                        .toolkit(new Toolkit())
+                        .memory(new InMemoryMemory())
+                        .checkRunning(false)
+                        .enablePendingToolRecovery(false)
+                        .build();
+
+        SessionManager.forSessionId("recover-disabled")
+                .withSession(new JsonSession(tempDir))
+                .addComponent(restoredAgent)
+                .loadIfExists();
+
+        IllegalStateException error =
+                assertThrows(
+                        IllegalStateException.class,
+                        () -> restoredAgent.call(createUserMsg("resume")).block(TEST_TIMEOUT));
+        assertTrue(error.getMessage().contains(pendingToolId));
+    }
+
+    private Hook createPostReasoningStopHook() {
+        return new Hook() {
+            @Override
+            public <T extends io.agentscope.core.hook.HookEvent>
+                    reactor.core.publisher.Mono<T> onEvent(T event) {
+                if (event instanceof PostReasoningEvent e) {
+                    e.stopAgent();
+                }
+                return reactor.core.publisher.Mono.just(event);
+            }
+        };
+    }
+
+    private Msg createUserMsg(String text) {
+        return Msg.builder()
+                .name("user")
+                .role(MsgRole.USER)
+                .content(TextBlock.builder().text(text).build())
+                .build();
+    }
+
+    private String extractFirstText(Msg msg) {
+        List<TextBlock> textBlocks = msg.getContentBlocks(TextBlock.class);
+        return textBlocks.isEmpty() ? "" : textBlocks.get(0).getText();
+    }
+
+    private boolean containsErrorToolResult(List<Msg> messages, String toolId) {
+        return messages.stream()
+                .flatMap(msg -> msg.getContentBlocks(ToolResultBlock.class).stream())
+                .anyMatch(
+                        result ->
+                                toolId.equals(result.getId())
+                                        && result.getOutput().stream()
+                                                .filter(TextBlock.class::isInstance)
+                                                .map(TextBlock.class::cast)
+                                                .anyMatch(
+                                                        text ->
+                                                                text.getText()
+                                                                        .contains("[ERROR]")));
+    }
+
+    private boolean modelSawToolResult(List<Msg> messages, String toolId) {
+        return messages.stream()
+                .flatMap(msg -> msg.getContentBlocks(ToolResultBlock.class).stream())
+                .anyMatch(result -> toolId.equals(result.getId()));
+    }
+}


### PR DESCRIPTION
## Summary
- enable pending tool recovery by default for ReActAgent.Builder
- keep explicit opt-out behavior unchanged for callers that disable recovery
- add a restore-from-session regression test that exercises the orphaned tool-call path
## Why this fix
When a ReActAgent session is restored with pending tool calls that never produced results, the existing PendingToolRecoveryHook can repair the state before the next call. The builder currently leaves that hook disabled by default, so a normal follow-up message can still fail with IllegalStateException after session restore. Enabling the recovery hook by default matches the documented behavior and preserves explicit opt-out support.
## Validation
- mvn -pl agentscope-core '-Dtest=ReActAgentSessionPendingToolRecoveryTest,HookStopAgentTest,SessionManagerTest,ReActAgentStateTest' test
Closes #918.