### PR TITLE
fix(formatter): ensure assistant messages with tool_calls always include content field

### DIFF
--- a/agentscope-core/src/main/java/io/agentscope/core/formatter/dashscope/DashScopeMessageConverter.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/formatter/dashscope/DashScopeMessageConverter.java
@@ -217,11 +217,10 @@ public class DashScopeMessageConverter {
                 // Assistant with tool calls
                 builder.toolCalls(toolsHelper.convertToolCalls(toolBlocks));
                 String textContent = extractTextContent(msg);
-                if (textContent.isEmpty()) {
-                    builder.content((String) null);
-                } else {
-                    builder.content(textContent);
-                }
+                // Qwen3 and similar models in thinking mode may produce assistant
+                // messages with reasoning_content + tool_calls but null content.
+                // DashScope API requires the content field to be present.
+                builder.content(textContent.isEmpty() ? "" : textContent);
             } else {
                 builder.content(extractTextContent(msg));
             }

--- a/agentscope-core/src/main/java/io/agentscope/core/formatter/dashscope/DashScopeMultiAgentFormatter.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/formatter/dashscope/DashScopeMultiAgentFormatter.java
@@ -302,9 +302,8 @@ public class DashScopeMultiAgentFormatter
         List<ToolUseBlock> toolBlocks = msg.getContentBlocks(ToolUseBlock.class);
         if (!toolBlocks.isEmpty()) {
             builder.toolCalls(toolsHelper.convertToolCalls(toolBlocks));
-            // Set content to null if empty when tool calls exist (Python behavior)
             String textContent = extractTextContent(msg);
-            builder.content(textContent.isEmpty() ? null : textContent);
+            builder.content(textContent.isEmpty() ? "" : textContent);
         } else {
             builder.content(extractTextContent(msg));
         }

--- a/agentscope-core/src/main/java/io/agentscope/core/formatter/openai/OpenAIMessageConverter.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/formatter/openai/OpenAIMessageConverter.java
@@ -265,7 +265,8 @@ public class OpenAIMessageConverter {
         OpenAIMessage.Builder builder = OpenAIMessage.builder().role("assistant");
 
         String textContent = textExtractor.apply(msg);
-        if (textContent != null && !textContent.isEmpty()) {
+        boolean hasTextContent = textContent != null && !textContent.isEmpty();
+        if (hasTextContent) {
             builder.content(textContent);
         }
 
@@ -373,6 +374,13 @@ public class OpenAIMessageConverter {
 
             if (!reasoningDetails.isEmpty()) {
                 builder.reasoningDetails(reasoningDetails);
+            }
+
+            // Qwen3 and similar models in thinking mode may produce assistant messages
+            // with reasoning_content + tool_calls but null content. APIs like vLLM and
+            // DashScope require the content field to be present. Ensure it is at least "".
+            if (!hasTextContent) {
+                builder.content("");
             }
         }
 

--- a/agentscope-core/src/main/java/io/agentscope/core/formatter/openai/OpenAIMessageConverter.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/formatter/openai/OpenAIMessageConverter.java
@@ -265,9 +265,15 @@ public class OpenAIMessageConverter {
         OpenAIMessage.Builder builder = OpenAIMessage.builder().role("assistant");
 
         String textContent = textExtractor.apply(msg);
-        boolean hasTextContent = textContent != null && !textContent.isEmpty();
-        if (hasTextContent) {
+        // Qwen3 and similar models in thinking mode may produce assistant messages with
+        // reasoning_content + tool_calls but null content. Due to @JsonInclude(NON_NULL),
+        // a null content would be omitted from the JSON, causing strict OpenAI-compatible
+        // APIs (e.g. vLLM) to reject with "Field required: input.messages.N.content".
+        // Always ensure content is present — use the actual text or fall back to "".
+        if (textContent != null && !textContent.isEmpty()) {
             builder.content(textContent);
+        } else {
+            builder.content("");
         }
 
         // Handle ThinkingBlock for reasoning models (e.g. Gemini via OpenRouter)
@@ -374,13 +380,6 @@ public class OpenAIMessageConverter {
 
             if (!reasoningDetails.isEmpty()) {
                 builder.reasoningDetails(reasoningDetails);
-            }
-
-            // Qwen3 and similar models in thinking mode may produce assistant messages
-            // with reasoning_content + tool_calls but null content. APIs like vLLM and
-            // DashScope require the content field to be present. Ensure it is at least "".
-            if (!hasTextContent) {
-                builder.content("");
             }
         }
 

--- a/agentscope-core/src/test/java/io/agentscope/core/formatter/DashScopeTextOnlyGroundTruthTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/formatter/DashScopeTextOnlyGroundTruthTest.java
@@ -592,7 +592,7 @@ public class DashScopeTextOnlyGroundTruthTest {
 
         return DashScopeMessage.builder()
                 .role("assistant")
-                .content((String) null)
+                .content("")
                 .toolCalls(toolCallList)
                 .build();
     }

--- a/agentscope-core/src/test/java/io/agentscope/core/formatter/dashscope/DashScopeMessageConverterTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/formatter/dashscope/DashScopeMessageConverterTest.java
@@ -18,7 +18,6 @@ package io.agentscope.core.formatter.dashscope;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.agentscope.core.formatter.dashscope.dto.DashScopeContentPart;
@@ -38,6 +37,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
@@ -164,7 +165,7 @@ class DashScopeMessageConverterTest {
         DashScopeMessage dsMsg = converter.convertToMessage(msg, false);
 
         assertEquals("assistant", dsMsg.getRole());
-        assertNull(dsMsg.getContentAsString());
+        assertEquals("", dsMsg.getContentAsString());
         assertNotNull(dsMsg.getToolCalls());
         assertEquals(1, dsMsg.getToolCalls().size());
     }
@@ -562,5 +563,69 @@ class DashScopeMessageConverterTest {
         assertNotNull(args);
         assertTrue(args.contains("city"));
         assertTrue(args.contains("Shanghai"));
+    }
+
+    @Nested
+    @DisplayName("Qwen3 Thinking Mode Tests (Issue #1268)")
+    class Qwen3ThinkingModeTests {
+
+        @Test
+        @DisplayName(
+                "Should set empty content for assistant with ThinkingBlock + ToolUseBlock but no"
+                        + " TextBlock")
+        void testThinkingModeAssistantWithToolCallsHasNonNullContent() {
+            ThinkingBlock thinkingBlock =
+                    ThinkingBlock.builder().thinking("Let me call the tool...").build();
+            ToolUseBlock toolBlock =
+                    ToolUseBlock.builder()
+                            .id("call_123")
+                            .name("get_weather")
+                            .input(Map.of("city", "Shanghai"))
+                            .build();
+
+            Msg msg =
+                    Msg.builder()
+                            .role(MsgRole.ASSISTANT)
+                            .content(List.of(thinkingBlock, toolBlock))
+                            .build();
+
+            DashScopeMessage result = converter.convertToMessage(msg, false);
+
+            assertNotNull(result);
+            assertEquals("assistant", result.getRole());
+            assertNotNull(result.getToolCalls());
+            assertNotNull(
+                    result.getContentAsString(),
+                    "Content should not be null to comply with DashScope API");
+            assertEquals("", result.getContentAsString());
+        }
+
+        @Test
+        @DisplayName(
+                "Should preserve text content when both TextBlock and ThinkingBlock exist with tool"
+                        + " calls")
+        void testThinkingModeAssistantWithTextAndToolCalls() {
+            Msg msg =
+                    Msg.builder()
+                            .role(MsgRole.ASSISTANT)
+                            .content(
+                                    List.of(
+                                            ThinkingBlock.builder()
+                                                    .thinking("reasoning...")
+                                                    .build(),
+                                            TextBlock.builder().text("Here is my answer").build(),
+                                            ToolUseBlock.builder()
+                                                    .id("call_456")
+                                                    .name("search")
+                                                    .input(Map.of("q", "test"))
+                                                    .build()))
+                            .build();
+
+            DashScopeMessage result = converter.convertToMessage(msg, false);
+
+            assertNotNull(result);
+            assertEquals("Here is my answer", result.getContentAsString());
+            assertNotNull(result.getToolCalls());
+        }
     }
 }

--- a/agentscope-core/src/test/java/io/agentscope/core/formatter/openai/OpenAIMessageConverterTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/formatter/openai/OpenAIMessageConverterTest.java
@@ -951,4 +951,91 @@ class OpenAIMessageConverterTest {
             assertEquals("assistant", result.getRole());
         }
     }
+
+    @Nested
+    @DisplayName("Qwen3 Thinking Mode Tests (Issue #1268)")
+    class Qwen3ThinkingModeTests {
+
+        @Test
+        @DisplayName(
+                "Should set empty content for assistant with ThinkingBlock + ToolUseBlock but no"
+                        + " TextBlock")
+        void testThinkingModeWithToolCallsHasNonNullContent() {
+            ThinkingBlock thinkingBlock =
+                    ThinkingBlock.builder().thinking("Let me call the tool...").build();
+            ToolUseBlock toolBlock =
+                    ToolUseBlock.builder()
+                            .id("call_123")
+                            .name("get_weather")
+                            .input(Map.of("city", "Shanghai"))
+                            .build();
+
+            Msg msg =
+                    Msg.builder()
+                            .role(MsgRole.ASSISTANT)
+                            .content(List.of(thinkingBlock, toolBlock))
+                            .build();
+
+            OpenAIMessage result = converter.convertToMessage(msg, false);
+
+            assertNotNull(result);
+            assertEquals("assistant", result.getRole());
+            assertNotNull(result.getToolCalls());
+            assertNotNull(
+                    result.getContent(),
+                    "Content should not be null to comply with strict OpenAI-compatible APIs");
+            assertEquals("", result.getContentAsString());
+        }
+
+        @Test
+        @DisplayName(
+                "Should preserve text content when both TextBlock and ThinkingBlock exist with tool"
+                        + " calls")
+        void testThinkingModeWithTextAndToolCalls() {
+            Msg msg =
+                    Msg.builder()
+                            .role(MsgRole.ASSISTANT)
+                            .content(
+                                    List.of(
+                                            ThinkingBlock.builder()
+                                                    .thinking("reasoning...")
+                                                    .build(),
+                                            TextBlock.builder().text("Here is my answer").build(),
+                                            ToolUseBlock.builder()
+                                                    .id("call_456")
+                                                    .name("search")
+                                                    .input(Map.of("q", "test"))
+                                                    .build()))
+                            .build();
+
+            OpenAIMessage result = converter.convertToMessage(msg, false);
+
+            assertNotNull(result);
+            assertEquals("Here is my answer", result.getContentAsString());
+            assertNotNull(result.getToolCalls());
+            assertEquals("reasoning...", result.getReasoningContent());
+        }
+
+        @Test
+        @DisplayName(
+                "Should set empty content for assistant with only ToolUseBlock (no text or"
+                        + " thinking)")
+        void testToolCallsOnlyWithoutTextOrThinking() {
+            ToolUseBlock toolBlock =
+                    ToolUseBlock.builder()
+                            .id("call_789")
+                            .name("calculate")
+                            .input(Map.of("expr", "1+1"))
+                            .build();
+
+            Msg msg = Msg.builder().role(MsgRole.ASSISTANT).content(List.of(toolBlock)).build();
+
+            OpenAIMessage result = converter.convertToMessage(msg, false);
+
+            assertNotNull(result);
+            assertNotNull(
+                    result.getContent(), "Content should not be null even without ThinkingBlock");
+            assertEquals("", result.getContentAsString());
+        }
+    }
 }


### PR DESCRIPTION
## Description

When Qwen3 and similar models operate in thinking mode, assistant messages may contain `reasoning_content` + `tool_calls` but `null` content. Due to `@JsonInclude(NON_NULL)` on `OpenAIMessage` and `DashScopeMessage`, the `null` content field was entirely omitted from the JSON request body, causing strict OpenAI-compatible APIs (e.g. vLLM) to reject the request with:

```
Input error. Field required: input.messages.N.content
```

### Root Cause

In both `OpenAIMessageConverter` and `DashScopeMessageConverter`, when an assistant message has `tool_calls` but no `TextBlock`, the `content` field was left as `null` on the DTO. Jackson's `@JsonInclude(NON_NULL)` then omitted the field entirely during serialization.

### Fix

Explicitly set `content` to an empty string `""` (instead of leaving it `null`) when an assistant message has `tool_calls` but no text content. This ensures the `content` field is always present in the serialized JSON.

**Changed files:**
- `OpenAIMessageConverter.convertAssistantMessage()` — set `content=""` when `hasTextContent` is false and tool calls exist
- `DashScopeMessageConverter.convertToSimpleContent()` — replace `null` content with `""` for assistant messages with tool calls

Close #1268

## Checklist

- [x] Code has been formatted with `mvn spotless:apply`
- [x] All tests are passing (`mvn test`)
- [x] Javadoc comments are complete and follow project conventions
- [x] Related documentation has been updated (e.g. links, examples, etc.)
- [x] Code is ready for review

Made with [Cursor](https://cursor.com)