### PR TITLE
feat(core): Support return_direct tool call

### DIFF
--- a/agentscope-core/src/main/java/io/agentscope/core/ReActAgent.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/ReActAgent.java
@@ -724,6 +724,19 @@ public class ReActAgent extends StructuredOutputCapableAgent {
                                                             buildSuspendedMsg(pendingPairs));
                                                 }
 
+                                                // Return directly: if any tool result has
+                                                // return_directly flag, breaking iterations
+                                                boolean hasReturnDirect =
+                                                        successPairs.stream()
+                                                                .anyMatch(
+                                                                        entry ->
+                                                                                entry.getValue()
+                                                                                        .isReturnDirect());
+                                                if (hasReturnDirect) {
+                                                    return Mono.just(
+                                                            buildReturnDirectMsg(successPairs));
+                                                }
+
                                                 // Continue next iteration
                                                 return executeIteration(iter + 1);
                                             });
@@ -751,6 +764,28 @@ public class ReActAgent extends StructuredOutputCapableAgent {
                 .content(content)
                 .generateReason(GenerateReason.TOOL_SUSPENDED)
                 .build();
+    }
+
+    /**
+     * Build a return_direct message from tool results.
+     *
+     * @param successPairs List of (ToolUseBlock, ToolResultBlock) pairs for successful results
+     * @return Msg with {@link GenerateReason#TOOL_RETURN_DIRECT}
+     */
+    private Msg buildReturnDirectMsg(List<Map.Entry<ToolUseBlock, ToolResultBlock>> successPairs) {
+        List<ContentBlock> content = new ArrayList<>();
+        for (Map.Entry<ToolUseBlock, ToolResultBlock> pair : successPairs) {
+            content.addAll(pair.getValue().getOutput());
+        }
+        Msg returnDirectMsg =
+                Msg.builder()
+                        .name(getName())
+                        .role(MsgRole.ASSISTANT)
+                        .content(content)
+                        .generateReason(GenerateReason.TOOL_RETURN_DIRECT)
+                        .build();
+        memory.addMessage(returnDirectMsg);
+        return returnDirectMsg;
     }
 
     /**

--- a/agentscope-core/src/main/java/io/agentscope/core/message/GenerateReason.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/message/GenerateReason.java
@@ -47,6 +47,9 @@ public enum GenerateReason {
     /** Tool execution was suspended, waiting for user to provide results. */
     TOOL_SUSPENDED,
 
+    /** Tool result marked with return_directly, breaking ReAct iterations. */
+    TOOL_RETURN_DIRECT,
+
     /** Reasoning phase was stopped by a Hook (PostReasoningEvent.stopAgent()). */
     REASONING_STOP_REQUESTED,
 

--- a/agentscope-core/src/main/java/io/agentscope/core/message/Msg.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/message/Msg.java
@@ -453,7 +453,10 @@ public class Msg implements State {
      * <p>This method helps users understand the context of agent execution:
      * <ul>
      *   <li>{@link GenerateReason#MODEL_STOP} - Task completed normally</li>
+     *   <li>{@link GenerateReason#TOOL_CALLS} - Model returned tool calls (internal tools)</li>
+     *   <li>{@link GenerateReason#STRUCTURED_OUTPUT} - Structured output completed</li>
      *   <li>{@link GenerateReason#TOOL_SUSPENDED} - External tools need user execution</li>
+     *   <li>{@link GenerateReason#TOOL_RETURN_DIRECT} - Tool result marked return_direct</li>
      *   <li>{@link GenerateReason#REASONING_STOP_REQUESTED} - HITL stop in reasoning phase</li>
      *   <li>{@link GenerateReason#ACTING_STOP_REQUESTED} - HITL stop in acting phase</li>
      *   <li>{@link GenerateReason#INTERRUPTED} - Agent was interrupted</li>

--- a/agentscope-core/src/main/java/io/agentscope/core/message/ToolResultBlock.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/message/ToolResultBlock.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.agentscope.core.tool.ToolSuspendException;
 import java.beans.Transient;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -36,6 +37,9 @@ public final class ToolResultBlock extends ContentBlock {
 
     /** Metadata key indicating this result is suspended for external execution. */
     public static final String METADATA_SUSPENDED = "agentscope_suspended";
+
+    /** Metadata key indicating this result should be returned directly, breaking ReAct iterations. */
+    public static final String METADATA_RETURN_DIRECT = "agentscope_return_direct";
 
     private final String id;
     private final String name;
@@ -124,6 +128,20 @@ public final class ToolResultBlock extends ContentBlock {
     @JsonInclude
     public boolean isSuspended() {
         return Boolean.TRUE.equals(metadata.get(METADATA_SUSPENDED));
+    }
+
+    /**
+     * Checks if this result should be returned directly, breaking ReAct iterations.
+     *
+     * <p>When true, the agent will return this tool result as the final response immediately
+     * without sending it back to the model for additional reasoning.
+     *
+     * @return true if this result should be returned directly
+     */
+    @Transient
+    @JsonInclude
+    public boolean isReturnDirect() {
+        return Boolean.TRUE.equals(metadata.get(METADATA_RETURN_DIRECT));
     }
 
     /**
@@ -287,6 +305,17 @@ public final class ToolResultBlock extends ContentBlock {
      */
     public ToolResultBlock withIdAndName(String id, String name) {
         return new ToolResultBlock(id, name, this.output, this.metadata);
+    }
+
+    /**
+     * Creates a new ToolResultBlock with the return_directly metadata flag set.
+     *
+     * @return A ToolResultBlock with agentscope_return_directly=true
+     */
+    public ToolResultBlock withReturnDirect() {
+        Map<String, Object> newMetadata = new HashMap<>(this.metadata);
+        newMetadata.put(METADATA_RETURN_DIRECT, true);
+        return of(this.id, this.name, this.output, newMetadata);
     }
 
     /**

--- a/agentscope-core/src/main/java/io/agentscope/core/tool/AgentTool.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/tool/AgentTool.java
@@ -101,6 +101,19 @@ public interface AgentTool {
     }
 
     /**
+     * Whether this tool's result should be returned directly, breaking ReAct iterations.
+     *
+     * <p>When {@code true}, after this tool executes successfully, the agent returns the tool
+     * result as the final response without sending it back to the model for additional reasoning.
+     * This corresponds to the {@code returnDirect} attribute on the {@link Tool @Tool} annotation.
+     *
+     * @return true if this tool's result should be returned directly, false by default
+     */
+    default boolean isReturnDirect() {
+        return false;
+    }
+
+    /**
      * Execute the tool with the given parameters (asynchronous).
      *
      * <p>This method accepts a {@link ToolCallParam} object containing all necessary context for

--- a/agentscope-core/src/main/java/io/agentscope/core/tool/Tool.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/tool/Tool.java
@@ -97,6 +97,17 @@ public @interface Tool {
     boolean strict() default false;
 
     /**
+     * Whether this tool's result should be returned directly to the caller, breaking ReAct loop iterations.
+     *
+     * <p>When {@code true}, after this tool executes successfully, the agent will return the tool
+     * result as the final response immediately — without sending it back to the model for
+     * additional reasoning.
+     *
+     * @return true to enable return directly for this tool
+     */
+    boolean returnDirect() default false;
+
+    /**
      * Custom result converter for this tool.
      *
      * <p>Converters transform tool method return values into {@link io.agentscope.core.message.ToolResultBlock}

--- a/agentscope-core/src/main/java/io/agentscope/core/tool/ToolExecutor.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/tool/ToolExecutor.java
@@ -242,6 +242,13 @@ class ToolExecutor {
                         .build();
 
         return tool.callAsync(executionParam)
+                .map(
+                        result -> {
+                            if (tool.isReturnDirect()) {
+                                return result.withReturnDirect();
+                            }
+                            return result;
+                        })
                 .onErrorResume(
                         ToolSuspendException.class,
                         e -> {

--- a/agentscope-core/src/main/java/io/agentscope/core/tool/Toolkit.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/tool/Toolkit.java
@@ -382,6 +382,11 @@ public class Toolkit {
                     }
 
                     @Override
+                    public boolean isReturnDirect() {
+                        return toolAnnotation.returnDirect();
+                    }
+
+                    @Override
                     public Mono<ToolResultBlock> callAsync(ToolCallParam param) {
                         // Pass custom converter to method invoker
                         return methodInvoker.invokeAsync(

--- a/agentscope-core/src/test/java/io/agentscope/core/agent/ReActAgentTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/agent/ReActAgentTest.java
@@ -314,6 +314,170 @@ class ReActAgentTest {
     }
 
     @Test
+    @DisplayName("Should return tool result directly when tool is marked as returnDirect")
+    void testToolCallingReturnDirect() {
+        // Register a returnDirect tool
+        mockToolkit.withReturnDirectTool(
+                TestConstants.RETURN_DIRECT_TOOL_NAME, "ReturnDirect tool result");
+
+        final int[] callCount = {0};
+        MockModel toolModel =
+                new MockModel(
+                        messages -> {
+                            int currentCall = callCount[0]++;
+                            if (currentCall == 0) {
+                                // Return tool call for the returnDirect tool
+                                return List.of(
+                                        createToolCallResponseHelper(
+                                                TestConstants.RETURN_DIRECT_TOOL_NAME,
+                                                "tool_call_return_direct_1",
+                                                TestUtils.createToolArguments()));
+                            }
+                            // This should never be reached because returnDirect breaks the loop
+                            return List.of(
+                                    ChatResponse.builder()
+                                            .content(
+                                                    List.of(
+                                                            TextBlock.builder()
+                                                                    .text("Should not reach this")
+                                                                    .build()))
+                                            .usage(new ChatUsage(10, 20, 30))
+                                            .build());
+                        });
+
+        agent =
+                ReActAgent.builder()
+                        .name(TestConstants.TEST_REACT_AGENT_NAME)
+                        .sysPrompt(TestConstants.DEFAULT_SYS_PROMPT)
+                        .model(toolModel)
+                        .toolkit(mockToolkit)
+                        .memory(memory)
+                        .build();
+
+        Msg userMsg = TestUtils.createUserMessage("User", "Call the returnDirect tool");
+        Msg response =
+                agent.call(userMsg).block(Duration.ofMillis(TestConstants.DEFAULT_TEST_TIMEOUT_MS));
+
+        // Verify response
+        assertNotNull(response, "Response should not be null");
+        assertEquals(
+                GenerateReason.TOOL_RETURN_DIRECT,
+                response.getGenerateReason(),
+                "GenerateReason should be TOOL_RETURN_DIRECT");
+
+        // Verify the response contains the tool result content
+        String text = TestUtils.extractTextContent(response);
+        assertTrue(
+                text.contains("ReturnDirect tool result"),
+                "Response should contain the return direct tool result");
+
+        // Verify the model was called only once (no second reasoning iteration)
+        assertEquals(1, toolModel.getCallCount(), "Model should be called only once");
+
+        // Verify tool was called
+        assertTrue(
+                mockToolkit.wasToolCalled(TestConstants.RETURN_DIRECT_TOOL_NAME),
+                "ReturnDirect tool should be called");
+    }
+
+    @Test
+    @DisplayName(
+            "Should return multiple tool results directly when a tool is marked as returnDirect")
+    void testMultipleToolCallingReturnDirect() {
+        mockToolkit.withTool(TestConstants.TEST_TOOL_NAME, "Test tool result");
+        mockToolkit.withReturnDirectTool(
+                TestConstants.RETURN_DIRECT_TOOL_NAME, "ReturnDirect tool result");
+
+        final int[] callCount = {0};
+        MockModel toolModel =
+                new MockModel(
+                        messages -> {
+                            int currentCall = callCount[0]++;
+                            if (currentCall == 0) {
+                                Map<String, Object> args1 = new HashMap<>();
+                                args1.put("param1", "value1");
+                                Map<String, Object> args2 = new HashMap<>();
+                                args2.put("param2", "value2");
+                                return List.of(
+                                        ChatResponse.builder()
+                                                .content(
+                                                        List.of(
+                                                                ToolUseBlock.builder()
+                                                                        .id("tool_call_1")
+                                                                        .name(
+                                                                                TestConstants
+                                                                                        .TEST_TOOL_NAME)
+                                                                        .input(args1)
+                                                                        .content(
+                                                                                JsonUtils
+                                                                                        .getJsonCodec()
+                                                                                        .toJson(
+                                                                                                args1))
+                                                                        .build(),
+                                                                ToolUseBlock.builder()
+                                                                        .id(
+                                                                                "tool_call_return_direct_1")
+                                                                        .name(
+                                                                                TestConstants
+                                                                                        .RETURN_DIRECT_TOOL_NAME)
+                                                                        .input(args2)
+                                                                        .content(
+                                                                                JsonUtils
+                                                                                        .getJsonCodec()
+                                                                                        .toJson(
+                                                                                                args2))
+                                                                        .build()))
+                                                .usage(new ChatUsage(10, 20, 30))
+                                                .build());
+                            }
+                            return List.of(
+                                    ChatResponse.builder()
+                                            .content(
+                                                    List.of(
+                                                            TextBlock.builder()
+                                                                    .text("Should not reach this")
+                                                                    .build()))
+                                            .usage(new ChatUsage(10, 20, 30))
+                                            .build());
+                        });
+
+        agent =
+                ReActAgent.builder()
+                        .name(TestConstants.TEST_REACT_AGENT_NAME)
+                        .sysPrompt(TestConstants.DEFAULT_SYS_PROMPT)
+                        .model(toolModel)
+                        .toolkit(mockToolkit)
+                        .memory(memory)
+                        .build();
+
+        Msg userMsg = TestUtils.createUserMessage("User", "Call multiple returnDirect tools");
+        Msg response =
+                agent.call(userMsg).block(Duration.ofMillis(TestConstants.DEFAULT_TEST_TIMEOUT_MS));
+
+        assertNotNull(response, "Response should not be null");
+        assertEquals(
+                GenerateReason.TOOL_RETURN_DIRECT,
+                response.getGenerateReason(),
+                "GenerateReason should be TOOL_RETURN_DIRECT");
+
+        String text = TestUtils.extractTextContent(response);
+        assertTrue(text.contains("Test tool result"), "Response should contain test tool result");
+        assertTrue(
+                text.contains("ReturnDirect tool result"),
+                "Response should contain return direct tool result");
+
+        assertEquals(1, toolModel.getCallCount(), "Model should be called only once");
+
+        assertTrue(
+                mockToolkit.wasToolCalled(TestConstants.TEST_TOOL_NAME),
+                "Test tool should be called");
+        assertTrue(
+                mockToolkit.wasToolCalled(TestConstants.RETURN_DIRECT_TOOL_NAME),
+                "ReturnDirect tool should be called");
+        assertEquals(2, mockToolkit.getCallCount(), "Two tools should be called");
+    }
+
+    @Test
     @DisplayName("Should handle tool execution errors in acting phase")
     void testToolExecutionError() {
         // Register a tool that throws an error

--- a/agentscope-core/src/test/java/io/agentscope/core/agent/test/MockToolkit.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/agent/test/MockToolkit.java
@@ -65,6 +65,15 @@ public class MockToolkit extends Toolkit {
     }
 
     /**
+     * Register a tool that returns its result directly (breaking ReAct loop).
+     */
+    public MockToolkit withReturnDirectTool(String toolName, String result) {
+        toolBehaviors.put(toolName, args -> result);
+        registerMockTool(toolName, "Mock returnDirect tool: " + toolName, true);
+        return this;
+    }
+
+    /**
      * Register a tool that throws an error.
      */
     public MockToolkit withErrorTool(String toolName, String errorMessage) {
@@ -117,6 +126,13 @@ public class MockToolkit extends Toolkit {
      * Register a mock tool with the toolkit.
      */
     private void registerMockTool(String name, String description) {
+        registerMockTool(name, description, false);
+    }
+
+    /**
+     * Register a mock tool with the toolkit, optionally marking it as returnDirect.
+     */
+    private void registerMockTool(String name, String description, boolean returnDirect) {
         AgentTool tool =
                 new AgentTool() {
                     @Override
@@ -135,6 +151,11 @@ public class MockToolkit extends Toolkit {
                         schema.put("type", "object");
                         schema.put("properties", new HashMap<String, Object>());
                         return schema;
+                    }
+
+                    @Override
+                    public boolean isReturnDirect() {
+                        return returnDirect;
                     }
 
                     @Override

--- a/agentscope-core/src/test/java/io/agentscope/core/agent/test/TestConstants.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/agent/test/TestConstants.java
@@ -42,6 +42,7 @@ public class TestConstants {
     public static final String TEST_TOOL_NAME = "test_tool";
     public static final String CALCULATOR_TOOL_NAME = "calculator";
     public static final String FINISH_TOOL_NAME = "generate_response";
+    public static final String RETURN_DIRECT_TOOL_NAME = "return_direct_tool";
 
     // Timeouts
     public static final long DEFAULT_TEST_TIMEOUT_MS = 5000L;

--- a/agentscope-core/src/test/java/io/agentscope/core/message/GenerateReasonTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/message/GenerateReasonTest.java
@@ -35,13 +35,14 @@ class GenerateReasonTest {
     @DisplayName("Should have all expected enum values")
     void testEnumValues() {
         GenerateReason[] values = GenerateReason.values();
-        assertEquals(8, values.length);
+        assertEquals(9, values.length);
 
         // Verify all expected values exist
         assertNotNull(GenerateReason.MODEL_STOP);
         assertNotNull(GenerateReason.TOOL_CALLS);
         assertNotNull(GenerateReason.STRUCTURED_OUTPUT);
         assertNotNull(GenerateReason.TOOL_SUSPENDED);
+        assertNotNull(GenerateReason.TOOL_RETURN_DIRECT);
         assertNotNull(GenerateReason.REASONING_STOP_REQUESTED);
         assertNotNull(GenerateReason.ACTING_STOP_REQUESTED);
         assertNotNull(GenerateReason.INTERRUPTED);


### PR DESCRIPTION
## AgentScope-Java Version

1.1.0

## Description

* Support return_direct for agent tool call to breaking ReAct loop iterations and return the tool result immediately.
* Closes: #1408 

## Checklist

Please check the following items before code is ready to be reviewed.

- [x]  Code has been formatted with `mvn spotless:apply`
- [x]  All tests are passing (`mvn test`)
- [x]  Javadoc comments are complete and follow project conventions
- [x]  Related documentation has been updated (e.g. links, examples, etc.)
- [x]  Code is ready for review
