### PR TITLE
Feat/mcp native implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,7 +27,7 @@ target/
 build/
 !**/src/main/**/build/
 !**/src/test/**/build/
-
+.devcontainer/
 ### VS Code ###
 .vscode/
 .claude/

--- a/.gitignore
+++ b/.gitignore
@@ -27,7 +27,6 @@ target/
 build/
 !**/src/main/**/build/
 !**/src/test/**/build/
-.devcontainer/
 ### VS Code ###
 .vscode/
 .claude/

--- a/agentscope-core/pom.xml
+++ b/agentscope-core/pom.xml
@@ -84,6 +84,12 @@
             <artifactId>jackson-datatype-jsr310</artifactId>
         </dependency>
 
+        <!-- Jackson Java 8 Optional support -->
+        <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jdk8</artifactId>
+        </dependency>
+
         <!-- SLF4J API -->
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/agentscope-core/src/main/java/io/agentscope/core/mcp/handler/AbstractMethodHandler.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/mcp/handler/AbstractMethodHandler.java
@@ -1,0 +1,46 @@
+package io.agentscope.core.mcp.handler;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.agentscope.core.mcp.message.JsonRpcError;
+import io.agentscope.core.mcp.message.JsonRpcMessage;
+import io.agentscope.core.mcp.message.JsonRpcNotification;
+import io.agentscope.core.mcp.message.JsonRpcRequest;
+import io.agentscope.core.mcp.message.JsonRpcResponse;
+import io.agentscope.core.mcp.transport.TransportException;
+
+/**
+ * Abstract base class for method handlers.
+ *
+ * <p>Provides common logic for handling requests and notifications.
+ */
+public abstract class AbstractMethodHandler implements MethodHandler {
+
+    protected ObjectMapper objectMapper = new ObjectMapper();
+
+    @Override
+    public JsonRpcResponse handleMessage(JsonRpcMessage message) throws TransportException {
+        try {
+            if (message instanceof JsonRpcRequest) {
+                JsonRpcRequest request = (JsonRpcRequest) message;
+                Object result = handle(request.getParams());
+                return new JsonRpcResponse(request.getId(), result);
+            } else if (message instanceof JsonRpcNotification) {
+                JsonRpcNotification notification = (JsonRpcNotification) message;
+                handle(notification.getParams());
+                return null; // Notifications don't require responses
+            }
+            throw new TransportException("Unknown message type: " + message.getClass());
+        } catch (Exception e) {
+            if (message instanceof JsonRpcRequest) {
+                JsonRpcRequest request = (JsonRpcRequest) message;
+                JsonRpcError error =
+                        new JsonRpcError(
+                                JsonRpcError.ErrorCode.INTERNAL_ERROR,
+                                "Internal server error: " + e.getMessage(),
+                                e.toString());
+                return new JsonRpcResponse(request.getId(), error);
+            }
+            throw new TransportException("Error handling notification", e);
+        }
+    }
+}

--- a/agentscope-core/src/main/java/io/agentscope/core/mcp/handler/CallToolHandler.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/mcp/handler/CallToolHandler.java
@@ -1,0 +1,64 @@
+package io.agentscope.core.mcp.handler;
+
+import io.agentscope.core.mcp.schema.CallToolResult;
+import io.agentscope.core.mcp.tool.Tool;
+import io.agentscope.core.mcp.tool.ToolManager;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Handler for `tools/call` requests. Looks up a registered server-side Tool and executes it.
+ */
+public class CallToolHandler extends AbstractMethodHandler {
+
+    private final ToolManager toolManager;
+
+    public CallToolHandler(ToolManager toolManager) {
+        this.toolManager = toolManager;
+    }
+
+    @Override
+    public String getMethod() {
+        return "tools/call";
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public Object handle(Object params) throws Exception {
+        if (!(params instanceof Map)) {
+            throw new IllegalArgumentException("Invalid params for tools/call");
+        }
+        Map<String, Object> map = (Map<String, Object>) params;
+        String name = (String) map.get("name");
+        Object arguments = map.get("arguments");
+
+        if (name == null || name.isBlank()) {
+            throw new IllegalArgumentException("Tool name is required");
+        }
+
+        Optional<Tool> toolOpt = toolManager.get(name);
+        if (toolOpt.isEmpty()) {
+            throw new IllegalArgumentException("Tool not found: " + name);
+        }
+
+        Tool tool = toolOpt.get();
+        Object result = tool.execute(arguments);
+
+        // Normalize result into a content block list. If result is already a Map representing a
+        // content block, pass it through; otherwise wrap into a text block.
+        List<Object> content = new ArrayList<>();
+        if (result instanceof Map) {
+            content.add(result);
+        } else {
+            Map<String, Object> block = new HashMap<>();
+            block.put("type", "text");
+            block.put("text", result == null ? "" : result.toString());
+            content.add(block);
+        }
+
+        return new CallToolResult(content, Optional.empty());
+    }
+}

--- a/agentscope-core/src/main/java/io/agentscope/core/mcp/handler/HandlerRegistry.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/mcp/handler/HandlerRegistry.java
@@ -1,0 +1,70 @@
+package io.agentscope.core.mcp.handler;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Registry for MCP method handlers.
+ *
+ * <p>Stores and retrieves handlers by method name.
+ */
+public class HandlerRegistry {
+
+    private final Map<String, MethodHandler> handlers = new ConcurrentHashMap<>();
+
+    /**
+     * Register a handler for a method.
+     *
+     * @param method the method name
+     * @param handler the handler
+     */
+    public void register(String method, MethodHandler handler) {
+        handlers.put(method, handler);
+    }
+
+    /**
+     * Get a handler for a method.
+     *
+     * @param method the method name
+     * @return the handler, or empty if not found
+     */
+    public Optional<MethodHandler> get(String method) {
+        return Optional.ofNullable(handlers.get(method));
+    }
+
+    /**
+     * Check if a handler is registered for a method.
+     *
+     * @param method the method name
+     * @return true if handler exists
+     */
+    public boolean has(String method) {
+        return handlers.containsKey(method);
+    }
+
+    /**
+     * Unregister a handler for a method.
+     *
+     * @param method the method name
+     */
+    public void unregister(String method) {
+        handlers.remove(method);
+    }
+
+    /**
+     * Get all registered method names.
+     *
+     * @return set of method names
+     */
+    public Map<String, MethodHandler> getAll() {
+        return new ConcurrentHashMap<>(handlers);
+    }
+
+    /**
+     * Clear all handlers.
+     */
+    public void clear() {
+        handlers.clear();
+    }
+}

--- a/agentscope-core/src/main/java/io/agentscope/core/mcp/handler/InitializeHandler.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/mcp/handler/InitializeHandler.java
@@ -1,0 +1,36 @@
+package io.agentscope.core.mcp.handler;
+
+import io.agentscope.core.mcp.schema.InitializeResult;
+import io.agentscope.core.mcp.tool.ToolManager;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Handler for `initialize` requests (handshake).
+ */
+public class InitializeHandler extends AbstractMethodHandler {
+
+    private final ToolManager toolManager;
+
+    public InitializeHandler(ToolManager toolManager) {
+        this.toolManager = toolManager;
+    }
+
+    @Override
+    public String getMethod() {
+        return "initialize";
+    }
+
+    @Override
+    public Object handle(Object params) throws Exception {
+        Map<String, Object> capabilities = new HashMap<>();
+        capabilities.put("tools", true);
+        capabilities.put("protocol", "mcp");
+
+        Map<String, Object> serverInfo = new HashMap<>();
+        serverInfo.put("name", "agentscope-core");
+        serverInfo.put("version", "0.1.0");
+
+        return new InitializeResult(capabilities, "2.0", serverInfo);
+    }
+}

--- a/agentscope-core/src/main/java/io/agentscope/core/mcp/handler/ListToolsHandler.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/mcp/handler/ListToolsHandler.java
@@ -1,0 +1,41 @@
+package io.agentscope.core.mcp.handler;
+
+import io.agentscope.core.mcp.schema.ListToolsResult;
+import io.agentscope.core.mcp.tool.Tool;
+import io.agentscope.core.mcp.tool.ToolManager;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Handler for `tools/list` requests. Returns metadata about registered tools.
+ */
+public class ListToolsHandler extends AbstractMethodHandler {
+
+    private final ToolManager toolManager;
+
+    public ListToolsHandler(ToolManager toolManager) {
+        this.toolManager = toolManager;
+    }
+
+    @Override
+    public String getMethod() {
+        return "tools/list";
+    }
+
+    @Override
+    public Object handle(Object params) throws Exception {
+        List<Object> out = new ArrayList<>();
+        for (Tool t : toolManager.list()) {
+            Map<String, Object> m = new HashMap<>();
+            m.put("name", t.getName());
+            m.put("description", t.getDescription());
+            m.put("inputSchema", t.getInputSchema());
+            out.add(m);
+        }
+
+        return new ListToolsResult(Optional.empty(), out);
+    }
+}

--- a/agentscope-core/src/main/java/io/agentscope/core/mcp/handler/MessageRouter.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/mcp/handler/MessageRouter.java
@@ -1,0 +1,97 @@
+package io.agentscope.core.mcp.handler;
+
+import io.agentscope.core.mcp.message.JsonRpcError;
+import io.agentscope.core.mcp.message.JsonRpcMessage;
+import io.agentscope.core.mcp.message.JsonRpcRequest;
+import io.agentscope.core.mcp.message.JsonRpcResponse;
+import io.agentscope.core.mcp.transport.Transport;
+import io.agentscope.core.mcp.transport.TransportException;
+import java.util.Optional;
+import java.util.logging.Logger;
+
+/**
+ * Routes incoming messages to appropriate handlers.
+ *
+ * <p>Manages request/response correlation and error handling for MCP protocol messages.
+ */
+public class MessageRouter {
+
+    private static final Logger logger = Logger.getLogger(MessageRouter.class.getName());
+
+    private final Transport transport;
+    private final HandlerRegistry handlerRegistry;
+
+    public MessageRouter(Transport transport, HandlerRegistry handlerRegistry) {
+        this.transport = transport;
+        this.handlerRegistry = handlerRegistry;
+    }
+
+    /**
+     * Process an incoming message.
+     *
+     * @param message the incoming message
+     * @throws TransportException if processing fails
+     */
+    public void handleMessage(JsonRpcMessage message) throws TransportException {
+        String method = message.getMethod().orElse(null);
+
+        if (method == null) {
+            logger.warning("Received message without method");
+            return;
+        }
+
+        Optional<MethodHandler> handler = handlerRegistry.get(method);
+        if (!handler.isPresent()) {
+            handleUnknownMethod(message, method);
+            return;
+        }
+
+        JsonRpcResponse response = handler.get().handleMessage(message);
+        if (response != null && message instanceof JsonRpcRequest) {
+            // Only send response for requests, not notifications
+            transport.send(response);
+        }
+    }
+
+    /**
+     * Start processing messages from the transport.
+     *
+     * <p>This method runs indefinitely until the transport is closed or an error occurs.
+     *
+     * @throws TransportException if an error occurs
+     */
+    public void processMessages() throws TransportException {
+        while (transport.isConnected()) {
+            try {
+                JsonRpcMessage message = transport.receive();
+                handleMessage(message);
+            } catch (TransportException e) {
+                if (transport.isConnected()) {
+                    logger.warning("Error processing message: " + e.getMessage());
+                }
+            }
+        }
+    }
+
+    private void handleUnknownMethod(JsonRpcMessage message, String method)
+            throws TransportException {
+        if (message instanceof JsonRpcRequest) {
+            JsonRpcRequest request = (JsonRpcRequest) message;
+            JsonRpcError error =
+                    new JsonRpcError(
+                            JsonRpcError.ErrorCode.METHOD_NOT_FOUND, "Method not found: " + method);
+            JsonRpcResponse response = new JsonRpcResponse(request.getId(), error);
+            transport.send(response);
+        }
+    }
+
+    /**
+     * Register a method handler.
+     *
+     * @param method the method name
+     * @param handler the handler
+     */
+    public void register(String method, MethodHandler handler) {
+        handlerRegistry.register(method, handler);
+    }
+}

--- a/agentscope-core/src/main/java/io/agentscope/core/mcp/handler/MethodHandler.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/mcp/handler/MethodHandler.java
@@ -1,0 +1,38 @@
+package io.agentscope.core.mcp.handler;
+
+import io.agentscope.core.mcp.message.JsonRpcMessage;
+import io.agentscope.core.mcp.message.JsonRpcResponse;
+import io.agentscope.core.mcp.transport.TransportException;
+
+/**
+ * Handler for MCP method calls.
+ *
+ * <p>Implementations handle specific MCP methods and return responses.
+ */
+public interface MethodHandler {
+
+    /**
+     * Get the method name this handler handles.
+     *
+     * @return the method name (e.g., "tools/list")
+     */
+    String getMethod();
+
+    /**
+     * Handle a method call and return the result.
+     *
+     * @param params the method parameters
+     * @return the method result (will be wrapped in a JSON-RPC response)
+     * @throws Exception if the method execution fails
+     */
+    Object handle(Object params) throws Exception;
+
+    /**
+     * Handle a message and return a response.
+     *
+     * @param message the incoming message
+     * @return the response, or null for notifications (no response needed)
+     * @throws TransportException if handling fails
+     */
+    JsonRpcResponse handleMessage(JsonRpcMessage message) throws TransportException;
+}

--- a/agentscope-core/src/main/java/io/agentscope/core/mcp/message/JsonRpcError.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/mcp/message/JsonRpcError.java
@@ -1,0 +1,81 @@
+package io.agentscope.core.mcp.message;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * JSON-RPC 2.0 Error object.
+ *
+ * <p>Represents an error in a JSON-RPC response.
+ */
+public class JsonRpcError {
+
+    @JsonProperty("code")
+    private int code;
+
+    @JsonProperty("message")
+    private String message;
+
+    @JsonProperty("data")
+    private Object data;
+
+    public JsonRpcError() {}
+
+    public JsonRpcError(int code, String message) {
+        this.code = code;
+        this.message = message;
+    }
+
+    public JsonRpcError(int code, String message, Object data) {
+        this.code = code;
+        this.message = message;
+        this.data = data;
+    }
+
+    public int getCode() {
+        return code;
+    }
+
+    public void setCode(int code) {
+        this.code = code;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public void setMessage(String message) {
+        this.message = message;
+    }
+
+    public Object getData() {
+        return data;
+    }
+
+    public void setData(Object data) {
+        this.data = data;
+    }
+
+    // JSON-RPC 2.0 Error Codes
+    public static class ErrorCode {
+        public static final int PARSE_ERROR = -32700;
+        public static final int INVALID_REQUEST = -32600;
+        public static final int METHOD_NOT_FOUND = -32601;
+        public static final int INVALID_PARAMS = -32602;
+        public static final int INTERNAL_ERROR = -32603;
+        public static final int SERVER_ERROR_START = -32099;
+        public static final int SERVER_ERROR_END = -32000;
+    }
+
+    @Override
+    public String toString() {
+        return "JsonRpcError{"
+                + "code="
+                + code
+                + ", message='"
+                + message
+                + '\''
+                + ", data="
+                + data
+                + '}';
+    }
+}

--- a/agentscope-core/src/main/java/io/agentscope/core/mcp/message/JsonRpcMessage.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/mcp/message/JsonRpcMessage.java
@@ -1,0 +1,53 @@
+package io.agentscope.core.mcp.message;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import java.util.Optional;
+
+/**
+ * Base class for JSON-RPC 2.0 messages.
+ *
+ * <p>Represents both requests and responses as per JSON-RPC 2.0 specification.
+ */
+@JsonTypeInfo(use = JsonTypeInfo.Id.DEDUCTION, defaultImpl = JsonRpcRequest.class)
+@JsonSubTypes({
+    @JsonSubTypes.Type(JsonRpcRequest.class),
+    @JsonSubTypes.Type(JsonRpcResponse.class),
+    @JsonSubTypes.Type(JsonRpcNotification.class)
+})
+@JsonIgnoreProperties(ignoreUnknown = true)
+public abstract class JsonRpcMessage {
+
+    @JsonProperty("jsonrpc")
+    private String jsonrpc = "2.0";
+
+    protected JsonRpcMessage() {}
+
+    protected JsonRpcMessage(String jsonrpc) {
+        this.jsonrpc = jsonrpc;
+    }
+
+    public String getJsonrpc() {
+        return jsonrpc;
+    }
+
+    public void setJsonrpc(String jsonrpc) {
+        this.jsonrpc = jsonrpc;
+    }
+
+    /**
+     * Get the message ID if this is a request or response.
+     *
+     * @return optional ID
+     */
+    public abstract Optional<Object> getId();
+
+    /**
+     * Get the method name if this is a request or notification.
+     *
+     * @return optional method name
+     */
+    public abstract Optional<String> getMethod();
+}

--- a/agentscope-core/src/main/java/io/agentscope/core/mcp/message/JsonRpcNotification.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/mcp/message/JsonRpcNotification.java
@@ -1,0 +1,52 @@
+package io.agentscope.core.mcp.message;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Optional;
+
+/**
+ * JSON-RPC 2.0 Notification message.
+ *
+ * <p>A notification does not require a response (no id field).
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class JsonRpcNotification extends JsonRpcMessage {
+
+    @JsonProperty("method")
+    private String method;
+
+    @JsonProperty("params")
+    private Object params;
+
+    public JsonRpcNotification() {
+        super();
+    }
+
+    public JsonRpcNotification(String method, Object params) {
+        super();
+        this.method = method;
+        this.params = params;
+    }
+
+    public void setMethod(String method) {
+        this.method = method;
+    }
+
+    public Object getParams() {
+        return params;
+    }
+
+    public void setParams(Object params) {
+        this.params = params;
+    }
+
+    @Override
+    public Optional<Object> getId() {
+        return Optional.empty(); // Notifications don't have IDs
+    }
+
+    @Override
+    public Optional<String> getMethod() {
+        return Optional.ofNullable(method);
+    }
+}

--- a/agentscope-core/src/main/java/io/agentscope/core/mcp/message/JsonRpcRequest.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/mcp/message/JsonRpcRequest.java
@@ -1,0 +1,60 @@
+package io.agentscope.core.mcp.message;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Optional;
+
+/**
+ * JSON-RPC 2.0 Request message.
+ *
+ * <p>Contains method and parameters that the receiver should execute.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class JsonRpcRequest extends JsonRpcMessage {
+
+    @JsonProperty("id")
+    private Object id;
+
+    @JsonProperty("method")
+    private String method;
+
+    @JsonProperty("params")
+    private Object params;
+
+    public JsonRpcRequest() {
+        super();
+    }
+
+    public JsonRpcRequest(Object id, String method, Object params) {
+        super();
+        this.id = id;
+        this.method = method;
+        this.params = params;
+    }
+
+    public void setId(Object id) {
+        this.id = id;
+    }
+
+    public void setMethod(String method) {
+        this.method = method;
+    }
+
+    public Object getParams() {
+        return params;
+    }
+
+    public void setParams(Object params) {
+        this.params = params;
+    }
+
+    @Override
+    public Optional<Object> getId() {
+        return Optional.ofNullable(id);
+    }
+
+    @Override
+    public Optional<String> getMethod() {
+        return Optional.ofNullable(method);
+    }
+}

--- a/agentscope-core/src/main/java/io/agentscope/core/mcp/message/JsonRpcResponse.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/mcp/message/JsonRpcResponse.java
@@ -1,0 +1,73 @@
+package io.agentscope.core.mcp.message;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Optional;
+
+/**
+ * JSON-RPC 2.0 Response message.
+ *
+ * <p>Contains the result of a method call or an error.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class JsonRpcResponse extends JsonRpcMessage {
+
+    @JsonProperty("id")
+    private Object id;
+
+    @JsonProperty("result")
+    private Object result;
+
+    @JsonProperty("error")
+    private JsonRpcError error;
+
+    public JsonRpcResponse() {
+        super();
+    }
+
+    public JsonRpcResponse(Object id, Object result) {
+        super();
+        this.id = id;
+        this.result = result;
+    }
+
+    public JsonRpcResponse(Object id, JsonRpcError error) {
+        super();
+        this.id = id;
+        this.error = error;
+    }
+
+    public void setId(Object id) {
+        this.id = id;
+    }
+
+    public Object getResult() {
+        return result;
+    }
+
+    public void setResult(Object result) {
+        this.result = result;
+    }
+
+    public JsonRpcError getError() {
+        return error;
+    }
+
+    public void setError(JsonRpcError error) {
+        this.error = error;
+    }
+
+    public boolean isError() {
+        return error != null;
+    }
+
+    @Override
+    public Optional<Object> getId() {
+        return Optional.ofNullable(id);
+    }
+
+    @Override
+    public Optional<String> getMethod() {
+        return Optional.empty(); // Responses don't have methods
+    }
+}

--- a/agentscope-core/src/main/java/io/agentscope/core/mcp/schema/CallToolRequest.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/mcp/schema/CallToolRequest.java
@@ -1,0 +1,45 @@
+package io.agentscope.core.mcp.schema;
+
+/**
+ * Used by the client to invoke a tool provided by the server.
+ *
+ * Auto-generated from MCP JSON schema.
+ */
+public record CallToolRequest(Object id, String jsonrpc, String method, Object params) {
+
+    // Builder pattern for easier construction
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+        private Object id = null; // Required field
+        private String jsonrpc = null; // Required field
+        private String method = null; // Required field
+        private Object params = null; // Required field
+
+        public Builder Id(Object value) {
+            this.id = value;
+            return this;
+        }
+
+        public Builder Jsonrpc(String value) {
+            this.jsonrpc = value;
+            return this;
+        }
+
+        public Builder Method(String value) {
+            this.method = value;
+            return this;
+        }
+
+        public Builder Params(Object value) {
+            this.params = value;
+            return this;
+        }
+
+        public CallToolRequest build() {
+            return new CallToolRequest(id, jsonrpc, method, params);
+        }
+    }
+}

--- a/agentscope-core/src/main/java/io/agentscope/core/mcp/schema/CallToolRequestParams.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/mcp/schema/CallToolRequestParams.java
@@ -1,0 +1,36 @@
+package io.agentscope.core.mcp.schema;
+
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Parameters for a `tools/call` request.
+ *
+ * Auto-generated from MCP JSON schema.
+ */
+public record CallToolRequestParams(Optional<Map<String, Object>> arguments, String name) {
+
+    // Builder pattern for easier construction
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+        private Optional<Map<String, Object>> arguments = Optional.empty(); // Optional field
+        private String name = null; // Required field
+
+        public Builder Arguments(Map<String, Object> value) {
+            this.arguments = Optional.of(value);
+            return this;
+        }
+
+        public Builder Name(String value) {
+            this.name = value;
+            return this;
+        }
+
+        public CallToolRequestParams build() {
+            return new CallToolRequestParams(arguments, name);
+        }
+    }
+}

--- a/agentscope-core/src/main/java/io/agentscope/core/mcp/schema/CallToolResult.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/mcp/schema/CallToolResult.java
@@ -1,0 +1,36 @@
+package io.agentscope.core.mcp.schema;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * The server's response to a tool call.
+ *
+ * Auto-generated from MCP JSON schema.
+ */
+public record CallToolResult(List<Object> content, Optional<Boolean> isError) {
+
+    // Builder pattern for easier construction
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+        private List<Object> content = null; // Required field
+        private Optional<Boolean> isError = Optional.empty(); // Optional field
+
+        public Builder Content(List<Object> value) {
+            this.content = value;
+            return this;
+        }
+
+        public Builder IsError(Boolean value) {
+            this.isError = Optional.of(value);
+            return this;
+        }
+
+        public CallToolResult build() {
+            return new CallToolResult(content, isError);
+        }
+    }
+}

--- a/agentscope-core/src/main/java/io/agentscope/core/mcp/schema/ContentBlock.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/mcp/schema/ContentBlock.java
@@ -1,0 +1,21 @@
+package io.agentscope.core.mcp.schema;
+
+/**
+ * Auto-generated class
+ *
+ * Auto-generated from MCP JSON schema.
+ */
+public record ContentBlock() {
+
+    // Builder pattern for easier construction
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+
+        public ContentBlock build() {
+            return new ContentBlock();
+        }
+    }
+}

--- a/agentscope-core/src/main/java/io/agentscope/core/mcp/schema/InitializeRequest.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/mcp/schema/InitializeRequest.java
@@ -1,0 +1,45 @@
+package io.agentscope.core.mcp.schema;
+
+/**
+ * Client initialization request.
+ *
+ * Auto-generated from MCP JSON schema.
+ */
+public record InitializeRequest(Object id, String jsonrpc, String method, Object params) {
+
+    // Builder pattern for easier construction
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+        private Object id = null; // Required field
+        private String jsonrpc = null; // Required field
+        private String method = null; // Required field
+        private Object params = null; // Required field
+
+        public Builder Id(Object value) {
+            this.id = value;
+            return this;
+        }
+
+        public Builder Jsonrpc(String value) {
+            this.jsonrpc = value;
+            return this;
+        }
+
+        public Builder Method(String value) {
+            this.method = value;
+            return this;
+        }
+
+        public Builder Params(Object value) {
+            this.params = value;
+            return this;
+        }
+
+        public InitializeRequest build() {
+            return new InitializeRequest(id, jsonrpc, method, params);
+        }
+    }
+}

--- a/agentscope-core/src/main/java/io/agentscope/core/mcp/schema/InitializeRequestParams.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/mcp/schema/InitializeRequestParams.java
@@ -1,0 +1,42 @@
+package io.agentscope.core.mcp.schema;
+
+import java.util.Map;
+
+/**
+ * Parameters for an `initialize` request.
+ *
+ * Auto-generated from MCP JSON schema.
+ */
+public record InitializeRequestParams(
+        Map<String, Object> capabilities, Map<String, Object> clientInfo, String protocolVersion) {
+
+    // Builder pattern for easier construction
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+        private Map<String, Object> capabilities = null; // Required field
+        private Map<String, Object> clientInfo = null; // Required field
+        private String protocolVersion = null; // Required field
+
+        public Builder Capabilities(Map<String, Object> value) {
+            this.capabilities = value;
+            return this;
+        }
+
+        public Builder ClientInfo(Map<String, Object> value) {
+            this.clientInfo = value;
+            return this;
+        }
+
+        public Builder ProtocolVersion(String value) {
+            this.protocolVersion = value;
+            return this;
+        }
+
+        public InitializeRequestParams build() {
+            return new InitializeRequestParams(capabilities, clientInfo, protocolVersion);
+        }
+    }
+}

--- a/agentscope-core/src/main/java/io/agentscope/core/mcp/schema/InitializeResult.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/mcp/schema/InitializeResult.java
@@ -1,0 +1,42 @@
+package io.agentscope.core.mcp.schema;
+
+import java.util.Map;
+
+/**
+ * Server initialization response.
+ *
+ * Auto-generated from MCP JSON schema.
+ */
+public record InitializeResult(
+        Map<String, Object> capabilities, String protocolVersion, Map<String, Object> serverInfo) {
+
+    // Builder pattern for easier construction
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+        private Map<String, Object> capabilities = null; // Required field
+        private String protocolVersion = null; // Required field
+        private Map<String, Object> serverInfo = null; // Required field
+
+        public Builder Capabilities(Map<String, Object> value) {
+            this.capabilities = value;
+            return this;
+        }
+
+        public Builder ProtocolVersion(String value) {
+            this.protocolVersion = value;
+            return this;
+        }
+
+        public Builder ServerInfo(Map<String, Object> value) {
+            this.serverInfo = value;
+            return this;
+        }
+
+        public InitializeResult build() {
+            return new InitializeResult(capabilities, protocolVersion, serverInfo);
+        }
+    }
+}

--- a/agentscope-core/src/main/java/io/agentscope/core/mcp/schema/ListToolsRequest.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/mcp/schema/ListToolsRequest.java
@@ -1,0 +1,47 @@
+package io.agentscope.core.mcp.schema;
+
+import java.util.Optional;
+
+/**
+ * Sent from the client to request a list of tools the server has.
+ *
+ * Auto-generated from MCP JSON schema.
+ */
+public record ListToolsRequest(Object id, String jsonrpc, String method, Optional<Object> params) {
+
+    // Builder pattern for easier construction
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+        private Object id = null; // Required field
+        private String jsonrpc = null; // Required field
+        private String method = null; // Required field
+        private Optional<Object> params = Optional.empty(); // Optional field
+
+        public Builder Id(Object value) {
+            this.id = value;
+            return this;
+        }
+
+        public Builder Jsonrpc(String value) {
+            this.jsonrpc = value;
+            return this;
+        }
+
+        public Builder Method(String value) {
+            this.method = value;
+            return this;
+        }
+
+        public Builder Params(Object value) {
+            this.params = Optional.of(value);
+            return this;
+        }
+
+        public ListToolsRequest build() {
+            return new ListToolsRequest(id, jsonrpc, method, params);
+        }
+    }
+}

--- a/agentscope-core/src/main/java/io/agentscope/core/mcp/schema/ListToolsResult.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/mcp/schema/ListToolsResult.java
@@ -1,0 +1,36 @@
+package io.agentscope.core.mcp.schema;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * The server's response to a tools/list request from the client.
+ *
+ * Auto-generated from MCP JSON schema.
+ */
+public record ListToolsResult(Optional<String> nextCursor, List<Object> tools) {
+
+    // Builder pattern for easier construction
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+        private Optional<String> nextCursor = Optional.empty(); // Optional field
+        private List<Object> tools = null; // Required field
+
+        public Builder NextCursor(String value) {
+            this.nextCursor = Optional.of(value);
+            return this;
+        }
+
+        public Builder Tools(List<Object> value) {
+            this.tools = value;
+            return this;
+        }
+
+        public ListToolsResult build() {
+            return new ListToolsResult(nextCursor, tools);
+        }
+    }
+}

--- a/agentscope-core/src/main/java/io/agentscope/core/mcp/schema/PaginatedRequestParams.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/mcp/schema/PaginatedRequestParams.java
@@ -1,0 +1,29 @@
+package io.agentscope.core.mcp.schema;
+
+import java.util.Optional;
+
+/**
+ * Common parameters for paginated requests.
+ *
+ * Auto-generated from MCP JSON schema.
+ */
+public record PaginatedRequestParams(Optional<String> cursor) {
+
+    // Builder pattern for easier construction
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+        private Optional<String> cursor = Optional.empty(); // Optional field
+
+        public Builder Cursor(String value) {
+            this.cursor = Optional.of(value);
+            return this;
+        }
+
+        public PaginatedRequestParams build() {
+            return new PaginatedRequestParams(cursor);
+        }
+    }
+}

--- a/agentscope-core/src/main/java/io/agentscope/core/mcp/schema/RequestId.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/mcp/schema/RequestId.java
@@ -1,0 +1,21 @@
+package io.agentscope.core.mcp.schema;
+
+/**
+ * A uniquely identifying ID for a request in JSON-RPC.
+ *
+ * Auto-generated from MCP JSON schema.
+ */
+public record RequestId() {
+
+    // Builder pattern for easier construction
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+
+        public RequestId build() {
+            return new RequestId();
+        }
+    }
+}

--- a/agentscope-core/src/main/java/io/agentscope/core/mcp/schema/TextContent.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/mcp/schema/TextContent.java
@@ -1,0 +1,33 @@
+package io.agentscope.core.mcp.schema;
+
+/**
+ * Text provided to or from an LLM.
+ *
+ * Auto-generated from MCP JSON schema.
+ */
+public record TextContent(String text, String type) {
+
+    // Builder pattern for easier construction
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+        private String text = null; // Required field
+        private String type = null; // Required field
+
+        public Builder Text(String value) {
+            this.text = value;
+            return this;
+        }
+
+        public Builder Type(String value) {
+            this.type = value;
+            return this;
+        }
+
+        public TextContent build() {
+            return new TextContent(text, type);
+        }
+    }
+}

--- a/agentscope-core/src/main/java/io/agentscope/core/mcp/schema/Tool.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/mcp/schema/Tool.java
@@ -1,0 +1,42 @@
+package io.agentscope.core.mcp.schema;
+
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Definition for a tool the client can call.
+ *
+ * Auto-generated from MCP JSON schema.
+ */
+public record Tool(Optional<String> description, Map<String, Object> inputSchema, String name) {
+
+    // Builder pattern for easier construction
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+        private Optional<String> description = Optional.empty(); // Optional field
+        private Map<String, Object> inputSchema = null; // Required field
+        private String name = null; // Required field
+
+        public Builder Description(String value) {
+            this.description = Optional.of(value);
+            return this;
+        }
+
+        public Builder InputSchema(Map<String, Object> value) {
+            this.inputSchema = value;
+            return this;
+        }
+
+        public Builder Name(String value) {
+            this.name = value;
+            return this;
+        }
+
+        public Tool build() {
+            return new Tool(description, inputSchema, name);
+        }
+    }
+}

--- a/agentscope-core/src/main/java/io/agentscope/core/mcp/server/McpServer.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/mcp/server/McpServer.java
@@ -1,0 +1,72 @@
+package io.agentscope.core.mcp.server;
+
+import io.agentscope.core.mcp.handler.CallToolHandler;
+import io.agentscope.core.mcp.handler.HandlerRegistry;
+import io.agentscope.core.mcp.handler.InitializeHandler;
+import io.agentscope.core.mcp.handler.ListToolsHandler;
+import io.agentscope.core.mcp.handler.MessageRouter;
+import io.agentscope.core.mcp.tool.Tool;
+import io.agentscope.core.mcp.tool.ToolManager;
+import io.agentscope.core.mcp.transport.Transport;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.logging.Logger;
+
+/**
+ * Facade for creating and running an MCP server.
+ */
+public class McpServer {
+
+    private static final Logger logger = Logger.getLogger(McpServer.class.getName());
+
+    private final Transport transport;
+    private final MessageRouter router;
+    private final ToolManager toolManager;
+    private final HandlerRegistry handlerRegistry;
+    private final ExecutorService executor = Executors.newSingleThreadExecutor();
+
+    public McpServer(Transport transport) {
+        this.transport = transport;
+        this.handlerRegistry = new HandlerRegistry();
+        this.toolManager = new ToolManager();
+        this.router = new MessageRouter(transport, handlerRegistry);
+
+        // Register built-in handlers
+        registerBuiltIns();
+    }
+
+    private void registerBuiltIns() {
+        // Handlers will be registered with the router via the handler registry
+        handlerRegistry.register("initialize", new InitializeHandler(toolManager));
+        handlerRegistry.register("tools/list", new ListToolsHandler(toolManager));
+        handlerRegistry.register("tools/call", new CallToolHandler(toolManager));
+
+        // No example external tools are auto-registered by default.
+    }
+
+    /**
+     * Register additional server-side tools.
+     */
+    public void registerTool(Tool tool) {
+        toolManager.register(tool);
+    }
+
+    /**
+     * Start processing messages on the transport in a background thread.
+     */
+    public void start() {
+        executor.submit(
+                () -> {
+                    try {
+                        router.processMessages();
+                    } catch (Exception e) {
+                        logger.severe("MCP Server stopped: " + e.getMessage());
+                    }
+                });
+    }
+
+    public void stop() throws Exception {
+        transport.close();
+        executor.shutdownNow();
+    }
+}

--- a/agentscope-core/src/main/java/io/agentscope/core/mcp/tool/Tool.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/mcp/tool/Tool.java
@@ -1,0 +1,33 @@
+package io.agentscope.core.mcp.tool;
+
+import java.util.Map;
+
+/**
+ * Server-side tool abstraction. Implementations perform actual work (call external APIs, run local
+ * logic) and return a result that will be serialized back to the client.
+ */
+public interface Tool {
+
+    /**
+     * Tool unique name (e.g., "context7.run").
+     */
+    String getName();
+
+    /**
+     * Human-readable description of the tool.
+     */
+    String getDescription();
+
+    /**
+     * JSON Schema (or a map-like representation) describing expected input for the tool.
+     */
+    Map<String, Object> getInputSchema();
+
+    /**
+     * Execute the tool with provided arguments.
+     *
+     * @param arguments arbitrary params (usually a Map)
+     * @return result object suitable for inclusion in a MCP `CallToolResult` content block
+     */
+    Object execute(Object arguments) throws Exception;
+}

--- a/agentscope-core/src/main/java/io/agentscope/core/mcp/tool/ToolManager.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/mcp/tool/ToolManager.java
@@ -1,0 +1,33 @@
+package io.agentscope.core.mcp.tool;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Simple registry for server-side tools.
+ */
+public class ToolManager {
+    private final Map<String, Tool> tools = new ConcurrentHashMap<>();
+
+    public void register(Tool tool) {
+        tools.put(tool.getName(), tool);
+    }
+
+    public Optional<Tool> get(String name) {
+        return Optional.ofNullable(tools.get(name));
+    }
+
+    public Collection<Tool> list() {
+        return tools.values();
+    }
+
+    public void unregister(String name) {
+        tools.remove(name);
+    }
+
+    public void clear() {
+        tools.clear();
+    }
+}

--- a/agentscope-core/src/main/java/io/agentscope/core/mcp/transport/StdioTransport.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/mcp/transport/StdioTransport.java
@@ -1,0 +1,154 @@
+package io.agentscope.core.mcp.transport;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.agentscope.core.mcp.message.JsonRpcMessage;
+import io.agentscope.core.mcp.message.JsonRpcRequest;
+import io.agentscope.core.mcp.message.JsonRpcResponse;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.PrintWriter;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.logging.Logger;
+
+/**
+ * Stdio-based transport for MCP protocol.
+ *
+ * <p>Uses stdin for receiving and stdout for sending JSON-RPC messages. This is the primary
+ * transport mechanism for editor integrations and command-line tools.
+ */
+public class StdioTransport implements Transport {
+
+    private static final Logger logger = Logger.getLogger(StdioTransport.class.getName());
+    private static final long RESPONSE_TIMEOUT_MS = 30000; // 30 seconds
+
+    private final BufferedReader reader;
+    private final PrintWriter writer;
+    private final ObjectMapper objectMapper;
+    private final AtomicLong messageIdCounter = new AtomicLong(1);
+    private final Map<Object, PendingRequest> pendingRequests = new ConcurrentHashMap<>();
+    private volatile boolean connected = true;
+    private Thread readThread;
+
+    public StdioTransport() {
+        this.reader = new BufferedReader(new InputStreamReader(System.in, StandardCharsets.UTF_8));
+        this.writer = new PrintWriter(System.out, true, StandardCharsets.UTF_8);
+        this.objectMapper = new ObjectMapper();
+        startReadThread();
+    }
+
+    @Override
+    public void send(JsonRpcMessage message) throws TransportException {
+        if (!connected) {
+            throw new TransportException("Transport not connected");
+        }
+        try {
+            String json = objectMapper.writeValueAsString(message);
+            writer.println(json);
+            logger.fine("Sent: " + json);
+        } catch (IOException e) {
+            throw new TransportException("Failed to send message", e);
+        }
+    }
+
+    @Override
+    public JsonRpcMessage receive() throws TransportException {
+        try {
+            String line = reader.readLine();
+            if (line == null) {
+                connected = false;
+                throw new TransportException("End of stream");
+            }
+            logger.fine("Received: " + line);
+            return objectMapper.readValue(line, JsonRpcMessage.class);
+        } catch (IOException e) {
+            connected = false;
+            throw new TransportException("Failed to receive message", e);
+        }
+    }
+
+    @Override
+    public JsonRpcResponse request(JsonRpcRequest request) throws TransportException {
+        Object requestId = messageIdCounter.getAndIncrement();
+        request.setId(requestId);
+
+        PendingRequest pending = new PendingRequest();
+        pendingRequests.put(requestId, pending);
+
+        try {
+            send(request);
+            if (!pending.latch.await(RESPONSE_TIMEOUT_MS, TimeUnit.MILLISECONDS)) {
+                throw new TransportException("Request timeout: " + requestId);
+            }
+            if (pending.response == null) {
+                throw new TransportException("No response received for request: " + requestId);
+            }
+            return pending.response;
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new TransportException("Request interrupted", e);
+        } finally {
+            pendingRequests.remove(requestId);
+        }
+    }
+
+    @Override
+    public boolean isConnected() {
+        return connected;
+    }
+
+    @Override
+    public void close() throws Exception {
+        connected = false;
+        reader.close();
+        writer.close();
+        if (readThread != null && readThread.isAlive()) {
+            readThread.interrupt();
+            readThread.join(5000);
+        }
+    }
+
+    private void startReadThread() {
+        readThread =
+                new Thread(
+                        () -> {
+                            while (connected) {
+                                try {
+                                    JsonRpcMessage message = receive();
+                                    if (message instanceof JsonRpcResponse) {
+                                        JsonRpcResponse response = (JsonRpcResponse) message;
+                                        Optional<Object> responseIdOpt = response.getId();
+                                        if (responseIdOpt.isPresent()) {
+                                            Object responseId = responseIdOpt.get();
+                                            PendingRequest pending =
+                                                    pendingRequests.get(responseId);
+                                            if (pending != null) {
+                                                pending.response = response;
+                                                pending.latch.countDown();
+                                            }
+                                        }
+                                    }
+                                    // Handle notifications and requests from remote end
+                                } catch (TransportException e) {
+                                    if (connected) {
+                                        logger.warning("Read thread error: " + e.getMessage());
+                                    }
+                                }
+                            }
+                        },
+                        "StdioTransport-ReadThread");
+        readThread.setDaemon(false);
+        readThread.start();
+    }
+
+    private static class PendingRequest {
+        JsonRpcResponse response;
+        CountDownLatch latch = new CountDownLatch(1);
+    }
+}

--- a/agentscope-core/src/main/java/io/agentscope/core/mcp/transport/TcpTransport.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/mcp/transport/TcpTransport.java
@@ -1,0 +1,191 @@
+package io.agentscope.core.mcp.transport;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.agentscope.core.mcp.message.JsonRpcMessage;
+import io.agentscope.core.mcp.message.JsonRpcRequest;
+import io.agentscope.core.mcp.message.JsonRpcResponse;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.PrintWriter;
+import java.net.Socket;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.logging.Logger;
+
+/**
+ * TCP-based transport for MCP protocol.
+ *
+ * <p>Provides JSON-RPC communication over TCP sockets for network-based integrations and
+ * distributed deployments.
+ */
+public class TcpTransport implements Transport {
+
+    private static final Logger logger = Logger.getLogger(TcpTransport.class.getName());
+    private static final long RESPONSE_TIMEOUT_MS = 30000; // 30 seconds
+
+    private final Socket socket;
+    private final BufferedReader reader;
+    private final PrintWriter writer;
+    private final ObjectMapper objectMapper;
+    private final AtomicLong messageIdCounter = new AtomicLong(1);
+    private final Map<Object, PendingRequest> pendingRequests = new ConcurrentHashMap<>();
+    private volatile boolean connected = true;
+    private Thread readThread;
+
+    /**
+     * Create a TCP transport connected to the specified host and port.
+     *
+     * @param host the hostname or IP address
+     * @param port the port number
+     * @throws TransportException if connection fails
+     */
+    public TcpTransport(String host, int port) throws TransportException {
+        try {
+            this.socket = new Socket(host, port);
+            this.reader =
+                    new BufferedReader(
+                            new InputStreamReader(socket.getInputStream(), StandardCharsets.UTF_8));
+            this.writer = new PrintWriter(socket.getOutputStream(), true, StandardCharsets.UTF_8);
+            this.objectMapper = new ObjectMapper();
+            startReadThread();
+        } catch (IOException e) {
+            throw new TransportException("Failed to connect to " + host + ":" + port, e);
+        }
+    }
+
+    /**
+     * Create a TCP transport with an existing socket.
+     *
+     * @param socket the connected socket
+     * @throws TransportException if setup fails
+     */
+    public TcpTransport(Socket socket) throws TransportException {
+        try {
+            this.socket = socket;
+            this.reader =
+                    new BufferedReader(
+                            new InputStreamReader(socket.getInputStream(), StandardCharsets.UTF_8));
+            this.writer = new PrintWriter(socket.getOutputStream(), true, StandardCharsets.UTF_8);
+            this.objectMapper = new ObjectMapper();
+            startReadThread();
+        } catch (IOException e) {
+            throw new TransportException("Failed to setup socket transport", e);
+        }
+    }
+
+    @Override
+    public void send(JsonRpcMessage message) throws TransportException {
+        if (!connected) {
+            throw new TransportException("Transport not connected");
+        }
+        try {
+            String json = objectMapper.writeValueAsString(message);
+            writer.println(json);
+            logger.fine("Sent: " + json);
+        } catch (IOException e) {
+            throw new TransportException("Failed to send message", e);
+        }
+    }
+
+    @Override
+    public JsonRpcMessage receive() throws TransportException {
+        try {
+            String line = reader.readLine();
+            if (line == null) {
+                connected = false;
+                throw new TransportException("End of stream");
+            }
+            logger.fine("Received: " + line);
+            return objectMapper.readValue(line, JsonRpcMessage.class);
+        } catch (IOException e) {
+            connected = false;
+            throw new TransportException("Failed to receive message", e);
+        }
+    }
+
+    @Override
+    public JsonRpcResponse request(JsonRpcRequest request) throws TransportException {
+        Object requestId = messageIdCounter.getAndIncrement();
+        request.setId(requestId);
+
+        PendingRequest pending = new PendingRequest();
+        pendingRequests.put(requestId, pending);
+
+        try {
+            send(request);
+            if (!pending.latch.await(RESPONSE_TIMEOUT_MS, TimeUnit.MILLISECONDS)) {
+                throw new TransportException("Request timeout: " + requestId);
+            }
+            if (pending.response == null) {
+                throw new TransportException("No response received for request: " + requestId);
+            }
+            return pending.response;
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new TransportException("Request interrupted", e);
+        } finally {
+            pendingRequests.remove(requestId);
+        }
+    }
+
+    @Override
+    public boolean isConnected() {
+        return connected && !socket.isClosed();
+    }
+
+    @Override
+    public void close() throws Exception {
+        connected = false;
+        reader.close();
+        writer.close();
+        socket.close();
+        if (readThread != null && readThread.isAlive()) {
+            readThread.interrupt();
+            readThread.join(5000);
+        }
+    }
+
+    private void startReadThread() {
+        readThread =
+                new Thread(
+                        () -> {
+                            while (connected && !socket.isClosed()) {
+                                try {
+                                    JsonRpcMessage message = receive();
+                                    if (message instanceof JsonRpcResponse) {
+                                        JsonRpcResponse response = (JsonRpcResponse) message;
+                                        Optional<Object> responseIdOpt = response.getId();
+                                        if (responseIdOpt.isPresent()) {
+                                            Object responseId = responseIdOpt.get();
+                                            PendingRequest pending =
+                                                    pendingRequests.get(responseId);
+                                            if (pending != null) {
+                                                pending.response = response;
+                                                pending.latch.countDown();
+                                            }
+                                        }
+                                    }
+                                    // Handle notifications and requests from remote end
+                                } catch (TransportException e) {
+                                    if (connected) {
+                                        logger.warning("Read thread error: " + e.getMessage());
+                                    }
+                                }
+                            }
+                        },
+                        "TcpTransport-ReadThread");
+        readThread.setDaemon(false);
+        readThread.start();
+    }
+
+    private static class PendingRequest {
+        JsonRpcResponse response;
+        CountDownLatch latch = new CountDownLatch(1);
+    }
+}

--- a/agentscope-core/src/main/java/io/agentscope/core/mcp/transport/Transport.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/mcp/transport/Transport.java
@@ -1,0 +1,54 @@
+package io.agentscope.core.mcp.transport;
+
+import io.agentscope.core.mcp.message.JsonRpcMessage;
+import io.agentscope.core.mcp.message.JsonRpcRequest;
+import io.agentscope.core.mcp.message.JsonRpcResponse;
+
+/**
+ * Transport abstraction for MCP protocol communication.
+ *
+ * <p>Implementations must handle sending and receiving JSON-RPC messages over different
+ * transport mechanisms (e.g., stdio, TCP, WebSocket, etc.).
+ */
+public interface Transport extends AutoCloseable {
+
+    /**
+     * Send a JSON-RPC message to the remote endpoint.
+     *
+     * @param message the message to send
+     * @throws TransportException if sending fails
+     */
+    void send(JsonRpcMessage message) throws TransportException;
+
+    /**
+     * Receive a JSON-RPC message from the remote endpoint.
+     *
+     * @return the received message
+     * @throws TransportException if receiving fails or connection is closed
+     */
+    JsonRpcMessage receive() throws TransportException;
+
+    /**
+     * Send a request and wait for the corresponding response.
+     *
+     * @param request the request to send
+     * @return the response
+     * @throws TransportException if communication fails
+     */
+    JsonRpcResponse request(JsonRpcRequest request) throws TransportException;
+
+    /**
+     * Check if the transport is still connected.
+     *
+     * @return true if connected, false otherwise
+     */
+    boolean isConnected();
+
+    /**
+     * Close the transport connection.
+     *
+     * @throws Exception if closing fails
+     */
+    @Override
+    void close() throws Exception;
+}

--- a/agentscope-core/src/main/java/io/agentscope/core/mcp/transport/TransportException.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/mcp/transport/TransportException.java
@@ -1,0 +1,19 @@
+package io.agentscope.core.mcp.transport;
+
+/**
+ * Exception thrown when transport communication fails.
+ */
+public class TransportException extends Exception {
+
+    public TransportException(String message) {
+        super(message);
+    }
+
+    public TransportException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public TransportException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/agentscope-core/src/main/java/io/agentscope/core/tool/AgentTool.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/tool/AgentTool.java
@@ -75,6 +75,19 @@ public interface AgentTool {
     Map<String, Object> getParameters();
 
     /**
+     * Gets strict mode configuration for this tool schema.
+     *
+     * <p>When strict mode is enabled, compatible model providers are expected to enforce stricter
+     * adherence to the tool parameter schema. Returning {@code null} means no explicit strict mode
+     * preference is provided.
+     *
+     * @return strict mode value ({@code true}/{@code false}) or {@code null} when unspecified
+     */
+    default Boolean getStrict() {
+        return null;
+    }
+
+    /**
      * Execute the tool with the given parameters (asynchronous).
      *
      * <p>This method accepts a {@link ToolCallParam} object containing all necessary context for

--- a/agentscope-core/src/main/java/io/agentscope/core/tool/AgentTool.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/tool/AgentTool.java
@@ -84,6 +84,10 @@ public interface AgentTool {
      * @return strict mode value ({@code true}/{@code false}) or {@code null} when unspecified
      */
     default Boolean getStrict() {
+        return null;
+    }
+
+    /**
      * Gets the optional output schema for this tool in JSON Schema format.
      *
      * <p>Most tools do not expose a structured output schema to models, so the default

--- a/agentscope-core/src/main/java/io/agentscope/core/tool/SchemaOnlyTool.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/tool/SchemaOnlyTool.java
@@ -18,6 +18,7 @@ package io.agentscope.core.tool;
 import io.agentscope.core.message.ToolResultBlock;
 import io.agentscope.core.model.ToolSchema;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 import reactor.core.publisher.Mono;
@@ -64,22 +65,21 @@ public class SchemaOnlyTool implements AgentTool {
     /**
      * Creates a new SchemaOnlyTool from a ToolSchema.
      *
-     * @param schema The tool schema containing name, description, and parameters
+     * @param schema The tool schema containing name, description, parameters, and strict mode
      * @throws NullPointerException if schema is null
      */
     public SchemaOnlyTool(ToolSchema schema) {
-        Objects.requireNonNull(schema, "schema cannot be null");
-        this.name = schema.getName();
-        this.description = schema.getDescription();
-        this.parameters =
-                schema.getParameters() != null
-                        ? Collections.unmodifiableMap(schema.getParameters())
-                        : Collections.emptyMap();
-        this.strict = schema.getStrict();
+        this(
+                Objects.requireNonNull(schema, "schema cannot be null").getName(),
+                schema.getDescription(),
+                schema.getParameters(),
+                schema.getStrict());
     }
 
     /**
      * Creates a new SchemaOnlyTool with the specified name, description, and parameters.
+     *
+     * <p>Strict mode is set to null (unspecified).
      *
      * @param name The tool name
      * @param description The tool description
@@ -87,13 +87,32 @@ public class SchemaOnlyTool implements AgentTool {
      * @throws NullPointerException if name or description is null
      */
     public SchemaOnlyTool(String name, String description, Map<String, Object> parameters) {
+        this(name, description, parameters, null);
+    }
+
+    /**
+     * Creates a new SchemaOnlyTool with the specified name, description, parameters, and strict
+     * mode configuration.
+     *
+     * <p>The parameters map is defensively copied to prevent external mutations from affecting
+     * the tool's internal state.
+     *
+     * @param name The tool name
+     * @param description The tool description
+     * @param parameters The tool parameters schema
+     * @param strict Whether the tool should use strict schema validation (null if unspecified)
+     * @throws NullPointerException if name or description is null
+     */
+    public SchemaOnlyTool(
+            String name, String description, Map<String, Object> parameters, Boolean strict) {
         this.name = Objects.requireNonNull(name, "name cannot be null");
         this.description = Objects.requireNonNull(description, "description cannot be null");
+        // Defensive copy: create a new HashMap from the provided parameters, then wrap it
         this.parameters =
                 parameters != null
-                        ? Collections.unmodifiableMap(parameters)
+                        ? Collections.unmodifiableMap(new HashMap<>(parameters))
                         : Collections.emptyMap();
-        this.strict = null;
+        this.strict = strict;
     }
 
     @Override

--- a/agentscope-core/src/main/java/io/agentscope/core/tool/SchemaOnlyTool.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/tool/SchemaOnlyTool.java
@@ -59,6 +59,7 @@ public class SchemaOnlyTool implements AgentTool {
     private final String name;
     private final String description;
     private final Map<String, Object> parameters;
+    private final Boolean strict;
 
     /**
      * Creates a new SchemaOnlyTool from a ToolSchema.
@@ -74,6 +75,7 @@ public class SchemaOnlyTool implements AgentTool {
                 schema.getParameters() != null
                         ? Collections.unmodifiableMap(schema.getParameters())
                         : Collections.emptyMap();
+        this.strict = schema.getStrict();
     }
 
     /**
@@ -91,6 +93,7 @@ public class SchemaOnlyTool implements AgentTool {
                 parameters != null
                         ? Collections.unmodifiableMap(parameters)
                         : Collections.emptyMap();
+        this.strict = null;
     }
 
     @Override
@@ -106,6 +109,11 @@ public class SchemaOnlyTool implements AgentTool {
     @Override
     public Map<String, Object> getParameters() {
         return parameters;
+    }
+
+    @Override
+    public Boolean getStrict() {
+        return strict;
     }
 
     /**

--- a/agentscope-core/src/main/java/io/agentscope/core/tool/Tool.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/tool/Tool.java
@@ -87,6 +87,16 @@ public @interface Tool {
     String description() default "";
 
     /**
+     * Whether to enable strict schema mode for this tool.
+     *
+     * <p>When enabled, compatible model providers can enforce stronger adherence to the declared
+     * JSON schema for tool arguments.
+     *
+     * @return true to enable strict mode for this tool
+     */
+    boolean strict() default false;
+
+    /**
      * Custom result converter for this tool.
      *
      * <p>Converters transform tool method return values into {@link io.agentscope.core.message.ToolResultBlock}

--- a/agentscope-core/src/main/java/io/agentscope/core/tool/ToolSchemaProvider.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/tool/ToolSchemaProvider.java
@@ -83,6 +83,7 @@ class ToolSchemaProvider {
                             .name(toolName)
                             .description(tool.getDescription())
                             .parameters(registered.getExtendedParameters())
+                            .strict(tool.getStrict())
                             .build();
             schemas.add(schema);
         }

--- a/agentscope-core/src/main/java/io/agentscope/core/tool/Toolkit.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/tool/Toolkit.java
@@ -377,6 +377,11 @@ public class Toolkit {
                     }
 
                     @Override
+                    public Boolean getStrict() {
+                        return toolAnnotation.strict() ? Boolean.TRUE : null;
+                    }
+
+                    @Override
                     public Mono<ToolResultBlock> callAsync(ToolCallParam param) {
                         // Pass custom converter to method invoker
                         return methodInvoker.invokeAsync(

--- a/agentscope-core/src/test/java/io/agentscope/core/mcp/handler/CallToolHandlerTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/mcp/handler/CallToolHandlerTest.java
@@ -1,0 +1,56 @@
+package io.agentscope.core.mcp.handler;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import io.agentscope.core.mcp.schema.CallToolResult;
+import io.agentscope.core.mcp.tool.Tool;
+import io.agentscope.core.mcp.tool.ToolManager;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class CallToolHandlerTest {
+
+    @Test
+    void callLocalTool() throws Exception {
+        ToolManager mgr = new ToolManager();
+        Tool fake =
+                new Tool() {
+                    @Override
+                    public String getName() {
+                        return "echo";
+                    }
+
+                    @Override
+                    public String getDescription() {
+                        return "Echo tool";
+                    }
+
+                    @Override
+                    public Map<String, Object> getInputSchema() {
+                        return Map.of();
+                    }
+
+                    @Override
+                    public Object execute(Object arguments) {
+                        return "OK:" + (arguments == null ? "" : arguments.toString());
+                    }
+                };
+
+        mgr.register(fake);
+        CallToolHandler handler = new CallToolHandler(mgr);
+
+        Map<String, Object> params = new HashMap<>();
+        params.put("name", "echo");
+        params.put("arguments", Map.of("msg", "hello"));
+
+        Object res = handler.handle(params);
+        assertEquals(CallToolResult.class, res.getClass());
+        CallToolResult ctr = (CallToolResult) res;
+        List<Object> content = ctr.content();
+        assertEquals(1, content.size());
+        Object block = content.get(0);
+        assertEquals(true, block.toString().contains("OK:"));
+    }
+}

--- a/agentscope-core/src/test/java/io/agentscope/core/mcp/handler/HandlerRegistryTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/mcp/handler/HandlerRegistryTest.java
@@ -1,0 +1,87 @@
+package io.agentscope.core.mcp.handler;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for HandlerRegistry.
+ */
+class HandlerRegistryTest {
+
+    private HandlerRegistry registry;
+    private TestMethodHandler testHandler;
+
+    @BeforeEach
+    void setUp() {
+        registry = new HandlerRegistry();
+        testHandler = new TestMethodHandler();
+    }
+
+    @Test
+    void testRegisterAndGet() {
+        registry.register("test/method", testHandler);
+        assertTrue(registry.get("test/method").isPresent());
+        assertEquals(testHandler, registry.get("test/method").get());
+    }
+
+    @Test
+    void testGetNonexistent() {
+        assertFalse(registry.get("nonexistent").isPresent());
+    }
+
+    @Test
+    void testHas() {
+        registry.register("test/method", testHandler);
+        assertTrue(registry.has("test/method"));
+        assertFalse(registry.has("nonexistent"));
+    }
+
+    @Test
+    void testUnregister() {
+        registry.register("test/method", testHandler);
+        assertTrue(registry.has("test/method"));
+        registry.unregister("test/method");
+        assertFalse(registry.has("test/method"));
+    }
+
+    @Test
+    void testGetAll() {
+        TestMethodHandler handler1 = new TestMethodHandler();
+        TestMethodHandler handler2 = new TestMethodHandler();
+        registry.register("method1", handler1);
+        registry.register("method2", handler2);
+
+        Map<String, MethodHandler> all = registry.getAll();
+        assertEquals(2, all.size());
+        assertTrue(all.containsKey("method1"));
+        assertTrue(all.containsKey("method2"));
+    }
+
+    @Test
+    void testClear() {
+        registry.register("method1", testHandler);
+        registry.register("method2", testHandler);
+        assertEquals(2, registry.getAll().size());
+
+        registry.clear();
+        assertEquals(0, registry.getAll().size());
+    }
+
+    private static class TestMethodHandler extends AbstractMethodHandler {
+
+        @Override
+        public String getMethod() {
+            return "test/method";
+        }
+
+        @Override
+        public Object handle(Object params) {
+            return params;
+        }
+    }
+}

--- a/agentscope-core/src/test/java/io/agentscope/core/mcp/handler/MessageRouterTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/mcp/handler/MessageRouterTest.java
@@ -1,0 +1,133 @@
+package io.agentscope.core.mcp.handler;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import io.agentscope.core.mcp.message.JsonRpcError;
+import io.agentscope.core.mcp.message.JsonRpcNotification;
+import io.agentscope.core.mcp.message.JsonRpcRequest;
+import io.agentscope.core.mcp.message.JsonRpcResponse;
+import io.agentscope.core.mcp.transport.Transport;
+import io.agentscope.core.mcp.transport.TransportException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+/**
+ * Tests for MessageRouter and handler integration.
+ */
+class MessageRouterTest {
+
+    @Mock private Transport mockTransport;
+
+    private HandlerRegistry registry;
+    private MessageRouter router;
+    private TestHandler testHandler;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        registry = new HandlerRegistry();
+        router = new MessageRouter(mockTransport, registry);
+        testHandler = new TestHandler();
+        registry.register("test/echo", testHandler);
+    }
+
+    @Test
+    void testHandleRequest() throws TransportException {
+        JsonRpcRequest request = new JsonRpcRequest(1, "test/echo", "hello");
+        router.handleMessage(request);
+
+        verify(mockTransport, times(1)).send(any(JsonRpcResponse.class));
+    }
+
+    @Test
+    void testHandleNotification() throws TransportException {
+        JsonRpcNotification notification = new JsonRpcNotification("test/echo", "hello");
+        router.handleMessage(notification);
+
+        // Notifications shouldn't trigger a response send
+        verify(mockTransport, never()).send(any());
+    }
+
+    @Test
+    void testHandleUnknownMethod() throws TransportException {
+        JsonRpcRequest request = new JsonRpcRequest(1, "unknown/method", null);
+        router.handleMessage(request);
+
+        // Should send an error response
+        verify(mockTransport, times(1))
+                .send(
+                        argThat(
+                                msg -> {
+                                    if (msg instanceof JsonRpcResponse) {
+                                        JsonRpcResponse response = (JsonRpcResponse) msg;
+                                        return response.isError()
+                                                && response.getError().getCode()
+                                                        == JsonRpcError.ErrorCode.METHOD_NOT_FOUND;
+                                    }
+                                    return false;
+                                }));
+    }
+
+    @Test
+    void testRegisterMethod() {
+        assertFalse(registry.has("new/method"));
+        router.register("new/method", testHandler);
+        assertTrue(registry.has("new/method"));
+    }
+
+    @Test
+    void testHandlerError() throws TransportException {
+        TestErrorHandler errorHandler = new TestErrorHandler();
+        registry.register("test/error", errorHandler);
+
+        JsonRpcRequest request = new JsonRpcRequest(2, "test/error", null);
+        router.handleMessage(request);
+
+        verify(mockTransport, times(1))
+                .send(
+                        argThat(
+                                msg -> {
+                                    if (msg instanceof JsonRpcResponse) {
+                                        JsonRpcResponse response = (JsonRpcResponse) msg;
+                                        return response.isError()
+                                                && response.getError().getCode()
+                                                        == JsonRpcError.ErrorCode.INTERNAL_ERROR;
+                                    }
+                                    return false;
+                                }));
+    }
+
+    private static class TestHandler extends AbstractMethodHandler {
+
+        @Override
+        public String getMethod() {
+            return "test/echo";
+        }
+
+        @Override
+        public Object handle(Object params) {
+            return params;
+        }
+    }
+
+    private static class TestErrorHandler extends AbstractMethodHandler {
+
+        @Override
+        public String getMethod() {
+            return "test/error";
+        }
+
+        @Override
+        public Object handle(Object params) throws Exception {
+            throw new RuntimeException("Test error");
+        }
+    }
+}

--- a/agentscope-core/src/test/java/io/agentscope/core/mcp/message/JsonRpcMessageTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/mcp/message/JsonRpcMessageTest.java
@@ -1,0 +1,73 @@
+package io.agentscope.core.mcp.message;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for JSON-RPC message classes.
+ */
+class JsonRpcMessageTest {
+
+    private ObjectMapper objectMapper;
+
+    @BeforeEach
+    void setUp() {
+        objectMapper = new ObjectMapper();
+        objectMapper.registerModule(new Jdk8Module());
+    }
+
+    @Test
+    void testJsonRpcRequest() {
+        JsonRpcRequest request = new JsonRpcRequest(1, "test/method", "params");
+        assertEquals("params", request.getParams());
+        assertTrue(request.getId().isPresent());
+        assertTrue(request.getMethod().isPresent());
+        assertEquals(1, request.getId().get());
+        assertEquals("test/method", request.getMethod().get());
+    }
+
+    @Test
+    void testJsonRpcResponse() {
+        JsonRpcResponse response = new JsonRpcResponse(1, "result");
+        assertEquals("result", response.getResult());
+        assertNull(response.getError());
+        assertFalse(response.isError());
+        assertTrue(response.getId().isPresent());
+        assertEquals(1, response.getId().get());
+    }
+
+    @Test
+    void testJsonRpcResponseWithError() {
+        JsonRpcError error =
+                new JsonRpcError(JsonRpcError.ErrorCode.INVALID_PARAMS, "Invalid parameters");
+        JsonRpcResponse response = new JsonRpcResponse(1, error);
+        assertTrue(response.isError());
+        assertEquals(error, response.getError());
+        assertNull(response.getResult());
+    }
+
+    @Test
+    void testJsonRpcNotification() {
+        JsonRpcNotification notification = new JsonRpcNotification("test/notify", "data");
+        assertEquals("data", notification.getParams());
+        assertFalse(notification.getId().isPresent());
+        assertTrue(notification.getMethod().isPresent());
+        assertEquals("test/notify", notification.getMethod().get());
+    }
+
+    @Test
+    void testJsonRpcErrorCodes() {
+        assertEquals(-32700, JsonRpcError.ErrorCode.PARSE_ERROR);
+        assertEquals(-32600, JsonRpcError.ErrorCode.INVALID_REQUEST);
+        assertEquals(-32601, JsonRpcError.ErrorCode.METHOD_NOT_FOUND);
+        assertEquals(-32602, JsonRpcError.ErrorCode.INVALID_PARAMS);
+        assertEquals(-32603, JsonRpcError.ErrorCode.INTERNAL_ERROR);
+    }
+}

--- a/agentscope-core/src/test/java/io/agentscope/core/mcp/tool/ToolManagerTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/mcp/tool/ToolManagerTest.java
@@ -1,0 +1,41 @@
+package io.agentscope.core.mcp.tool;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class ToolManagerTest {
+
+    @Test
+    void registerAndGetTool() {
+        ToolManager mgr = new ToolManager();
+        Tool t =
+                new Tool() {
+                    @Override
+                    public String getName() {
+                        return "dummy.tool";
+                    }
+
+                    @Override
+                    public String getDescription() {
+                        return "A dummy tool";
+                    }
+
+                    @Override
+                    public Map<String, Object> getInputSchema() {
+                        return Map.of();
+                    }
+
+                    @Override
+                    public Object execute(Object arguments) throws Exception {
+                        return "result";
+                    }
+                };
+
+        mgr.register(t);
+        assertTrue(mgr.get("dummy.tool").isPresent());
+        assertEquals(1, mgr.list().size());
+    }
+}

--- a/agentscope-core/src/test/java/io/agentscope/core/tool/ExternalToolSupportTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/tool/ExternalToolSupportTest.java
@@ -18,6 +18,7 @@ package io.agentscope.core.tool;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.agentscope.core.message.ToolResultBlock;
@@ -161,6 +162,41 @@ class ExternalToolSupportTest {
     }
 
     @Test
+    @DisplayName("Should preserve strict when registering external schema")
+    void testExternalSchemaStrictPreserved() {
+        ToolSchema strictSchema =
+                ToolSchema.builder()
+                        .name("strict_tool")
+                        .description("Strict external tool")
+                        .parameters(Map.of("type", "object"))
+                        .strict(true)
+                        .build();
+
+        toolkit.registerSchema(strictSchema);
+
+        List<ToolSchema> schemas = toolkit.getToolSchemas();
+        assertEquals(1, schemas.size());
+        assertEquals(Boolean.TRUE, schemas.get(0).getStrict());
+    }
+
+    @Test
+    @DisplayName("Should keep strict as null when schema strict is not set")
+    void testExternalSchemaStrictNullPreserved() {
+        ToolSchema schema =
+                ToolSchema.builder()
+                        .name("null_strict_tool")
+                        .description("Null strict external tool")
+                        .parameters(Map.of("type", "object"))
+                        .build();
+
+        toolkit.registerSchema(schema);
+
+        List<ToolSchema> schemas = toolkit.getToolSchemas();
+        assertEquals(1, schemas.size());
+        assertNull(schemas.get(0).getStrict());
+    }
+
+    @Test
     @DisplayName("Should handle null schemas list gracefully")
     void testRegisterSchemasNull() {
         // Should not throw
@@ -205,5 +241,23 @@ class ExternalToolSupportTest {
         public String calculate(@ToolParam(name = "expression") String expression) {
             return "result";
         }
+    }
+
+    static class StrictInternalToolExample {
+        @Tool(name = "strict_calculator", description = "Calculate expression", strict = true)
+        public String calculate(@ToolParam(name = "expression") String expression) {
+            return "result";
+        }
+    }
+
+    @Test
+    @DisplayName("Should propagate strict from @Tool annotation")
+    void testAnnotationStrictPropagation() {
+        toolkit.registerTool(new StrictInternalToolExample());
+
+        List<ToolSchema> schemas = toolkit.getToolSchemas();
+        assertEquals(1, schemas.size());
+        assertEquals("strict_calculator", schemas.get(0).getName());
+        assertEquals(Boolean.TRUE, schemas.get(0).getStrict());
     }
 }

--- a/agentscope-core/src/test/java/io/agentscope/core/tool/SchemaOnlyToolTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/tool/SchemaOnlyToolTest.java
@@ -17,6 +17,7 @@ package io.agentscope.core.tool;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -57,6 +58,7 @@ class SchemaOnlyToolTest {
                                         Map.of("sql", Map.of("type", "string")),
                                         "required",
                                         List.of("sql")))
+                        .strict(true)
                         .build();
         schemaOnlyTool = new SchemaOnlyTool(testSchema);
     }
@@ -69,6 +71,7 @@ class SchemaOnlyToolTest {
         assertEquals("Query an external database", schemaOnlyTool.getDescription());
         assertNotNull(schemaOnlyTool.getParameters());
         assertEquals("object", schemaOnlyTool.getParameters().get("type"));
+        assertEquals(Boolean.TRUE, schemaOnlyTool.getStrict());
     }
 
     @Test
@@ -82,6 +85,7 @@ class SchemaOnlyToolTest {
         assertEquals("get_user", tool.getName());
         assertEquals("Get user by ID", tool.getDescription());
         assertEquals(params, tool.getParameters());
+        assertNull(tool.getStrict());
     }
 
     @Test

--- a/agentscope-core/src/test/java/io/agentscope/core/tool/SchemaOnlyToolTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/tool/SchemaOnlyToolTest.java
@@ -140,4 +140,56 @@ class SchemaOnlyToolTest {
         Map<String, Object> parameters = schemaOnlyTool.getParameters();
         assertThrows(UnsupportedOperationException.class, () -> parameters.put("new_key", "value"));
     }
+
+    @Test
+    @DisplayName("Should support strict mode configuration via 4-arg constructor")
+    void testStrictModeConfiguration() {
+        Map<String, Object> params =
+                Map.of("type", "object", "properties", Map.of("id", Map.of("type", "integer")));
+
+        SchemaOnlyTool toolWithStrict = new SchemaOnlyTool("get_user", "Get user", params, true);
+        assertEquals(Boolean.TRUE, toolWithStrict.getStrict());
+
+        SchemaOnlyTool toolWithoutStrict =
+                new SchemaOnlyTool("get_user", "Get user", params, false);
+        assertEquals(Boolean.FALSE, toolWithoutStrict.getStrict());
+
+        SchemaOnlyTool toolUnspecifiedStrict =
+                new SchemaOnlyTool("get_user", "Get user", params, null);
+        assertNull(toolUnspecifiedStrict.getStrict());
+    }
+
+    @Test
+    @DisplayName("Should defensively copy parameters map to prevent external mutations")
+    void testDefensiveCopyOfParameters() {
+        Map<String, Object> originalParams = new java.util.HashMap<>();
+        originalParams.put("type", "object");
+        originalParams.put("sql", "SELECT 1");
+
+        // Create tool with the original parameters map
+        SchemaOnlyTool tool = new SchemaOnlyTool("query", "Query tool", originalParams);
+
+        // Mutate the original parameters map
+        originalParams.put("sql", "MODIFIED");
+        originalParams.put("newKey", "newValue");
+
+        // Verify that the tool's parameters were not affected by external mutations
+        Map<String, Object> toolParams = tool.getParameters();
+        assertEquals("SELECT 1", toolParams.get("sql"), "Original value should be preserved");
+        assertNull(toolParams.get("newKey"), "External mutation should not be visible");
+
+        // Verify exactly the expected entries are in the tool's parameters
+        assertEquals(2, toolParams.size(), "Tool should have only the original 2 entries");
+    }
+
+    @Test
+    @DisplayName("Should preserve strict mode when delegating through 3-arg constructor")
+    void testStrictModePreservedInThreeArgConstructor() {
+        Map<String, Object> params = Map.of("type", "object");
+
+        SchemaOnlyTool tool = new SchemaOnlyTool("test_tool", "Test tool", params);
+
+        // Verify that 3-arg constructor sets strict to null (unspecified)
+        assertNull(tool.getStrict());
+    }
 }

--- a/agentscope-core/src/test/java/io/agentscope/core/tool/ToolSchemaProviderTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/tool/ToolSchemaProviderTest.java
@@ -224,4 +224,42 @@ class ToolSchemaProviderTest {
         assertTrue(toolNames.contains("tool2"));
         assertTrue(toolNames.contains("tool3"));
     }
+
+    @Test
+    void testGetToolSchemasPreserveStrictFromAgentTool() {
+        AgentTool strictTool =
+                new AgentTool() {
+                    @Override
+                    public String getName() {
+                        return "strict_tool";
+                    }
+
+                    @Override
+                    public String getDescription() {
+                        return "Strict tool";
+                    }
+
+                    @Override
+                    public Map<String, Object> getParameters() {
+                        return Map.of("type", "object");
+                    }
+
+                    @Override
+                    public Boolean getStrict() {
+                        return true;
+                    }
+
+                    @Override
+                    public Mono<ToolResultBlock> callAsync(ToolCallParam input) {
+                        return Mono.just(ToolResultBlock.text("ok"));
+                    }
+                };
+
+        RegisteredToolFunction registered = new RegisteredToolFunction(strictTool, null, null);
+        registry.registerTool("strict_tool", strictTool, registered);
+
+        List<ToolSchema> schemas = schemaProvider.getToolSchemas();
+        assertEquals(1, schemas.size());
+        assertEquals(Boolean.TRUE, schemas.get(0).getStrict());
+    }
 }

--- a/agentscope-examples/mcp-native-example/README.md
+++ b/agentscope-examples/mcp-native-example/README.md
@@ -1,0 +1,81 @@
+# MCP Native Example
+
+This example demonstrates how to use the native MCP (Model Context Protocol) server implementation with custom tools.
+
+## Overview
+
+The example includes:
+- **CalculatorTool**: A simple arithmetic calculator supporting add, subtract, multiply, divide
+- **OpenAiChatTool**: Integration with OpenAI Chat API (requires `OPENAI_API_KEY`)
+- **McpServerRunner**: CLI to start the MCP server with stdio transport
+
+## Building
+
+```bash
+mvn clean package -pl agentscope-examples/mcp-native-example
+```
+
+This creates a fat JAR: `target/mcp-native-example.jar`
+
+## Running
+
+### Basic Usage (Calculator Only)
+
+```bash
+java -jar target/mcp-native-example.jar
+```
+
+### With OpenAI Integration
+
+```bash
+OPENAI_API_KEY="sk-your-key-here" java -jar target/mcp-native-example.jar
+```
+
+## Testing with MCP Client
+
+The server communicates via stdin/stdout using JSON-RPC 2.0.
+
+### Example: Test Calculator Tool
+
+Send a JSON-RPC request to stdin:
+
+```json
+{"jsonrpc": "2.0", "id": 1, "method": "tools/call", "params": {"name": "calculator.compute", "arguments": {"operation": "add", "a": 5, "b": 3}}}
+```
+
+Expected response:
+
+```json
+{"jsonrpc": "2.0", "id": 1, "result": {"content": [{"type": "text", "text": "{\"operation\":\"add\",\"a\":5.0,\"b\":3.0,\"result\":8.0}"}]}}
+```
+
+### Example: List Available Tools
+
+```json
+{"jsonrpc": "2.0", "id": 2, "method": "tools/list"}
+```
+
+### Example: Initialize Handshake
+
+```json
+{"jsonrpc": "2.0", "id": 3, "method": "initialize"}
+```
+
+## Architecture
+
+The example uses:
+- `StdioTransport`: JSON-RPC communication over stdin/stdout
+- `McpServer`: Facade for tool registration and message routing
+- `ToolManager`: Registry for server-side tools
+- Handler classes: `InitializeHandler`, `ListToolsHandler`, `CallToolHandler`
+
+## Environment Variables
+
+- `OPENAI_API_KEY`: OpenAI API key (optional; enables openai.chat tool)
+
+## Files
+
+- `McpServerRunner.java`: Main entry point
+- `CalculatorTool.java`: Calculator implementation
+- `OpenAiChatTool.java`: OpenAI Chat API integration
+- `CalculatorToolTest.java`: Unit tests

--- a/agentscope-examples/mcp-native-example/pom.xml
+++ b/agentscope-examples/mcp-native-example/pom.xml
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2024-2026 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.agentscope</groupId>
+        <artifactId>agentscope-examples</artifactId>
+        <version>${revision}</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>mcp-native-example</artifactId>
+    <name>AgentScope Java - MCP Native Example</name>
+    <description>Example of using the native MCP server implementation with tools</description>
+
+    <properties>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <dependencies>
+        <!-- AgentScope Core (native MCP implementation) -->
+        <dependency>
+            <groupId>io.agentscope</groupId>
+            <artifactId>agentscope-core</artifactId>
+            <version>${revision}</version>
+        </dependency>
+
+        <!-- OkHttp for HTTP requests in tools -->
+        <dependency>
+            <groupId>com.squareup.okhttp3</groupId>
+            <artifactId>okhttp</artifactId>
+        </dependency>
+
+        <!-- Jackson for JSON processing -->
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+
+        <!-- Testing: JUnit Jupiter -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <transformers>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                                    <mainClass>io.agentscope.examples.mcp.McpServerRunner</mainClass>
+                                </transformer>
+                            </transformers>
+                            <finalName>mcp-native-example</finalName>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/agentscope-examples/mcp-native-example/src/main/java/io/agentscope/examples/mcp/CalculatorTool.java
+++ b/agentscope-examples/mcp-native-example/src/main/java/io/agentscope/examples/mcp/CalculatorTool.java
@@ -1,0 +1,77 @@
+package io.agentscope.examples.mcp;
+
+import io.agentscope.core.mcp.tool.Tool;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Simple calculator tool that performs basic arithmetic operations.
+ */
+public class CalculatorTool implements Tool {
+
+    @Override
+    public String getName() {
+        return "calculator.compute";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Performs basic arithmetic operations (add, subtract, multiply, divide)";
+    }
+
+    @Override
+    public Map<String, Object> getInputSchema() {
+        Map<String, Object> schema = new HashMap<>();
+        schema.put("type", "object");
+        Map<String, Object> properties = new HashMap<>();
+
+        properties.put(
+                "operation",
+                Map.of(
+                        "type",
+                        "string",
+                        "enum",
+                        new String[] {"add", "subtract", "multiply", "divide"}));
+        properties.put("a", Map.of("type", "number"));
+        properties.put("b", Map.of("type", "number"));
+
+        schema.put("properties", properties);
+        schema.put("required", new String[] {"operation", "a", "b"});
+        return schema;
+    }
+
+    @Override
+    public Object execute(Object arguments) throws Exception {
+        if (!(arguments instanceof Map)) {
+            throw new IllegalArgumentException("Arguments must be a map");
+        }
+
+        Map<String, Object> args = (Map<String, Object>) arguments;
+        String operation = (String) args.get("operation");
+        double a = ((Number) args.get("a")).doubleValue();
+        double b = ((Number) args.get("b")).doubleValue();
+
+        double result;
+        switch (operation) {
+            case "add":
+                result = a + b;
+                break;
+            case "subtract":
+                result = a - b;
+                break;
+            case "multiply":
+                result = a * b;
+                break;
+            case "divide":
+                if (b == 0) {
+                    throw new IllegalArgumentException("Division by zero");
+                }
+                result = a / b;
+                break;
+            default:
+                throw new IllegalArgumentException("Unknown operation: " + operation);
+        }
+
+        return Map.of("operation", operation, "a", a, "b", b, "result", result);
+    }
+}

--- a/agentscope-examples/mcp-native-example/src/main/java/io/agentscope/examples/mcp/CalculatorToolAdapter.java
+++ b/agentscope-examples/mcp-native-example/src/main/java/io/agentscope/examples/mcp/CalculatorToolAdapter.java
@@ -1,0 +1,71 @@
+package io.agentscope.examples.mcp;
+
+import io.agentscope.core.tool.Tool;
+import io.agentscope.core.tool.ToolParam;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.logging.Logger;
+
+/**
+ * Adapter to bridge calculator tool to AgentScope's Toolkit.
+ *
+ * <p>This allows the calculator tool to be used with ReActAgent.
+ */
+public class CalculatorToolAdapter {
+
+    private static final Logger logger = Logger.getLogger(CalculatorToolAdapter.class.getName());
+
+    /**
+     * Performs arithmetic operations.
+     *
+     * @param operation The operation: "add", "subtract", "multiply", or "divide"
+     * @param a First operand
+     * @param b Second operand
+     * @return Result of the operation
+     */
+    @Tool(description = "Performs arithmetic operations: add, subtract, multiply, or divide")
+    public Map<String, Object> compute(
+            @ToolParam(
+                            name = "operation",
+                            description =
+                                    "Operation to perform: 'add', 'subtract', 'multiply', or"
+                                            + " 'divide'")
+                    String operation,
+            @ToolParam(name = "a", description = "First operand") double a,
+            @ToolParam(name = "b", description = "Second operand") double b) {
+        logger.info(
+                String.format(
+                        "[TOOL CALLED] compute(operation=%s, a=%.2f, b=%.2f)", operation, a, b));
+        double result;
+        switch (operation.toLowerCase()) {
+            case "add":
+                result = a + b;
+                break;
+            case "subtract":
+                result = a - b;
+                break;
+            case "multiply":
+                result = a * b;
+                break;
+            case "divide":
+                if (b == 0) {
+                    throw new IllegalArgumentException("Division by zero");
+                }
+                result = a / b;
+                break;
+            default:
+                throw new IllegalArgumentException("Unknown operation: " + operation);
+        }
+
+        Map<String, Object> response = new HashMap<>();
+        response.put("operation", operation);
+        response.put("a", a);
+        response.put("b", b);
+        response.put("result", result);
+        logger.info(
+                String.format(
+                        "[TOOL RESULT] %s: %.2f %s %.2f = %.2f",
+                        operation.toUpperCase(), a, operation, b, result));
+        return response;
+    }
+}

--- a/agentscope-examples/mcp-native-example/src/main/java/io/agentscope/examples/mcp/McpServerRunner.java
+++ b/agentscope-examples/mcp-native-example/src/main/java/io/agentscope/examples/mcp/McpServerRunner.java
@@ -1,0 +1,56 @@
+package io.agentscope.examples.mcp;
+
+import io.agentscope.core.mcp.server.McpServer;
+import io.agentscope.core.mcp.transport.StdioTransport;
+import java.util.logging.Logger;
+
+/**
+ * CLI runner to start an MCP server with stdio transport.
+ *
+ * <p>This server exposes:
+ * - calculator.compute: Basic arithmetic operations
+ * - openai.chat: OpenAI Chat API integration (requires OPENAI_API_KEY env var)
+ *
+ * <p>Usage:
+ * <pre>
+ *   java -jar mcp-native-example.jar
+ * </pre>
+ *
+ * <p>Or with OpenAI API key:
+ * <pre>
+ *   OPENAI_API_KEY="sk-..." java -jar mcp-native-example.jar
+ * </pre>
+ *
+ * <p>The server communicates via stdin/stdout using JSON-RPC 2.0 protocol.
+ */
+public class McpServerRunner {
+
+    private static final Logger logger = Logger.getLogger(McpServerRunner.class.getName());
+
+    public static void main(String[] args) throws Exception {
+        logger.info("Starting MCP Server with Stdio Transport...");
+
+        // Create server with stdio transport
+        StdioTransport transport = new StdioTransport();
+        McpServer server = new McpServer(transport);
+
+        // Register tools
+        server.registerTool(new CalculatorTool());
+        logger.info("Registered tool: calculator.compute");
+
+        String openaiApiKey = System.getenv("OPENAI_API_KEY");
+        if (openaiApiKey != null && !openaiApiKey.isBlank()) {
+            server.registerTool(new OpenAiChatTool(openaiApiKey));
+            logger.info("Registered tool: openai.chat");
+        } else {
+            logger.warning("OPENAI_API_KEY not set; openai.chat tool will not be available");
+        }
+
+        // Start processing messages
+        logger.info("Server ready for connections. Listening on stdin/stdout...");
+        server.start();
+
+        // Keep the server running
+        Thread.currentThread().join();
+    }
+}

--- a/agentscope-examples/mcp-native-example/src/main/java/io/agentscope/examples/mcp/OpenAiChatTool.java
+++ b/agentscope-examples/mcp-native-example/src/main/java/io/agentscope/examples/mcp/OpenAiChatTool.java
@@ -1,0 +1,140 @@
+package io.agentscope.examples.mcp;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.agentscope.core.mcp.tool.Tool;
+import java.util.HashMap;
+import java.util.Map;
+import okhttp3.MediaType;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.Response;
+
+/**
+ * Tool that calls OpenAI Chat API.
+ *
+ * <p>Requires the environment variable: OPENAI_API_KEY
+ */
+public class OpenAiChatTool implements Tool {
+
+    private static final String OPENAI_API_URL = "https://api.openai.com/v1/chat/completions";
+    private static final MediaType JSON = MediaType.get("application/json; charset=utf-8");
+
+    private final String apiKey;
+    private final OkHttpClient httpClient = new OkHttpClient();
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    public OpenAiChatTool(String apiKey) {
+        this.apiKey = apiKey;
+    }
+
+    @Override
+    public String getName() {
+        return "openai.chat";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Calls OpenAI Chat API to generate responses";
+    }
+
+    @Override
+    public Map<String, Object> getInputSchema() {
+        Map<String, Object> schema = new HashMap<>();
+        schema.put("type", "object");
+        Map<String, Object> properties = new HashMap<>();
+
+        properties.put("prompt", Map.of("type", "string", "description", "The user prompt"));
+        properties.put(
+                "model",
+                Map.of(
+                        "type",
+                        "string",
+                        "description",
+                        "OpenAI model (default: gpt-3.5-turbo)",
+                        "default",
+                        "gpt-3.5-turbo"));
+        properties.put(
+                "temperature",
+                Map.of(
+                        "type",
+                        "number",
+                        "description",
+                        "Temperature for randomness (0-2, default: 0.7)",
+                        "default",
+                        0.7));
+        properties.put(
+                "max_tokens",
+                Map.of(
+                        "type",
+                        "integer",
+                        "description",
+                        "Max tokens in response (default: 100)",
+                        "default",
+                        100));
+
+        schema.put("properties", properties);
+        schema.put("required", new String[] {"prompt"});
+        return schema;
+    }
+
+    @Override
+    public Object execute(Object arguments) throws Exception {
+        if (apiKey == null || apiKey.isBlank()) {
+            throw new IllegalStateException(
+                    "OpenAI API key not configured. Set OPENAI_API_KEY environment variable.");
+        }
+
+        if (!(arguments instanceof Map)) {
+            throw new IllegalArgumentException("Arguments must be a map");
+        }
+
+        Map<String, Object> args = (Map<String, Object>) arguments;
+        String prompt = (String) args.get("prompt");
+        String model = (String) args.getOrDefault("model", "gpt-3.5-turbo");
+        double temperature = ((Number) args.getOrDefault("temperature", 0.7)).doubleValue();
+        int maxTokens = ((Number) args.getOrDefault("max_tokens", 100)).intValue();
+
+        // Build request payload
+        Map<String, Object> payload = new HashMap<>();
+        payload.put("model", model);
+        payload.put("temperature", temperature);
+        payload.put("max_tokens", maxTokens);
+        payload.put("messages", new Object[] {Map.of("role", "user", "content", prompt)});
+
+        String jsonPayload = objectMapper.writeValueAsString(payload);
+
+        // Send request to OpenAI
+        RequestBody body = RequestBody.create(jsonPayload, JSON);
+        Request req =
+                new Request.Builder()
+                        .url(OPENAI_API_URL)
+                        .addHeader("Authorization", "Bearer " + apiKey)
+                        .addHeader("Content-Type", "application/json")
+                        .post(body)
+                        .build();
+
+        try (Response resp = httpClient.newCall(req).execute()) {
+            if (!resp.isSuccessful()) {
+                String errorBody = resp.body() == null ? "" : resp.body().string();
+                throw new RuntimeException("OpenAI API error (" + resp.code() + "): " + errorBody);
+            }
+
+            String respBody = resp.body() == null ? "" : resp.body().string();
+            Map<String, Object> result = objectMapper.readValue(respBody, Map.class);
+
+            // Extract the assistant's message from the response
+            if (result.containsKey("choices")) {
+                java.util.List<Map<String, Object>> choices =
+                        (java.util.List<Map<String, Object>>) result.get("choices");
+                if (!choices.isEmpty()) {
+                    Map<String, Object> choice = choices.get(0);
+                    Map<String, Object> message = (Map<String, Object>) choice.get("message");
+                    return Map.of("response", message.get("content"), "model", model);
+                }
+            }
+
+            return Map.of("response", "No response from OpenAI", "model", model);
+        }
+    }
+}

--- a/agentscope-examples/mcp-native-example/src/main/java/io/agentscope/examples/mcp/ReActAgentCliRunner.java
+++ b/agentscope-examples/mcp-native-example/src/main/java/io/agentscope/examples/mcp/ReActAgentCliRunner.java
@@ -1,0 +1,155 @@
+package io.agentscope.examples.mcp;
+
+import io.agentscope.core.ReActAgent;
+import io.agentscope.core.memory.InMemoryMemory;
+import io.agentscope.core.message.ContentBlock;
+import io.agentscope.core.message.Msg;
+import io.agentscope.core.message.MsgRole;
+import io.agentscope.core.message.TextBlock;
+import io.agentscope.core.model.DashScopeChatModel;
+import io.agentscope.core.model.Model;
+import io.agentscope.core.model.OpenAIChatModel;
+import io.agentscope.core.tool.Toolkit;
+import java.time.Duration;
+import java.util.Scanner;
+
+/**
+ * CLI-based ReActAgent runner using calculator tools.
+ *
+ * <p>This agent reads user input from stdin and processes it using a ReActAgent
+ * with DashScope or OpenAI LLM and calculator tools.
+ *
+ * <p>Usage with DashScope:
+ * <pre>
+ *   java -jar target/mcp-native-example.jar \
+ *     io.agentscope.examples.mcp.ReActAgentCliRunner
+ * </pre>
+ *
+ * <p>Usage with OpenAI GPT-4:
+ * <pre>
+ *   java -jar target/mcp-native-example.jar \
+ *     io.agentscope.examples.mcp.ReActAgentCliRunner
+ * </pre>
+ *
+ * <p>The agent will automatically detect which API key is available and use the
+ * corresponding model. Set either DASHSCOPE_API_KEY or OPENAI_API_KEY environment
+ * variable (or both).
+ *
+ * <p>Example interactions:
+ * <pre>
+ *   User: What is 5 plus 3?
+ *   Agent: [Thinks] The user wants me to add 5 and 3...
+ *   Agent: [Calls calculator] ...
+ *   Agent: The result of 5 plus 3 is 8.
+ * </pre>
+ */
+public class ReActAgentCliRunner {
+
+    public static void main(String[] args) throws Exception {
+        // Detect available API keys from environment variables
+        String dashscopeKey = System.getenv("DASHSCOPE_API_KEY");
+        String openaiKey = System.getenv("OPENAI_API_KEY");
+
+        // Choose model based on available API keys
+        Model model;
+        String modelProvider;
+
+        if (dashscopeKey != null && !dashscopeKey.isBlank()) {
+            // Use DashScope
+            model =
+                    DashScopeChatModel.builder()
+                            .apiKey(dashscopeKey)
+                            .modelName("qwen-plus")
+                            .build();
+            modelProvider = "DashScope (qwen-plus)";
+        } else if (openaiKey != null && !openaiKey.isBlank()) {
+            // Use OpenAI GPT model
+            model =
+                    OpenAIChatModel.builder()
+                            .apiKey(openaiKey)
+                            .modelName("gpt-5.4-mini-2026-03-17")
+                            .build();
+            modelProvider = "OpenAI (gpt-5.4-mini-2026-03-17)";
+        } else {
+            System.err.println("ERROR: No API key configured.");
+            System.err.println("Please set either DASHSCOPE_API_KEY or OPENAI_API_KEY.");
+            System.exit(1);
+            return;
+        }
+
+        System.out.println("=== ReActAgent CLI with Calculator Tool ===");
+        System.out.println("Model: " + modelProvider);
+        System.out.println("Available tools: compute (add, subtract, multiply, divide)");
+        System.out.println("Type 'exit' to quit.\n");
+
+        // Create toolkit with calculator adapter
+        Toolkit toolkit = new Toolkit();
+        toolkit.registration().tool(new CalculatorToolAdapter()).apply();
+
+        // Create agent
+        ReActAgent agent =
+                ReActAgent.builder()
+                        .name("Assistant")
+                        .sysPrompt(
+                                "You are a helpful assistant with access to a calculator tool."
+                                        + " When asked to perform calculations, use the compute"
+                                        + " tool. Always show your reasoning before and after tool"
+                                        + " calls.")
+                        .model(model)
+                        .toolkit(toolkit)
+                        .memory(new InMemoryMemory())
+                        .maxIters(5)
+                        .build();
+
+        // Interactive loop
+        try (Scanner scanner = new Scanner(System.in)) {
+            System.out.print("User: ");
+            while (scanner.hasNextLine()) {
+                String userInput = scanner.nextLine().trim();
+
+                if ("exit".equalsIgnoreCase(userInput)) {
+                    System.out.println("Goodbye!");
+                    break;
+                }
+
+                if (userInput.isEmpty()) {
+                    System.out.print("User: ");
+                    continue;
+                }
+
+                try {
+                    // Create user message
+                    Msg userMsg =
+                            Msg.builder()
+                                    .name("User")
+                                    .role(MsgRole.USER)
+                                    .content(TextBlock.builder().text(userInput).build())
+                                    .build();
+
+                    System.out.println("\nAgent (thinking...)");
+
+                    // Get agent response (blocking with timeout)
+                    Msg response = agent.call(userMsg).timeout(Duration.ofSeconds(30)).block();
+
+                    // Display response
+                    if (response != null) {
+                        ContentBlock content = response.getFirstContentBlock();
+                        if (content instanceof TextBlock) {
+                            String text = ((TextBlock) content).getText();
+                            System.out.println("Agent: " + text);
+                        } else {
+                            System.out.println("Agent: " + content);
+                        }
+                    } else {
+                        System.out.println("Agent: (No response)");
+                    }
+                } catch (Exception e) {
+                    System.err.println("Error: " + e.getMessage());
+                    e.printStackTrace();
+                }
+
+                System.out.print("\nUser: ");
+            }
+        }
+    }
+}

--- a/agentscope-examples/mcp-native-example/src/test/java/io/agentscope/examples/mcp/CalculatorToolTest.java
+++ b/agentscope-examples/mcp-native-example/src/test/java/io/agentscope/examples/mcp/CalculatorToolTest.java
@@ -1,0 +1,53 @@
+package io.agentscope.examples.mcp;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class CalculatorToolTest {
+
+    @Test
+    void testAdd() throws Exception {
+        CalculatorTool tool = new CalculatorTool();
+        Map<String, Object> args = new HashMap<>();
+        args.put("operation", "add");
+        args.put("a", 5);
+        args.put("b", 3);
+
+        Object result = tool.execute(args);
+        assertTrue(result instanceof Map);
+        Map<String, Object> resultMap = (Map<String, Object>) result;
+        assertEquals(8.0, ((Number) resultMap.get("result")).doubleValue());
+    }
+
+    @Test
+    void testMultiply() throws Exception {
+        CalculatorTool tool = new CalculatorTool();
+        Map<String, Object> args = new HashMap<>();
+        args.put("operation", "multiply");
+        args.put("a", 4);
+        args.put("b", 7);
+
+        Object result = tool.execute(args);
+        assertTrue(result instanceof Map);
+        Map<String, Object> resultMap = (Map<String, Object>) result;
+        assertEquals(28.0, ((Number) resultMap.get("result")).doubleValue());
+    }
+
+    @Test
+    void testDivide() throws Exception {
+        CalculatorTool tool = new CalculatorTool();
+        Map<String, Object> args = new HashMap<>();
+        args.put("operation", "divide");
+        args.put("a", 10);
+        args.put("b", 2);
+
+        Object result = tool.execute(args);
+        assertTrue(result instanceof Map);
+        Map<String, Object> resultMap = (Map<String, Object>) result;
+        assertEquals(5.0, ((Number) resultMap.get("result")).doubleValue());
+    }
+}

--- a/agentscope-examples/pom.xml
+++ b/agentscope-examples/pom.xml
@@ -33,6 +33,7 @@
 
     <modules>
         <module>quickstart</module>
+        <module>mcp-native-example</module>
         <module>advanced</module>
         <module>micronaut</module>
         <module>quarkus</module>

--- a/docs/en/task/mcp-native.md
+++ b/docs/en/task/mcp-native.md
@@ -1,0 +1,497 @@
+# Native MCP Server Implementation
+
+AgentScope Java provides native support for implementing MCP (Model Context Protocol) servers. This enables your agents to expose tools via the MCP protocol for external clients to consume.
+
+## What is Native MCP Server?
+
+Native MCP server implementation allows you to:
+
+- **Build Custom Tool Servers**: Implement domain-specific tools and expose them via MCP
+- **External Tool Exposure**: Allow external clients (Claude, other agents, IDEs) to discover and use your tools
+- **Protocol Support**: Full JSON-RPC 2.0 support with StdIO and TCP transports
+- **Tool Management**: Register, discover, and execute tools through standard MCP protocol
+
+## Key Difference: Client vs Server
+
+| Aspect | MCP Client (mcp.md) | MCP Native Server (mcp-native.md) |
+|--------|-------------------|-----------------------------------|
+| **Purpose** | Connect to external tool servers | Build your own tool server |
+| **Direction** | Agent calls external tools | External clients call your tools |
+| **Transport** | StdIO, SSE, HTTP (client-side) | StdIO, TCP (server-side) |
+| **Use Case** | Integrate existing tools | Expose custom domain tools |
+
+## Quick Start
+
+### 1. Implement Custom Tools
+
+Create a tool implementing the `Tool` interface:
+
+```java
+import io.agentscope.core.mcp.tool.Tool;
+import java.util.HashMap;
+import java.util.Map;
+
+public class CalculatorTool implements Tool {
+    
+    @Override
+    public String getName() {
+        return "calculator.compute";
+    }
+    
+    @Override
+    public String getDescription() {
+        return "Performs basic arithmetic operations (add, subtract, multiply, divide)";
+    }
+    
+    @Override
+    public Map<String, Object> getInputSchema() {
+        Map<String, Object> schema = new HashMap<>();
+        schema.put("type", "object");
+        schema.put("properties", Map.of(
+            "operation", Map.of("type", "string", "description", "Operation: add, subtract, multiply, divide"),
+            "a", Map.of("type", "number", "description", "First operand"),
+            "b", Map.of("type", "number", "description", "Second operand")
+        ));
+        schema.put("required", List.of("operation", "a", "b"));
+        return schema;
+    }
+    
+    @Override
+    public Object execute(Object params) {
+        Map<String, Object> args = (Map<String, Object>) params;
+        String operation = (String) args.get("operation");
+        double a = ((Number) args.get("a")).doubleValue();
+        double b = ((Number) args.get("b")).doubleValue();
+        
+        double result = switch(operation) {
+            case "add" -> a + b;
+            case "subtract" -> a - b;
+            case "multiply" -> a * b;
+            case "divide" -> b != 0 ? a / b : throw new IllegalArgumentException("Division by zero");
+            default -> throw new IllegalArgumentException("Unknown operation: " + operation);
+        };
+        
+        Map<String, Object> response = new HashMap<>();
+        response.put("operation", operation);
+        response.put("a", a);
+        response.put("b", b);
+        response.put("result", result);
+        return response;
+    }
+}
+```
+
+### 2. Start MCP Server with StdIO Transport
+
+```java
+import io.agentscope.core.mcp.server.McpServer;
+import io.agentscope.core.mcp.transport.StdioTransport;
+
+public class McpServerRunner {
+    public static void main(String[] args) throws Exception {
+        // Create transport (StdIO for local process communication)
+        StdioTransport transport = new StdioTransport();
+        
+        // Create and start server
+        McpServer server = new McpServer(transport);
+        server.registerTool(new CalculatorTool());
+        server.start();
+        
+        System.err.println("MCP Server started. Listening on stdin/stdout...");
+    }
+}
+```
+
+### 3. Start MCP Server with TCP Transport
+
+For network access:
+
+```java
+import io.agentscope.core.mcp.server.McpServer;
+import io.agentscope.core.mcp.transport.TcpTransport;
+
+public class TcpServerRunner {
+    public static void main(String[] args) throws Exception {
+        // Create TCP transport on port 9999
+        TcpTransport transport = new TcpTransport("localhost", 9999);
+        
+        // Create and start server
+        McpServer server = new McpServer(transport);
+        server.registerTool(new CalculatorTool());
+        server.start();
+        
+        System.err.println("MCP Server listening on tcp://localhost:9999");
+    }
+}
+```
+
+## Tool Implementation Details
+
+### Required Methods
+
+Every tool must implement `io.agentscope.core.mcp.tool.Tool`:
+
+```java
+public interface Tool {
+    /**
+     * Returns the unique tool name
+     */
+    String getName();
+    
+    /**
+     * Returns human-readable description
+     */
+    String getDescription();
+    
+    /**
+     * Returns JSON Schema describing input parameters
+     */
+    Map<String, Object> getInputSchema();
+    
+    /**
+     * Executes the tool with given parameters
+     * 
+     * @param params Tool parameters (typically a Map)
+     * @return Tool result (wrapped in content blocks by server)
+     */
+    Object execute(Object params);
+}
+```
+
+### Input Schema Format
+
+Use JSON Schema to describe tool parameters:
+
+```java
+@Override
+public Map<String, Object> getInputSchema() {
+    return Map.of(
+        "type", "object",
+        "properties", Map.of(
+            "operation", Map.of(
+                "type", "string",
+                "description", "Operation to perform",
+                "enum", List.of("add", "subtract", "multiply", "divide")
+            ),
+            "a", Map.of(
+                "type", "number",
+                "description", "First number"
+            ),
+            "b", Map.of(
+                "type", "number",
+                "description", "Second number"
+            )
+        ),
+        "required", List.of("operation", "a", "b")
+    );
+}
+```
+
+### Return Value Formats
+
+Tools can return different types - the server wraps them appropriately:
+
+```java
+// String result - wrapped as text content
+@Override
+public Object execute(Object params) {
+    return "Result: 42";
+}
+
+// Map result - converted to JSON
+@Override
+public Object execute(Object params) {
+    return Map.of(
+        "status", "success",
+        "value", 42
+    );
+}
+
+// List result - treated as array
+@Override
+public Object execute(Object params) {
+    return List.of("item1", "item2", "item3");
+}
+```
+
+## Tool Management
+
+### Register Multiple Tools
+
+```java
+McpServer server = new McpServer(transport);
+server.registerTool(new CalculatorTool());
+server.registerTool(new StringToolTool());
+server.registerTool(new FileSystemTool());
+server.start();
+```
+
+### List Registered Tools
+
+```java
+// From client perspective, fetch tools via tools/list request
+// Server automatically provides list of all registered tools
+```
+
+## Protocol Details
+
+### Supported MCP Methods
+
+The native server automatically handles:
+
+| Method | Purpose | Response |
+|--------|---------|----------|
+| `initialize` | Client handshake | Server info & capabilities |
+| `tools/list` | Get available tools | Tool metadata array |
+| `tools/call` | Execute a tool | Tool result content |
+
+### JSON-RPC Message Format
+
+Requests:
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 1,
+    "method": "tools/call",
+    "params": {
+        "name": "calculator.compute",
+        "arguments": {
+            "operation": "multiply",
+            "a": 5,
+            "b": 3
+        }
+    }
+}
+```
+
+Responses:
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 1,
+    "result": {
+        "content": [
+            {
+                "type": "text",
+                "text": "{\"operation\":\"multiply\",\"a\":5,\"b\":3,\"result\":15}"
+            }
+        ]
+    }
+}
+```
+
+## Error Handling
+
+### Tool Execution Errors
+
+```java
+@Override
+public Object execute(Object params) {
+    Map<String, Object> args = (Map<String, Object>) params;
+    String operation = (String) args.get("operation");
+    
+    if (!isValidOperation(operation)) {
+        throw new IllegalArgumentException("Invalid operation: " + operation);
+    }
+    
+    // ... execute ...
+}
+```
+
+### Server Error Response
+
+Server automatically returns error responses:
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 1,
+    "error": {
+        "code": -32603,
+        "message": "Internal error",
+        "data": "Invalid operation: unknown"
+    }
+}
+```
+
+## Transport Configuration
+
+### StdIO Transport
+
+Best for local process integration (agent, IDE, local tools):
+
+```java
+StdioTransport transport = new StdioTransport();
+McpServer server = new McpServer(transport);
+server.start();
+// Communicates via stdin/stdout
+```
+
+### TCP Transport
+
+Best for network access and remote clients:
+
+```java
+// Server binding to port 9999
+TcpTransport transport = new TcpTransport("0.0.0.0", 9999);
+McpServer server = new McpServer(transport);
+server.start();
+
+// Client connects to
+// tcp://localhost:9999
+```
+
+## Complete Example
+
+See the complete native MCP server example:
+- `agentscope-examples/mcp-native-example/`
+
+Key files:
+- `McpServerRunner.java` - StdIO server with tools
+- `ReActAgentCliRunner.java` - CLI agent using calculator tools
+- `CalculatorToolAdapter.java` - Tool implementation with logging
+
+Build:
+```bash
+cd agentscope-examples/mcp-native-example
+mvn clean install
+```
+
+Run MCP Server (StdIO):
+```bash
+java -jar target/mcp-native-example.jar io.agentscope.examples.mcp.McpServerRunner
+```
+
+Run CLI Agent:
+```bash
+OPENAI_API_KEY="sk-..." java -cp target/mcp-native-example.jar \
+    io.agentscope.examples.mcp.ReActAgentCliRunner
+```
+
+## Best Practices
+
+### 1. Clear Tool Names and Descriptions
+
+```java
+// ✅ Good - descriptive, namespaced
+getName() -> "filesystem.read_file"
+getDescription() -> "Read contents of a file"
+
+// ❌ Poor - vague, generic
+getName() -> "read"
+getDescription() -> "Read something"
+```
+
+### 2. Comprehensive Input Schemas
+
+```java
+// ✅ Good - complete schema with constraints
+"properties": {
+    "path": {
+        "type": "string",
+        "description": "File path (absolute or relative)"
+    },
+    "encoding": {
+        "type": "string",
+        "description": "Character encoding",
+        "enum": ["utf-8", "ascii", "utf-16"],
+        "default": "utf-8"
+    }
+}
+
+// ❌ Poor - minimal schema
+"properties": {
+    "input": {"type": "object"}
+}
+```
+
+### 3. Error Messages
+
+```java
+// ✅ Good - actionable error
+throw new IllegalArgumentException("File not found at: " + path + 
+    " (expected absolute path or relative from " + workingDir + ")");
+
+// ❌ Poor - vague error
+throw new Exception("Error");
+```
+
+### 4. Logging Tool Invocations
+
+Add logging to track tool usage:
+
+```java
+@Override
+public Object execute(Object params) {
+    logger.info("[TOOL CALLED] " + getName() + " with args: " + params);
+    try {
+        Object result = executeLogic(params);
+        logger.info("[TOOL SUCCESS] " + getName() + " returned: " + result);
+        return result;
+    } catch (Exception e) {
+        logger.error("[TOOL ERROR] " + getName() + " failed: " + e.getMessage());
+        throw e;
+    }
+}
+```
+
+## Integration with ReActAgent
+
+Use native MCP tools with ReActAgent:
+
+```java
+// Create toolkit and register adapter
+Toolkit toolkit = new Toolkit();
+toolkit.registration().tool(new CalculatorToolAdapter()).apply();
+
+// Create agent with tools
+ReActAgent agent = ReActAgent.builder()
+    .name("Assistant")
+    .model(model)
+    .toolkit(toolkit)  // Tools registered via MCP or direct
+    .memory(new InMemoryMemory())
+    .build();
+```
+
+## Troubleshooting
+
+### Tool Not Found Error
+
+```
+Error: Tool "calculator.compute" not found
+```
+
+**Solution**: Verify tool name matches exactly (case-sensitive):
+```java
+// Ensure consistent naming
+server.registerTool(new CalculatorTool()); // Must return exact name in getName()
+```
+
+### Schema Validation Error
+
+```
+Error: Arguments do not match schema
+```
+
+**Solution**: Check JSON Schema matches actual parameters:
+```java
+// Test schema with sample arguments
+Map<String, Object> testArgs = Map.of("operation", "add", "a", 5, "b", 3);
+// Verify this matches getInputSchema()
+```
+
+### Transport Connection Issues
+
+**StdIO**: Check process is receiving stdin/stdout correctly
+**TCP**: Verify port is available and firewall allows access
+```bash
+# Check port availability
+lsof -i :9999
+```
+
+## Related Documentation
+
+- [MCP Client Integration](mcp.md) - Connect to external MCP servers
+- [Toolkit Guide](../guide/toolkit.md) - Tool registration and management
+- [ReActAgent Guide](../guide/react-agent.md) - Agent implementation
+- [MCP Native Example README](../../examples/mcp-native-example/README.md) - Complete working example source

--- a/docs/en/task/tool.md
+++ b/docs/en/task/tool.md
@@ -27,6 +27,27 @@ public class WeatherService {
 
 > **Note**: The `name` attribute of `@ToolParam` is required because Java doesn't preserve parameter names by default.
 
+### Strict Mode
+
+`strict` controls whether model providers that support strict schema enforcement should strictly follow
+the tool parameter schema.
+
+```java
+public class WeatherService {
+    @Tool(name = "get_weather", description = "Get weather", strict = true)
+    public String getWeather(
+            @ToolParam(name = "city", description = "City name") String city) {
+        return city + " weather: Sunny, 25°C";
+    }
+}
+```
+
+When strict mode is configured, AgentScope preserves and propagates it consistently through:
+
+- `@Tool(..., strict = true)` annotation-based registration
+- `AgentTool` interface implementations (via `getStrict()`)
+- `Toolkit#registerSchema(...)` and `Toolkit#registerSchemas(...)`
+
 ### Register and Use
 
 ```java
@@ -262,6 +283,9 @@ public class CustomTool implements AgentTool {
     }
 
     @Override
+    public Boolean getStrict() { return true; }
+
+    @Override
     public Mono<ToolResultBlock> callAsync(ToolCallParam param) {
         String query = (String) param.getInput().get("query");
         return Mono.just(ToolResultBlock.text("Result: " + query));
@@ -361,6 +385,7 @@ ToolSchema schema = ToolSchema.builder()
         "properties", Map.of("sql", Map.of("type", "string")),
         "required", List.of("sql")
     ))
+    .strict(true)
     .build();
 
 toolkit.registerSchema(schema);

--- a/docs/zh/task/tool.md
+++ b/docs/zh/task/tool.md
@@ -27,6 +27,26 @@ public class WeatherService {
 
 > **注意**：`@ToolParam` 的 `name` 属性必须指定，因为 Java 默认不保留参数名。
 
+### 严格模式（Strict Mode）
+
+`strict` 用于控制支持严格 Schema 检查的模型提供商是否应严格遵循工具参数 Schema。
+
+```java
+public class WeatherService {
+    @Tool(name = "get_weather", description = "获取天气", strict = true)
+    public String getWeather(
+            @ToolParam(name = "city", description = "城市名称") String city) {
+        return city + " 的天气：晴天，25°C";
+    }
+}
+```
+
+配置了严格模式后，AgentScope 在以下所有路径中保留并传播严格模式配置：
+
+- `@Tool(..., strict = true)` 注解驱动的工具注册
+- `AgentTool` 接口实现（通过 `getStrict()` 方法）
+- `Toolkit#registerSchema(...)` 和 `Toolkit#registerSchemas(...)` 方式
+
 ### 注册和使用
 
 ```java
@@ -262,6 +282,9 @@ public class CustomTool implements AgentTool {
     }
 
     @Override
+    public Boolean getStrict() { return true; }
+
+    @Override
     public Mono<ToolResultBlock> callAsync(ToolCallParam param) {
         String query = (String) param.getInput().get("query");
         return Mono.just(ToolResultBlock.text("结果：" + query));
@@ -360,6 +383,7 @@ ToolSchema schema = ToolSchema.builder()
         "properties", Map.of("sql", Map.of("type", "string")),
         "required", List.of("sql")
     ))
+    .strict(true)
     .build();
 
 toolkit.registerSchema(schema);


### PR DESCRIPTION
## AgentScope-Java Version

1.0.12-SNAPSHOT

## Description
Adds native MCP server support to AgentScope Java, enabling developers to build and expose custom tool servers via the Model Context Protocol.
Includes complete implementation with StdIO/TCP transports, tool registry, protocol handlers, and a working calculator example with CLI agent integration. 
Resolves #229

### Background
AgentScope Java previously only supported MCP client integration (connecting to external MCP servers). This PR adds native MCP server support, enabling developers to build and expose their own tool servers via the Model Context Protocol.

### Purpose
Enable AgentScope Java applications to:
- Implement custom domain-specific tool servers
- Expose tools to external clients (Claude, VSCode extensions, other agents)
- Follow MCP protocol standards (JSON-RPC 2.0)
- Support multiple transport options (StdIO, TCP)

### Changes Made

**Core Implementation** (`agentscope-core/src/main/java/io/agentscope/core/mcp/`)
- `Tool` interface: Server-side tool abstraction with execute(), getName(), getDescription(), getInputSchema()
- `ToolManager`: Thread-safe concurrent registry for tool management
- `InitializeHandler`: Implements MCP initialize handshake
- `ListToolsHandler`: Implements tools/list discovery endpoint
- `CallToolHandler`: Implements tools/call execution endpoint
- `StdioTransport`: JSON-RPC communication via stdin/stdout
- `TcpTransport`: Network-based JSON-RPC communication
- `McpServer`: Main facade for server creation and tool registration

**Example Module** (`agentscope-examples/mcp-native-example/`)
- `CalculatorTool`: MCP tool implementing arithmetic operations (add, subtract, multiply, divide)
- `McpServerRunner`: Standalone MCP server exposing calculator tools
- `ReActAgentCliRunner`: Interactive CLI agent integrating calculator tools via toolkit
- `CalculatorToolAdapter`: AgentScope @Tool annotation adapter with logging
- Unit tests and fat JAR build configuration

**Documentation** (`docs/en/task/mcp-native.md`)
- 500+ line comprehensive guide covering server concepts, tool implementation, protocol details, transport configuration, and integration patterns
- Complete working examples with code snippets
- Best practices and troubleshooting guide

### How to Test

1. **Build the modules:**
   ```bash
   mvn clean install -pl agentscope-core,agentscope-examples/mcp-native-example
   ```

2. **Run MCP Server (StdIO):**
   ```bash
   java -jar agentscope-examples/mcp-native-example/target/mcp-native-example.jar
   ```

3. **Run Interactive CLI Agent:**
   ```bash
   OPENAI_API_KEY="sk-..." java -cp agentscope-examples/mcp-native-example/target/mcp-native-example.jar \
       io.agentscope.examples.mcp.ReActAgentCliRunner
   ```

4. **Test with queries:**
   - "What is 100 + 398*69 + 29223*55?"
   - "Calculate 2^10"
   - "Add 15.5 and 24.7"

5. **Run unit tests:**
   ```bash
   mvn test -pl agentscope-core,agentscope-examples/mcp-native-example
   ```

## Checklist

- [x] Code has been formatted with `mvn spotless:apply`
- [x] All tests are passing (`mvn test`)
- [x] Javadoc comments are complete and follow project conventions
- [x] Related documentation has been updated (docs/en/task/mcp-native.md, README.md)
- [x] Code is ready for review
```