### PR TITLE
fix(autocontext): avoid blocking pre-reasoning compression

### DIFF
--- a/agentscope-extensions/agentscope-extensions-autocontext-memory/src/main/java/io/agentscope/core/memory/autocontext/AutoContextHook.java
+++ b/agentscope-extensions/agentscope-extensions-autocontext-memory/src/main/java/io/agentscope/core/memory/autocontext/AutoContextHook.java
@@ -33,6 +33,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
 
 /**
  * Hook for automatically registering AutoContextMemory integration with ReActAgent.
@@ -214,27 +215,32 @@ public class AutoContextHook implements Hook {
     private Mono<PreReasoningEvent> handlePreReasoning(PreReasoningEvent event) {
         Agent agent = event.getAgent();
 
-        // Only process ReActAgent instances
         if (!(agent instanceof ReActAgent reActAgent)) {
             return Mono.just(event);
         }
 
-        // Get memory from agent and verify it's an AutoContextMemory instance
         Memory memory = reActAgent.getMemory();
         if (!(memory instanceof AutoContextMemory autoContextMemory)) {
             return Mono.just(event);
         }
 
-        // Trigger compression if needed (this modifies workingMemoryStorage in place)
-        autoContextMemory.compressIfNeeded();
+        return autoContextMemory
+                .compressIfNeededAsync()
+                .map(
+                        ignored -> {
+                            event.setInputMessages(buildInputMessages(event, autoContextMemory));
+                            return event;
+                        })
+                .subscribeOn(Schedulers.boundedElastic());
+    }
 
-        // Always append system prompt instruction about compressed messages
+    private List<Msg> buildInputMessages(
+            PreReasoningEvent event, AutoContextMemory autoContextMemory) {
         List<Msg> originalInputMessages = event.getInputMessages();
         List<Msg> newInputMessages = new ArrayList<>();
 
         if (!originalInputMessages.isEmpty()
                 && originalInputMessages.get(0).getRole() == MsgRole.SYSTEM) {
-            // Append instruction to existing system prompt
             Msg originalSystemMsg = originalInputMessages.get(0);
             String originalSystemText = originalSystemMsg.getTextContent();
             String appendedInstruction =
@@ -260,7 +266,6 @@ public class AutoContextHook implements Hook {
 
             newInputMessages.add(updatedSystemMsg);
         } else {
-            // No system message exists, create a new one with the instruction
             String instruction =
                     "You may see compressed messages containing <!-- CONTEXT_OFFLOAD uuid=..."
                             + " -->.\n"
@@ -276,10 +281,7 @@ public class AutoContextHook implements Hook {
                             .build());
         }
 
-        // Add memory messages (compressed or not)
         newInputMessages.addAll(autoContextMemory.getMessages());
-        event.setInputMessages(newInputMessages);
-
-        return Mono.just(event);
+        return newInputMessages;
     }
 }

--- a/agentscope-extensions/agentscope-extensions-autocontext-memory/src/main/java/io/agentscope/core/memory/autocontext/AutoContextMemory.java
+++ b/agentscope-extensions/agentscope-extensions-autocontext-memory/src/main/java/io/agentscope/core/memory/autocontext/AutoContextMemory.java
@@ -43,6 +43,7 @@ import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
 
 /**
  * AutoContextMemory - Intelligent context memory management system.
@@ -302,6 +303,10 @@ public class AutoContextMemory implements StateModule, Memory, ContextOffLoader 
 
         log.warn("All compression strategies exhausted but context still exceeds threshold");
         return false;
+    }
+
+    Mono<Boolean> compressIfNeededAsync() {
+        return Mono.fromCallable(this::compressIfNeeded).subscribeOn(Schedulers.boundedElastic());
     }
 
     private List<Msg> replaceWorkingMessage(List<Msg> newMessages) {

--- a/agentscope-extensions/agentscope-extensions-autocontext-memory/src/test/java/io/agentscope/core/memory/autocontext/AutoContextHookTest.java
+++ b/agentscope-extensions/agentscope-extensions-autocontext-memory/src/test/java/io/agentscope/core/memory/autocontext/AutoContextHookTest.java
@@ -48,6 +48,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
 
 /**
  * Unit tests for AutoContextHook.
@@ -541,6 +543,145 @@ class AutoContextHookTest {
         // Both calls should complete without errors
         assertNotNull(event1);
         assertNotNull(event2);
+    }
+
+    @Test
+    @DisplayName("Should handle PreReasoningEvent on non-blocking scheduler")
+    void testPreReasoningEventOnNonBlockingScheduler() {
+        AutoContextMemory compressionMemory =
+                new AutoContextMemory(
+                        createCompressionConfig(), new TestModel("Compressed summary"));
+        populateCompressibleConversation(compressionMemory, 3);
+        compressionMemory.addMessage(
+                Msg.builder()
+                        .role(MsgRole.USER)
+                        .name("user")
+                        .content(TextBlock.builder().text("Latest request").build())
+                        .build());
+
+        ReActAgent agent =
+                ReActAgent.builder()
+                        .name("TestAgent")
+                        .model(mockModel)
+                        .memory(compressionMemory)
+                        .toolkit(toolkit)
+                        .build();
+
+        PreReasoningEvent event =
+                new PreReasoningEvent(
+                        agent,
+                        "test-model",
+                        null,
+                        new ArrayList<>(compressionMemory.getMessages()));
+
+        PreReasoningEvent result =
+                Mono.defer(() -> hook.onEvent(event)).subscribeOn(Schedulers.parallel()).block();
+
+        assertNotNull(result);
+        assertEquals(MsgRole.SYSTEM, result.getInputMessages().get(0).getRole());
+        assertTrue(
+                result.getInputMessages().get(0).getTextContent().contains("context_reload"),
+                "System prompt should include compressed-context instructions");
+        assertEquals(
+                compressionMemory.getMessages().size() + 1,
+                result.getInputMessages().size(),
+                "Result should include system prompt plus compressed memory messages");
+    }
+
+    @Test
+    @DisplayName("Should preserve existing system prompt on non-blocking scheduler")
+    void testPreReasoningEventPreservesSystemPromptOnNonBlockingScheduler() {
+        AutoContextMemory compressionMemory =
+                new AutoContextMemory(
+                        createCompressionConfig(), new TestModel("Compressed summary"));
+        populateCompressibleConversation(compressionMemory, 3);
+        compressionMemory.addMessage(
+                Msg.builder()
+                        .role(MsgRole.USER)
+                        .name("user")
+                        .content(TextBlock.builder().text("Latest request").build())
+                        .build());
+
+        ReActAgent agent =
+                ReActAgent.builder()
+                        .name("TestAgent")
+                        .model(mockModel)
+                        .memory(compressionMemory)
+                        .toolkit(toolkit)
+                        .build();
+
+        List<Msg> inputMessages = new ArrayList<>();
+        inputMessages.add(
+                Msg.builder()
+                        .role(MsgRole.SYSTEM)
+                        .name("system")
+                        .content(TextBlock.builder().text("Base system prompt").build())
+                        .build());
+        inputMessages.addAll(compressionMemory.getMessages());
+
+        PreReasoningEvent event = new PreReasoningEvent(agent, "test-model", null, inputMessages);
+        PreReasoningEvent result =
+                Mono.defer(() -> hook.onEvent(event)).subscribeOn(Schedulers.parallel()).block();
+
+        assertNotNull(result);
+        String updatedSystemPrompt = result.getInputMessages().get(0).getTextContent();
+        assertTrue(updatedSystemPrompt.startsWith("Base system prompt"));
+        assertTrue(updatedSystemPrompt.contains("context_reload"));
+    }
+
+    private AutoContextConfig createCompressionConfig() {
+        return AutoContextConfig.builder()
+                .msgThreshold(5)
+                .maxToken(10000)
+                .tokenRatio(0.9)
+                .lastKeep(2)
+                .minConsecutiveToolMessages(10)
+                .largePayloadThreshold(10000)
+                .minCompressionTokenThreshold(0)
+                .build();
+    }
+
+    private void populateCompressibleConversation(AutoContextMemory memory, int rounds) {
+        for (int i = 0; i < rounds; i++) {
+            memory.addMessage(
+                    Msg.builder()
+                            .role(MsgRole.USER)
+                            .name("user")
+                            .content(TextBlock.builder().text("User message " + i).build())
+                            .build());
+            memory.addMessage(
+                    Msg.builder()
+                            .role(MsgRole.ASSISTANT)
+                            .name("assistant")
+                            .content(
+                                    ToolUseBlock.builder()
+                                            .name("test_tool")
+                                            .id("call_" + i)
+                                            .input(new HashMap<>())
+                                            .build())
+                            .build());
+            memory.addMessage(
+                    Msg.builder()
+                            .role(MsgRole.TOOL)
+                            .name("test_tool")
+                            .content(
+                                    ToolResultBlock.builder()
+                                            .name("test_tool")
+                                            .id("call_" + i)
+                                            .output(
+                                                    List.of(
+                                                            TextBlock.builder()
+                                                                    .text("Result " + i)
+                                                                    .build()))
+                                            .build())
+                            .build());
+            memory.addMessage(
+                    Msg.builder()
+                            .role(MsgRole.ASSISTANT)
+                            .name("assistant")
+                            .content(TextBlock.builder().text("Assistant response " + i).build())
+                            .build());
+        }
     }
 
     /**

--- a/agentscope-extensions/agentscope-extensions-autocontext-memory/src/test/java/io/agentscope/core/memory/autocontext/AutoContextMemoryTest.java
+++ b/agentscope-extensions/agentscope-extensions-autocontext-memory/src/test/java/io/agentscope/core/memory/autocontext/AutoContextMemoryTest.java
@@ -48,6 +48,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
 
 /**
  * Unit tests for AutoContextMemory.
@@ -968,7 +970,86 @@ class AutoContextMemoryTest {
                 "Should have tool compression event with plan-aware hint");
     }
 
+    @Test
+    @DisplayName("Should compress asynchronously on non-blocking scheduler")
+    void testCompressIfNeededAsyncOnNonBlockingScheduler() {
+        AutoContextConfig asyncConfig =
+                AutoContextConfig.builder()
+                        .msgThreshold(5)
+                        .maxToken(10000)
+                        .tokenRatio(0.9)
+                        .lastKeep(2)
+                        .minConsecutiveToolMessages(10)
+                        .largePayloadThreshold(10000)
+                        .minCompressionTokenThreshold(0)
+                        .build();
+        TestModel asyncModel = new TestModel("Conversation summary");
+        AutoContextMemory asyncMemory = new AutoContextMemory(asyncConfig, asyncModel);
+
+        addCompressibleConversation(asyncMemory, 3);
+        asyncMemory.addMessage(createTextMessage("Latest request", MsgRole.USER));
+        int initialCount = asyncMemory.getMessages().size();
+
+        Boolean compressed =
+                Mono.defer(asyncMemory::compressIfNeededAsync)
+                        .subscribeOn(Schedulers.parallel())
+                        .block();
+
+        assertTrue(Boolean.TRUE.equals(compressed));
+        assertTrue(asyncModel.getCallCount() >= 1, "Compression should invoke the model");
+        assertTrue(asyncMemory.getMessages().size() < initialCount);
+        assertFalse(asyncMemory.getOffloadContext().isEmpty());
+    }
+
+    @Test
+    @DisplayName("Should allow repeated async compression calls")
+    void testCompressIfNeededAsyncMultipleCalls() {
+        AutoContextConfig asyncConfig =
+                AutoContextConfig.builder()
+                        .msgThreshold(5)
+                        .maxToken(10000)
+                        .tokenRatio(0.9)
+                        .lastKeep(2)
+                        .minConsecutiveToolMessages(10)
+                        .largePayloadThreshold(10000)
+                        .minCompressionTokenThreshold(0)
+                        .build();
+        TestModel asyncModel = new TestModel("Conversation summary");
+        AutoContextMemory asyncMemory = new AutoContextMemory(asyncConfig, asyncModel);
+
+        addCompressibleConversation(asyncMemory, 3);
+        asyncMemory.addMessage(createTextMessage("Latest request", MsgRole.USER));
+        Boolean firstCompressed =
+                Mono.defer(asyncMemory::compressIfNeededAsync)
+                        .subscribeOn(Schedulers.parallel())
+                        .block();
+
+        addCompressibleConversation(asyncMemory, 2);
+        asyncMemory.addMessage(createTextMessage("Another request", MsgRole.USER));
+        Boolean secondCompressed =
+                Mono.defer(asyncMemory::compressIfNeededAsync)
+                        .subscribeOn(Schedulers.parallel())
+                        .block();
+
+        assertTrue(Boolean.TRUE.equals(firstCompressed));
+        assertTrue(Boolean.TRUE.equals(secondCompressed));
+        assertTrue(
+                asyncModel.getCallCount() >= 2, "Both async compressions should reach the model");
+        assertFalse(asyncMemory.getMessages().isEmpty());
+    }
+
     // Helper methods
+
+    private void addCompressibleConversation(AutoContextMemory targetMemory, int rounds) {
+        for (int i = 0; i < rounds; i++) {
+            String callId = "call_" + i + "_" + targetMemory.getMessages().size();
+            targetMemory.addMessage(createTextMessage("User message " + i, MsgRole.USER));
+            targetMemory.addMessage(createToolUseMessage("test_tool", callId));
+            targetMemory.addMessage(createToolResultMessage("test_tool", callId, "Result " + i));
+            targetMemory.addMessage(
+                    createTextMessage("Assistant response " + i, MsgRole.ASSISTANT));
+        }
+    }
 
     private Msg createTextMessage(String text, MsgRole role) {
         return Msg.builder()


### PR DESCRIPTION
## Summary
- move AutoContextMemory compression off Reactor non-blocking threads before `PreReasoningEvent` continues
- add an async compression entrypoint for hook integration while preserving the existing synchronous compression API
- add regression coverage for hook execution and direct async compression on non-blocking schedulers

## Why this fix
`AutoContextHook` currently calls `compressIfNeeded()` inline. When the hook runs on a Reactor non-blocking thread, the internal summarization flow eventually reaches `block()` inside AutoContextMemory and fails before reasoning can proceed. Running the compression work on a bounded-elastic scheduler keeps the existing compression logic intact while avoiding reactive-thread blocking errors.

## Validation
- `mvn -pl agentscope-extensions/agentscope-extensions-autocontext-memory -am '-Dtest=AutoContextHookTest,AutoContextMemoryTest' test`