### PR TITLE
refactor(examples): remove Lombok from graceful-shutdown module

### DIFF
--- a/agentscope-examples/documentation/graceful-shutdown/pom.xml
+++ b/agentscope-examples/documentation/graceful-shutdown/pom.xml
@@ -67,11 +67,6 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>
-
-        <dependency>
-            <groupId>org.projectlombok</groupId>
-            <artifactId>lombok</artifactId>
-        </dependency>
     </dependencies>
 
     <build>

--- a/agentscope-examples/documentation/graceful-shutdown/src/main/java/io/agentscope/examples/shutdown/e2e/AgentService.java
+++ b/agentscope-examples/documentation/graceful-shutdown/src/main/java/io/agentscope/examples/shutdown/e2e/AgentService.java
@@ -36,7 +36,8 @@ import java.time.Duration;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.stream.Collectors;
-import lombok.extern.slf4j.Slf4j;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -45,9 +46,10 @@ import org.springframework.stereotype.Service;
 /**
  * Service for managing agent instances and chat operations.
  */
-@Slf4j
 @Service
 public class AgentService {
+
+    private static final Logger log = LoggerFactory.getLogger(AgentService.class);
 
     private static final String DATA_ANALYZE_SYS_PROMPT =
             "You are a data analysis assistant. "


### PR DESCRIPTION
## Summary

- Remove `lombok` dependency from `agentscope-examples/graceful-shutdown/pom.xml`
- Replace `@Slf4j` annotation with manual `LoggerFactory.getLogger()` declaration in `AgentService.java`

## Motivation

The graceful-shutdown example module declared a dependency on Lombok (`org.projectlombok:lombok`), which caused **compilation failure** for projects that do not have Lombok configured in their IDE or build environment (no annotation processor setup). This created an unnecessary barrier for users trying to build the examples.

## Verification

- Module contains zero remaining Lombok references
- `log` variable name unchanged — all 4 call sites (`log.info`, `log.warn`) work without modification
- SLF4J is already available as a transitive dependency via `spring-boot-starter-web`