### PR TITLE
fix(agui): fix AG-UI reasoning/tool event handling

### DIFF
--- a/agentscope-extensions/agentscope-extensions-agui/src/main/java/io/agentscope/core/agui/adapter/AguiAgentAdapter.java
+++ b/agentscope-extensions/agentscope-extensions-agui/src/main/java/io/agentscope/core/agui/adapter/AguiAgentAdapter.java
@@ -253,6 +253,10 @@ public class AguiAgentAdapter {
             for (ContentBlock block : msg.getContent()) {
                 if (block instanceof ToolResultBlock toolResult) {
                     String toolCallId = toolResult.getId();
+                    if (toolCallId == null) {
+                        toolCallId = UUID.randomUUID().toString();
+                    }
+
                     String result = extractToolResultText(toolResult);
 
                     boolean hasStarted = state.hasStartedToolCall(toolCallId);
@@ -396,7 +400,7 @@ public class AguiAgentAdapter {
 
         void endMessage(String messageId) {
             endedMessages.add(messageId);
-            if (messageId.equals(currentTextMessageId)) {
+            if (Objects.equals(messageId, currentTextMessageId)) {
                 currentTextMessageId = null;
             }
         }
@@ -448,7 +452,7 @@ public class AguiAgentAdapter {
 
         void endReasoningMessage(String messageId) {
             endedReasoningMessages.add(messageId);
-            if (messageId.equals(currentReasoningMessageId)) {
+            if (Objects.equals(messageId, currentReasoningMessageId)) {
                 currentReasoningMessageId = null;
             }
         }

--- a/agentscope-extensions/agentscope-extensions-agui/src/main/java/io/agentscope/core/agui/adapter/AguiAgentAdapter.java
+++ b/agentscope-extensions/agentscope-extensions-agui/src/main/java/io/agentscope/core/agui/adapter/AguiAgentAdapter.java
@@ -182,7 +182,7 @@ public class AguiAgentAdapter {
                                                 state.threadId,
                                                 state.runId,
                                                 messageId,
-                                                "assistant"));
+                                                "reasoning"));
                                 state.startReasoningMessage(messageId);
                             }
 
@@ -210,6 +210,15 @@ public class AguiAgentAdapter {
                                 new AguiEvent.TextMessageEnd(
                                         state.threadId, state.runId, activeMessageId));
                         state.endMessage(activeMessageId);
+                    }
+
+                    // End any active reasoning message before starting tool call
+                    if (state.hasActiveReasoningMessage()) {
+                        String activeReasoningMessageId = state.getCurrentReasoningMessageId();
+                        events.add(
+                                new AguiEvent.ReasoningMessageEnd(
+                                        state.threadId, state.runId, activeReasoningMessageId));
+                        state.endReasoningMessage(activeReasoningMessageId);
                     }
 
                     // Emit tool call start
@@ -248,9 +257,13 @@ public class AguiAgentAdapter {
 
                     boolean hasStarted = state.hasStartedToolCall(toolCallId);
                     if (!hasStarted) {
+                        String toolName = toolResult.getName();
+                        if (toolName == null || toolName.isBlank()) {
+                            toolName = "unknown";
+                        }
                         events.add(
                                 new AguiEvent.ToolCallStart(
-                                        state.threadId, state.runId, toolCallId, "unknown"));
+                                        state.threadId, state.runId, toolCallId, toolName));
                         state.startToolCall(toolCallId);
                     }
 
@@ -365,6 +378,7 @@ public class AguiAgentAdapter {
         private final Set<String> startedReasoningMessages = new LinkedHashSet<>();
         private final Set<String> endedReasoningMessages = new LinkedHashSet<>();
         private String currentTextMessageId = null;
+        private String currentReasoningMessageId = null;
 
         EventConversionState(String threadId, String runId) {
             this.threadId = threadId;
@@ -429,14 +443,27 @@ public class AguiAgentAdapter {
 
         void startReasoningMessage(String messageId) {
             startedReasoningMessages.add(messageId);
+            currentReasoningMessageId = messageId;
         }
 
         void endReasoningMessage(String messageId) {
             endedReasoningMessages.add(messageId);
+            if (messageId.equals(currentReasoningMessageId)) {
+                currentReasoningMessageId = null;
+            }
         }
 
         boolean hasEndedReasoningMessage(String messageId) {
             return endedReasoningMessages.contains(messageId);
+        }
+
+        String getCurrentReasoningMessageId() {
+            return currentReasoningMessageId;
+        }
+
+        boolean hasActiveReasoningMessage() {
+            return currentReasoningMessageId != null
+                    && !hasEndedReasoningMessage(currentReasoningMessageId);
         }
 
         Set<String> getStartedReasoningMessages() {

--- a/agentscope-extensions/agentscope-extensions-agui/src/test/java/io/agentscope/core/agui/adapter/AguiAgentAdapterTest.java
+++ b/agentscope-extensions/agentscope-extensions-agui/src/test/java/io/agentscope/core/agui/adapter/AguiAgentAdapterTest.java
@@ -910,7 +910,7 @@ class AguiAgentAdapterTest {
 
         assertNotNull(reasoningMessageStart, "Should have ReasoningMessageStart");
         assertEquals("msg-r1", reasoningMessageStart.messageId());
-        assertEquals("assistant", reasoningMessageStart.role());
+        assertEquals("reasoning", reasoningMessageStart.role());
 
         AguiEvent.ReasoningMessageContent reasoningMessageContent =
                 events.stream()
@@ -989,6 +989,7 @@ class AguiAgentAdapterTest {
                         .content(
                                 ToolResultBlock.builder()
                                         .id("tc-unknown")
+                                        .name("weather_lookup")
                                         .output(TextBlock.builder().text("result").build())
                                         .build())
                         .build();
@@ -1013,6 +1014,17 @@ class AguiAgentAdapterTest {
         long toolStartCount =
                 events.stream().filter(e -> e instanceof AguiEvent.ToolCallStart).count();
         assertEquals(1, toolStartCount, "Should backfill ToolCallStart for unknown tool result");
+
+        AguiEvent.ToolCallStart backfilledStart =
+                events.stream()
+                        .filter(e -> e instanceof AguiEvent.ToolCallStart)
+                        .map(e -> (AguiEvent.ToolCallStart) e)
+                        .findFirst()
+                        .orElse(null);
+
+        assertNotNull(backfilledStart, "Should backfill ToolCallStart");
+        assertEquals("tc-unknown", backfilledStart.toolCallId());
+        assertEquals("weather_lookup", backfilledStart.toolCallName());
     }
 
     @Test
@@ -1291,6 +1303,41 @@ class AguiAgentAdapterTest {
         assertTrue(hasReasoningMessageStart, "Should have ReasoningMessageStart");
         assertTrue(hasReasoningMessageContent, "Should have ReasoningMessageContent");
         assertTrue(hasToolStart, "Should have ToolCallStart for tool call");
+
+        int reasoningStartIdx = -1;
+        int reasoningContentIdx = -1;
+        int reasoningEndIdx = -1;
+        int toolStartIdx = -1;
+
+        for (int i = 0; i < events.size(); i++) {
+            AguiEvent e = events.get(i);
+            if (reasoningStartIdx < 0 && e instanceof AguiEvent.ReasoningMessageStart) {
+                reasoningStartIdx = i;
+            } else if (reasoningContentIdx < 0 && e instanceof AguiEvent.ReasoningMessageContent) {
+                reasoningContentIdx = i;
+            } else if (reasoningEndIdx < 0 && e instanceof AguiEvent.ReasoningMessageEnd) {
+                reasoningEndIdx = i;
+            } else if (toolStartIdx < 0 && e instanceof AguiEvent.ToolCallStart) {
+                toolStartIdx = i;
+            }
+        }
+
+        assertTrue(reasoningStartIdx >= 0, "Should have ReasoningMessageStart");
+        assertTrue(reasoningContentIdx >= 0, "Should have ReasoningMessageContent");
+        assertTrue(reasoningEndIdx >= 0, "Should have ReasoningMessageEnd before tool call");
+        assertTrue(toolStartIdx >= 0, "Should have ToolCallStart");
+
+        assertTrue(
+                reasoningStartIdx < reasoningContentIdx,
+                "Reasoning start should be before content");
+        assertTrue(reasoningContentIdx < reasoningEndIdx, "Reasoning content should be before end");
+        assertTrue(
+                reasoningEndIdx < toolStartIdx, "Reasoning should be closed before ToolCallStart");
+
+        // ReasoningMessage must be explicitly closed before ToolCallStart.
+        long reasoningEndCount =
+                events.stream().filter(e -> e instanceof AguiEvent.ReasoningMessageEnd).count();
+        assertEquals(1, reasoningEndCount, "Should emit exactly one ReasoningMessageEnd");
     }
 
     @Test


### PR DESCRIPTION
## Description

Close #1230
This PR fixes three AG-UI adapter issues: 
(1) ReasoningMessageStart now uses role reasoning (instead of assistant) to match protocol expectations(current issue).
(2) Active reasoning messages are explicitly closed before emitting ToolCallStart when a ToolUseBlock arrives.
(3) Backfilled ToolCallStart now uses the real tool name from ToolResultBlock (falling back to unknown only when missing).

## Checklist

Please check the following items before code is ready to be reviewed.

- [ ]  Code has been formatted with `mvn spotless:apply`
- [ ]  All tests are passing (`mvn test`)
- [ ]  Javadoc comments are complete and follow project conventions
- [ ]  Related documentation has been updated (e.g. links, examples, etc.)
- [ ]  Code is ready for review
