### PR TITLE
fix(test): handle non-ASCII project paths in ShellCommandToolTest

### DIFF
--- a/agentscope-core/src/test/java/io/agentscope/core/tool/coding/ShellCommandToolTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/tool/coding/ShellCommandToolTest.java
@@ -873,10 +873,17 @@ class ShellCommandToolTest {
         @Test
         @DisplayName("Should handle pre-created large test file without deadlock")
         @EnabledOnOs({OS.LINUX, OS.MAC})
-        void reproduceLargeFileCatDeadlockWithTestResource() {
+        void reproduceLargeFileCatDeadlockWithTestResource() throws Exception {
             // Use the pre-created test resource file (20KB)
+            // Use Paths.get(url.toURI()) instead of url.getPath() to properly decode
+            // URL-encoded characters (e.g. Chinese characters in project path)
             String resourcePath =
-                    getClass().getClassLoader().getResource("large_output_test.txt").getPath();
+                    Paths.get(
+                                    getClass()
+                                            .getClassLoader()
+                                            .getResource("large_output_test.txt")
+                                            .toURI())
+                            .toString();
             String command = "cat " + resourcePath;
 
             // Set a reasonable timeout - should complete quickly with the fix


### PR DESCRIPTION
## Summary

- Fix `reproduceLargeFileCatDeadlockWithTestResource` test failure when the project directory contains non-ASCII characters (e.g. Chinese characters like `工程`)

## Root Cause

`URL.getPath()` returns URL-encoded paths (e.g. `%E5%AD%A6%E4%B9%A0`). When this encoded path is passed to `sh -c "cat ..."`, the shell treats the percent-encoded characters as literal characters and cannot find the file, causing the test to fail with a non-zero return code.

## Fix

Replace `getClass().getClassLoader().getResource("large_output_test.txt").getPath()` with `Paths.get(getClass().getClassLoader().getResource("large_output_test.txt").toURI()).toString()` to properly decode the URI into a valid filesystem path.

## Test Plan

- [x] Verified: `mvn test -f agentscope-core/pom.xml -Dtest="ShellCommandToolTest\$BufferDeadlockTests#reproduceLargeFileCatDeadlockWithTestResource"` passes
- [x] Spotless formatting check passes