### PR TITLE
fix subagent runtime context propagation and glob root matching

### DIFF
--- a/agentscope-core/src/main/java/io/agentscope/core/tool/subagent/SubAgentTool.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/tool/subagent/SubAgentTool.java
@@ -15,8 +15,11 @@
  */
 package io.agentscope.core.tool.subagent;
 
+import io.agentscope.core.ReActAgent;
 import io.agentscope.core.agent.Agent;
+import io.agentscope.core.agent.AgentBase;
 import io.agentscope.core.agent.Event;
+import io.agentscope.core.agent.RuntimeContext;
 import io.agentscope.core.agent.StreamOptions;
 import io.agentscope.core.message.Msg;
 import io.agentscope.core.message.MsgRole;
@@ -27,6 +30,7 @@ import io.agentscope.core.state.StateModule;
 import io.agentscope.core.tool.AgentTool;
 import io.agentscope.core.tool.ToolCallParam;
 import io.agentscope.core.tool.ToolEmitter;
+import io.agentscope.core.tool.ToolExecutionContext;
 import io.agentscope.core.util.JsonUtils;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
@@ -36,6 +40,7 @@ import java.util.Map;
 import java.util.UUID;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 /**
@@ -157,6 +162,7 @@ public class SubAgentTool implements AgentTool {
                                         .role(MsgRole.USER)
                                         .content(TextBlock.builder().text(message).build())
                                         .build();
+                        RuntimeContext runtimeContext = resolveRuntimeContext(param);
 
                         logger.debug(
                                 "Session {} with agent '{}': {}",
@@ -170,9 +176,17 @@ public class SubAgentTool implements AgentTool {
                         // Execute and save state after completion
                         Mono<ToolResultBlock> result;
                         if (config.isForwardEvents()) {
-                            result = executeWithStreaming(agent, userMsg, finalSessionId, emitter);
+                            result =
+                                    executeWithStreaming(
+                                            agent,
+                                            userMsg,
+                                            finalSessionId,
+                                            emitter,
+                                            runtimeContext);
                         } else {
-                            result = executeWithoutStreaming(agent, userMsg, finalSessionId);
+                            result =
+                                    executeWithoutStreaming(
+                                            agent, userMsg, finalSessionId, runtimeContext);
                         }
 
                         // Save state after execution
@@ -241,7 +255,11 @@ public class SubAgentTool implements AgentTool {
      * @return A Mono emitting the tool result block
      */
     private Mono<ToolResultBlock> executeWithStreaming(
-            Agent agent, Msg userMsg, String sessionId, ToolEmitter emitter) {
+            Agent agent,
+            Msg userMsg,
+            String sessionId,
+            ToolEmitter emitter,
+            RuntimeContext runtimeContext) {
 
         StreamOptions streamOptions =
                 config.getStreamOptions() != null
@@ -250,7 +268,7 @@ public class SubAgentTool implements AgentTool {
 
         return Mono.deferContextual(
                 ctxView ->
-                        agent.stream(List.of(userMsg), streamOptions)
+                        streamWithContext(agent, userMsg, streamOptions, runtimeContext)
                                 .doOnNext(event -> forwardEvent(event, emitter, agent, sessionId))
                                 .filter(Event::isLast)
                                 .last()
@@ -283,11 +301,11 @@ public class SubAgentTool implements AgentTool {
      * @return A Mono emitting the tool result block
      */
     private Mono<ToolResultBlock> executeWithoutStreaming(
-            Agent agent, Msg userMsg, String sessionId) {
+            Agent agent, Msg userMsg, String sessionId, RuntimeContext runtimeContext) {
 
         return Mono.deferContextual(
                 ctxView ->
-                        agent.call(List.of(userMsg))
+                        callWithContext(agent, userMsg, runtimeContext)
                                 .map(response -> buildResult(response, sessionId))
                                 .onErrorResume(
                                         e -> {
@@ -298,6 +316,35 @@ public class SubAgentTool implements AgentTool {
                                                             "Execution error: " + e.getMessage()));
                                         })
                                 .contextWrite(context -> context.putAll(ctxView)));
+    }
+
+    private Flux<Event> streamWithContext(
+            Agent agent, Msg userMsg, StreamOptions options, RuntimeContext runtimeContext) {
+        if (runtimeContext != null && agent instanceof ReActAgent reActAgent) {
+            return reActAgent.stream(List.of(userMsg), options, runtimeContext);
+        }
+        return agent.stream(List.of(userMsg), options);
+    }
+
+    private Mono<Msg> callWithContext(Agent agent, Msg userMsg, RuntimeContext runtimeContext) {
+        if (runtimeContext != null && agent instanceof ReActAgent reActAgent) {
+            return reActAgent.call(List.of(userMsg), runtimeContext);
+        }
+        return agent.call(List.of(userMsg));
+    }
+
+    private RuntimeContext resolveRuntimeContext(ToolCallParam param) {
+        ToolExecutionContext context = param.getContext();
+        if (context != null) {
+            RuntimeContext runtimeContext = context.get(RuntimeContext.class);
+            if (runtimeContext != null) {
+                return runtimeContext;
+            }
+        }
+        if (param.getAgent() instanceof AgentBase agentBase) {
+            return agentBase.getRuntimeContext();
+        }
+        return null;
     }
 
     /**

--- a/agentscope-core/src/test/java/io/agentscope/core/tool/subagent/SubAgentToolTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/tool/subagent/SubAgentToolTest.java
@@ -20,14 +20,17 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import io.agentscope.core.ReActAgent;
 import io.agentscope.core.agent.Agent;
 import io.agentscope.core.agent.Event;
 import io.agentscope.core.agent.EventType;
+import io.agentscope.core.agent.RuntimeContext;
 import io.agentscope.core.agent.StreamOptions;
 import io.agentscope.core.message.Msg;
 import io.agentscope.core.message.MsgRole;
@@ -36,6 +39,7 @@ import io.agentscope.core.message.ToolResultBlock;
 import io.agentscope.core.message.ToolUseBlock;
 import io.agentscope.core.tool.ToolCallParam;
 import io.agentscope.core.tool.ToolEmitter;
+import io.agentscope.core.tool.ToolExecutionContext;
 import io.agentscope.core.tool.Toolkit;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -426,6 +430,87 @@ class SubAgentToolTest {
 
         // Verify stream was called with custom options
         verify(mockAgent).stream(any(List.class), any(StreamOptions.class));
+    }
+
+    @Test
+    @DisplayName("Should pass RuntimeContext to ReActAgent in non-streaming mode")
+    void testPassRuntimeContextToReActAgentCall() {
+        ReActAgent subAgent = mock(ReActAgent.class);
+        when(subAgent.getName()).thenReturn("CtxSubAgent");
+        when(subAgent.getDescription()).thenReturn("Sub agent with ctx");
+        when(subAgent.call(any(List.class), any(RuntimeContext.class)))
+                .thenReturn(
+                        Mono.just(
+                                Msg.builder()
+                                        .role(MsgRole.ASSISTANT)
+                                        .content(TextBlock.builder().text("ctx-ok").build())
+                                        .build()));
+
+        SubAgentTool tool =
+                new SubAgentTool(
+                        () -> subAgent, SubAgentConfig.builder().forwardEvents(false).build());
+
+        RuntimeContext runtimeContext = RuntimeContext.builder().userId("parent-user").build();
+
+        Map<String, Object> input = new HashMap<>();
+        input.put("message", "Hello");
+        ToolUseBlock toolUse =
+                ToolUseBlock.builder().id("ctx-1").name("call_ctxsubagent").input(input).build();
+
+        ToolCallParam param =
+                ToolCallParam.builder()
+                        .toolUseBlock(toolUse)
+                        .input(input)
+                        .context(runtimeContext.asToolExecutionContext())
+                        .build();
+
+        ToolResultBlock result = tool.callAsync(param).block();
+
+        assertNotNull(result);
+        verify(subAgent).call(any(List.class), eq(runtimeContext));
+        verify(subAgent, never()).call(any(List.class));
+    }
+
+    @Test
+    @DisplayName("Should pass RuntimeContext to ReActAgent in streaming mode")
+    void testPassRuntimeContextToReActAgentStream() {
+        ReActAgent subAgent = mock(ReActAgent.class);
+        when(subAgent.getName()).thenReturn("CtxStreamSubAgent");
+        when(subAgent.getDescription()).thenReturn("Sub agent with ctx stream");
+
+        Msg responseMsg =
+                Msg.builder()
+                        .role(MsgRole.ASSISTANT)
+                        .content(TextBlock.builder().text("stream-ctx-ok").build())
+                        .build();
+        Event reasoningEvent = new Event(EventType.REASONING, responseMsg, true);
+        when(subAgent.stream(any(List.class), any(StreamOptions.class), any(RuntimeContext.class)))
+                .thenReturn(Flux.just(reasoningEvent));
+
+        SubAgentTool tool = new SubAgentTool(() -> subAgent, SubAgentConfig.defaults());
+        RuntimeContext runtimeContext = RuntimeContext.builder().userId("parent-user").build();
+
+        Map<String, Object> input = new HashMap<>();
+        input.put("message", "Hello");
+        ToolUseBlock toolUse =
+                ToolUseBlock.builder()
+                        .id("ctx-stream-1")
+                        .name("call_ctxstreamsubagent")
+                        .input(input)
+                        .build();
+
+        ToolCallParam param =
+                ToolCallParam.builder()
+                        .toolUseBlock(toolUse)
+                        .input(input)
+                        .context(ToolExecutionContext.builder().register(runtimeContext).build())
+                        .build();
+
+        ToolResultBlock result = tool.callAsync(param).block();
+
+        assertNotNull(result);
+        verify(subAgent).stream(any(List.class), any(StreamOptions.class), eq(runtimeContext));
+        verify(subAgent, never()).stream(any(List.class), any(StreamOptions.class));
     }
 
     @Test

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/filesystem/local/LocalFilesystem.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/filesystem/local/LocalFilesystem.java
@@ -358,6 +358,7 @@ public class LocalFilesystem implements AbstractFilesystem {
                 effectivePattern.startsWith("**") ? effectivePattern : "**/" + effectivePattern;
         FileSystem fs = FileSystems.getDefault();
         PathMatcher matcher = fs.getPathMatcher("glob:" + globExpr);
+        PathMatcher directMatcher = fs.getPathMatcher("glob:" + effectivePattern);
 
         List<FileInfo> results = new ArrayList<>();
         try {
@@ -367,7 +368,7 @@ public class LocalFilesystem implements AbstractFilesystem {
                         @Override
                         public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) {
                             Path rel = searchPath.relativize(file);
-                            if (matcher.matches(rel)) {
+                            if (matcher.matches(rel) || directMatcher.matches(rel)) {
                                 String filePath =
                                         virtualMode
                                                 ? toVirtualPath(file)

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/filesystem/remote/RemoteFilesystem.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/filesystem/remote/RemoteFilesystem.java
@@ -307,6 +307,8 @@ public class RemoteFilesystem implements AbstractFilesystem {
                                         + (effectivePattern.startsWith("**")
                                                 ? effectivePattern
                                                 : "**/" + effectivePattern));
+        PathMatcher directMatcher =
+                FileSystems.getDefault().getPathMatcher("glob:" + effectivePattern);
 
         List<FileInfo> results = new ArrayList<>();
         for (StoreItem item : items) {
@@ -322,7 +324,8 @@ public class RemoteFilesystem implements AbstractFilesystem {
                 relativePath = key.substring(normalizedPath.length() + 1);
             }
 
-            if (matcher.matches(java.nio.file.Path.of(relativePath))) {
+            if (matcher.matches(java.nio.file.Path.of(relativePath))
+                    || directMatcher.matches(java.nio.file.Path.of(relativePath))) {
                 FileData fd = convertItemToFileData(item);
                 int size = (fd != null && fd.content() != null) ? fd.content().length() : 0;
                 String modifiedAt = (fd != null && fd.modifiedAt() != null) ? fd.modifiedAt() : "";

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/subagent/task/WorkspaceTaskRepository.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/subagent/task/WorkspaceTaskRepository.java
@@ -132,15 +132,16 @@ public class WorkspaceTaskRepository implements TaskRepository {
      */
     static WorkspaceTaskRepository forTests(
             WorkspaceManager workspaceManager, String parentAgentId) {
-        return forTests(
-                workspaceManager,
-                parentAgentId,
+        ExecutorService testExecutor =
                 Executors.newCachedThreadPool(
                         r -> {
                             Thread t = new Thread(r, "ws-task-test");
                             t.setDaemon(true);
                             return t;
-                        }));
+                        });
+        // Test helper creates its own executor, so repository must own and shut it down.
+        return new WorkspaceTaskRepository(
+                workspaceManager, parentAgentId, testExecutor, true, false);
     }
 
     static WorkspaceTaskRepository forTests(

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/filesystem/FilesystemGlobTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/filesystem/FilesystemGlobTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.harness.agent.filesystem;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.agentscope.core.agent.RuntimeContext;
+import io.agentscope.harness.agent.filesystem.local.LocalFilesystem;
+import io.agentscope.harness.agent.filesystem.model.GlobResult;
+import io.agentscope.harness.agent.filesystem.remote.RemoteFilesystem;
+import io.agentscope.harness.agent.store.InMemoryStore;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/** Verifies glob behavior for local and remote filesystem implementations. */
+class FilesystemGlobTest {
+
+    private static final RuntimeContext RT = RuntimeContext.empty();
+
+    @Test
+    void local_glob_plainPattern_matchesFilesInSearchRootAndSubdirectories(@TempDir Path tmp)
+            throws Exception {
+        Path memoryDir = Files.createDirectories(tmp.resolve("memory"));
+        Files.writeString(memoryDir.resolve("2026-05-13.md"), "daily note");
+        Files.createDirectories(memoryDir.resolve("sub"));
+        Files.writeString(memoryDir.resolve("sub").resolve("2026-05-14.md"), "next note");
+
+        LocalFilesystem fs = new LocalFilesystem(tmp);
+        GlobResult result = fs.glob(RT, "*.md", "memory");
+
+        assertTrue(result.isSuccess());
+        Set<String> relPaths =
+                result.matches().stream()
+                        .map(fi -> tmp.relativize(Path.of(fi.path())).toString().replace('\\', '/'))
+                        .collect(Collectors.toSet());
+
+        assertEquals(Set.of("memory/2026-05-13.md", "memory/sub/2026-05-14.md"), relPaths);
+    }
+
+    @Test
+    void remote_glob_plainPattern_matchesFilesInSearchRootAndSubdirectories() {
+        InMemoryStore store = new InMemoryStore();
+        List<String> ns = List.of("test-ns");
+        store.put(ns, "/agents/demo-session.log.jsonl", Map.of("content", "root log"));
+        store.put(ns, "/agents/sub/demo-session.log.jsonl", Map.of("content", "sub log"));
+
+        RemoteFilesystem fs = new RemoteFilesystem(store, ns);
+        GlobResult result = fs.glob(RT, "*.log.jsonl", "agents");
+
+        assertTrue(result.isSuccess());
+        Set<String> paths =
+                result.matches().stream()
+                        .map(fi -> fi.path().replace('\\', '/'))
+                        .collect(Collectors.toSet());
+        assertEquals(
+                Set.of("/agents/demo-session.log.jsonl", "/agents/sub/demo-session.log.jsonl"),
+                paths);
+    }
+}


### PR DESCRIPTION
Propagate RuntimeContext from parent tool calls into ReActAgent subagents, and make local/remote glob matching include both root-level and nested files for patterns like *.md and *.log.jsonl.