### PR TITLE
fix(model): parse non-standard rate limit errors in OpenAIClient to enable auto-retries

### DIFF
--- a/agentscope-core/src/main/java/io/agentscope/core/formatter/openai/dto/OpenAIResponse.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/formatter/openai/dto/OpenAIResponse.java
@@ -100,6 +100,18 @@ public class OpenAIResponse {
     @JsonProperty("error")
     private OpenAIError error;
 
+    /** Error code for non-standard error responses. */
+    @JsonProperty("code")
+    private String code;
+
+    /** Error message for non-standard error responses. */
+    @JsonProperty("message")
+    private String message;
+
+    /** Status for non-standard error responses. */
+    @JsonProperty("status")
+    private String status;
+
     public OpenAIResponse() {}
 
     public String getId() {
@@ -166,13 +178,42 @@ public class OpenAIResponse {
         this.error = error;
     }
 
+    public String getCode() {
+        return code;
+    }
+
+    public void setCode(String code) {
+        this.code = code;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public void setMessage(String message) {
+        this.message = message;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public void setStatus(String status) {
+        this.status = status;
+    }
+
     /**
      * Check if this response represents an error.
+     *
+     * Support the detection of standard OpenAI error structures
+     * and non-standard code/status error structures.
      *
      * @return true if the response contains an error
      */
     public boolean isError() {
-        return error != null;
+        return error != null
+                || "error".equalsIgnoreCase(status)
+                || (code != null && !code.equals("200") && !code.equals("0"));
     }
 
     /**

--- a/agentscope-core/src/main/java/io/agentscope/core/formatter/openai/dto/OpenAIResponse.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/formatter/openai/dto/OpenAIResponse.java
@@ -217,6 +217,26 @@ public class OpenAIResponse {
     }
 
     /**
+     * Get the effective error message, handling both standard and non-standard formats.
+     */
+    public String getEffectiveErrorMessage() {
+        if (error != null && error.getMessage() != null) {
+            return error.getMessage();
+        }
+        return message != null ? message : "Unknown error";
+    }
+
+    /**
+     * Get the effective error code, handling both standard and non-standard formats.
+     */
+    public String getEffectiveErrorCode() {
+        if (error != null && error.getCode() != null) {
+            return error.getCode();
+        }
+        return code != null ? code : "unknown_error";
+    }
+
+    /**
      * Check if this is a streaming chunk response.
      *
      * <p>Detects streaming chunks by:

--- a/agentscope-core/src/main/java/io/agentscope/core/formatter/openai/dto/OpenAIResponse.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/formatter/openai/dto/OpenAIResponse.java
@@ -206,14 +206,36 @@ public class OpenAIResponse {
      * Check if this response represents an error.
      *
      * Support the detection of standard OpenAI error structures
-     * and non-standard code/status error structures.
+     * and non-standard code/status error structures using a blacklist strategy.
      *
      * @return true if the response contains an error
      */
     public boolean isError() {
-        return error != null
-                || "error".equalsIgnoreCase(status)
-                || (code != null && !code.equals("200") && !code.equals("0"));
+        // Standard OpenAI error format
+        if (error != null) {
+            return true;
+        }
+
+        // Double check using the status field
+        if ("error".equalsIgnoreCase(status) || "failed".equalsIgnoreCase(status)) {
+            return true;
+        }
+
+        // Blacklist strategy for custom error codes
+        if (code != null) {
+            try {
+                int numericCode = Integer.parseInt(code);
+                if (numericCode >= 400 && numericCode <= 599) {
+                    return true;
+                }
+            } catch (NumberFormatException e) {
+                // If code is not numeric (e.g., "ok", "success", "invalid_key"),
+                // we rely on the 'status' or 'error' fields checked above.
+                // Do not blindly assume it's an error.
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/agentscope-core/src/main/java/io/agentscope/core/model/OpenAIClient.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/model/OpenAIClient.java
@@ -16,7 +16,6 @@
 package io.agentscope.core.model;
 
 import io.agentscope.core.Version;
-import io.agentscope.core.formatter.openai.dto.OpenAIError;
 import io.agentscope.core.formatter.openai.dto.OpenAIRequest;
 import io.agentscope.core.formatter.openai.dto.OpenAIResponse;
 import io.agentscope.core.model.exception.OpenAIException;
@@ -333,31 +332,9 @@ public class OpenAIClient {
             }
 
             if (response.isError()) {
-                OpenAIError error = response.getError();
-
-                // Prioritize the message in the standard error,
-                // otherwise take the non-standard message in the outer layer
-                String errorMessage =
-                        error != null && error.getMessage() != null
-                                ? error.getMessage()
-                                : (response.getMessage() != null
-                                        ? response.getMessage()
-                                        : "Unknown error");
-
-                String errorCode =
-                        error != null && error.getCode() != null
-                                ? error.getCode()
-                                : (response.getCode() != null
-                                        ? response.getCode()
-                                        : "unknown_error");
-
-                int statusCode = httpResponse.getStatusCode();
-                if (statusCode == 200
-                        && ("429".equals(errorCode)
-                                || (errorCode != null && errorCode.contains("429")))) {
-                    statusCode = 429;
-                }
-
+                String errorMessage = response.getEffectiveErrorMessage();
+                String errorCode = response.getEffectiveErrorCode();
+                int statusCode = resolveErrorStatusCode(httpResponse.getStatusCode(), errorCode);
                 throw OpenAIException.create(
                         statusCode, "OpenAI API error: " + errorMessage, errorCode, responseBody);
             }
@@ -426,40 +403,16 @@ public class OpenAIClient {
                                 if (response != null) {
                                     // Check for error in streaming response chunk
                                     if (response.isError()) {
-                                        OpenAIError error = response.getError();
-
-                                        // Prioritize the message in the standard error,
-                                        // otherwise take the non-standard message in the outer
-                                        // layer
-                                        String errorMessage =
-                                                error != null && error.getMessage() != null
-                                                        ? error.getMessage()
-                                                        : (response.getMessage() != null
-                                                                ? response.getMessage()
-                                                                : "Unknown error in streaming"
-                                                                        + " response");
-
-                                        String errorCode =
-                                                error != null && error.getCode() != null
-                                                        ? error.getCode()
-                                                        : (response.getCode() != null
-                                                                ? response.getCode()
-                                                                : "unknown_error");
-
-                                        int statusCode = 400;
-                                        if ("429".equals(errorCode)
-                                                || (errorCode != null
-                                                        && errorCode.contains("429"))) {
-                                            statusCode = 429;
-                                        }
-
+                                        String errorMessage = response.getEffectiveErrorMessage();
+                                        String errorCode = response.getEffectiveErrorCode();
+                                        int statusCode = resolveErrorStatusCode(200, errorCode);
                                         sink.error(
                                                 OpenAIException.create(
                                                         statusCode,
                                                         "OpenAI API error in streaming response: "
                                                                 + errorMessage,
                                                         errorCode,
-                                                        null));
+                                                        data));
                                         return;
                                     }
                                     sink.next(response);
@@ -485,6 +438,39 @@ public class OpenAIClient {
             return Flux.error(
                     new OpenAIException("Failed to initialize request: " + e.getMessage(), e));
         }
+    }
+
+    /**
+     * Resolve the actual HTTP error status code when the API returns 200 OK
+     * but contains an error payload.
+     *
+     * @param httpStatusCode the original HTTP status code
+     * @param errorCode the error code extracted from the response body
+     * @return a valid HTTP error status code (4xx or 5xx)
+     */
+    private int resolveErrorStatusCode(int httpStatusCode, String errorCode) {
+        if (httpStatusCode >= 400) {
+            return httpStatusCode;
+        }
+
+        // Handling HTTP 200 with Body containing errors
+        if (errorCode != null) {
+            if (errorCode.contains("429")) {
+                return 429;
+            }
+
+            try {
+                int parsedCode = Integer.parseInt(errorCode);
+                if (parsedCode >= 400 && parsedCode <= 599) {
+                    return parsedCode;
+                }
+            } catch (NumberFormatException e) {
+                // Ignore error codes of non numeric types
+            }
+        }
+
+        // Extraction failed, return to default
+        return 400;
     }
 
     /**

--- a/agentscope-core/src/main/java/io/agentscope/core/model/OpenAIClient.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/model/OpenAIClient.java
@@ -334,21 +334,32 @@ public class OpenAIClient {
 
             if (response.isError()) {
                 OpenAIError error = response.getError();
-                if (error == null) {
-                    throw new OpenAIException(
-                            "OpenAI API returned error but error details are null",
-                            400,
-                            "unknown_error",
-                            responseBody);
-                }
+
+                // Prioritize the message in the standard error,
+                // otherwise take the non-standard message in the outer layer
                 String errorMessage =
-                        error.getMessage() != null ? error.getMessage() : "Unknown error";
-                String errorCode = error.getCode() != null ? error.getCode() : "unknown_error";
+                        error != null && error.getMessage() != null
+                                ? error.getMessage()
+                                : (response.getMessage() != null
+                                        ? response.getMessage()
+                                        : "Unknown error");
+
+                String errorCode =
+                        error != null && error.getCode() != null
+                                ? error.getCode()
+                                : (response.getCode() != null
+                                        ? response.getCode()
+                                        : "unknown_error");
+
+                int statusCode = httpResponse.getStatusCode();
+                if (statusCode == 200
+                        && ("429".equals(errorCode)
+                                || (errorCode != null && errorCode.contains("429")))) {
+                    statusCode = 429;
+                }
+
                 throw OpenAIException.create(
-                        httpResponse.getStatusCode(),
-                        "OpenAI API error: " + errorMessage,
-                        errorCode,
-                        responseBody);
+                        statusCode, "OpenAI API error: " + errorMessage, errorCode, responseBody);
             }
 
             return response;
@@ -416,17 +427,35 @@ public class OpenAIClient {
                                     // Check for error in streaming response chunk
                                     if (response.isError()) {
                                         OpenAIError error = response.getError();
+
+                                        // Prioritize the message in the standard error,
+                                        // otherwise take the non-standard message in the outer
+                                        // layer
                                         String errorMessage =
                                                 error != null && error.getMessage() != null
                                                         ? error.getMessage()
-                                                        : "Unknown error in streaming response";
+                                                        : (response.getMessage() != null
+                                                                ? response.getMessage()
+                                                                : "Unknown error in streaming"
+                                                                        + " response");
+
                                         String errorCode =
                                                 error != null && error.getCode() != null
                                                         ? error.getCode()
-                                                        : null;
+                                                        : (response.getCode() != null
+                                                                ? response.getCode()
+                                                                : "unknown_error");
+
+                                        int statusCode = 400;
+                                        if ("429".equals(errorCode)
+                                                || (errorCode != null
+                                                        && errorCode.contains("429"))) {
+                                            statusCode = 429;
+                                        }
+
                                         sink.error(
                                                 OpenAIException.create(
-                                                        400,
+                                                        statusCode,
                                                         "OpenAI API error in streaming response: "
                                                                 + errorMessage,
                                                         errorCode,

--- a/agentscope-core/src/main/java/io/agentscope/core/model/OpenAIClient.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/model/OpenAIClient.java
@@ -455,7 +455,7 @@ public class OpenAIClient {
 
         // Handling HTTP 200 with Body containing errors
         if (errorCode != null) {
-            if (errorCode.contains("429")) {
+            if ("429".equals(errorCode) || "rate_limit_exceeded".equals(errorCode)) {
                 return 429;
             }
 

--- a/agentscope-core/src/main/java/io/agentscope/core/model/OpenAIClient.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/model/OpenAIClient.java
@@ -95,6 +95,7 @@ public class OpenAIClient {
     }
 
     private static final Pattern VERSION_PATTERN = Pattern.compile(".*/v\\d+$");
+    private static final Pattern RATE_LIMIT_PATTERN = Pattern.compile(".*\\b429\\b.*");
 
     /**
      * Normalize the base URL by removing trailing slashes.
@@ -455,7 +456,11 @@ public class OpenAIClient {
 
         // Handling HTTP 200 with Body containing errors
         if (errorCode != null) {
-            if ("429".equals(errorCode) || "rate_limit_exceeded".equals(errorCode)) {
+            // Use a regex to ensure "429" appears as a standalone word
+            // For example, "HTTP 429 Too Many Requests"
+            // And compatible with OpenAI's standard strings
+            if (RATE_LIMIT_PATTERN.matcher(errorCode).matches()
+                    || "rate_limit_exceeded".equalsIgnoreCase(errorCode)) {
                 return 429;
             }
 

--- a/agentscope-core/src/test/java/io/agentscope/core/formatter/openai/dto/OpenAIResponseTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/formatter/openai/dto/OpenAIResponseTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.core.formatter.openai.dto;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for OpenAIResponse error detection logic covering both standard OpenAI errors
+ * and non-standard gateway errors based on code, status, or message fields.
+ */
+class OpenAIResponseTest {
+
+    @Test
+    @DisplayName("Should detect standard OpenAI error")
+    void testStandardOpenAIError() {
+        OpenAIResponse response = new OpenAIResponse();
+        OpenAIError error = new OpenAIError();
+        error.setCode("invalid_api_key");
+        response.setError(error);
+
+        assertTrue(response.isError());
+    }
+
+    @Test
+    @DisplayName("Should detect non-standard gateway error by code")
+    void testNonStandardErrorByCode() {
+        OpenAIResponse response = new OpenAIResponse();
+        response.setCode("429");
+        response.setMessage("Rate limit exceeded");
+
+        assertTrue(response.isError());
+    }
+
+    @Test
+    @DisplayName("Should detect non-standard gateway error by status")
+    void testNonStandardErrorByStatus() {
+        OpenAIResponse response = new OpenAIResponse();
+        response.setStatus("error");
+
+        assertTrue(response.isError());
+    }
+
+    @Test
+    @DisplayName("Should not detect error for successful response")
+    void testSuccessfulResponse() {
+        OpenAIResponse response = new OpenAIResponse();
+        response.setCode("200");
+        response.setStatus("success");
+
+        assertFalse(response.isError());
+
+        OpenAIResponse response2 = new OpenAIResponse();
+        response2.setCode("0");
+
+        assertFalse(response2.isError());
+    }
+}

--- a/agentscope-core/src/test/java/io/agentscope/core/formatter/openai/dto/OpenAIResponseTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/formatter/openai/dto/OpenAIResponseTest.java
@@ -58,17 +58,51 @@ class OpenAIResponseTest {
     }
 
     @Test
-    @DisplayName("Should not detect error for successful response")
+    @DisplayName("Should not detect error for successful response including custom gateway codes")
     void testSuccessfulResponse() {
-        OpenAIResponse response = new OpenAIResponse();
-        response.setCode("200");
-        response.setStatus("success");
-
-        assertFalse(response.isError());
+        OpenAIResponse response1 = new OpenAIResponse();
+        response1.setCode("200");
+        response1.setStatus("success");
+        assertFalse(response1.isError(), "Code 200 should not be an error");
 
         OpenAIResponse response2 = new OpenAIResponse();
         response2.setCode("0");
+        assertFalse(response2.isError(), "Code 0 should not be an error");
 
-        assertFalse(response2.isError());
+        OpenAIResponse response3 = new OpenAIResponse();
+        response3.setCode("ok");
+        assertFalse(response3.isError(), "String code 'ok' should not be an error");
+
+        OpenAIResponse response4 = new OpenAIResponse();
+        response4.setCode("success");
+        assertFalse(response4.isError(), "String code 'success' should not be an error");
+    }
+
+    @Test
+    @DisplayName("Should detect error based on valid HTTP error code range (400-599)")
+    void testErrorDetectionByHttpCodeRange() {
+        OpenAIResponse response400 = new OpenAIResponse();
+        response400.setCode("400");
+        assertTrue(response400.isError(), "Code 400 should be detected as error");
+
+        OpenAIResponse response500 = new OpenAIResponse();
+        response500.setCode("500");
+        assertTrue(response500.isError(), "Code 500 should be detected as error");
+
+        OpenAIResponse response399 = new OpenAIResponse();
+        response399.setCode("399");
+        assertFalse(response399.isError(), "Code 399 should not be an error by default");
+
+        OpenAIResponse response600 = new OpenAIResponse();
+        response600.setCode("600");
+        assertFalse(response600.isError(), "Code 600 should not be an error by default");
+    }
+
+    @Test
+    @DisplayName("Should detect non-standard gateway error by status 'failed' ignoring case")
+    void testNonStandardErrorByStatusFailed() {
+        OpenAIResponse response = new OpenAIResponse();
+        response.setStatus("Failed");
+        assertTrue(response.isError(), "Status 'Failed' should be detected as error");
     }
 }

--- a/agentscope-core/src/test/java/io/agentscope/core/model/OpenAIClientTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/model/OpenAIClientTest.java
@@ -41,6 +41,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Flux;
 
 /**
  * Unit tests for OpenAIClient.
@@ -914,5 +915,94 @@ class OpenAIClientTest {
         assertThrows(
                 OpenAIException.class,
                 () -> client.stream(TEST_API_KEY, baseUrl, request, options).collectList().block());
+    }
+
+    @Test
+    @DisplayName("Should handle non-standard rate limit error in sync response body")
+    void testNonStandardErrorInResponseBody() {
+        String errorResponse =
+                """
+                {
+                    "code": "429",
+                    "message": "The request has triggered the maximum tokens per minute limit.",
+                    "status": "error"
+                }
+                """;
+
+        mockServer.enqueue(
+                new MockResponse()
+                        .setResponseCode(200)
+                        .setBody(errorResponse)
+                        .setHeader("Content-Type", "application/json"));
+
+        OpenAIRequest request =
+                OpenAIRequest.builder()
+                        .model("gpt-4")
+                        .messages(
+                                List.of(
+                                        OpenAIMessage.builder()
+                                                .role("user")
+                                                .content("Hello")
+                                                .build()))
+                        .build();
+
+        OpenAIException exception =
+                assertThrows(
+                        OpenAIException.class, () -> client.call(TEST_API_KEY, baseUrl, request));
+
+        assertNotNull(exception);
+        assertEquals(429, exception.getStatusCode());
+        assertEquals("429", exception.getErrorCode());
+        assertTrue(exception.getMessage().contains("maximum tokens per minute"));
+    }
+
+    @Test
+    @DisplayName("Should handle non-standard rate limit error in streaming chunk")
+    void testNonStandardErrorInStreamChunk() {
+        String chunk1 =
+                "data:"
+                    + " {\"id\":\"chatcmpl-123\",\"object\":\"chat.completion.chunk\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"Hello\"}}]}\n\n";
+        String chunk2 =
+                "data: {\"code\":\"429\",\"message\":\"MAX_TPM limit"
+                        + " exceeded\",\"status\":\"error\"}\n\n";
+
+        mockServer.enqueue(
+                new MockResponse()
+                        .setResponseCode(200)
+                        .setBody(chunk1 + chunk2)
+                        .setHeader("Content-Type", "text/event-stream"));
+
+        OpenAIRequest request =
+                OpenAIRequest.builder()
+                        .model("gpt-4")
+                        .messages(
+                                List.of(
+                                        OpenAIMessage.builder()
+                                                .role("user")
+                                                .content("Hello")
+                                                .build()))
+                        .build();
+
+        GenerateOptions options = GenerateOptions.builder().build();
+
+        List<OpenAIResponse> responses = new ArrayList<>();
+        Throwable[] capturedError = new Throwable[1];
+
+        client.stream(TEST_API_KEY, baseUrl, request, options)
+                .doOnNext(responses::add)
+                .doOnError(e -> capturedError[0] = e)
+                .onErrorResume(e -> Flux.empty())
+                .blockLast();
+
+        assertEquals(1, responses.size());
+        assertEquals("chatcmpl-123", responses.get(0).getId());
+
+        assertNotNull(capturedError[0]);
+        assertTrue(capturedError[0] instanceof OpenAIException);
+
+        OpenAIException exception = (OpenAIException) capturedError[0];
+        assertEquals(429, exception.getStatusCode());
+        assertEquals("429", exception.getErrorCode());
+        assertTrue(exception.getMessage().contains("MAX_TPM limit exceeded"));
     }
 }

--- a/agentscope-core/src/test/java/io/agentscope/core/model/OpenAIClientTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/model/OpenAIClientTest.java
@@ -1046,13 +1046,12 @@ class OpenAIClientTest {
     }
 
     @Test
-    @DisplayName("Should not falsely resolve out-of-bounds numeric code containing 429")
-    void testFalsePositiveRateLimitNumericError() {
+    @DisplayName("Should intelligently resolve complex 429 string codes to trigger retry")
+    void testComplexRateLimitStringCode() {
         String errorResponse =
                 """
                 {
-                    "code": "4290",
-                    "message": "Custom error 4290",
+                    "code": "HTTP 429 Too Many Requests",
                     "status": "error"
                 }
                 """;
@@ -1078,8 +1077,46 @@ class OpenAIClientTest {
                 assertThrows(
                         OpenAIException.class, () -> client.call(TEST_API_KEY, baseUrl, request));
 
-        // Cannot accurately match 429, so fallback to default 400
+        // Matches RATE_LIMIT_PATTERN (\b429\b) and resolves to 429 status code
+        assertEquals(429, exception.getStatusCode());
+        assertEquals("HTTP 429 Too Many Requests", exception.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("Should not falsely resolve string codes containing 429 as rate limit error")
+    void testFalsePositiveRateLimitStringError() {
+        String errorResponse =
+                """
+                {
+                    "code": "err_4291_token",
+                    "message": "Token limit error, not a rate limit",
+                    "status": "error"
+                }
+                """;
+
+        mockServer.enqueue(
+                new MockResponse()
+                        .setResponseCode(200)
+                        .setBody(errorResponse)
+                        .setHeader("Content-Type", "application/json"));
+
+        OpenAIRequest request =
+                OpenAIRequest.builder()
+                        .model("gpt-4")
+                        .messages(
+                                List.of(
+                                        OpenAIMessage.builder()
+                                                .role("user")
+                                                .content("Hello")
+                                                .build()))
+                        .build();
+
+        OpenAIException exception =
+                assertThrows(
+                        OpenAIException.class, () -> client.call(TEST_API_KEY, baseUrl, request));
+
+        // Cannot accurately match word boundary 429, so fallback to default 400
         assertEquals(400, exception.getStatusCode());
-        assertEquals("4290", exception.getErrorCode());
+        assertEquals("err_4291_token", exception.getErrorCode());
     }
 }

--- a/agentscope-core/src/test/java/io/agentscope/core/model/OpenAIClientTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/model/OpenAIClientTest.java
@@ -1005,4 +1005,81 @@ class OpenAIClientTest {
         assertEquals("429", exception.getErrorCode());
         assertTrue(exception.getMessage().contains("MAX_TPM limit exceeded"));
     }
+
+    @Test
+    @DisplayName("Should resolve standard OpenAI rate limit string to 429 status code")
+    void testStandardRateLimitStringCode() {
+        String errorResponse =
+                """
+                {
+                    "error": {
+                        "message": "Rate limit reached",
+                        "type": "requests",
+                        "code": "rate_limit_exceeded"
+                    }
+                }
+                """;
+
+        mockServer.enqueue(
+                new MockResponse()
+                        .setResponseCode(200)
+                        .setBody(errorResponse)
+                        .setHeader("Content-Type", "application/json"));
+
+        OpenAIRequest request =
+                OpenAIRequest.builder()
+                        .model("gpt-4")
+                        .messages(
+                                List.of(
+                                        OpenAIMessage.builder()
+                                                .role("user")
+                                                .content("Hello")
+                                                .build()))
+                        .build();
+
+        OpenAIException exception =
+                assertThrows(
+                        OpenAIException.class, () -> client.call(TEST_API_KEY, baseUrl, request));
+
+        assertEquals(429, exception.getStatusCode());
+        assertEquals("rate_limit_exceeded", exception.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("Should not falsely resolve out-of-bounds numeric code containing 429")
+    void testFalsePositiveRateLimitNumericError() {
+        String errorResponse =
+                """
+                {
+                    "code": "4290",
+                    "message": "Custom error 4290",
+                    "status": "error"
+                }
+                """;
+
+        mockServer.enqueue(
+                new MockResponse()
+                        .setResponseCode(200)
+                        .setBody(errorResponse)
+                        .setHeader("Content-Type", "application/json"));
+
+        OpenAIRequest request =
+                OpenAIRequest.builder()
+                        .model("gpt-4")
+                        .messages(
+                                List.of(
+                                        OpenAIMessage.builder()
+                                                .role("user")
+                                                .content("Hello")
+                                                .build()))
+                        .build();
+
+        OpenAIException exception =
+                assertThrows(
+                        OpenAIException.class, () -> client.call(TEST_API_KEY, baseUrl, request));
+
+        // Cannot accurately match 429, so fallback to default 400
+        assertEquals(400, exception.getStatusCode());
+        assertEquals("4290", exception.getErrorCode());
+    }
 }


### PR DESCRIPTION
## Description

Close #761 
Fixes an issue where non-standard gateway errors were swallowed in OpenAIClient, ensuring rate limit (429) errors correctly trigger the auto-retry mechanism.

## Checklist

Please check the following items before code is ready to be reviewed.

- [ ]  Code has been formatted with `mvn spotless:apply`
- [ ]  All tests are passing (`mvn test`)
- [ ]  Javadoc comments are complete and follow project conventions
- [ ]  Related documentation has been updated (e.g. links, examples, etc.)
- [ ]  Code is ready for review
