### PR TITLE
fix(tool): make active tool groups concurrency-safe

### DIFF
--- a/agentscope-core/src/main/java/io/agentscope/core/tool/ToolGroup.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/tool/ToolGroup.java
@@ -43,7 +43,7 @@ public class ToolGroup {
 
     private final String name;
     private final String description;
-    private boolean active;
+    private volatile boolean active;
     private final Set<String> tools; // Tool names in this group
 
     private ToolGroup(Builder builder) {

--- a/agentscope-core/src/main/java/io/agentscope/core/tool/ToolGroupManager.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/tool/ToolGroupManager.java
@@ -17,10 +17,12 @@ package io.agentscope.core.tool;
 
 import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArraySet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -33,7 +35,7 @@ class ToolGroupManager {
 
     private final Map<String, ToolGroup> toolGroups = new ConcurrentHashMap<>(); // group -> tools
     private final Map<String, Set<String>> tools = new ConcurrentHashMap<>(); // tool -> groups
-    private List<String> activeGroups = new ArrayList<>();
+    private final Set<String> activeGroups = new CopyOnWriteArraySet<>();
 
     /**
      * Create tool groups and record them in the manager.
@@ -54,8 +56,8 @@ class ToolGroupManager {
 
         toolGroups.put(groupName, group);
 
-        if (active && !activeGroups.contains(groupName)) {
-            activeGroups.add(groupName);
+        if (active) {
+            setGroupActiveState(groupName, group, true);
         }
 
         logger.info("Created tool group '{}': {}", groupName, description);
@@ -86,16 +88,7 @@ class ToolGroupManager {
                 throw new IllegalArgumentException(
                         String.format("Tool group '%s' does not exist", groupName));
             }
-
-            group.setActive(active);
-
-            if (active) {
-                if (!activeGroups.contains(groupName)) {
-                    activeGroups.add(groupName);
-                }
-            } else {
-                activeGroups.remove(groupName);
-            }
+            setGroupActiveState(groupName, group, active);
 
             logger.info("Tool group '{}' active status set to: {}", groupName, active);
         }
@@ -144,12 +137,13 @@ class ToolGroupManager {
      * @return Formatted string describing active tool groups
      */
     public String getActivatedNotes() {
-        if (activeGroups.isEmpty()) {
+        List<String> activeGroupSnapshot = getActiveGroups();
+        if (activeGroupSnapshot.isEmpty()) {
             return "No tool groups are currently activated.";
         }
 
         StringBuilder notes = new StringBuilder("Activated tool groups:\n");
-        for (String groupName : activeGroups) {
+        for (String groupName : activeGroupSnapshot) {
             ToolGroup group = toolGroups.get(groupName);
             if (group != null) {
                 notes.append(String.format("- %s: %s\n", groupName, group.getDescription()));
@@ -324,14 +318,12 @@ class ToolGroupManager {
      * @param activeGroups List of group names to mark as active
      */
     public void setActiveGroups(List<String> activeGroups) {
-        this.activeGroups = new ArrayList<>(activeGroups);
+        Set<String> desiredActiveGroups = new LinkedHashSet<>(activeGroups);
+        this.activeGroups.clear();
+        this.activeGroups.addAll(desiredActiveGroups);
 
-        // Mark corresponding groups as active
-        for (String groupName : activeGroups) {
-            ToolGroup group = toolGroups.get(groupName);
-            if (group != null) {
-                group.setActive(true);
-            }
+        for (ToolGroup group : toolGroups.values()) {
+            group.setActive(desiredActiveGroups.contains(group.getName()));
         }
     }
 
@@ -373,8 +365,17 @@ class ToolGroupManager {
             target.tools.put(entry.getKey(), new HashSet<>(entry.getValue()));
         }
 
-        // Copy activeGroups list
-        target.activeGroups = new ArrayList<>(this.activeGroups);
+        target.activeGroups.clear();
+        target.activeGroups.addAll(this.activeGroups);
+    }
+
+    private void setGroupActiveState(String groupName, ToolGroup group, boolean active) {
+        group.setActive(active);
+        if (active) {
+            activeGroups.add(groupName);
+            return;
+        }
+        activeGroups.remove(groupName);
     }
 
     private boolean removeGroupFromToolIndex(String toolName, String groupName) {

--- a/agentscope-core/src/test/java/io/agentscope/core/tool/ToolGroupManagerConcurrencyTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/tool/ToolGroupManagerConcurrencyTest.java
@@ -1,0 +1,203 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.core.tool;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Queue;
+import java.util.Set;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.Test;
+
+class ToolGroupManagerConcurrencyTest {
+
+    private static final int GROUP_COUNT = 10;
+    private static final int WORKER_COUNT = 6;
+    private static final int ITERATIONS = 250;
+
+    @Test
+    void concurrentReadersAndWritersShouldKeepActiveGroupSnapshotsConsistent() throws Exception {
+        ToolGroupManager manager = createManagerWithGroups();
+        Queue<Throwable> failures = new ConcurrentLinkedQueue<>();
+        ExecutorService executor = Executors.newFixedThreadPool(WORKER_COUNT);
+        CyclicBarrier startBarrier = new CyclicBarrier(WORKER_COUNT);
+
+        try {
+            List<Future<?>> futures = new ArrayList<>();
+            for (int worker = 0; worker < WORKER_COUNT / 2; worker++) {
+                final int workerIndex = worker;
+                futures.add(
+                        executor.submit(
+                                () -> {
+                                    await(startBarrier, failures);
+                                    for (int iteration = 0;
+                                            iteration < ITERATIONS && failures.isEmpty();
+                                            iteration++) {
+                                        String groupName =
+                                                "group-"
+                                                        + ((workerIndex + iteration) % GROUP_COUNT);
+                                        boolean active = (iteration + workerIndex) % 2 == 0;
+                                        try {
+                                            manager.updateToolGroups(List.of(groupName), active);
+                                        } catch (Throwable error) {
+                                            failures.add(error);
+                                            return;
+                                        }
+                                    }
+                                }));
+            }
+
+            for (int worker = WORKER_COUNT / 2; worker < WORKER_COUNT; worker++) {
+                futures.add(
+                        executor.submit(
+                                () -> {
+                                    await(startBarrier, failures);
+                                    for (int iteration = 0;
+                                            iteration < ITERATIONS && failures.isEmpty();
+                                            iteration++) {
+                                        try {
+                                            List<String> snapshot = manager.getActiveGroups();
+                                            assertEquals(
+                                                    new HashSet<>(snapshot).size(),
+                                                    snapshot.size(),
+                                                    "Concurrent snapshots should not contain"
+                                                            + " duplicates");
+                                            manager.getActivatedNotes();
+                                            manager.getNotes();
+                                            manager.getActiveToolNames();
+                                        } catch (Throwable error) {
+                                            failures.add(error);
+                                            return;
+                                        }
+                                    }
+                                }));
+            }
+
+            for (Future<?> future : futures) {
+                future.get(30, TimeUnit.SECONDS);
+            }
+        } finally {
+            executor.shutdownNow();
+        }
+
+        assertTrue(failures.isEmpty(), formatFailures(failures));
+        assertManagerConsistency(manager);
+    }
+
+    @Test
+    void setActiveGroupsShouldReplacePreviousActiveStateSnapshot() {
+        ToolGroupManager manager = createManagerWithGroups();
+
+        manager.setActiveGroups(List.of("group-1", "group-3", "missing-group"));
+
+        assertEquals(
+                List.of("group-1", "group-3", "missing-group"),
+                manager.getActiveGroups(),
+                "setActiveGroups should publish a stable snapshot in the provided order");
+        assertTrue(manager.getToolGroup("group-1").isActive());
+        assertTrue(manager.getToolGroup("group-3").isActive());
+        assertFalse(manager.getToolGroup("group-0").isActive());
+        assertFalse(manager.getToolGroup("group-2").isActive());
+        assertFalse(manager.getToolGroup("group-4").isActive());
+
+        String notes = manager.getActivatedNotes();
+        assertTrue(notes.contains("group-1"));
+        assertTrue(notes.contains("group-3"));
+        assertFalse(notes.contains("missing-group"));
+    }
+
+    @Test
+    void copyToShouldPreserveAnIndependentActiveGroupSnapshot() {
+        ToolGroupManager source = createManagerWithGroups();
+        source.setActiveGroups(List.of("group-2", "group-4", "missing-group"));
+
+        ToolGroupManager copy = new ToolGroupManager();
+        source.copyTo(copy);
+
+        assertEquals(source.getToolGroupNames(), copy.getToolGroupNames());
+        assertEquals(source.getActiveGroups(), copy.getActiveGroups());
+        assertManagerConsistency(copy);
+
+        copy.updateToolGroups(List.of("group-2"), false);
+        copy.updateToolGroups(List.of("group-5"), true);
+
+        assertTrue(source.getActiveGroups().contains("group-2"));
+        assertFalse(source.getActiveGroups().contains("group-5"));
+        assertFalse(copy.getActiveGroups().contains("group-2"));
+        assertTrue(copy.getActiveGroups().contains("group-5"));
+        assertManagerConsistency(source);
+        assertManagerConsistency(copy);
+    }
+
+    private ToolGroupManager createManagerWithGroups() {
+        ToolGroupManager manager = new ToolGroupManager();
+        for (int index = 0; index < GROUP_COUNT; index++) {
+            String groupName = "group-" + index;
+            manager.createToolGroup(groupName, "Description for " + groupName, index % 2 == 0);
+            manager.addToolToGroup(groupName, "tool-" + index);
+        }
+        return manager;
+    }
+
+    private void assertManagerConsistency(ToolGroupManager manager) {
+        List<String> activeGroups = manager.getActiveGroups();
+        Set<String> activeGroupSet = new HashSet<>(activeGroups);
+        assertEquals(
+                activeGroupSet.size(),
+                activeGroups.size(),
+                "activeGroups should stay deduplicated");
+
+        for (String groupName : manager.getToolGroupNames()) {
+            ToolGroup group = manager.getToolGroup(groupName);
+            assertEquals(
+                    activeGroupSet.contains(groupName),
+                    group.isActive(),
+                    "ToolGroup active flag should stay aligned with activeGroups snapshots");
+        }
+    }
+
+    private void await(CyclicBarrier startBarrier, Queue<Throwable> failures) {
+        try {
+            startBarrier.await(10, TimeUnit.SECONDS);
+        } catch (Throwable error) {
+            failures.add(error);
+        }
+    }
+
+    private String formatFailures(Queue<Throwable> failures) {
+        StringBuilder builder = new StringBuilder();
+        for (Throwable failure : failures) {
+            if (builder.length() > 0) {
+                builder.append(" | ");
+            }
+            builder.append(failure.getClass().getSimpleName())
+                    .append(':')
+                    .append(' ')
+                    .append(failure.getMessage());
+        }
+        return builder.toString();
+    }
+}


### PR DESCRIPTION
## Summary
- store active tool-group names in a concurrency-safe snapshot set instead of a plain ArrayList
- keep ToolGroup.active aligned with setActiveGroups(...) replacements and concurrent updates
- add regression coverage for concurrent read/write access, snapshot replacement, and copyTo(...) isolation

## Why this fix
ToolGroupManager already uses concurrent maps for group and tool indexes, but ctiveGroups remained a mutable ArrayList. In concurrent agent scenarios, activation/deactivation and snapshot reads such as getActiveGroups() / getActivatedNotes() can race, and the list can diverge from each ToolGroup's active flag. This patch makes the active-group snapshot safe for concurrent access while preserving the existing public API.

## Validation
- mvn -pl agentscope-core spotless:apply
- mvn -pl agentscope-core '-Dtest=ToolGroupManagerTest,ToolGroupManagerConcurrencyTest,ToolkitTest,ToolGroupsE2ETest' test

Closes #1165.