### PR TITLE
feat: add gen_ai.session.id to trace spans

### DIFF
--- a/agentscope-core/src/main/java/io/agentscope/core/ReActAgent.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/ReActAgent.java
@@ -234,12 +234,14 @@ public class ReActAgent extends StructuredOutputCapableAgent {
      */
     @Override
     public boolean loadIfExists(Session session, SessionKey sessionKey) {
+        setCurrentSessionKey(sessionKey);
         shutdownManager.bindSession(this, session, sessionKey);
         return super.loadIfExists(session, sessionKey);
     }
 
     @Override
     public void loadFrom(Session session, SessionKey sessionKey) {
+        setCurrentSessionKey(sessionKey);
         shutdownManager.bindSession(this, session, sessionKey);
         // Load memory if managed
         if (statePersistence.memoryManaged()) {

--- a/agentscope-core/src/main/java/io/agentscope/core/agent/AgentBase.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/agent/AgentBase.java
@@ -25,6 +25,8 @@ import io.agentscope.core.interruption.InterruptSource;
 import io.agentscope.core.message.Msg;
 import io.agentscope.core.shutdown.GracefulShutdownHook;
 import io.agentscope.core.shutdown.GracefulShutdownManager;
+import io.agentscope.core.session.Session;
+import io.agentscope.core.state.SessionKey;
 import io.agentscope.core.state.StateModule;
 import io.agentscope.core.tracing.TracerRegistry;
 import java.util.ArrayList;
@@ -100,6 +102,9 @@ public abstract class AgentBase implements StateModule, Agent {
                     List.of(new GracefulShutdownHook(GracefulShutdownManager.getInstance())));
     private final Map<String, List<AgentBase>> hubSubscribers = new ConcurrentHashMap<>();
 
+    // Session key for tracing (set by loadFrom/loadIfExists)
+    private volatile SessionKey currentSessionKey;
+
     // Interrupt state management (available to all agents)
     private final AtomicBoolean interruptFlag = new AtomicBoolean(false);
     private final AtomicReference<Msg> userInterruptMessage = new AtomicReference<>(null);
@@ -158,6 +163,28 @@ public abstract class AgentBase implements StateModule, Agent {
     @Override
     public final String getDescription() {
         return description != null ? description : Agent.super.getDescription();
+    }
+
+    /**
+     * Returns the current session key associated with this agent.
+     *
+     * <p>The session key is set when {@link #loadFrom(Session, SessionKey)} or {@link
+     * #loadIfExists(Session, SessionKey)} is called. It is used by tracing to populate the {@code
+     * gen_ai.session.id} attribute on spans.
+     *
+     * @return the current session key, or null if no session has been loaded
+     */
+    public SessionKey getCurrentSessionKey() {
+        return currentSessionKey;
+    }
+
+    /**
+     * Sets the current session key for this agent.
+     *
+     * @param sessionKey the session key to set
+     */
+    protected void setCurrentSessionKey(SessionKey sessionKey) {
+        this.currentSessionKey = sessionKey;
     }
 
     /**

--- a/agentscope-extensions/agentscope-extensions-studio/src/main/java/io/agentscope/core/tracing/telemetry/GenAiIncubatingAttributes.java
+++ b/agentscope-extensions/agentscope-extensions-studio/src/main/java/io/agentscope/core/tracing/telemetry/GenAiIncubatingAttributes.java
@@ -47,6 +47,8 @@ public final class GenAiIncubatingAttributes {
 
     static final AttributeKey<String> GEN_AI_CONVERSATION_ID = stringKey("gen_ai.conversation.id");
 
+    static final AttributeKey<String> GEN_AI_SESSION_ID = stringKey("gen_ai.session.id");
+
     static final AttributeKey<String> GEN_AI_DATA_SOURCE_ID = stringKey("gen_ai.data_source.id");
 
     static final AttributeKey<String> GEN_AI_OPERATION_NAME = stringKey("gen_ai.operation.name");

--- a/agentscope-extensions/agentscope-extensions-studio/src/main/java/io/agentscope/core/tracing/telemetry/TelemetryTracer.java
+++ b/agentscope-extensions/agentscope-extensions-studio/src/main/java/io/agentscope/core/tracing/telemetry/TelemetryTracer.java
@@ -28,12 +28,14 @@ import static io.agentscope.core.tracing.telemetry.AttributesExtractors.getLLMRe
 import static io.agentscope.core.tracing.telemetry.AttributesExtractors.getLLMResponseAttributes;
 import static io.agentscope.core.tracing.telemetry.AttributesExtractors.getToolRequestAttributes;
 import static io.agentscope.core.tracing.telemetry.AttributesExtractors.getToolResponseAttributes;
+import static io.agentscope.core.tracing.telemetry.GenAiIncubatingAttributes.GEN_AI_SESSION_ID;
 import static io.agentscope.core.tracing.telemetry.GenAiIncubatingAttributes.GenAiOperationNameIncubatingValues.CHAT;
 import static io.agentscope.core.tracing.telemetry.GenAiIncubatingAttributes.GenAiOperationNameIncubatingValues.EXECUTE_TOOL;
 import static io.agentscope.core.tracing.telemetry.GenAiIncubatingAttributes.GenAiOperationNameIncubatingValues.INVOKE_AGENT;
 
 import io.agentscope.core.Version;
 import io.agentscope.core.agent.AgentBase;
+import io.agentscope.core.state.SessionKey;
 import io.agentscope.core.formatter.AbstractBaseFormatter;
 import io.agentscope.core.message.Msg;
 import io.agentscope.core.message.ToolResultBlock;
@@ -50,6 +52,7 @@ import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.SpanBuilder;
 import io.opentelemetry.api.trace.TracerProvider;
 import io.opentelemetry.context.Context;
+import io.opentelemetry.context.ContextKey;
 import io.opentelemetry.context.Scope;
 import io.opentelemetry.exporter.otlp.http.trace.OtlpHttpSpanExporter;
 import io.opentelemetry.instrumentation.reactor.v3_1.ContextPropagationOperator;
@@ -66,10 +69,33 @@ import reactor.util.context.ContextView;
 
 public class TelemetryTracer implements Tracer {
 
+    static final ContextKey<String> SESSION_ID_KEY = ContextKey.named("gen_ai.session.id");
+
     private final io.opentelemetry.api.trace.Tracer tracer;
 
     public TelemetryTracer(io.opentelemetry.api.trace.Tracer tracer) {
         this.tracer = tracer;
+    }
+
+    private static String resolveSessionId(AgentBase instance, Context parentContext) {
+        SessionKey sessionKey = instance.getCurrentSessionKey();
+        if (sessionKey != null) {
+            return sessionKey.toIdentifier();
+        }
+        return parentContext.get(SESSION_ID_KEY);
+    }
+
+    private static Context enrichContextWithSessionId(Context context, String sessionId) {
+        if (sessionId != null) {
+            return context.with(SESSION_ID_KEY, sessionId);
+        }
+        return context;
+    }
+
+    private static void setSessionIdAttribute(Span span, String sessionId) {
+        if (sessionId != null) {
+            span.setAttribute(GEN_AI_SESSION_ID, sessionId);
+        }
     }
 
     @Override
@@ -90,7 +116,11 @@ public class TelemetryTracer implements Tracer {
                             AGENTSCOPE_FUNCTION_NAME, getFunctionName(instance, "callAgent"));
 
                     Span span = spanBuilder.startSpan();
-                    Context otelContext = span.storeInContext(Context.current());
+                    String sessionId = resolveSessionId(instance, parentContext);
+                    setSessionIdAttribute(span, sessionId);
+                    Context otelContext =
+                            enrichContextWithSessionId(
+                                    span.storeInContext(Context.current()), sessionId);
 
                     return otelContext
                             .wrapSupplier(agentCall)
@@ -128,7 +158,11 @@ public class TelemetryTracer implements Tracer {
                             AGENTSCOPE_FUNCTION_NAME, getFunctionName(instance, "callModel"));
 
                     Span span = spanBuilder.startSpan();
-                    Context otelContext = span.storeInContext(Context.current());
+                    String sessionId = parentContext.get(SESSION_ID_KEY);
+                    setSessionIdAttribute(span, sessionId);
+                    Context otelContext =
+                            enrichContextWithSessionId(
+                                    span.storeInContext(Context.current()), sessionId);
 
                     StreamChatResponseAggregator aggregator = StreamChatResponseAggregator.create();
 
@@ -172,7 +206,11 @@ public class TelemetryTracer implements Tracer {
                             AGENTSCOPE_FUNCTION_NAME, getFunctionName(instance, "callTool"));
 
                     Span span = spanBuilder.startSpan();
-                    Context otelContext = span.storeInContext(Context.current());
+                    String sessionId = parentContext.get(SESSION_ID_KEY);
+                    setSessionIdAttribute(span, sessionId);
+                    Context otelContext =
+                            enrichContextWithSessionId(
+                                    span.storeInContext(Context.current()), sessionId);
 
                     return otelContext
                             .wrapSupplier(toolKitCall)
@@ -205,6 +243,9 @@ public class TelemetryTracer implements Tracer {
         spanBuilder.setAllAttributes(getCommonAttributes());
         spanBuilder.setAttribute(AGENTSCOPE_FUNCTION_NAME, getFunctionName(formatter, "format"));
         Span span = spanBuilder.startSpan();
+
+        String sessionId = Context.current().get(SESSION_ID_KEY);
+        setSessionIdAttribute(span, sessionId);
 
         List<TReq> result = null;
         try (Scope scope = span.makeCurrent()) {


### PR DESCRIPTION
## Summary
- Add `gen_ai.session.id` attribute to all trace spans (Agent/Model/Tool/Format) for session-level aggregation and analysis
- Store `currentSessionKey` on `AgentBase` (set during `loadFrom`/`loadIfExists`) and propagate it through OTel Context to child spans in `TelemetryTracer`

## Changes
- **AgentBase**: add `currentSessionKey` field with getter/setter
- **ReActAgent**: call `setCurrentSessionKey(sessionKey)` in `loadFrom` and `loadIfExists`
- **GenAiIncubatingAttributes**: add `GEN_AI_SESSION_ID` attribute key
- **TelemetryTracer**: resolve sessionId from `AgentBase.getCurrentSessionKey()` in `callAgent`, propagate via `ContextKey` to `callModel`/`callTool`/`callFormat`

## Test plan
- [ ] Verify `mvn test` passes for core and extensions-studio modules
- [ ] Integration test: run ReActAgent with session, verify all spans carry `gen_ai.session.id`
- [ ] Verify spans without session gracefully omit the attribute (no errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)