### PR TITLE
fix(deps): downgrade json-schema-validator from 3.0.1 to 2.0.0 to resolve dependency conflict

### DIFF
--- a/agentscope-dependencies-bom/pom.xml
+++ b/agentscope-dependencies-bom/pom.xml
@@ -105,7 +105,7 @@
         <spring.version>7.0.6</spring.version>
         <spring-boot.version>4.0.4</spring-boot.version>
         <nacos-client.version>3.2.1-2026.03.30</nacos-client.version>
-        <json-schema-validator.version>3.0.1</json-schema-validator.version>
+        <json-schema-validator.version>2.0.0</json-schema-validator.version>
         <jsonschema-generator.version>4.38.0</jsonschema-generator.version>
         <snakeyaml.version>2.6</snakeyaml.version>
         <commons-lang3.version>3.20.0</commons-lang3.version>


### PR DESCRIPTION
## AgentScope-Java Version

1.0.12

## Description

* downgrade `com.networknt:json-schema-validator` from 3.0.1 to 2.0.0 to resolve dependency conflict, which is also the same version used by `io.modelcontextprotocol.sdk:mcp:0.17.0`.
* Fixes: #1100 
* Fixes: #1122 
* Fixes: #1040 

## Checklist

Please check the following items before code is ready to be reviewed.

- [x]  Code has been formatted with `mvn spotless:apply`
- [x]  All tests are passing (`mvn test`)
- [x]  Javadoc comments are complete and follow project conventions
- [x]  Related documentation has been updated (e.g. links, examples, etc.)
- [x]  Code is ready for review
