### PR TITLE
feat(agui): support tool execution progress and fix stream delta loss

### DIFF
--- a/agentscope-extensions/agentscope-extensions-agui/src/main/java/io/agentscope/core/agui/adapter/AguiAdapterConfig.java
+++ b/agentscope-extensions/agentscope-extensions-agui/src/main/java/io/agentscope/core/agui/adapter/AguiAdapterConfig.java
@@ -32,6 +32,7 @@ public class AguiAdapterConfig {
     private final boolean enableReasoning;
     private final Duration runTimeout;
     private final String defaultAgentId;
+    private final boolean enableToolProgressStream;
 
     private AguiAdapterConfig(Builder builder) {
         this.toolMergeMode = builder.toolMergeMode;
@@ -40,6 +41,7 @@ public class AguiAdapterConfig {
         this.enableReasoning = builder.enableReasoning;
         this.runTimeout = builder.runTimeout;
         this.defaultAgentId = builder.defaultAgentId;
+        this.enableToolProgressStream = builder.enableToolProgressStream;
     }
 
     /**
@@ -101,6 +103,18 @@ public class AguiAdapterConfig {
     }
 
     /**
+     * Check if tool execution progress should be streamed.
+     *
+     * <p>When enabled, intermediate tool execution events will be converted into
+     * reasoning messages (Thinking UI) to provide real-time feedback to the frontend.
+     *
+     * @return true if tool progress streaming is enabled
+     */
+    public boolean isEnableToolProgressStream() {
+        return enableToolProgressStream;
+    }
+
+    /**
      * Creates a new builder for AguiAdapterConfig.
      *
      * @return A new builder instance
@@ -129,6 +143,7 @@ public class AguiAdapterConfig {
         private boolean enableReasoning = false;
         private Duration runTimeout = Duration.ofMinutes(10);
         private String defaultAgentId;
+        private boolean enableToolProgressStream = false;
 
         /**
          * Set the tool merge mode.
@@ -197,6 +212,22 @@ public class AguiAdapterConfig {
          */
         public Builder defaultAgentId(String defaultAgentId) {
             this.defaultAgentId = defaultAgentId;
+            return this;
+        }
+
+        /**
+         * Set whether to enable tool execution progress stream.
+         *
+         * <p>When enabled, intermediate progress chunks generated during tool execution
+         * (e.g., download progress, code execution stdout) will be converted into
+         * {@code ReasoningMessage} events. This leverages the frontend's "Thinking" UI
+         * to display real-time feedback without modifying the AG-UI protocol.
+         *
+         * @param enableToolProgressStream true to convert progress events to thinking blocks
+         * @return This builder
+         */
+        public Builder enableToolProgressStream(boolean enableToolProgressStream) {
+            this.enableToolProgressStream = enableToolProgressStream;
             return this;
         }
 

--- a/agentscope-extensions/agentscope-extensions-agui/src/main/java/io/agentscope/core/agui/adapter/AguiAgentAdapter.java
+++ b/agentscope-extensions/agentscope-extensions-agui/src/main/java/io/agentscope/core/agui/adapter/AguiAgentAdapter.java
@@ -102,6 +102,7 @@ public class AguiAgentAdapter {
                             StreamOptions.builder()
                                     .eventTypes(EventType.ALL)
                                     .incremental(true)
+                                    .includeActingChunk(config.isEnableToolProgressStream())
                                     .build();
 
                     // Track state for event conversion
@@ -147,13 +148,13 @@ public class AguiAgentAdapter {
         EventType type = event.getType();
 
         if (type == EventType.REASONING || type == EventType.SUMMARY) {
+            String messageId = msg.getId();
+
             // Handle reasoning/summary events - convert to text messages and tool calls
             for (ContentBlock block : msg.getContent()) {
                 if (block instanceof TextBlock textBlock) {
                     String text = textBlock.getText();
                     if (text != null && !text.isEmpty()) {
-                        String messageId = msg.getId();
-
                         // Start message if not started
                         if (!state.hasStartedMessage(messageId)) {
                             events.add(
@@ -161,21 +162,9 @@ public class AguiAgentAdapter {
                                             state.threadId, state.runId, messageId, "assistant"));
                             state.startMessage(messageId);
                         }
-
-                        if (!event.isLast()) {
-                            // In incremental mode, text is already the delta
-                            events.add(
-                                    new AguiEvent.TextMessageContent(
-                                            state.threadId, state.runId, messageId, text));
-                        } else {
-                            // End message if this is the last event
-                            if (!state.hasEndedMessage(messageId)) {
-                                events.add(
-                                        new AguiEvent.TextMessageEnd(
-                                                state.threadId, state.runId, messageId));
-                                state.endMessage(messageId);
-                            }
-                        }
+                        events.add(
+                                new AguiEvent.TextMessageContent(
+                                        state.threadId, state.runId, messageId, text));
                     }
                 } else if (block instanceof ThinkingBlock thinkingBlock) {
                     // Handle thinking blocks - convert to REASONING_* events (only if enabled)
@@ -183,8 +172,6 @@ public class AguiAgentAdapter {
                     if (config.isEnableReasoning()) {
                         String thinking = thinkingBlock.getThinking();
                         if (thinking != null && !thinking.isEmpty()) {
-                            String messageId = msg.getId();
-
                             // Start reasoning message if not started
                             if (!state.hasStartedReasoningMessage(messageId)) {
                                 events.add(
@@ -195,19 +182,9 @@ public class AguiAgentAdapter {
                                                 "reasoning"));
                                 state.startReasoningMessage(messageId);
                             }
-
-                            if (!event.isLast()) {
-                                // In incremental mode, thinking is already the delta
-                                events.add(
-                                        new AguiEvent.ReasoningMessageContent(
-                                                state.threadId, state.runId, messageId, thinking));
-                            } else {
-                                // End reasoning message if this is the last event
-                                events.add(
-                                        new AguiEvent.ReasoningMessageEnd(
-                                                state.threadId, state.runId, messageId));
-                                state.endReasoningMessage(messageId);
-                            }
+                            events.add(
+                                    new AguiEvent.ReasoningMessageContent(
+                                            state.threadId, state.runId, messageId, thinking));
                         }
                     }
                     // If reasoning is disabled, ThinkingBlock content is ignored (backward
@@ -248,7 +225,7 @@ public class AguiAgentAdapter {
                     }
 
                     // Emit tool call args if enabled
-                    if (config.isEmitToolCallArgs() && !event.isLast()) {
+                    if (config.isEmitToolCallArgs()) {
                         String args = toolUse.getContent();
                         if (args != null && !args.isEmpty()) {
                             events.add(
@@ -258,7 +235,25 @@ public class AguiAgentAdapter {
                     }
                 }
             }
-        } else if (type == EventType.TOOL_RESULT && event.isLast()) {
+
+            // Independent lifecycle check: prevents dropping the final data chunk
+            // and safely handles empty termination packets.
+            if (event.isLast()) {
+                if (state.hasStartedMessage(messageId) && !state.hasEndedMessage(messageId)) {
+                    events.add(
+                            new AguiEvent.TextMessageEnd(state.threadId, state.runId, messageId));
+                    state.endMessage(messageId);
+                }
+                if (config.isEnableReasoning()
+                        && state.hasStartedReasoningMessage(messageId)
+                        && !state.hasEndedReasoningMessage(messageId)) {
+                    events.add(
+                            new AguiEvent.ReasoningMessageEnd(
+                                    state.threadId, state.runId, messageId));
+                    state.endReasoningMessage(messageId);
+                }
+            }
+        } else if (type == EventType.TOOL_RESULT) {
             // Handle tool results
             for (ContentBlock block : msg.getContent()) {
                 if (block instanceof ToolResultBlock toolResult) {
@@ -267,7 +262,7 @@ public class AguiAgentAdapter {
                         toolCallId = UUID.randomUUID().toString();
                     }
 
-                    String result = extractToolResultText(toolResult);
+                    String resultText = extractToolResultText(toolResult);
 
                     boolean hasStarted = state.hasStartedToolCall(toolCallId);
                     if (!hasStarted) {
@@ -281,18 +276,57 @@ public class AguiAgentAdapter {
                         state.startToolCall(toolCallId);
                     }
 
-                    // Ensure ToolCallEnd is emitted to close arguments phase
-                    events.add(new AguiEvent.ToolCallEnd(state.threadId, state.runId, toolCallId));
+                    if (resultText != null && !resultText.isEmpty()) {
+                        if (config.isEnableToolProgressStream()) {
+                            // Handle the intermediate progress of tool execution
+                            // (borrowing from the Reasoning block)
+                            String thinkingMsgId = "tool-thinking-" + toolCallId;
 
-                    events.add(
-                            new AguiEvent.ToolCallResult(
-                                    state.threadId,
-                                    state.runId,
-                                    toolCallId,
-                                    result,
-                                    "tool",
-                                    msg.getId()));
-                    state.endToolCall(toolCallId);
+                            if (!state.hasStartedReasoningMessage(thinkingMsgId)) {
+                                events.add(
+                                        new AguiEvent.ReasoningMessageStart(
+                                                state.threadId,
+                                                state.runId,
+                                                thinkingMsgId,
+                                                "assistant"));
+                                state.startReasoningMessage(thinkingMsgId);
+                            }
+
+                            events.add(
+                                    new AguiEvent.ReasoningMessageContent(
+                                            state.threadId,
+                                            state.runId,
+                                            thinkingMsgId,
+                                            resultText));
+                        }
+                    }
+
+                    // Decouple termination logic from content extraction
+                    // to ensure the final progress chunk is emitted before closing.
+                    if (event.isLast()) {
+                        // Clear up the fabricated Reasoning blocks
+                        String thinkingMsgId = "tool-thinking-" + toolCallId;
+                        if (state.hasStartedReasoningMessage(thinkingMsgId)
+                                && !state.hasEndedReasoningMessage(thinkingMsgId)) {
+                            events.add(
+                                    new AguiEvent.ReasoningMessageEnd(
+                                            state.threadId, state.runId, thinkingMsgId));
+                            state.endReasoningMessage(thinkingMsgId);
+                        }
+
+                        // Send real tool call end and result events
+                        events.add(
+                                new AguiEvent.ToolCallEnd(state.threadId, state.runId, toolCallId));
+                        events.add(
+                                new AguiEvent.ToolCallResult(
+                                        state.threadId,
+                                        state.runId,
+                                        toolCallId,
+                                        resultText,
+                                        "tool",
+                                        msg.getId()));
+                        state.endToolCall(toolCallId);
+                    }
                 }
             }
         }

--- a/agentscope-extensions/agentscope-extensions-agui/src/main/java/io/agentscope/core/agui/adapter/AguiAgentAdapter.java
+++ b/agentscope-extensions/agentscope-extensions-agui/src/main/java/io/agentscope/core/agui/adapter/AguiAgentAdapter.java
@@ -276,7 +276,7 @@ public class AguiAgentAdapter {
                         state.startToolCall(toolCallId);
                     }
 
-                    if (resultText != null && !resultText.isEmpty()) {
+                    if (!event.isLast() && resultText != null && !resultText.isEmpty()) {
                         if (config.isEnableToolProgressStream()) {
                             // Handle the intermediate progress of tool execution
                             // (borrowing from the Reasoning block)

--- a/agentscope-extensions/agentscope-extensions-agui/src/main/java/io/agentscope/core/agui/adapter/AguiAgentAdapter.java
+++ b/agentscope-extensions/agentscope-extensions-agui/src/main/java/io/agentscope/core/agui/adapter/AguiAgentAdapter.java
@@ -156,11 +156,11 @@ public class AguiAgentAdapter {
                     String text = textBlock.getText();
                     if (text != null && !text.isEmpty()) {
                         // Start message if not started
-                        if (!state.hasStartedMessage(messageId)) {
+                        if (!state.hasStartedTextMessage(messageId)) {
                             events.add(
                                     new AguiEvent.TextMessageStart(
                                             state.threadId, state.runId, messageId, "assistant"));
-                            state.startMessage(messageId);
+                            state.startTextMessage(messageId);
                         }
                         events.add(
                                 new AguiEvent.TextMessageContent(
@@ -196,7 +196,7 @@ public class AguiAgentAdapter {
                         events.add(
                                 new AguiEvent.TextMessageEnd(
                                         state.threadId, state.runId, activeMessageId));
-                        state.endMessage(activeMessageId);
+                        state.endTextMessage(activeMessageId);
                     }
 
                     // End any active reasoning message before starting tool call
@@ -239,10 +239,11 @@ public class AguiAgentAdapter {
             // Independent lifecycle check: prevents dropping the final data chunk
             // and safely handles empty termination packets.
             if (event.isLast()) {
-                if (state.hasStartedMessage(messageId) && !state.hasEndedMessage(messageId)) {
+                if (state.hasStartedTextMessage(messageId)
+                        && !state.hasEndedTextMessage(messageId)) {
                     events.add(
                             new AguiEvent.TextMessageEnd(state.threadId, state.runId, messageId));
-                    state.endMessage(messageId);
+                    state.endTextMessage(messageId);
                 }
                 if (config.isEnableReasoning()
                         && state.hasStartedReasoningMessage(messageId)
@@ -277,26 +278,26 @@ public class AguiAgentAdapter {
                     }
 
                     if (!event.isLast() && resultText != null && !resultText.isEmpty()) {
+                        // Handle the progress of tool execution (only if enabled)
+                        // (borrowing from the Reasoning block)
                         if (config.isEnableToolProgressStream()) {
-                            // Handle the intermediate progress of tool execution
-                            // (borrowing from the Reasoning block)
-                            String thinkingMsgId = "tool-thinking-" + toolCallId;
+                            String progressMsgId = "tool-progress-" + toolCallId;
 
-                            if (!state.hasStartedReasoningMessage(thinkingMsgId)) {
+                            if (!state.hasStartedReasoningMessage(progressMsgId)) {
                                 events.add(
                                         new AguiEvent.ReasoningMessageStart(
                                                 state.threadId,
                                                 state.runId,
-                                                thinkingMsgId,
+                                                progressMsgId,
                                                 "assistant"));
-                                state.startReasoningMessage(thinkingMsgId);
+                                state.startReasoningMessage(progressMsgId);
                             }
 
                             events.add(
                                     new AguiEvent.ReasoningMessageContent(
                                             state.threadId,
                                             state.runId,
-                                            thinkingMsgId,
+                                            progressMsgId,
                                             resultText));
                         }
                     }
@@ -304,8 +305,7 @@ public class AguiAgentAdapter {
                     // Decouple termination logic from content extraction
                     // to ensure the final progress chunk is emitted before closing.
                     if (event.isLast()) {
-                        // Clear up the fabricated Reasoning blocks
-                        String thinkingMsgId = "tool-thinking-" + toolCallId;
+                        String thinkingMsgId = "tool-progress-" + toolCallId;
                         if (state.hasStartedReasoningMessage(thinkingMsgId)
                                 && !state.hasEndedReasoningMessage(thinkingMsgId)) {
                             events.add(
@@ -343,9 +343,9 @@ public class AguiAgentAdapter {
     private Flux<AguiEvent> finishRun(EventConversionState state) {
         List<AguiEvent> events = new ArrayList<>();
 
-        // End any messages that weren't properly ended
-        for (String messageId : state.getStartedMessages()) {
-            if (!state.hasEndedMessage(messageId)) {
+        // End any text messages that weren't properly ended
+        for (String messageId : state.getStartedTextMessages()) {
+            if (!state.hasEndedTextMessage(messageId)) {
                 events.add(new AguiEvent.TextMessageEnd(state.threadId, state.runId, messageId));
             }
         }
@@ -419,8 +419,8 @@ public class AguiAgentAdapter {
     private static class EventConversionState {
         final String threadId;
         final String runId;
-        private final Set<String> startedMessages = new LinkedHashSet<>();
-        private final Set<String> endedMessages = new LinkedHashSet<>();
+        private final Set<String> startedTextMessages = new LinkedHashSet<>();
+        private final Set<String> endedTextMessages = new LinkedHashSet<>();
         private final Set<String> startedToolCalls = new LinkedHashSet<>();
         private final Set<String> endedToolCalls = new LinkedHashSet<>();
         private final Set<String> startedReasoningMessages = new LinkedHashSet<>();
@@ -433,24 +433,24 @@ public class AguiAgentAdapter {
             this.runId = runId;
         }
 
-        boolean hasStartedMessage(String messageId) {
-            return startedMessages.contains(messageId);
+        boolean hasStartedTextMessage(String messageId) {
+            return startedTextMessages.contains(messageId);
         }
 
-        void startMessage(String messageId) {
-            startedMessages.add(messageId);
+        void startTextMessage(String messageId) {
+            startedTextMessages.add(messageId);
             currentTextMessageId = messageId;
         }
 
-        void endMessage(String messageId) {
-            endedMessages.add(messageId);
+        void endTextMessage(String messageId) {
+            endedTextMessages.add(messageId);
             if (Objects.equals(messageId, currentTextMessageId)) {
                 currentTextMessageId = null;
             }
         }
 
-        boolean hasEndedMessage(String messageId) {
-            return endedMessages.contains(messageId);
+        boolean hasEndedTextMessage(String messageId) {
+            return endedTextMessages.contains(messageId);
         }
 
         String getCurrentTextMessageId() {
@@ -458,11 +458,11 @@ public class AguiAgentAdapter {
         }
 
         boolean hasActiveTextMessage() {
-            return currentTextMessageId != null && !hasEndedMessage(currentTextMessageId);
+            return currentTextMessageId != null && !hasEndedTextMessage(currentTextMessageId);
         }
 
-        Set<String> getStartedMessages() {
-            return startedMessages;
+        Set<String> getStartedTextMessages() {
+            return startedTextMessages;
         }
 
         boolean hasStartedToolCall(String toolCallId) {

--- a/agentscope-extensions/agentscope-extensions-agui/src/test/java/io/agentscope/core/agui/adapter/AguiAgentAdapterTest.java
+++ b/agentscope-extensions/agentscope-extensions-agui/src/test/java/io/agentscope/core/agui/adapter/AguiAgentAdapterTest.java
@@ -758,8 +758,7 @@ class AguiAgentAdapterTest {
     @Test
     void testTextMessageEndWithLastEventDirectly() {
         // Test that when the last event contains text blocks and the message hasn't been ended,
-        // the TextMessageEnd is emitted through the new hasEndedMessage check
-        // This test specifically covers the new code path at lines 153-158
+        // the TextMessageContent is emitted to prevent tail-data loss, followed by TextMessageEnd.
         String msgId = "msg-text";
         Msg textMsg =
                 Msg.builder()
@@ -797,10 +796,13 @@ class AguiAgentAdapterTest {
         assertEquals(1, textEndCount, "Should have exactly 1 TextMessageEnd");
 
         // Verify the event sequence
+        assertEquals(5, events.size(), "Should emit 5 events exactly");
         assertInstanceOf(AguiEvent.RunStarted.class, events.get(0));
         assertInstanceOf(AguiEvent.TextMessageStart.class, events.get(1));
-        assertInstanceOf(AguiEvent.TextMessageEnd.class, events.get(2));
-        assertInstanceOf(AguiEvent.RunFinished.class, events.get(3));
+        assertInstanceOf(AguiEvent.TextMessageContent.class, events.get(2));
+        assertEquals("Hello world", ((AguiEvent.TextMessageContent) events.get(2)).delta());
+        assertInstanceOf(AguiEvent.TextMessageEnd.class, events.get(3));
+        assertInstanceOf(AguiEvent.RunFinished.class, events.get(4));
     }
 
     @Test
@@ -1695,5 +1697,203 @@ class AguiAgentAdapterTest {
         assertTrue(
                 !hasReasoningMessageStart,
                 "Should NOT have ReasoningMessageStart for null thinking");
+    }
+
+    @Test
+    void testToolResultProgressStreamingAndAccumulation() {
+        // Test that tool intermediate progress is converted to reasoning blocks
+        // and final result is accumulated correctly.
+        AguiAdapterConfig config =
+                AguiAdapterConfig.builder().enableToolProgressStream(true).build();
+        AguiAgentAdapter adapterWithProgress = new AguiAgentAdapter(mockAgent, config);
+
+        // Chunk 1: isLast = false
+        Msg trChunk1 =
+                Msg.builder()
+                        .id("msg-tr1")
+                        .role(MsgRole.TOOL)
+                        .content(
+                                ToolResultBlock.builder()
+                                        .id("tc-1")
+                                        .output(TextBlock.builder().text("Downloading 50%").build())
+                                        .build())
+                        .build();
+        Event event1 = new Event(EventType.TOOL_RESULT, trChunk1, false);
+
+        // Chunk 2: isLast = true
+        Msg trChunk2 =
+                Msg.builder()
+                        .id("msg-tr1")
+                        .role(MsgRole.TOOL)
+                        .content(
+                                ToolResultBlock.builder()
+                                        .id("tc-1")
+                                        .output(TextBlock.builder().text(", Done").build())
+                                        .build())
+                        .build();
+        Event event2 = new Event(EventType.TOOL_RESULT, trChunk2, true);
+
+        when(mockAgent.stream(anyList(), any(StreamOptions.class)))
+                .thenReturn(Flux.just(event1, event2));
+
+        RunAgentInput input =
+                RunAgentInput.builder()
+                        .threadId("thread-1")
+                        .runId("run-1")
+                        .messages(List.of(AguiMessage.userMessage("msg-1", "Download it")))
+                        .build();
+
+        List<AguiEvent> events = adapterWithProgress.run(input).collectList().block();
+        assertNotNull(events);
+
+        String expectedThinkingId = "tool-thinking-tc-1";
+
+        // Verify fake reasoning block for progress was created and ended
+        boolean hasFakeReasoningStart =
+                events.stream()
+                        .filter(e -> e instanceof AguiEvent.ReasoningMessageStart)
+                        .anyMatch(
+                                e ->
+                                        expectedThinkingId.equals(
+                                                ((AguiEvent.ReasoningMessageStart) e).messageId()));
+        assertTrue(hasFakeReasoningStart, "Should emit ReasoningMessageStart for tool progress");
+
+        boolean hasFakeReasoningEnd =
+                events.stream()
+                        .filter(e -> e instanceof AguiEvent.ReasoningMessageEnd)
+                        .anyMatch(
+                                e ->
+                                        expectedThinkingId.equals(
+                                                ((AguiEvent.ReasoningMessageEnd) e).messageId()));
+        assertTrue(hasFakeReasoningEnd, "Should emit ReasoningMessageEnd to close tool progress");
+
+        // Verify final accumulated result
+        AguiEvent.ToolCallResult toolResult =
+                events.stream()
+                        .filter(e -> e instanceof AguiEvent.ToolCallResult)
+                        .map(e -> (AguiEvent.ToolCallResult) e)
+                        .findFirst()
+                        .orElse(null);
+
+        assertNotNull(toolResult, "Should have ToolCallResult");
+        assertEquals(", Done", toolResult.content(), "Should accumulate all chunks");
+    }
+
+    @Test
+    void testTailEndDataPreservationWhenIsLastIsTrue() {
+        // Test that content in the very last event (isLast=true) is NOT dropped
+        Msg lastMsgWithContent =
+                Msg.builder()
+                        .id("msg-text")
+                        .role(MsgRole.ASSISTANT)
+                        .content(TextBlock.builder().text("Last crucial words.").build())
+                        .build();
+
+        // One single event, carries content AND isLast=true
+        Event event = new Event(EventType.REASONING, lastMsgWithContent, true);
+        when(mockAgent.stream(anyList(), any(StreamOptions.class))).thenReturn(Flux.just(event));
+
+        RunAgentInput input =
+                RunAgentInput.builder()
+                        .threadId("t1")
+                        .runId("r1")
+                        .messages(List.of(AguiMessage.userMessage("m1", "Hi")))
+                        .build();
+
+        List<AguiEvent> events = adapter.run(input).collectList().block();
+        assertNotNull(events);
+
+        // Find events associated with this message
+        boolean hasContent =
+                events.stream().anyMatch(e -> e instanceof AguiEvent.TextMessageContent);
+        boolean hasEnd = events.stream().anyMatch(e -> e instanceof AguiEvent.TextMessageEnd);
+
+        assertTrue(hasContent, "Must emit TextMessageContent even if isLast is true");
+        assertTrue(hasEnd, "Must emit TextMessageEnd");
+
+        // Verify Content comes before End
+        int contentIndex =
+                events.indexOf(
+                        events.stream()
+                                .filter(e -> e instanceof AguiEvent.TextMessageContent)
+                                .findFirst()
+                                .get());
+        int endIndex =
+                events.indexOf(
+                        events.stream()
+                                .filter(e -> e instanceof AguiEvent.TextMessageEnd)
+                                .findFirst()
+                                .get());
+        assertTrue(contentIndex < endIndex, "Content must be emitted before End");
+    }
+
+    @Test
+    void testEmptyContentListClosesActiveLifecycle() {
+        // Test that an empty content list with isLast=true properly closes active states
+        Msg msg1 =
+                Msg.builder()
+                        .id("msg-1")
+                        .role(MsgRole.ASSISTANT)
+                        .content(TextBlock.builder().text("Start ").build())
+                        .build();
+        Event event1 = new Event(EventType.REASONING, msg1, false);
+
+        // Empty content, but signals end
+        Msg msg2 =
+                Msg.builder()
+                        .id("msg-1")
+                        .role(MsgRole.ASSISTANT)
+                        .content(List.of()) // Empty content!
+                        .build();
+        Event event2 = new Event(EventType.REASONING, msg2, true);
+
+        when(mockAgent.stream(anyList(), any(StreamOptions.class)))
+                .thenReturn(Flux.just(event1, event2));
+
+        RunAgentInput input = RunAgentInput.builder().threadId("t1").runId("r1").build();
+
+        List<AguiEvent> events = adapter.run(input).collectList().block();
+        assertNotNull(events);
+
+        long endCount = events.stream().filter(e -> e instanceof AguiEvent.TextMessageEnd).count();
+        assertEquals(
+                1,
+                endCount,
+                "Should successfully close the text message even if last content block is empty");
+    }
+
+    @Test
+    void testToolCallArgsTailEndPreservation() {
+        // Test that tool argument JSON in the final chunk is not dropped
+        Msg toolMsg =
+                Msg.builder()
+                        .id("msg-tc1")
+                        .role(MsgRole.ASSISTANT)
+                        .content(
+                                ToolUseBlock.builder()
+                                        .id("tc-1")
+                                        .name("tool")
+                                        .content("}") // The final closing bracket
+                                        .build())
+                        .build();
+
+        // The tool use block comes with isLast=true
+        Event event = new Event(EventType.REASONING, toolMsg, true);
+        when(mockAgent.stream(anyList(), any(StreamOptions.class))).thenReturn(Flux.just(event));
+
+        RunAgentInput input = RunAgentInput.builder().threadId("t1").runId("r1").build();
+
+        List<AguiEvent> events = adapter.run(input).collectList().block();
+        assertNotNull(events);
+
+        AguiEvent.ToolCallArgs toolArgs =
+                events.stream()
+                        .filter(e -> e instanceof AguiEvent.ToolCallArgs)
+                        .map(e -> (AguiEvent.ToolCallArgs) e)
+                        .findFirst()
+                        .orElse(null);
+
+        assertNotNull(toolArgs, "Must emit ToolCallArgs even if event.isLast() is true");
+        assertEquals("}", toolArgs.delta());
     }
 }

--- a/agentscope-extensions/agentscope-extensions-agui/src/test/java/io/agentscope/core/agui/adapter/AguiAgentAdapterTest.java
+++ b/agentscope-extensions/agentscope-extensions-agui/src/test/java/io/agentscope/core/agui/adapter/AguiAgentAdapterTest.java
@@ -269,7 +269,7 @@ class AguiAgentAdapterTest {
 
         long contentCount =
                 events.stream().filter(e -> e instanceof AguiEvent.TextMessageContent).count();
-        assertEquals(2, contentCount, "Should stream summary chunks as text deltas");
+        assertEquals(3, contentCount, "Should stream summary chunks as text deltas");
 
         long startCount =
                 events.stream().filter(e -> e instanceof AguiEvent.TextMessageStart).count();
@@ -1746,7 +1746,7 @@ class AguiAgentAdapterTest {
         List<AguiEvent> events = adapterWithProgress.run(input).collectList().block();
         assertNotNull(events);
 
-        String expectedThinkingId = "tool-thinking-tc-1";
+        String expectedThinkingId = "tool-progress-tc-1";
 
         // Verify fake reasoning block for progress was created and ended
         boolean hasFakeReasoningStart =


### PR DESCRIPTION
## Description

Close #1222 
This PR introduces support for real-time tool execution progress and addresses the streaming data loss edge cases.

## Key Changes

1. **Support Tool Progress Stream:** - Added `enableToolProgressStream` in `AguiAdapterConfig`.
   - Elegantly converts intermediate tool execution chunks (`!event.isLast()`) into `ReasoningMessage` events to display real-time progress on the frontend without modifying the AG-UI protocol.
   
2. **Fix Tail-End Data Loss:**
   - Decoupled the `isLast` termination logic from the data extraction process in `convertEvent()`. 
   - Ensures that the final data chunks (Text, Reasoning, and Tool JSON args) carried by the termination packet are fully emitted before the state machine closes the component.

## Checklist

Please check the following items before code is ready to be reviewed.

- [ ]  Code has been formatted with `mvn spotless:apply`
- [ ]  All tests are passing (`mvn test`)
- [ ]  Javadoc comments are complete and follow project conventions
- [ ]  Related documentation has been updated (e.g. links, examples, etc.)
- [ ]  Code is ready for review
