### PR TITLE
fix(nacos): preserve shared config for A2A defaults

### DIFF
--- a/agentscope-extensions/agentscope-spring-boot-starters/agentscope-nacos-spring-boot-starter/src/main/java/io/agentscope/spring/boot/nacos/AgentscopeA2aNacosAutoConfiguration.java
+++ b/agentscope-extensions/agentscope-spring-boot-starters/agentscope-nacos-spring-boot-starter/src/main/java/io/agentscope/spring/boot/nacos/AgentscopeA2aNacosAutoConfiguration.java
@@ -81,7 +81,7 @@ public class AgentscopeA2aNacosAutoConfiguration implements Closeable {
             AgentScopeA2aNacosProperties a2aNacosProperties)
             throws NacosException {
         Properties nacosClientProperties = nacosProperties.getNacosProperties();
-        nacosClientProperties.putAll(a2aNacosProperties.getNacosProperties());
+        nacosClientProperties.putAll(a2aNacosProperties.getExplicitNacosProperties());
         return AiFactory.createAiService(nacosClientProperties);
     }
 

--- a/agentscope-extensions/agentscope-spring-boot-starters/agentscope-nacos-spring-boot-starter/src/test/java/io/agentscope/spring/boot/nacos/AgentscopeA2aNacosAutoConfigurationTest.java
+++ b/agentscope-extensions/agentscope-spring-boot-starters/agentscope-nacos-spring-boot-starter/src/test/java/io/agentscope/spring/boot/nacos/AgentscopeA2aNacosAutoConfigurationTest.java
@@ -21,6 +21,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
+import com.alibaba.nacos.api.PropertyKeyConst;
 import com.alibaba.nacos.api.ai.AiFactory;
 import com.alibaba.nacos.api.ai.AiService;
 import io.agentscope.core.a2a.agent.card.AgentCardResolver;
@@ -32,6 +33,8 @@ import io.agentscope.spring.boot.nacos.properties.a2a.AgentScopeA2aNacosProperti
 import io.agentscope.spring.boot.nacos.properties.a2a.NacosA2aDiscoveryProperties;
 import io.agentscope.spring.boot.nacos.properties.a2a.NacosA2aRegistryProperties;
 import java.util.Map;
+import java.util.Properties;
+import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
@@ -222,6 +225,39 @@ class AgentscopeA2aNacosAutoConfigurationTest {
                                 NacosA2aDiscoveryProperties discoveryProperties =
                                         properties.getDiscovery();
                                 assertThat(discoveryProperties.isEnabled()).isTrue();
+                            });
+        }
+    }
+
+    @Test
+    void shouldNotOverwriteGlobalNacosServerWhenA2aServerNotSet() {
+        try (MockedStatic<AiFactory> mockedStatic = Mockito.mockStatic(AiFactory.class)) {
+            AtomicReference<Properties> capturedProperties = new AtomicReference<>();
+            mockedStatic
+                    .when(() -> AiFactory.createAiService(any(Properties.class)))
+                    .thenAnswer(
+                            invocation -> {
+                                capturedProperties.set(invocation.getArgument(0));
+                                return mockAiService;
+                            });
+
+            new ApplicationContextRunner()
+                    .withConfiguration(
+                            AutoConfigurations.of(AgentscopeA2aNacosAutoConfiguration.class))
+                    .withPropertyValues(
+                            "agentscope.nacos.server-addr=production.nacos.com:8848",
+                            "agentscope.nacos.namespace=prod-ns",
+                            "agentscope.a2a.nacos.enabled=true")
+                    .run(
+                            context -> {
+                                assertThat(capturedProperties.get()).isNotNull();
+                                assertThat(
+                                                capturedProperties
+                                                        .get()
+                                                        .get(PropertyKeyConst.SERVER_ADDR))
+                                        .isEqualTo("production.nacos.com:8848");
+                                assertThat(capturedProperties.get().get(PropertyKeyConst.NAMESPACE))
+                                        .isEqualTo("prod-ns");
                             });
         }
     }


### PR DESCRIPTION
Fixes #1381.

The A2A Nacos auto-configuration was overlaying `a2aNacosProperties.getNacosProperties()` on top of the shared Nacos properties. That method also fills default values, so leaving the A2A Nacos section unset can still replace the shared `server-addr` / `namespace` values.

This follows the prompt Nacos auto-configuration path and only overlays the A2A values that were explicitly configured. I also added a context-runner test for the shared server/namespace case.

Checked with:
- `mvn -pl agentscope-extensions/agentscope-spring-boot-starters/agentscope-nacos-spring-boot-starter spotless:check`
- `mvn -pl agentscope-extensions/agentscope-spring-boot-starters/agentscope-nacos-spring-boot-starter -am -Dtest=AgentscopeA2aNacosAutoConfigurationTest -Dspotless.check.skip=true -Dmaven.javadoc.skip=true test`