### PR TITLE
fix: check matching IDs before skipping pending tool recovery

### DIFF
--- a/agentscope-core/src/main/java/io/agentscope/core/hook/PendingToolRecoveryHook.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/hook/PendingToolRecoveryHook.java
@@ -107,9 +107,11 @@ public class PendingToolRecoveryHook implements Hook {
             return Mono.just(event);
         }
 
-        boolean userProvidedResults =
-                inputMessages.stream().anyMatch(m -> m.hasContentBlocks(ToolResultBlock.class));
-        if (userProvidedResults) {
+        boolean userProvidedMatchingResults = inputMessages.stream()
+                .flatMap(m -> m.getContentBlocks(ToolResultBlock.class).stream())
+                .map(ToolResultBlock::getId)
+                .anyMatch(pendingIds::contains);
+        if (userProvidedMatchingResults) {
             return Mono.just(event);
         }
 

--- a/agentscope-core/src/main/java/io/agentscope/core/hook/PendingToolRecoveryHook.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/hook/PendingToolRecoveryHook.java
@@ -107,10 +107,11 @@ public class PendingToolRecoveryHook implements Hook {
             return Mono.just(event);
         }
 
-        boolean userProvidedMatchingResults = inputMessages.stream()
-                .flatMap(m -> m.getContentBlocks(ToolResultBlock.class).stream())
-                .map(ToolResultBlock::getId)
-                .anyMatch(pendingIds::contains);
+        boolean userProvidedMatchingResults =
+                inputMessages.stream()
+                        .flatMap(m -> m.getContentBlocks(ToolResultBlock.class).stream())
+                        .map(ToolResultBlock::getId)
+                        .anyMatch(pendingIds::contains);
         if (userProvidedMatchingResults) {
             return Mono.just(event);
         }


### PR DESCRIPTION
 Fixes #1406

  ## Problem
  The hook was skipping auto-recovery whenever any `ToolResultBlock` existed
  in the input messages, even if those results were unrelated to the pending
  tool call IDs.

  ## Fix
  Instead of checking if any `ToolResultBlock` exists, now we extract the IDs
  from the input `ToolResultBlock`s and check if they actually match the
  pending tool call IDs. Recovery is only skipped when there is a genuine match.
  4. Make sure the base repository is agentscope-ai/agentscope-java and base branch is main
  5. Click Create pull request