### PR TITLE
fix(memory): preserve ToolUseBlock structure during large message compression

### DIFF
--- a/agentscope-extensions/agentscope-extensions-autocontext-memory/src/main/java/io/agentscope/core/memory/autocontext/AutoContextMemory.java
+++ b/agentscope-extensions/agentscope-extensions-autocontext-memory/src/main/java/io/agentscope/core/memory/autocontext/AutoContextMemory.java
@@ -510,7 +510,15 @@ public class AutoContextMemory implements StateModule, Memory, ContextOffLoader 
             String textContent = msg.getTextContent();
 
             // Check if message content exceeds threshold
-            if (textContent == null || textContent.length() <= threshold) {
+            // Use calculateMessageCharCount for accurate size check across all block types
+            // (including ToolResultBlock output which getTextContent() doesn't cover)
+            if ((textContent == null || textContent.isEmpty())
+                    && MsgUtils.calculateMessageCharCount(msg) <= threshold) {
+                continue;
+            }
+            if (textContent != null
+                    && !textContent.isEmpty()
+                    && textContent.length() <= threshold) {
                 continue;
             }
 
@@ -522,7 +530,7 @@ public class AutoContextMemory implements StateModule, Memory, ContextOffLoader 
             log.info(
                     "Offloaded current round large message: index={}, size={} chars, uuid={}",
                     i,
-                    textContent.length(),
+                    MsgUtils.calculateMessageCharCount(msg),
                     uuid);
 
             // Step 5: Generate summary using LLM
@@ -566,15 +574,20 @@ public class AutoContextMemory implements StateModule, Memory, ContextOffLoader 
      * triggering model's tool detection), and the compressed result preserves the ToolUseBlock
      * structure while replacing TextBlock with the LLM summary.
      *
+     * <p>For messages containing ToolResultBlock (e.g., TOOL messages), the text content inside
+     * ToolResultBlock's output is extracted for summarization, and the compressed result preserves
+     * the ToolResultBlock structure (id, name, metadata) while replacing output with the summary.
+     *
      * @param message the message to summarize
      * @param offloadUuid the UUID of offloaded message
      * @return a summary message preserving the original role and name
      */
     private Msg generateLargeMessageSummary(Msg message, String offloadUuid) {
         boolean hasToolUse = message.hasContentBlocks(ToolUseBlock.class);
+        boolean hasToolResult = message.hasContentBlocks(ToolResultBlock.class);
 
         // Step 1: Call model to generate summary
-        Msg block = callModelForSummary(message, hasToolUse);
+        Msg block = callModelForSummary(message, hasToolUse, hasToolResult);
 
         // Step 2: Build summary text with optional offload hint
         String summaryContent = block != null ? block.getTextContent() : "";
@@ -587,11 +600,15 @@ public class AutoContextMemory implements StateModule, Memory, ContextOffLoader 
         // Step 3: Build metadata
         Map<String, Object> metadata = buildCompressionMetadata(message, offloadUuid, block);
 
-        // Step 4: Build result message
-        List<ContentBlock> contentBlocks =
-                hasToolUse
-                        ? buildToolUsePreservingBlocks(message, finalContent)
-                        : List.of(TextBlock.builder().text(finalContent).build());
+        // Step 4: Build result message content blocks
+        List<ContentBlock> contentBlocks;
+        if (hasToolUse) {
+            contentBlocks = buildToolUsePreservingBlocks(message, finalContent);
+        } else if (hasToolResult) {
+            contentBlocks = buildToolResultPreservingBlocks(message, finalContent);
+        } else {
+            contentBlocks = List.of(TextBlock.builder().text(finalContent).build());
+        }
 
         return Msg.builder()
                 .role(message.getRole())
@@ -605,22 +622,22 @@ public class AutoContextMemory implements StateModule, Memory, ContextOffLoader 
      * Call model to generate a summary of the message content.
      *
      * <p>For messages with ToolUseBlock, only TextBlock content is extracted and sent to the model
-     * to avoid triggering tool detection mechanism.
+     * to avoid triggering tool detection mechanism. For messages with ToolResultBlock, the text
+     * content inside ToolResultBlock's output is extracted for summarization.
      */
-    private Msg callModelForSummary(Msg message, boolean hasToolUse) {
+    private Msg callModelForSummary(Msg message, boolean hasToolUse, boolean hasToolResult) {
         GenerateOptions options = GenerateOptions.builder().build();
         ReasoningContext context = new ReasoningContext("large_message_summary");
 
         // Build the message to send for compression
         Msg messageForCompression = message;
-        String textContent = message.getTextContent();
-        if (hasToolUse && textContent != null && !textContent.isEmpty()) {
-            // Extract only TextBlock content to avoid triggering model's tool detection
+        String textForCompression = extractTextForCompression(message, hasToolUse, hasToolResult);
+        if (textForCompression != null && !textForCompression.isEmpty()) {
             messageForCompression =
                     Msg.builder()
                             .role(message.getRole())
                             .name(message.getName())
-                            .content(TextBlock.builder().text(textContent).build())
+                            .content(TextBlock.builder().text(textForCompression).build())
                             .build();
         }
 
@@ -686,6 +703,32 @@ public class AutoContextMemory implements StateModule, Memory, ContextOffLoader 
     }
 
     /**
+     * Extract text content for compression based on the message's content block types.
+     *
+     * @return extracted text content, or null if no special extraction is needed
+     */
+    private String extractTextForCompression(
+            Msg message, boolean hasToolUse, boolean hasToolResult) {
+        if (hasToolUse) {
+            // Extract only top-level TextBlock content to avoid triggering model's tool detection
+            return message.getTextContent();
+        }
+        if (hasToolResult) {
+            // Extract text from ToolResultBlock's output since Msg.getTextContent() only
+            // extracts top-level TextBlocks and returns empty for ToolResultBlock content
+            return message.getContent().stream()
+                    .filter(ToolResultBlock.class::isInstance)
+                    .map(ToolResultBlock.class::cast)
+                    .flatMap(trb -> trb.getOutput().stream())
+                    .filter(TextBlock.class::isInstance)
+                    .map(TextBlock.class::cast)
+                    .map(TextBlock::getText)
+                    .collect(Collectors.joining("\n"));
+        }
+        return null;
+    }
+
+    /**
      * Build content blocks that preserve ToolUseBlock structure while replacing TextBlock with
      * compressed summary.
      */
@@ -709,6 +752,33 @@ public class AutoContextMemory implements StateModule, Memory, ContextOffLoader 
         // Defensive: if no TextBlock existed, still add the summary
         if (!hasTextBlock && !summaryText.isEmpty()) {
             blocks.add(0, TextBlock.builder().text(summaryText).build());
+        }
+        return blocks;
+    }
+
+    /**
+     * Build content blocks that preserve ToolResultBlock structure (id, name, metadata) while
+     * replacing its output with the compressed summary.
+     */
+    private List<ContentBlock> buildToolResultPreservingBlocks(Msg message, String summaryText) {
+        List<ContentBlock> blocks = new ArrayList<>();
+        boolean hasReplacedToolResult = false;
+
+        for (ContentBlock originalBlock : message.getContent()) {
+            if (originalBlock instanceof ToolResultBlock toolResult) {
+                if (!hasReplacedToolResult) {
+                    // Replace output with compressed summary, preserve id/name/metadata
+                    blocks.add(
+                            ToolResultBlock.of(
+                                    toolResult.getId(),
+                                    toolResult.getName(),
+                                    TextBlock.builder().text(summaryText).build(),
+                                    toolResult.getMetadata()));
+                    hasReplacedToolResult = true;
+                }
+            } else {
+                blocks.add(originalBlock);
+            }
         }
         return blocks;
     }

--- a/agentscope-extensions/agentscope-extensions-autocontext-memory/src/main/java/io/agentscope/core/memory/autocontext/AutoContextMemory.java
+++ b/agentscope-extensions/agentscope-extensions-autocontext-memory/src/main/java/io/agentscope/core/memory/autocontext/AutoContextMemory.java
@@ -17,6 +17,7 @@ package io.agentscope.core.memory.autocontext;
 
 import io.agentscope.core.agent.accumulator.ReasoningContext;
 import io.agentscope.core.memory.Memory;
+import io.agentscope.core.message.ContentBlock;
 import io.agentscope.core.message.MessageMetadataKeys;
 import io.agentscope.core.message.Msg;
 import io.agentscope.core.message.MsgRole;
@@ -560,18 +561,68 @@ public class AutoContextMemory implements StateModule, Memory, ContextOffLoader 
     /**
      * Generate a summary of a large message using the model.
      *
+     * <p>For messages containing ToolUseBlock (e.g., ReAct ASSISTANT messages with reasoning +
+     * tool call), only the TextBlock content is sent to the model for summarization (to avoid
+     * triggering model's tool detection), and the compressed result preserves the ToolUseBlock
+     * structure while replacing TextBlock with the LLM summary.
+     *
      * @param message the message to summarize
      * @param offloadUuid the UUID of offloaded message
      * @return a summary message preserving the original role and name
      */
     private Msg generateLargeMessageSummary(Msg message, String offloadUuid) {
-        GenerateOptions options = GenerateOptions.builder().build();
-        ReasoningContext context = new ReasoningContext("large_message_summary");
+        boolean hasToolUse = message.hasContentBlocks(ToolUseBlock.class);
 
+        // Step 1: Call model to generate summary
+        Msg block = callModelForSummary(message, hasToolUse);
+
+        // Step 2: Build summary text with optional offload hint
+        String summaryContent = block != null ? block.getTextContent() : "";
         String offloadHint =
                 offloadUuid != null
                         ? String.format(Prompts.CONTEXT_OFFLOAD_TAG_FORMAT, offloadUuid)
                         : "";
+        String finalContent = offloadHint.isEmpty() ? summaryContent : summaryContent + offloadHint;
+
+        // Step 3: Build metadata
+        Map<String, Object> metadata = buildCompressionMetadata(message, offloadUuid, block);
+
+        // Step 4: Build result message
+        List<ContentBlock> contentBlocks =
+                hasToolUse
+                        ? buildToolUsePreservingBlocks(message, finalContent)
+                        : List.of(TextBlock.builder().text(finalContent).build());
+
+        return Msg.builder()
+                .role(message.getRole())
+                .name(message.getName())
+                .content(contentBlocks)
+                .metadata(metadata)
+                .build();
+    }
+
+    /**
+     * Call model to generate a summary of the message content.
+     *
+     * <p>For messages with ToolUseBlock, only TextBlock content is extracted and sent to the model
+     * to avoid triggering tool detection mechanism.
+     */
+    private Msg callModelForSummary(Msg message, boolean hasToolUse) {
+        GenerateOptions options = GenerateOptions.builder().build();
+        ReasoningContext context = new ReasoningContext("large_message_summary");
+
+        // Build the message to send for compression
+        Msg messageForCompression = message;
+        String textContent = message.getTextContent();
+        if (hasToolUse && textContent != null && !textContent.isEmpty()) {
+            // Extract only TextBlock content to avoid triggering model's tool detection
+            messageForCompression =
+                    Msg.builder()
+                            .role(message.getRole())
+                            .name(message.getName())
+                            .content(TextBlock.builder().text(textContent).build())
+                            .build();
+        }
 
         List<Msg> newMessages = new ArrayList<>();
         newMessages.add(
@@ -585,7 +636,7 @@ public class AutoContextMemory implements StateModule, Memory, ContextOffLoader 
                                                         customPrompt))
                                         .build())
                         .build());
-        newMessages.add(message);
+        newMessages.add(messageForCompression);
         newMessages.add(
                 Msg.builder()
                         .role(MsgRole.USER)
@@ -595,7 +646,6 @@ public class AutoContextMemory implements StateModule, Memory, ContextOffLoader 
                                         .text(Prompts.COMPRESSION_MESSAGE_LIST_END)
                                         .build())
                         .build());
-        // Insert plan-aware hint message at the end to leverage recency effect
         addPlanAwareHintIfNeeded(newMessages);
 
         Msg block =
@@ -611,34 +661,56 @@ public class AutoContextMemory implements StateModule, Memory, ContextOffLoader 
                     block.getChatUsage().getInputTokens(),
                     block.getChatUsage().getOutputTokens());
         }
+        return block;
+    }
 
-        // Build metadata with compression information
+    /** Build compression metadata including offload UUID and chat usage. */
+    private Map<String, Object> buildCompressionMetadata(
+            Msg message, String offloadUuid, Msg block) {
         Map<String, Object> compressMeta = new HashMap<>();
         if (offloadUuid != null) {
             compressMeta.put("offloaduuid", offloadUuid);
         }
 
-        Map<String, Object> metadata = new HashMap<>();
+        // Preserve original message metadata
+        Map<String, Object> metadata =
+                message.getMetadata() != null
+                        ? new HashMap<>(message.getMetadata())
+                        : new HashMap<>();
         metadata.put("_compress_meta", compressMeta);
 
-        // Preserve _chat_usage from the block if available
         if (block != null && block.getChatUsage() != null) {
             metadata.put(MessageMetadataKeys.CHAT_USAGE, block.getChatUsage());
         }
+        return metadata;
+    }
 
-        // Create summary message preserving original role and name
-        String summaryContent = block != null ? block.getTextContent() : "";
-        String finalContent = summaryContent;
-        if (!offloadHint.isEmpty()) {
-            finalContent = summaryContent + "\n" + offloadHint;
+    /**
+     * Build content blocks that preserve ToolUseBlock structure while replacing TextBlock with
+     * compressed summary.
+     */
+    private List<ContentBlock> buildToolUsePreservingBlocks(Msg message, String summaryText) {
+        List<ContentBlock> blocks = new ArrayList<>();
+        boolean hasTextBlock = false;
+
+        for (ContentBlock originalBlock : message.getContent()) {
+            if (originalBlock instanceof ToolUseBlock) {
+                blocks.add(originalBlock);
+            } else if (originalBlock instanceof TextBlock) {
+                if (!hasTextBlock) {
+                    blocks.add(TextBlock.builder().text(summaryText).build());
+                    hasTextBlock = true;
+                }
+            } else {
+                blocks.add(originalBlock);
+            }
         }
 
-        return Msg.builder()
-                .role(message.getRole())
-                .name(message.getName())
-                .content(TextBlock.builder().text(finalContent).build())
-                .metadata(metadata)
-                .build();
+        // Defensive: if no TextBlock existed, still add the summary
+        if (!hasTextBlock && !summaryText.isEmpty()) {
+            blocks.add(0, TextBlock.builder().text(summaryText).build());
+        }
+        return blocks;
     }
 
     /**

--- a/agentscope-extensions/agentscope-extensions-autocontext-memory/src/test/java/io/agentscope/core/memory/autocontext/AutoContextMemoryTest.java
+++ b/agentscope-extensions/agentscope-extensions-autocontext-memory/src/test/java/io/agentscope/core/memory/autocontext/AutoContextMemoryTest.java
@@ -17,6 +17,7 @@ package io.agentscope.core.memory.autocontext;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -2072,5 +2073,105 @@ class AutoContextMemoryTest {
                 1,
                 testModel.getCallCount(),
                 "Model should be called exactly once for the second high-token tool group");
+    }
+
+    // ==================== ToolUseBlock Compression Format Tests ====================
+
+    @Test
+    @DisplayName(
+            "Should preserve ToolUseBlock and compress TextBlock when compressing mixed ASSISTANT"
+                    + " message")
+    void testToolUseBlockPreservedAndTextBlockCompressedDuringLargeMessageCompression()
+            throws Exception {
+        // Use CapturingModel to verify messages sent to the model
+        CapturingModel capturingModel = new CapturingModel("Compressed summary of reasoning");
+        AutoContextConfig config =
+                AutoContextConfig.builder()
+                        .msgThreshold(10)
+                        .largePayloadThreshold(100) // low threshold to trigger compression
+                        .lastKeep(5)
+                        .minConsecutiveToolMessages(100) // disable Strategy 1
+                        .minCompressionTokenThreshold(Integer.MAX_VALUE) // disable LLM compression
+                        .build();
+        AutoContextMemory testMemory = new AutoContextMemory(config, capturingModel);
+
+        // Add messages to exceed msgThreshold
+        for (int i = 0; i < 8; i++) {
+            testMemory.addMessage(createTextMessage("Message " + i, MsgRole.USER));
+        }
+
+        // Add a user message (this becomes the latest user)
+        testMemory.addMessage(createTextMessage("User query", MsgRole.USER));
+
+        // Create a large ASSISTANT message with both TextBlock and ToolUseBlock
+        String largeReasoning = "x".repeat(200); // exceeds largePayloadThreshold
+        Msg mixedMsg =
+                Msg.builder()
+                        .role(MsgRole.ASSISTANT)
+                        .name("assistant")
+                        .content(
+                                List.of(
+                                        TextBlock.builder().text(largeReasoning).build(),
+                                        ToolUseBlock.builder()
+                                                .name("search")
+                                                .id("call_001")
+                                                .input(new HashMap<>())
+                                                .build()))
+                        .build();
+        testMemory.addMessage(mixedMsg);
+
+        // Trigger compression
+        testMemory.compressIfNeeded();
+
+        // Verify: model was called for compression
+        assertTrue(
+                capturingModel.getCapturedMessages().size() > 0,
+                "Model should be called for compression");
+
+        // Verify: messages sent to model should NOT contain ToolUseBlock
+        List<List<Msg>> captured = capturingModel.getCapturedMessages();
+        for (List<Msg> msgs : captured) {
+            for (Msg msg : msgs) {
+                assertFalse(
+                        msg.hasContentBlocks(ToolUseBlock.class),
+                        "Messages sent to model for compression should not contain ToolUseBlock");
+            }
+        }
+
+        // Verify: the compressed message in memory should preserve ToolUseBlock
+        List<Msg> finalMessages = testMemory.getMessages();
+        boolean foundCompressedMixed = false;
+        for (Msg msg : finalMessages) {
+            if (msg.hasContentBlocks(ToolUseBlock.class) && msg.getRole() == MsgRole.ASSISTANT) {
+                foundCompressedMixed = true;
+                // Should still have ToolUseBlock
+                boolean hasToolUse = false;
+                boolean hasText = false;
+                for (var block : msg.getContent()) {
+                    if (block instanceof ToolUseBlock toolUse) {
+                        hasToolUse = true;
+                        assertEquals(
+                                "call_001", toolUse.getId(), "ToolUseBlock id should be preserved");
+                        assertEquals(
+                                "search",
+                                toolUse.getName(),
+                                "ToolUseBlock name should be preserved");
+                    } else if (block instanceof TextBlock textBlock) {
+                        hasText = true;
+                        // TextBlock should be compressed (not the original large text)
+                        assertNotEquals(
+                                largeReasoning,
+                                textBlock.getText(),
+                                "TextBlock should be compressed, not original");
+                    }
+                }
+                assertTrue(hasToolUse, "Compressed message should preserve ToolUseBlock");
+                assertTrue(hasText, "Compressed message should have summary TextBlock");
+            }
+        }
+
+        assertTrue(
+                foundCompressedMixed,
+                "Should find a compressed ASSISTANT message with preserved ToolUseBlock");
     }
 }

--- a/agentscope-extensions/agentscope-extensions-autocontext-memory/src/test/java/io/agentscope/core/memory/autocontext/AutoContextMemoryTest.java
+++ b/agentscope-extensions/agentscope-extensions-autocontext-memory/src/test/java/io/agentscope/core/memory/autocontext/AutoContextMemoryTest.java
@@ -43,6 +43,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -2173,5 +2174,111 @@ class AutoContextMemoryTest {
         assertTrue(
                 foundCompressedMixed,
                 "Should find a compressed ASSISTANT message with preserved ToolUseBlock");
+    }
+
+    @Test
+    @DisplayName(
+            "Should preserve ToolResultBlock structure and compress output during large TOOL"
+                    + " message compression")
+    void testToolResultBlockPreservedAndOutputCompressedDuringLargeMessageCompression()
+            throws Exception {
+        CapturingModel capturingModel = new CapturingModel("Compressed tool result summary");
+        AutoContextConfig config =
+                AutoContextConfig.builder()
+                        .msgThreshold(10)
+                        .largePayloadThreshold(100)
+                        .lastKeep(5)
+                        .minConsecutiveToolMessages(100) // disable Strategy 1
+                        .minCompressionTokenThreshold(Integer.MAX_VALUE) // disable LLM compression
+                        .build();
+        AutoContextMemory testMemory = new AutoContextMemory(config, capturingModel);
+
+        // Add messages to exceed msgThreshold
+        for (int i = 0; i < 8; i++) {
+            testMemory.addMessage(createTextMessage("Message " + i, MsgRole.USER));
+        }
+
+        // Add user + assistant with tool use (to pair with the tool result)
+        testMemory.addMessage(createTextMessage("User query", MsgRole.USER));
+        testMemory.addMessage(
+                Msg.builder()
+                        .role(MsgRole.ASSISTANT)
+                        .name("assistant")
+                        .content(
+                                List.of(
+                                        TextBlock.builder().text("Let me search").build(),
+                                        ToolUseBlock.builder()
+                                                .name("search")
+                                                .id("call_tr_001")
+                                                .input(new HashMap<>())
+                                                .build()))
+                        .build());
+
+        // Create a large TOOL message with ToolResultBlock containing large output
+        String largeToolOutput = "y".repeat(200); // exceeds largePayloadThreshold
+        Msg toolMsg =
+                Msg.builder()
+                        .role(MsgRole.TOOL)
+                        .name("search")
+                        .content(
+                                ToolResultBlock.builder()
+                                        .id("call_tr_001")
+                                        .name("search")
+                                        .output(
+                                                List.of(
+                                                        TextBlock.builder()
+                                                                .text(largeToolOutput)
+                                                                .build()))
+                                        .build())
+                        .build();
+        testMemory.addMessage(toolMsg);
+
+        // Trigger compression
+        testMemory.compressIfNeeded();
+
+        // Verify: model was called for compression
+        assertTrue(
+                capturingModel.getCapturedMessages().size() > 0,
+                "Model should be called for compression");
+
+        // Verify: messages sent to model should NOT contain ToolResultBlock
+        for (List<Msg> msgs : capturingModel.getCapturedMessages()) {
+            for (Msg msg : msgs) {
+                assertFalse(
+                        msg.hasContentBlocks(ToolResultBlock.class),
+                        "Messages sent to model should not contain ToolResultBlock");
+            }
+        }
+
+        // Verify: the compressed TOOL message should preserve ToolResultBlock structure
+        List<Msg> finalMessages = testMemory.getMessages();
+        boolean foundCompressedTool = false;
+        for (Msg msg : finalMessages) {
+            if (msg.getRole() == MsgRole.TOOL && msg.hasContentBlocks(ToolResultBlock.class)) {
+                ToolResultBlock resultBlock = msg.getFirstContentBlock(ToolResultBlock.class);
+                if (resultBlock != null && "call_tr_001".equals(resultBlock.getId())) {
+                    foundCompressedTool = true;
+                    assertEquals(
+                            "search",
+                            resultBlock.getName(),
+                            "ToolResultBlock name should be preserved");
+                    // Output should be compressed, not the original
+                    String outputText =
+                            resultBlock.getOutput().stream()
+                                    .filter(TextBlock.class::isInstance)
+                                    .map(TextBlock.class::cast)
+                                    .map(TextBlock::getText)
+                                    .collect(Collectors.joining());
+                    assertNotEquals(
+                            largeToolOutput,
+                            outputText,
+                            "ToolResultBlock output should be compressed, not original");
+                }
+            }
+        }
+
+        assertTrue(
+                foundCompressedTool,
+                "Should find a compressed TOOL message with preserved ToolResultBlock structure");
     }
 }


### PR DESCRIPTION
## AgentScope-Java Version

1.0.11

## Description

[Please describe the background, purpose, changes made, and how to test this PR]

## Checklist

Please check the following items before code is ready to be reviewed.

- [x]  Code has been formatted with `mvn spotless:apply`
- [x]  All tests are passing (`mvn test`)
- [x]  Javadoc comments are complete and follow project conventions
- [x]  Related documentation has been updated (e.g. links, examples, etc.)
- [x]  Code is ready for review
