### PR TITLE
fix(PlanNotebook): Reset expired in-progress subtasks during the loading state.

### DIFF
--- a/agentscope-core/src/main/java/io/agentscope/core/plan/PlanNotebook.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/plan/PlanNotebook.java
@@ -163,6 +163,14 @@ public class PlanNotebook implements StateModule {
     /**
      * Load PlanNotebook state from the session.
      *
+     * <p>After deserialization, any {@link SubTaskState#IN_PROGRESS} subtasks are reset to {@link
+     * SubTaskState#TODO}. The {@code IN_PROGRESS} state implies an active execution flow is
+     * driving the subtask; once the process has been interrupted and resumed, that invariant no
+     * longer holds, so leftover {@code IN_PROGRESS} entries are stale data. Without this
+     * normalization, the state-machine guards in {@link #updateSubtaskState} would refuse to
+     * re-activate the very subtask we just resumed (because "another subtask is already
+     * in_progress"), effectively dead-locking the plan.
+     *
      * @param session the session to load state from
      * @param sessionKey the session identifier
      */
@@ -171,7 +179,30 @@ public class PlanNotebook implements StateModule {
         // Clear existing state first to avoid stale data
         this.currentPlan = null;
         session.get(sessionKey, keyPrefix + "_state", PlanNotebookState.class)
-                .ifPresent(state -> this.currentPlan = state.currentPlan());
+                .ifPresent(
+                        state -> {
+                            this.currentPlan = state.currentPlan();
+                            resetStaleInProgressSubtasks();
+                        });
+    }
+
+    /**
+     * Reset any subtask still marked as {@link SubTaskState#IN_PROGRESS} back to {@link
+     * SubTaskState#TODO}.
+     *
+     * <p>Called right after {@link #loadFrom} to recover a clean, re-entrant state machine after
+     * an interruption. Without this, the next call to {@link #updateSubtaskState} would be
+     * blocked by the "no other subtask is in_progress" guard.
+     */
+    private void resetStaleInProgressSubtasks() {
+        if (currentPlan == null || currentPlan.getSubtasks() == null) {
+            return;
+        }
+        for (SubTask subtask : currentPlan.getSubtasks()) {
+            if (subtask.getState() == SubTaskState.IN_PROGRESS) {
+                subtask.setState(SubTaskState.TODO);
+            }
+        }
     }
 
     /** Builder for constructing PlanNotebook instances with customizable settings. */

--- a/agentscope-core/src/test/java/io/agentscope/core/plan/PlanNotebookStateModuleTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/plan/PlanNotebookStateModuleTest.java
@@ -20,10 +20,14 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import io.agentscope.core.plan.model.Plan;
 import io.agentscope.core.plan.model.SubTask;
+import io.agentscope.core.plan.model.SubTaskState;
 import io.agentscope.core.session.InMemorySession;
+import io.agentscope.core.state.PlanNotebookState;
 import io.agentscope.core.state.SessionKey;
 import io.agentscope.core.state.SimpleSessionKey;
+import java.util.ArrayList;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -90,8 +94,10 @@ class PlanNotebookStateModuleTest {
         }
 
         @Test
-        @DisplayName("Should preserve plan state across save/load")
-        void testPlanStatePreservation() {
+        @DisplayName(
+                "Should reset IN_PROGRESS subtasks back to TODO on load to recover from"
+                        + " interruption")
+        void testInProgressSubtasksAreResetOnLoad() {
             PlanNotebook notebook = PlanNotebook.builder().build();
 
             // Create a plan and update subtask state
@@ -104,18 +110,169 @@ class PlanNotebookStateModuleTest {
                                     new SubTask("Task 2", "Desc 2", "Outcome 2")))
                     .block();
 
-            // Mark first subtask as in_progress
+            // Mark first subtask as in_progress, then simulate an interruption by saving while
+            // the subtask is still mid-flight.
             notebook.updateSubtaskState(0, "in_progress").block();
+            notebook.saveTo(session, sessionKey);
+
+            PlanNotebook loadedNotebook = PlanNotebook.builder().build();
+            loadedNotebook.loadFrom(session, sessionKey);
+
+            // Plan structure (names, descriptions, count) is preserved...
+            assertNotNull(loadedNotebook.getCurrentPlan());
+            assertEquals("Stateful Plan", loadedNotebook.getCurrentPlan().getName());
+            assertEquals(2, loadedNotebook.getCurrentPlan().getSubtasks().size());
+
+            // ...but the previously IN_PROGRESS subtask has been normalized back to TODO so the
+            // state machine is re-entrant after recovery.
+            assertEquals(
+                    SubTaskState.TODO,
+                    loadedNotebook.getCurrentPlan().getSubtasks().get(0).getState());
+            assertEquals(
+                    SubTaskState.TODO,
+                    loadedNotebook.getCurrentPlan().getSubtasks().get(1).getState());
+        }
+
+        @Test
+        @DisplayName(
+                "Should allow re-activating subtask after recovery without being blocked by stale"
+                        + " IN_PROGRESS")
+        void testReActivateSubtaskAfterRecovery() {
+            PlanNotebook notebook = PlanNotebook.builder().build();
+            notebook.createPlanWithSubTasks(
+                            "Recovery Plan",
+                            "Plan to test recovery",
+                            "Recovered outcome",
+                            List.of(
+                                    new SubTask("Task 1", "Desc 1", "Outcome 1"),
+                                    new SubTask("Task 2", "Desc 2", "Outcome 2")))
+                    .block();
+            notebook.updateSubtaskState(0, "in_progress").block();
+
+            // Simulate interrupt + persist
+            notebook.saveTo(session, sessionKey);
+
+            // Recover into a fresh notebook
+            PlanNotebook loadedNotebook = PlanNotebook.builder().build();
+            loadedNotebook.loadFrom(session, sessionKey);
+
+            // Caller (LLM/business code) should be able to re-activate the subtask without being
+            // rejected by the "another subtask is already in_progress" guard.
+            String result = loadedNotebook.updateSubtaskState(0, "in_progress").block();
+
+            assertNotNull(result);
+            assertTrue(
+                    result.contains("successfully"),
+                    "Expected re-activation to succeed after recovery, but got: " + result);
+            assertEquals(
+                    SubTaskState.IN_PROGRESS,
+                    loadedNotebook.getCurrentPlan().getSubtasks().get(0).getState());
+        }
+
+        @Test
+        @DisplayName(
+                "Should reset IN_PROGRESS even when the plan is loaded from a freshly-constructed"
+                        + " independent Plan instance (no shared reference)")
+        void testInProgressResetWorksOnIndependentlyConstructedPlan() {
+            // Build a Plan instance from scratch (no PlanNotebook ever touched it). This emulates
+            // what a real serializing Session would hand back: a brand-new object graph with no
+            // reference shared with any in-memory PlanNotebook.
+            SubTask t0 = new SubTask("Task 1", "Desc 1", "Outcome 1");
+            t0.setState(SubTaskState.IN_PROGRESS);
+            SubTask t1 = new SubTask("Task 2", "Desc 2", "Outcome 2");
+            t1.setState(SubTaskState.TODO);
+            List<SubTask> subtasks = new ArrayList<>();
+            subtasks.add(t0);
+            subtasks.add(t1);
+            Plan independentPlan =
+                    new Plan(
+                            "Independent Plan",
+                            "Built outside any notebook",
+                            "Recovered outcome",
+                            subtasks);
+
+            // Inject directly into the session so loadFrom must rely on its own normalization
+            // logic rather than picking up state mutated by another notebook instance.
+            session.save(sessionKey, "planNotebook_state", new PlanNotebookState(independentPlan));
+
+            PlanNotebook loadedNotebook = PlanNotebook.builder().build();
+            loadedNotebook.loadFrom(session, sessionKey);
+
+            assertNotNull(loadedNotebook.getCurrentPlan());
+            // The previously IN_PROGRESS subtask must be normalized back to TODO purely by the
+            // loadFrom logic (no other code path could have changed it).
+            assertEquals(
+                    SubTaskState.TODO,
+                    loadedNotebook.getCurrentPlan().getSubtasks().get(0).getState());
+            assertEquals(
+                    SubTaskState.TODO,
+                    loadedNotebook.getCurrentPlan().getSubtasks().get(1).getState());
+
+            // And the recovered notebook must accept re-activation without being blocked by stale
+            // IN_PROGRESS guards.
+            String result = loadedNotebook.updateSubtaskState(0, "in_progress").block();
+            assertNotNull(result);
+            assertTrue(
+                    result.contains("successfully"),
+                    "Expected re-activation to succeed on independently-loaded plan, but got: "
+                            + result);
+        }
+
+        @Test
+        @DisplayName("Should tolerate a plan whose subtasks list is null when normalizing on load")
+        void testLoadFromTolerantOfNullSubtasks() {
+            // A plan with a null subtasks list could legitimately appear (e.g. an early-stage
+            // plan persisted before subtasks were attached). resetStaleInProgressSubtasks must
+            // not NPE on this shape.
+            Plan planWithNullSubtasks =
+                    new Plan("Plan No Subtasks", "desc", "outcome", /* subtasks */ null);
+
+            session.save(
+                    sessionKey, "planNotebook_state", new PlanNotebookState(planWithNullSubtasks));
+
+            PlanNotebook loadedNotebook = PlanNotebook.builder().build();
+            loadedNotebook.loadFrom(session, sessionKey);
+
+            assertNotNull(loadedNotebook.getCurrentPlan());
+            assertNull(loadedNotebook.getCurrentPlan().getSubtasks());
+            assertEquals("Plan No Subtasks", loadedNotebook.getCurrentPlan().getName());
+        }
+
+        @Test
+        @DisplayName("Should preserve DONE / ABANDONED subtask states across save/load")
+        void testTerminalSubtaskStatesArePreserved() {
+            PlanNotebook notebook = PlanNotebook.builder().build();
+            notebook.createPlanWithSubTasks(
+                            "Mixed-state Plan",
+                            "desc",
+                            "outcome",
+                            List.of(
+                                    new SubTask("Task 1", "Desc 1", "Outcome 1"),
+                                    new SubTask("Task 2", "Desc 2", "Outcome 2"),
+                                    new SubTask("Task 3", "Desc 3", "Outcome 3")))
+                    .block();
+
+            // Task 0: finish (DONE) -> auto activates Task 1 as IN_PROGRESS
+            notebook.finishSubtask(0, "Task 1 done").block();
+            // Task 1: abandon
+            notebook.updateSubtaskState(1, "abandoned").block();
+            // Task 2: keep TODO
 
             notebook.saveTo(session, sessionKey);
 
             PlanNotebook loadedNotebook = PlanNotebook.builder().build();
             loadedNotebook.loadFrom(session, sessionKey);
 
-            assertNotNull(loadedNotebook.getCurrentPlan());
+            // Terminal states must survive the round-trip; only IN_PROGRESS gets normalized.
             assertEquals(
-                    "IN_PROGRESS",
-                    loadedNotebook.getCurrentPlan().getSubtasks().get(0).getState().name());
+                    SubTaskState.DONE,
+                    loadedNotebook.getCurrentPlan().getSubtasks().get(0).getState());
+            assertEquals(
+                    SubTaskState.ABANDONED,
+                    loadedNotebook.getCurrentPlan().getSubtasks().get(1).getState());
+            assertEquals(
+                    SubTaskState.TODO,
+                    loadedNotebook.getCurrentPlan().getSubtasks().get(2).getState());
         }
     }
 


### PR DESCRIPTION
## AgentScope-Java Version

io.agentscope:agentscope-parent:pom:1.0.12-SNAPSHOT

## Description

* Closes: [#1343](https://github.com/agentscope-ai/agentscope-java/issues/1343)
* Reset expired in-progress subtasks during the loading state.

## Checklist

Please check the following items before code is ready to be reviewed.

- [x]  Code has been formatted with `mvn spotless:apply`
- [x]  All tests are passing (`mvn test`)
- [ ]  Javadoc comments are complete and follow project conventions
- [ ]  Related documentation has been updated (e.g. links, examples, etc.)
- [x]  Code is ready for review