### PR TITLE
fix(agent): preserve cumulative stream history after tool calls

### DIFF
--- a/agentscope-core/src/main/java/io/agentscope/core/agent/StreamingHook.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/agent/StreamingHook.java
@@ -26,7 +26,10 @@ import io.agentscope.core.hook.SummaryChunkEvent;
 import io.agentscope.core.message.ContentBlock;
 import io.agentscope.core.message.Msg;
 import io.agentscope.core.message.MsgRole;
+import io.agentscope.core.message.TextBlock;
+import io.agentscope.core.message.ThinkingBlock;
 import io.agentscope.core.message.ToolResultBlock;
+import io.agentscope.core.message.ToolUseBlock;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -48,6 +51,10 @@ class StreamingHook implements Hook {
     // Track previous content for incremental mode
     private final Map<String, List<ContentBlock>> previousContent = new HashMap<>();
 
+    // Track cumulative reasoning content across ReAct reasoning/acting boundaries.
+    private final List<ContentBlock> cumulativeReasoningContent = new ArrayList<>();
+    private final Map<String, Integer> cumulativeReasoningPositions = new HashMap<>();
+
     /**
      * Creates a new streaming hook.
      *
@@ -67,7 +74,11 @@ class StreamingHook implements Hook {
             // This is the last/complete message
             if (options.shouldStream(EventType.REASONING)
                     && options.shouldIncludeReasoningEmission(false)) {
-                emitEvent(EventType.REASONING, e.getReasoningMessage(), true);
+                Msg msgToEmit =
+                        options.isIncremental()
+                                ? e.getReasoningMessage()
+                                : accumulateReasoning(e.getReasoningMessage());
+                emitEvent(EventType.REASONING, msgToEmit, true);
             }
             return Mono.just(event);
         } else if (event instanceof ReasoningChunkEvent) {
@@ -77,7 +88,9 @@ class StreamingHook implements Hook {
                     && options.shouldIncludeReasoningEmission(true)) {
                 // Use incremental or accumulated based on StreamOptions
                 Msg msgToEmit =
-                        options.isIncremental() ? e.getIncrementalChunk() : e.getAccumulated();
+                        options.isIncremental()
+                                ? e.getIncrementalChunk()
+                                : accumulateReasoning(e.getAccumulated());
                 emitEvent(EventType.REASONING, msgToEmit, false);
             }
             return Mono.just(event);
@@ -134,6 +147,47 @@ class StreamingHook implements Hook {
                 .role(MsgRole.TOOL)
                 .content(List.of(toolResultBlock))
                 .build();
+    }
+
+    private Msg accumulateReasoning(Msg reasoningMsg) {
+        for (int index = 0; index < reasoningMsg.getContent().size(); index++) {
+            ContentBlock block = reasoningMsg.getContent().get(index);
+            String key = reasoningContentKey(reasoningMsg.getId(), block, index);
+            Integer position = cumulativeReasoningPositions.get(key);
+
+            if (position == null) {
+                cumulativeReasoningPositions.put(key, cumulativeReasoningContent.size());
+                cumulativeReasoningContent.add(block);
+            } else {
+                cumulativeReasoningContent.set(position, block);
+            }
+        }
+
+        return Msg.builder()
+                .id(reasoningMsg.getId())
+                .name(reasoningMsg.getName())
+                .role(reasoningMsg.getRole())
+                .content(new ArrayList<>(cumulativeReasoningContent))
+                .metadata(new HashMap<>(reasoningMsg.getMetadata()))
+                .timestamp(reasoningMsg.getTimestamp())
+                .build();
+    }
+
+    private String reasoningContentKey(String messageId, ContentBlock block, int index) {
+        if (block instanceof ThinkingBlock) {
+            return messageId + ":thinking";
+        }
+        if (block instanceof TextBlock) {
+            return messageId + ":text";
+        }
+        if (block instanceof ToolUseBlock toolUseBlock) {
+            String toolCallId = toolUseBlock.getId();
+            if (toolCallId == null || toolCallId.isBlank()) {
+                toolCallId = toolUseBlock.getName() + ":" + index;
+            }
+            return messageId + ":tool:" + toolCallId;
+        }
+        return messageId + ":" + block.getClass().getName() + ":" + index;
     }
 
     /**

--- a/agentscope-core/src/test/java/io/agentscope/core/agent/ReActAgentTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/agent/ReActAgentTest.java
@@ -36,6 +36,7 @@ import io.agentscope.core.message.GenerateReason;
 import io.agentscope.core.message.Msg;
 import io.agentscope.core.message.MsgRole;
 import io.agentscope.core.message.TextBlock;
+import io.agentscope.core.message.ThinkingBlock;
 import io.agentscope.core.message.ToolResultBlock;
 import io.agentscope.core.message.ToolUseBlock;
 import io.agentscope.core.model.ChatResponse;
@@ -805,6 +806,188 @@ class ReActAgentTest {
         ToolUseBlock accumulatedTub = accumulatedToolUseBlocks.get(0);
         assertEquals(
                 "call_stream_1", accumulatedTub.getId(), "Accumulated tool call ID should match");
+    }
+
+    @Test
+    @DisplayName("Should keep cumulative reasoning chunks across tool calls")
+    void testCumulativeReasoningStreamKeepsHistoryAfterToolCall() {
+        MockModel toolModel = createTwoRoundStreamingModel();
+
+        agent =
+                ReActAgent.builder()
+                        .name(TestConstants.TEST_REACT_AGENT_NAME)
+                        .sysPrompt(TestConstants.DEFAULT_SYS_PROMPT)
+                        .model(toolModel)
+                        .toolkit(mockToolkit)
+                        .memory(memory)
+                        .build();
+
+        StreamOptions options =
+                StreamOptions.builder()
+                        .eventTypes(EventType.REASONING)
+                        .incremental(false)
+                        .includeReasoningResult(false)
+                        .build();
+
+        List<Event> events =
+                agent.stream(
+                                TestUtils.createUserMessage("User", "Use a tool, then continue."),
+                                options)
+                        .collectList()
+                        .block(Duration.ofMillis(TestConstants.DEFAULT_TEST_TIMEOUT_MS));
+
+        assertNotNull(events, "Streaming events should not be null");
+
+        List<Msg> reasoningChunks =
+                events.stream()
+                        .filter(event -> event.getType() == EventType.REASONING)
+                        .filter(event -> !event.isLast())
+                        .map(Event::getMessage)
+                        .toList();
+
+        assertEquals(5, reasoningChunks.size(), "Should emit every streamed reasoning chunk");
+
+        Msg finalCumulativeChunk = reasoningChunks.get(reasoningChunks.size() - 1);
+        List<ContentBlock> cumulativeContent = finalCumulativeChunk.getContent();
+
+        assertTrue(
+                cumulativeContent.stream()
+                        .filter(ThinkingBlock.class::isInstance)
+                        .map(ThinkingBlock.class::cast)
+                        .anyMatch(block -> block.getThinking().contains("think before tool.")),
+                "Cumulative mode should keep pre-tool thinking content");
+        assertTrue(
+                cumulativeContent.stream()
+                        .filter(TextBlock.class::isInstance)
+                        .map(TextBlock.class::cast)
+                        .anyMatch(block -> block.getText().contains("text before tool.")),
+                "Cumulative mode should keep pre-tool text content");
+        assertTrue(
+                cumulativeContent.stream()
+                        .filter(ToolUseBlock.class::isInstance)
+                        .map(ToolUseBlock.class::cast)
+                        .anyMatch(block -> "call_stream_reset_1".equals(block.getId())),
+                "Cumulative mode should keep the tool call that split reasoning rounds");
+        assertTrue(
+                cumulativeContent.stream()
+                        .filter(ThinkingBlock.class::isInstance)
+                        .map(ThinkingBlock.class::cast)
+                        .anyMatch(block -> block.getThinking().contains("think after tool.")),
+                "Cumulative mode should include post-tool thinking content");
+        assertTrue(
+                cumulativeContent.stream()
+                        .filter(TextBlock.class::isInstance)
+                        .map(TextBlock.class::cast)
+                        .anyMatch(block -> block.getText().contains("text after tool.")),
+                "Cumulative mode should include post-tool text content");
+    }
+
+    @Test
+    @DisplayName("Should keep incremental reasoning chunks as deltas after tool calls")
+    void testIncrementalReasoningStreamStillEmitsDeltasAfterToolCall() {
+        MockModel toolModel = createTwoRoundStreamingModel();
+
+        agent =
+                ReActAgent.builder()
+                        .name(TestConstants.TEST_REACT_AGENT_NAME)
+                        .sysPrompt(TestConstants.DEFAULT_SYS_PROMPT)
+                        .model(toolModel)
+                        .toolkit(mockToolkit)
+                        .memory(memory)
+                        .build();
+
+        StreamOptions options =
+                StreamOptions.builder()
+                        .eventTypes(EventType.REASONING)
+                        .incremental(true)
+                        .includeReasoningResult(false)
+                        .build();
+
+        List<Event> events =
+                agent.stream(
+                                TestUtils.createUserMessage("User", "Use a tool, then continue."),
+                                options)
+                        .collectList()
+                        .block(Duration.ofMillis(TestConstants.DEFAULT_TEST_TIMEOUT_MS));
+
+        assertNotNull(events, "Streaming events should not be null");
+
+        List<Msg> reasoningChunks =
+                events.stream()
+                        .filter(event -> event.getType() == EventType.REASONING)
+                        .filter(event -> !event.isLast())
+                        .map(Event::getMessage)
+                        .toList();
+
+        assertEquals(5, reasoningChunks.size(), "Should emit every streamed reasoning chunk");
+
+        Msg finalIncrementalChunk = reasoningChunks.get(reasoningChunks.size() - 1);
+        List<ContentBlock> incrementalContent = finalIncrementalChunk.getContent();
+
+        assertEquals(1, incrementalContent.size(), "Incremental mode should emit only the delta");
+        TextBlock textBlock = assertInstanceOf(TextBlock.class, incrementalContent.get(0));
+        assertEquals("text after tool.", textBlock.getText());
+    }
+
+    private static MockModel createTwoRoundStreamingModel() {
+        final int[] callCount = {0};
+        return new MockModel(
+                messages -> {
+                    int currentCall = callCount[0]++;
+                    if (currentCall == 0) {
+                        return List.of(
+                                ChatResponse.builder()
+                                        .id("reasoning-round-1")
+                                        .content(
+                                                List.of(
+                                                        ThinkingBlock.builder()
+                                                                .thinking("think before tool. ")
+                                                                .build()))
+                                        .usage(new ChatUsage(10, 20, 30))
+                                        .build(),
+                                ChatResponse.builder()
+                                        .id("reasoning-round-1")
+                                        .content(
+                                                List.of(
+                                                        TextBlock.builder()
+                                                                .text("text before tool. ")
+                                                                .build()))
+                                        .usage(new ChatUsage(10, 20, 30))
+                                        .build(),
+                                ChatResponse.builder()
+                                        .id("reasoning-round-1")
+                                        .content(
+                                                List.of(
+                                                        ToolUseBlock.builder()
+                                                                .id("call_stream_reset_1")
+                                                                .name(TestConstants.TEST_TOOL_NAME)
+                                                                .input(Map.of())
+                                                                .content("{}")
+                                                                .build()))
+                                        .usage(new ChatUsage(10, 20, 30))
+                                        .build());
+                    }
+
+                    return List.of(
+                            ChatResponse.builder()
+                                    .id("reasoning-round-2")
+                                    .content(
+                                            List.of(
+                                                    ThinkingBlock.builder()
+                                                            .thinking("think after tool. ")
+                                                            .build()))
+                                    .usage(new ChatUsage(10, 20, 30))
+                                    .build(),
+                            ChatResponse.builder()
+                                    .id("reasoning-round-2")
+                                    .content(
+                                            List.of(
+                                                    TextBlock.builder()
+                                                            .text("text after tool.")
+                                                            .build()))
+                                    .usage(new ChatUsage(10, 20, 30))
+                                    .build());
+                });
     }
 
     @Test


### PR DESCRIPTION
## Summary
- preserve cumulative reasoning stream output across ReAct reasoning/acting boundaries
- keep incremental streaming behavior unchanged
- add regression coverage for thinking + text + tool-call + post-tool reasoning chunks

## Why this fix
In cumulative streaming mode (`StreamOptions.builder().incremental(false)`), `StreamingHook` used the current `ReasoningChunkEvent#getAccumulated()` message directly. That message is scoped to a single reasoning round, so after a tool call starts the next reasoning round, previously streamed thinking/text/tool-call content is dropped from subsequent cumulative emissions.

This change keeps a stream-scoped cumulative reasoning view inside `StreamingHook`, replacing in-round accumulated blocks while preserving earlier reasoning-round blocks across tool execution boundaries.

## Validation
- `mvn -pl agentscope-core '-Dtest=ReActAgentTest#testCumulativeReasoningStreamKeepsHistoryAfterToolCall+testIncrementalReasoningStreamStillEmitsDeltasAfterToolCall' test -q`
- `mvn -pl agentscope-core '-Dtest=ReActAgentTest,AgentStreamingTest' test -q`
- `mvn -pl agentscope-core spotless:check -q`

Fixes #1211