### PR TITLE
feat(scheduler): support passing initial input messages in Quartz scheduler

### DIFF
--- a/agentscope-extensions/agentscope-extensions-scheduler/agentscope-extensions-scheduler-common/src/main/java/io/agentscope/extensions/scheduler/AgentScheduler.java
+++ b/agentscope-extensions/agentscope-extensions-scheduler/agentscope-extensions-scheduler-common/src/main/java/io/agentscope/extensions/scheduler/AgentScheduler.java
@@ -15,6 +15,7 @@
  */
 package io.agentscope.extensions.scheduler;
 
+import io.agentscope.core.message.Msg;
 import io.agentscope.extensions.scheduler.config.AgentConfig;
 import io.agentscope.extensions.scheduler.config.ScheduleConfig;
 import java.util.List;
@@ -101,6 +102,28 @@ public interface AgentScheduler {
      * @throws IllegalArgumentException if agentConfig or scheduleConfig is null or invalid
      */
     ScheduleAgentTask schedule(AgentConfig agentConfig, ScheduleConfig scheduleConfig);
+
+    /**
+     * Schedule an agent to run with an initial input message.
+     *
+     * <p>This method extends {@link #schedule(AgentConfig, ScheduleConfig)} by allowing
+     * developers to pass an initial {@link Msg} object. When the scheduled task is triggered,
+     * the newly created Agent instance will be executed with this input message.
+     *
+     * <p>This is particularly useful for tasks that require specific context, parameters,
+     * or initial instructions to begin their execution.
+     *
+     * @param agentConfig The agent configuration defining how to create agents (can be AgentConfig or RuntimeAgentConfig)
+     * @param scheduleConfig The scheduling configuration including timing and execution policies
+     * @param input The initial message to pass to the agent when triggered (can be null)
+     * @return The ScheduleAgentTask handle for controlling the scheduled task
+     * @throws UnsupportedOperationException if the specific scheduler implementation does not support initial input
+     */
+    default ScheduleAgentTask schedule(
+            AgentConfig agentConfig, ScheduleConfig scheduleConfig, Msg input) {
+        throw new UnsupportedOperationException(
+                "This scheduler implementation does not support initial input.");
+    }
 
     /**
      * Cancel and remove a scheduled task permanently.

--- a/agentscope-extensions/agentscope-extensions-scheduler/agentscope-extensions-scheduler-quartz/src/main/java/io/agentscope/extensions/scheduler/quartz/AgentQuartzJob.java
+++ b/agentscope-extensions/agentscope-extensions-scheduler/agentscope-extensions-scheduler-quartz/src/main/java/io/agentscope/extensions/scheduler/quartz/AgentQuartzJob.java
@@ -16,11 +16,14 @@
 package io.agentscope.extensions.scheduler.quartz;
 
 import io.agentscope.core.message.Msg;
+import io.agentscope.core.util.JsonUtils;
 import io.agentscope.extensions.scheduler.ScheduleAgentTask;
 import io.agentscope.extensions.scheduler.config.ScheduleMode;
 import org.quartz.InterruptableJob;
 import org.quartz.JobExecutionContext;
 import org.quartz.JobExecutionException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Quartz Job implementation that executes an AgentScope agent task.
@@ -30,6 +33,8 @@ import org.quartz.JobExecutionException;
  * It also handles the rescheduling for {@code FIXED_DELAY} tasks.
  */
 public class AgentQuartzJob implements InterruptableJob {
+
+    private static final Logger logger = LoggerFactory.getLogger(AgentQuartzJob.class);
 
     private volatile boolean interrupted;
 
@@ -57,16 +62,48 @@ public class AgentQuartzJob implements InterruptableJob {
         if (task == null) {
             return;
         }
+
+        ScheduleAgentTask<Msg> t = task;
+        Msg inputMsg = null;
+        String msgJson = context.getJobDetail().getJobDataMap().getString("inputMsg");
+
+        if (msgJson != null && !msgJson.trim().isEmpty()) {
+            try {
+                inputMsg = JsonUtils.getJsonCodec().fromJson(msgJson, Msg.class);
+            } catch (Exception ex) {
+                logger.error(
+                        "Failed to deserialize inputMsg. schedulerId={}, taskName={}, jobKey={},"
+                                + " triggerKey={}, msgLen={}",
+                        schedulerId,
+                        taskName,
+                        context.getJobDetail().getKey(),
+                        context.getTrigger().getKey(),
+                        msgJson.length(),
+                        ex);
+
+                JobExecutionException jee =
+                        new JobExecutionException(
+                                "Invalid inputMsg JSON for scheduled task: " + taskName, ex, false);
+                jee.setUnscheduleFiringTrigger(true);
+                throw jee;
+            }
+        }
+
         try {
-            ScheduleAgentTask<Msg> t = task;
             // Blocking is acceptable here because Quartz jobs run in their own dedicated thread
             // pool
             // and are executed synchronously; we need to wait for the reactive pipeline to
             // complete.
-            t.run().block();
+            if (inputMsg != null) {
+                t.run(inputMsg).block();
+            } else {
+                t.run().block();
+            }
         } catch (Exception e) {
+            logger.error("Error executing scheduled agent task: {}", taskName, e);
             throw new JobExecutionException(e);
         }
+
         if (interrupted) {
             return;
         }

--- a/agentscope-extensions/agentscope-extensions-scheduler/agentscope-extensions-scheduler-quartz/src/main/java/io/agentscope/extensions/scheduler/quartz/QuartzAgentScheduler.java
+++ b/agentscope-extensions/agentscope-extensions-scheduler/agentscope-extensions-scheduler-quartz/src/main/java/io/agentscope/extensions/scheduler/quartz/QuartzAgentScheduler.java
@@ -15,7 +15,9 @@
  */
 package io.agentscope.extensions.scheduler.quartz;
 
+import io.agentscope.core.message.Msg;
 import io.agentscope.core.model.Model;
+import io.agentscope.core.util.JsonUtils;
 import io.agentscope.extensions.scheduler.AgentScheduler;
 import io.agentscope.extensions.scheduler.ScheduleAgentTask;
 import io.agentscope.extensions.scheduler.config.AgentConfig;
@@ -154,14 +156,10 @@ public class QuartzAgentScheduler implements AgentScheduler {
     }
 
     /**
-     * Schedule an agent execution based on the provided configuration.
+     * Schedule an agent execution based on the provided configuration with no initial input.
      *
-     * <p>This method creates a Quartz Job and Trigger based on the schedule mode:
-     * <ul>
-     *   <li>{@code CRON}: Uses CronTrigger</li>
-     *   <li>{@code FIXED_RATE}: Uses SimpleTrigger with repeat forever</li>
-     *   <li>{@code FIXED_DELAY}: Uses a one-time trigger and reschedules upon completion</li>
-     * </ul>
+     * <p>This is a convenience method that delegates to {@link #schedule(AgentConfig, ScheduleConfig, Msg)},
+     * passing {@code null} as the initial input message.
      *
      * @param agentConfig The configuration for the agent to be scheduled
      * @param scheduleConfig The scheduling configuration (time, mode, etc.)
@@ -170,6 +168,32 @@ public class QuartzAgentScheduler implements AgentScheduler {
      */
     @Override
     public ScheduleAgentTask schedule(AgentConfig agentConfig, ScheduleConfig scheduleConfig) {
+        return this.schedule(agentConfig, scheduleConfig, null);
+    }
+
+    /**
+     * Schedule an agent execution based on the provided configuration and initial input message.
+     *
+     * <p>This method creates a Quartz Job and Trigger based on the schedule mode:
+     * <ul>
+     *   <li>{@code CRON}: Uses CronTrigger</li>
+     *   <li>{@code FIXED_RATE}: Uses SimpleTrigger with repeat forever</li>
+     *   <li>{@code FIXED_DELAY}: Uses a one-time trigger and reschedules upon completion</li>
+     * </ul>
+     *
+     * <p>If an initial {@code input} message is provided, it will be safely serialized into JSON
+     * and stored within the Quartz JobDataMap. This ensures compatibility with persistent and
+     * clustered Quartz environments (e.g., JDBCJobStore).
+     *
+     * @param agentConfig The configuration for the agent to be scheduled
+     * @param scheduleConfig The scheduling configuration (time, mode, etc.)
+     * @param input The initial message to pass to the agent when triggered (can be null)
+     * @return A task handle for the scheduled agent
+     * @throws RuntimeException if scheduling fails or if the input message serialization fails
+     */
+    @Override
+    public ScheduleAgentTask schedule(
+            AgentConfig agentConfig, ScheduleConfig scheduleConfig, Msg input) {
         if (agentConfig == null) {
             throw new IllegalArgumentException("AgentConfig must not be null");
         }
@@ -205,6 +229,16 @@ public class QuartzAgentScheduler implements AgentScheduler {
                         .usingJobData("schedulerId", schedulerId)
                         .usingJobData("taskName", jobName)
                         .build();
+
+        if (input != null) {
+            try {
+                String msgJson = JsonUtils.getJsonCodec().toJson(input);
+                jobDetail.getJobDataMap().put("inputMsg", msgJson);
+            } catch (Exception e) {
+                logger.error("Failed to serialize input message for task: {}", jobName, e);
+                throw new RuntimeException("Serialization failed for input message", e);
+            }
+        }
 
         QuartzScheduleAgentTask task =
                 new QuartzScheduleAgentTask(runtimeConfig, scheduleConfig, this, jobKey, scheduler);

--- a/agentscope-extensions/agentscope-extensions-scheduler/agentscope-extensions-scheduler-quartz/src/test/java/io/agentscope/extensions/scheduler/quartz/AgentQuartzJobTest.java
+++ b/agentscope-extensions/agentscope-extensions-scheduler/agentscope-extensions-scheduler-quartz/src/test/java/io/agentscope/extensions/scheduler/quartz/AgentQuartzJobTest.java
@@ -39,6 +39,7 @@ import org.quartz.JobExecutionContext;
 import org.quartz.JobExecutionException;
 import org.quartz.JobKey;
 import org.quartz.Trigger;
+import org.quartz.TriggerKey;
 import reactor.core.publisher.Mono;
 
 /** Unit tests for {@link AgentQuartzJob}. */
@@ -258,9 +259,9 @@ class AgentQuartzJobTest {
     void testExecuteWithInputMsgDeserializationFailure() {
         when(mockScheduler.getScheduledAgent(taskName)).thenReturn(mockTask);
 
-        Trigger mockTrigger = mock(org.quartz.Trigger.class);
+        Trigger mockTrigger = mock(Trigger.class);
         when(mockContext.getTrigger()).thenReturn(mockTrigger);
-        when(mockTrigger.getKey()).thenReturn(new org.quartz.TriggerKey("test-trigger"));
+        when(mockTrigger.getKey()).thenReturn(new TriggerKey("test-trigger"));
         when(mockJobDetail.getKey()).thenReturn(new JobKey(taskName));
 
         // Setup invalid JSON in JobDataMap to force a deserialization exception

--- a/agentscope-extensions/agentscope-extensions-scheduler/agentscope-extensions-scheduler-quartz/src/test/java/io/agentscope/extensions/scheduler/quartz/AgentQuartzJobTest.java
+++ b/agentscope-extensions/agentscope-extensions-scheduler/agentscope-extensions-scheduler-quartz/src/test/java/io/agentscope/extensions/scheduler/quartz/AgentQuartzJobTest.java
@@ -17,6 +17,7 @@ package io.agentscope.extensions.scheduler.quartz;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.mock;
@@ -37,6 +38,7 @@ import org.quartz.JobDetail;
 import org.quartz.JobExecutionContext;
 import org.quartz.JobExecutionException;
 import org.quartz.JobKey;
+import org.quartz.Trigger;
 import reactor.core.publisher.Mono;
 
 /** Unit tests for {@link AgentQuartzJob}. */
@@ -228,5 +230,57 @@ class AgentQuartzJobTest {
 
         verify(mockTask, never()).run();
         verify(mockScheduler, never()).rescheduleNextFixedDelay(any(), anyLong());
+    }
+
+    @Test
+    void testExecuteWithInputMsgSuccess() throws JobExecutionException {
+        when(mockScheduler.getScheduledAgent(taskName)).thenReturn(mockTask);
+        when(mockTask.run(any(Msg.class)))
+                .thenReturn(
+                        Mono.just(
+                                Msg.builder()
+                                        .content(
+                                                TextBlock.builder().text("test with input").build())
+                                        .build()));
+
+        ScheduleConfig scheduleConfig = mock(ScheduleConfig.class);
+        when(scheduleConfig.getScheduleMode()).thenReturn(ScheduleMode.CRON);
+        when(mockTask.getScheduleConfig()).thenReturn(scheduleConfig);
+        when(mockJobDataMap.getString("inputMsg")).thenReturn("{\"name\":\"test_input\"}");
+
+        assertDoesNotThrow(() -> agentQuartzJob.execute(mockContext));
+
+        verify(mockTask, times(1)).run(any(Msg.class));
+        verify(mockTask, never()).run();
+    }
+
+    @Test
+    void testExecuteWithInputMsgDeserializationFailure() {
+        when(mockScheduler.getScheduledAgent(taskName)).thenReturn(mockTask);
+
+        Trigger mockTrigger = mock(org.quartz.Trigger.class);
+        when(mockContext.getTrigger()).thenReturn(mockTrigger);
+        when(mockTrigger.getKey()).thenReturn(new org.quartz.TriggerKey("test-trigger"));
+        when(mockJobDetail.getKey()).thenReturn(new JobKey(taskName));
+
+        // Setup invalid JSON in JobDataMap to force a deserialization exception
+        when(mockJobDataMap.getString("inputMsg")).thenReturn("{invalid-json-format}");
+
+        // Execute and capture the thrown JobExecutionException
+        JobExecutionException exception =
+                assertThrows(
+                        JobExecutionException.class, () -> agentQuartzJob.execute(mockContext));
+
+        // Verify that the exception is marked to unschedule the firing trigger
+        assertTrue(
+                exception.unscheduleFiringTrigger(),
+                "The exception should trigger unscheduling due to toxic data.");
+        assertTrue(
+                exception.getMessage().contains("Invalid inputMsg JSON"),
+                "The exception message should indicate an invalid JSON format.");
+
+        // Verify that neither run() nor run(Msg) was called because execution was aborted
+        verify(mockTask, never()).run();
+        verify(mockTask, never()).run(any(Msg.class));
     }
 }


### PR DESCRIPTION
## Description

Close #1218 
Support passing initial input messages in AgentScheduler, and improve Quartz job error handling and logging security.

## Checklist

Please check the following items before code is ready to be reviewed.

- [ ]  Code has been formatted with `mvn spotless:apply`
- [ ]  All tests are passing (`mvn test`)
- [ ]  Javadoc comments are complete and follow project conventions
- [ ]  Related documentation has been updated (e.g. links, examples, etc.)
- [ ]  Code is ready for review
