### PR TITLE
fix(core): handle pending tool calls when maxIters reached (#1005)

### DIFF
--- a/agentscope-core/src/main/java/io/agentscope/core/ReActAgent.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/ReActAgent.java
@@ -728,6 +728,37 @@ public class ReActAgent extends StructuredOutputCapableAgent {
     protected Mono<Msg> summarizing() {
         log.debug("Maximum iterations reached. Generating summary...");
 
+        // Handle pending tool calls that were not completed before max iterations
+        if (hasPendingToolUse()) {
+            List<ToolUseBlock> pendingTools = extractPendingToolCalls();
+            log.warn(
+                    "Max iterations reached with {} pending tool calls. Adding error results.",
+                    pendingTools.size());
+
+            for (ToolUseBlock toolUse : pendingTools) {
+                ToolResultBlock errorResult =
+                        ToolResultBlock.builder()
+                                .id(toolUse.getId())
+                                .output(
+                                        TextBlock.builder()
+                                                .text(
+                                                        "Error: Tool execution cancelled because maximum"
+                                                                + " iterations limit ("
+                                                                + maxIters
+                                                                + ") was reached")
+                                                .build())
+                                .build();
+
+                Msg errorResultMsg =
+                        Msg.builder()
+                                .name(getName())
+                                .role(MsgRole.ASSISTANT)
+                                .content(errorResult)
+                                .build();
+                memory.addMessage(errorResultMsg);
+            }
+        }
+
         List<Msg> messageList = prepareSummaryMessages();
         GenerateOptions generateOptions = buildGenerateOptions();
 

--- a/agentscope-core/src/main/java/io/agentscope/core/ReActAgent.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/ReActAgent.java
@@ -737,24 +737,15 @@ public class ReActAgent extends StructuredOutputCapableAgent {
 
             for (ToolUseBlock toolUse : pendingTools) {
                 ToolResultBlock errorResult =
-                        ToolResultBlock.builder()
-                                .id(toolUse.getId())
-                                .output(
-                                        TextBlock.builder()
-                                                .text(
-                                                        "Error: Tool execution cancelled because"
-                                                                + " maximum iterations limit ("
-                                                                + maxIters
-                                                                + ") was reached")
-                                                .build())
-                                .build();
+                        buildErrorToolResult(
+                                toolUse.getId(),
+                                "Tool execution cancelled because maximum iterations limit ("
+                                        + maxIters
+                                        + ") was reached");
 
                 Msg errorResultMsg =
-                        Msg.builder()
-                                .name(getName())
-                                .role(MsgRole.ASSISTANT)
-                                .content(errorResult)
-                                .build();
+                        ToolResultMessageBuilder.buildToolResultMsg(
+                                errorResult, toolUse, getName());
                 memory.addMessage(errorResultMsg);
             }
         }

--- a/agentscope-core/src/main/java/io/agentscope/core/ReActAgent.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/ReActAgent.java
@@ -742,8 +742,8 @@ public class ReActAgent extends StructuredOutputCapableAgent {
                                 .output(
                                         TextBlock.builder()
                                                 .text(
-                                                        "Error: Tool execution cancelled because maximum"
-                                                                + " iterations limit ("
+                                                        "Error: Tool execution cancelled because"
+                                                                + " maximum iterations limit ("
                                                                 + maxIters
                                                                 + ") was reached")
                                                 .build())

--- a/agentscope-core/src/test/java/io/agentscope/core/agent/ReActAgentSummarizingTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/agent/ReActAgentSummarizingTest.java
@@ -28,6 +28,7 @@ import io.agentscope.core.memory.InMemoryMemory;
 import io.agentscope.core.message.Msg;
 import io.agentscope.core.message.MsgRole;
 import io.agentscope.core.message.TextBlock;
+import io.agentscope.core.message.ToolResultBlock;
 import io.agentscope.core.message.ToolUseBlock;
 import io.agentscope.core.model.ChatResponse;
 import io.agentscope.core.model.ChatUsage;
@@ -396,5 +397,160 @@ class ReActAgentSummarizingTest {
         assertEquals(response, lastMessage, "Last message in memory should be the summary");
         assertEquals(
                 MsgRole.ASSISTANT, lastMessage.getRole(), "Summary message should be ASSISTANT");
+    }
+
+    @Test
+    @DisplayName("Should handle second call after maxIters with pending tool calls - Issue #1005")
+    void testSecondCallAfterMaxItersWithPendingToolCalls() {
+        // This test reproduces the bug reported in Issue #1005:
+        // 1. User has multi-round conversation with tool call
+        // 2. Tool doesn't respond (or times out), leaving pending tool calls
+        // 3. maxIters is reached, session auto-ends
+        // 4. User sends new message -> Should NOT throw IllegalStateException
+
+        InMemoryMemory memory = new InMemoryMemory();
+        final String toolId = "call_638e428da2cf48ceb8b05762";
+
+        // Mock model that returns a tool call on first call, then summary
+        final int[] callCount = {0};
+        MockModel mockModel =
+                new MockModel(
+                        messages -> {
+                            int callNum = callCount[0]++;
+                            if (callNum == 0) {
+                                // First call: return tool use block (simulating tool call)
+                                return List.of(
+                                        ChatResponse.builder()
+                                                .id("msg_0")
+                                                .content(
+                                                        List.of(
+                                                                ToolUseBlock.builder()
+                                                                        .name("search_tool")
+                                                                        .id(toolId)
+                                                                        .input(Map.of("query", "test"))
+                                                                        .build()))
+                                                .usage(new ChatUsage(10, 20, 30))
+                                                .build());
+                            } else {
+                                // Second call: summarizing (because maxIters=1 reached)
+                                return List.of(
+                                        ChatResponse.builder()
+                                                .id("msg_summary")
+                                                .content(
+                                                        List.of(
+                                                                TextBlock.builder()
+                                                                        .text(
+                                                                                "I reached the maximum"
+                                                                                    + " iteration limit."
+                                                                                    + " Please try again.")
+                                                                        .build()))
+                                                .usage(new ChatUsage(10, 20, 30))
+                                                .build());
+                            }
+                        });
+
+        MockToolkit mockToolkit = new MockToolkit();
+
+        // Create agent with maxIters=1 to quickly trigger summarizing
+        ReActAgent agent =
+                ReActAgent.builder()
+                        .name("TestAgent")
+                        .sysPrompt("You are a helpful assistant.")
+                        .model(mockModel)
+                        .toolkit(mockToolkit)
+                        .memory(memory)
+                        .maxIters(1)
+                        .build();
+
+        // First user message - triggers tool call and maxIters summarizing
+        Msg firstUserMsg = TestUtils.createUserMessage("User", "Please search for something");
+        Msg firstResponse =
+                agent.call(firstUserMsg)
+                        .block(Duration.ofMillis(TestConstants.DEFAULT_TEST_TIMEOUT_MS));
+
+        // Verify first response
+        assertNotNull(firstResponse, "First response should not be null");
+        assertEquals(MsgRole.ASSISTANT, firstResponse.getRole());
+
+        // CRITICAL: Verify that the pending tool call has been resolved in memory
+        // Before the fix, memory would have pending tool calls without results
+        // After the fix, summarizing() should add error results for pending tools
+        List<Msg> memoryMessages = memory.getMessages();
+
+        // Find if there's a tool result message for the pending tool
+        boolean hasToolResultForPendingTool =
+                memoryMessages.stream()
+                        .flatMap(m -> m.getContentBlocks(ToolResultBlock.class).stream())
+                        .anyMatch(tr -> tr.getId() != null && tr.getId().equals(toolId));
+
+        assertTrue(
+                hasToolResultForPendingTool,
+                "Memory should contain error result for pending tool call after summarizing");
+
+        // Verify the tool result indicates cancellation due to max iterations
+        ToolResultBlock toolResult =
+                memoryMessages.stream()
+                        .flatMap(m -> m.getContentBlocks(ToolResultBlock.class).stream())
+                        .filter(tr -> tr.getId() != null && tr.getId().equals(toolId))
+                        .findFirst()
+                        .orElse(null);
+
+        // Tool result should be present (either from toolkit or from summarizing fix)
+        assertNotNull(toolResult);
+
+        // SECOND CALL - This is the critical test for Issue #1005
+        // Before the fix, this would throw:
+        // IllegalStateException: Cannot add messages without tool results when pending tool calls exist
+
+        // Reset model for second user interaction
+        final int[] secondCallCount = {0};
+        MockModel secondMockModel =
+                new MockModel(
+                        messages -> {
+                            int callNum = secondCallCount[0]++;
+                            if (callNum == 0) {
+                                return List.of(
+                                        ChatResponse.builder()
+                                                .id("msg_second_0")
+                                                .content(
+                                                        List.of(
+                                                                TextBlock.builder()
+                                                                        .text(
+                                                                                "Hello! How can I help"
+                                                                                    + " you today?")
+                                                                        .build()))
+                                                .usage(new ChatUsage(5, 10, 15))
+                                                .build());
+                            }
+                            return List.of();
+                        });
+
+        ReActAgent secondAgent =
+                ReActAgent.builder()
+                        .name("TestAgent")
+                        .sysPrompt("You are a helpful assistant.")
+                        .model(secondMockModel)
+                        .toolkit(mockToolkit)
+                        .memory(memory) // Same memory
+                        .maxIters(2)
+                        .build();
+
+        // Second user message - this would throw IllegalStateException before the fix
+        Msg secondUserMsg = TestUtils.createUserMessage("User", "Hello again");
+
+        // This should NOT throw: "Cannot add messages without tool results when pending tool calls exist"
+        Msg secondResponse =
+                secondAgent.call(secondUserMsg)
+                        .block(Duration.ofMillis(TestConstants.DEFAULT_TEST_TIMEOUT_MS));
+
+        // Verify second response succeeded
+        assertNotNull(secondResponse, "Second response should not be null");
+        assertEquals(MsgRole.ASSISTANT, secondResponse.getRole());
+        assertTrue(
+                secondResponse.getFirstContentBlock() instanceof TextBlock,
+                "Second response should contain TextBlock");
+
+        TextBlock secondText = (TextBlock) secondResponse.getFirstContentBlock();
+        assertEquals("Hello! How can I help you today?", secondText.getText());
     }
 }

--- a/agentscope-core/src/test/java/io/agentscope/core/agent/ReActAgentSummarizingTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/agent/ReActAgentSummarizingTest.java
@@ -427,7 +427,10 @@ class ReActAgentSummarizingTest {
                                                                 ToolUseBlock.builder()
                                                                         .name("search_tool")
                                                                         .id(toolId)
-                                                                        .input(Map.of("query", "test"))
+                                                                        .input(
+                                                                                Map.of(
+                                                                                        "query",
+                                                                                        "test"))
                                                                         .build()))
                                                 .usage(new ChatUsage(10, 20, 30))
                                                 .build());
@@ -440,9 +443,12 @@ class ReActAgentSummarizingTest {
                                                         List.of(
                                                                 TextBlock.builder()
                                                                         .text(
-                                                                                "I reached the maximum"
-                                                                                    + " iteration limit."
-                                                                                    + " Please try again.")
+                                                                                "I reached the"
+                                                                                    + " maximum"
+                                                                                    + " iteration"
+                                                                                    + " limit."
+                                                                                    + " Please try"
+                                                                                    + " again.")
                                                                         .build()))
                                                 .usage(new ChatUsage(10, 20, 30))
                                                 .build());
@@ -500,7 +506,8 @@ class ReActAgentSummarizingTest {
 
         // SECOND CALL - This is the critical test for Issue #1005
         // Before the fix, this would throw:
-        // IllegalStateException: Cannot add messages without tool results when pending tool calls exist
+        // IllegalStateException: Cannot add messages without tool results when pending tool calls
+        // exist
 
         // Reset model for second user interaction
         final int[] secondCallCount = {0};
@@ -516,8 +523,9 @@ class ReActAgentSummarizingTest {
                                                         List.of(
                                                                 TextBlock.builder()
                                                                         .text(
-                                                                                "Hello! How can I help"
-                                                                                    + " you today?")
+                                                                                "Hello! How can I"
+                                                                                    + " help you"
+                                                                                    + " today?")
                                                                         .build()))
                                                 .usage(new ChatUsage(5, 10, 15))
                                                 .build());
@@ -538,9 +546,11 @@ class ReActAgentSummarizingTest {
         // Second user message - this would throw IllegalStateException before the fix
         Msg secondUserMsg = TestUtils.createUserMessage("User", "Hello again");
 
-        // This should NOT throw: "Cannot add messages without tool results when pending tool calls exist"
+        // This should NOT throw: "Cannot add messages without tool results when pending tool calls
+        // exist"
         Msg secondResponse =
-                secondAgent.call(secondUserMsg)
+                secondAgent
+                        .call(secondUserMsg)
                         .block(Duration.ofMillis(TestConstants.DEFAULT_TEST_TIMEOUT_MS));
 
         // Verify second response succeeded

--- a/agentscope-core/src/test/java/io/agentscope/core/agent/ReActAgentSummarizingTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/agent/ReActAgentSummarizingTest.java
@@ -32,6 +32,7 @@ import io.agentscope.core.message.ToolResultBlock;
 import io.agentscope.core.message.ToolUseBlock;
 import io.agentscope.core.model.ChatResponse;
 import io.agentscope.core.model.ChatUsage;
+import java.lang.reflect.Method;
 import java.time.Duration;
 import java.util.List;
 import java.util.Map;
@@ -493,6 +494,24 @@ class ReActAgentSummarizingTest {
                 hasToolResultForPendingTool,
                 "Memory should contain error result for pending tool call after summarizing");
 
+        Msg pendingToolResultMsg =
+                memoryMessages.stream()
+                        .filter(
+                                m ->
+                                        m.getContentBlocks(ToolResultBlock.class).stream()
+                                                .anyMatch(
+                                                        tr ->
+                                                                tr.getId() != null
+                                                                        && tr.getId()
+                                                                                .equals(toolId)))
+                        .findFirst()
+                        .orElse(null);
+        assertNotNull(pendingToolResultMsg, "Pending tool call should have a result message");
+        assertEquals(
+                MsgRole.TOOL,
+                pendingToolResultMsg.getRole(),
+                "Pending tool error result should be stored as TOOL message");
+
         // Verify the tool result indicates cancellation due to max iterations
         ToolResultBlock toolResult =
                 memoryMessages.stream()
@@ -562,5 +581,137 @@ class ReActAgentSummarizingTest {
 
         TextBlock secondText = (TextBlock) secondResponse.getFirstContentBlock();
         assertEquals("Hello! How can I help you today?", secondText.getText());
+    }
+
+    @Test
+    @DisplayName("Should add exactly one TOOL result for each pending tool during summarizing")
+    void testSummarizingAddsOneToolResultPerPendingTool() {
+        InMemoryMemory memory = new InMemoryMemory();
+        final String toolId1 = "call_pending_1";
+        final String toolId2 = "call_pending_2";
+
+        Msg pendingAssistantMsg =
+                Msg.builder()
+                        .name("TestAgent")
+                        .role(MsgRole.ASSISTANT)
+                        .content(
+                                List.of(
+                                        ToolUseBlock.builder()
+                                                .name("search_tool")
+                                                .id(toolId1)
+                                                .input(Map.of("query", "weather"))
+                                                .build(),
+                                        ToolUseBlock.builder()
+                                                .name("search_tool")
+                                                .id(toolId2)
+                                                .input(Map.of("query", "news"))
+                                                .build()))
+                        .build();
+        memory.addMessage(pendingAssistantMsg);
+
+        MockModel mockModel =
+                new MockModel(
+                        messages ->
+                                List.of(
+                                        ChatResponse.builder()
+                                                .id("msg_summary")
+                                                .content(
+                                                        List.of(
+                                                                TextBlock.builder()
+                                                                        .text(
+                                                                                "Iteration limit"
+                                                                                    + " reached.")
+                                                                        .build()))
+                                                .usage(new ChatUsage(10, 20, 30))
+                                                .build()));
+
+        MockToolkit mockToolkit = new MockToolkit();
+        ReActAgent agent =
+                ReActAgent.builder()
+                        .name("TestAgent")
+                        .sysPrompt("You are a helpful assistant.")
+                        .model(mockModel)
+                        .toolkit(mockToolkit)
+                        .memory(memory)
+                        .maxIters(1)
+                        .build();
+
+        Msg summaryResponse = invokeSummarizing(agent);
+        assertNotNull(summaryResponse, "Summary response should not be null");
+
+        List<Msg> memoryMessages = memory.getMessages();
+
+        long toolId1ToolRoleCount =
+                memoryMessages.stream()
+                        .filter(m -> m.getRole() == MsgRole.TOOL)
+                        .filter(
+                                m ->
+                                        m.getContentBlocks(ToolResultBlock.class).stream()
+                                                .anyMatch(
+                                                        tr ->
+                                                                tr.getId() != null
+                                                                        && tr.getId()
+                                                                                .equals(toolId1)))
+                        .count();
+        long toolId2ToolRoleCount =
+                memoryMessages.stream()
+                        .filter(m -> m.getRole() == MsgRole.TOOL)
+                        .filter(
+                                m ->
+                                        m.getContentBlocks(ToolResultBlock.class).stream()
+                                                .anyMatch(
+                                                        tr ->
+                                                                tr.getId() != null
+                                                                        && tr.getId()
+                                                                                .equals(toolId2)))
+                        .count();
+
+        assertEquals(
+                1L, toolId1ToolRoleCount, "toolId1 should have exactly one TOOL result message");
+        assertEquals(
+                1L, toolId2ToolRoleCount, "toolId2 should have exactly one TOOL result message");
+
+        long toolId1NonToolRoleCount =
+                memoryMessages.stream()
+                        .filter(m -> m.getRole() != MsgRole.TOOL)
+                        .filter(
+                                m ->
+                                        m.getContentBlocks(ToolResultBlock.class).stream()
+                                                .anyMatch(
+                                                        tr ->
+                                                                tr.getId() != null
+                                                                        && tr.getId()
+                                                                                .equals(toolId1)))
+                        .count();
+        long toolId2NonToolRoleCount =
+                memoryMessages.stream()
+                        .filter(m -> m.getRole() != MsgRole.TOOL)
+                        .filter(
+                                m ->
+                                        m.getContentBlocks(ToolResultBlock.class).stream()
+                                                .anyMatch(
+                                                        tr ->
+                                                                tr.getId() != null
+                                                                        && tr.getId()
+                                                                                .equals(toolId2)))
+                        .count();
+
+        assertEquals(
+                0L, toolId1NonToolRoleCount, "toolId1 should not have non-TOOL result messages");
+        assertEquals(
+                0L, toolId2NonToolRoleCount, "toolId2 should not have non-TOOL result messages");
+    }
+
+    private static Msg invokeSummarizing(ReActAgent agent) {
+        try {
+            Method method = ReActAgent.class.getDeclaredMethod("summarizing");
+            method.setAccessible(true);
+            @SuppressWarnings("unchecked")
+            reactor.core.publisher.Mono<Msg> mono =
+                    (reactor.core.publisher.Mono<Msg>) method.invoke(agent);
+            return mono.block(Duration.ofMillis(TestConstants.DEFAULT_TEST_TIMEOUT_MS));
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to invoke summarizing()", e);
+        }
     }
 }


### PR DESCRIPTION
## AgentScope-Java Version

io.agentscope:agentscope-parent:pom:1.0.12-SNAPSHOT

## Description

Closes #1005 

This PR fixes a session-state consistency bug in ReActAgent when maxIters is reached with pending tool calls.
What was wrong:
- If an iteration ended at maxIters while there were unresolved ToolUseBlocks, the agent could leave memory with tool_use entries but no matching tool_result.
- On the next user turn, validation throw failed.

## Checklist

Please check the following items before code is ready to be reviewed.

- [x]  Code has been formatted with `mvn spotless:apply`
- [x]  All tests are passing (`mvn test`)
- [ ]  Javadoc comments are complete and follow project conventions
- [ ]  Related documentation has been updated (e.g. links, examples, etc.)
- [x]  Code is ready for review
