### PR TITLE
fix(agui): fix stream state leak causing duplicate events on retry

### DIFF
--- a/agentscope-extensions/agentscope-extensions-agui/src/main/java/io/agentscope/core/agui/adapter/AguiAgentAdapter.java
+++ b/agentscope-extensions/agentscope-extensions-agui/src/main/java/io/agentscope/core/agui/adapter/AguiAgentAdapter.java
@@ -88,40 +88,49 @@ public class AguiAgentAdapter {
      * @return A Flux of AG-UI events
      */
     public Flux<AguiEvent> run(RunAgentInput input) {
-        String threadId = input.getThreadId();
-        String runId = input.getRunId();
+        return Flux.defer(
+                () -> {
+                    String threadId = input.getThreadId();
+                    String runId = input.getRunId();
 
-        // Convert AG-UI messages to AgentScope messages
-        List<Msg> msgs = messageConverter.toMsgList(input.getMessages());
+                    // Convert AG-UI messages to AgentScope messages
+                    List<Msg> msgs = messageConverter.toMsgList(input.getMessages());
 
-        // Create stream options - use incremental mode for true streaming
-        StreamOptions options =
-                StreamOptions.builder().eventTypes(EventType.ALL).incremental(true).build();
+                    // Create stream options - use incremental mode for true streaming
+                    StreamOptions options =
+                            StreamOptions.builder()
+                                    .eventTypes(EventType.ALL)
+                                    .incremental(true)
+                                    .build();
 
-        // Track state for event conversion
-        EventConversionState state = new EventConversionState(threadId, runId);
+                    // Track state for event conversion
+                    EventConversionState state = new EventConversionState(threadId, runId);
 
-        return Flux.concat(
-                        // Emit RUN_STARTED
-                        Flux.just(new AguiEvent.RunStarted(threadId, runId)),
-                        // Stream agent events and convert to AG-UI events
-                        // Use concatMapIterable to preserve strict event ordering
-                        agent.stream(msgs, options)
-                                .concatMapIterable(event -> convertEvent(event, state)),
-                        // Emit any pending end events and RUN_FINISHED
-                        Flux.defer(() -> finishRun(state)))
-                .onErrorResume(
-                        error -> {
-                            // On error, emit RawEvent with error info followed by RunFinished
-                            String errorMessage =
-                                    error.getMessage() != null
-                                            ? error.getMessage()
-                                            : error.getClass().getSimpleName();
-                            return Flux.just(
-                                    new AguiEvent.Raw(
-                                            threadId, runId, Map.of("error", errorMessage)),
-                                    new AguiEvent.RunFinished(threadId, runId));
-                        });
+                    return Flux.concat(
+                                    // Emit RUN_STARTED
+                                    Flux.just(new AguiEvent.RunStarted(threadId, runId)),
+                                    // Stream agent events and convert to AG-UI events
+                                    // Use concatMapIterable to preserve strict event ordering
+                                    agent.stream(msgs, options)
+                                            .concatMapIterable(event -> convertEvent(event, state)),
+                                    // Emit any pending end events and RUN_FINISHED
+                                    Flux.defer(() -> finishRun(state)))
+                            .onErrorResume(
+                                    error -> {
+                                        // On error, emit RawEvent with error info followed by
+                                        // RunFinished
+                                        String errorMessage =
+                                                error.getMessage() != null
+                                                        ? error.getMessage()
+                                                        : error.getClass().getSimpleName();
+                                        return Flux.just(
+                                                new AguiEvent.Raw(
+                                                        threadId,
+                                                        runId,
+                                                        Map.of("error", errorMessage)),
+                                                new AguiEvent.RunFinished(threadId, runId));
+                                    });
+                });
     }
 
     /**

--- a/agentscope-extensions/agentscope-extensions-agui/src/test/java/io/agentscope/core/agui/adapter/AguiAgentAdapterTest.java
+++ b/agentscope-extensions/agentscope-extensions-agui/src/test/java/io/agentscope/core/agui/adapter/AguiAgentAdapterTest.java
@@ -981,6 +981,89 @@ class AguiAgentAdapterTest {
     }
 
     @Test
+    void testStateLeakOnMultipleSubscriptions() {
+        // Verifies the fix for Issue #510
+        String bugMessageId = "chatcmpl-afaa1eae32eae120";
+        String bugToolId = "chatcmpl-tool-ab42f73d312799c7";
+
+        // Simulate the first streaming text chunk
+        Msg textChunk =
+                Msg.builder()
+                        .id(bugMessageId)
+                        .role(MsgRole.ASSISTANT)
+                        .content(
+                                List.of(
+                                        TextBlock.builder()
+                                                .text("Preparing to call the tool...")
+                                                .build()))
+                        .build();
+        Event textEvent = new Event(EventType.REASONING, textChunk, false);
+
+        Msg toolCallMsg =
+                Msg.builder()
+                        .id(bugMessageId)
+                        .role(MsgRole.ASSISTANT)
+                        .content(
+                                List.of(
+                                        ToolUseBlock.builder()
+                                                .id(bugToolId)
+                                                .name("getUniversityInfo")
+                                                .input(Map.of())
+                                                .build()))
+                        .build();
+        Event toolEvent = new Event(EventType.REASONING, toolCallMsg, false);
+
+        // Mock the agent stream to return the same events for every subscription
+        when(mockAgent.stream(anyList(), any(StreamOptions.class)))
+                .thenReturn(Flux.just(textEvent, toolEvent));
+
+        RunAgentInput input =
+                RunAgentInput.builder()
+                        .threadId("2010331348305129474")
+                        .runId("17816087-d4aa-4743-baee-9989a4ab3c8d")
+                        .messages(
+                                List.of(
+                                        AguiMessage.userMessage(
+                                                "msg-1", "Check university score lines")))
+                        .build();
+
+        // Get the Flux pipeline to test
+        Flux<AguiEvent> resultFlux = adapter.run(input);
+
+        // First subscription: simulate a normal initial streaming request
+        List<AguiEvent> firstRunEvents = resultFlux.collectList().block();
+        assertNotNull(firstRunEvents);
+
+        long firstRunStartCount =
+                firstRunEvents.stream()
+                        .filter(e -> e instanceof AguiEvent.TextMessageStart)
+                        .count();
+        assertEquals(1, firstRunStartCount, "First execution should contain 1 TextMessageStart");
+
+        // Second subscription: simulate an automatic retry or buffer flush from the adapter layer
+        List<AguiEvent> secondRunEvents = resultFlux.collectList().block();
+        assertNotNull(secondRunEvents);
+
+        long secondRunStartCount =
+                secondRunEvents.stream()
+                        .filter(e -> e instanceof AguiEvent.TextMessageStart)
+                        .count();
+
+        // Verify state isolation is effective; the second subscription should emit START normally
+        assertEquals(
+                1,
+                secondRunStartCount,
+                "State should be isolated; second execution should contain 1 TextMessageStart");
+
+        // Verify that CONTENT is still emitted
+        long secondRunContentCount =
+                secondRunEvents.stream()
+                        .filter(e -> e instanceof AguiEvent.TextMessageContent)
+                        .count();
+        assertTrue(secondRunContentCount > 0, "Second execution should contain TextMessageContent");
+    }
+
+    @Test
     void testToolCallStartBackfillWithoutCache() {
         Msg toolResultMsg =
                 Msg.builder()


### PR DESCRIPTION
## Description

Close #510 
Fixes issue 510 by isolating the event conversion state per subscription, preventing duplicate AG-UI events during network retries or multiple subscriptions.

## Checklist

Please check the following items before code is ready to be reviewed.

- [ ]  Code has been formatted with `mvn spotless:apply`
- [ ]  All tests are passing (`mvn test`)
- [ ]  Javadoc comments are complete and follow project conventions
- [ ]  Related documentation has been updated (e.g. links, examples, etc.)
- [ ]  Code is ready for review
