### PR TITLE
fix(skill): validate resource path before activating skill

### DIFF
--- a/agentscope-core/src/main/java/io/agentscope/core/skill/SkillToolFactory.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/skill/SkillToolFactory.java
@@ -254,11 +254,12 @@ class SkillToolFactory {
     }
 
     /**
-     * Validate skill exists and activate it and its tool group.
+     * Validates that a skill is registered and returns its instance.
      *
      * @param skillId The unique identifier of the skill
-     * @return The skill instance
-     * @throws IllegalArgumentException if skill doesn't exist
+     * @return The registered skill instance
+     * @throws IllegalArgumentException if the skill is not registered
+     * @throws IllegalStateException if the skill cannot be loaded after validation
      */
     private AgentSkill validateSkillExists(String skillId) {
         if (!skillRegistry.exists(skillId)) {

--- a/agentscope-core/src/main/java/io/agentscope/core/skill/SkillToolFactory.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/skill/SkillToolFactory.java
@@ -79,10 +79,13 @@ class SkillToolFactory {
                         + "**Functionality:**\n"
                         + "1. Activates the specified skill (making its tools available)\n"
                         + "2. Returns the requested resource content\n"
-                        + " usage instructions)\n"
-                        + "- 'SKILL.md': The skill's markdown documentation (name, description,"
-                        + "- Other paths: Additional resources like scripts, configs, templates, or"
-                        + " data files";
+                        + "\n"
+                        + "**Path rules:**\n"
+                        + "- Use path=\"SKILL.md\" to load the skill's markdown documentation"
+                        + " (name, description, usage instructions).\n"
+                        + "- Use exact resource paths listed by the skill, such as"
+                        + " \"references/guide.md\" or \"scripts/run.py\".\n"
+                        + "- Do not use '.', './', the skill directory, or an absolute path.";
             }
 
             @Override
@@ -108,9 +111,11 @@ class SkillToolFactory {
                                                         "type",
                                                         "string",
                                                         "description",
-                                                        "The path to the resource file within the"
-                                                                + " skill (e.g., 'SKILL.md,"
-                                                                + " references/references.md')")),
+                                                        "The exact resource path within the skill."
+                                                                + " Use 'SKILL.md' to load the"
+                                                                + " skill instructions. Do not use"
+                                                                + " '.', './', directories, or"
+                                                                + " absolute paths.")),
                         "required", List.of("skillId", "path"));
             }
 
@@ -155,10 +160,11 @@ class SkillToolFactory {
      * @throws IllegalArgumentException if skill doesn't exist or resource not found
      */
     private String loadSkillResourceImpl(String skillId, String path) {
-        AgentSkill skill = validatedActiveSkill(skillId);
+        AgentSkill skill = validateSkillExists(skillId);
 
         // Special handling for SKILL.md - return the skill's markdown content
         if ("SKILL.md".equals(path)) {
+            activateSkill(skillId);
             return buildSkillMarkdownResponse(skillId, skill);
         }
 
@@ -171,6 +177,7 @@ class SkillToolFactory {
         }
 
         String resourceContent = resources.get(path);
+        activateSkill(skillId);
         return buildResourceResponse(skillId, path, resourceContent);
     }
 
@@ -253,7 +260,7 @@ class SkillToolFactory {
      * @return The skill instance
      * @throws IllegalArgumentException if skill doesn't exist
      */
-    private AgentSkill validatedActiveSkill(String skillId) {
+    private AgentSkill validateSkillExists(String skillId) {
         if (!skillRegistry.exists(skillId)) {
             throw new IllegalArgumentException(
                     String.format("Skill not found: '%s'. Please check the skill ID.", skillId));
@@ -267,7 +274,10 @@ class SkillToolFactory {
                                     + " error.",
                             skillId));
         }
-        // Set skill as active
+        return skill;
+    }
+
+    private void activateSkill(String skillId) {
         skillRegistry.setSkillActive(skillId, true);
         logger.info("Activated skill: {}", skillId);
 
@@ -279,7 +289,5 @@ class SkillToolFactory {
                     toolsGroupName,
                     toolkit.getToolGroup(toolsGroupName).getTools());
         }
-
-        return skill;
     }
 }

--- a/agentscope-core/src/test/java/io/agentscope/core/skill/SkillBoxToolsTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/skill/SkillBoxToolsTest.java
@@ -110,6 +110,8 @@ class SkillBoxToolsTest {
         assertEquals("load_skill_through_path", tool.getName());
         assertNotNull(tool.getDescription());
         assertTrue(tool.getDescription().contains("Load and activate"));
+        assertTrue(tool.getDescription().contains("path=\"SKILL.md\""));
+        assertTrue(tool.getDescription().contains("Do not use '.'"));
     }
 
     @Test
@@ -136,6 +138,12 @@ class SkillBoxToolsTest {
         @SuppressWarnings("unchecked")
         Map<String, Object> skillIdParam = (Map<String, Object>) properties.get("skillId");
         assertNotNull(skillIdParam.get("enum"));
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> pathParam = (Map<String, Object>) properties.get("path");
+        String pathDescription = (String) pathParam.get("description");
+        assertTrue(pathDescription.contains("Use 'SKILL.md'"));
+        assertTrue(pathDescription.contains("Do not use '.'"));
     }
 
     @Test
@@ -482,5 +490,29 @@ class SkillBoxToolsTest {
         assertTrue(skillBox.isSkillActive(skillId), "Skill should still be activated");
         assertNull(
                 toolkit.getToolGroup(skillId + "_skill_tools"), "Tool group should not be created");
+    }
+
+    @Test
+    @DisplayName("Should not activate skill when resource path is invalid")
+    void testInvalidResourcePathDoesNotActivateSkill() {
+        AgentTool tool = toolkit.getTool("load_skill_through_path");
+        String skillId = "test_skill_custom";
+        assertFalse(skillBox.isSkillActive(skillId));
+
+        Map<String, Object> input = Map.of("skillId", skillId, "path", ".");
+        ToolUseBlock toolUseBlock =
+                ToolUseBlock.builder()
+                        .id("test-call-016")
+                        .name("load_skill_through_path")
+                        .input(input)
+                        .build();
+        ToolCallParam param =
+                ToolCallParam.builder().toolUseBlock(toolUseBlock).input(input).build();
+
+        ToolResultBlock result = tool.callAsync(param).block(TIMEOUT);
+
+        assertNotNull(result);
+        assertTrue(isErrorResult(result));
+        assertFalse(skillBox.isSkillActive(skillId));
     }
 }


### PR DESCRIPTION
## AgentScope-Java Version

1.0.12-SNAPSHOT

## Description

Closes #1289.

This PR fixes the `load_skill_through_path` behavior when the model passes an invalid resource path such as `.`.

Background:
- The tool description and `path` parameter schema were incomplete/malformed, which could mislead models about how to load skill content.
- Calling `load_skill_through_path` with an invalid path returned an error, but still activated the skill before validating the resource path.

Changes made:
- Clarified the tool description to explicitly instruct models to use `path="SKILL.md"` for skill documentation.
- Clarified the `path` parameter description and explicitly disallowed `.`, `./`, directories, and absolute paths.
- Changed activation order so a skill is activated only after `SKILL.md` or a valid resource path is successfully loaded.
- Added regression tests for tool/schema guidance and invalid-path activation behavior.

How to test:
- Run `mvn -pl agentscope-core -Dtest='io.agentscope.core.skill.*Test' test`

## Checklist

Please check the following items before code is ready to be reviewed.

- [ ] Code has been formatted with `mvn spotless:apply`
- [x] All tests are passing (`mvn -pl agentscope-core -Dtest='io.agentscope.core.skill.*Test' test`)
- [x] Javadoc comments are complete and follow project conventions
- [ ] Related documentation has been updated (e.g. links, examples, etc.)
- [x] Code is ready for review
