### PR TITLE
Use content hashes for session list states

### DIFF
--- a/agentscope-core/src/main/java/io/agentscope/core/session/ListHashUtil.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/session/ListHashUtil.java
@@ -16,6 +16,7 @@
 package io.agentscope.core.session;
 
 import io.agentscope.core.state.State;
+import io.agentscope.core.util.JsonUtils;
 import java.util.List;
 
 /**
@@ -65,7 +66,7 @@ public final class ListHashUtil {
      *
      * <ul>
      *   <li>List size
-     *   <li>Hash codes of sampled elements
+     *   <li>Content hashes of sampled elements
      * </ul>
      *
      * <p>This method is designed to be lightweight and fast, using sampling for large lists to
@@ -88,11 +89,20 @@ public final class ListHashUtil {
 
         for (int idx : sampleIndices) {
             State item = values.get(idx);
-            int itemHash = item != null ? item.hashCode() : 0;
+            int itemHash = computeItemHash(item);
             sb.append(idx).append(":").append(itemHash).append(",");
         }
 
         return Integer.toHexString(sb.toString().hashCode());
+    }
+
+    private static int computeItemHash(State item) {
+        if (item == null) {
+            return 0;
+        }
+
+        String serialized = JsonUtils.getJsonCodec().toJson(item);
+        return serialized.hashCode();
     }
 
     /**

--- a/agentscope-core/src/test/java/io/agentscope/core/session/ListHashUtilTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/session/ListHashUtilTest.java
@@ -56,6 +56,17 @@ class ListHashUtilTest {
     }
 
     @Test
+    void testComputeHashEquivalentMsgListsSameHash() {
+        List<Msg> list1 = createStableMsgList(5);
+        List<Msg> list2 = createStableMsgList(5);
+
+        String hash1 = ListHashUtil.computeHash(list1);
+        String hash2 = ListHashUtil.computeHash(list2);
+
+        assertEquals(hash1, hash2);
+    }
+
+    @Test
     void testComputeHashListModifiedDifferentHash() {
         List<Msg> list = createMsgList(5);
 
@@ -201,6 +212,21 @@ class ListHashUtilTest {
                     Msg.builder()
                             .role(MsgRole.USER)
                             .content(TextBlock.builder().text("message " + i).build())
+                            .build());
+        }
+        return list;
+    }
+
+    private List<Msg> createStableMsgList(int size) {
+        List<Msg> list = new ArrayList<>();
+        for (int i = 0; i < size; i++) {
+            list.add(
+                    Msg.builder()
+                            .id("msg-" + i)
+                            .name("user")
+                            .role(MsgRole.USER)
+                            .content(TextBlock.builder().text("message " + i).build())
+                            .timestamp("2026-01-01 00:00:0" + i + ".000")
                             .build());
         }
         return list;


### PR DESCRIPTION
## Summary
- replace sampled `State.hashCode()` usage in `ListHashUtil` with sampled content hashes derived from serialized state payloads
- keep the existing lightweight sampling strategy while making hash comparisons stable across equivalent `Msg` instances
- add a regression test that builds two logically identical message lists and verifies they now produce the same hash

## Root cause
`ListHashUtil.computeHash()` sampled `item.hashCode()`, but `Msg` does not override `hashCode()`. That made session change detection depend on JVM object identity instead of serialized message content, which could force unnecessary full rewrites even when the stored list was logically unchanged.

## Testing
- `mvn -pl agentscope-core -Dtest=ListHashUtilTest test`

Closes #1357