### PR TITLE
feat(tool): expose MCP output schemas in tool definitions

### DIFF
--- a/agentscope-core/src/main/java/io/agentscope/core/model/ToolSchema.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/model/ToolSchema.java
@@ -29,6 +29,7 @@ public class ToolSchema {
     private final String name;
     private final String description;
     private final Map<String, Object> parameters;
+    private final Map<String, Object> outputSchema;
     private final Boolean strict;
 
     /**
@@ -43,6 +44,10 @@ public class ToolSchema {
                 builder.parameters != null
                         ? Collections.unmodifiableMap(new HashMap<>(builder.parameters))
                         : Collections.emptyMap();
+        this.outputSchema =
+                builder.outputSchema != null
+                        ? Collections.unmodifiableMap(new HashMap<>(builder.outputSchema))
+                        : null;
         this.strict = builder.strict;
     }
 
@@ -74,6 +79,15 @@ public class ToolSchema {
     }
 
     /**
+     * Gets the optional tool output schema as a JSON Schema.
+     *
+     * @return an unmodifiable map containing the output schema, or null if unspecified
+     */
+    public Map<String, Object> getOutputSchema() {
+        return outputSchema;
+    }
+
+    /**
      * Gets the strict mode flag for schema validation.
      *
      * @return true if strict mode is enabled, false otherwise, or null if not specified
@@ -98,6 +112,7 @@ public class ToolSchema {
         private String name;
         private String description;
         private Map<String, Object> parameters;
+        private Map<String, Object> outputSchema;
         private Boolean strict;
 
         /**
@@ -130,6 +145,17 @@ public class ToolSchema {
          */
         public Builder parameters(Map<String, Object> parameters) {
             this.parameters = parameters;
+            return this;
+        }
+
+        /**
+         * Sets the optional tool output schema as a JSON Schema.
+         *
+         * @param outputSchema the output schema
+         * @return this builder instance
+         */
+        public Builder outputSchema(Map<String, Object> outputSchema) {
+            this.outputSchema = outputSchema;
             return this;
         }
 

--- a/agentscope-core/src/main/java/io/agentscope/core/tool/AgentTool.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/tool/AgentTool.java
@@ -75,6 +75,19 @@ public interface AgentTool {
     Map<String, Object> getParameters();
 
     /**
+     * Gets the optional output schema for this tool in JSON Schema format.
+     *
+     * <p>Most tools do not expose a structured output schema to models, so the default
+     * implementation returns {@code null}. MCP tools can override this to surface the
+     * server-provided {@code outputSchema} definition.
+     *
+     * @return Map representing the JSON Schema for tool outputs, or null if unsupported
+     */
+    default Map<String, Object> getOutputSchema() {
+        return null;
+    }
+
+    /**
      * Execute the tool with the given parameters (asynchronous).
      *
      * <p>This method accepts a {@link ToolCallParam} object containing all necessary context for

--- a/agentscope-core/src/main/java/io/agentscope/core/tool/McpClientManager.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/tool/McpClientManager.java
@@ -178,7 +178,12 @@ class McpClientManager {
                                                     toolPresetParams != null
                                                             ? toolPresetParams.keySet()
                                                             : Collections.emptySet()),
-                                            mcpClientWrapper);
+                                            mcpTool.outputSchema() != null
+                                                    ? new ConcurrentHashMap<>(
+                                                            mcpTool.outputSchema())
+                                                    : null,
+                                            mcpClientWrapper,
+                                            toolPresetParams);
 
                             // Register with group, MCP client name, and preset parameters via
                             // callback

--- a/agentscope-core/src/main/java/io/agentscope/core/tool/McpClientManager.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/tool/McpClientManager.java
@@ -183,7 +183,7 @@ class McpClientManager {
                                                             mcpTool.outputSchema())
                                                     : null,
                                             mcpClientWrapper,
-                                            toolPresetParams);
+                                            null);
 
                             // Register with group, MCP client name, and preset parameters via
                             // callback

--- a/agentscope-core/src/main/java/io/agentscope/core/tool/ToolSchemaProvider.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/tool/ToolSchemaProvider.java
@@ -83,6 +83,7 @@ class ToolSchemaProvider {
                             .name(toolName)
                             .description(tool.getDescription())
                             .parameters(registered.getExtendedParameters())
+                            .outputSchema(tool.getOutputSchema())
                             .build();
             schemas.add(schema);
         }

--- a/agentscope-core/src/main/java/io/agentscope/core/tool/mcp/McpTool.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/tool/mcp/McpTool.java
@@ -61,6 +61,7 @@ public class McpTool implements AgentTool {
     private final String name;
     private final String description;
     private final Map<String, Object> parameters;
+    private final Map<String, Object> outputSchema;
     private final McpClientWrapper clientWrapper;
     private final Map<String, Object> presetArguments;
 
@@ -77,7 +78,7 @@ public class McpTool implements AgentTool {
             String description,
             Map<String, Object> parameters,
             McpClientWrapper clientWrapper) {
-        this(name, description, parameters, clientWrapper, null);
+        this(name, description, parameters, null, clientWrapper, null);
     }
 
     /**
@@ -95,9 +96,30 @@ public class McpTool implements AgentTool {
             Map<String, Object> parameters,
             McpClientWrapper clientWrapper,
             Map<String, Object> presetArguments) {
+        this(name, description, parameters, null, clientWrapper, presetArguments);
+    }
+
+    /**
+     * Constructs a new McpTool with an optional output schema and preset arguments.
+     *
+     * @param name the tool name
+     * @param description the tool description
+     * @param parameters the JSON schema for tool parameters
+     * @param outputSchema the JSON schema for tool outputs (can be null)
+     * @param clientWrapper the MCP client wrapper
+     * @param presetArguments preset arguments to merge with each call (can be null)
+     */
+    public McpTool(
+            String name,
+            String description,
+            Map<String, Object> parameters,
+            Map<String, Object> outputSchema,
+            McpClientWrapper clientWrapper,
+            Map<String, Object> presetArguments) {
         this.name = name;
         this.description = description;
         this.parameters = parameters;
+        this.outputSchema = outputSchema != null ? new HashMap<>(outputSchema) : null;
         this.clientWrapper = clientWrapper;
         this.presetArguments = presetArguments != null ? new HashMap<>(presetArguments) : null;
     }
@@ -130,6 +152,11 @@ public class McpTool implements AgentTool {
     @Override
     public Map<String, Object> getParameters() {
         return parameters;
+    }
+
+    @Override
+    public Map<String, Object> getOutputSchema() {
+        return outputSchema != null ? new HashMap<>(outputSchema) : null;
     }
 
     /**

--- a/agentscope-core/src/test/java/io/agentscope/core/tool/McpClientManagerTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/tool/McpClientManagerTest.java
@@ -342,4 +342,71 @@ class McpClientManagerTest {
         verify(clientWrapper).listTools();
         assertTrue(callbackCalled[0]);
     }
+
+    @Test
+    void testRegisterMcpClient_PreservesOutputSchemaInRegisteredTool() {
+        ToolRegistry toolRegistry = mock(ToolRegistry.class);
+        ToolGroupManager groupManager = mock(ToolGroupManager.class);
+        McpClientWrapper clientWrapper = mock(McpClientWrapper.class);
+
+        AgentTool[] registeredTool = new AgentTool[1];
+        String[] registeredGroupName = new String[1];
+        String[] registeredClientName = new String[1];
+        Map<String, Object>[] registeredPresetParams = new Map[1];
+
+        McpClientManager manager =
+                new McpClientManager(
+                        toolRegistry,
+                        groupManager,
+                        (tool, groupName, mcpClientName, presetParams) -> {
+                            registeredTool[0] = tool;
+                            registeredGroupName[0] = groupName;
+                            registeredClientName[0] = mcpClientName;
+                            registeredPresetParams[0] = presetParams;
+                        });
+
+        when(clientWrapper.getName()).thenReturn("test-client");
+        when(clientWrapper.initialize()).thenReturn(Mono.empty());
+
+        McpSchema.Tool mockMcpTool = mock(McpSchema.Tool.class);
+        when(mockMcpTool.name()).thenReturn("structured-tool");
+        when(mockMcpTool.description()).thenReturn("Tool with output schema");
+        when(mockMcpTool.inputSchema())
+                .thenReturn(
+                        new McpSchema.JsonSchema(
+                                "object",
+                                Map.of("query", Map.of("type", "string")),
+                                List.of("query"),
+                                null,
+                                null,
+                                null));
+
+        Map<String, Object> outputSchema =
+                Map.of(
+                        "type",
+                        "object",
+                        "properties",
+                        Map.of(
+                                "result",
+                                Map.of("type", "string"),
+                                "confidence",
+                                Map.of("type", "number")));
+        when(mockMcpTool.outputSchema()).thenReturn(outputSchema);
+        when(clientWrapper.listTools()).thenReturn(Mono.just(List.of(mockMcpTool)));
+
+        Map<String, Object> toolPresetParams = Map.of("temperature", 0.2);
+        Map<String, Map<String, Object>> presetParamsMapping =
+                Map.of("structured-tool", toolPresetParams);
+
+        manager.registerMcpClient(clientWrapper, null, null, "mcp-group", presetParamsMapping)
+                .block();
+
+        verify(clientWrapper).initialize();
+        verify(clientWrapper).listTools();
+        assertNotNull(registeredTool[0]);
+        assertEquals(outputSchema, registeredTool[0].getOutputSchema());
+        assertEquals("mcp-group", registeredGroupName[0]);
+        assertEquals("test-client", registeredClientName[0]);
+        assertEquals(toolPresetParams, registeredPresetParams[0]);
+    }
 }

--- a/agentscope-core/src/test/java/io/agentscope/core/tool/McpClientManagerTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/tool/McpClientManagerTest.java
@@ -18,12 +18,14 @@ package io.agentscope.core.tool;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.agentscope.core.tool.mcp.McpClientWrapper;
+import io.agentscope.core.tool.mcp.McpTool;
 import io.modelcontextprotocol.spec.McpSchema;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
@@ -405,6 +407,8 @@ class McpClientManagerTest {
         verify(clientWrapper).listTools();
         assertNotNull(registeredTool[0]);
         assertEquals(outputSchema, registeredTool[0].getOutputSchema());
+        assertTrue(registeredTool[0] instanceof McpTool);
+        assertNull(((McpTool) registeredTool[0]).getPresetArguments());
         assertEquals("mcp-group", registeredGroupName[0]);
         assertEquals("test-client", registeredClientName[0]);
         assertEquals(toolPresetParams, registeredPresetParams[0]);

--- a/agentscope-core/src/test/java/io/agentscope/core/tool/ToolSchemaProviderTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/tool/ToolSchemaProviderTest.java
@@ -100,6 +100,50 @@ class ToolSchemaProviderTest {
         assertEquals("test_tool", schema.getName());
         assertEquals("Test tool", schema.getDescription());
         assertNotNull(schema.getParameters());
+        assertEquals(null, schema.getOutputSchema());
+    }
+
+    @Test
+    void testGetToolSchemasIncludesOutputSchemaWhenProvided() {
+        AgentTool tool =
+                new AgentTool() {
+                    @Override
+                    public String getName() {
+                        return "schema_tool";
+                    }
+
+                    @Override
+                    public String getDescription() {
+                        return "Schema-aware tool";
+                    }
+
+                    @Override
+                    public Map<String, Object> getParameters() {
+                        return Map.of("type", "object", "properties", Map.of());
+                    }
+
+                    @Override
+                    public Map<String, Object> getOutputSchema() {
+                        return Map.of(
+                                "type",
+                                "object",
+                                "properties",
+                                Map.of("result", Map.of("type", "string")));
+                    }
+
+                    @Override
+                    public Mono<ToolResultBlock> callAsync(ToolCallParam input) {
+                        return Mono.just(ToolResultBlock.text("ok"));
+                    }
+                };
+        RegisteredToolFunction registered = new RegisteredToolFunction(tool, null, null);
+        registry.registerTool("schema_tool", tool, registered);
+
+        List<ToolSchema> schemas = schemaProvider.getToolSchemas();
+
+        assertEquals(1, schemas.size());
+        assertNotNull(schemas.get(0).getOutputSchema());
+        assertEquals("object", schemas.get(0).getOutputSchema().get("type"));
     }
 
     @Test

--- a/agentscope-core/src/test/java/io/agentscope/core/tool/ToolkitTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/tool/ToolkitTest.java
@@ -34,6 +34,7 @@ import io.agentscope.core.tool.mcp.McpClientWrapper;
 import io.agentscope.core.tool.test.SampleTools;
 import io.agentscope.core.tool.test.ToolTestUtils;
 import io.agentscope.core.util.JsonUtils;
+import io.modelcontextprotocol.spec.McpSchema;
 import java.lang.reflect.Type;
 import java.util.List;
 import java.util.Map;
@@ -1222,5 +1223,44 @@ class ToolkitTest {
 
         AgentTool tool = toolkit.getTool("tool_with_default_converter");
         assertNotNull(tool, "Tool should be registered");
+    }
+
+    @Test
+    @DisplayName("Should expose MCP output schema through getToolSchemas")
+    void testGetToolSchemasIncludesMcpOutputSchema() {
+        McpClientWrapper mcpClientWrapper = mock(McpClientWrapper.class);
+        when(mcpClientWrapper.getName()).thenReturn("mcp-client");
+        when(mcpClientWrapper.initialize()).thenReturn(Mono.empty());
+
+        McpSchema.Tool mcpTool = mock(McpSchema.Tool.class);
+        when(mcpTool.name()).thenReturn("structured_mcp_tool");
+        when(mcpTool.description()).thenReturn("Returns structured MCP output");
+        when(mcpTool.inputSchema())
+                .thenReturn(
+                        new McpSchema.JsonSchema("object", Map.of(), List.of(), null, null, null));
+        when(mcpTool.outputSchema())
+                .thenReturn(
+                        Map.of(
+                                "type",
+                                "object",
+                                "properties",
+                                Map.of("answer", Map.of("type", "string"))));
+        when(mcpClientWrapper.listTools()).thenReturn(Mono.just(List.of(mcpTool)));
+
+        toolkit.registerMcpClient(mcpClientWrapper).block();
+
+        ToolSchema schema =
+                toolkit.getToolSchemas().stream()
+                        .filter(s -> "structured_mcp_tool".equals(getToolName(s)))
+                        .findFirst()
+                        .orElse(null);
+
+        assertNotNull(schema);
+        assertNotNull(schema.getOutputSchema());
+        assertEquals("object", schema.getOutputSchema().get("type"));
+        @SuppressWarnings("unchecked")
+        Map<String, Object> properties =
+                (Map<String, Object>) schema.getOutputSchema().get("properties");
+        assertTrue(properties.containsKey("answer"));
     }
 }

--- a/agentscope-core/src/test/java/io/agentscope/core/tool/mcp/McpToolTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/tool/mcp/McpToolTest.java
@@ -61,8 +61,29 @@ class McpToolTest {
         assertEquals("test-tool", tool.getName());
         assertEquals("A test tool", tool.getDescription());
         assertEquals(parameters, tool.getParameters());
+        assertNull(tool.getOutputSchema());
         assertEquals("test-client", tool.getClientName());
         assertNull(tool.getPresetArguments());
+    }
+
+    @Test
+    void testConstructor_WithOutputSchema() {
+        Map<String, Object> outputSchema = new HashMap<>();
+        outputSchema.put("type", "object");
+        outputSchema.put("properties", Map.of("answer", Map.of("type", "string")));
+
+        McpTool tool =
+                new McpTool(
+                        "test-tool",
+                        "A test tool",
+                        parameters,
+                        outputSchema,
+                        mockClientWrapper,
+                        null);
+
+        assertNotNull(tool.getOutputSchema());
+        assertEquals("object", tool.getOutputSchema().get("type"));
+        assertTrue(tool.getOutputSchema().containsKey("properties"));
     }
 
     @Test


### PR DESCRIPTION
## Summary
- expose MCP `outputSchema` through `AgentTool`, `McpTool`, and `ToolSchema`
- preserve output schemas when registering MCP tools via `McpClientManager`
- add regression coverage for schema propagation and toolkit exposure

## Why this fix
`McpSchema.Tool` already provides `outputSchema()`, but the current registration flow drops it before the tool reaches AgentScope's tool schema layer. This prevents downstream consumers from seeing structured output contracts for MCP-backed tools.

## Validation
- `mvn -pl agentscope-core -Dtest=McpClientManagerTest,ExternalToolSupportTest,ToolSchemaProviderTest,McpToolTest,ToolkitTest test -q`
- `mvn -pl agentscope-core spotless:check -q`