### PR TITLE
fix(formatter): preserve reasoning_content for tool-call segments in …

### DIFF
--- a/agentscope-core/src/main/java/io/agentscope/core/formatter/openai/DeepSeekFormatter.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/formatter/openai/DeepSeekFormatter.java
@@ -29,7 +29,7 @@ import java.util.List;
  *   <li>No name field in messages (returns HTTP 400 if present)</li>
  *   <li>System messages should be converted to user messages</li>
  *   <li>Does NOT support strict parameter in tool definitions</li>
- *   <li>reasoning_content must be kept within current turn but removed for previous turns</li>
+ *   <li>In thinking mode, reasoning_content is preserved for segments with tool calls</li>
  * </ul>
  *
  * <p>Usage:
@@ -85,8 +85,8 @@ public class DeepSeekFormatter extends OpenAIChatFormatter {
      * <ul>
      *   <li>No name field in messages</li>
      *   <li>System messages converted to user</li>
-     *   <li>reasoning_content kept within current turn (after last user message)</li>
-     *   <li>reasoning_content removed for previous turns (before last user message)</li>
+     *   <li>In thinking mode, reasoning_content preserved for segments with tool calls</li>
+     *   <li>reasoning_content removed for segments without tool calls in thinking mode</li>
      * </ul>
      *
      * <p>This method is static to allow sharing with {@link DeepSeekMultiAgentFormatter}.
@@ -95,14 +95,49 @@ public class DeepSeekFormatter extends OpenAIChatFormatter {
      * @return the fixed messages for DeepSeek API
      */
     static List<OpenAIMessage> applyDeepSeekFixes(List<OpenAIMessage> messages) {
-        // Find the last user message index to determine current turn boundary
         int lastUserIndex = findLastUserIndex(messages);
+        boolean thinkingMode = messages.stream().anyMatch(m -> m.getReasoningContent() != null);
+        boolean[] segHasTool = thinkingMode ? computeSegmentToolFlags(messages) : null;
 
         List<OpenAIMessage> result = new ArrayList<>(messages.size());
         for (int i = 0; i < messages.size(); i++) {
-            result.add(fixMessage(messages.get(i), i >= lastUserIndex));
+            boolean isCurrentTurn = i >= lastUserIndex;
+            boolean needReasoning =
+                    thinkingMode
+                            ? (isCurrentTurn || (segHasTool != null && segHasTool[i]))
+                            : isCurrentTurn;
+            result.add(fixMessage(messages.get(i), needReasoning));
         }
         return result;
+    }
+
+    /**
+     * Scans messages in a single pass to identify segments (between consecutive
+     * user messages) that contain tool calls. Messages within such segments
+     * are flagged to preserve their reasoning_content.
+     */
+    private static boolean[] computeSegmentToolFlags(List<OpenAIMessage> messages) {
+        boolean[] flags = new boolean[messages.size()];
+        int prevUser = -1;
+        for (int i = 0; i <= messages.size(); i++) {
+            if (i == messages.size() || "user".equals(messages.get(i).getRole())) {
+                if (prevUser >= 0) {
+                    // Check if segment (prevUser, i) has any tool call
+                    boolean hasTool = false;
+                    for (int j = prevUser + 1; j < i && !hasTool; j++) {
+                        OpenAIMessage m = messages.get(j);
+                        hasTool = m.getToolCalls() != null && !m.getToolCalls().isEmpty();
+                    }
+                    if (hasTool) {
+                        for (int j = prevUser + 1; j < i; j++) {
+                            flags[j] = true;
+                        }
+                    }
+                }
+                prevUser = i;
+            }
+        }
+        return flags;
     }
 
     /**
@@ -133,12 +168,13 @@ public class DeepSeekFormatter extends OpenAIChatFormatter {
     }
 
     @SuppressWarnings("unchecked")
-    private static OpenAIMessage fixMessage(OpenAIMessage msg, boolean isCurrentTurn) {
+    private static OpenAIMessage fixMessage(OpenAIMessage msg, boolean needReasoning) {
         boolean isSystem = "system".equals(msg.getRole());
         boolean hasName = msg.getName() != null;
         boolean hasReasoning = msg.getReasoningContent() != null;
-        // Remove reasoning_content for previous turns, keep for current turn
-        boolean shouldRemoveReasoning = hasReasoning && !isCurrentTurn;
+        // needReasoning is determined by applyDeepSeekFixes:
+        // true = current turn, or segment had tool calls in thinking mode
+        boolean shouldRemoveReasoning = hasReasoning && !needReasoning;
 
         if (!isSystem && !hasName && !shouldRemoveReasoning) {
             return msg;
@@ -162,8 +198,7 @@ public class DeepSeekFormatter extends OpenAIChatFormatter {
             builder.toolCallId(msg.getToolCallId());
         }
 
-        // Keep reasoning_content only for current turn
-        if (hasReasoning && isCurrentTurn) {
+        if (needReasoning && hasReasoning) {
             builder.reasoningContent(msg.getReasoningContent());
         }
 

--- a/agentscope-core/src/test/java/io/agentscope/core/formatter/openai/DeepSeekFormatterTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/formatter/openai/DeepSeekFormatterTest.java
@@ -327,6 +327,277 @@ class DeepSeekFormatterTest {
             // Same object reference if no changes
             assertEquals(original, result.get(0));
         }
+    }
+
+    @Nested
+    @DisplayName("Reasoning Preservation for Thinking Mode")
+    class ReasoningPreservationTests {
+
+        @Test
+        @DisplayName("Should use original behavior when thinking mode is not enabled")
+        void testShouldUseOriginalBehaviorWithoutThinkingMode() {
+            // No reasoning_content in any message → thinking mode is off.
+            // Falls back to original logic: only current turn keeps reasoning.
+            List<OpenAIMessage> messages =
+                    List.of(
+                            OpenAIMessage.builder().role("user").content("Search it").build(),
+                            OpenAIMessage.builder()
+                                    .role("assistant")
+                                    .name("Agent")
+                                    .toolCalls(
+                                            List.of(
+                                                    OpenAIToolCall.builder()
+                                                            .id("call_1")
+                                                            .type("function")
+                                                            .function(
+                                                                    OpenAIFunction.of(
+                                                                            "web_search",
+                                                                            "{\"q\":\"x\"}"))
+                                                            .build()))
+                                    .build(),
+                            OpenAIMessage.builder().role("user").content("Search again").build(),
+                            OpenAIMessage.builder()
+                                    .role("assistant")
+                                    .name("Agent")
+                                    .toolCalls(
+                                            List.of(
+                                                    OpenAIToolCall.builder()
+                                                            .id("call_2")
+                                                            .type("function")
+                                                            .function(
+                                                                    OpenAIFunction.of(
+                                                                            "web_search",
+                                                                            "{\"q\":\"y\"}"))
+                                                            .build()))
+                                    .build());
+
+            List<OpenAIMessage> result = DeepSeekFormatter.applyDeepSeekFixes(messages);
+
+            assertEquals(4, result.size());
+            // name removed in both messages (original behavior still applies)
+            assertNull(result.get(1).getName());
+            assertNull(result.get(3).getName());
+            // tool_calls preserved
+            assertNotNull(result.get(1).getToolCalls());
+            assertNotNull(result.get(3).getToolCalls());
+        }
+
+        @Test
+        @DisplayName("Should preserve reasoning_content across multiple rounds with tool calls")
+        void testShouldPreserveReasoningAcrossMultipleRounds() {
+            // Three consecutive rounds, each with a tool call.
+            // When thinking mode is enabled and tool calls were made, DeepSeek API
+            // requires reasoning_content to be preserved for all rounds (not just
+            // the current turn), even when there are no tool_calls in the message
+            // itself.
+            // See: https://api-docs.deepseek.com/guides/thinking_mode#tool-calls
+            List<OpenAIMessage> messages =
+                    List.of(
+                            OpenAIMessage.builder().role("user").content("Question 1").build(),
+                            OpenAIMessage.builder()
+                                    .role("assistant")
+                                    .reasoningContent("Reasoning round 1")
+                                    .toolCalls(
+                                            List.of(
+                                                    OpenAIToolCall.builder()
+                                                            .id("c1")
+                                                            .type("function")
+                                                            .function(
+                                                                    OpenAIFunction.of(
+                                                                            "tool_a", "{}"))
+                                                            .build()))
+                                    .build(),
+                            OpenAIMessage.builder().role("user").content("Question 2").build(),
+                            OpenAIMessage.builder()
+                                    .role("assistant")
+                                    .reasoningContent("Reasoning round 2")
+                                    .toolCalls(
+                                            List.of(
+                                                    OpenAIToolCall.builder()
+                                                            .id("c2")
+                                                            .type("function")
+                                                            .function(
+                                                                    OpenAIFunction.of(
+                                                                            "tool_b", "{}"))
+                                                            .build()))
+                                    .build(),
+                            OpenAIMessage.builder().role("user").content("Question 3").build(),
+                            OpenAIMessage.builder()
+                                    .role("assistant")
+                                    .reasoningContent("Reasoning round 3")
+                                    .toolCalls(
+                                            List.of(
+                                                    OpenAIToolCall.builder()
+                                                            .id("c3")
+                                                            .type("function")
+                                                            .function(
+                                                                    OpenAIFunction.of(
+                                                                            "tool_c", "{}"))
+                                                            .build()))
+                                    .build());
+
+            List<OpenAIMessage> result = DeepSeekFormatter.applyDeepSeekFixes(messages);
+
+            assertEquals(6, result.size());
+            // All three rounds had tool calls, so all reasoning should be preserved
+            assertEquals("Reasoning round 1", result.get(1).getReasoningContent());
+            assertEquals("Reasoning round 2", result.get(3).getReasoningContent());
+            assertEquals("Reasoning round 3", result.get(5).getReasoningContent());
+        }
+
+        @Test
+        @DisplayName("Should only preserve reasoning_content for segments that had tool calls")
+        void testShouldOnlyPreserveReasoningForSegmentsWithToolCalls() {
+            // Round 1: text only, no tool calls → reasoning not needed, should be removed
+            // Round 2: has tool calls → reasoning must be preserved
+            // Round 3: has tool calls → reasoning must be preserved
+            // Round 4: text only, current turn → reasoning preserved as usual
+            List<OpenAIMessage> messages =
+                    List.of(
+                            OpenAIMessage.builder().role("user").content("Hello").build(),
+                            OpenAIMessage.builder()
+                                    .role("assistant")
+                                    .content("Hi, how can I help?")
+                                    .reasoningContent("Just greeting, reply directly")
+                                    .build(),
+                            OpenAIMessage.builder().role("user").content("Search DeepSeek").build(),
+                            OpenAIMessage.builder()
+                                    .role("assistant")
+                                    .reasoningContent("Need to call search tool")
+                                    .toolCalls(
+                                            List.of(
+                                                    OpenAIToolCall.builder()
+                                                            .id("c1")
+                                                            .type("function")
+                                                            .function(
+                                                                    OpenAIFunction.of(
+                                                                            "web_search",
+                                                                            "{\"q\":\"DeepSeek\"}"))
+                                                            .build()))
+                                    .build(),
+                            OpenAIMessage.builder().role("user").content("Check wiki too").build(),
+                            OpenAIMessage.builder()
+                                    .role("assistant")
+                                    .reasoningContent("Query wiki")
+                                    .toolCalls(
+                                            List.of(
+                                                    OpenAIToolCall.builder()
+                                                            .id("c2")
+                                                            .type("function")
+                                                            .function(
+                                                                    OpenAIFunction.of(
+                                                                            "wiki_search",
+                                                                            "{\"q\":\"DeepSeek\"}"))
+                                                            .build()))
+                                    .build(),
+                            OpenAIMessage.builder().role("user").content("Summarize").build(),
+                            OpenAIMessage.builder()
+                                    .role("assistant")
+                                    .content("DeepSeek is...")
+                                    .reasoningContent("Summarizing results")
+                                    .build());
+
+            List<OpenAIMessage> result = DeepSeekFormatter.applyDeepSeekFixes(messages);
+
+            assertEquals(8, result.size());
+            assertNull(result.get(1).getReasoningContent());
+            assertEquals("Need to call search tool", result.get(3).getReasoningContent());
+            assertEquals("Query wiki", result.get(5).getReasoningContent());
+            assertEquals("Summarizing results", result.get(7).getReasoningContent());
+        }
+
+        @Test
+        @DisplayName(
+                "Should preserve reasoning_content for text-only assistant in a tool-call segment")
+        void testShouldPreserveReasoningForTextOnlyAssistantInToolCallSegment() {
+            // Within a single user turn, the model first calls a tool, then gives a final text
+            // answer. Even the text-only assistant message must keep its reasoning_content
+            // because the segment had tool calls.
+            List<OpenAIMessage> messages =
+                    List.of(
+                            OpenAIMessage.builder().role("user").content("What time is it").build(),
+                            OpenAIMessage.builder()
+                                    .role("assistant")
+                                    .reasoningContent("Need to call get_time tool")
+                                    .toolCalls(
+                                            List.of(
+                                                    OpenAIToolCall.builder()
+                                                            .id("call_1")
+                                                            .type("function")
+                                                            .function(
+                                                                    OpenAIFunction.of(
+                                                                            "get_time", "{}"))
+                                                            .build()))
+                                    .build(),
+                            OpenAIMessage.builder()
+                                    .role("tool")
+                                    .toolCallId("call_1")
+                                    .content("14:06:51")
+                                    .build(),
+                            OpenAIMessage.builder()
+                                    .role("assistant")
+                                    .content("It is now 14:06")
+                                    .reasoningContent(
+                                            "The current time based on the tool result is 14:06")
+                                    .build(),
+                            OpenAIMessage.builder().role("user").content("Check again").build(),
+                            OpenAIMessage.builder()
+                                    .role("assistant")
+                                    .reasoningContent("Fetch time again")
+                                    .toolCalls(
+                                            List.of(
+                                                    OpenAIToolCall.builder()
+                                                            .id("call_2")
+                                                            .type("function")
+                                                            .function(
+                                                                    OpenAIFunction.of(
+                                                                            "get_time", "{}"))
+                                                            .build()))
+                                    .build());
+
+            List<OpenAIMessage> result = DeepSeekFormatter.applyDeepSeekFixes(messages);
+
+            assertEquals(6, result.size());
+            assertEquals("Need to call get_time tool", result.get(1).getReasoningContent());
+            assertEquals(
+                    "The current time based on the tool result is 14:06",
+                    result.get(3).getReasoningContent());
+            assertEquals("Fetch time again", result.get(5).getReasoningContent());
+        }
+
+        @Test
+        @DisplayName("Should remove reasoning_content for previous turns without tool calls")
+        void testShouldRemoveReasoningForPreviousTurnsWithoutToolCalls() {
+            // Previous-turn text-only messages without tool calls should have
+            // reasoning_content removed to save context space.
+            List<OpenAIMessage> messages =
+                    List.of(
+                            OpenAIMessage.builder().role("user").content("Hello").build(),
+                            OpenAIMessage.builder()
+                                    .role("assistant")
+                                    .content("Hi there!")
+                                    .reasoningContent("Just greeting, reply directly")
+                                    .build(),
+                            OpenAIMessage.builder().role("user").content("Goodbye").build(),
+                            OpenAIMessage.builder()
+                                    .role("assistant")
+                                    .content("Goodbye!")
+                                    .reasoningContent("User is saying goodbye")
+                                    .build());
+
+            List<OpenAIMessage> result = DeepSeekFormatter.applyDeepSeekFixes(messages);
+
+            assertEquals(4, result.size());
+            // Previous turn text-only → reasoning removed
+            assertNull(result.get(1).getReasoningContent());
+            // Current turn → reasoning preserved
+            assertEquals("User is saying goodbye", result.get(3).getReasoningContent());
+        }
+    }
+
+    @Nested
+    @DisplayName("applyDeepSeekFixes Tests (continued)")
+    class ApplyDeepSeekFixesContinued {
 
         @Test
         @DisplayName("Should handle no user messages - treat all as current turn")


### PR DESCRIPTION
When thinking mode is enabled and a user turn contains tool calls,
all assistant messages in that turn must preserve their
reasoning_content when sent back to the DeepSeek API in subsequent
requests. Previously, reasoning_content was only kept for the
current turn, causing HTTP 400 errors in multi-turn tool-calling
scenarios.

See: https://api-docs.deepseek.com/guides/thinking_mode#tool-calls
Fixes #1281

## AgentScope-Java Version

1.0.12-SNAPSHOT

## Description

**Background:** DeepSeek's thinking mode requires `reasoning_content` to be preserved for all
assistant messages within a user turn that contains tool calls. The original code only preserved it
for the current turn, causing HTTP 400 errors in multi-turn tool-calling scenarios.

**Changes:**

- `applyDeepSeekFixes()`: Added segment-level tool call detection via `computeSegmentToolFlags()`. A
segment is defined as messages between two consecutive user messages. If any message in a segment
contains tool calls, all assistant messages in that segment are flagged to preserve their
`reasoning_content`.
- `fixMessage()`: Renamed parameter from `isCurrentTurn` to `needReasoning` to reflect that
preservation is now determined by the segment analysis, not just the turn boundary.
- Added `ReasoningPreservationTests` nested test class covering key scenarios: non-thinking mode
fallback, multiple rounds with tool calls, mixed text/tool rounds, text-only messages in tool-call
segments, and regression for text-only segments.

## Checklist

- [x] Code has been formatted with `mvn spotless:apply`
- [x] All tests are passing (`mvn test`)
- [x] Javadoc comments are complete and follow project conventions
- [ ] Related documentation has been updated
- [x] Code is ready for review