### PR TITLE
fix(tool): make tool group activation thread-safe

### DIFF
--- a/agentscope-core/src/main/java/io/agentscope/core/tool/ToolGroup.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/tool/ToolGroup.java
@@ -43,7 +43,7 @@ public class ToolGroup {
 
     private final String name;
     private final String description;
-    private boolean active;
+    private volatile boolean active;
     private final Set<String> tools; // Tool names in this group
 
     private ToolGroup(Builder builder) {

--- a/agentscope-core/src/main/java/io/agentscope/core/tool/ToolGroupManager.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/tool/ToolGroupManager.java
@@ -33,6 +33,7 @@ class ToolGroupManager {
 
     private final Map<String, ToolGroup> toolGroups = new ConcurrentHashMap<>(); // group -> tools
     private final Map<String, Set<String>> tools = new ConcurrentHashMap<>(); // tool -> groups
+    private final Object activeGroupsLock = new Object();
     private List<String> activeGroups = new ArrayList<>();
 
     /**
@@ -54,8 +55,12 @@ class ToolGroupManager {
 
         toolGroups.put(groupName, group);
 
-        if (active && !activeGroups.contains(groupName)) {
-            activeGroups.add(groupName);
+        if (active) {
+            synchronized (activeGroupsLock) {
+                if (!activeGroups.contains(groupName)) {
+                    activeGroups.add(groupName);
+                }
+            }
         }
 
         logger.info("Created tool group '{}': {}", groupName, description);
@@ -89,12 +94,14 @@ class ToolGroupManager {
 
             group.setActive(active);
 
-            if (active) {
-                if (!activeGroups.contains(groupName)) {
-                    activeGroups.add(groupName);
+            synchronized (activeGroupsLock) {
+                if (active) {
+                    if (!activeGroups.contains(groupName)) {
+                        activeGroups.add(groupName);
+                    }
+                } else {
+                    activeGroups.remove(groupName);
                 }
-            } else {
-                activeGroups.remove(groupName);
             }
 
             logger.info("Tool group '{}' active status set to: {}", groupName, active);
@@ -129,7 +136,9 @@ class ToolGroupManager {
             }
 
             // Remove from active groups
-            activeGroups.remove(groupName);
+            synchronized (activeGroupsLock) {
+                activeGroups.remove(groupName);
+            }
 
             logger.info(
                     "Removed tool group '{}' with {} tools", groupName, group.getTools().size());
@@ -144,18 +153,20 @@ class ToolGroupManager {
      * @return Formatted string describing active tool groups
      */
     public String getActivatedNotes() {
-        if (activeGroups.isEmpty()) {
-            return "No tool groups are currently activated.";
-        }
-
-        StringBuilder notes = new StringBuilder("Activated tool groups:\n");
-        for (String groupName : activeGroups) {
-            ToolGroup group = toolGroups.get(groupName);
-            if (group != null) {
-                notes.append(String.format("- %s: %s\n", groupName, group.getDescription()));
+        synchronized (activeGroupsLock) {
+            if (activeGroups.isEmpty()) {
+                return "No tool groups are currently activated.";
             }
+
+            StringBuilder notes = new StringBuilder("Activated tool groups:\n");
+            for (String groupName : activeGroups) {
+                ToolGroup group = toolGroups.get(groupName);
+                if (group != null) {
+                    notes.append(String.format("- %s: %s\n", groupName, group.getDescription()));
+                }
+            }
+            return notes.toString();
         }
-        return notes.toString();
     }
 
     /**
@@ -315,7 +326,9 @@ class ToolGroupManager {
      * @return List of active group names
      */
     public List<String> getActiveGroups() {
-        return new ArrayList<>(activeGroups);
+        synchronized (activeGroupsLock) {
+            return new ArrayList<>(activeGroups);
+        }
     }
 
     /**
@@ -324,7 +337,9 @@ class ToolGroupManager {
      * @param activeGroups List of group names to mark as active
      */
     public void setActiveGroups(List<String> activeGroups) {
-        this.activeGroups = new ArrayList<>(activeGroups);
+        synchronized (activeGroupsLock) {
+            this.activeGroups = new ArrayList<>(activeGroups);
+        }
 
         // Mark corresponding groups as active
         for (String groupName : activeGroups) {
@@ -373,8 +388,13 @@ class ToolGroupManager {
             target.tools.put(entry.getKey(), new HashSet<>(entry.getValue()));
         }
 
-        // Copy activeGroups list
-        target.activeGroups = new ArrayList<>(this.activeGroups);
+        List<String> activeGroupsSnapshot;
+        synchronized (activeGroupsLock) {
+            activeGroupsSnapshot = new ArrayList<>(this.activeGroups);
+        }
+        synchronized (target.activeGroupsLock) {
+            target.activeGroups = activeGroupsSnapshot;
+        }
     }
 
     private boolean removeGroupFromToolIndex(String toolName, String groupName) {

--- a/agentscope-core/src/test/java/io/agentscope/core/tool/ToolGroupManagerTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/tool/ToolGroupManagerTest.java
@@ -22,8 +22,14 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -443,6 +449,46 @@ class ToolGroupManagerTest {
         // Assert - should not have duplicates
         List<String> activeGroups = manager.getActiveGroups();
         assertEquals(1, activeGroups.stream().filter(g -> g.equals("group1")).count());
+    }
+
+    @Test
+    void testConcurrentActivationPreventsDuplicatesInActiveGroups() throws Exception {
+        int threadCount = 64;
+
+        for (int attempt = 0; attempt < 20; attempt++) {
+            ToolGroupManager concurrentManager = new ToolGroupManager();
+            concurrentManager.createToolGroup("group1", "Group 1", false);
+
+            ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+            CountDownLatch ready = new CountDownLatch(threadCount);
+            CountDownLatch start = new CountDownLatch(1);
+            List<Future<?>> futures = new ArrayList<>();
+
+            for (int i = 0; i < threadCount; i++) {
+                futures.add(
+                        executor.submit(
+                                () -> {
+                                    ready.countDown();
+                                    start.await();
+                                    concurrentManager.updateToolGroups(List.of("group1"), true);
+                                    return null;
+                                }));
+            }
+
+            assertTrue(ready.await(5, TimeUnit.SECONDS));
+            start.countDown();
+            executor.shutdown();
+            assertTrue(executor.awaitTermination(5, TimeUnit.SECONDS));
+            for (Future<?> future : futures) {
+                future.get();
+            }
+
+            long activeGroupCount =
+                    concurrentManager.getActiveGroups().stream()
+                            .filter(groupName -> groupName.equals("group1"))
+                            .count();
+            assertEquals(1, activeGroupCount);
+        }
     }
 
     @Test


### PR DESCRIPTION
## AgentScope-Java Version

1.0.12-SNAPSHOT

## Description

Closes #1306.

This PR fixes a concurrency issue in tool group activation state management.

Background:
`ToolGroupManager` stores active group names in `activeGroups`, which was backed by a plain `ArrayList`. Concurrent calls to activate the same tool group could race between `contains` and `add`, causing duplicate active group entries. `ToolGroup.active` was also not declared `volatile`, so updates to a group's active state were not guaranteed to be visible across threads.

Changes made:
- Marked `ToolGroup.active` as `volatile` to ensure cross-thread visibility.
- Added synchronization around `ToolGroupManager.activeGroups` reads and writes.
- Added a regression test that concurrently activates the same group and verifies it appears only once in `activeGroups`.

How to test:
- `mvn -pl agentscope-core -Dtest=ToolGroupManagerTest test`
- `mvn -pl agentscope-core test`

Both commands pass locally.

## Checklist

Please check the following items before code is ready to be reviewed.

- [ ] Code has been formatted with `mvn spotless:apply`
- [x] All tests are passing (`mvn test`)
- [x] Javadoc comments are complete and follow project conventions
- [ ] Related documentation has been updated (e.g. links, examples, etc.)
- [x] Code is ready for review
