### PR TITLE
fix(embedding): make dimensions parameter optional in OpenAITextEmbedding

### DIFF
--- a/agentscope-extensions/agentscope-extensions-rag-simple/src/main/java/io/agentscope/core/embedding/openai/OpenAITextEmbedding.java
+++ b/agentscope-extensions/agentscope-extensions-rag-simple/src/main/java/io/agentscope/core/embedding/openai/OpenAITextEmbedding.java
@@ -142,7 +142,7 @@ public class OpenAITextEmbedding implements EmbeddingModel {
 
                                         // Only include dimensions if explicitly set
                                         if (dimensions != null) {
-                                                paramsBuilder = paramsBuilder.dimensions(dimensions);
+                                            paramsBuilder = paramsBuilder.dimensions(dimensions);
                                         }
 
                                         EmbeddingCreateParams createParams = paramsBuilder.build();
@@ -187,7 +187,8 @@ public class OpenAITextEmbedding implements EmbeddingModel {
                                                         embeddingValues);
 
                                         // Validate dimension if expected dimensions were set
-                                        if (dimensions != null && embeddingArray.length != dimensions) {
+                                        if (dimensions != null
+                                                && embeddingArray.length != dimensions) {
                                             log.warn(
                                                     "Embedding dimension mismatch: expected={},"
                                                             + " actual={}",

--- a/agentscope-extensions/agentscope-extensions-rag-simple/src/main/java/io/agentscope/core/embedding/openai/OpenAITextEmbedding.java
+++ b/agentscope-extensions/agentscope-extensions-rag-simple/src/main/java/io/agentscope/core/embedding/openai/OpenAITextEmbedding.java
@@ -49,7 +49,7 @@ public class OpenAITextEmbedding implements EmbeddingModel {
 
     private final String apiKey;
     private final String modelName;
-    private final int dimensions;
+    private final Integer dimensions;
     private final ExecutionConfig defaultExecutionConfig;
 
     private final String baseUrl;
@@ -59,14 +59,14 @@ public class OpenAITextEmbedding implements EmbeddingModel {
      *
      * @param apiKey the API key for OpenAI authentication
      * @param modelName the model name (e.g., "text-embedding-3-small")
-     * @param dimensions the dimension of embedding vectors
+     * @param dimensions the dimension of embedding vectors (optional, null to omit)
      * @param defaultExecutionConfig default execution configuration for timeout and retry
      * @param baseUrl custom base URL for OpenAI API (null for default)
      */
     public OpenAITextEmbedding(
             String apiKey,
             String modelName,
-            int dimensions,
+            Integer dimensions,
             ExecutionConfig defaultExecutionConfig,
             String baseUrl) {
         this.apiKey = apiKey;
@@ -132,15 +132,20 @@ public class OpenAITextEmbedding implements EmbeddingModel {
 
                                         OpenAIClient client = clientBuilder.build();
 
-                                        EmbeddingCreateParams createParams =
+                                        EmbeddingCreateParams.Builder paramsBuilder =
                                                 EmbeddingCreateParams.builder()
                                                         .model(modelName)
-                                                        .dimensions(dimensions)
                                                         .encodingFormat(
                                                                 EmbeddingCreateParams.EncodingFormat
                                                                         .FLOAT)
-                                                        .inputOfArrayOfStrings(List.of(text))
-                                                        .build();
+                                                        .inputOfArrayOfStrings(List.of(text));
+
+                                        // Only include dimensions if explicitly set
+                                        if (dimensions != null) {
+                                                paramsBuilder = paramsBuilder.dimensions(dimensions);
+                                        }
+
+                                        EmbeddingCreateParams createParams = paramsBuilder.build();
 
                                         log.debug(
                                                 "OpenAI embedding call: model={},"
@@ -181,8 +186,8 @@ public class OpenAITextEmbedding implements EmbeddingModel {
                                                 EmbeddingUtils.convertFloatListToDoubleArray(
                                                         embeddingValues);
 
-                                        // Validate dimension
-                                        if (embeddingArray.length != dimensions) {
+                                        // Validate dimension if expected dimensions were set
+                                        if (dimensions != null && embeddingArray.length != dimensions) {
                                             log.warn(
                                                     "Embedding dimension mismatch: expected={},"
                                                             + " actual={}",
@@ -225,7 +230,7 @@ public class OpenAITextEmbedding implements EmbeddingModel {
 
     @Override
     public int getDimensions() {
-        return dimensions;
+        return dimensions != null ? dimensions : 1536;
     }
 
     /**
@@ -234,7 +239,7 @@ public class OpenAITextEmbedding implements EmbeddingModel {
     public static class Builder {
         private String apiKey;
         private String modelName;
-        private int dimensions = 1536;
+        private Integer dimensions;
         private ExecutionConfig defaultExecutionConfig;
         private String baseUrl;
 
@@ -261,12 +266,16 @@ public class OpenAITextEmbedding implements EmbeddingModel {
         }
 
         /**
-         * Sets the dimension of embedding vectors.
+         * Sets the dimension of embedding vectors (optional, only for OpenAI official models).
          *
-         * @param dimensions the dimension
+         * <p>The dimensions parameter is only supported by OpenAI official embedding models
+         * (e.g., text-embedding-3-small). Open-source embedding models (e.g., BAAI/bge) do not
+         * support this parameter. When null, the dimensions parameter will not be sent to the API.
+         *
+         * @param dimensions the dimension (null for no dimension specification)
          * @return this builder instance
          */
-        public Builder dimensions(int dimensions) {
+        public Builder dimensions(Integer dimensions) {
             this.dimensions = dimensions;
             return this;
         }
@@ -311,7 +320,8 @@ public class OpenAITextEmbedding implements EmbeddingModel {
                 throw new IllegalStateException(
                         "modelName is required and cannot be null or empty");
             }
-            if (dimensions <= 0) {
+            // Validate dimensions only if explicitly set
+            if (dimensions != null && dimensions <= 0) {
                 throw new IllegalStateException("dimensions must be positive, got: " + dimensions);
             }
 

--- a/agentscope-extensions/agentscope-extensions-rag-simple/src/test/java/io/agentscope/core/embedding/openai/OpenAITextEmbeddingTest.java
+++ b/agentscope-extensions/agentscope-extensions-rag-simple/src/test/java/io/agentscope/core/embedding/openai/OpenAITextEmbeddingTest.java
@@ -260,4 +260,70 @@ class OpenAITextEmbeddingTest {
                                 .dimensions(-1)
                                 .build());
     }
+
+    @Test
+    @DisplayName("Should build successfully without setting dimensions (open-source model support)")
+    void testBuilderWithoutDimensions() {
+        OpenAITextEmbedding model =
+                OpenAITextEmbedding.builder()
+                        .apiKey(TEST_API_KEY)
+                        .modelName(TEST_MODEL_NAME)
+                        .build();
+
+        assertNotNull(model);
+        assertEquals(TEST_MODEL_NAME, model.getModelName());
+    }
+
+    @Test
+    @DisplayName("Should return default 1536 from getDimensions when dimensions not set")
+    void testGetDimensionsReturnsDefaultWhenNotSet() {
+        OpenAITextEmbedding model =
+                OpenAITextEmbedding.builder()
+                        .apiKey(TEST_API_KEY)
+                        .modelName(TEST_MODEL_NAME)
+                        .build();
+
+        assertEquals(1536, model.getDimensions());
+    }
+
+    @Test
+    @DisplayName("Should return configured dimensions from getDimensions when explicitly set")
+    void testGetDimensionsReturnsConfiguredValue() {
+        OpenAITextEmbedding model =
+                OpenAITextEmbedding.builder()
+                        .apiKey(TEST_API_KEY)
+                        .modelName(TEST_MODEL_NAME)
+                        .dimensions(512)
+                        .build();
+
+        assertEquals(512, model.getDimensions());
+    }
+
+    @Test
+    @DisplayName("Should build with null dimensions explicitly passed (open-source model support)")
+    void testBuilderWithNullDimensions() {
+        OpenAITextEmbedding model =
+                OpenAITextEmbedding.builder()
+                        .apiKey(TEST_API_KEY)
+                        .modelName(TEST_MODEL_NAME)
+                        .dimensions(null)
+                        .build();
+
+        assertNotNull(model);
+        assertEquals(1536, model.getDimensions());
+    }
+
+    @Test
+    @DisplayName("Should reject null ContentBlock when no dimensions set")
+    void testNullContentBlockWithoutDimensions() {
+        OpenAITextEmbedding model =
+                OpenAITextEmbedding.builder()
+                        .apiKey(TEST_API_KEY)
+                        .modelName(TEST_MODEL_NAME)
+                        .build();
+
+        StepVerifier.create(model.embed((ContentBlock) null))
+                .expectError(EmbeddingException.class)
+                .verify();
+    }
 }


### PR DESCRIPTION
## Summary
Fixes issue #1095: OpenAITextEmbedding now supports open-source embedding models that don't support the matryoshka dimension parameter.

## Problem
- OpenAI text embedding component forced the `dimensions` parameter to be required
- This parameter is only supported by OpenAI official embedding models (e.g., text-embedding-3-small)
- Open-source models like BAAI/bge-large-zh-v1.5 return 400 error when this parameter is included
- Users could not use OpenAITextEmbedding with open-source models

## Solution
- Changed `dimensions` from required `int` to optional `Integer` (can be null)
- Only include `dimensions` in API request when explicitly configured by user
- Added documentation clarifying when to use this parameter
- Validation only applies when dimensions are explicitly set
- Backward compatible: existing code without explicit dimensions still works

## Changes
- Modified constructor to accept `Integer dimensions` (nullable)
- Updated builder to accept `Integer dimensions` 
- Updated API call logic to conditionally include dimensions parameter
- Updated Javadoc for `dimensions()` builder method

## Testing
- Existing tests continue to pass
- Code is backward compatible with existing configurations
- Now supports both OpenAI official and open-source embedding models