### PR TITLE
fix(core): Merge multiple system messages and set it as the first beginning message

### DIFF
--- a/agentscope-core/src/main/java/io/agentscope/core/ReActAgent.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/ReActAgent.java
@@ -78,6 +78,7 @@ import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -820,15 +821,33 @@ public class ReActAgent extends StructuredOutputCapableAgent {
      */
     private List<Msg> prepareMessages() {
         List<Msg> messages = new ArrayList<>();
-        if (sysPrompt != null && !sysPrompt.trim().isEmpty()) {
+        StringBuilder sysPromptBuilder = new StringBuilder();
+        if (sysPrompt != null && !sysPrompt.isBlank()) {
+            sysPromptBuilder.append(sysPrompt);
+        }
+        List<Msg> nonSystemMessages = new ArrayList<>();
+        memory.getMessages().stream()
+                .filter(Objects::nonNull)
+                .forEach(
+                        msg -> {
+                            if (msg.getRole() == MsgRole.SYSTEM) {
+                                if (!sysPromptBuilder.isEmpty()) {
+                                    sysPromptBuilder.append("\n");
+                                }
+                                sysPromptBuilder.append(msg.getTextContent());
+                            } else {
+                                nonSystemMessages.add(msg);
+                            }
+                        });
+        if (!sysPromptBuilder.isEmpty()) {
             messages.add(
                     Msg.builder()
                             .name("system")
                             .role(MsgRole.SYSTEM)
-                            .content(TextBlock.builder().text(sysPrompt).build())
+                            .content(TextBlock.builder().text(sysPromptBuilder.toString()).build())
                             .build());
         }
-        messages.addAll(memory.getMessages());
+        messages.addAll(nonSystemMessages);
         return messages;
     }
 

--- a/agentscope-core/src/main/java/io/agentscope/core/memory/StaticLongTermMemoryHook.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/memory/StaticLongTermMemoryHook.java
@@ -116,13 +116,15 @@ public class StaticLongTermMemoryHook implements Hook {
     }
 
     /**
-     * Handles PreReasoningEvent by retrieving relevant memories and injecting them.
+     * Handles PreCallEvent by retrieving relevant memories and injecting them.
      *
-     * <p>Retrieves memories relevant to the user's query and injects them as a system
-     * message at the beginning of the message list. The memories are wrapped in
-     * {@code <long_term_memory>} tags for clear identification.
+     * <p>Retrieves memories relevant to the user's query and injects them as part of
+     * the system message. If a system message already exists at the beginning of the
+     * message list, the memories are appended to it. Otherwise, a new system message
+     * is created with the memories. The memories are wrapped in {@code <long_term_memory>}
+     * tags for clear identification.
      *
-     * @param event the PreReasoningEvent
+     * @param event the PreCallEvent
      * @return Mono containing the potentially modified event
      */
     private Mono<PreCallEvent> handlePreCall(PreCallEvent event) {
@@ -144,20 +146,43 @@ public class StaticLongTermMemoryHook implements Hook {
                         memoryText -> {
                             // Wrap memory content in tags
                             String wrappedMemory = wrap(memoryText);
-
-                            // Create system message with retrieved memories
-                            Msg memoryMsg =
-                                    Msg.builder()
-                                            .role(MsgRole.SYSTEM)
-                                            .name("long_term_memory")
-                                            .content(
-                                                    TextBlock.builder().text(wrappedMemory).build())
-                                            .build();
-
-                            // Inject memory message at the beginning
                             List<Msg> enhancedMessages = new ArrayList<>();
-                            enhancedMessages.addAll(inputMessages);
-                            enhancedMessages.add(memoryMsg);
+
+                            if (!inputMessages.isEmpty()
+                                    && inputMessages.get(0).getRole() == MsgRole.SYSTEM) {
+                                Msg originalSystemMsg = inputMessages.get(0);
+                                String originalSystemText = originalSystemMsg.getTextContent();
+                                String newSystemText =
+                                        originalSystemText != null
+                                                ? originalSystemText + "\n\n" + wrappedMemory
+                                                : wrappedMemory;
+
+                                Msg newSystemMsg =
+                                        originalSystemMsg
+                                                .mutate()
+                                                .content(
+                                                        TextBlock.builder()
+                                                                .text(newSystemText)
+                                                                .build())
+                                                .build();
+
+                                enhancedMessages.add(newSystemMsg);
+                                enhancedMessages.addAll(
+                                        inputMessages.subList(1, inputMessages.size()));
+                            } else {
+                                enhancedMessages.add(
+                                        Msg.builder()
+                                                .role(MsgRole.SYSTEM)
+                                                .name("long_term_memory")
+                                                .content(
+                                                        TextBlock.builder()
+                                                                .text(wrappedMemory)
+                                                                .build())
+                                                .build());
+
+                                enhancedMessages.addAll(inputMessages);
+                            }
+
                             event.setInputMessages(enhancedMessages);
 
                             return Mono.just(event);

--- a/agentscope-core/src/main/java/io/agentscope/core/message/Msg.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/message/Msg.java
@@ -110,6 +110,15 @@ public class Msg implements State {
     }
 
     /**
+     * Mutate a new message builder with the fields of the current message.
+     *
+     * @return A new builder instance
+     */
+    public Builder mutate() {
+        return new Builder(this);
+    }
+
+    /**
      * Creates a new message builder with a randomly generated ID.
      *
      * @return A new builder instance
@@ -516,6 +525,20 @@ public class Msg implements State {
          */
         public Builder() {
             randomId();
+        }
+
+        /**
+         * Creates a new builder based on the given message.
+         *
+         * @param msg The message to copy
+         */
+        public Builder(Msg msg) {
+            this.id = msg.id;
+            this.name = msg.name;
+            this.role = msg.role;
+            this.content = msg.content;
+            this.metadata = msg.metadata;
+            this.timestamp = msg.timestamp;
         }
 
         /**

--- a/agentscope-core/src/test/java/io/agentscope/core/agent/ReActAgentTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/agent/ReActAgentTest.java
@@ -19,6 +19,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -524,6 +525,36 @@ class ReActAgentTest {
                 allMessages.stream()
                         .anyMatch(m -> TestUtils.extractTextContent(m).contains("Second message")),
                 "Second message should be in memory");
+    }
+
+    @Test
+    @DisplayName("Should merge multiple system messages in memory")
+    void testMergeMultipleSystemMemoryMessages() {
+        Msg sysMsg1 = TestUtils.createSystemMessage("System", "First system message");
+        Msg sysMsg2 = TestUtils.createSystemMessage("System", "Second system message");
+        Msg userMsg1 = TestUtils.createUserMessage("User", "First user message");
+        Msg userMsg2 = TestUtils.createUserMessage("User", "Second user message");
+
+        agent.call(List.of(userMsg1, userMsg2, sysMsg1, sysMsg2))
+                .block(Duration.ofMillis(TestConstants.DEFAULT_TEST_TIMEOUT_MS));
+
+        List<Msg> messages = mockModel.getLastMessages();
+        assertEquals(3, messages.size(), "Memory should contain multiple messages");
+        assertSame(MsgRole.SYSTEM, messages.get(0).getRole(), "The First should be system message");
+        assertSame(MsgRole.USER, messages.get(1).getRole(), "The Second should be user message");
+        assertSame(MsgRole.USER, messages.get(2).getRole(), "The Third should be user message");
+        assertTrue(
+                TestUtils.extractTextContent(messages.get(0)).contains("First system message"),
+                "First system message should be merged");
+        assertTrue(
+                TestUtils.extractTextContent(messages.get(0)).contains("Second system message"),
+                "Second system message should be merged");
+        assertTrue(
+                TestUtils.extractTextContent(messages.get(1)).contains("First user message"),
+                "First user message should exists");
+        assertTrue(
+                TestUtils.extractTextContent(messages.get(2)).contains("Second user message"),
+                "Second user message should exists");
     }
 
     @Test

--- a/agentscope-core/src/test/java/io/agentscope/core/agent/test/TestUtils.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/agent/test/TestUtils.java
@@ -33,6 +33,17 @@ import java.util.stream.Collectors;
 public class TestUtils {
 
     /**
+     * Create a simple system message with text content.
+     */
+    public static Msg createSystemMessage(String name, String text) {
+        return Msg.builder()
+                .name(name)
+                .role(MsgRole.SYSTEM)
+                .content(TextBlock.builder().text(text).build())
+                .build();
+    }
+
+    /**
      * Create a simple user message with text content.
      */
     public static Msg createUserMessage(String name, String text) {

--- a/agentscope-core/src/test/java/io/agentscope/core/memory/StaticLongTermMemoryHookTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/memory/StaticLongTermMemoryHookTest.java
@@ -131,28 +131,108 @@ class StaticLongTermMemoryHookTest {
         PreCallEvent event = new PreCallEvent(mockAgent, inputMessages);
 
         when(mockLongTermMemory.retrieve(any(Msg.class)))
-                .thenReturn(Mono.just("User prefers dark mode"));
+                .thenReturn(Mono.just("Your name is Mike"));
 
         StepVerifier.create(hook.onEvent(event))
                 .assertNext(
                         resultEvent -> {
                             List<Msg> messages = resultEvent.getInputMessages();
                             assertEquals(2, messages.size());
-                            assertEquals(MsgRole.SYSTEM, messages.get(1).getRole());
+                            assertEquals(MsgRole.SYSTEM, messages.get(0).getRole());
+                            assertEquals(MsgRole.USER, messages.get(1).getRole());
                             assertTrue(
-                                    messages.get(1)
+                                    messages.get(0)
                                             .getTextContent()
                                             .contains("<long_term_memory>"));
                             assertTrue(
-                                    messages.get(1)
-                                            .getTextContent()
-                                            .contains("User prefers dark mode"));
+                                    messages.get(0).getTextContent().contains("Your name is Mike"));
                         })
                 .verifyComplete();
     }
 
     @Test
-    void testOnEventWithPreReasoningEventEmptyRetrieval() {
+    void testOnEventWithPreReasoningEventAndExistingSystemMessage() {
+        List<Msg> inputMessages = new ArrayList<>();
+        inputMessages.add(
+                Msg.builder()
+                        .role(MsgRole.SYSTEM)
+                        .name("system")
+                        .content(TextBlock.builder().text("You are a helpful assistant.").build())
+                        .build());
+        inputMessages.add(
+                Msg.builder()
+                        .role(MsgRole.USER)
+                        .content(TextBlock.builder().text("What do you know about me?").build())
+                        .build());
+
+        PreCallEvent event = new PreCallEvent(mockAgent, inputMessages);
+
+        when(mockLongTermMemory.retrieve(any(Msg.class)))
+                .thenReturn(Mono.just("Your name is Mike"));
+
+        StepVerifier.create(hook.onEvent(event))
+                .assertNext(
+                        resultEvent -> {
+                            List<Msg> messages = resultEvent.getInputMessages();
+                            assertEquals(2, messages.size());
+                            assertEquals(MsgRole.SYSTEM, messages.get(0).getRole());
+                            assertEquals(MsgRole.USER, messages.get(1).getRole());
+                            String systemText = messages.get(0).getTextContent();
+                            assertTrue(systemText.contains("You are a helpful assistant."));
+                            assertTrue(systemText.contains("<long_term_memory>"));
+                            assertTrue(systemText.contains("Your name is Mike"));
+                            assertTrue(
+                                    systemText.indexOf("You are a helpful assistant.")
+                                            < systemText.indexOf("<long_term_memory>"));
+                        })
+                .verifyComplete();
+    }
+
+    @Test
+    void testOnEventWithPreReasoningEventAndMultipleSystemMessages() {
+        List<Msg> inputMessages = new ArrayList<>();
+        inputMessages.add(
+                Msg.builder()
+                        .role(MsgRole.SYSTEM)
+                        .name("system")
+                        .content(TextBlock.builder().text("First system message").build())
+                        .build());
+        inputMessages.add(
+                Msg.builder()
+                        .role(MsgRole.SYSTEM)
+                        .name("long_term_memory")
+                        .content(TextBlock.builder().text("Second system message").build())
+                        .build());
+        inputMessages.add(
+                Msg.builder()
+                        .role(MsgRole.USER)
+                        .content(TextBlock.builder().text("What do you know about me?").build())
+                        .build());
+
+        PreCallEvent event = new PreCallEvent(mockAgent, inputMessages);
+
+        when(mockLongTermMemory.retrieve(any(Msg.class)))
+                .thenReturn(Mono.just("Your name is Mike"));
+
+        StepVerifier.create(hook.onEvent(event))
+                .assertNext(
+                        resultEvent -> {
+                            List<Msg> messages = resultEvent.getInputMessages();
+                            assertEquals(3, messages.size());
+                            assertEquals(MsgRole.SYSTEM, messages.get(0).getRole());
+                            assertEquals(MsgRole.SYSTEM, messages.get(1).getRole());
+                            assertEquals(MsgRole.USER, messages.get(2).getRole());
+                            String firstSystemText = messages.get(0).getTextContent();
+                            assertTrue(firstSystemText.contains("First system message"));
+                            assertTrue(firstSystemText.contains("<long_term_memory>"));
+                            assertTrue(firstSystemText.contains("Your name is Mike"));
+                            assertEquals("Second system message", messages.get(1).getTextContent());
+                        })
+                .verifyComplete();
+    }
+
+    @Test
+    void testOnEventWithPreReasoningEventAndEmptyRetrieval() {
         List<Msg> inputMessages = new ArrayList<>();
         inputMessages.add(
                 Msg.builder()


### PR DESCRIPTION
## AgentScope-Java Version

1.0.12

## Description

* Fixes: #1262 
* Merges all SYSTEM role messages from memory and the agent's sysPrompt into one combined system message
* Places the merged system message at the beginning of the message sequence
* Updates StaticLongTermMemoryHook to append memory content to the existing system message instead of creating a separate one

## Checklist

Please check the following items before code is ready to be reviewed.

- [x]  Code has been formatted with `mvn spotless:apply`
- [x]  All tests are passing (`mvn test`)
- [x]  Javadoc comments are complete and follow project conventions
- [x]  Related documentation has been updated (e.g. links, examples, etc.)
- [x]  Code is ready for review