### PR TITLE
fix(rag): fix document ID Python compatibility and respect defaultConfig limit

### DIFF
--- a/agentscope-core/src/main/java/io/agentscope/core/rag/KnowledgeRetrievalTools.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/rag/KnowledgeRetrievalTools.java
@@ -133,7 +133,7 @@ public class KnowledgeRetrievalTools {
 
         // Set default value
         if (limit == null) {
-            limit = 5;
+            limit = defaultConfig.getLimit();
         }
 
         // Extract conversation history from agent if available

--- a/agentscope-core/src/main/java/io/agentscope/core/rag/model/Document.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/rag/model/Document.java
@@ -214,7 +214,7 @@ public class Document {
         Map<String, Object> keyMap = new LinkedHashMap<>();
         keyMap.put("doc_id", metadata.getDocId());
         keyMap.put("chunk_id", metadata.getChunkId());
-        keyMap.put("content", metadata.getContent());
+        keyMap.put("content", metadata.getContentText());
 
         // Serialize to JSON (ensure_ascii=False in Python, so we use default UTF-8)
         String jsonKey = JsonUtils.getJsonCodec().toJson(keyMap);

--- a/agentscope-core/src/test/java/io/agentscope/core/rag/KnowledgeRetrievalToolsTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/rag/KnowledgeRetrievalToolsTest.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.core.rag;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.agentscope.core.message.TextBlock;
+import io.agentscope.core.rag.model.Document;
+import io.agentscope.core.rag.model.DocumentMetadata;
+import io.agentscope.core.rag.model.RetrieveConfig;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Mono;
+
+/**
+ * Unit tests for KnowledgeRetrievalTools.
+ */
+@Tag("unit")
+@DisplayName("KnowledgeRetrievalTools Unit Tests")
+class KnowledgeRetrievalToolsTest {
+
+    private static Document makeDoc(String text) {
+        return new Document(
+                new DocumentMetadata(TextBlock.builder().text(text).build(), "doc-1", "0"));
+    }
+
+    @Test
+    @DisplayName("When LLM omits limit, defaultConfig.getLimit() should be used")
+    void testNullLimitFallsBackToDefaultConfig() {
+        AtomicReference<RetrieveConfig> capturedConfig = new AtomicReference<>();
+
+        Knowledge knowledge =
+                new Knowledge() {
+                    @Override
+                    public Mono<Void> addDocuments(List<Document> documents) {
+                        return Mono.empty();
+                    }
+
+                    @Override
+                    public Mono<List<Document>> retrieve(String query, RetrieveConfig config) {
+                        capturedConfig.set(config);
+                        return Mono.just(List.of());
+                    }
+                };
+
+        RetrieveConfig defaultConfig = RetrieveConfig.builder().limit(8).build();
+        KnowledgeRetrievalTools tools = new KnowledgeRetrievalTools(knowledge, defaultConfig);
+
+        // Simulate LLM not providing limit (null)
+        tools.retrieveKnowledge("test query", null, null);
+
+        assertNotNull(capturedConfig.get());
+        assertEquals(
+                8,
+                capturedConfig.get().getLimit(),
+                "When limit is null, defaultConfig.getLimit() should be used, not hardcoded 5");
+    }
+
+    @Test
+    @DisplayName("When LLM provides explicit limit, it should override defaultConfig")
+    void testExplicitLimitOverridesDefault() {
+        AtomicReference<RetrieveConfig> capturedConfig = new AtomicReference<>();
+
+        Knowledge knowledge =
+                new Knowledge() {
+                    @Override
+                    public Mono<Void> addDocuments(List<Document> documents) {
+                        return Mono.empty();
+                    }
+
+                    @Override
+                    public Mono<List<Document>> retrieve(String query, RetrieveConfig config) {
+                        capturedConfig.set(config);
+                        return Mono.just(List.of());
+                    }
+                };
+
+        RetrieveConfig defaultConfig = RetrieveConfig.builder().limit(8).build();
+        KnowledgeRetrievalTools tools = new KnowledgeRetrievalTools(knowledge, defaultConfig);
+
+        tools.retrieveKnowledge("test query", 3, null);
+
+        assertNotNull(capturedConfig.get());
+        assertEquals(
+                3,
+                capturedConfig.get().getLimit(),
+                "Explicit limit from LLM should override defaultConfig.getLimit()");
+    }
+
+    @Test
+    @DisplayName("formatDocumentsForTool should return no-results message for empty list")
+    void testFormatEmptyResults() {
+        Knowledge knowledge =
+                new Knowledge() {
+                    @Override
+                    public Mono<Void> addDocuments(List<Document> docs) {
+                        return Mono.empty();
+                    }
+
+                    @Override
+                    public Mono<List<Document>> retrieve(String query, RetrieveConfig config) {
+                        return Mono.just(List.of());
+                    }
+                };
+
+        KnowledgeRetrievalTools tools = new KnowledgeRetrievalTools(knowledge);
+        String result = tools.retrieveKnowledge("query", null, null);
+
+        assertTrue(
+                result.contains("No relevant documents found"),
+                "Empty results should return no-results message");
+    }
+
+    @Test
+    @DisplayName("formatDocumentsForTool should include document content and score")
+    void testFormatDocumentsWithScore() {
+        Document doc = makeDoc("Important content");
+        doc.setScore(0.87);
+
+        Knowledge knowledge =
+                new Knowledge() {
+                    @Override
+                    public Mono<Void> addDocuments(List<Document> docs) {
+                        return Mono.empty();
+                    }
+
+                    @Override
+                    public Mono<List<Document>> retrieve(String query, RetrieveConfig config) {
+                        return Mono.just(List.of(doc));
+                    }
+                };
+
+        KnowledgeRetrievalTools tools = new KnowledgeRetrievalTools(knowledge);
+        String result = tools.retrieveKnowledge("query", null, null);
+
+        assertTrue(result.contains("Important content"));
+        assertTrue(result.contains("0.870"));
+    }
+}

--- a/agentscope-core/src/test/java/io/agentscope/core/rag/model/DocumentTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/rag/model/DocumentTest.java
@@ -70,6 +70,29 @@ class DocumentTest {
     }
 
     @Test
+    @DisplayName("Should generate ID based on text content, not ContentBlock object structure")
+    void testDocumentIdUsesTextNotContentBlockObject() {
+        // Two TextBlock instances with identical text but different object references
+        // must produce the same document ID, proving the ID is derived from the text
+        // string rather than the ContentBlock object's serialized form.
+        TextBlock content1 = TextBlock.builder().text("hello world").build();
+        TextBlock content2 = TextBlock.builder().text("hello world").build();
+        DocumentMetadata metadata1 = new DocumentMetadata(content1, "doc-1", "0");
+        DocumentMetadata metadata2 = new DocumentMetadata(content2, "doc-1", "0");
+
+        Document doc1 = new Document(metadata1);
+        Document doc2 = new Document(metadata2);
+
+        assertEquals(doc1.getId(), doc2.getId());
+
+        // Also verify that different text produces a different ID
+        TextBlock differentContent = TextBlock.builder().text("different text").build();
+        DocumentMetadata metadata3 = new DocumentMetadata(differentContent, "doc-1", "0");
+        Document doc3 = new Document(metadata3);
+        assertFalse(doc1.getId().equals(doc3.getId()));
+    }
+
+    @Test
     @DisplayName("Should generate different IDs for different content")
     void testDocumentIdUniqueness() {
         TextBlock content1 = TextBlock.builder().text("Test content 1").build();


### PR DESCRIPTION
## Summary

- **`Document.generateDocumentId`**: 将 `getContent()`（返回 `ContentBlock` 对象）替换为 `getContentText()`（返回纯文本字符串）。原来 Jackson 序列化后的 JSON key 是 `{"content":{"text":"...","type":"text"}}`，而 Python 端的 `_map_text_to_uuid` 用的是 `{"content":"..."}`，导致同一份文档 Java/Python 生成的 UUID 不同，跨语言共用向量库时文档无法正确匹配。
- **`KnowledgeRetrievalTools.retrieveKnowledge`**: LLM 未传 `limit` 参数时，从硬编码的 `5` 改为使用 `defaultConfig.getLimit()`，使构建时配置的 limit 生效。

## Test plan

- [ ] `DocumentTest#testDocumentIdUsesTextNotContentBlockObject`：验证 ID 基于文本字符串而非 ContentBlock 对象结构生成
- [ ] `KnowledgeRetrievalToolsTest#testNullLimitFallsBackToDefaultConfig`：验证 null limit 时使用 defaultConfig.getLimit()
- [ ] `KnowledgeRetrievalToolsTest#testExplicitLimitOverridesDefault`：验证显式传入的 limit 优先于 defaultConfig
- [ ] 原有 `DocumentTest`、`KnowledgeTest`、`ReActAgentRAGConfigTest` 全部通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)