### PR TITLE
fix(formatter): preserve reasoning_content from ThinkingBlock in DashScopeMessageConverter

### DIFF
--- a/agentscope-core/src/main/java/io/agentscope/core/formatter/dashscope/DashScopeMessageConverter.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/formatter/dashscope/DashScopeMessageConverter.java
@@ -212,6 +212,14 @@ public class DashScopeMessageConverter {
                 DashScopeMessage.builder().role(msg.getRole().name().toLowerCase());
 
         if (msg.getRole() == MsgRole.ASSISTANT) {
+            ThinkingBlock thinkingBlock = msg.getFirstContentBlock(ThinkingBlock.class);
+            if (thinkingBlock != null) {
+                String thinking = thinkingBlock.getThinking();
+                if (thinking != null && !thinking.isEmpty()) {
+                    builder.reasoningContent(thinking);
+                }
+            }
+
             List<ToolUseBlock> toolBlocks = msg.getContentBlocks(ToolUseBlock.class);
             if (!toolBlocks.isEmpty()) {
                 // Assistant with tool calls

--- a/agentscope-core/src/test/java/io/agentscope/core/formatter/dashscope/DashScopeMessageConverterTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/formatter/dashscope/DashScopeMessageConverterTest.java
@@ -38,6 +38,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
@@ -562,5 +564,105 @@ class DashScopeMessageConverterTest {
         assertNotNull(args);
         assertTrue(args.contains("city"));
         assertTrue(args.contains("Shanghai"));
+    }
+
+    @Nested
+    @DisplayName("DashScope Reasoning Content Preservation Tests (Issue #1284)")
+    class ReasoningContentPreservationTests {
+
+        @Test
+        @DisplayName(
+                "Should preserve reasoning_content from ThinkingBlock for assistant with tool"
+                        + " calls")
+        void testReasoningContentPreservedWithToolCalls() {
+            ThinkingBlock thinkingBlock =
+                    ThinkingBlock.builder().thinking("Let me analyze the request...").build();
+            ToolUseBlock toolBlock =
+                    ToolUseBlock.builder()
+                            .id("call_123")
+                            .name("get_weather")
+                            .input(Map.of("city", "Shanghai"))
+                            .build();
+
+            Msg msg =
+                    Msg.builder()
+                            .role(MsgRole.ASSISTANT)
+                            .content(List.of(thinkingBlock, toolBlock))
+                            .build();
+
+            DashScopeMessage result = converter.convertToMessage(msg, false);
+
+            assertNotNull(result);
+            assertEquals("assistant", result.getRole());
+            assertEquals(
+                    "Let me analyze the request...",
+                    result.getReasoningContent(),
+                    "reasoning_content should be preserved from ThinkingBlock");
+            assertNotNull(result.getToolCalls());
+        }
+
+        @Test
+        @DisplayName(
+                "Should preserve reasoning_content from ThinkingBlock for assistant without tool"
+                        + " calls")
+        void testReasoningContentPreservedWithoutToolCalls() {
+            ThinkingBlock thinkingBlock =
+                    ThinkingBlock.builder().thinking("Thinking about the answer...").build();
+            TextBlock textBlock = TextBlock.builder().text("Here is my answer.").build();
+
+            Msg msg =
+                    Msg.builder()
+                            .role(MsgRole.ASSISTANT)
+                            .content(List.of(thinkingBlock, textBlock))
+                            .build();
+
+            DashScopeMessage result = converter.convertToMessage(msg, false);
+
+            assertNotNull(result);
+            assertEquals("assistant", result.getRole());
+            assertEquals(
+                    "Thinking about the answer...",
+                    result.getReasoningContent(),
+                    "reasoning_content should be preserved from ThinkingBlock");
+            assertEquals("Here is my answer.", result.getContentAsString());
+        }
+
+        @Test
+        @DisplayName("Should not set reasoning_content when ThinkingBlock is absent")
+        void testNoReasoningContentWhenNoThinkingBlock() {
+            TextBlock textBlock = TextBlock.builder().text("Simple answer.").build();
+
+            Msg msg = Msg.builder().role(MsgRole.ASSISTANT).content(List.of(textBlock)).build();
+
+            DashScopeMessage result = converter.convertToMessage(msg, false);
+
+            assertNotNull(result);
+            assertNull(
+                    result.getReasoningContent(),
+                    "reasoning_content should be null when no ThinkingBlock");
+            assertEquals("Simple answer.", result.getContentAsString());
+        }
+
+        @Test
+        @DisplayName(
+                "Should not set reasoning_content when ThinkingBlock has empty thinking content")
+        void testNoReasoningContentWhenThinkingEmpty() {
+            ThinkingBlock thinkingBlock = ThinkingBlock.builder().thinking("").build();
+            TextBlock textBlock = TextBlock.builder().text("Answer.").build();
+
+            Msg msg =
+                    Msg.builder()
+                            .role(MsgRole.ASSISTANT)
+                            .content(List.of(thinkingBlock, textBlock))
+                            .build();
+
+            DashScopeMessage result = converter.convertToMessage(msg, false);
+
+            assertNotNull(result);
+            assertNull(
+                    result.getReasoningContent(),
+                    "reasoning_content should be null when thinking is empty");
+            assertEquals("Answer.", result.getContentAsString());
+        }
     }
 }


### PR DESCRIPTION
## Description

When Qwen3 and similar models operate in thinking mode, assistant messages contain `reasoning_content` (chain-of-thought reasoning). AgentScope correctly parses this into `ThinkingBlock` internally via `DashScopeResponseParser`.

However, `DashScopeMessageConverter` did not preserve this `reasoning_content` when converting internal `Msg` objects back to `DashScopeMessage` DTOs for subsequent API calls (i.e., as conversation history). The reasoning context was silently dropped, causing the model to lose its thinking history in multi-turn conversations.

### Root Cause

In `DashScopeMessageConverter.convertToSimpleContent()`, there was no logic to extract `ThinkingBlock` from the internal `Msg` and set it as `reasoning_content` on the outgoing `DashScopeMessage`.

### Fix

For assistant messages, extract the first `ThinkingBlock` and set its content as `reasoning_content` on the `DashScopeMessage.Builder`:

```java
ThinkingBlock thinkingBlock = msg.getFirstContentBlock(ThinkingBlock.class);
if (thinkingBlock != null) {
    String thinking = thinkingBlock.getThinking();
    if (thinking != null && !thinking.isEmpty()) {
        builder.reasoningContent(thinking);
    }
}
```

**Changed files:**
- `DashScopeMessageConverter.convertToSimpleContent()` — extract and preserve `reasoning_content` from `ThinkingBlock`

Close #1284

## Checklist

- [x] Code has been formatted with `mvn spotless:apply`
- [x] All tests are passing (`mvn test`)
- [x] Javadoc comments are complete and follow project conventions
- [x] Related documentation has been updated (e.g. links, examples, etc.)
- [x] Code is ready for review

Made with [Cursor](https://cursor.com)