### PR TITLE
fix(skill): support custom charset for zip extraction

### DIFF
--- a/agentscope-core/src/main/java/io/agentscope/core/skill/util/SkillUtil.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/skill/util/SkillUtil.java
@@ -22,6 +22,7 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -118,7 +119,24 @@ public class SkillUtil {
      *                                  zip entries are invalid
      */
     public static AgentSkill createFromZip(byte[] zipBytes) {
-        return createFromZip(zipBytes, DEFAULT_SOURCE);
+        return createFromZip(zipBytes, DEFAULT_SOURCE, StandardCharsets.UTF_8);
+    }
+
+    /**
+     * Creates an AgentSkill from a skill package zip using the given charset.
+     *
+     * <p>The package must contain a {@value #SKILL_FILE_NAME} entry and any optional resource
+     * files. The .skill and .zip extensions are aliases for the same package format.
+     *
+     * @param zipBytes Zip content as bytes
+     * @param charset Charset used to decode zip entry names and file contents (null defaults to
+     *                UTF-8). Use this when the zip was created with a non-UTF-8 charset such as
+     *                GBK/GB18030 and the default overload fails during zip entry decoding with
+     *                errors like {@code malformed input}
+     * @return Created AgentSkill instance
+     */
+    public static AgentSkill createFromZip(byte[] zipBytes, Charset charset) {
+        return createFromZip(zipBytes, DEFAULT_SOURCE, charset);
     }
 
     /**
@@ -133,7 +151,24 @@ public class SkillUtil {
      * @throws RuntimeException if the zip file cannot be read
      */
     public static AgentSkill createFromZip(Path zipPath) {
-        return createFromZip(zipPath, DEFAULT_SOURCE);
+        return createFromZip(zipPath, DEFAULT_SOURCE, StandardCharsets.UTF_8);
+    }
+
+    /**
+     * Creates an AgentSkill from a skill package zip file path using the given charset.
+     *
+     * <p>The package must contain a {@value #SKILL_FILE_NAME} entry and any optional resource
+     * files. The .skill and .zip extensions are aliases for the same package format.
+     *
+     * @param zipPath Zip file path
+     * @param charset Charset used to decode zip entry names and file contents (null defaults to
+     *                UTF-8). Use this when the zip was created with a non-UTF-8 charset such as
+     *                GBK/GB18030 and the default overload fails during zip entry decoding with
+     *                errors like {@code malformed input}
+     * @return Created AgentSkill instance
+     */
+    public static AgentSkill createFromZip(Path zipPath, Charset charset) {
+        return createFromZip(zipPath, DEFAULT_SOURCE, charset);
     }
 
     /**
@@ -147,7 +182,24 @@ public class SkillUtil {
      * @throws IllegalArgumentException if zipStream is null
      */
     public static AgentSkill createFromZip(InputStream zipStream) {
-        return createFromZip(zipStream, DEFAULT_SOURCE);
+        return createFromZip(zipStream, DEFAULT_SOURCE, StandardCharsets.UTF_8);
+    }
+
+    /**
+     * Creates an AgentSkill from a skill package zip input stream using the given charset.
+     *
+     * <p>The package must contain a {@value #SKILL_FILE_NAME} entry and any optional resource
+     * files. The .skill and .zip extensions are aliases for the same package format.
+     *
+     * @param zipStream Zip content stream
+     * @param charset Charset used to decode zip entry names and file contents (null defaults to
+     *                UTF-8). Use this when the zip was created with a non-UTF-8 charset such as
+     *                GBK/GB18030 and the default overload fails during zip entry decoding with
+     *                errors like {@code malformed input}
+     * @return Created AgentSkill instance
+     */
+    public static AgentSkill createFromZip(InputStream zipStream, Charset charset) {
+        return createFromZip(zipStream, DEFAULT_SOURCE, charset);
     }
 
     /**
@@ -163,10 +215,30 @@ public class SkillUtil {
      *                                  zip entries are invalid
      */
     public static AgentSkill createFromZip(byte[] zipBytes, String source) {
+        return createFromZip(zipBytes, source, StandardCharsets.UTF_8);
+    }
+
+    /**
+     * Creates an AgentSkill from a skill package zip with custom source and charset.
+     *
+     * <p>The package must contain a {@value #SKILL_FILE_NAME} entry and any optional resource
+     * files. The .skill and .zip extensions are aliases for the same package format.
+     *
+     * @param zipBytes Zip content as bytes
+     * @param source Source identifier for the skill (null defaults to "custom")
+     * @param charset Charset used to decode zip entry names and file contents (null defaults to
+     *                UTF-8). Use this when the zip was created with a non-UTF-8 charset such as
+     *                GBK/GB18030 and the default overload fails during zip entry decoding with
+     *                errors like {@code malformed input}
+     * @return Created AgentSkill instance
+     * @throws IllegalArgumentException if zipBytes is null/empty, if no SKILL.md is found, or if
+     *                                  zip entries are invalid
+     */
+    public static AgentSkill createFromZip(byte[] zipBytes, String source, Charset charset) {
         if (zipBytes == null || zipBytes.length == 0) {
             throw new IllegalArgumentException("Zip content cannot be null or empty.");
         }
-        return createFromZip(new ByteArrayInputStream(zipBytes), source);
+        return createFromZip(new ByteArrayInputStream(zipBytes), source, charset);
     }
 
     /**
@@ -182,11 +254,31 @@ public class SkillUtil {
      * @throws RuntimeException if the zip file cannot be read
      */
     public static AgentSkill createFromZip(Path zipPath, String source) {
+        return createFromZip(zipPath, source, StandardCharsets.UTF_8);
+    }
+
+    /**
+     * Creates an AgentSkill from a skill package zip file path with custom source and charset.
+     *
+     * <p>The package must contain a {@value #SKILL_FILE_NAME} entry and any optional resource
+     * files. The .skill and .zip extensions are aliases for the same package format.
+     *
+     * @param zipPath Zip file path
+     * @param source Source identifier for the skill (null defaults to "custom")
+     * @param charset Charset used to decode zip entry names and file contents (null defaults to
+     *                UTF-8). Use this when the zip was created with a non-UTF-8 charset such as
+     *                GBK/GB18030 and the default overload fails during zip entry decoding with
+     *                errors like {@code malformed input}
+     * @return Created AgentSkill instance
+     * @throws IllegalArgumentException if zipPath is null
+     * @throws RuntimeException if the zip file cannot be read
+     */
+    public static AgentSkill createFromZip(Path zipPath, String source, Charset charset) {
         if (zipPath == null) {
             throw new IllegalArgumentException("Zip path cannot be null.");
         }
         try (InputStream inputStream = Files.newInputStream(zipPath)) {
-            return createFromZip(inputStream, source);
+            return createFromZip(inputStream, source, charset);
         } catch (IOException e) {
             throw new RuntimeException("Failed to read skill zip content.", e);
         }
@@ -205,16 +297,37 @@ public class SkillUtil {
      * @throws RuntimeException if the zip content cannot be read
      */
     public static AgentSkill createFromZip(InputStream zipStream, String source) {
+        return createFromZip(zipStream, source, StandardCharsets.UTF_8);
+    }
+
+    /**
+     * Creates an AgentSkill from a skill package zip input stream with custom source and charset.
+     *
+     * <p>The package must contain a {@value #SKILL_FILE_NAME} entry and any optional resource
+     * files. The .skill and .zip extensions are aliases for the same package format.
+     *
+     * @param zipStream Zip content stream
+     * @param source Source identifier for the skill (null defaults to "custom")
+     * @param charset Charset used to decode zip entry names and file contents (null defaults to
+     *                UTF-8). Use this when the zip was created with a non-UTF-8 charset such as
+     *                GBK/GB18030 and the default overload fails during zip entry decoding with
+     *                errors like {@code malformed input}
+     * @return Created AgentSkill instance
+     * @throws IllegalArgumentException if zipStream is null
+     * @throws RuntimeException if the zip content cannot be read
+     */
+    public static AgentSkill createFromZip(InputStream zipStream, String source, Charset charset) {
         if (zipStream == null) {
             throw new IllegalArgumentException("Zip stream cannot be null.");
         }
 
+        Charset zipCharset = charset == null ? StandardCharsets.UTF_8 : charset;
         String skillEntryName = null;
         String skillMdContent = null;
         String rootDir = null;
         Map<String, String> resources = new HashMap<>();
 
-        try (ZipInputStream zipInputStream = new ZipInputStream(zipStream)) {
+        try (ZipInputStream zipInputStream = new ZipInputStream(zipStream, zipCharset)) {
             ZipEntry entry;
             while ((entry = zipInputStream.getNextEntry()) != null) {
                 if (entry.isDirectory()) {
@@ -233,7 +346,7 @@ public class SkillUtil {
                     throw new IllegalArgumentException(
                             "Zip entries must share the same root directory.");
                 }
-                String content = readZipEntryContent(zipInputStream);
+                String content = readZipEntryContent(zipInputStream, zipCharset);
 
                 String expectedSkillEntry = entryRoot + "/" + SKILL_FILE_NAME;
                 if (entryName.endsWith("/" + SKILL_FILE_NAME)
@@ -288,14 +401,15 @@ public class SkillUtil {
         return normalized;
     }
 
-    private static String readZipEntryContent(ZipInputStream zipInputStream) throws IOException {
+    private static String readZipEntryContent(ZipInputStream zipInputStream, Charset charset)
+            throws IOException {
         byte[] buffer = new byte[8192];
         int read;
         try (ByteArrayOutputStream outputStream = new ByteArrayOutputStream()) {
             while ((read = zipInputStream.read(buffer)) != -1) {
                 outputStream.write(buffer, 0, read);
             }
-            return outputStream.toString(StandardCharsets.UTF_8);
+            return outputStream.toString(charset);
         }
     }
 }

--- a/agentscope-core/src/main/java/io/agentscope/core/skill/util/SkillUtil.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/skill/util/SkillUtil.java
@@ -123,23 +123,6 @@ public class SkillUtil {
     }
 
     /**
-     * Creates an AgentSkill from a skill package zip using the given charset.
-     *
-     * <p>The package must contain a {@value #SKILL_FILE_NAME} entry and any optional resource
-     * files. The .skill and .zip extensions are aliases for the same package format.
-     *
-     * @param zipBytes Zip content as bytes
-     * @param charset Charset used to decode zip entry names and file contents (null defaults to
-     *                UTF-8). Use this when the zip was created with a non-UTF-8 charset such as
-     *                GBK/GB18030 and the default overload fails during zip entry decoding with
-     *                errors like {@code malformed input}
-     * @return Created AgentSkill instance
-     */
-    public static AgentSkill createFromZip(byte[] zipBytes, Charset charset) {
-        return createFromZip(zipBytes, DEFAULT_SOURCE, charset);
-    }
-
-    /**
      * Creates an AgentSkill from a skill package zip file path.
      *
      * <p>The package must contain a {@value #SKILL_FILE_NAME} entry and any optional resource
@@ -183,23 +166,6 @@ public class SkillUtil {
      */
     public static AgentSkill createFromZip(InputStream zipStream) {
         return createFromZip(zipStream, DEFAULT_SOURCE, StandardCharsets.UTF_8);
-    }
-
-    /**
-     * Creates an AgentSkill from a skill package zip input stream using the given charset.
-     *
-     * <p>The package must contain a {@value #SKILL_FILE_NAME} entry and any optional resource
-     * files. The .skill and .zip extensions are aliases for the same package format.
-     *
-     * @param zipStream Zip content stream
-     * @param charset Charset used to decode zip entry names and file contents (null defaults to
-     *                UTF-8). Use this when the zip was created with a non-UTF-8 charset such as
-     *                GBK/GB18030 and the default overload fails during zip entry decoding with
-     *                errors like {@code malformed input}
-     * @return Created AgentSkill instance
-     */
-    public static AgentSkill createFromZip(InputStream zipStream, Charset charset) {
-        return createFromZip(zipStream, DEFAULT_SOURCE, charset);
     }
 
     /**

--- a/agentscope-core/src/test/java/io/agentscope/core/skill/SkillUtilTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/skill/SkillUtilTest.java
@@ -25,6 +25,7 @@ import io.agentscope.core.skill.util.SkillUtil;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -257,6 +258,30 @@ class SkillUtilTest {
         }
 
         @Test
+        @DisplayName("Should create from zip content with custom charset")
+        void testCreateFromZipWithCustomCharset() throws IOException {
+            Charset charset = Charset.forName("GBK");
+            String skillMd =
+                    "---\n"
+                            + "name: gbk_skill\n"
+                            + "description: GBK zip package\n"
+                            + "---\n"
+                            + "技能内容";
+
+            byte[] zipBytes =
+                    buildZipBytes(
+                            Map.of("gbk-skill/SKILL.md", skillMd, "gbk-skill/docs/说明.txt", "资源内容"),
+                            charset);
+
+            AgentSkill skill = SkillUtil.createFromZip(zipBytes, "zip", charset);
+
+            assertEquals("gbk_skill", skill.getName());
+            assertEquals("GBK zip package", skill.getDescription());
+            assertEquals("技能内容", skill.getSkillContent());
+            assertEquals("资源内容", skill.getResources().get("docs/说明.txt"));
+        }
+
+        @Test
         @DisplayName("Should create from zip with root folder")
         void testCreateFromZipWithRootFolder() throws IOException {
             String skillMd =
@@ -364,12 +389,17 @@ class SkillUtilTest {
     }
 
     private static byte[] buildZipBytes(Map<String, String> entries) throws IOException {
+        return buildZipBytes(entries, StandardCharsets.UTF_8);
+    }
+
+    private static byte[] buildZipBytes(Map<String, String> entries, Charset charset)
+            throws IOException {
         ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
-        try (ZipOutputStream zipOutputStream = new ZipOutputStream(outputStream)) {
+        try (ZipOutputStream zipOutputStream = new ZipOutputStream(outputStream, charset)) {
             for (Map.Entry<String, String> entry : entries.entrySet()) {
                 ZipEntry zipEntry = new ZipEntry(entry.getKey());
                 zipOutputStream.putNextEntry(zipEntry);
-                byte[] content = entry.getValue().getBytes(StandardCharsets.UTF_8);
+                byte[] content = entry.getValue().getBytes(charset);
                 zipOutputStream.write(content);
                 zipOutputStream.closeEntry();
             }


### PR DESCRIPTION
## AgentScope-Java Version

1.0.11

## Description

- add `Charset` overloads to `SkillUtil.createFromZip(...)` for byte arrays, paths, and input streams
- use the provided charset to decode zip entry names and text content during extraction
- document that this option is intended for non-UTF-8 zip packages that may fail with `malformed input` during entry decoding

## Checklist

Please check the following items before code is ready to be reviewed.

- [x]  Code has been formatted with `mvn spotless:apply`
- [x]  All tests are passing (`mvn test`)
- [x]  Javadoc comments are complete and follow project conventions
- [x]  Related documentation has been updated (e.g. links, examples, etc.)
- [x]  Code is ready for review
