### PR TITLE
docs: clarify enableThinking example comment

### DIFF
--- a/docs/en/task/model.md
+++ b/docs/en/task/model.md
@@ -159,7 +159,7 @@ DashScopeChatModel model = DashScopeChatModel.builder()
 DashScopeChatModel model = DashScopeChatModel.builder()
         .apiKey(System.getenv("DASHSCOPE_API_KEY"))
         .modelName("qwen3-max")
-        .enableThinking(true)  // Automatically enables streaming
+        .enableThinking(true)  // Enables thinking mode and automatically enables streaming
         .defaultOptions(GenerateOptions.builder()
                 .thinkingBudget(5000)  // Token budget for thinking
                 .build())

--- a/docs/zh/task/model.md
+++ b/docs/zh/task/model.md
@@ -159,7 +159,7 @@ DashScopeChatModel model = DashScopeChatModel.builder()
 DashScopeChatModel model = DashScopeChatModel.builder()
         .apiKey(System.getenv("DASHSCOPE_API_KEY"))
         .modelName("qwen3-max")
-        .enableThinking(true)  // 自动启用流式输出
+        .enableThinking(true)  // 启用思考模式，并自动启用流式输出
         .defaultOptions(GenerateOptions.builder()
                 .thinkingBudget(5000)  // 思考 token 预算
                 .build())


### PR DESCRIPTION
## AgentScope-Java Version

1.0.13-SNAPSHOT

## Description

Fixes #1393.

### Background

The DashScope thinking mode example comment described `.enableThinking(true)` only as automatically enabling streaming. This was incomplete because the primary behavior is enabling thinking mode, while streaming is also enabled implicitly by the current implementation.

### Changes

- Clarified the Chinese docs comment for `.enableThinking(true)`.
- Applied the same clarification to the English docs.
- Kept the comment aligned with the implementation: thinking mode is enabled and streaming is automatically enabled.

### How to test

Verified the updated comments in:

    docs/zh/task/model.md
    docs/en/task/model.md

No Java tests were run because this is a docs-only comment change.

## Checklist

Please check the following items before code is ready to be reviewed.

- Related documentation has been updated.
- Code is ready for review.