### PR TITLE
fix(mem0): fix memory search returning no results (#1224)

### DIFF
--- a/agentscope-examples/quickstart/pom.xml
+++ b/agentscope-examples/quickstart/pom.xml
@@ -109,6 +109,10 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-webflux</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.agentscope</groupId>
+            <artifactId>agentscope-extensions-mem0</artifactId>
+        </dependency>
 
     </dependencies>
 </project>

--- a/agentscope-examples/quickstart/src/main/java/io/agentscope/examples/quickstart/Mem0Example.java
+++ b/agentscope-examples/quickstart/src/main/java/io/agentscope/examples/quickstart/Mem0Example.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.examples.quickstart;
+
+import io.agentscope.core.ReActAgent;
+import io.agentscope.core.agent.user.UserAgent;
+import io.agentscope.core.memory.LongTermMemoryMode;
+import io.agentscope.core.memory.mem0.Mem0ApiType;
+import io.agentscope.core.memory.mem0.Mem0LongTermMemory;
+import io.agentscope.core.message.Msg;
+import io.agentscope.core.model.DashScopeChatModel;
+import java.util.HashMap;
+import java.util.Map;
+
+public class Mem0Example {
+
+    public static void main(String[] args) throws Exception {
+        // Get API keys
+        String dashscopeApiKey = System.getenv("AI_DASHSCOPE_API_KEY");
+        String mem0BaseUrl = getMem0BaseUrl();
+        Mem0ApiType mem0ApiType = getMem0ApiType();
+        Map<String, Object> metadata = new HashMap<>();
+        metadata.put("agentName", "SmartAssistant");
+        Mem0LongTermMemory.Builder memoryBuilder =
+                Mem0LongTermMemory.builder()
+                        .agentName("SmartAssistant")
+                        .userId("static-control01126")
+                        .apiBaseUrl(mem0BaseUrl)
+                        .apiKey(System.getenv("MEM0_API_KEY"))
+                        .apiType(mem0ApiType)
+                        .metadata(metadata);
+
+        Mem0LongTermMemory longTermMemory = memoryBuilder.build();
+
+        // Create agent with AGENT_CONTROL mode
+        ReActAgent agent =
+                ReActAgent.builder()
+                        .name("Assistant")
+                        .model(
+                                DashScopeChatModel.builder()
+                                        .apiKey(dashscopeApiKey)
+                                        .modelName("qwen-plus")
+                                        .build())
+                        .longTermMemory(longTermMemory)
+                        .longTermMemoryMode(LongTermMemoryMode.STATIC_CONTROL)
+                        .build();
+
+        UserAgent userAgent = UserAgent.builder().name("User").build();
+
+        Msg msg = null;
+        while (true) {
+            msg = userAgent.call(msg).block();
+            if (msg.getTextContent().equals("exit")) {
+                break;
+            }
+            msg = agent.call(msg).block();
+        }
+    }
+
+    /**
+     * Gets Mem0 API base URL from environment variable or uses default.
+     */
+    private static String getMem0BaseUrl() {
+        String baseUrl = System.getenv("MEM0_API_BASE_URL");
+        if (baseUrl == null || baseUrl.isEmpty()) {
+            return "https://api.mem0.ai";
+        }
+        return baseUrl;
+    }
+
+    /**
+     * Gets Mem0 API type from environment variable.
+     *
+     * @return API type enum: PLATFORM (default) or SELF_HOSTED
+     */
+    private static Mem0ApiType getMem0ApiType() {
+        String apiTypeStr = System.getenv("MEM0_API_TYPE");
+        if (apiTypeStr == null || apiTypeStr.isEmpty()) {
+            return Mem0ApiType.PLATFORM;
+        }
+        return Mem0ApiType.fromString(apiTypeStr);
+    }
+}

--- a/agentscope-extensions/agentscope-extensions-mem0/src/main/java/io/agentscope/core/memory/mem0/Mem0LongTermMemory.java
+++ b/agentscope-extensions/agentscope-extensions-mem0/src/main/java/io/agentscope/core/memory/mem0/Mem0LongTermMemory.java
@@ -22,6 +22,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import reactor.core.publisher.Mono;
 
 /**
@@ -111,6 +113,8 @@ import reactor.core.publisher.Mono;
  * @see Mem0Client
  */
 public class Mem0LongTermMemory implements LongTermMemory {
+
+    private static final Logger log = LoggerFactory.getLogger(Mem0LongTermMemory.class);
 
     private final Mem0Client client;
     private final String agentId;
@@ -227,10 +231,11 @@ public class Mem0LongTermMemory implements LongTermMemory {
     /**
      * Builds a search request with the given query.
      *
-     * <p>The search request includes:
+     * <p>The search request follows Mem0 v2 API filter structure:
      * <ul>
-     *   <li>Standard filters: userId, agentId, runId (added by builder convenience methods)</li>
-     *   <li>Custom metadata filters: merged into filters via builder.getFilters()</li>
+     *   <li>Entity filters (userId, agentId, runId) are OR-connected</li>
+     *   <li>Metadata filters are OR-connected</li>
+     *   <li>Entity and metadata filters are AND-connected at top level</li>
      * </ul>
      *
      * @param query The search query string
@@ -245,9 +250,8 @@ public class Mem0LongTermMemory implements LongTermMemory {
                         .runId(runId)
                         .topK(5);
 
-        // Merge custom metadata into filters if present
         if (metadata != null && !metadata.isEmpty()) {
-            builder.getFilters().putAll(metadata);
+            builder.metadata(metadata);
         }
 
         return builder.build();
@@ -288,6 +292,12 @@ public class Mem0LongTermMemory implements LongTermMemory {
                                     .filter(Objects::nonNull)
                                     .collect(Collectors.joining("\n"));
                         })
+                .doOnError(
+                        error ->
+                                log.warn(
+                                        "Failed to retrieve memories for query '{}': {}",
+                                        query,
+                                        error.getMessage()))
                 .onErrorReturn("");
     }
 

--- a/agentscope-extensions/agentscope-extensions-mem0/src/main/java/io/agentscope/core/memory/mem0/Mem0SearchRequest.java
+++ b/agentscope-extensions/agentscope-extensions-mem0/src/main/java/io/agentscope/core/memory/mem0/Mem0SearchRequest.java
@@ -17,6 +17,7 @@ package io.agentscope.core.memory.mem0;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -28,10 +29,35 @@ import java.util.Map;
  * to retrieve relevant memories based on a query string. The search uses semantic
  * similarity to find the most relevant memories.
  *
- * <p>The v2 API uses a filters object to specify search criteria (user_id, agent_id,
- * run_id, app_id, etc.), enabling proper memory isolation in multi-tenant scenarios.
- * The filters field is required by the API and will be sent as an empty object if no
- * filters are specified.
+ * <p>The v2 API requires filters to be structured with logical operators (AND, OR, NOT):
+ * <ul>
+ *   <li>Entity filters (user_id, agent_id, app_id, run_id) must be OR-connected
+ *       because a single memory cannot have multiple entity values</li>
+ *   <li>Metadata filters are OR-connected for multiple key-value pairs</li>
+ *   <li>Entity filters and metadata filters are AND-connected at the top level</li>
+ * </ul>
+ *
+ * <p>Example of correct filter structure:
+ * <pre>{@code
+ * {
+ *   "filters": {
+ *     "AND": [
+ *       {
+ *         "OR": [
+ *           { "user_id": "user123" },
+ *           { "agent_id": "agentA" }
+ *         ]
+ *       },
+ *       {
+ *         "OR": [
+ *           { "metadata": { "category": "travel" } },
+ *           { "metadata": { "priority": "high" } }
+ *         ]
+ *       }
+ *     ]
+ *   }
+ * }
+ * }</pre>
  */
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class Mem0SearchRequest {
@@ -43,8 +69,8 @@ public class Mem0SearchRequest {
     private String version = "v2";
 
     /**
-     * Filters to apply to the search (user_id, agent_id, run_id, app_id, etc.).
-     * This field is required by the API. An empty map will be sent if no filters are specified.
+     * Filters to apply to the search using logical operators (AND, OR, NOT).
+     * This field is required by the API and must follow the nested structure.
      */
     @JsonInclude(JsonInclude.Include.ALWAYS)
     private Map<String, Object> filters = new HashMap<>();
@@ -78,18 +104,12 @@ public class Mem0SearchRequest {
     @JsonProperty("project_id")
     private String projectId;
 
-    /** User identifier for filtering memories (optional). */
-    @JsonProperty("user_id")
-    private String userId;
-
     /** Default constructor for Jackson. */
     public Mem0SearchRequest() {
-        this.topK = 10; // Default value per v2 API spec
+        this.topK = 10;
         this.version = "v2";
-        this.filters = new HashMap<>(); // Ensure filters is never null
+        this.filters = new HashMap<>();
     }
-
-    // Getters and Setters
 
     public String getQuery() {
         return query;
@@ -179,32 +199,13 @@ public class Mem0SearchRequest {
         this.projectId = projectId;
     }
 
-    public String getUserId() {
-        return userId;
-    }
-
-    public void setUserId(String userId) {
-        this.userId = userId;
-        // Automatically sync to filters if set
-        if (userId != null && filters != null) {
-            filters.put("user_id", userId);
-        }
-    }
-
-    /**
-     * Creates a new builder for Mem0SearchRequest.
-     *
-     * @return A new builder instance
-     */
     public static Builder builder() {
         return new Builder();
     }
 
-    /** Builder for Mem0SearchRequest. */
     public static class Builder {
         private String query;
         private String version = "v2";
-        private Map<String, Object> filters = new HashMap<>();
         private Integer topK = 10;
         private List<String> fields;
         private Boolean rerank;
@@ -213,7 +214,12 @@ public class Mem0SearchRequest {
         private Double threshold;
         private String orgId;
         private String projectId;
+
         private String userId;
+        private String agentId;
+        private String runId;
+        private String appId;
+        private Map<String, Object> metadata = new HashMap<>();
 
         public Builder query(String query) {
             this.query = query;
@@ -225,66 +231,29 @@ public class Mem0SearchRequest {
             return this;
         }
 
-        public Builder filters(Map<String, Object> filters) {
-            this.filters = filters;
-            return this;
-        }
-
-        public Map<String, Object> getFilters() {
-            return this.filters;
-        }
-
-        /**
-         * Convenience method to add agent_id to filters.
-         *
-         * @param agentId The agent identifier
-         * @return This builder
-         */
-        public Builder agentId(String agentId) {
-            if (agentId != null) {
-                this.filters.put("agent_id", agentId);
-            }
-            return this;
-        }
-
-        /**
-         * Sets the user identifier.
-         *
-         * <p>This method sets the userId field and also adds it to filters for v2 API compatibility.
-         *
-         * @param userId The user identifier
-         * @return This builder
-         */
         public Builder userId(String userId) {
             this.userId = userId;
-            if (userId != null) {
-                this.filters.put("user_id", userId);
-            }
             return this;
         }
 
-        /**
-         * Convenience method to add run_id to filters.
-         *
-         * @param runId The run/session identifier
-         * @return This builder
-         */
+        public Builder agentId(String agentId) {
+            this.agentId = agentId;
+            return this;
+        }
+
         public Builder runId(String runId) {
-            if (runId != null) {
-                this.filters.put("run_id", runId);
-            }
+            this.runId = runId;
             return this;
         }
 
-        /**
-         * Convenience method to add app_id to filters.
-         *
-         * @param appId The application identifier
-         * @return This builder
-         */
         public Builder appId(String appId) {
-            if (appId != null) {
-                this.filters.put("app_id", appId);
+            this.appId = appId;
+            return this;
+        }
+
+        public Builder metadata(Map<String, Object> metadata) {
+            if (metadata != null) {
+                this.metadata.putAll(metadata);
             }
             return this;
         }
@@ -294,13 +263,6 @@ public class Mem0SearchRequest {
             return this;
         }
 
-        /**
-         * Convenience method for backward compatibility.
-         *
-         * @param limit Maximum number of results (maps to top_k)
-         * @return This builder
-         * @deprecated Use {@link #topK(Integer)} instead
-         */
         @Deprecated
         public Builder limit(Integer limit) {
             this.topK = limit;
@@ -346,7 +308,6 @@ public class Mem0SearchRequest {
             Mem0SearchRequest request = new Mem0SearchRequest();
             request.setQuery(query);
             request.setVersion(version);
-            request.setFilters(filters);
             request.setTopK(topK);
             request.setFields(fields);
             request.setRerank(rerank);
@@ -355,11 +316,79 @@ public class Mem0SearchRequest {
             request.setThreshold(threshold);
             request.setOrgId(orgId);
             request.setProjectId(projectId);
-            // Set userId after filters to ensure it's synced
-            if (userId != null) {
-                request.setUserId(userId);
-            }
+
+            request.setFilters(buildNestedFilters());
+
             return request;
+        }
+
+        private Map<String, Object> buildNestedFilters() {
+            List<Map<String, Object>> andConditions = new ArrayList<>();
+
+            List<Map<String, Object>> entityFilters = buildEntityFilters();
+            if (!entityFilters.isEmpty()) {
+                Map<String, Object> entityOr = new HashMap<>();
+                entityOr.put("OR", entityFilters);
+                andConditions.add(entityOr);
+            }
+
+            List<Map<String, Object>> metadataFilters = buildMetadataFilters();
+            if (!metadataFilters.isEmpty()) {
+                Map<String, Object> metadataOr = new HashMap<>();
+                metadataOr.put("OR", metadataFilters);
+                andConditions.add(metadataOr);
+            }
+
+            if (andConditions.isEmpty()) {
+                return new HashMap<>();
+            } else if (andConditions.size() == 1) {
+                return andConditions.get(0);
+            } else {
+                Map<String, Object> result = new HashMap<>();
+                result.put("AND", andConditions);
+                return result;
+            }
+        }
+
+        private List<Map<String, Object>> buildEntityFilters() {
+            List<Map<String, Object>> filters = new ArrayList<>();
+
+            if (userId != null && !userId.isEmpty()) {
+                Map<String, Object> filter = new HashMap<>();
+                filter.put("user_id", userId);
+                filters.add(filter);
+            }
+            if (agentId != null && !agentId.isEmpty()) {
+                Map<String, Object> filter = new HashMap<>();
+                filter.put("agent_id", agentId);
+                filters.add(filter);
+            }
+            if (runId != null && !runId.isEmpty()) {
+                Map<String, Object> filter = new HashMap<>();
+                filter.put("run_id", runId);
+                filters.add(filter);
+            }
+            if (appId != null && !appId.isEmpty()) {
+                Map<String, Object> filter = new HashMap<>();
+                filter.put("app_id", appId);
+                filters.add(filter);
+            }
+
+            return filters;
+        }
+
+        private List<Map<String, Object>> buildMetadataFilters() {
+            List<Map<String, Object>> filters = new ArrayList<>();
+
+            for (Map.Entry<String, Object> entry : metadata.entrySet()) {
+                Map<String, Object> metadataFilter = new HashMap<>();
+                Map<String, Object> metadataValue = new HashMap<>();
+                metadataValue.put(entry.getKey(), entry.getValue());
+                metadataFilter.put("metadata", metadataValue);
+                filters.add(metadataFilter);
+            }
+
+            return filters;
         }
     }
 }

--- a/agentscope-extensions/agentscope-extensions-mem0/src/test/java/io/agentscope/core/memory/mem0/Mem0SearchRequestTest.java
+++ b/agentscope-extensions/agentscope-extensions-mem0/src/test/java/io/agentscope/core/memory/mem0/Mem0SearchRequestTest.java
@@ -49,22 +49,17 @@ class Mem0SearchRequestTest {
     }
 
     @Test
-    void testBuilderWithFilters() {
-        Map<String, Object> filters = new HashMap<>();
-        filters.put("category", "personal");
-
-        Mem0SearchRequest request = Mem0SearchRequest.builder().filters(filters).build();
-
-        assertEquals(filters, request.getFilters());
-    }
-
-    @Test
     void testBuilderWithUserIdFilter() {
         Mem0SearchRequest request =
                 Mem0SearchRequest.builder().query("test").userId("user123").build();
 
         assertNotNull(request.getFilters());
-        assertEquals("user123", request.getFilters().get("user_id"));
+        Map<String, Object> filters = request.getFilters();
+        assertTrue(filters.containsKey("OR"));
+        @SuppressWarnings("unchecked")
+        List<Map<String, Object>> orList = (List<Map<String, Object>>) filters.get("OR");
+        assertEquals(1, orList.size());
+        assertEquals("user123", orList.get(0).get("user_id"));
     }
 
     @Test
@@ -73,7 +68,12 @@ class Mem0SearchRequestTest {
                 Mem0SearchRequest.builder().query("test").agentId("agent456").build();
 
         assertNotNull(request.getFilters());
-        assertEquals("agent456", request.getFilters().get("agent_id"));
+        Map<String, Object> filters = request.getFilters();
+        assertTrue(filters.containsKey("OR"));
+        @SuppressWarnings("unchecked")
+        List<Map<String, Object>> orList = (List<Map<String, Object>>) filters.get("OR");
+        assertEquals(1, orList.size());
+        assertEquals("agent456", orList.get(0).get("agent_id"));
     }
 
     @Test
@@ -82,7 +82,12 @@ class Mem0SearchRequestTest {
                 Mem0SearchRequest.builder().query("test").runId("run789").build();
 
         assertNotNull(request.getFilters());
-        assertEquals("run789", request.getFilters().get("run_id"));
+        Map<String, Object> filters = request.getFilters();
+        assertTrue(filters.containsKey("OR"));
+        @SuppressWarnings("unchecked")
+        List<Map<String, Object>> orList = (List<Map<String, Object>>) filters.get("OR");
+        assertEquals(1, orList.size());
+        assertEquals("run789", orList.get(0).get("run_id"));
     }
 
     @Test
@@ -91,11 +96,16 @@ class Mem0SearchRequestTest {
                 Mem0SearchRequest.builder().query("test").appId("app999").build();
 
         assertNotNull(request.getFilters());
-        assertEquals("app999", request.getFilters().get("app_id"));
+        Map<String, Object> filters = request.getFilters();
+        assertTrue(filters.containsKey("OR"));
+        @SuppressWarnings("unchecked")
+        List<Map<String, Object>> orList = (List<Map<String, Object>>) filters.get("OR");
+        assertEquals(1, orList.size());
+        assertEquals("app999", orList.get(0).get("app_id"));
     }
 
     @Test
-    void testBuilderWithMultipleFilters() {
+    void testBuilderWithMultipleEntityFilters() {
         Mem0SearchRequest request =
                 Mem0SearchRequest.builder()
                         .query("test")
@@ -104,9 +114,59 @@ class Mem0SearchRequestTest {
                         .runId("run3")
                         .build();
 
-        assertEquals("user1", request.getFilters().get("user_id"));
-        assertEquals("agent2", request.getFilters().get("agent_id"));
-        assertEquals("run3", request.getFilters().get("run_id"));
+        Map<String, Object> filters = request.getFilters();
+        assertTrue(filters.containsKey("OR"));
+        @SuppressWarnings("unchecked")
+        List<Map<String, Object>> orList = (List<Map<String, Object>>) filters.get("OR");
+        assertEquals(3, orList.size());
+    }
+
+    @Test
+    void testBuilderWithMetadataFilter() {
+        Map<String, Object> metadata = new HashMap<>();
+        metadata.put("category", "personal");
+
+        Mem0SearchRequest request =
+                Mem0SearchRequest.builder().query("test").metadata(metadata).build();
+
+        Map<String, Object> filters = request.getFilters();
+        assertTrue(filters.containsKey("OR"));
+        @SuppressWarnings("unchecked")
+        List<Map<String, Object>> orList = (List<Map<String, Object>>) filters.get("OR");
+        assertEquals(1, orList.size());
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> metadataFilter = (Map<String, Object>) orList.get(0).get("metadata");
+        assertEquals("personal", metadataFilter.get("category"));
+    }
+
+    @Test
+    void testBuilderWithEntityAndMetadataFilters() {
+        Map<String, Object> metadata = new HashMap<>();
+        metadata.put("category", "travel");
+        metadata.put("priority", "high");
+
+        Mem0SearchRequest request =
+                Mem0SearchRequest.builder()
+                        .query("test")
+                        .userId("user1")
+                        .agentId("agent2")
+                        .metadata(metadata)
+                        .build();
+
+        Map<String, Object> filters = request.getFilters();
+        assertTrue(filters.containsKey("AND"));
+        @SuppressWarnings("unchecked")
+        List<Map<String, Object>> andList = (List<Map<String, Object>>) filters.get("AND");
+        assertEquals(2, andList.size());
+
+        @SuppressWarnings("unchecked")
+        List<Map<String, Object>> entityOr = (List<Map<String, Object>>) andList.get(0).get("OR");
+        assertEquals(2, entityOr.size());
+
+        @SuppressWarnings("unchecked")
+        List<Map<String, Object>> metadataOr = (List<Map<String, Object>>) andList.get(1).get("OR");
+        assertEquals(2, metadataOr.size());
     }
 
     @Test
@@ -184,7 +244,7 @@ class Mem0SearchRequestTest {
         request.setTopK(15);
 
         Map<String, Object> filters = new HashMap<>();
-        filters.put("user_id", "user123");
+        filters.put("OR", List.of(Map.of("user_id", "user123")));
         request.setFilters(filters);
 
         assertEquals("test query", request.getQuery());
@@ -212,6 +272,7 @@ class Mem0SearchRequestTest {
         assertTrue(json.contains("\"filters\""));
         assertTrue(json.contains("\"top_k\""));
         assertTrue(json.contains("\"threshold\""));
+        assertTrue(json.contains("\"OR\""));
     }
 
     @Test
@@ -220,7 +281,7 @@ class Mem0SearchRequestTest {
                 "{"
                         + "\"query\":\"test\","
                         + "\"version\":\"v2\","
-                        + "\"filters\":{\"user_id\":\"user123\"},"
+                        + "\"filters\":{\"OR\":[{\"user_id\":\"user123\"}]},"
                         + "\"top_k\":10,"
                         + "\"threshold\":0.5"
                         + "}";
@@ -233,7 +294,7 @@ class Mem0SearchRequestTest {
         assertEquals("v2", request.getVersion());
         assertEquals(10, request.getTopK());
         assertEquals(0.5, request.getThreshold());
-        assertEquals("user123", request.getFilters().get("user_id"));
+        assertTrue(request.getFilters().containsKey("OR"));
     }
 
     @Test
@@ -255,13 +316,11 @@ class Mem0SearchRequestTest {
         assertEquals(original.getVersion(), deserialized.getVersion());
         assertEquals(original.getTopK(), deserialized.getTopK());
         assertEquals(original.getThreshold(), deserialized.getThreshold());
-        assertEquals(
-                original.getFilters().get("user_id"), deserialized.getFilters().get("user_id"));
+        assertNotNull(deserialized.getFilters());
     }
 
     @Test
     void testFiltersAlwaysIncluded() throws Exception {
-        // Filters should always be included in JSON, even if empty
         Mem0SearchRequest request = Mem0SearchRequest.builder().query("test").build();
 
         String json = JsonUtils.getJsonCodec().toJson(request);
@@ -275,7 +334,6 @@ class Mem0SearchRequestTest {
 
         String json = JsonUtils.getJsonCodec().toJson(request);
 
-        // Null optional fields should be excluded
         assertFalse(json.contains("\"fields\""));
         assertFalse(json.contains("\"rerank\""));
         assertFalse(json.contains("\"keyword_search\""));
@@ -286,7 +344,6 @@ class Mem0SearchRequestTest {
         Mem0SearchRequest request = new Mem0SearchRequest();
         request.setFilters(null);
 
-        // Should be replaced with empty map
         assertNotNull(request.getFilters());
         assertTrue(request.getFilters().isEmpty());
     }
@@ -301,9 +358,37 @@ class Mem0SearchRequestTest {
                         .runId(null)
                         .build();
 
-        // Only non-null filters should be added
-        assertFalse(request.getFilters().containsKey("user_id"));
-        assertTrue(request.getFilters().containsKey("agent_id"));
-        assertFalse(request.getFilters().containsKey("run_id"));
+        Map<String, Object> filters = request.getFilters();
+        assertTrue(filters.containsKey("OR"));
+        @SuppressWarnings("unchecked")
+        List<Map<String, Object>> orList = (List<Map<String, Object>>) filters.get("OR");
+        assertEquals(1, orList.size());
+        assertTrue(orList.get(0).containsKey("agent_id"));
+    }
+
+    @Test
+    void testNestedFilterStructure() throws Exception {
+        Map<String, Object> metadata = new HashMap<>();
+        metadata.put("level", "pro");
+        metadata.put("region", "cn");
+
+        Mem0SearchRequest request =
+                Mem0SearchRequest.builder()
+                        .query("test query")
+                        .userId("user123")
+                        .agentId("SmartAssistant")
+                        .metadata(metadata)
+                        .topK(5)
+                        .build();
+
+        String json = JsonUtils.getJsonCodec().toJson(request);
+
+        assertTrue(json.contains("\"AND\""));
+        assertTrue(json.contains("\"OR\""));
+        assertTrue(json.contains("\"user_id\""));
+        assertTrue(json.contains("\"agent_id\""));
+        assertTrue(json.contains("\"metadata\""));
+        assertTrue(json.contains("\"level\""));
+        assertTrue(json.contains("\"region\""));
     }
 }


### PR DESCRIPTION
related issue 
#1224 

Fix the bug where Mem0 search requests fail to retrieve stored memories due to incorrect filter structure.

Root cause:
- The buildNestedFilters() method in Mem0SearchRequest generates an incorrect filter format when both entity filters (userId/agentId/runId) and metadata filters are present
- The original code incorrectly placed all conditions in a single OR level instead of the proper nested AND/OR structure required by Mem0 v2 API

Changes:
- Refactor buildNestedFilters() to correctly build the nested filter structure: {AND: [{OR: entityFilters}, {OR: metadataFilters}]}
- Add logging for debugging search failures
- Add unit tests for various filter combination scenarios

Affected files:
- Mem0SearchRequest
- Mem0LongTermMemory

## AgentScope-Java Version

[The version of AgentScope-Java you are working on, e.g. 1.0.11, check your pom.xml dependency version or run `mvn dependency:tree | grep agentscope-parent:pom`(only mac/linux)]

## Description

[Please describe the background, purpose, changes made, and how to test this PR]

## Checklist

Please check the following items before code is ready to be reviewed.

- [ ]  Code has been formatted with `mvn spotless:apply`
- [ ]  All tests are passing (`mvn test`)
- [ ]  Javadoc comments are complete and follow project conventions
- [ ]  Related documentation has been updated (e.g. links, examples, etc.)
- [ ]  Code is ready for review
