### PR TITLE
feat(tool): preserve Event block types in SubAgentTool forwardEvent

### DIFF
--- a/agentscope-core/src/main/java/io/agentscope/core/tool/subagent/SubAgentTool.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/tool/subagent/SubAgentTool.java
@@ -18,6 +18,7 @@ package io.agentscope.core.tool.subagent;
 import io.agentscope.core.agent.Agent;
 import io.agentscope.core.agent.Event;
 import io.agentscope.core.agent.StreamOptions;
+import io.agentscope.core.message.ContentBlock;
 import io.agentscope.core.message.Msg;
 import io.agentscope.core.message.MsgRole;
 import io.agentscope.core.message.TextBlock;
@@ -27,7 +28,6 @@ import io.agentscope.core.state.StateModule;
 import io.agentscope.core.tool.AgentTool;
 import io.agentscope.core.tool.ToolCallParam;
 import io.agentscope.core.tool.ToolEmitter;
-import io.agentscope.core.util.JsonUtils;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.List;
@@ -301,10 +301,11 @@ public class SubAgentTool implements AgentTool {
     }
 
     /**
-     * Forwards an event to the emitter as serialized JSON.
+     * Forwards an event to the emitter.
      *
-     * <p>Serializes the event using JsonCodec and emits it as a text block. Serialization
-     * failures are logged but do not interrupt execution.
+     * <p>Extracts content blocks from the event message to preserve original types
+     * and emits them with event metadata. If no content is present, a default empty
+     * text block is emitted. Failures are logged but do not interrupt execution.
      *
      * @param event The event to forward
      * @param emitter The emitter to send the event to
@@ -313,17 +314,32 @@ public class SubAgentTool implements AgentTool {
      */
     private void forwardEvent(Event event, ToolEmitter emitter, Agent agent, String sessionId) {
         try {
-            String json = JsonUtils.getJsonCodec().toJson(event);
             Map<String, Object> metadata = new HashMap<>();
-            metadata.put("subagent_event", event == null ? "" : event);
             metadata.put("subagent_name", agent.getName() == null ? "" : agent.getName());
             metadata.put("subagent_id", agent.getAgentId() == null ? "" : agent.getAgentId());
             metadata.put("subagent_session_id", sessionId == null ? "" : sessionId);
-            emitter.emit(
-                    new ToolResultBlock(
-                            null, null, List.of(TextBlock.builder().text(json).build()), metadata));
+
+            List<ContentBlock> outputBlocks = null;
+
+            if (event != null) {
+                metadata.put(
+                        "subagent_event_type",
+                        event.getType() != null ? event.getType().name() : "");
+                metadata.put("subagent_event_last", event.isLast());
+
+                Msg msg = event.getMessage();
+                if (msg != null && msg.getContent() != null && !msg.getContent().isEmpty()) {
+                    outputBlocks = msg.getContent();
+                }
+            }
+
+            if (outputBlocks == null || outputBlocks.isEmpty()) {
+                outputBlocks = List.of(TextBlock.builder().text("").build());
+            }
+
+            emitter.emit(new ToolResultBlock(null, null, outputBlocks, metadata));
         } catch (Exception e) {
-            logger.warn("Failed to serialize event to JSON: {}", e.getMessage());
+            logger.warn("Failed to forward event: {}", e.getMessage());
         }
     }
 

--- a/agentscope-core/src/test/java/io/agentscope/core/tool/subagent/SubAgentToolTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/tool/subagent/SubAgentToolTest.java
@@ -245,18 +245,20 @@ class SubAgentToolTest {
     }
 
     @Test
-    @DisplayName("Should forward events when forwardEvents is true and emitter is provided")
+    @DisplayName("Should forward events with preserved block types and metadata")
     void testEventForwardingEnabled() {
         // Create mock agent that supports streaming
         Agent mockAgent = mock(Agent.class);
         when(mockAgent.getName()).thenReturn("StreamAgent");
+        when(mockAgent.getAgentId()).thenReturn("stream-agent-123");
         when(mockAgent.getDescription()).thenReturn("Streaming agent");
 
-        Msg responseMsg =
-                Msg.builder()
-                        .role(MsgRole.ASSISTANT)
-                        .content(TextBlock.builder().text("Thinking...").build())
-                        .build();
+        Map<String, Object> mockArgs = new HashMap<>();
+        mockArgs.put("param", "value");
+        ToolUseBlock originalToolBlock =
+                ToolUseBlock.builder().id("call-123").name("nested_tool").input(mockArgs).build();
+
+        Msg responseMsg = Msg.builder().role(MsgRole.ASSISTANT).content(originalToolBlock).build();
 
         // Mock stream() to return events
         Event reasoningEvent = new Event(EventType.REASONING, responseMsg, true);
@@ -290,8 +292,29 @@ class SubAgentToolTest {
         // Verify stream() was called (not call())
         verify(mockAgent).stream(any(List.class), any(StreamOptions.class));
         verify(mockAgent, never()).call(any(List.class));
-        // Verify events were forwarded
+
+        // Verify events were forwarded and structure is preserved
         assertFalse(emittedChunks.isEmpty());
+        ToolResultBlock emittedResult = emittedChunks.get(0);
+
+        assertNotNull(emittedResult.getOutput());
+        assertEquals(1, emittedResult.getOutput().size());
+        assertTrue(
+                emittedResult.getOutput().get(0) instanceof ToolUseBlock,
+                "The forwarded block should preserve its original specific type (ToolUseBlock)");
+
+        ToolUseBlock forwardedBlock = (ToolUseBlock) emittedResult.getOutput().get(0);
+        assertEquals("call-123", forwardedBlock.getId());
+        assertEquals("nested_tool", forwardedBlock.getName());
+
+        // Verify metadata was populated correctly instead of JSON serialization
+        Map<String, Object> metadata = emittedResult.getMetadata();
+        assertNotNull(metadata);
+        assertEquals("StreamAgent", metadata.get("subagent_name"));
+        assertEquals("stream-agent-123", metadata.get("subagent_id"));
+        assertEquals(EventType.REASONING.name(), metadata.get("subagent_event_type"));
+        assertEquals(true, metadata.get("subagent_event_last"));
+        assertTrue(metadata.containsKey("subagent_session_id"));
     }
 
     @Test

--- a/agentscope-core/src/test/java/io/agentscope/core/tool/subagent/SubAgentToolTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/tool/subagent/SubAgentToolTest.java
@@ -318,6 +318,67 @@ class SubAgentToolTest {
     }
 
     @Test
+    @DisplayName("Should forward event with default text block when content is empty")
+    void testEventForwardingWithEmptyContent() {
+        Agent mockAgent = mock(Agent.class);
+        when(mockAgent.getName()).thenReturn("EmptyEventAgent");
+        when(mockAgent.getDescription()).thenReturn("Agent that yields empty events");
+
+        // Create a message with NO content (null or empty list)
+        Msg emptyResponseMsg =
+                Msg.builder()
+                        .role(MsgRole.ASSISTANT)
+                        // Intentionally not setting content
+                        .build();
+
+        Event stateEvent = new Event(EventType.REASONING, emptyResponseMsg, false);
+
+        Msg finalMsg =
+                Msg.builder()
+                        .role(MsgRole.ASSISTANT)
+                        .content(TextBlock.builder().text("Done").build())
+                        .build();
+        Event endEvent = new Event(EventType.SUMMARY, finalMsg, true);
+
+        when(mockAgent.stream(any(List.class), any(StreamOptions.class)))
+                .thenReturn(Flux.just(stateEvent, endEvent));
+
+        SubAgentConfig config = SubAgentConfig.builder().forwardEvents(true).build();
+        SubAgentTool tool = new SubAgentTool(() -> mockAgent, config);
+
+        List<ToolResultBlock> emittedChunks = new ArrayList<>();
+        ToolEmitter testEmitter = emittedChunks::add;
+
+        Map<String, Object> input = new HashMap<>();
+        input.put("message", "Trigger");
+        ToolUseBlock toolUse =
+                ToolUseBlock.builder().id("1").name("call_emptyeventagent").input(input).build();
+
+        tool.callAsync(
+                        ToolCallParam.builder()
+                                .toolUseBlock(toolUse)
+                                .input(input)
+                                .emitter(testEmitter)
+                                .build())
+                .block();
+
+        // We expect 2 chunks emitted
+        assertEquals(2, emittedChunks.size());
+
+        // Verify the first chunk (the empty one)
+        ToolResultBlock emptyChunk = emittedChunks.get(0);
+        assertNotNull(emptyChunk.getOutput());
+        assertEquals(1, emptyChunk.getOutput().size(), "Should insert a default empty block");
+        assertTrue(emptyChunk.getOutput().get(0) instanceof TextBlock);
+        assertEquals(
+                "",
+                ((TextBlock) emptyChunk.getOutput().get(0)).getText(),
+                "Default block should contain empty string");
+        assertEquals(
+                EventType.REASONING.name(), emptyChunk.getMetadata().get("subagent_event_type"));
+    }
+
+    @Test
     @DisplayName("Should not use streaming when forwardEvents is false")
     void testEventForwardingDisabled() {
         Agent mockAgent = mock(Agent.class);


### PR DESCRIPTION
## Description

Close #980 
Enhance SubAgentTool forwardEvent to preserve original ContentBlock types and provide empty block fallback.

## Checklist

Please check the following items before code is ready to be reviewed.

- [ ]  Code has been formatted with `mvn spotless:apply`
- [ ]  All tests are passing (`mvn test`)
- [ ]  Javadoc comments are complete and follow project conventions
- [ ]  Related documentation has been updated (e.g. links, examples, etc.)
- [ ]  Code is ready for review
