### PR TITLE
fix(transport): resolve SSE stream timeout in JdkHttpTransport

### DIFF
--- a/agentscope-core/src/main/java/io/agentscope/core/model/transport/HttpTransportConfig.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/model/transport/HttpTransportConfig.java
@@ -28,14 +28,14 @@ public class HttpTransportConfig {
     /** Default connect timeout: 30 seconds. */
     public static final Duration DEFAULT_CONNECT_TIMEOUT = Duration.ofSeconds(30);
 
+    /** Default read timeout: 5 minutes (Overall timeout for non-streaming calls). */
+    public static final Duration DEFAULT_READ_TIMEOUT = Duration.ofMinutes(5);
+
     /** Default response timeout (TTFT): 5 minutes (Time To First Token for streaming). */
     public static final Duration DEFAULT_RESPONSE_TIMEOUT = Duration.ofMinutes(5);
 
-    /** Default stream idle timeout: 30 seconds (Maximum wait time between consecutive data chunks). */
-    public static final Duration DEFAULT_STREAM_IDLE_TIMEOUT = Duration.ofSeconds(30);
-
-    /** Default read timeout: 5 minutes (Overall timeout for non-streaming calls). */
-    public static final Duration DEFAULT_READ_TIMEOUT = Duration.ofMinutes(5);
+    /** Default stream idle timeout: 5 minutes (maximum wait between consecutive data chunks). */
+    public static final Duration DEFAULT_STREAM_IDLE_TIMEOUT = DEFAULT_READ_TIMEOUT;
 
     /** Default write timeout: 30 seconds. */
     public static final Duration DEFAULT_WRITE_TIMEOUT = Duration.ofSeconds(30);
@@ -92,7 +92,10 @@ public class HttpTransportConfig {
     }
 
     /**
-     * Get the read timeout(for non-streaming).
+     * Get the read timeout.
+     *
+     * <p>For {@link JdkHttpTransport} streaming requests, response and idle timeouts are controlled
+     * by {@link #getResponseTimeout()} and {@link #getStreamIdleTimeout()} instead.
      *
      * @return the read timeout duration
      */

--- a/agentscope-core/src/main/java/io/agentscope/core/model/transport/HttpTransportConfig.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/model/transport/HttpTransportConfig.java
@@ -28,13 +28,16 @@ public class HttpTransportConfig {
     /** Default connect timeout: 30 seconds. */
     public static final Duration DEFAULT_CONNECT_TIMEOUT = Duration.ofSeconds(30);
 
-    /** Default read timeout: 5 minutes (Overall timeout for non-streaming calls). */
+    /** Default read timeout: 5 minutes. */
     public static final Duration DEFAULT_READ_TIMEOUT = Duration.ofMinutes(5);
 
-    /** Default response timeout: 5 minutes (request start to first emitted streaming chunk). */
+    /**
+     * Default streaming response timeout: 5 minutes (request start to first emitted streaming
+     * chunk).
+     */
     public static final Duration DEFAULT_RESPONSE_TIMEOUT = Duration.ofMinutes(5);
 
-    /** Default stream idle timeout: 5 minutes (maximum wait between consecutive data chunks). */
+    /** Default streaming idle timeout: 5 minutes (maximum wait between data chunks). */
     public static final Duration DEFAULT_STREAM_IDLE_TIMEOUT = DEFAULT_READ_TIMEOUT;
 
     /** Default write timeout: 30 seconds. */
@@ -77,7 +80,8 @@ public class HttpTransportConfig {
      * Get the response timeout for streaming requests.
      *
      * <p>For {@link JdkHttpTransport} streaming requests, this bounds the time from request start
-     * until the first emitted SSE/NDJSON chunk.
+     * until the first emitted SSE/NDJSON chunk. {@link OkHttpTransport} does not consume this
+     * option; it relies on OkHttp's {@link #getReadTimeout()} for stream reads.
      *
      * @return the response timeout duration
      */
@@ -86,7 +90,11 @@ public class HttpTransportConfig {
     }
 
     /**
-     * Get the stream idle timeout (maximum time between two consecutive data chunks).
+     * Get the stream idle timeout.
+     *
+     * <p>For {@link JdkHttpTransport} streaming requests, this bounds the maximum wait between two
+     * consecutive emitted SSE/NDJSON chunks. {@link OkHttpTransport} does not consume this option;
+     * it relies on OkHttp's {@link #getReadTimeout()} for stream reads.
      *
      * @return the stream idle timeout duration
      */
@@ -97,8 +105,10 @@ public class HttpTransportConfig {
     /**
      * Get the read timeout.
      *
-     * <p>For {@link JdkHttpTransport} streaming requests, response and idle timeouts are controlled
-     * by {@link #getResponseTimeout()} and {@link #getStreamIdleTimeout()} instead.
+     * <p>{@link OkHttpTransport} applies this as OkHttp's read timeout for both standard and
+     * streaming requests. {@link JdkHttpTransport} applies this to non-streaming requests only; JDK
+     * streaming requests use {@link #getResponseTimeout()} and {@link #getStreamIdleTimeout()}
+     * instead.
      *
      * @return the read timeout duration
      */
@@ -212,7 +222,8 @@ public class HttpTransportConfig {
          * Set the response timeout for streaming requests.
          *
          * <p>For {@link JdkHttpTransport} streaming requests, this bounds the time from request
-         * start until the first emitted SSE/NDJSON chunk.
+         * start until the first emitted SSE/NDJSON chunk. {@link OkHttpTransport} does not consume
+         * this option; it relies on OkHttp's {@link #getReadTimeout()} for stream reads.
          *
          * @param responseTimeout the response timeout duration
          * @return this builder
@@ -225,6 +236,10 @@ public class HttpTransportConfig {
         /**
          * Set the stream idle timeout.
          *
+         * <p>For {@link JdkHttpTransport} streaming requests, this bounds the maximum wait between
+         * two consecutive emitted SSE/NDJSON chunks. {@link OkHttpTransport} does not consume this
+         * option; it relies on OkHttp's {@link #getReadTimeout()} for stream reads.
+         *
          * @param streamIdleTimeout the stream idle timeout duration
          * @return this builder
          */
@@ -235,6 +250,11 @@ public class HttpTransportConfig {
 
         /**
          * Set the read timeout.
+         *
+         * <p>{@link OkHttpTransport} applies this as OkHttp's read timeout for both standard and
+         * streaming requests. {@link JdkHttpTransport} applies this to non-streaming requests only;
+         * JDK streaming requests use {@link #getResponseTimeout()} and
+         * {@link #getStreamIdleTimeout()} instead.
          *
          * @param readTimeout the read timeout duration
          * @return this builder

--- a/agentscope-core/src/main/java/io/agentscope/core/model/transport/HttpTransportConfig.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/model/transport/HttpTransportConfig.java
@@ -31,7 +31,7 @@ public class HttpTransportConfig {
     /** Default read timeout: 5 minutes (Overall timeout for non-streaming calls). */
     public static final Duration DEFAULT_READ_TIMEOUT = Duration.ofMinutes(5);
 
-    /** Default response timeout (TTFT): 5 minutes (Time To First Token for streaming). */
+    /** Default response timeout: 5 minutes (request start to first emitted streaming chunk). */
     public static final Duration DEFAULT_RESPONSE_TIMEOUT = Duration.ofMinutes(5);
 
     /** Default stream idle timeout: 5 minutes (maximum wait between consecutive data chunks). */
@@ -74,7 +74,10 @@ public class HttpTransportConfig {
     }
 
     /**
-     * Get the response timeout (Time To First Token for streaming).
+     * Get the response timeout for streaming requests.
+     *
+     * <p>For {@link JdkHttpTransport} streaming requests, this bounds the time from request start
+     * until the first emitted SSE/NDJSON chunk.
      *
      * @return the response timeout duration
      */
@@ -206,7 +209,10 @@ public class HttpTransportConfig {
         }
 
         /**
-         * Set the response timeout (Time To First Byte).
+         * Set the response timeout for streaming requests.
+         *
+         * <p>For {@link JdkHttpTransport} streaming requests, this bounds the time from request
+         * start until the first emitted SSE/NDJSON chunk.
          *
          * @param responseTimeout the response timeout duration
          * @return this builder

--- a/agentscope-core/src/main/java/io/agentscope/core/model/transport/HttpTransportConfig.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/model/transport/HttpTransportConfig.java
@@ -28,13 +28,21 @@ public class HttpTransportConfig {
     /** Default connect timeout: 30 seconds. */
     public static final Duration DEFAULT_CONNECT_TIMEOUT = Duration.ofSeconds(30);
 
-    /** Default read timeout: 5 minutes (for long-running model calls). */
+    /** Default response timeout (TTFT): 5 minutes (Time To First Token for streaming). */
+    public static final Duration DEFAULT_RESPONSE_TIMEOUT = Duration.ofMinutes(5);
+
+    /** Default stream idle timeout: 30 seconds (Maximum wait time between consecutive data chunks). */
+    public static final Duration DEFAULT_STREAM_IDLE_TIMEOUT = Duration.ofSeconds(30);
+
+    /** Default read timeout: 5 minutes (Overall timeout for non-streaming calls). */
     public static final Duration DEFAULT_READ_TIMEOUT = Duration.ofMinutes(5);
 
     /** Default write timeout: 30 seconds. */
     public static final Duration DEFAULT_WRITE_TIMEOUT = Duration.ofSeconds(30);
 
     private final Duration connectTimeout;
+    private final Duration responseTimeout;
+    private final Duration streamIdleTimeout;
     private final Duration readTimeout;
     private final Duration writeTimeout;
     private final int maxIdleConnections;
@@ -45,6 +53,8 @@ public class HttpTransportConfig {
 
     private HttpTransportConfig(Builder builder) {
         this.connectTimeout = builder.connectTimeout;
+        this.responseTimeout = builder.responseTimeout;
+        this.streamIdleTimeout = builder.streamIdleTimeout;
         this.readTimeout = builder.readTimeout;
         this.writeTimeout = builder.writeTimeout;
         this.maxIdleConnections = builder.maxIdleConnections;
@@ -64,7 +74,25 @@ public class HttpTransportConfig {
     }
 
     /**
-     * Get the read timeout.
+     * Get the response timeout (Time To First Token for streaming).
+     *
+     * @return the response timeout duration
+     */
+    public Duration getResponseTimeout() {
+        return responseTimeout;
+    }
+
+    /**
+     * Get the stream idle timeout (maximum time between two consecutive data chunks).
+     *
+     * @return the stream idle timeout duration
+     */
+    public Duration getStreamIdleTimeout() {
+        return streamIdleTimeout;
+    }
+
+    /**
+     * Get the read timeout(for non-streaming).
      *
      * @return the read timeout duration
      */
@@ -153,6 +181,8 @@ public class HttpTransportConfig {
      */
     public static class Builder {
         private Duration connectTimeout = DEFAULT_CONNECT_TIMEOUT;
+        private Duration responseTimeout = DEFAULT_RESPONSE_TIMEOUT;
+        private Duration streamIdleTimeout = DEFAULT_STREAM_IDLE_TIMEOUT;
         private Duration readTimeout = DEFAULT_READ_TIMEOUT;
         private Duration writeTimeout = DEFAULT_WRITE_TIMEOUT;
         private int maxIdleConnections = 5;
@@ -169,6 +199,28 @@ public class HttpTransportConfig {
          */
         public Builder connectTimeout(Duration connectTimeout) {
             this.connectTimeout = connectTimeout;
+            return this;
+        }
+
+        /**
+         * Set the response timeout (Time To First Byte).
+         *
+         * @param responseTimeout the response timeout duration
+         * @return this builder
+         */
+        public Builder responseTimeout(Duration responseTimeout) {
+            this.responseTimeout = responseTimeout;
+            return this;
+        }
+
+        /**
+         * Set the stream idle timeout.
+         *
+         * @param streamIdleTimeout the stream idle timeout duration
+         * @return this builder
+         */
+        public Builder streamIdleTimeout(Duration streamIdleTimeout) {
+            this.streamIdleTimeout = streamIdleTimeout;
             return this;
         }
 

--- a/agentscope-core/src/main/java/io/agentscope/core/model/transport/JdkHttpTransport.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/model/transport/JdkHttpTransport.java
@@ -200,11 +200,16 @@ public class JdkHttpTransport implements HttpTransport {
         return Flux.defer(
                 () -> {
                     AtomicReference<InputStream> responseBody = new AtomicReference<>();
+                    long requestStartNanos = System.nanoTime();
                     return sendInputStreamAsync(jdkRequest, responseBody)
                             .timeout(Mono.delay(streamResponseTimeout()))
                             .flatMapMany(
                                     response ->
-                                            handleStreamResponse(response, request, responseBody))
+                                            handleStreamResponse(
+                                                    response,
+                                                    request,
+                                                    responseBody,
+                                                    requestStartNanos))
                             .doFinally(signal -> closeQuietly(responseBody.getAndSet(null)))
                             .onErrorMap(this::mapStreamError);
                 });
@@ -244,7 +249,8 @@ public class JdkHttpTransport implements HttpTransport {
     private Flux<String> handleStreamResponse(
             java.net.http.HttpResponse<InputStream> response,
             HttpRequest request,
-            AtomicReference<InputStream> responseBody) {
+            AtomicReference<InputStream> responseBody,
+            long requestStartNanos) {
         InputStream inputStream = response.body();
         responseBody.set(inputStream);
 
@@ -273,9 +279,9 @@ public class JdkHttpTransport implements HttpTransport {
 
         return processStreamResponse(inputStream, request)
                 .timeout(
-                        // Timeout strategy 1: Time To First Token (TTFT).
-                        // The maximum time to wait for the first piece of data after headers.
-                        Mono.delay(streamResponseTimeout()),
+                        // Timeout strategy 1: Time To First Chunk.
+                        // This uses the remaining response timeout budget from request start.
+                        Mono.delay(remainingResponseTimeout(requestStartNanos)),
 
                         // Timeout strategy 2: Inter-token gap (Stream Idle Timeout).
                         // The maximum time to wait between receiving two consecutive data chunks.
@@ -438,6 +444,12 @@ public class JdkHttpTransport implements HttpTransport {
         return config.getResponseTimeout() != null
                 ? config.getResponseTimeout()
                 : HttpTransportConfig.DEFAULT_RESPONSE_TIMEOUT;
+    }
+
+    private Duration remainingResponseTimeout(long requestStartNanos) {
+        Duration elapsed = Duration.ofNanos(System.nanoTime() - requestStartNanos);
+        Duration remaining = streamResponseTimeout().minus(elapsed);
+        return remaining.isNegative() || remaining.isZero() ? Duration.ZERO : remaining;
     }
 
     private Duration streamIdleTimeout() {

--- a/agentscope-core/src/main/java/io/agentscope/core/model/transport/JdkHttpTransport.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/model/transport/JdkHttpTransport.java
@@ -34,6 +34,7 @@ import java.security.KeyManagementException;
 import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
 import java.security.cert.X509Certificate;
+import java.time.Duration;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -41,6 +42,7 @@ import java.util.Objects;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.TrustManager;
 import javax.net.ssl.X509TrustManager;
@@ -195,15 +197,64 @@ public class JdkHttpTransport implements HttpTransport {
 
         var jdkRequest = buildJdkRequest(request, true);
 
-        // Use Mono.fromFuture() to ensure lazy execution and proper cancellation propagation.
-        // This prevents "ghost connections" from leaking if the downstream cancels or times out
-        // before headers arrive.
-        return Mono.fromFuture(() -> client.sendAsync(jdkRequest, BodyHandlers.ofInputStream()))
-                .flatMapMany(
-                        response -> {
-                            int statusCode = response.statusCode();
-                            if (statusCode < 200 || statusCode >= 300) {
-                                String errorBody = readInputStream(response.body());
+        return Flux.defer(
+                () -> {
+                    AtomicReference<InputStream> responseBody = new AtomicReference<>();
+                    return sendInputStreamAsync(jdkRequest, responseBody)
+                            .timeout(Mono.delay(streamResponseTimeout()))
+                            .flatMapMany(
+                                    response ->
+                                            handleStreamResponse(response, request, responseBody))
+                            .doFinally(signal -> closeQuietly(responseBody.getAndSet(null)))
+                            .onErrorMap(this::mapStreamError);
+                });
+    }
+
+    private Mono<java.net.http.HttpResponse<InputStream>> sendInputStreamAsync(
+            java.net.http.HttpRequest request, AtomicReference<InputStream> responseBody) {
+        return Mono.create(
+                sink -> {
+                    AtomicBoolean cancelled = new AtomicBoolean(false);
+                    var future = client.sendAsync(request, BodyHandlers.ofInputStream());
+                    sink.onCancel(
+                            () -> {
+                                cancelled.set(true);
+                                future.cancel(true);
+                                closeQuietly(responseBody.getAndSet(null));
+                            });
+                    future.whenComplete(
+                            (response, error) -> {
+                                if (error != null) {
+                                    if (!cancelled.get()) {
+                                        sink.error(error);
+                                    }
+                                    return;
+                                }
+
+                                responseBody.set(response.body());
+                                if (cancelled.get()) {
+                                    closeQuietly(responseBody.getAndSet(null));
+                                    return;
+                                }
+                                sink.success(response);
+                            });
+                });
+    }
+
+    private Flux<String> handleStreamResponse(
+            java.net.http.HttpResponse<InputStream> response,
+            HttpRequest request,
+            AtomicReference<InputStream> responseBody) {
+        InputStream inputStream = response.body();
+        responseBody.set(inputStream);
+
+        int statusCode = response.statusCode();
+        if (statusCode < 200 || statusCode >= 300) {
+            return readInputStreamAsync(inputStream)
+                    .timeout(streamResponseTimeout())
+                    .onErrorReturn("")
+                    .flatMapMany(
+                            errorBody -> {
                                 log.warn(
                                         "HTTP request failed. URL: {} | Status: {} | Error: {}",
                                         request.getUrl(),
@@ -217,45 +268,21 @@ public class JdkHttpTransport implements HttpTransport {
                                                         + errorBody,
                                                 statusCode,
                                                 errorBody));
-                            }
-                            return processStreamResponse(response, request);
-                        })
+                            });
+        }
+
+        return processStreamResponse(inputStream, request)
                 .timeout(
                         // Timeout strategy 1: Time To First Token (TTFT).
-                        // The maximum time to wait for the first piece of data.
-                        Mono.delay(
-                                config.getResponseTimeout() != null
-                                        ? config.getResponseTimeout()
-                                        : HttpTransportConfig.DEFAULT_RESPONSE_TIMEOUT),
+                        // The maximum time to wait for the first piece of data after headers.
+                        Mono.delay(streamResponseTimeout()),
 
                         // Timeout strategy 2: Inter-token gap (Stream Idle Timeout).
                         // The maximum time to wait between receiving two consecutive data chunks.
-                        data ->
-                                Mono.delay(
-                                        config.getStreamIdleTimeout() != null
-                                                ? config.getStreamIdleTimeout()
-                                                : HttpTransportConfig.DEFAULT_STREAM_IDLE_TIMEOUT))
-                .onErrorMap(
-                        e -> {
-                            if (e instanceof TimeoutException) {
-                                return new HttpTransportException(
-                                        "Stream timeout: " + e.getMessage(), e);
-                            }
-                            if (e instanceof HttpTransportException) {
-                                return e;
-                            }
-                            Throwable cause = e instanceof CompletionException ? e.getCause() : e;
-                            if (cause instanceof HttpTransportException) {
-                                return cause;
-                            }
-                            return new HttpTransportException(
-                                    "SSE/NDJSON stream failed: " + e.getMessage(), e);
-                        });
+                        data -> Mono.delay(streamIdleTimeout()));
     }
 
-    private Flux<String> processStreamResponse(
-            java.net.http.HttpResponse<InputStream> response, HttpRequest request) {
-        InputStream inputStream = response.body();
+    private Flux<String> processStreamResponse(InputStream inputStream, HttpRequest request) {
         if (inputStream == null) {
             return Flux.empty();
         }
@@ -399,6 +426,38 @@ public class JdkHttpTransport implements HttpTransport {
             log.warn("Failed to read response body: {}", e.getMessage());
             return null;
         }
+    }
+
+    private Mono<String> readInputStreamAsync(InputStream inputStream) {
+        return Mono.fromCallable(() -> readInputStream(inputStream))
+                .defaultIfEmpty("")
+                .subscribeOn(Schedulers.boundedElastic());
+    }
+
+    private Duration streamResponseTimeout() {
+        return config.getResponseTimeout() != null
+                ? config.getResponseTimeout()
+                : HttpTransportConfig.DEFAULT_RESPONSE_TIMEOUT;
+    }
+
+    private Duration streamIdleTimeout() {
+        return config.getStreamIdleTimeout() != null
+                ? config.getStreamIdleTimeout()
+                : HttpTransportConfig.DEFAULT_STREAM_IDLE_TIMEOUT;
+    }
+
+    private Throwable mapStreamError(Throwable e) {
+        if (e instanceof TimeoutException) {
+            return new HttpTransportException("Stream timeout: " + e.getMessage(), e);
+        }
+        if (e instanceof HttpTransportException) {
+            return e;
+        }
+        Throwable cause = e instanceof CompletionException ? e.getCause() : e;
+        if (cause instanceof HttpTransportException) {
+            return cause;
+        }
+        return new HttpTransportException("SSE/NDJSON stream failed: " + e.getMessage(), e);
     }
 
     private void closeQuietly(AutoCloseable closeable) {

--- a/agentscope-core/src/main/java/io/agentscope/core/model/transport/JdkHttpTransport.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/model/transport/JdkHttpTransport.java
@@ -38,8 +38,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.TrustManager;
@@ -174,7 +174,7 @@ public class JdkHttpTransport implements HttpTransport {
             throw new HttpTransportException("Transport has been closed");
         }
 
-        var jdkRequest = buildJdkRequest(request);
+        var jdkRequest = buildJdkRequest(request, false);
 
         try {
             var response = client.send(jdkRequest, BodyHandlers.ofString());
@@ -193,50 +193,64 @@ public class JdkHttpTransport implements HttpTransport {
             return Flux.error(new HttpTransportException("Transport has been closed"));
         }
 
-        var jdkRequest = buildJdkRequest(request);
+        var jdkRequest = buildJdkRequest(request, true);
 
-        // Check status code and read error body immediately when CompletableFuture completes
-        // to avoid stream being closed before we can read it
-        CompletableFuture<java.net.http.HttpResponse<InputStream>> future =
-                client.sendAsync(jdkRequest, BodyHandlers.ofInputStream())
-                        .thenApply(
-                                response -> {
-                                    int statusCode = response.statusCode();
-                                    if (statusCode < 200 || statusCode >= 300) {
-                                        // Read error body immediately while stream is still open
-                                        String errorBody = readInputStream(response.body());
-                                        log.warn(
-                                                "HTTP request failed. URL: {} | Status: {} | Error:"
-                                                        + " {}",
-                                                request.getUrl(),
+        // Use Mono.fromFuture() to ensure lazy execution and proper cancellation propagation.
+        // This prevents "ghost connections" from leaking if the downstream cancels or times out
+        // before headers arrive.
+        return Mono.fromFuture(() -> client.sendAsync(jdkRequest, BodyHandlers.ofInputStream()))
+                .flatMapMany(
+                        response -> {
+                            int statusCode = response.statusCode();
+                            if (statusCode < 200 || statusCode >= 300) {
+                                String errorBody = readInputStream(response.body());
+                                log.warn(
+                                        "HTTP request failed. URL: {} | Status: {} | Error: {}",
+                                        request.getUrl(),
+                                        statusCode,
+                                        errorBody);
+                                return Flux.error(
+                                        new HttpTransportException(
+                                                "HTTP request failed with status "
+                                                        + statusCode
+                                                        + " | "
+                                                        + errorBody,
                                                 statusCode,
-                                                errorBody);
-                                        throw new CompletionException(
-                                                new HttpTransportException(
-                                                        "HTTP request failed with status "
-                                                                + statusCode
-                                                                + " | "
-                                                                + errorBody,
-                                                        statusCode,
-                                                        errorBody));
-                                    }
-                                    return response;
-                                });
+                                                errorBody));
+                            }
+                            return processStreamResponse(response, request);
+                        })
+                .timeout(
+                        // Timeout strategy 1: Time To First Token (TTFT).
+                        // The maximum time to wait for the first piece of data.
+                        Mono.delay(
+                                config.getResponseTimeout() != null
+                                        ? config.getResponseTimeout()
+                                        : HttpTransportConfig.DEFAULT_RESPONSE_TIMEOUT),
 
-        return Mono.fromCompletionStage(future)
-                .flatMapMany(response -> processStreamResponse(response, request))
-                .publishOn(Schedulers.boundedElastic())
+                        // Timeout strategy 2: Inter-token gap (Stream Idle Timeout).
+                        // The maximum time to wait between receiving two consecutive data chunks.
+                        data ->
+                                Mono.delay(
+                                        config.getStreamIdleTimeout() != null
+                                                ? config.getStreamIdleTimeout()
+                                                : HttpTransportConfig.DEFAULT_STREAM_IDLE_TIMEOUT))
                 .onErrorMap(
-                        e -> !(e instanceof HttpTransportException),
                         e -> {
+                            if (e instanceof TimeoutException) {
+                                return new HttpTransportException(
+                                        "Stream timeout: " + e.getMessage(), e);
+                            }
+                            if (e instanceof HttpTransportException) {
+                                return e;
+                            }
                             Throwable cause = e instanceof CompletionException ? e.getCause() : e;
                             if (cause instanceof HttpTransportException) {
-                                return (HttpTransportException) cause;
+                                return cause;
                             }
                             return new HttpTransportException(
                                     "SSE/NDJSON stream failed: " + e.getMessage(), e);
-                        })
-                .subscribeOn(Schedulers.boundedElastic());
+                        });
     }
 
     private Flux<String> processStreamResponse(
@@ -253,11 +267,13 @@ public class JdkHttpTransport implements HttpTransport {
 
         // Use Flux.using to manage resource lifecycle
         return Flux.using(
-                () ->
-                        new BufferedReader(
-                                new InputStreamReader(inputStream, StandardCharsets.UTF_8)),
-                reader -> isNdjson ? readNdJsonLines(reader) : readSseLines(reader),
-                this::closeQuietly);
+                        () ->
+                                new BufferedReader(
+                                        new InputStreamReader(inputStream, StandardCharsets.UTF_8)),
+                        reader -> isNdjson ? readNdJsonLines(reader) : readSseLines(reader),
+                        this::closeQuietly)
+                // reader.lines() uses blocking I/O internally
+                .subscribeOn(Schedulers.boundedElastic());
     }
 
     private Flux<String> readSseLines(BufferedReader reader) {
@@ -310,7 +326,7 @@ public class JdkHttpTransport implements HttpTransport {
         return closed.get();
     }
 
-    private java.net.http.HttpRequest buildJdkRequest(HttpRequest request) {
+    private java.net.http.HttpRequest buildJdkRequest(HttpRequest request, boolean isStreaming) {
         URI uri;
         try {
             uri = URI.create(request.getUrl());
@@ -318,8 +334,11 @@ public class JdkHttpTransport implements HttpTransport {
             throw new HttpTransportException("Invalid URL: " + request.getUrl(), e);
         }
 
-        var builder =
-                java.net.http.HttpRequest.newBuilder().uri(uri).timeout(config.getReadTimeout());
+        var builder = java.net.http.HttpRequest.newBuilder().uri(uri);
+
+        if (!isStreaming && config.getReadTimeout() != null) {
+            builder.timeout(config.getReadTimeout());
+        }
 
         for (Map.Entry<String, String> header : request.getHeaders().entrySet()) {
             builder.header(header.getKey(), header.getValue());

--- a/agentscope-core/src/main/java/io/agentscope/core/model/transport/JdkHttpTransport.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/model/transport/JdkHttpTransport.java
@@ -215,6 +215,9 @@ public class JdkHttpTransport implements HttpTransport {
                 });
     }
 
+    /**
+     * Send a streaming request and propagate Reactor cancellation to the JDK future/socket.
+     */
     private Mono<java.net.http.HttpResponse<InputStream>> sendInputStreamAsync(
             java.net.http.HttpRequest request, AtomicReference<InputStream> responseBody) {
         return Mono.create(
@@ -246,6 +249,9 @@ public class JdkHttpTransport implements HttpTransport {
                 });
     }
 
+    /**
+     * Validate the streaming response and apply first-chunk and inter-chunk timeouts.
+     */
     private Flux<String> handleStreamResponse(
             java.net.http.HttpResponse<InputStream> response,
             HttpRequest request,
@@ -288,6 +294,9 @@ public class JdkHttpTransport implements HttpTransport {
                         data -> Mono.delay(streamIdleTimeout()));
     }
 
+    /**
+     * Parse SSE or NDJSON lines on a bounded elastic worker because BufferedReader blocks.
+     */
     private Flux<String> processStreamResponse(InputStream inputStream, HttpRequest request) {
         if (inputStream == null) {
             return Flux.empty();
@@ -309,6 +318,9 @@ public class JdkHttpTransport implements HttpTransport {
                 .subscribeOn(Schedulers.boundedElastic());
     }
 
+    /**
+     * Extract non-empty SSE data payloads and stop before the terminal marker.
+     */
     private Flux<String> readSseLines(BufferedReader reader) {
         return Flux.fromStream(reader.lines())
                 .filter(line -> line.startsWith(SSE_DATA_PREFIX))
@@ -318,6 +330,9 @@ public class JdkHttpTransport implements HttpTransport {
                 .filter(data -> !data.isEmpty());
     }
 
+    /**
+     * Extract non-empty NDJSON records as already-delimited stream chunks.
+     */
     private Flux<String> readNdJsonLines(BufferedReader reader) {
         return Flux.fromStream(reader.lines())
                 .doOnNext(line -> log.debug("Received NDJSON line"))
@@ -434,30 +449,45 @@ public class JdkHttpTransport implements HttpTransport {
         }
     }
 
+    /**
+     * Read an error response body away from the JDK HTTP worker threads.
+     */
     private Mono<String> readInputStreamAsync(InputStream inputStream) {
         return Mono.fromCallable(() -> readInputStream(inputStream))
                 .defaultIfEmpty("")
                 .subscribeOn(Schedulers.boundedElastic());
     }
 
+    /**
+     * Resolve the configured request-start-to-first-chunk timeout.
+     */
     private Duration streamResponseTimeout() {
         return config.getResponseTimeout() != null
                 ? config.getResponseTimeout()
                 : HttpTransportConfig.DEFAULT_RESPONSE_TIMEOUT;
     }
 
+    /**
+     * Keep the first-chunk timeout as one budget across header wait and body parsing.
+     */
     private Duration remainingResponseTimeout(long requestStartNanos) {
         Duration elapsed = Duration.ofNanos(System.nanoTime() - requestStartNanos);
         Duration remaining = streamResponseTimeout().minus(elapsed);
         return remaining.isNegative() || remaining.isZero() ? Duration.ZERO : remaining;
     }
 
+    /**
+     * Resolve the configured maximum idle gap between emitted stream chunks.
+     */
     private Duration streamIdleTimeout() {
         return config.getStreamIdleTimeout() != null
                 ? config.getStreamIdleTimeout()
                 : HttpTransportConfig.DEFAULT_STREAM_IDLE_TIMEOUT;
     }
 
+    /**
+     * Normalize low-level streaming failures into the transport exception type.
+     */
     private Throwable mapStreamError(Throwable e) {
         if (e instanceof TimeoutException) {
             return new HttpTransportException("Stream timeout: " + e.getMessage(), e);

--- a/agentscope-core/src/main/java/io/agentscope/core/model/transport/OkHttpTransport.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/model/transport/OkHttpTransport.java
@@ -106,6 +106,9 @@ public class OkHttpTransport implements HttpTransport {
                 new OkHttpClient.Builder()
                         .connectTimeout(
                                 config.getConnectTimeout().toMillis(), TimeUnit.MILLISECONDS)
+                        // OkHttp readTimeout is a socket-read idle timeout. It remains suitable
+                        // for streaming reads and is distinct from JDK streaming response/idle
+                        // timeouts in HttpTransportConfig.
                         .readTimeout(config.getReadTimeout().toMillis(), TimeUnit.MILLISECONDS)
                         .writeTimeout(config.getWriteTimeout().toMillis(), TimeUnit.MILLISECONDS)
                         .connectionPool(

--- a/agentscope-core/src/test/java/io/agentscope/core/model/transport/JdkHttpTransportTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/model/transport/JdkHttpTransportTest.java
@@ -22,14 +22,31 @@ import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.Authenticator;
+import java.net.CookieHandler;
+import java.net.ProxySelector;
+import java.net.URI;
 import java.net.http.HttpClient;
+import java.net.http.HttpClient.Redirect;
+import java.net.http.HttpClient.Version;
+import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLParameters;
+import javax.net.ssl.SSLSession;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
 import okhttp3.mockwebserver.RecordedRequest;
@@ -1139,14 +1156,14 @@ class JdkHttpTransportTest {
     @Test
     void testStreamIdleTimeout() {
         // Test Timeout Strategy 2 (Inter-token gap):
-        // Throttle body to emit 1 byte every 2 seconds.
-        // This exceeds the configured streamIdleTimeout (1 second).
+        // Emit the first complete event immediately, then delay the second event long enough to
+        // exceed streamIdleTimeout.
         mockServer.enqueue(
                 new MockResponse()
                         .setResponseCode(200)
                         .setHeader("Content-Type", "text/event-stream")
                         .setBody("data: {\"id\":\"1\"}\n\ndata: {\"id\":\"2\"}\n\n")
-                        .throttleBody(1, 2, TimeUnit.SECONDS));
+                        .throttleBody(19, 2, TimeUnit.SECONDS));
 
         HttpRequest request =
                 HttpRequest.builder()
@@ -1156,11 +1173,51 @@ class JdkHttpTransportTest {
                         .build();
 
         StepVerifier.create(transport.stream(request))
+                .expectNextMatches(data -> data.contains("\"id\":\"1\""))
                 .expectErrorMatches(
                         e ->
                                 e instanceof HttpTransportException
                                         && e.getMessage().contains("Stream timeout"))
                 .verify(Duration.ofSeconds(5));
+    }
+
+    @Test
+    void testStreamTimeoutClosesBodyWhenFutureCompletesAfterCancellation() {
+        HttpTransportConfig customConfig =
+                HttpTransportConfig.builder()
+                        .responseTimeout(Duration.ofMillis(100))
+                        .streamIdleTimeout(Duration.ofSeconds(1))
+                        .build();
+        BlockingInputStream body = new BlockingInputStream();
+        AtomicReference<CompletableFuture<java.net.http.HttpResponse<InputStream>>> futureRef =
+                new AtomicReference<>();
+        JdkHttpTransport customTransport =
+                new JdkHttpTransport(new DeferredBodyHttpClient(futureRef, body), customConfig);
+
+        try {
+            HttpRequest request =
+                    HttpRequest.builder()
+                            .url("http://localhost/deferred-body")
+                            .method("POST")
+                            .body("{}")
+                            .build();
+
+            StepVerifier.create(customTransport.stream(request))
+                    .expectErrorMatches(
+                            e ->
+                                    e instanceof HttpTransportException
+                                            && e.getMessage().contains("Stream timeout"))
+                    .verify(Duration.ofSeconds(2));
+
+            CompletableFuture<java.net.http.HttpResponse<InputStream>> future = futureRef.get();
+            assertNotNull(future);
+            assertTrue(future.isCancelled(), "Timeout should cancel the pending async request");
+
+            future.complete(new TestHttpResponse(200, body));
+            assertTrue(body.awaitClosed(), "Response body must be closed after late completion");
+        } finally {
+            customTransport.close();
+        }
     }
 
     @Test
@@ -1194,5 +1251,185 @@ class JdkHttpTransportTest {
         StepVerifier.create(transport.stream(request))
                 .expectNextCount(5) // Should successfully receive all 5 data chunks
                 .verifyComplete();
+    }
+
+    private static class DeferredBodyHttpClient extends HttpClient {
+        private final AtomicReference<CompletableFuture<java.net.http.HttpResponse<InputStream>>>
+                futureRef;
+        private final InputStream body;
+
+        DeferredBodyHttpClient(
+                AtomicReference<CompletableFuture<java.net.http.HttpResponse<InputStream>>>
+                        futureRef,
+                InputStream body) {
+            this.futureRef = futureRef;
+            this.body = body;
+        }
+
+        @Override
+        public Optional<CookieHandler> cookieHandler() {
+            return Optional.empty();
+        }
+
+        @Override
+        public Optional<Duration> connectTimeout() {
+            return Optional.empty();
+        }
+
+        @Override
+        public Redirect followRedirects() {
+            return Redirect.NEVER;
+        }
+
+        @Override
+        public Optional<ProxySelector> proxy() {
+            return Optional.empty();
+        }
+
+        @Override
+        public SSLContext sslContext() {
+            return null;
+        }
+
+        @Override
+        public SSLParameters sslParameters() {
+            return new SSLParameters();
+        }
+
+        @Override
+        public Optional<Authenticator> authenticator() {
+            return Optional.empty();
+        }
+
+        @Override
+        public Version version() {
+            return Version.HTTP_2;
+        }
+
+        @Override
+        public Optional<Executor> executor() {
+            return Optional.empty();
+        }
+
+        @Override
+        public <T> java.net.http.HttpResponse<T> send(
+                java.net.http.HttpRequest request,
+                java.net.http.HttpResponse.BodyHandler<T> responseBodyHandler) {
+            throw new UnsupportedOperationException("send is not used in this test");
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public <T> CompletableFuture<java.net.http.HttpResponse<T>> sendAsync(
+                java.net.http.HttpRequest request,
+                java.net.http.HttpResponse.BodyHandler<T> responseBodyHandler) {
+            CompletableFuture<java.net.http.HttpResponse<T>> future = new LateCompletableFuture<>();
+            futureRef.set(
+                    (CompletableFuture<java.net.http.HttpResponse<InputStream>>)
+                            (CompletableFuture<?>) future);
+            return future;
+        }
+
+        @Override
+        public <T> CompletableFuture<java.net.http.HttpResponse<T>> sendAsync(
+                java.net.http.HttpRequest request,
+                java.net.http.HttpResponse.BodyHandler<T> responseBodyHandler,
+                java.net.http.HttpResponse.PushPromiseHandler<T> pushPromiseHandler) {
+            return sendAsync(request, responseBodyHandler);
+        }
+    }
+
+    private static class LateCompletableFuture<T> extends CompletableFuture<T> {
+        private final AtomicBoolean cancelled = new AtomicBoolean(false);
+
+        @Override
+        public boolean cancel(boolean mayInterruptIfRunning) {
+            cancelled.set(true);
+            return true;
+        }
+
+        @Override
+        public boolean isCancelled() {
+            return cancelled.get();
+        }
+    }
+
+    private static class TestHttpResponse implements java.net.http.HttpResponse<InputStream> {
+        private final int statusCode;
+        private final InputStream body;
+
+        TestHttpResponse(int statusCode, InputStream body) {
+            this.statusCode = statusCode;
+            this.body = body;
+        }
+
+        @Override
+        public int statusCode() {
+            return statusCode;
+        }
+
+        @Override
+        public java.net.http.HttpRequest request() {
+            return null;
+        }
+
+        @Override
+        public Optional<java.net.http.HttpResponse<InputStream>> previousResponse() {
+            return Optional.empty();
+        }
+
+        @Override
+        public java.net.http.HttpHeaders headers() {
+            return java.net.http.HttpHeaders.of(Map.of(), (name, value) -> true);
+        }
+
+        @Override
+        public InputStream body() {
+            return body;
+        }
+
+        @Override
+        public Optional<SSLSession> sslSession() {
+            return Optional.empty();
+        }
+
+        @Override
+        public URI uri() {
+            return URI.create("http://localhost/deferred-body");
+        }
+
+        @Override
+        public Version version() {
+            return Version.HTTP_2;
+        }
+    }
+
+    private static class BlockingInputStream extends InputStream {
+        private final CountDownLatch closed = new CountDownLatch(1);
+
+        @Override
+        public int read() {
+            return -1;
+        }
+
+        @Override
+        public byte[] readAllBytes() {
+            return "closed".getBytes(StandardCharsets.UTF_8);
+        }
+
+        @Override
+        public void close() throws IOException {
+            closed.countDown();
+            super.close();
+        }
+
+        boolean awaitClosed() {
+            try {
+                return closed.await(1, TimeUnit.SECONDS);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                return false;
+            }
+        }
     }
 }

--- a/agentscope-core/src/test/java/io/agentscope/core/model/transport/JdkHttpTransportTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/model/transport/JdkHttpTransportTest.java
@@ -57,7 +57,9 @@ class JdkHttpTransportTest {
         HttpTransportConfig config =
                 HttpTransportConfig.builder()
                         .connectTimeout(Duration.ofSeconds(5))
-                        .readTimeout(Duration.ofSeconds(10))
+                        .readTimeout(Duration.ofSeconds(2)) // Global timeout for sync calls
+                        .responseTimeout(Duration.ofSeconds(2)) // TTFT for streaming
+                        .streamIdleTimeout(Duration.ofSeconds(1)) // Inter-token gap for streaming
                         .build();
         transport = new JdkHttpTransport(config);
     }
@@ -304,6 +306,8 @@ class JdkHttpTransportTest {
                 HttpTransportConfig.builder()
                         .connectTimeout(Duration.ofSeconds(10))
                         .readTimeout(Duration.ofSeconds(30))
+                        .responseTimeout(Duration.ofSeconds(45))
+                        .streamIdleTimeout(Duration.ofSeconds(15))
                         .build();
 
         JdkHttpTransport builtTransport = JdkHttpTransport.builder().config(config).build();
@@ -311,6 +315,8 @@ class JdkHttpTransportTest {
         assertNotNull(builtTransport);
         assertNotNull(builtTransport.getClient());
         assertEquals(config, builtTransport.getConfig());
+        assertEquals(Duration.ofSeconds(45), builtTransport.getConfig().getResponseTimeout());
+        assertEquals(Duration.ofSeconds(15), builtTransport.getConfig().getStreamIdleTimeout());
         assertFalse(builtTransport.isClosed());
         builtTransport.close();
         assertTrue(builtTransport.isClosed());
@@ -1062,5 +1068,131 @@ class JdkHttpTransportTest {
         assertEquals(HttpClient.Version.HTTP_1_1, config.getHttpVersion().toJdkHttpVersion());
         assertNotNull(jdkHttpTransport);
         assertNotNull(jdkHttpTransport2);
+    }
+
+    @Test
+    void testStreamColdStartSurvivesGlobalTimeout() throws Exception {
+        // Reproduces the bug reported in the issue 1302
+
+        HttpTransportConfig customConfig =
+                HttpTransportConfig.builder()
+                        .readTimeout(Duration.ofSeconds(1)) // Very tight global timeout
+                        .responseTimeout(Duration.ofSeconds(4)) // Ample Time-To-First-Token timeout
+                        .streamIdleTimeout(Duration.ofSeconds(2))
+                        .build();
+
+        JdkHttpTransport customTransport = new JdkHttpTransport(customConfig);
+
+        try {
+            // Simulate the cold start overhead + LLM thinking time by delaying headers for 2
+            // seconds.
+            mockServer.enqueue(
+                    new MockResponse()
+                            .setResponseCode(200)
+                            .setHeader("Content-Type", "text/event-stream")
+                            .setBody("data: {\"id\":\"1\"}\n\ndata: [DONE]\n\n")
+                            .setHeadersDelay(2, TimeUnit.SECONDS));
+
+            HttpRequest request =
+                    HttpRequest.builder()
+                            .url(mockServer.url("/cold-start-bug-reproduction").toString())
+                            .method("POST")
+                            .body("{}")
+                            .build();
+
+            // The test succeeds ONLY if the stream survives the 2-second initial delay
+            // without being killed by the 1-second global readTimeout.
+            StepVerifier.create(customTransport.stream(request))
+                    .expectNextMatches(data -> data.contains("\"id\":\"1\""))
+                    .verifyComplete();
+        } finally {
+            customTransport.close();
+        }
+    }
+
+    @Test
+    void testStreamResponseTimeout() {
+        // Test Timeout Strategy 1 (TTFT):
+        // Delay headers by 3 seconds, which exceeds the configured responseTimeout (2 seconds).
+        mockServer.enqueue(
+                new MockResponse()
+                        .setResponseCode(200)
+                        .setBody("data: {\"id\":\"1\"}\n\ndata: [DONE]\n\n")
+                        .setHeader("Content-Type", "text/event-stream")
+                        .setHeadersDelay(3, TimeUnit.SECONDS));
+
+        HttpRequest request =
+                HttpRequest.builder()
+                        .url(mockServer.url("/ttft-timeout").toString())
+                        .method("POST")
+                        .body("{}")
+                        .build();
+
+        StepVerifier.create(transport.stream(request))
+                .expectErrorMatches(
+                        e ->
+                                e instanceof HttpTransportException
+                                        && e.getMessage().contains("Stream timeout"))
+                .verify(Duration.ofSeconds(5));
+    }
+
+    @Test
+    void testStreamIdleTimeout() {
+        // Test Timeout Strategy 2 (Inter-token gap):
+        // Throttle body to emit 1 byte every 2 seconds.
+        // This exceeds the configured streamIdleTimeout (1 second).
+        mockServer.enqueue(
+                new MockResponse()
+                        .setResponseCode(200)
+                        .setHeader("Content-Type", "text/event-stream")
+                        .setBody("data: {\"id\":\"1\"}\n\ndata: {\"id\":\"2\"}\n\n")
+                        .throttleBody(1, 2, TimeUnit.SECONDS));
+
+        HttpRequest request =
+                HttpRequest.builder()
+                        .url(mockServer.url("/idle-timeout").toString())
+                        .method("POST")
+                        .body("{}")
+                        .build();
+
+        StepVerifier.create(transport.stream(request))
+                .expectErrorMatches(
+                        e ->
+                                e instanceof HttpTransportException
+                                        && e.getMessage().contains("Stream timeout"))
+                .verify(Duration.ofSeconds(5));
+    }
+
+    @Test
+    void testStreamSurvivesGlobalReadTimeout() {
+        // Verify that streaming requests are NOT killed by the global readTimeout.
+        // readTimeout is 2s, but we will make the stream take roughly 3s overall.
+        // We throttle 10 bytes every 500ms. Inter-token gap is < 1s, so streamIdleTimeout is
+        // respected.
+        String sseBody =
+                "data: 1\n\n"
+                        + "data: 2\n\n"
+                        + "data: 3\n\n"
+                        + "data: 4\n\n"
+                        + "data: 5\n\n"
+                        + "data: [DONE]\n\n";
+
+        mockServer.enqueue(
+                new MockResponse()
+                        .setResponseCode(200)
+                        .setHeader("Content-Type", "text/event-stream")
+                        .setBody(sseBody)
+                        .throttleBody(10, 500, TimeUnit.MILLISECONDS));
+
+        HttpRequest request =
+                HttpRequest.builder()
+                        .url(mockServer.url("/survive-timeout").toString())
+                        .method("POST")
+                        .body("{}")
+                        .build();
+
+        StepVerifier.create(transport.stream(request))
+                .expectNextCount(5) // Should successfully receive all 5 data chunks
+                .verifyComplete();
     }
 }

--- a/agentscope-core/src/test/java/io/agentscope/core/model/transport/JdkHttpTransportTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/model/transport/JdkHttpTransportTest.java
@@ -75,7 +75,7 @@ class JdkHttpTransportTest {
                 HttpTransportConfig.builder()
                         .connectTimeout(Duration.ofSeconds(5))
                         .readTimeout(Duration.ofSeconds(2)) // Global timeout for sync calls
-                        .responseTimeout(Duration.ofSeconds(2)) // TTFT for streaming
+                        .responseTimeout(Duration.ofSeconds(2)) // First emitted chunk for streaming
                         .streamIdleTimeout(Duration.ofSeconds(1)) // Inter-token gap for streaming
                         .build();
         transport = new JdkHttpTransport(config);
@@ -1094,7 +1094,7 @@ class JdkHttpTransportTest {
         HttpTransportConfig customConfig =
                 HttpTransportConfig.builder()
                         .readTimeout(Duration.ofSeconds(1)) // Very tight global timeout
-                        .responseTimeout(Duration.ofSeconds(4)) // Ample Time-To-First-Token timeout
+                        .responseTimeout(Duration.ofSeconds(4)) // Ample first-chunk timeout
                         .streamIdleTimeout(Duration.ofSeconds(2))
                         .build();
 
@@ -1129,7 +1129,7 @@ class JdkHttpTransportTest {
 
     @Test
     void testStreamResponseTimeout() {
-        // Test Timeout Strategy 1 (TTFT):
+        // Test Timeout Strategy 1:
         // Delay headers by 3 seconds, which exceeds the configured responseTimeout (2 seconds).
         mockServer.enqueue(
                 new MockResponse()
@@ -1151,6 +1151,42 @@ class JdkHttpTransportTest {
                                 e instanceof HttpTransportException
                                         && e.getMessage().contains("Stream timeout"))
                 .verify(Duration.ofSeconds(5));
+    }
+
+    @Test
+    void testStreamResponseTimeoutSpansRequestStartToFirstChunk() {
+        HttpTransportConfig customConfig =
+                HttpTransportConfig.builder()
+                        .responseTimeout(Duration.ofSeconds(1))
+                        .streamIdleTimeout(Duration.ofSeconds(2))
+                        .build();
+        JdkHttpTransport customTransport = new JdkHttpTransport(customConfig);
+
+        try {
+            mockServer.enqueue(
+                    new MockResponse()
+                            .setResponseCode(200)
+                            .setHeader("Content-Type", "text/event-stream")
+                            .setBody("data: {\"id\":\"late\"}\n\ndata: [DONE]\n\n")
+                            .setHeadersDelay(600, TimeUnit.MILLISECONDS)
+                            .setBodyDelay(700, TimeUnit.MILLISECONDS));
+
+            HttpRequest request =
+                    HttpRequest.builder()
+                            .url(mockServer.url("/first-chunk-budget").toString())
+                            .method("POST")
+                            .body("{}")
+                            .build();
+
+            StepVerifier.create(customTransport.stream(request))
+                    .expectErrorMatches(
+                            e ->
+                                    e instanceof HttpTransportException
+                                            && e.getMessage().contains("Stream timeout"))
+                    .verify(Duration.ofSeconds(3));
+        } finally {
+            customTransport.close();
+        }
     }
 
     @Test

--- a/agentscope-core/src/test/java/io/agentscope/core/model/transport/JdkHttpTransportTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/model/transport/JdkHttpTransportTest.java
@@ -1154,42 +1154,6 @@ class JdkHttpTransportTest {
     }
 
     @Test
-    void testStreamResponseTimeoutSpansRequestStartToFirstChunk() {
-        HttpTransportConfig customConfig =
-                HttpTransportConfig.builder()
-                        .responseTimeout(Duration.ofSeconds(1))
-                        .streamIdleTimeout(Duration.ofSeconds(2))
-                        .build();
-        JdkHttpTransport customTransport = new JdkHttpTransport(customConfig);
-
-        try {
-            mockServer.enqueue(
-                    new MockResponse()
-                            .setResponseCode(200)
-                            .setHeader("Content-Type", "text/event-stream")
-                            .setBody("data: {\"id\":\"late\"}\n\ndata: [DONE]\n\n")
-                            .setHeadersDelay(600, TimeUnit.MILLISECONDS)
-                            .setBodyDelay(700, TimeUnit.MILLISECONDS));
-
-            HttpRequest request =
-                    HttpRequest.builder()
-                            .url(mockServer.url("/first-chunk-budget").toString())
-                            .method("POST")
-                            .body("{}")
-                            .build();
-
-            StepVerifier.create(customTransport.stream(request))
-                    .expectErrorMatches(
-                            e ->
-                                    e instanceof HttpTransportException
-                                            && e.getMessage().contains("Stream timeout"))
-                    .verify(Duration.ofSeconds(3));
-        } finally {
-            customTransport.close();
-        }
-    }
-
-    @Test
     void testStreamIdleTimeout() {
         // Test Timeout Strategy 2 (Inter-token gap):
         // Emit the first complete event immediately, then delay the second event long enough to


### PR DESCRIPTION
## Description

Close #1302

This PR fixes `JdkHttpTransport` streaming behavior for long-running SSE/NDJSON responses, especially LLM streams with long Time-To-First-Token (TTFT). Previously, JDK `HttpRequest.timeout()` used absolute timeout semantics for streaming requests, which could terminate healthy long-lived streams. In addition, blocking stream reads and error-body reads could run on the JDK HttpClient callback path, and cancellation/timeout did not reliably close response bodies in all intermediate states.

### Key Changes

- **Removed absolute JDK request timeout for streaming requests**
  - `HttpRequest.timeout()` is still applied to non-streaming requests.
  - Streaming requests are timed out at the Reactor layer instead, so active long-running streams are not cut off by an absolute request deadline.

- **Added Reactor-managed streaming timeouts**
  - `responseTimeout`: maximum time to wait for response headers / first stream data.
  - `streamIdleTimeout`: maximum gap between emitted stream chunks.
  - Defaults are 5 minutes for both, preserving the previous effective read-timeout behavior unless explicitly configured.

- **Hardened cancellation and timeout cleanup**
  - Replaced the simple `Mono.fromFuture(...)` flow with an explicit cancellation-aware wrapper around `HttpClient.sendAsync(...)`.
  - Tracks the response `InputStream` as soon as it becomes available.
  - Ensures the response body is closed on completion, error, cancellation, timeout, and late future completion after cancellation.

- **Prevented blocking work on JDK HttpClient callback threads**
  - SSE/NDJSON stream parsing continues to run on `Schedulers.boundedElastic()`.
  - Error response body reading is also offloaded to `boundedElastic()` to avoid blocking the JDK HttpClient internal executor.

- **Expanded regression coverage**
  - Added coverage for long TTFT streams surviving global read timeout.
  - Added true inter-token idle timeout coverage.
  - Added late async completion cleanup coverage to ensure response bodies are closed after timeout/cancellation.

## Checklist

Please check the following items before code is ready to be reviewed.

- [ ]  Code has been formatted with `mvn spotless:apply`
- [ ]  All tests are passing (`mvn test`)
- [ ]  Javadoc comments are complete and follow project conventions
- [ ]  Related documentation has been updated (e.g. links, examples, etc.)
- [ ]  Code is ready for review
