### PR TITLE
feat(agui): Add multimodal input support (image/video/audio) to AguiM…

### DIFF
--- a/agentscope-extensions/agentscope-extensions-agui/src/main/java/io/agentscope/core/agui/converter/AguiMessageConverter.java
+++ b/agentscope-extensions/agentscope-extensions-agui/src/main/java/io/agentscope/core/agui/converter/AguiMessageConverter.java
@@ -19,12 +19,18 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import io.agentscope.core.agui.model.AguiFunctionCall;
 import io.agentscope.core.agui.model.AguiMessage;
 import io.agentscope.core.agui.model.AguiToolCall;
+import io.agentscope.core.message.AudioBlock;
+import io.agentscope.core.message.Base64Source;
 import io.agentscope.core.message.ContentBlock;
+import io.agentscope.core.message.ImageBlock;
 import io.agentscope.core.message.Msg;
 import io.agentscope.core.message.MsgRole;
+import io.agentscope.core.message.Source;
 import io.agentscope.core.message.TextBlock;
 import io.agentscope.core.message.ToolResultBlock;
 import io.agentscope.core.message.ToolUseBlock;
+import io.agentscope.core.message.URLSource;
+import io.agentscope.core.message.VideoBlock;
 import io.agentscope.core.util.JsonException;
 import io.agentscope.core.util.JsonUtils;
 import java.util.ArrayList;
@@ -37,6 +43,17 @@ import java.util.stream.Collectors;
  *
  * <p>This class handles the bidirectional conversion between the AG-UI protocol's
  * message format and AgentScope's internal message format.
+ *
+ * <p>Supports multimodal input per AG-UI protocol:
+ * <ul>
+ *   <li>{@code text} → {@link TextBlock}</li>
+ *   <li>{@code image} → {@link ImageBlock}</li>
+ *   <li>{@code video} → {@link VideoBlock}</li>
+ *   <li>{@code audio} → {@link AudioBlock}</li>
+ *   <li>{@code document} → {@link TextBlock} (with description)</li>
+ * </ul>
+ *
+ * <p>See https://docs.ag-ui.com/concepts/messages.md for AG-UI InputContent spec.
  */
 public class AguiMessageConverter {
     /**
@@ -54,8 +71,20 @@ public class AguiMessageConverter {
         MsgRole role = convertRole(aguiMessage.getRole());
         List<ContentBlock> blocks = new ArrayList<>();
 
-        // Add text content if present
-        if (aguiMessage.getContent() != null && !aguiMessage.getContent().isEmpty()) {
+        // Handle multimodal content (InputContent array per AG-UI protocol)
+        if (aguiMessage.isMultimodalContent()) {
+            List<Map<String, Object>> parts = aguiMessage.getMultimodalContent();
+            if (parts != null) {
+                for (Map<String, Object> part : parts) {
+                    ContentBlock block = convertInputContent(part);
+                    if (block != null) {
+                        blocks.add(block);
+                    }
+                }
+            }
+        }
+        // Handle simple text content (backward compatible)
+        else if (aguiMessage.getContent() != null && !aguiMessage.getContent().isEmpty()) {
             if (aguiMessage.isToolMessage() && aguiMessage.getToolCallId() != null) {
                 // For tool messages, wrap content in ToolResultBlock
                 blocks.add(
@@ -76,6 +105,91 @@ public class AguiMessageConverter {
         }
 
         return Msg.builder().id(aguiMessage.getId()).role(role).content(blocks).build();
+    }
+
+    /**
+     * Convert a single AG-UI InputContent part to an AgentScope ContentBlock.
+     *
+     * @param part The InputContent map from AG-UI protocol
+     * @return The converted ContentBlock, or null if type is unrecognized
+     */
+    @SuppressWarnings("unchecked")
+    private ContentBlock convertInputContent(Map<String, Object> part) {
+        String type = (String) part.get("type");
+        if (type == null) {
+            return null;
+        }
+
+        switch (type) {
+            case "text":
+                String text = (String) part.get("text");
+                return text != null ? TextBlock.builder().text(text).build() : null;
+
+            case "image":
+                Source source = extractSource(part);
+                return source != null ? ImageBlock.builder().source(source).build() : null;
+
+            case "video":
+                Source videoSource = extractSource(part);
+                return videoSource != null
+                        ? VideoBlock.builder().source(videoSource).build()
+                        : null;
+
+            case "audio":
+                Source audioSource = extractSource(part);
+                return audioSource != null
+                        ? AudioBlock.builder().source(audioSource).build()
+                        : null;
+
+            case "document":
+                // Convert document to TextBlock with description
+                Source docSource = extractSource(part);
+                if (docSource != null) {
+                    String docDesc = "[Document: " + extractMimeType(part) + "]";
+                    return TextBlock.builder().text(docDesc).build();
+                }
+                return null;
+
+            default:
+                return null;
+        }
+    }
+
+    /**
+     * Extract Source from an InputContent part.
+     * Supports both 'url' and 'data' (base64) source types.
+     */
+    @SuppressWarnings("unchecked")
+    private Source extractSource(Map<String, Object> part) {
+        Map<String, Object> sourceMap = (Map<String, Object>) part.get("source");
+        if (sourceMap == null) {
+            return null;
+        }
+
+        String sourceType = (String) sourceMap.get("type");
+        if ("url".equals(sourceType)) {
+            String url = (String) sourceMap.get("value");
+            return url != null ? new URLSource(url) : null;
+        } else if ("data".equals(sourceType)) {
+            String data = (String) sourceMap.get("value");
+            String mimeType = (String) sourceMap.get("mimeType");
+            if (data != null && mimeType != null) {
+                return new Base64Source(data, mimeType);
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Extract mimeType from an InputContent part (for document type).
+     */
+    private String extractMimeType(Map<String, Object> part) {
+        @SuppressWarnings("unchecked")
+        Map<String, Object> sourceMap = (Map<String, Object>) part.get("source");
+        if (sourceMap != null) {
+            return (String) sourceMap.get("mimeType");
+        }
+        return null;
     }
 
     /**

--- a/agentscope-extensions/agentscope-extensions-agui/src/main/java/io/agentscope/core/agui/model/AguiMessage.java
+++ b/agentscope-extensions/agentscope-extensions-agui/src/main/java/io/agentscope/core/agui/model/AguiMessage.java
@@ -19,6 +19,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 
 /**
@@ -34,12 +35,24 @@ import java.util.Objects;
  *   <li>system - System instructions</li>
  *   <li>tool - Tool execution results</li>
  * </ul>
+ *
+ * <p>Content can be a simple string or a multimodal array of
+ * {@code InputContent} objects (per AG-UI protocol).
+ * See https://docs.ag-ui.com/concepts/messages.md for details.
+ *
+ * <p>InputContent array element structure:
+ * <pre>{@code
+ * { "type": "text", "text": "Hello" }
+ * { "type": "image", "source": { "type": "url", "value": "https://...", "mimeType": "image/png" } }
+ * { "type": "video", "source": { "type": "url", "value": "https://...", "mimeType": "video/mp4" } }
+ * { "type": "audio", "source": { "type": "url", "value": "https://...", "mimeType": "audio/wav" } }
+ * }</pre>
  */
 public class AguiMessage {
 
     private final String id;
     private final String role;
-    private final String content;
+    private final Object content; // String or List<map<string,object>> for multimodal
     private final List<AguiToolCall> toolCalls;
     private final String toolCallId;
 
@@ -48,7 +61,8 @@ public class AguiMessage {
      *
      * @param id The unique message ID
      * @param role The message role (user, assistant, system, tool)
-     * @param content The message content
+     * @param content The message content - may be a String or a List of InputContent objects
+     *                (multimodal input per AG-UI protocol)
      * @param toolCalls Tool calls for assistant messages (optional)
      * @param toolCallId Tool call ID for tool messages (optional)
      */
@@ -56,7 +70,7 @@ public class AguiMessage {
     public AguiMessage(
             @JsonProperty("id") String id,
             @JsonProperty("role") String role,
-            @JsonProperty("content") String content,
+            @JsonProperty("content") Object content,
             @JsonProperty("toolCalls") List<AguiToolCall> toolCalls,
             @JsonProperty("toolCallId") String toolCallId) {
         this.id = Objects.requireNonNull(id, "id cannot be null");
@@ -135,10 +149,42 @@ public class AguiMessage {
     /**
      * Get the message content.
      *
-     * @return The content, may be null
+     * @return The content as a String if it is a simple text message, or null if
+     *         the content is multimodal (InputContent array). Use {@link #getContentObject()}
+     *         for full multimodal support.
      */
     public String getContent() {
+        return content instanceof String ? (String) content : null;
+    }
+
+    /**
+     * Get the raw content object.
+     *
+     * @return The content as an Object - either a String for simple text messages
+     *         or a List of InputContent maps for multimodal messages.
+     */
+    public Object getContentObject() {
         return content;
+    }
+
+    /**
+     * Check if this message contains multimodal content (InputContent array).
+     *
+     * @return true if content is a List (multimodal), false if it's a String or null
+     */
+    public boolean isMultimodalContent() {
+        return content instanceof List;
+    }
+
+    /**
+     * Get the multimodal content as a list of InputContent objects.
+     * Each item is a Map with keys: type, text/source/etc.
+     *
+     * @return The content as a List if it is multimodal, or null if it's a simple String
+     */
+    @SuppressWarnings("unchecked")
+    public List<Map<String, Object>> getMultimodalContent() {
+        return content instanceof List ? (List<Map<String, Object>>) content : null;
     }
 
     /**

--- a/agentscope-extensions/agentscope-extensions-agui/src/test/java/io/agentscope/core/agui/converter/AguiMessageConverterTest.java
+++ b/agentscope-extensions/agentscope-extensions-agui/src/test/java/io/agentscope/core/agui/converter/AguiMessageConverterTest.java
@@ -17,6 +17,7 @@ package io.agentscope.core.agui.converter;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -24,11 +25,17 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import io.agentscope.core.agui.model.AguiFunctionCall;
 import io.agentscope.core.agui.model.AguiMessage;
 import io.agentscope.core.agui.model.AguiToolCall;
+import io.agentscope.core.message.AudioBlock;
+import io.agentscope.core.message.Base64Source;
+import io.agentscope.core.message.ContentBlock;
+import io.agentscope.core.message.ImageBlock;
 import io.agentscope.core.message.Msg;
 import io.agentscope.core.message.MsgRole;
 import io.agentscope.core.message.TextBlock;
 import io.agentscope.core.message.ToolResultBlock;
 import io.agentscope.core.message.ToolUseBlock;
+import io.agentscope.core.message.URLSource;
+import io.agentscope.core.message.VideoBlock;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -369,5 +376,240 @@ class AguiMessageConverterTest {
         assertNotNull(tub);
         // Invalid JSON should result in empty map
         assertTrue(tub.getInput().isEmpty());
+    }
+
+    // ===== Multimodal content conversion tests =====
+
+    @Test
+    void testConvertMultimodalTextContent() {
+        List<Map<String, Object>> parts =
+                List.of(Map.of("type", "text", "text", "Hello multimodal"));
+        AguiMessage aguiMsg = new AguiMessage("msg-mm-1", "user", parts, null, null);
+
+        Msg msg = converter.toMsg(aguiMsg);
+
+        assertEquals("msg-mm-1", msg.getId());
+        assertEquals(MsgRole.USER, msg.getRole());
+        assertTrue(msg.hasContentBlocks(TextBlock.class));
+        assertEquals("Hello multimodal", msg.getTextContent());
+    }
+
+    @Test
+    void testConvertMultimodalImageWithUrl() {
+        Map<String, Object> source = Map.of("type", "url", "value", "https://example.com/img.png");
+        List<Map<String, Object>> parts = List.of(Map.of("type", "image", "source", source));
+        AguiMessage aguiMsg = new AguiMessage("msg-mm-2", "user", parts, null, null);
+
+        Msg msg = converter.toMsg(aguiMsg);
+
+        assertTrue(msg.hasContentBlocks(ImageBlock.class));
+        ImageBlock imageBlock = msg.getFirstContentBlock(ImageBlock.class);
+        assertNotNull(imageBlock);
+        assertInstanceOf(URLSource.class, imageBlock.getSource());
+        assertEquals("https://example.com/img.png", ((URLSource) imageBlock.getSource()).getUrl());
+    }
+
+    @Test
+    void testConvertMultimodalImageWithBase64() {
+        Map<String, Object> source =
+                Map.of("type", "data", "value", "iVBORw0KGgo=", "mimeType", "image/png");
+        List<Map<String, Object>> parts = List.of(Map.of("type", "image", "source", source));
+        AguiMessage aguiMsg = new AguiMessage("msg-mm-3", "user", parts, null, null);
+
+        Msg msg = converter.toMsg(aguiMsg);
+
+        assertTrue(msg.hasContentBlocks(ImageBlock.class));
+        ImageBlock imageBlock = msg.getFirstContentBlock(ImageBlock.class);
+        assertNotNull(imageBlock);
+        assertInstanceOf(Base64Source.class, imageBlock.getSource());
+    }
+
+    @Test
+    void testConvertMultimodalVideoWithUrl() {
+        Map<String, Object> source =
+                Map.of("type", "url", "value", "https://example.com/video.mp4");
+        List<Map<String, Object>> parts = List.of(Map.of("type", "video", "source", source));
+        AguiMessage aguiMsg = new AguiMessage("msg-mm-4", "user", parts, null, null);
+
+        Msg msg = converter.toMsg(aguiMsg);
+
+        assertTrue(msg.hasContentBlocks(VideoBlock.class));
+        VideoBlock videoBlock = msg.getFirstContentBlock(VideoBlock.class);
+        assertNotNull(videoBlock);
+        assertInstanceOf(URLSource.class, videoBlock.getSource());
+        assertEquals(
+                "https://example.com/video.mp4", ((URLSource) videoBlock.getSource()).getUrl());
+    }
+
+    @Test
+    void testConvertMultimodalAudioWithUrl() {
+        Map<String, Object> source =
+                Map.of("type", "url", "value", "https://example.com/audio.wav");
+        List<Map<String, Object>> parts = List.of(Map.of("type", "audio", "source", source));
+        AguiMessage aguiMsg = new AguiMessage("msg-mm-5", "user", parts, null, null);
+
+        Msg msg = converter.toMsg(aguiMsg);
+
+        assertTrue(msg.hasContentBlocks(AudioBlock.class));
+        AudioBlock audioBlock = msg.getFirstContentBlock(AudioBlock.class);
+        assertNotNull(audioBlock);
+        assertInstanceOf(URLSource.class, audioBlock.getSource());
+        assertEquals(
+                "https://example.com/audio.wav", ((URLSource) audioBlock.getSource()).getUrl());
+    }
+
+    @Test
+    void testConvertMultimodalDocument() {
+        Map<String, Object> source =
+                Map.of(
+                        "type",
+                        "url",
+                        "value",
+                        "https://example.com/doc.pdf",
+                        "mimeType",
+                        "application/pdf");
+        List<Map<String, Object>> parts = List.of(Map.of("type", "document", "source", source));
+        AguiMessage aguiMsg = new AguiMessage("msg-mm-6", "user", parts, null, null);
+
+        Msg msg = converter.toMsg(aguiMsg);
+
+        assertTrue(msg.hasContentBlocks(TextBlock.class));
+        assertEquals("[Document: application/pdf]", msg.getTextContent());
+    }
+
+    @Test
+    void testConvertMultimodalMixedContent() {
+        Map<String, Object> imgSource =
+                Map.of("type", "url", "value", "https://example.com/img.jpg");
+        List<Map<String, Object>> parts =
+                List.of(
+                        Map.of("type", "text", "text", "Look at this image:"),
+                        Map.of("type", "image", "source", imgSource));
+        AguiMessage aguiMsg = new AguiMessage("msg-mm-7", "user", parts, null, null);
+
+        Msg msg = converter.toMsg(aguiMsg);
+
+        List<ContentBlock> blocks = msg.getContent();
+        assertEquals(2, blocks.size());
+        assertInstanceOf(TextBlock.class, blocks.get(0));
+        assertInstanceOf(ImageBlock.class, blocks.get(1));
+    }
+
+    @Test
+    void testConvertMultimodalUnknownType() {
+        List<Map<String, Object>> parts = List.of(Map.of("type", "unknown_type", "data", "xyz"));
+        AguiMessage aguiMsg = new AguiMessage("msg-mm-8", "user", parts, null, null);
+
+        Msg msg = converter.toMsg(aguiMsg);
+
+        // Unknown type should be skipped, resulting in no content blocks
+        assertTrue(msg.getContent().isEmpty());
+    }
+
+    @Test
+    void testConvertMultimodalNullType() {
+        List<Map<String, Object>> parts = List.of(Map.of("data", "xyz"));
+        AguiMessage aguiMsg = new AguiMessage("msg-mm-9", "user", parts, null, null);
+
+        Msg msg = converter.toMsg(aguiMsg);
+
+        assertTrue(msg.getContent().isEmpty());
+    }
+
+    @Test
+    void testConvertMultimodalImageWithNullSource() {
+        List<Map<String, Object>> parts = List.of(Map.of("type", "image"));
+        AguiMessage aguiMsg = new AguiMessage("msg-mm-10", "user", parts, null, null);
+
+        Msg msg = converter.toMsg(aguiMsg);
+
+        // Image without source should be skipped
+        assertFalse(msg.hasContentBlocks(ImageBlock.class));
+    }
+
+    @Test
+    void testConvertMultimodalTextWithNullText() {
+        List<Map<String, Object>> parts = List.of(Map.of("type", "text"));
+        AguiMessage aguiMsg = new AguiMessage("msg-mm-11", "user", parts, null, null);
+
+        Msg msg = converter.toMsg(aguiMsg);
+
+        // Text without text value should be skipped
+        assertFalse(msg.hasContentBlocks(TextBlock.class));
+    }
+
+    @Test
+    void testConvertMultimodalBase64SourceMissingMimeType() {
+        Map<String, Object> source = Map.of("type", "data", "value", "iVBORw0KGgo=");
+        List<Map<String, Object>> parts = List.of(Map.of("type", "image", "source", source));
+        AguiMessage aguiMsg = new AguiMessage("msg-mm-12", "user", parts, null, null);
+
+        Msg msg = converter.toMsg(aguiMsg);
+
+        // Base64 source without mimeType should be skipped
+        assertFalse(msg.hasContentBlocks(ImageBlock.class));
+    }
+
+    @Test
+    void testConvertMultimodalUrlSourceMissingValue() {
+        Map<String, Object> source = Map.of("type", "url");
+        List<Map<String, Object>> parts = List.of(Map.of("type", "image", "source", source));
+        AguiMessage aguiMsg = new AguiMessage("msg-mm-13", "user", parts, null, null);
+
+        Msg msg = converter.toMsg(aguiMsg);
+
+        // URL source without value should be skipped
+        assertFalse(msg.hasContentBlocks(ImageBlock.class));
+    }
+
+    @Test
+    void testConvertMultimodalDocumentWithoutSource() {
+        List<Map<String, Object>> parts = List.of(Map.of("type", "document"));
+        AguiMessage aguiMsg = new AguiMessage("msg-mm-14", "user", parts, null, null);
+
+        Msg msg = converter.toMsg(aguiMsg);
+
+        // Document without source should be skipped
+        assertFalse(msg.hasContentBlocks(TextBlock.class));
+    }
+
+    @Test
+    void testConvertMultimodalSourceWithUnknownSourceType() {
+        Map<String, Object> source = Map.of("type", "ftp", "value", "ftp://file.dat");
+        List<Map<String, Object>> parts = List.of(Map.of("type", "image", "source", source));
+        AguiMessage aguiMsg = new AguiMessage("msg-mm-15", "user", parts, null, null);
+
+        Msg msg = converter.toMsg(aguiMsg);
+
+        // Unknown source type should be skipped
+        assertFalse(msg.hasContentBlocks(ImageBlock.class));
+    }
+
+    @Test
+    void testConvertMultimodalAudioWithBase64() {
+        Map<String, Object> source =
+                Map.of("type", "data", "value", "AAAA", "mimeType", "audio/wav");
+        List<Map<String, Object>> parts = List.of(Map.of("type", "audio", "source", source));
+        AguiMessage aguiMsg = new AguiMessage("msg-mm-16", "user", parts, null, null);
+
+        Msg msg = converter.toMsg(aguiMsg);
+
+        assertTrue(msg.hasContentBlocks(AudioBlock.class));
+        AudioBlock audioBlock = msg.getFirstContentBlock(AudioBlock.class);
+        assertInstanceOf(Base64Source.class, audioBlock.getSource());
+    }
+
+    @Test
+    void testConvertMultimodalVideoWithBase64() {
+        Map<String, Object> source =
+                Map.of("type", "data", "value", "AAAA", "mimeType", "video/mp4");
+        List<Map<String, Object>> parts = List.of(Map.of("type", "video", "source", source));
+        AguiMessage aguiMsg = new AguiMessage("msg-mm-17", "user", parts, null, null);
+
+        Msg msg = converter.toMsg(aguiMsg);
+
+        assertTrue(msg.hasContentBlocks(VideoBlock.class));
+        VideoBlock videoBlock = msg.getFirstContentBlock(VideoBlock.class);
+        assertInstanceOf(Base64Source.class, videoBlock.getSource());
     }
 }

--- a/agentscope-extensions/agentscope-extensions-agui/src/test/java/io/agentscope/core/agui/model/AguiModelTest.java
+++ b/agentscope-extensions/agentscope-extensions-agui/src/test/java/io/agentscope/core/agui/model/AguiModelTest.java
@@ -176,6 +176,63 @@ class AguiModelTest {
 
             assertNull(msg.getContent());
         }
+
+        @Test
+        void testMultimodalContentDetection() {
+            List<Map<String, Object>> parts = List.of(Map.of("type", "text", "text", "Hello"));
+            AguiMessage msg = new AguiMessage("msg-1", "user", parts, null, null);
+
+            assertTrue(msg.isMultimodalContent());
+            assertNull(msg.getContent()); // String content returns null for multimodal
+            assertNotNull(msg.getMultimodalContent());
+            assertEquals(1, msg.getMultimodalContent().size());
+            assertEquals(parts, msg.getContentObject());
+        }
+
+        @Test
+        void testSimpleTextContentIsNotMultimodal() {
+            AguiMessage msg = AguiMessage.userMessage("msg-1", "Hello world");
+
+            assertFalse(msg.isMultimodalContent());
+            assertEquals("Hello world", msg.getContent());
+            assertNull(msg.getMultimodalContent());
+            assertEquals("Hello world", msg.getContentObject());
+        }
+
+        @Test
+        void testNullContentIsNotMultimodal() {
+            AguiMessage msg = new AguiMessage("msg-1", "user", null, null, null);
+
+            assertFalse(msg.isMultimodalContent());
+            assertNull(msg.getContent());
+            assertNull(msg.getMultimodalContent());
+            assertNull(msg.getContentObject());
+        }
+
+        @Test
+        void testMultimodalJsonDeserialization() throws JsonProcessingException {
+            String json =
+                    "{\"id\":\"msg-1\",\"role\":\"user\",\"content\":"
+                            + "[{\"type\":\"text\",\"text\":\"Hello\"}]}";
+
+            AguiMessage msg = JsonUtils.getJsonCodec().fromJson(json, AguiMessage.class);
+
+            assertEquals("msg-1", msg.getId());
+            assertEquals("user", msg.getRole());
+            assertTrue(msg.isMultimodalContent());
+            assertNotNull(msg.getMultimodalContent());
+            assertEquals(1, msg.getMultimodalContent().size());
+        }
+
+        @Test
+        void testMultimodalContentEquals() {
+            List<Map<String, Object>> parts = List.of(Map.of("type", "text", "text", "Hello"));
+            AguiMessage msg1 = new AguiMessage("msg-1", "user", parts, null, null);
+            AguiMessage msg2 = new AguiMessage("msg-1", "user", parts, null, null);
+
+            assertEquals(msg1, msg2);
+            assertEquals(msg1.hashCode(), msg2.hashCode());
+        }
     }
 
     @Nested


### PR DESCRIPTION
…essage and AguiMessageConverter

Adds support for multimodal input (image, video, audio, document) in the AG-UI extension, aligning with the AG-UI Protocol InputContent specification.

- AguiMessage.content: String -> Object (backward compatible)
- AguiMessageConverter: InputContent[] -> ContentBlock conversion
- Supports both url and data (base64) source types

## AgentScope-Java Version

[The version of AgentScope-Java you are working on, e.g. 1.0.12, check your pom.xml dependency version or run `mvn dependency:tree | grep agentscope-parent:pom`(only mac/linux)]

## Description

[Please describe the background, purpose, changes made, and how to test this PR]

## Checklist

Please check the following items before code is ready to be reviewed.

- [ ]  Code has been formatted with `mvn spotless:apply`
- [ ]  All tests are passing (`mvn test`)
- [ ]  Javadoc comments are complete and follow project conventions
- [ ]  Related documentation has been updated (e.g. links, examples, etc.)
- [ ]  Code is ready for review
