### PR TITLE
fix(core): AgentScopeJvmShutdownHook conflict with spring (#1093)

### DIFF
--- a/agentscope-core/src/main/java/io/agentscope/core/shutdown/AgentScopeJvmShutdownHook.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/shutdown/AgentScopeJvmShutdownHook.java
@@ -40,7 +40,20 @@ public final class AgentScopeJvmShutdownHook {
 
     private AgentScopeJvmShutdownHook() {}
 
+    /**
+     * Resets the REGISTERED flag for testing purposes.
+     *
+     * <p>This method is intended for testing only. It allows tests to verify
+     * the JVM hook registration behavior in isolation.
+     */
+    static void resetForTesting() {
+        REGISTERED.set(false);
+    }
+
     public static void register(GracefulShutdownManager manager) {
+        if (!manager.getConfig().isRegister()) {
+            return;
+        }
         if (!REGISTERED.compareAndSet(false, true)) {
             return;
         }

--- a/agentscope-core/src/main/java/io/agentscope/core/shutdown/AgentScopeJvmShutdownHook.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/shutdown/AgentScopeJvmShutdownHook.java
@@ -18,6 +18,7 @@ package io.agentscope.core.shutdown;
 import io.agentscope.core.model.transport.HttpTransportFactory;
 import java.time.Duration;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -35,6 +36,7 @@ public final class AgentScopeJvmShutdownHook {
 
     private static final Logger log = LoggerFactory.getLogger(AgentScopeJvmShutdownHook.class);
     private static final AtomicBoolean REGISTERED = new AtomicBoolean(false);
+    private static final AtomicReference<Thread> SHUTDOWN_HOOK_THREAD = new AtomicReference<>();
 
     private static final Duration INTERRUPT_GRACE_PERIOD = Duration.ofSeconds(5);
 
@@ -47,37 +49,41 @@ public final class AgentScopeJvmShutdownHook {
      * the JVM hook registration behavior in isolation.
      */
     static void resetForTesting() {
-        REGISTERED.set(false);
+        if (REGISTERED.get() && REGISTERED.compareAndSet(true, false)) {
+            Runtime.getRuntime().removeShutdownHook(SHUTDOWN_HOOK_THREAD.get());
+            SHUTDOWN_HOOK_THREAD.set(null);
+        }
     }
 
     public static void register(GracefulShutdownManager manager) {
-        if (!manager.getConfig().isRegister()) {
-            return;
-        }
         if (!REGISTERED.compareAndSet(false, true)) {
             return;
         }
-        Runtime.getRuntime()
-                .addShutdownHook(
-                        new Thread(
-                                () -> {
-                                    try {
-                                        manager.performGracefulShutdown();
-                                        Duration timeout = manager.getConfig().shutdownTimeout();
-                                        // Wait for shutdown timeout + an extra grace period,
-                                        // so agents have time to handle the interrupt and
-                                        // clean up before HTTP transports are closed.
-                                        Duration awaitTimeout =
-                                                timeout != null
-                                                        ? timeout.plus(INTERRUPT_GRACE_PERIOD)
-                                                        : null;
-                                        manager.awaitTermination(awaitTimeout);
-                                    } catch (Exception e) {
-                                        log.warn("Graceful shutdown hook failed", e);
-                                    } finally {
-                                        HttpTransportFactory.shutdown();
-                                    }
-                                },
-                                "agentscope-jvm-shutdown-hook"));
+        Thread hook =
+                new Thread(
+                        () -> {
+                            if (!manager.getConfig().enableShutdownHook()) {
+                                return;
+                            }
+                            try {
+                                manager.performGracefulShutdown();
+                                Duration timeout = manager.getConfig().shutdownTimeout();
+                                // Wait for shutdown timeout + an extra grace period,
+                                // so agents have time to handle the interrupt and
+                                // clean up before HTTP transports are closed.
+                                Duration awaitTimeout =
+                                        timeout != null
+                                                ? timeout.plus(INTERRUPT_GRACE_PERIOD)
+                                                : null;
+                                manager.awaitTermination(awaitTimeout);
+                            } catch (Exception e) {
+                                log.warn("Graceful shutdown hook failed", e);
+                            } finally {
+                                HttpTransportFactory.shutdown();
+                            }
+                        },
+                        "agentscope-jvm-shutdown-hook");
+        SHUTDOWN_HOOK_THREAD.set(hook);
+        Runtime.getRuntime().addShutdownHook(hook);
     }
 }

--- a/agentscope-core/src/main/java/io/agentscope/core/shutdown/GracefulShutdownConfig.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/shutdown/GracefulShutdownConfig.java
@@ -25,6 +25,7 @@ import java.util.Objects;
  * <ul>
  *   <li>Maximum time to wait for ongoing operations to complete</li>
  *   <li>Policy for handling partial reasoning results</li>
+ *   <li>Policy for control register jvm shutdown hook</li>
  * </ul>
  *
  * @param shutdownTimeout       maximum duration to wait for shutdown completion;
@@ -32,9 +33,12 @@ import java.util.Objects;
  *                              to complete; if specified, must be a positive duration
  * @param partialReasoningPolicy policy for handling incomplete reasoning results during shutdown;
  *                              cannot be null
+ * @param isRegister Policy for control register jvm shutdown hook
  */
 public record GracefulShutdownConfig(
-        Duration shutdownTimeout, PartialReasoningPolicy partialReasoningPolicy) {
+        Duration shutdownTimeout,
+        PartialReasoningPolicy partialReasoningPolicy,
+        boolean isRegister) {
 
     /**
      * Default configuration instance.
@@ -43,10 +47,25 @@ public record GracefulShutdownConfig(
      * <ul>
      *   <li>Shutdown timeout: null (wait indefinitely)</li>
      *   <li>Partial reasoning policy: {@link PartialReasoningPolicy#SAVE}</li>
+     *   <li>Is register jvm shutdownHook: {@code false}</li>
      * </ul>
      */
     public static final GracefulShutdownConfig DEFAULT =
-            new GracefulShutdownConfig(null, PartialReasoningPolicy.SAVE);
+            new GracefulShutdownConfig(null, PartialReasoningPolicy.SAVE, false);
+
+    /**
+     *
+     *
+     * <p>Uses the following settings:
+     * <ul>
+     *   <li>Shutdown timeout: null (wait indefinitely)</li>
+     *   <li>Partial reasoning policy: {@link PartialReasoningPolicy#SAVE}</li>
+     * </ul>
+     */
+    public GracefulShutdownConfig(
+            Duration shutdownTimeout, PartialReasoningPolicy partialReasoningPolicy) {
+        this(shutdownTimeout, partialReasoningPolicy, false);
+    }
 
     /**
      * Compact constructor for validation.

--- a/agentscope-core/src/main/java/io/agentscope/core/shutdown/GracefulShutdownConfig.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/shutdown/GracefulShutdownConfig.java
@@ -25,7 +25,7 @@ import java.util.Objects;
  * <ul>
  *   <li>Maximum time to wait for ongoing operations to complete</li>
  *   <li>Policy for handling partial reasoning results</li>
- *   <li>Policy for control register jvm shutdown hook</li>
+ *   <li>Whether AgentScope should run graceful shutdown from the JVM shutdown hook</li>
  * </ul>
  *
  * @param shutdownTimeout       maximum duration to wait for shutdown completion;
@@ -33,12 +33,13 @@ import java.util.Objects;
  *                              to complete; if specified, must be a positive duration
  * @param partialReasoningPolicy policy for handling incomplete reasoning results during shutdown;
  *                              cannot be null
- * @param isRegister Policy for control register jvm shutdown hook
+ * @param enableShutdownHook   whether AgentScope should run graceful shutdown from the JVM
+ *                             shutdown hook
  */
 public record GracefulShutdownConfig(
         Duration shutdownTimeout,
         PartialReasoningPolicy partialReasoningPolicy,
-        boolean isRegister) {
+        boolean enableShutdownHook) {
 
     /**
      * Default configuration instance.
@@ -47,11 +48,11 @@ public record GracefulShutdownConfig(
      * <ul>
      *   <li>Shutdown timeout: null (wait indefinitely)</li>
      *   <li>Partial reasoning policy: {@link PartialReasoningPolicy#SAVE}</li>
-     *   <li>Is register jvm shutdownHook: {@code false}</li>
+     *   <li>Enable AgentScope JVM shutdown hook behavior: {@code true}</li>
      * </ul>
      */
     public static final GracefulShutdownConfig DEFAULT =
-            new GracefulShutdownConfig(null, PartialReasoningPolicy.SAVE, false);
+            new GracefulShutdownConfig(null, PartialReasoningPolicy.SAVE, true);
 
     /**
      *
@@ -64,7 +65,7 @@ public record GracefulShutdownConfig(
      */
     public GracefulShutdownConfig(
             Duration shutdownTimeout, PartialReasoningPolicy partialReasoningPolicy) {
-        this(shutdownTimeout, partialReasoningPolicy, false);
+        this(shutdownTimeout, partialReasoningPolicy, true);
     }
 
     /**

--- a/agentscope-core/src/test/java/io/agentscope/core/shutdown/GracefulShutdownTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/shutdown/GracefulShutdownTest.java
@@ -113,6 +113,35 @@ class GracefulShutdownTest {
         void configRejectsNullPolicy() {
             assertThrows(NullPointerException.class, () -> new GracefulShutdownConfig(null, null));
         }
+
+        @Test
+        @DisplayName("DEFAULT config has isRegister set to false")
+        void defaultConfigJvmHookDisabled() {
+            GracefulShutdownConfig cfg = GracefulShutdownConfig.DEFAULT;
+            assertFalse(cfg.isRegister());
+        }
+
+        @Test
+        @DisplayName("2-param constructor sets isRegister to false")
+        void twoParamConstructorJvmHookEnabled() {
+            GracefulShutdownConfig cfg =
+                    new GracefulShutdownConfig(Duration.ofSeconds(10), PartialReasoningPolicy.SAVE);
+            assertFalse(cfg.isRegister());
+        }
+
+        @Test
+        @DisplayName("3-param constructor allows explicit isRegister value")
+        void threeParamConstructorExplicitValue() {
+            GracefulShutdownConfig cfgWithHook =
+                    new GracefulShutdownConfig(
+                            Duration.ofSeconds(10), PartialReasoningPolicy.SAVE, true);
+            assertTrue(cfgWithHook.isRegister());
+
+            GracefulShutdownConfig cfgWithoutHook =
+                    new GracefulShutdownConfig(
+                            Duration.ofSeconds(10), PartialReasoningPolicy.SAVE, false);
+            assertFalse(cfgWithoutHook.isRegister());
+        }
     }
 
     // ==================== GracefulShutdownManager ====================
@@ -573,6 +602,40 @@ class GracefulShutdownTest {
                     new io.agentscope.core.hook.ErrorEvent(agent, new RuntimeException("test"));
 
             StepVerifier.create(hook.onEvent(event)).expectNext(event).verifyComplete();
+        }
+    }
+
+    // ==================== AgentScopeJvmShutdownHook ====================
+
+    @Nested
+    @DisplayName("AgentScopeJvmShutdownHook")
+    class JvmShutdownHookTests {
+
+        @Test
+        @DisplayName("register does nothing when isRegister is false")
+        void registerSkippedWhenDisabled() {
+            AgentScopeJvmShutdownHook.resetForTesting();
+            manager.setConfig(
+                    new GracefulShutdownConfig(
+                            Duration.ofSeconds(10), PartialReasoningPolicy.SAVE, false));
+
+            // Should not throw and should not register the hook
+            assertDoesNotThrow(() -> AgentScopeJvmShutdownHook.register(manager));
+        }
+
+        @Test
+        @DisplayName("register is idempotent when isRegister is true")
+        void registerIdempotentWhenEnabled() {
+            AgentScopeJvmShutdownHook.resetForTesting();
+            manager.setConfig(
+                    new GracefulShutdownConfig(
+                            Duration.ofSeconds(10), PartialReasoningPolicy.SAVE, true));
+
+            // First call should succeed
+            assertDoesNotThrow(() -> AgentScopeJvmShutdownHook.register(manager));
+
+            // Second call should also succeed (idempotent)
+            assertDoesNotThrow(() -> AgentScopeJvmShutdownHook.register(manager));
         }
     }
 

--- a/agentscope-core/src/test/java/io/agentscope/core/shutdown/GracefulShutdownTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/shutdown/GracefulShutdownTest.java
@@ -115,32 +115,32 @@ class GracefulShutdownTest {
         }
 
         @Test
-        @DisplayName("DEFAULT config has isRegister set to false")
-        void defaultConfigJvmHookDisabled() {
+        @DisplayName("DEFAULT config has shutdown hook enabled")
+        void defaultConfigJvmHookEnabled() {
             GracefulShutdownConfig cfg = GracefulShutdownConfig.DEFAULT;
-            assertFalse(cfg.isRegister());
+            assertTrue(cfg.enableShutdownHook());
         }
 
         @Test
-        @DisplayName("2-param constructor sets isRegister to false")
+        @DisplayName("2-param constructor enables shutdown hook")
         void twoParamConstructorJvmHookEnabled() {
             GracefulShutdownConfig cfg =
                     new GracefulShutdownConfig(Duration.ofSeconds(10), PartialReasoningPolicy.SAVE);
-            assertFalse(cfg.isRegister());
+            assertTrue(cfg.enableShutdownHook());
         }
 
         @Test
-        @DisplayName("3-param constructor allows explicit isRegister value")
+        @DisplayName("3-param constructor allows explicit shutdown hook enabled value")
         void threeParamConstructorExplicitValue() {
             GracefulShutdownConfig cfgWithHook =
                     new GracefulShutdownConfig(
                             Duration.ofSeconds(10), PartialReasoningPolicy.SAVE, true);
-            assertTrue(cfgWithHook.isRegister());
+            assertTrue(cfgWithHook.enableShutdownHook());
 
             GracefulShutdownConfig cfgWithoutHook =
                     new GracefulShutdownConfig(
                             Duration.ofSeconds(10), PartialReasoningPolicy.SAVE, false);
-            assertFalse(cfgWithoutHook.isRegister());
+            assertFalse(cfgWithoutHook.enableShutdownHook());
         }
     }
 
@@ -612,19 +612,19 @@ class GracefulShutdownTest {
     class JvmShutdownHookTests {
 
         @Test
-        @DisplayName("register does nothing when isRegister is false")
-        void registerSkippedWhenDisabled() {
+        @DisplayName("register succeeds when shutdown hook logic is disabled")
+        void registerSucceedsWhenShutdownHookDisabled() {
             AgentScopeJvmShutdownHook.resetForTesting();
             manager.setConfig(
                     new GracefulShutdownConfig(
                             Duration.ofSeconds(10), PartialReasoningPolicy.SAVE, false));
 
-            // Should not throw and should not register the hook
+            // Registration still succeeds; the hook skips AgentScope graceful shutdown at runtime.
             assertDoesNotThrow(() -> AgentScopeJvmShutdownHook.register(manager));
         }
 
         @Test
-        @DisplayName("register is idempotent when isRegister is true")
+        @DisplayName("register is idempotent when shutdown hook logic is enabled")
         void registerIdempotentWhenEnabled() {
             AgentScopeJvmShutdownHook.resetForTesting();
             manager.setConfig(

--- a/agentscope-examples/graceful-shutdown/src/main/java/io/agentscope/examples/shutdown/e2e/AgentService.java
+++ b/agentscope-examples/graceful-shutdown/src/main/java/io/agentscope/examples/shutdown/e2e/AgentService.java
@@ -89,6 +89,9 @@ public class AgentService {
     @Value("${agent.shutdown-partial-reasoning-policy:save}")
     private String partialReasoningPolicy;
 
+    @Value("${agent.shutdown-hook-is-register:true}")
+    private boolean isRegister;
+
     @PostConstruct
     public void initShutdownConfig() {
         Duration gracefulShutdownTime =
@@ -100,7 +103,7 @@ public class AgentService {
         GracefulShutdownManager.getInstance()
                 .setConfig(
                         new GracefulShutdownConfig(
-                                gracefulShutdownTime, shutdownPartialReasoningPolicy));
+                                gracefulShutdownTime, shutdownPartialReasoningPolicy, isRegister));
     }
 
     /**

--- a/agentscope-examples/graceful-shutdown/src/main/java/io/agentscope/examples/shutdown/e2e/AgentService.java
+++ b/agentscope-examples/graceful-shutdown/src/main/java/io/agentscope/examples/shutdown/e2e/AgentService.java
@@ -89,8 +89,8 @@ public class AgentService {
     @Value("${agent.shutdown-partial-reasoning-policy:save}")
     private String partialReasoningPolicy;
 
-    @Value("${agent.shutdown-hook-is-register:true}")
-    private boolean isRegister;
+    @Value("${agent.shutdown-hook-enabled:true}")
+    private boolean enableShutdownHook;
 
     @PostConstruct
     public void initShutdownConfig() {
@@ -103,7 +103,9 @@ public class AgentService {
         GracefulShutdownManager.getInstance()
                 .setConfig(
                         new GracefulShutdownConfig(
-                                gracefulShutdownTime, shutdownPartialReasoningPolicy, isRegister));
+                                gracefulShutdownTime,
+                                shutdownPartialReasoningPolicy,
+                                enableShutdownHook));
     }
 
     /**

--- a/agentscope-examples/graceful-shutdown/src/main/java/io/agentscope/examples/shutdown/smoke/GracefulShutdownExample.java
+++ b/agentscope-examples/graceful-shutdown/src/main/java/io/agentscope/examples/shutdown/smoke/GracefulShutdownExample.java
@@ -129,7 +129,8 @@ public class GracefulShutdownExample {
 
         shutdownManager.resetForTesting();
         shutdownManager.setConfig(
-                new GracefulShutdownConfig(Duration.ofSeconds(5), PartialReasoningPolicy.SAVE));
+                new GracefulShutdownConfig(
+                        Duration.ofSeconds(5), PartialReasoningPolicy.SAVE, true));
 
         Toolkit toolkit = new Toolkit();
         toolkit.registerTool(new DataAnalysisTool());

--- a/agentscope-examples/graceful-shutdown/src/main/resources/application.yml
+++ b/agentscope-examples/graceful-shutdown/src/main/resources/application.yml
@@ -27,3 +27,4 @@ agent:
   model-name: qwen3.5-plus
   shutdown-timeout-seconds: -1
   shutdown-partial-reasoning-policy: save
+  shutdown-hook-is-register: true

--- a/agentscope-examples/graceful-shutdown/src/main/resources/application.yml
+++ b/agentscope-examples/graceful-shutdown/src/main/resources/application.yml
@@ -27,4 +27,4 @@ agent:
   model-name: qwen3.5-plus
   shutdown-timeout-seconds: -1
   shutdown-partial-reasoning-policy: save
-  shutdown-hook-is-register: true
+  shutdown-hook-enabled: true


### PR DESCRIPTION
## AgentScope-Java Version

io.agentscope:agentscope-parent:pom:1.0.12-SNAPSHOT

## Description

* Closes: #1093
* Fix AgentScopeJvmShutdownHook conflict with spring

## Checklist

Please check the following items before code is ready to be reviewed.

- [x] Code has been formatted with `mvn spotless:apply`
- [x] All tests are passing (`mvn test`)
- [x] Javadoc comments are complete and follow project conventions
- [x] Related documentation has been updated (e.g. links, examples, etc.)
- [x] Code is ready for review
