### PR TITLE
feat(core): add AgentEvent system + Middleware framework + event stream refactoring

### DIFF
--- a/agentscope-core/src/main/java/io/agentscope/core/ReActAgent.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/ReActAgent.java
@@ -21,6 +21,25 @@ import io.agentscope.core.agent.RuntimeContext;
 import io.agentscope.core.agent.StreamOptions;
 import io.agentscope.core.agent.StructuredOutputCapableAgent;
 import io.agentscope.core.agent.accumulator.ReasoningContext;
+import io.agentscope.core.event.AgentEvent;
+import io.agentscope.core.event.ExceedMaxItersEvent;
+import io.agentscope.core.event.ModelCallEndEvent;
+import io.agentscope.core.event.ModelCallStartEvent;
+import io.agentscope.core.event.ReplyEndEvent;
+import io.agentscope.core.event.ReplyStartEvent;
+import io.agentscope.core.event.TextBlockDeltaEvent;
+import io.agentscope.core.event.TextBlockEndEvent;
+import io.agentscope.core.event.TextBlockStartEvent;
+import io.agentscope.core.event.ThinkingBlockDeltaEvent;
+import io.agentscope.core.event.ThinkingBlockEndEvent;
+import io.agentscope.core.event.ThinkingBlockStartEvent;
+import io.agentscope.core.event.ToolCallDeltaEvent;
+import io.agentscope.core.event.ToolCallEndEvent;
+import io.agentscope.core.event.ToolCallStartEvent;
+import io.agentscope.core.event.ToolResultDataDeltaEvent;
+import io.agentscope.core.event.ToolResultEndEvent;
+import io.agentscope.core.event.ToolResultStartEvent;
+import io.agentscope.core.event.ToolResultTextDeltaEvent;
 import io.agentscope.core.hook.ActingChunkEvent;
 import io.agentscope.core.hook.Hook;
 import io.agentscope.core.hook.HookEvent;
@@ -49,11 +68,19 @@ import io.agentscope.core.message.MsgRole;
 import io.agentscope.core.message.TextBlock;
 import io.agentscope.core.message.ThinkingBlock;
 import io.agentscope.core.message.ToolResultBlock;
+import io.agentscope.core.message.ToolResultState;
 import io.agentscope.core.message.ToolUseBlock;
+import io.agentscope.core.middleware.ActingInput;
+import io.agentscope.core.middleware.Middleware;
+import io.agentscope.core.middleware.MiddlewareChain;
+import io.agentscope.core.middleware.ModelCallInput;
+import io.agentscope.core.middleware.ReasoningInput;
+import io.agentscope.core.middleware.ReplyInput;
 import io.agentscope.core.model.ExecutionConfig;
 import io.agentscope.core.model.GenerateOptions;
 import io.agentscope.core.model.Model;
 import io.agentscope.core.model.StructuredOutputReminder;
+import io.agentscope.core.model.ToolSchema;
 import io.agentscope.core.plan.PlanNotebook;
 import io.agentscope.core.rag.GenericRAGHook;
 import io.agentscope.core.rag.Knowledge;
@@ -83,11 +110,17 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import reactor.core.publisher.Flux;
+import reactor.core.publisher.FluxSink;
 import reactor.core.publisher.Mono;
 
 /**
@@ -155,6 +188,7 @@ public class ReActAgent extends StructuredOutputCapableAgent {
     private final PlanNotebook planNotebook;
     private final ToolExecutionContext toolExecutionContext;
     private final StatePersistence statePersistence;
+    private final List<Middleware> middlewares;
     private RuntimeContext pendingRuntimeContext;
 
     /**
@@ -166,6 +200,8 @@ public class ReActAgent extends StructuredOutputCapableAgent {
      */
     private final java.util.concurrent.atomic.AtomicReference<Msg> currentSystemMsg =
             new java.util.concurrent.atomic.AtomicReference<>();
+
+    private final AtomicReference<FluxSink<AgentEvent>> activeEventSink = new AtomicReference<>();
 
     // ==================== Constructor ====================
 
@@ -191,6 +227,7 @@ public class ReActAgent extends StructuredOutputCapableAgent {
                 builder.statePersistence != null
                         ? builder.statePersistence
                         : StatePersistence.all();
+        this.middlewares = List.copyOf(builder.middlewares);
     }
 
     // ==================== RuntimeContext ====================
@@ -209,14 +246,26 @@ public class ReActAgent extends StructuredOutputCapableAgent {
 
     @Override
     protected Msg seedSystemMsg() {
-        if (sysPrompt != null && !sysPrompt.trim().isEmpty()) {
-            return Msg.builder()
-                    .name("system")
-                    .role(MsgRole.SYSTEM)
-                    .content(TextBlock.builder().text(sysPrompt).build())
-                    .build();
+        if (sysPrompt == null || sysPrompt.trim().isEmpty()) {
+            return null;
         }
-        return null;
+        String prompt = applySystemPromptMiddlewares(sysPrompt);
+        return Msg.builder()
+                .name("system")
+                .role(MsgRole.SYSTEM)
+                .content(TextBlock.builder().text(prompt).build())
+                .build();
+    }
+
+    private String applySystemPromptMiddlewares(String prompt) {
+        if (middlewares.isEmpty()) {
+            return prompt;
+        }
+        Mono<String> result = Mono.just(prompt);
+        for (Middleware mw : middlewares) {
+            result = result.flatMap(p -> mw.onSystemPrompt(this, p));
+        }
+        return result.block();
     }
 
     @Override
@@ -276,6 +325,46 @@ public class ReActAgent extends StructuredOutputCapableAgent {
             List<Msg> msgs, StreamOptions options, JsonNode schema, RuntimeContext context) {
         this.pendingRuntimeContext = context;
         return stream(msgs, options, schema);
+    }
+
+    /**
+     * Stream fine-grained {@link AgentEvent}s from the full agent lifecycle.
+     *
+     * <p>This method goes through the same lifecycle as {@code call()} (acquire execution,
+     * hooks, pre/post call notification) but exposes the internal event stream. The lifecycle
+     * is driven by {@code call()} internally; events are captured via the shared
+     * {@code activeEventSink}.
+     *
+     * @param msgs input messages
+     * @return event stream covering the full reply lifecycle
+     */
+    public Flux<AgentEvent> streamEvents(List<Msg> msgs) {
+        String replyId = UUID.randomUUID().toString().replace("-", "");
+        return Flux.<AgentEvent>create(
+                        sink -> {
+                            activeEventSink.set(sink);
+                            sink.next(new ReplyStartEvent(null, replyId, getName()));
+                            call(msgs)
+                                    .doFinally(
+                                            signal -> {
+                                                sink.next(new ReplyEndEvent(replyId));
+                                                activeEventSink.set(null);
+                                                sink.complete();
+                                            })
+                                    .subscribe(finalMsg -> {}, sink::error);
+                        },
+                        FluxSink.OverflowStrategy.BUFFER)
+                .doOnError(e -> activeEventSink.set(null));
+    }
+
+    /**
+     * Stream fine-grained {@link AgentEvent}s for a single input message.
+     *
+     * @param msg input message
+     * @return event stream covering the full reply lifecycle
+     */
+    public Flux<AgentEvent> streamEvents(Msg msg) {
+        return streamEvents(List.of(msg));
     }
 
     // ==================== New StateModule API ====================
@@ -395,6 +484,52 @@ public class ReActAgent extends StructuredOutputCapableAgent {
                         + "Enable PendingToolRecoveryHook or provide tool results. "
                         + "Pending IDs: "
                         + pendingIds);
+    }
+
+    /**
+     * Execute the full reply as a {@link Flux} of fine-grained {@link AgentEvent}s.
+     *
+     * <p>This method wraps the existing {@code doCall()} logic and captures all events emitted
+     * by the internal stream methods ({@code reasoningStream}, {@code actingStream},
+     * {@code summaryStream}). The stream is bookended by {@link ReplyStartEvent} and
+     * {@link ReplyEndEvent}.
+     *
+     * @param msgs the input messages
+     * @return event stream covering the full reply lifecycle
+     */
+    Flux<AgentEvent> replyImpl(List<Msg> msgs) {
+        String replyId = UUID.randomUUID().toString().replace("-", "");
+
+        Function<ReplyInput, Flux<AgentEvent>> core =
+                input ->
+                        Flux.<AgentEvent>create(
+                                        sink -> {
+                                            activeEventSink.set(sink);
+                                            sink.next(
+                                                    new ReplyStartEvent(null, replyId, getName()));
+
+                                            doCall(input.msgs())
+                                                    .doFinally(
+                                                            signal -> {
+                                                                sink.next(
+                                                                        new ReplyEndEvent(replyId));
+                                                                activeEventSink.set(null);
+                                                                sink.complete();
+                                                            })
+                                                    .subscribe(finalMsg -> {}, sink::error);
+                                        },
+                                        FluxSink.OverflowStrategy.BUFFER)
+                                .doOnError(e -> activeEventSink.set(null));
+
+        return MiddlewareChain.build(middlewares, this, Middleware::onReply, core)
+                .apply(new ReplyInput(msgs));
+    }
+
+    private void publishEvent(AgentEvent event) {
+        FluxSink<AgentEvent> sink = activeEventSink.get();
+        if (sink != null) {
+            sink.next(event);
+        }
     }
 
     /**
@@ -567,7 +702,7 @@ public class ReActAgent extends StructuredOutputCapableAgent {
 
         return checkInterruptedAsync()
                 .then(notifyPreReasoningEvent(memory.getMessages()))
-                .flatMapMany(
+                .flatMap(
                         event -> {
                             GenerateOptions options =
                                     event.getEffectiveGenerateOptions() != null
@@ -576,18 +711,25 @@ public class ReActAgent extends StructuredOutputCapableAgent {
                             List<Msg> modelInput =
                                     prependSystemMsg(
                                             event.getInputMessages(), event.getSystemMessage());
-                            return model.stream(modelInput, toolkit.getToolSchemas(), options)
-                                    .concatMap(chunk -> checkInterruptedAsync().thenReturn(chunk));
+                            List<ToolSchema> tools = toolkit.getToolSchemas();
+                            Function<ReasoningInput, Flux<AgentEvent>> reasoningCore =
+                                    ri ->
+                                            reasoningStream(
+                                                    context,
+                                                    ri.messages(),
+                                                    ri.tools(),
+                                                    ri.options());
+                            Flux<AgentEvent> stream =
+                                    MiddlewareChain.build(
+                                                    middlewares,
+                                                    ReActAgent.this,
+                                                    Middleware::onReasoning,
+                                                    reasoningCore)
+                                            .apply(new ReasoningInput(modelInput, tools, options));
+                            return stream.then(
+                                    Mono.defer(
+                                            () -> Mono.justOrEmpty(context.buildFinalMessage())));
                         })
-                .doOnNext(
-                        chunk -> {
-                            List<Msg> chunkMsgs = context.processChunk(chunk);
-                            // Notify streaming hooks for each chunk message
-                            for (Msg msg : chunkMsgs) {
-                                notifyReasoningChunk(msg, context).subscribe();
-                            }
-                        })
-                .then(Mono.defer(() -> Mono.justOrEmpty(context.buildFinalMessage())))
                 .onErrorResume(
                         InterruptedException.class,
                         error -> {
@@ -599,8 +741,6 @@ public class ReActAgent extends StructuredOutputCapableAgent {
                                                                 .getConfig()
                                                                 .partialReasoningPolicy()
                                                         == PartialReasoningPolicy.DISCARD;
-                                // Manually interruption will save the msg, while system
-                                // interruption will discard on specific config
                                 if (!discard) {
                                     memory.addMessage(msg);
                                 }
@@ -624,12 +764,10 @@ public class ReActAgent extends StructuredOutputCapableAgent {
 
                             // gotoReasoning requested (e.g., by StructuredOutputHook)
                             if (event.isGotoReasoningRequested()) {
-                                // Validation already done in PostReasoningEvent.gotoReasoning()
                                 List<Msg> gotoMsgs = event.getGotoReasoningMsgs();
                                 if (gotoMsgs != null) {
                                     gotoMsgs.forEach(memory::addMessage);
                                 }
-                                // Continue to next iteration, ignoring maxIters for this entry
                                 return reasoning(iter + 1, true);
                             }
 
@@ -650,6 +788,134 @@ public class ReActAgent extends StructuredOutputCapableAgent {
     }
 
     /**
+     * Stream fine-grained {@link AgentEvent}s from a model call during reasoning.
+     *
+     * <p>Emits: {@link ModelCallStartEvent} → block start/delta/end events → {@link
+     * ModelCallEndEvent}. The provided {@link ReasoningContext} is used to accumulate chunks
+     * (for building the final {@link Msg}) and to notify legacy {@link Hook}s.
+     *
+     * @param context   reasoning context for chunk accumulation
+     * @param messages  the messages to send to the model
+     * @param tools     the tool schemas available
+     * @param options   generation options
+     * @return event stream from a single model call
+     */
+    Flux<AgentEvent> reasoningStream(
+            ReasoningContext context,
+            List<Msg> messages,
+            List<ToolSchema> tools,
+            GenerateOptions options) {
+
+        Function<ModelCallInput, Flux<AgentEvent>> modelCallCore =
+                mci -> modelCallStream(context, mci, true);
+
+        return MiddlewareChain.build(middlewares, this, Middleware::onModelCall, modelCallCore)
+                .apply(new ModelCallInput(messages, tools, options, model))
+                .doOnNext(this::publishEvent);
+    }
+
+    private Flux<AgentEvent> modelCallStream(
+            ReasoningContext context, ModelCallInput mci, boolean withToolEvents) {
+
+        String replyId = UUID.randomUUID().toString().replace("-", "");
+        AtomicBoolean textStarted = new AtomicBoolean(false);
+        AtomicBoolean thinkingStarted = new AtomicBoolean(false);
+        Set<String> startedToolCalls = ConcurrentHashMap.newKeySet();
+
+        Flux<AgentEvent> modelEvents =
+                mci.model().stream(mci.messages(), mci.tools(), mci.options())
+                        .concatMap(chunk -> checkInterruptedAsync().thenReturn(chunk))
+                        .concatMap(
+                                chunk -> {
+                                    List<Msg> chunkMsgs = context.processChunk(chunk);
+                                    for (Msg msg : chunkMsgs) {
+                                        notifyReasoningChunk(msg, context).subscribe();
+                                    }
+
+                                    List<AgentEvent> events = new ArrayList<>();
+                                    for (ContentBlock block : chunk.getContent()) {
+                                        emitBlockEvents(
+                                                block,
+                                                replyId,
+                                                context,
+                                                textStarted,
+                                                thinkingStarted,
+                                                withToolEvents
+                                                        ? startedToolCalls
+                                                        : ConcurrentHashMap.newKeySet(),
+                                                events);
+                                    }
+                                    return Flux.fromIterable(events);
+                                });
+
+        Flux<AgentEvent> endEvents =
+                Flux.defer(
+                        () -> {
+                            List<AgentEvent> events = new ArrayList<>();
+                            if (textStarted.get()) {
+                                events.add(new TextBlockEndEvent(replyId, "text"));
+                            }
+                            if (thinkingStarted.get()) {
+                                events.add(new ThinkingBlockEndEvent(replyId, "thinking"));
+                            }
+                            for (String toolId : startedToolCalls) {
+                                events.add(new ToolCallEndEvent(replyId, toolId));
+                            }
+                            events.add(new ModelCallEndEvent(replyId, context.getChatUsage()));
+                            return Flux.fromIterable(events);
+                        });
+
+        return Flux.concat(Flux.just(new ModelCallStartEvent(replyId)), modelEvents, endEvents);
+    }
+
+    private void emitBlockEvents(
+            ContentBlock block,
+            String replyId,
+            ReasoningContext context,
+            AtomicBoolean textStarted,
+            AtomicBoolean thinkingStarted,
+            Set<String> startedToolCalls,
+            List<AgentEvent> events) {
+
+        if (block instanceof TextBlock tb) {
+            if (textStarted.compareAndSet(false, true)) {
+                events.add(new TextBlockStartEvent(replyId, "text"));
+            }
+            if (tb.getText() != null && !tb.getText().isEmpty()) {
+                events.add(new TextBlockDeltaEvent(replyId, "text", tb.getText()));
+            }
+        } else if (block instanceof ThinkingBlock tb) {
+            if (thinkingStarted.compareAndSet(false, true)) {
+                events.add(new ThinkingBlockStartEvent(replyId, "thinking"));
+            }
+            if (tb.getThinking() != null && !tb.getThinking().isEmpty()) {
+                events.add(new ThinkingBlockDeltaEvent(replyId, "thinking", tb.getThinking()));
+            }
+        } else if (block instanceof ToolUseBlock tub) {
+            String toolId = resolveToolCallId(tub, context);
+            if (toolId != null && startedToolCalls.add(toolId)) {
+                String toolName = tub.getName();
+                if (toolName != null && !toolName.startsWith("__")) {
+                    events.add(new ToolCallStartEvent(replyId, toolId, toolName));
+                }
+            }
+            if (tub.getContent() != null && !tub.getContent().isEmpty()) {
+                events.add(
+                        new ToolCallDeltaEvent(
+                                replyId, toolId != null ? toolId : "", tub.getContent()));
+            }
+        }
+    }
+
+    private String resolveToolCallId(ToolUseBlock tub, ReasoningContext context) {
+        if (tub.getId() != null && !tub.getId().isEmpty()) {
+            return tub.getId();
+        }
+        ToolUseBlock accumulated = context.getAccumulatedToolCall(null);
+        return accumulated != null ? accumulated.getId() : null;
+    }
+
+    /**
      * Execute the acting phase.
      *
      * <p>This method executes only pending tools (those without results in memory),
@@ -667,24 +933,32 @@ public class ReActAgent extends StructuredOutputCapableAgent {
      * @return Mono containing the final result message
      */
     private Mono<Msg> acting(int iter) {
-        // Extract only pending tool calls (those without results in memory)
         List<ToolUseBlock> pendingToolCalls = extractPendingToolCalls();
 
         if (pendingToolCalls.isEmpty()) {
-            // No pending tools have been executed, continue to next iteration
             return executeIteration(iter + 1);
         }
 
-        // Forward tool chunks into ActingChunkEvent hooks without overwriting user callbacks.
-        toolkit.setInternalChunkCallback(
-                (toolUse, chunk) -> notifyActingChunk(toolUse, chunk).subscribe());
+        String replyId = UUID.randomUUID().toString().replace("-", "");
+        AtomicReference<List<Map.Entry<ToolUseBlock, ToolResultBlock>>> resultHolder =
+                new AtomicReference<>();
 
-        // Execute only pending tools (those without results in memory)
         return notifyPreActingHooks(pendingToolCalls)
-                .flatMap(this::executeToolCalls)
+                .flatMap(
+                        toolCalls -> {
+                            Function<ActingInput, Flux<AgentEvent>> actingCore =
+                                    ai -> actingStream(ai.toolCalls(), replyId, resultHolder);
+                            Flux<AgentEvent> stream =
+                                    MiddlewareChain.build(
+                                                    middlewares,
+                                                    this,
+                                                    Middleware::onActing,
+                                                    actingCore)
+                                            .apply(new ActingInput(toolCalls));
+                            return stream.then(Mono.defer(() -> Mono.just(resultHolder.get())));
+                        })
                 .flatMap(
                         results -> {
-                            // Separate success and pending results
                             List<Map.Entry<ToolUseBlock, ToolResultBlock>> successPairs =
                                     results.stream()
                                             .filter(e -> !e.getValue().isSuspended())
@@ -694,7 +968,6 @@ public class ReActAgent extends StructuredOutputCapableAgent {
                                             .filter(e -> e.getValue().isSuspended())
                                             .toList();
 
-                            // If no success results to process
                             if (successPairs.isEmpty()) {
                                 if (!pendingPairs.isEmpty()) {
                                     return Mono.just(buildSuspendedMsg(pendingPairs));
@@ -702,14 +975,11 @@ public class ReActAgent extends StructuredOutputCapableAgent {
                                 return executeIteration(iter + 1);
                             }
 
-                            // Process success results through hooks and add to memory
                             return Flux.fromIterable(successPairs)
                                     .concatMap(this::notifyPostActingHook)
                                     .last()
                                     .flatMap(
                                             event -> {
-                                                // HITL stop (also triggered by
-                                                // StructuredOutputHook when completed)
                                                 if (event.isStopRequested()) {
                                                     return Mono.just(
                                                             event.getToolResultMsg()
@@ -718,16 +988,102 @@ public class ReActAgent extends StructuredOutputCapableAgent {
                                                                                     .ACTING_STOP_REQUESTED));
                                                 }
 
-                                                // If there are pending results, build suspended Msg
                                                 if (!pendingPairs.isEmpty()) {
                                                     return Mono.just(
                                                             buildSuspendedMsg(pendingPairs));
                                                 }
 
-                                                // Continue next iteration
                                                 return executeIteration(iter + 1);
                                             });
                         });
+    }
+
+    /**
+     * Stream fine-grained {@link AgentEvent}s from tool execution during the acting phase.
+     *
+     * <p>Emits: {@link ToolResultStartEvent} → delta events → {@link ToolResultEndEvent}
+     * for each tool call. The provided {@code resultHolder} is populated with the execution
+     * results so the caller can process them afterward.
+     *
+     * @param toolCalls    the tool calls to execute
+     * @param replyId      the reply identifier for event correlation
+     * @param resultHolder populated with tool execution results on completion
+     * @return event stream from tool execution
+     */
+    Flux<AgentEvent> actingStream(
+            List<ToolUseBlock> toolCalls,
+            String replyId,
+            AtomicReference<List<Map.Entry<ToolUseBlock, ToolResultBlock>>> resultHolder) {
+
+        return Flux.<AgentEvent>create(
+                        sink -> {
+                            for (ToolUseBlock tool : toolCalls) {
+                                sink.next(
+                                        new ToolResultStartEvent(
+                                                replyId, tool.getId(), tool.getName()));
+                            }
+
+                            toolkit.setInternalChunkCallback(
+                                    (toolUse, chunk) -> {
+                                        if (chunk.getOutput() != null) {
+                                            for (ContentBlock block : chunk.getOutput()) {
+                                                if (block instanceof TextBlock tb) {
+                                                    sink.next(
+                                                            new ToolResultTextDeltaEvent(
+                                                                    replyId,
+                                                                    toolUse.getId(),
+                                                                    tb.getText()));
+                                                } else {
+                                                    sink.next(
+                                                            new ToolResultDataDeltaEvent(
+                                                                    replyId,
+                                                                    toolUse.getId(),
+                                                                    block));
+                                                }
+                                            }
+                                        }
+                                        notifyActingChunk(toolUse, chunk).subscribe();
+                                    });
+
+                            executeToolCalls(toolCalls)
+                                    .subscribe(
+                                            results -> {
+                                                resultHolder.set(results);
+                                                for (Map.Entry<ToolUseBlock, ToolResultBlock>
+                                                        entry : results) {
+                                                    ToolResultState state =
+                                                            determineToolResultState(
+                                                                    entry.getValue());
+                                                    sink.next(
+                                                            new ToolResultEndEvent(
+                                                                    replyId,
+                                                                    entry.getKey().getId(),
+                                                                    state));
+                                                }
+                                                sink.complete();
+                                            },
+                                            sink::error);
+                        })
+                .doOnNext(this::publishEvent);
+    }
+
+    private ToolResultState determineToolResultState(ToolResultBlock result) {
+        if (result.isSuspended()) {
+            return ToolResultState.RUNNING;
+        }
+        if (result.getState() != null && result.getState() != ToolResultState.RUNNING) {
+            return result.getState();
+        }
+        if (result.getOutput() != null
+                && result.getOutput().stream()
+                        .anyMatch(
+                                b ->
+                                        b instanceof TextBlock tb
+                                                && tb.getText() != null
+                                                && tb.getText().startsWith("[ERROR]"))) {
+            return ToolResultState.ERROR;
+        }
+        return ToolResultState.SUCCESS;
     }
 
     /**
@@ -830,6 +1186,8 @@ public class ReActAgent extends StructuredOutputCapableAgent {
 
         List<Msg> messageList = prepareSummaryMessages();
         GenerateOptions generateOptions = buildGenerateOptions();
+        ReasoningContext context = new ReasoningContext(getName());
+        publishEvent(new ExceedMaxItersEvent("", maxIters, maxIters));
 
         return notifyPreSummaryHook(messageList, generateOptions)
                 .flatMap(
@@ -841,7 +1199,12 @@ public class ReActAgent extends StructuredOutputCapableAgent {
                             GenerateOptions effectiveOptions =
                                     preSummaryEvent.getEffectiveGenerateOptions();
 
-                            return streamAndAccumulateSummary(effectiveMessages, effectiveOptions)
+                            return summaryStream(context, effectiveMessages, effectiveOptions)
+                                    .then(
+                                            Mono.defer(
+                                                    () ->
+                                                            Mono.justOrEmpty(
+                                                                    context.buildFinalMessage())))
                                     .flatMap(
                                             msg ->
                                                     notifyPostSummaryHook(msg, effectiveOptions)
@@ -860,21 +1223,92 @@ public class ReActAgent extends StructuredOutputCapableAgent {
                 .onErrorResume(this::handleSummaryError);
     }
 
-    private Mono<Msg> streamAndAccumulateSummary(
-            List<Msg> messages, GenerateOptions generateOptions) {
-        return model.stream(messages, null, generateOptions)
-                .concatMap(chunk -> checkInterruptedAsync().thenReturn(chunk))
-                .reduce(
-                        new ReasoningContext(getName()),
-                        (ctx, chunk) -> {
-                            List<Msg> streamedMessages = ctx.processChunk(chunk);
-                            for (Msg streamedMessage : streamedMessages) {
-                                notifySummaryChunk(streamedMessage, ctx, generateOptions)
-                                        .subscribe();
+    /**
+     * Stream fine-grained {@link AgentEvent}s from a model call during summarization.
+     *
+     * <p>Structurally identical to {@link #reasoningStream} but notifies summary-specific
+     * hooks ({@link SummaryChunkEvent}) and does not pass tool schemas to the model.
+     *
+     * @param context   reasoning context for chunk accumulation
+     * @param messages  the messages to send to the model
+     * @param options   generation options
+     * @return event stream from the summary model call
+     */
+    Flux<AgentEvent> summaryStream(
+            ReasoningContext context, List<Msg> messages, GenerateOptions options) {
+
+        Function<ModelCallInput, Flux<AgentEvent>> summaryModelCallCore =
+                mci -> summaryModelCallStream(context, mci, options);
+
+        return MiddlewareChain.build(
+                        middlewares, this, Middleware::onModelCall, summaryModelCallCore)
+                .apply(new ModelCallInput(messages, null, options, model))
+                .doOnNext(this::publishEvent);
+    }
+
+    private Flux<AgentEvent> summaryModelCallStream(
+            ReasoningContext context, ModelCallInput mci, GenerateOptions hookOptions) {
+
+        String replyId = UUID.randomUUID().toString().replace("-", "");
+        AtomicBoolean textStarted = new AtomicBoolean(false);
+        AtomicBoolean thinkingStarted = new AtomicBoolean(false);
+
+        Flux<AgentEvent> modelEvents =
+                mci.model().stream(mci.messages(), mci.tools(), mci.options())
+                        .concatMap(chunk -> checkInterruptedAsync().thenReturn(chunk))
+                        .concatMap(
+                                chunk -> {
+                                    List<Msg> chunkMsgs = context.processChunk(chunk);
+                                    for (Msg msg : chunkMsgs) {
+                                        notifySummaryChunk(msg, context, hookOptions).subscribe();
+                                    }
+
+                                    List<AgentEvent> events = new ArrayList<>();
+                                    for (ContentBlock block : chunk.getContent()) {
+                                        if (block instanceof TextBlock tb) {
+                                            if (textStarted.compareAndSet(false, true)) {
+                                                events.add(
+                                                        new TextBlockStartEvent(replyId, "text"));
+                                            }
+                                            if (tb.getText() != null && !tb.getText().isEmpty()) {
+                                                events.add(
+                                                        new TextBlockDeltaEvent(
+                                                                replyId, "text", tb.getText()));
+                                            }
+                                        } else if (block instanceof ThinkingBlock tb) {
+                                            if (thinkingStarted.compareAndSet(false, true)) {
+                                                events.add(
+                                                        new ThinkingBlockStartEvent(
+                                                                replyId, "thinking"));
+                                            }
+                                            if (tb.getThinking() != null
+                                                    && !tb.getThinking().isEmpty()) {
+                                                events.add(
+                                                        new ThinkingBlockDeltaEvent(
+                                                                replyId,
+                                                                "thinking",
+                                                                tb.getThinking()));
+                                            }
+                                        }
+                                    }
+                                    return Flux.fromIterable(events);
+                                });
+
+        Flux<AgentEvent> endEvents =
+                Flux.defer(
+                        () -> {
+                            List<AgentEvent> events = new ArrayList<>();
+                            if (textStarted.get()) {
+                                events.add(new TextBlockEndEvent(replyId, "text"));
                             }
-                            return ctx;
-                        })
-                .map(ReasoningContext::buildFinalMessage);
+                            if (thinkingStarted.get()) {
+                                events.add(new ThinkingBlockEndEvent(replyId, "thinking"));
+                            }
+                            events.add(new ModelCallEndEvent(replyId, context.getChatUsage()));
+                            return Flux.fromIterable(events);
+                        });
+
+        return Flux.concat(Flux.just(new ModelCallStartEvent(replyId)), modelEvents, endEvents);
     }
 
     private List<Msg> prepareSummaryMessages() {
@@ -1217,6 +1651,7 @@ public class ReActAgent extends StructuredOutputCapableAgent {
         private ExecutionConfig toolExecutionConfig;
         private GenerateOptions generateOptions;
         private final Set<Hook> hooks = new LinkedHashSet<>();
+        private final List<Middleware> middlewares = new ArrayList<>();
         private boolean enableMetaTool = false;
         private StructuredOutputReminder structuredOutputReminder =
                 StructuredOutputReminder.TOOL_CHOICE;
@@ -1347,6 +1782,28 @@ public class ReActAgent extends StructuredOutputCapableAgent {
          */
         public Builder hooks(List<Hook> hooks) {
             this.hooks.addAll(hooks);
+            return this;
+        }
+
+        /**
+         * Adds a middleware for intercepting agent execution.
+         *
+         * @param middleware the middleware to add
+         * @return this builder instance for method chaining
+         */
+        public Builder middleware(Middleware middleware) {
+            this.middlewares.add(middleware);
+            return this;
+        }
+
+        /**
+         * Adds multiple middlewares for intercepting agent execution.
+         *
+         * @param middlewares the list of middlewares to add
+         * @return this builder instance for method chaining
+         */
+        public Builder middlewares(List<Middleware> middlewares) {
+            this.middlewares.addAll(middlewares);
             return this;
         }
 

--- a/agentscope-core/src/main/java/io/agentscope/core/event/AgentEvent.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/event/AgentEvent.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.core.event;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import java.time.Instant;
+import java.util.UUID;
+
+/**
+ * Base class for all fine-grained agent events.
+ *
+ * <p>Each event carries a unique ID, creation timestamp, and type discriminator.
+ * Events are emitted during agent execution and can be consumed via reactive streams.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "type")
+@JsonSubTypes({
+    @JsonSubTypes.Type(value = ReplyStartEvent.class, name = "REPLY_START"),
+    @JsonSubTypes.Type(value = ReplyEndEvent.class, name = "REPLY_END"),
+    @JsonSubTypes.Type(value = ModelCallStartEvent.class, name = "MODEL_CALL_START"),
+    @JsonSubTypes.Type(value = ModelCallEndEvent.class, name = "MODEL_CALL_END"),
+    @JsonSubTypes.Type(value = TextBlockStartEvent.class, name = "TEXT_BLOCK_START"),
+    @JsonSubTypes.Type(value = TextBlockDeltaEvent.class, name = "TEXT_BLOCK_DELTA"),
+    @JsonSubTypes.Type(value = TextBlockEndEvent.class, name = "TEXT_BLOCK_END"),
+    @JsonSubTypes.Type(value = ThinkingBlockStartEvent.class, name = "THINKING_BLOCK_START"),
+    @JsonSubTypes.Type(value = ThinkingBlockDeltaEvent.class, name = "THINKING_BLOCK_DELTA"),
+    @JsonSubTypes.Type(value = ThinkingBlockEndEvent.class, name = "THINKING_BLOCK_END"),
+    @JsonSubTypes.Type(value = DataBlockStartEvent.class, name = "DATA_BLOCK_START"),
+    @JsonSubTypes.Type(value = DataBlockDeltaEvent.class, name = "DATA_BLOCK_DELTA"),
+    @JsonSubTypes.Type(value = DataBlockEndEvent.class, name = "DATA_BLOCK_END"),
+    @JsonSubTypes.Type(value = ToolCallStartEvent.class, name = "TOOL_CALL_START"),
+    @JsonSubTypes.Type(value = ToolCallDeltaEvent.class, name = "TOOL_CALL_DELTA"),
+    @JsonSubTypes.Type(value = ToolCallEndEvent.class, name = "TOOL_CALL_END"),
+    @JsonSubTypes.Type(value = ToolResultStartEvent.class, name = "TOOL_RESULT_START"),
+    @JsonSubTypes.Type(value = ToolResultTextDeltaEvent.class, name = "TOOL_RESULT_TEXT_DELTA"),
+    @JsonSubTypes.Type(value = ToolResultDataDeltaEvent.class, name = "TOOL_RESULT_DATA_DELTA"),
+    @JsonSubTypes.Type(value = ToolResultEndEvent.class, name = "TOOL_RESULT_END"),
+    @JsonSubTypes.Type(value = ExceedMaxItersEvent.class, name = "EXCEED_MAX_ITERS"),
+    @JsonSubTypes.Type(value = RequireUserConfirmEvent.class, name = "REQUIRE_USER_CONFIRM"),
+    @JsonSubTypes.Type(
+            value = RequireExternalExecutionEvent.class,
+            name = "REQUIRE_EXTERNAL_EXECUTION"),
+    @JsonSubTypes.Type(value = UserConfirmResultEvent.class, name = "USER_CONFIRM_RESULT"),
+    @JsonSubTypes.Type(
+            value = ExternalExecutionResultEvent.class,
+            name = "EXTERNAL_EXECUTION_RESULT")
+})
+public abstract class AgentEvent {
+
+    private final String id;
+    private final String createdAt;
+
+    protected AgentEvent() {
+        this.id = UUID.randomUUID().toString().replace("-", "");
+        this.createdAt = Instant.now().toString();
+    }
+
+    protected AgentEvent(String id, String createdAt) {
+        this.id = id;
+        this.createdAt = createdAt;
+    }
+
+    public abstract AgentEventType getType();
+
+    public String getId() {
+        return id;
+    }
+
+    public String getCreatedAt() {
+        return createdAt;
+    }
+
+    @Override
+    public String toString() {
+        return getClass().getSimpleName() + "{id='" + id + "', type=" + getType() + '}';
+    }
+}

--- a/agentscope-core/src/main/java/io/agentscope/core/event/AgentEventType.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/event/AgentEventType.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.core.event;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+
+/**
+ * Fine-grained event types emitted during agent execution.
+ *
+ * <p>Aligned with AgentScope Python 2.0 EventType. Each type corresponds to
+ * a specific phase or delta in the agent's reasoning/acting lifecycle.
+ */
+public enum AgentEventType {
+    REPLY_START("REPLY_START"),
+    REPLY_END("REPLY_END"),
+
+    MODEL_CALL_START("MODEL_CALL_START"),
+    MODEL_CALL_END("MODEL_CALL_END"),
+
+    TEXT_BLOCK_START("TEXT_BLOCK_START"),
+    TEXT_BLOCK_DELTA("TEXT_BLOCK_DELTA"),
+    TEXT_BLOCK_END("TEXT_BLOCK_END"),
+
+    THINKING_BLOCK_START("THINKING_BLOCK_START"),
+    THINKING_BLOCK_DELTA("THINKING_BLOCK_DELTA"),
+    THINKING_BLOCK_END("THINKING_BLOCK_END"),
+
+    DATA_BLOCK_START("DATA_BLOCK_START"),
+    DATA_BLOCK_DELTA("DATA_BLOCK_DELTA"),
+    DATA_BLOCK_END("DATA_BLOCK_END"),
+
+    TOOL_CALL_START("TOOL_CALL_START"),
+    TOOL_CALL_DELTA("TOOL_CALL_DELTA"),
+    TOOL_CALL_END("TOOL_CALL_END"),
+
+    TOOL_RESULT_START("TOOL_RESULT_START"),
+    TOOL_RESULT_TEXT_DELTA("TOOL_RESULT_TEXT_DELTA"),
+    TOOL_RESULT_DATA_DELTA("TOOL_RESULT_DATA_DELTA"),
+    TOOL_RESULT_END("TOOL_RESULT_END"),
+
+    EXCEED_MAX_ITERS("EXCEED_MAX_ITERS"),
+
+    REQUIRE_USER_CONFIRM("REQUIRE_USER_CONFIRM"),
+    REQUIRE_EXTERNAL_EXECUTION("REQUIRE_EXTERNAL_EXECUTION"),
+    USER_CONFIRM_RESULT("USER_CONFIRM_RESULT"),
+    EXTERNAL_EXECUTION_RESULT("EXTERNAL_EXECUTION_RESULT");
+
+    private final String value;
+
+    AgentEventType(String value) {
+        this.value = value;
+    }
+
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
+}

--- a/agentscope-core/src/main/java/io/agentscope/core/event/ConfirmResult.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/event/ConfirmResult.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.core.event;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.agentscope.core.message.ToolUseBlock;
+
+/**
+ * Represents the result of a single user confirmation decision for a tool call.
+ */
+public class ConfirmResult {
+
+    private final boolean confirmed;
+    private final ToolUseBlock toolCall;
+
+    @JsonCreator
+    public ConfirmResult(
+            @JsonProperty("confirmed") boolean confirmed,
+            @JsonProperty("toolCall") ToolUseBlock toolCall) {
+        this.confirmed = confirmed;
+        this.toolCall = toolCall;
+    }
+
+    public boolean isConfirmed() {
+        return confirmed;
+    }
+
+    public ToolUseBlock getToolCall() {
+        return toolCall;
+    }
+}

--- a/agentscope-core/src/main/java/io/agentscope/core/event/DataBlockDeltaEvent.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/event/DataBlockDeltaEvent.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.core.event;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class DataBlockDeltaEvent extends AgentEvent {
+
+    private final String replyId;
+    private final String blockId;
+    private final String delta;
+
+    @JsonCreator
+    public DataBlockDeltaEvent(
+            @JsonProperty("id") String id,
+            @JsonProperty("createdAt") String createdAt,
+            @JsonProperty("replyId") String replyId,
+            @JsonProperty("blockId") String blockId,
+            @JsonProperty("delta") String delta) {
+        super(id, createdAt);
+        this.replyId = replyId;
+        this.blockId = blockId;
+        this.delta = delta;
+    }
+
+    public DataBlockDeltaEvent(String replyId, String blockId, String delta) {
+        this.replyId = replyId;
+        this.blockId = blockId;
+        this.delta = delta;
+    }
+
+    @Override
+    public AgentEventType getType() {
+        return AgentEventType.DATA_BLOCK_DELTA;
+    }
+
+    public String getReplyId() {
+        return replyId;
+    }
+
+    public String getBlockId() {
+        return blockId;
+    }
+
+    public String getDelta() {
+        return delta;
+    }
+}

--- a/agentscope-core/src/main/java/io/agentscope/core/event/DataBlockEndEvent.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/event/DataBlockEndEvent.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.core.event;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class DataBlockEndEvent extends AgentEvent {
+
+    private final String replyId;
+    private final String blockId;
+
+    @JsonCreator
+    public DataBlockEndEvent(
+            @JsonProperty("id") String id,
+            @JsonProperty("createdAt") String createdAt,
+            @JsonProperty("replyId") String replyId,
+            @JsonProperty("blockId") String blockId) {
+        super(id, createdAt);
+        this.replyId = replyId;
+        this.blockId = blockId;
+    }
+
+    public DataBlockEndEvent(String replyId, String blockId) {
+        this.replyId = replyId;
+        this.blockId = blockId;
+    }
+
+    @Override
+    public AgentEventType getType() {
+        return AgentEventType.DATA_BLOCK_END;
+    }
+
+    public String getReplyId() {
+        return replyId;
+    }
+
+    public String getBlockId() {
+        return blockId;
+    }
+}

--- a/agentscope-core/src/main/java/io/agentscope/core/event/DataBlockStartEvent.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/event/DataBlockStartEvent.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.core.event;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class DataBlockStartEvent extends AgentEvent {
+
+    private final String replyId;
+    private final String blockId;
+
+    @JsonCreator
+    public DataBlockStartEvent(
+            @JsonProperty("id") String id,
+            @JsonProperty("createdAt") String createdAt,
+            @JsonProperty("replyId") String replyId,
+            @JsonProperty("blockId") String blockId) {
+        super(id, createdAt);
+        this.replyId = replyId;
+        this.blockId = blockId;
+    }
+
+    public DataBlockStartEvent(String replyId, String blockId) {
+        this.replyId = replyId;
+        this.blockId = blockId;
+    }
+
+    @Override
+    public AgentEventType getType() {
+        return AgentEventType.DATA_BLOCK_START;
+    }
+
+    public String getReplyId() {
+        return replyId;
+    }
+
+    public String getBlockId() {
+        return blockId;
+    }
+}

--- a/agentscope-core/src/main/java/io/agentscope/core/event/ExceedMaxItersEvent.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/event/ExceedMaxItersEvent.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.core.event;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Emitted when the agent's ReAct loop exceeds the configured maximum iterations.
+ */
+public class ExceedMaxItersEvent extends AgentEvent {
+
+    private final String replyId;
+    private final int maxIters;
+    private final int currentIter;
+
+    @JsonCreator
+    public ExceedMaxItersEvent(
+            @JsonProperty("id") String id,
+            @JsonProperty("createdAt") String createdAt,
+            @JsonProperty("replyId") String replyId,
+            @JsonProperty("maxIters") int maxIters,
+            @JsonProperty("currentIter") int currentIter) {
+        super(id, createdAt);
+        this.replyId = replyId;
+        this.maxIters = maxIters;
+        this.currentIter = currentIter;
+    }
+
+    public ExceedMaxItersEvent(String replyId, int maxIters, int currentIter) {
+        this.replyId = replyId;
+        this.maxIters = maxIters;
+        this.currentIter = currentIter;
+    }
+
+    @Override
+    public AgentEventType getType() {
+        return AgentEventType.EXCEED_MAX_ITERS;
+    }
+
+    public String getReplyId() {
+        return replyId;
+    }
+
+    public int getMaxIters() {
+        return maxIters;
+    }
+
+    public int getCurrentIter() {
+        return currentIter;
+    }
+}

--- a/agentscope-core/src/main/java/io/agentscope/core/event/ExternalExecutionResultEvent.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/event/ExternalExecutionResultEvent.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.core.event;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.agentscope.core.message.ToolResultBlock;
+import java.util.List;
+
+/**
+ * Emitted after externally-executed tool results are provided back to the agent.
+ */
+public class ExternalExecutionResultEvent extends AgentEvent {
+
+    private final String replyId;
+    private final List<ToolResultBlock> toolResults;
+
+    @JsonCreator
+    public ExternalExecutionResultEvent(
+            @JsonProperty("id") String id,
+            @JsonProperty("createdAt") String createdAt,
+            @JsonProperty("replyId") String replyId,
+            @JsonProperty("toolResults") List<ToolResultBlock> toolResults) {
+        super(id, createdAt);
+        this.replyId = replyId;
+        this.toolResults = toolResults != null ? List.copyOf(toolResults) : List.of();
+    }
+
+    public ExternalExecutionResultEvent(String replyId, List<ToolResultBlock> toolResults) {
+        this.replyId = replyId;
+        this.toolResults = toolResults != null ? List.copyOf(toolResults) : List.of();
+    }
+
+    @Override
+    public AgentEventType getType() {
+        return AgentEventType.EXTERNAL_EXECUTION_RESULT;
+    }
+
+    public String getReplyId() {
+        return replyId;
+    }
+
+    public List<ToolResultBlock> getToolResults() {
+        return toolResults;
+    }
+}

--- a/agentscope-core/src/main/java/io/agentscope/core/event/ModelCallEndEvent.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/event/ModelCallEndEvent.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.core.event;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.agentscope.core.model.ChatUsage;
+
+/**
+ * Emitted when the agent finishes a model (LLM) call.
+ */
+public class ModelCallEndEvent extends AgentEvent {
+
+    private final String replyId;
+    private final ChatUsage usage;
+
+    @JsonCreator
+    public ModelCallEndEvent(
+            @JsonProperty("id") String id,
+            @JsonProperty("createdAt") String createdAt,
+            @JsonProperty("replyId") String replyId,
+            @JsonProperty("usage") ChatUsage usage) {
+        super(id, createdAt);
+        this.replyId = replyId;
+        this.usage = usage;
+    }
+
+    public ModelCallEndEvent(String replyId, ChatUsage usage) {
+        this.replyId = replyId;
+        this.usage = usage;
+    }
+
+    @Override
+    public AgentEventType getType() {
+        return AgentEventType.MODEL_CALL_END;
+    }
+
+    public String getReplyId() {
+        return replyId;
+    }
+
+    public ChatUsage getUsage() {
+        return usage;
+    }
+}

--- a/agentscope-core/src/main/java/io/agentscope/core/event/ModelCallStartEvent.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/event/ModelCallStartEvent.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.core.event;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Emitted when the agent starts a model (LLM) call.
+ */
+public class ModelCallStartEvent extends AgentEvent {
+
+    private final String replyId;
+
+    @JsonCreator
+    public ModelCallStartEvent(
+            @JsonProperty("id") String id,
+            @JsonProperty("createdAt") String createdAt,
+            @JsonProperty("replyId") String replyId) {
+        super(id, createdAt);
+        this.replyId = replyId;
+    }
+
+    public ModelCallStartEvent(String replyId) {
+        this.replyId = replyId;
+    }
+
+    @Override
+    public AgentEventType getType() {
+        return AgentEventType.MODEL_CALL_START;
+    }
+
+    public String getReplyId() {
+        return replyId;
+    }
+}

--- a/agentscope-core/src/main/java/io/agentscope/core/event/ReplyEndEvent.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/event/ReplyEndEvent.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.core.event;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Emitted when an agent finishes processing a reply.
+ */
+public class ReplyEndEvent extends AgentEvent {
+
+    private final String replyId;
+
+    @JsonCreator
+    public ReplyEndEvent(
+            @JsonProperty("id") String id,
+            @JsonProperty("createdAt") String createdAt,
+            @JsonProperty("replyId") String replyId) {
+        super(id, createdAt);
+        this.replyId = replyId;
+    }
+
+    public ReplyEndEvent(String replyId) {
+        this.replyId = replyId;
+    }
+
+    @Override
+    public AgentEventType getType() {
+        return AgentEventType.REPLY_END;
+    }
+
+    public String getReplyId() {
+        return replyId;
+    }
+}

--- a/agentscope-core/src/main/java/io/agentscope/core/event/ReplyStartEvent.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/event/ReplyStartEvent.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.core.event;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Emitted when an agent begins processing a reply.
+ */
+public class ReplyStartEvent extends AgentEvent {
+
+    private final String sessionId;
+    private final String replyId;
+    private final String name;
+    private final String role;
+
+    @JsonCreator
+    public ReplyStartEvent(
+            @JsonProperty("id") String id,
+            @JsonProperty("createdAt") String createdAt,
+            @JsonProperty("sessionId") String sessionId,
+            @JsonProperty("replyId") String replyId,
+            @JsonProperty("name") String name,
+            @JsonProperty("role") String role) {
+        super(id, createdAt);
+        this.sessionId = sessionId;
+        this.replyId = replyId;
+        this.name = name;
+        this.role = role != null ? role : "assistant";
+    }
+
+    public ReplyStartEvent(String sessionId, String replyId, String name) {
+        this.sessionId = sessionId;
+        this.replyId = replyId;
+        this.name = name;
+        this.role = "assistant";
+    }
+
+    @Override
+    public AgentEventType getType() {
+        return AgentEventType.REPLY_START;
+    }
+
+    public String getSessionId() {
+        return sessionId;
+    }
+
+    public String getReplyId() {
+        return replyId;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getRole() {
+        return role;
+    }
+}

--- a/agentscope-core/src/main/java/io/agentscope/core/event/RequireExternalExecutionEvent.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/event/RequireExternalExecutionEvent.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.core.event;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.agentscope.core.message.ToolUseBlock;
+import java.util.List;
+
+/**
+ * Emitted when tool calls require external (out-of-process) execution.
+ */
+public class RequireExternalExecutionEvent extends AgentEvent {
+
+    private final String replyId;
+    private final List<ToolUseBlock> toolCalls;
+
+    @JsonCreator
+    public RequireExternalExecutionEvent(
+            @JsonProperty("id") String id,
+            @JsonProperty("createdAt") String createdAt,
+            @JsonProperty("replyId") String replyId,
+            @JsonProperty("toolCalls") List<ToolUseBlock> toolCalls) {
+        super(id, createdAt);
+        this.replyId = replyId;
+        this.toolCalls = toolCalls != null ? List.copyOf(toolCalls) : List.of();
+    }
+
+    public RequireExternalExecutionEvent(String replyId, List<ToolUseBlock> toolCalls) {
+        this.replyId = replyId;
+        this.toolCalls = toolCalls != null ? List.copyOf(toolCalls) : List.of();
+    }
+
+    @Override
+    public AgentEventType getType() {
+        return AgentEventType.REQUIRE_EXTERNAL_EXECUTION;
+    }
+
+    public String getReplyId() {
+        return replyId;
+    }
+
+    public List<ToolUseBlock> getToolCalls() {
+        return toolCalls;
+    }
+}

--- a/agentscope-core/src/main/java/io/agentscope/core/event/RequireUserConfirmEvent.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/event/RequireUserConfirmEvent.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.core.event;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.agentscope.core.message.ToolUseBlock;
+import java.util.List;
+
+/**
+ * Emitted when the agent requires user confirmation before executing tool calls (HITL).
+ */
+public class RequireUserConfirmEvent extends AgentEvent {
+
+    private final String replyId;
+    private final List<ToolUseBlock> toolCalls;
+
+    @JsonCreator
+    public RequireUserConfirmEvent(
+            @JsonProperty("id") String id,
+            @JsonProperty("createdAt") String createdAt,
+            @JsonProperty("replyId") String replyId,
+            @JsonProperty("toolCalls") List<ToolUseBlock> toolCalls) {
+        super(id, createdAt);
+        this.replyId = replyId;
+        this.toolCalls = toolCalls != null ? List.copyOf(toolCalls) : List.of();
+    }
+
+    public RequireUserConfirmEvent(String replyId, List<ToolUseBlock> toolCalls) {
+        this.replyId = replyId;
+        this.toolCalls = toolCalls != null ? List.copyOf(toolCalls) : List.of();
+    }
+
+    @Override
+    public AgentEventType getType() {
+        return AgentEventType.REQUIRE_USER_CONFIRM;
+    }
+
+    public String getReplyId() {
+        return replyId;
+    }
+
+    public List<ToolUseBlock> getToolCalls() {
+        return toolCalls;
+    }
+}

--- a/agentscope-core/src/main/java/io/agentscope/core/event/TextBlockDeltaEvent.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/event/TextBlockDeltaEvent.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.core.event;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class TextBlockDeltaEvent extends AgentEvent {
+
+    private final String replyId;
+    private final String blockId;
+    private final String delta;
+
+    @JsonCreator
+    public TextBlockDeltaEvent(
+            @JsonProperty("id") String id,
+            @JsonProperty("createdAt") String createdAt,
+            @JsonProperty("replyId") String replyId,
+            @JsonProperty("blockId") String blockId,
+            @JsonProperty("delta") String delta) {
+        super(id, createdAt);
+        this.replyId = replyId;
+        this.blockId = blockId;
+        this.delta = delta;
+    }
+
+    public TextBlockDeltaEvent(String replyId, String blockId, String delta) {
+        this.replyId = replyId;
+        this.blockId = blockId;
+        this.delta = delta;
+    }
+
+    @Override
+    public AgentEventType getType() {
+        return AgentEventType.TEXT_BLOCK_DELTA;
+    }
+
+    public String getReplyId() {
+        return replyId;
+    }
+
+    public String getBlockId() {
+        return blockId;
+    }
+
+    public String getDelta() {
+        return delta;
+    }
+}

--- a/agentscope-core/src/main/java/io/agentscope/core/event/TextBlockEndEvent.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/event/TextBlockEndEvent.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.core.event;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class TextBlockEndEvent extends AgentEvent {
+
+    private final String replyId;
+    private final String blockId;
+
+    @JsonCreator
+    public TextBlockEndEvent(
+            @JsonProperty("id") String id,
+            @JsonProperty("createdAt") String createdAt,
+            @JsonProperty("replyId") String replyId,
+            @JsonProperty("blockId") String blockId) {
+        super(id, createdAt);
+        this.replyId = replyId;
+        this.blockId = blockId;
+    }
+
+    public TextBlockEndEvent(String replyId, String blockId) {
+        this.replyId = replyId;
+        this.blockId = blockId;
+    }
+
+    @Override
+    public AgentEventType getType() {
+        return AgentEventType.TEXT_BLOCK_END;
+    }
+
+    public String getReplyId() {
+        return replyId;
+    }
+
+    public String getBlockId() {
+        return blockId;
+    }
+}

--- a/agentscope-core/src/main/java/io/agentscope/core/event/TextBlockStartEvent.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/event/TextBlockStartEvent.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.core.event;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class TextBlockStartEvent extends AgentEvent {
+
+    private final String replyId;
+    private final String blockId;
+
+    @JsonCreator
+    public TextBlockStartEvent(
+            @JsonProperty("id") String id,
+            @JsonProperty("createdAt") String createdAt,
+            @JsonProperty("replyId") String replyId,
+            @JsonProperty("blockId") String blockId) {
+        super(id, createdAt);
+        this.replyId = replyId;
+        this.blockId = blockId;
+    }
+
+    public TextBlockStartEvent(String replyId, String blockId) {
+        this.replyId = replyId;
+        this.blockId = blockId;
+    }
+
+    @Override
+    public AgentEventType getType() {
+        return AgentEventType.TEXT_BLOCK_START;
+    }
+
+    public String getReplyId() {
+        return replyId;
+    }
+
+    public String getBlockId() {
+        return blockId;
+    }
+}

--- a/agentscope-core/src/main/java/io/agentscope/core/event/ThinkingBlockDeltaEvent.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/event/ThinkingBlockDeltaEvent.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.core.event;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class ThinkingBlockDeltaEvent extends AgentEvent {
+
+    private final String replyId;
+    private final String blockId;
+    private final String delta;
+
+    @JsonCreator
+    public ThinkingBlockDeltaEvent(
+            @JsonProperty("id") String id,
+            @JsonProperty("createdAt") String createdAt,
+            @JsonProperty("replyId") String replyId,
+            @JsonProperty("blockId") String blockId,
+            @JsonProperty("delta") String delta) {
+        super(id, createdAt);
+        this.replyId = replyId;
+        this.blockId = blockId;
+        this.delta = delta;
+    }
+
+    public ThinkingBlockDeltaEvent(String replyId, String blockId, String delta) {
+        this.replyId = replyId;
+        this.blockId = blockId;
+        this.delta = delta;
+    }
+
+    @Override
+    public AgentEventType getType() {
+        return AgentEventType.THINKING_BLOCK_DELTA;
+    }
+
+    public String getReplyId() {
+        return replyId;
+    }
+
+    public String getBlockId() {
+        return blockId;
+    }
+
+    public String getDelta() {
+        return delta;
+    }
+}

--- a/agentscope-core/src/main/java/io/agentscope/core/event/ThinkingBlockEndEvent.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/event/ThinkingBlockEndEvent.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.core.event;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class ThinkingBlockEndEvent extends AgentEvent {
+
+    private final String replyId;
+    private final String blockId;
+
+    @JsonCreator
+    public ThinkingBlockEndEvent(
+            @JsonProperty("id") String id,
+            @JsonProperty("createdAt") String createdAt,
+            @JsonProperty("replyId") String replyId,
+            @JsonProperty("blockId") String blockId) {
+        super(id, createdAt);
+        this.replyId = replyId;
+        this.blockId = blockId;
+    }
+
+    public ThinkingBlockEndEvent(String replyId, String blockId) {
+        this.replyId = replyId;
+        this.blockId = blockId;
+    }
+
+    @Override
+    public AgentEventType getType() {
+        return AgentEventType.THINKING_BLOCK_END;
+    }
+
+    public String getReplyId() {
+        return replyId;
+    }
+
+    public String getBlockId() {
+        return blockId;
+    }
+}

--- a/agentscope-core/src/main/java/io/agentscope/core/event/ThinkingBlockStartEvent.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/event/ThinkingBlockStartEvent.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.core.event;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class ThinkingBlockStartEvent extends AgentEvent {
+
+    private final String replyId;
+    private final String blockId;
+
+    @JsonCreator
+    public ThinkingBlockStartEvent(
+            @JsonProperty("id") String id,
+            @JsonProperty("createdAt") String createdAt,
+            @JsonProperty("replyId") String replyId,
+            @JsonProperty("blockId") String blockId) {
+        super(id, createdAt);
+        this.replyId = replyId;
+        this.blockId = blockId;
+    }
+
+    public ThinkingBlockStartEvent(String replyId, String blockId) {
+        this.replyId = replyId;
+        this.blockId = blockId;
+    }
+
+    @Override
+    public AgentEventType getType() {
+        return AgentEventType.THINKING_BLOCK_START;
+    }
+
+    public String getReplyId() {
+        return replyId;
+    }
+
+    public String getBlockId() {
+        return blockId;
+    }
+}

--- a/agentscope-core/src/main/java/io/agentscope/core/event/ToolCallDeltaEvent.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/event/ToolCallDeltaEvent.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.core.event;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Emitted as tool call input arguments are streamed incrementally.
+ */
+public class ToolCallDeltaEvent extends AgentEvent {
+
+    private final String replyId;
+    private final String toolCallId;
+    private final String delta;
+
+    @JsonCreator
+    public ToolCallDeltaEvent(
+            @JsonProperty("id") String id,
+            @JsonProperty("createdAt") String createdAt,
+            @JsonProperty("replyId") String replyId,
+            @JsonProperty("toolCallId") String toolCallId,
+            @JsonProperty("delta") String delta) {
+        super(id, createdAt);
+        this.replyId = replyId;
+        this.toolCallId = toolCallId;
+        this.delta = delta;
+    }
+
+    public ToolCallDeltaEvent(String replyId, String toolCallId, String delta) {
+        this.replyId = replyId;
+        this.toolCallId = toolCallId;
+        this.delta = delta;
+    }
+
+    @Override
+    public AgentEventType getType() {
+        return AgentEventType.TOOL_CALL_DELTA;
+    }
+
+    public String getReplyId() {
+        return replyId;
+    }
+
+    public String getToolCallId() {
+        return toolCallId;
+    }
+
+    public String getDelta() {
+        return delta;
+    }
+}

--- a/agentscope-core/src/main/java/io/agentscope/core/event/ToolCallEndEvent.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/event/ToolCallEndEvent.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.core.event;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class ToolCallEndEvent extends AgentEvent {
+
+    private final String replyId;
+    private final String toolCallId;
+
+    @JsonCreator
+    public ToolCallEndEvent(
+            @JsonProperty("id") String id,
+            @JsonProperty("createdAt") String createdAt,
+            @JsonProperty("replyId") String replyId,
+            @JsonProperty("toolCallId") String toolCallId) {
+        super(id, createdAt);
+        this.replyId = replyId;
+        this.toolCallId = toolCallId;
+    }
+
+    public ToolCallEndEvent(String replyId, String toolCallId) {
+        this.replyId = replyId;
+        this.toolCallId = toolCallId;
+    }
+
+    @Override
+    public AgentEventType getType() {
+        return AgentEventType.TOOL_CALL_END;
+    }
+
+    public String getReplyId() {
+        return replyId;
+    }
+
+    public String getToolCallId() {
+        return toolCallId;
+    }
+}

--- a/agentscope-core/src/main/java/io/agentscope/core/event/ToolCallStartEvent.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/event/ToolCallStartEvent.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.core.event;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class ToolCallStartEvent extends AgentEvent {
+
+    private final String replyId;
+    private final String toolCallId;
+    private final String toolCallName;
+
+    @JsonCreator
+    public ToolCallStartEvent(
+            @JsonProperty("id") String id,
+            @JsonProperty("createdAt") String createdAt,
+            @JsonProperty("replyId") String replyId,
+            @JsonProperty("toolCallId") String toolCallId,
+            @JsonProperty("toolCallName") String toolCallName) {
+        super(id, createdAt);
+        this.replyId = replyId;
+        this.toolCallId = toolCallId;
+        this.toolCallName = toolCallName;
+    }
+
+    public ToolCallStartEvent(String replyId, String toolCallId, String toolCallName) {
+        this.replyId = replyId;
+        this.toolCallId = toolCallId;
+        this.toolCallName = toolCallName;
+    }
+
+    @Override
+    public AgentEventType getType() {
+        return AgentEventType.TOOL_CALL_START;
+    }
+
+    public String getReplyId() {
+        return replyId;
+    }
+
+    public String getToolCallId() {
+        return toolCallId;
+    }
+
+    public String getToolCallName() {
+        return toolCallName;
+    }
+}

--- a/agentscope-core/src/main/java/io/agentscope/core/event/ToolResultDataDeltaEvent.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/event/ToolResultDataDeltaEvent.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.core.event;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.agentscope.core.message.ContentBlock;
+
+public class ToolResultDataDeltaEvent extends AgentEvent {
+
+    private final String replyId;
+    private final String toolCallId;
+    private final ContentBlock data;
+
+    @JsonCreator
+    public ToolResultDataDeltaEvent(
+            @JsonProperty("id") String id,
+            @JsonProperty("createdAt") String createdAt,
+            @JsonProperty("replyId") String replyId,
+            @JsonProperty("toolCallId") String toolCallId,
+            @JsonProperty("data") ContentBlock data) {
+        super(id, createdAt);
+        this.replyId = replyId;
+        this.toolCallId = toolCallId;
+        this.data = data;
+    }
+
+    public ToolResultDataDeltaEvent(String replyId, String toolCallId, ContentBlock data) {
+        this.replyId = replyId;
+        this.toolCallId = toolCallId;
+        this.data = data;
+    }
+
+    @Override
+    public AgentEventType getType() {
+        return AgentEventType.TOOL_RESULT_DATA_DELTA;
+    }
+
+    public String getReplyId() {
+        return replyId;
+    }
+
+    public String getToolCallId() {
+        return toolCallId;
+    }
+
+    public ContentBlock getData() {
+        return data;
+    }
+}

--- a/agentscope-core/src/main/java/io/agentscope/core/event/ToolResultEndEvent.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/event/ToolResultEndEvent.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.core.event;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.agentscope.core.message.ToolResultState;
+
+public class ToolResultEndEvent extends AgentEvent {
+
+    private final String replyId;
+    private final String toolCallId;
+    private final ToolResultState state;
+
+    @JsonCreator
+    public ToolResultEndEvent(
+            @JsonProperty("id") String id,
+            @JsonProperty("createdAt") String createdAt,
+            @JsonProperty("replyId") String replyId,
+            @JsonProperty("toolCallId") String toolCallId,
+            @JsonProperty("state") ToolResultState state) {
+        super(id, createdAt);
+        this.replyId = replyId;
+        this.toolCallId = toolCallId;
+        this.state = state;
+    }
+
+    public ToolResultEndEvent(String replyId, String toolCallId, ToolResultState state) {
+        this.replyId = replyId;
+        this.toolCallId = toolCallId;
+        this.state = state;
+    }
+
+    @Override
+    public AgentEventType getType() {
+        return AgentEventType.TOOL_RESULT_END;
+    }
+
+    public String getReplyId() {
+        return replyId;
+    }
+
+    public String getToolCallId() {
+        return toolCallId;
+    }
+
+    public ToolResultState getState() {
+        return state;
+    }
+}

--- a/agentscope-core/src/main/java/io/agentscope/core/event/ToolResultStartEvent.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/event/ToolResultStartEvent.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.core.event;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class ToolResultStartEvent extends AgentEvent {
+
+    private final String replyId;
+    private final String toolCallId;
+    private final String toolCallName;
+
+    @JsonCreator
+    public ToolResultStartEvent(
+            @JsonProperty("id") String id,
+            @JsonProperty("createdAt") String createdAt,
+            @JsonProperty("replyId") String replyId,
+            @JsonProperty("toolCallId") String toolCallId,
+            @JsonProperty("toolCallName") String toolCallName) {
+        super(id, createdAt);
+        this.replyId = replyId;
+        this.toolCallId = toolCallId;
+        this.toolCallName = toolCallName;
+    }
+
+    public ToolResultStartEvent(String replyId, String toolCallId, String toolCallName) {
+        this.replyId = replyId;
+        this.toolCallId = toolCallId;
+        this.toolCallName = toolCallName;
+    }
+
+    @Override
+    public AgentEventType getType() {
+        return AgentEventType.TOOL_RESULT_START;
+    }
+
+    public String getReplyId() {
+        return replyId;
+    }
+
+    public String getToolCallId() {
+        return toolCallId;
+    }
+
+    public String getToolCallName() {
+        return toolCallName;
+    }
+}

--- a/agentscope-core/src/main/java/io/agentscope/core/event/ToolResultTextDeltaEvent.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/event/ToolResultTextDeltaEvent.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.core.event;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class ToolResultTextDeltaEvent extends AgentEvent {
+
+    private final String replyId;
+    private final String toolCallId;
+    private final String delta;
+
+    @JsonCreator
+    public ToolResultTextDeltaEvent(
+            @JsonProperty("id") String id,
+            @JsonProperty("createdAt") String createdAt,
+            @JsonProperty("replyId") String replyId,
+            @JsonProperty("toolCallId") String toolCallId,
+            @JsonProperty("delta") String delta) {
+        super(id, createdAt);
+        this.replyId = replyId;
+        this.toolCallId = toolCallId;
+        this.delta = delta;
+    }
+
+    public ToolResultTextDeltaEvent(String replyId, String toolCallId, String delta) {
+        this.replyId = replyId;
+        this.toolCallId = toolCallId;
+        this.delta = delta;
+    }
+
+    @Override
+    public AgentEventType getType() {
+        return AgentEventType.TOOL_RESULT_TEXT_DELTA;
+    }
+
+    public String getReplyId() {
+        return replyId;
+    }
+
+    public String getToolCallId() {
+        return toolCallId;
+    }
+
+    public String getDelta() {
+        return delta;
+    }
+}

--- a/agentscope-core/src/main/java/io/agentscope/core/event/UserConfirmResultEvent.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/event/UserConfirmResultEvent.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.core.event;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+
+/**
+ * Emitted after the user has responded to a {@link RequireUserConfirmEvent}.
+ */
+public class UserConfirmResultEvent extends AgentEvent {
+
+    private final String replyId;
+    private final List<ConfirmResult> confirmResults;
+
+    @JsonCreator
+    public UserConfirmResultEvent(
+            @JsonProperty("id") String id,
+            @JsonProperty("createdAt") String createdAt,
+            @JsonProperty("replyId") String replyId,
+            @JsonProperty("confirmResults") List<ConfirmResult> confirmResults) {
+        super(id, createdAt);
+        this.replyId = replyId;
+        this.confirmResults = confirmResults != null ? List.copyOf(confirmResults) : List.of();
+    }
+
+    public UserConfirmResultEvent(String replyId, List<ConfirmResult> confirmResults) {
+        this.replyId = replyId;
+        this.confirmResults = confirmResults != null ? List.copyOf(confirmResults) : List.of();
+    }
+
+    @Override
+    public AgentEventType getType() {
+        return AgentEventType.USER_CONFIRM_RESULT;
+    }
+
+    public String getReplyId() {
+        return replyId;
+    }
+
+    public List<ConfirmResult> getConfirmResults() {
+        return confirmResults;
+    }
+}

--- a/agentscope-core/src/main/java/io/agentscope/core/message/ContentBlock.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/message/ContentBlock.java
@@ -35,6 +35,7 @@ import io.agentscope.core.state.State;
  *   <li>{@link VideoBlock} - Video content (URL or Base64)
  *   <li>{@link ToolUseBlock} - Tool execution requests
  *   <li>{@link ToolResultBlock} - Tool execution results
+ *   <li>{@link HintBlock} - Hints for LLM reasoning (e.g., from RAG)
  * </ul>
  *
  * <p>Uses Jackson annotations for polymorphic JSON serialization with the "type" discriminator
@@ -49,7 +50,8 @@ import io.agentscope.core.state.State;
     @JsonSubTypes.Type(value = AudioBlock.class, name = "audio"),
     @JsonSubTypes.Type(value = VideoBlock.class, name = "video"),
     @JsonSubTypes.Type(value = ToolUseBlock.class, name = "tool_use"),
-    @JsonSubTypes.Type(value = ToolResultBlock.class, name = "tool_result")
+    @JsonSubTypes.Type(value = ToolResultBlock.class, name = "tool_result"),
+    @JsonSubTypes.Type(value = HintBlock.class, name = "hint")
 })
 public sealed class ContentBlock implements State
         permits TextBlock,
@@ -58,4 +60,5 @@ public sealed class ContentBlock implements State
                 VideoBlock,
                 ThinkingBlock,
                 ToolUseBlock,
-                ToolResultBlock {}
+                ToolResultBlock,
+                HintBlock {}

--- a/agentscope-core/src/main/java/io/agentscope/core/message/HintBlock.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/message/HintBlock.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.core.message;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * A content block that provides hints to the LLM during reasoning.
+ *
+ * <p>Hint blocks are injected by middleware or memory systems (e.g., RAG) to supply
+ * contextual information that guides the agent's reasoning without being part of
+ * the conversation history.
+ */
+public final class HintBlock extends ContentBlock {
+
+    private final String id;
+    private final String hint;
+
+    @JsonCreator
+    public HintBlock(@JsonProperty("id") String id, @JsonProperty("hint") String hint) {
+        this.id = id;
+        this.hint = hint;
+    }
+
+    /**
+     * Gets the unique identifier of this hint block.
+     *
+     * @return The hint block ID
+     */
+    public String getId() {
+        return id;
+    }
+
+    /**
+     * Gets the hint text.
+     *
+     * @return The hint content
+     */
+    public String getHint() {
+        return hint;
+    }
+}

--- a/agentscope-core/src/main/java/io/agentscope/core/message/ToolCallState.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/message/ToolCallState.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.core.message;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+
+public enum ToolCallState {
+    PENDING("pending"),
+
+    ASKING("asking"),
+
+    ALLOWED("allowed"),
+
+    SUBMITTED("submitted"),
+
+    FINISHED("finished");
+
+    private final String value;
+
+    ToolCallState(String value) {
+        this.value = value;
+    }
+
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
+}

--- a/agentscope-core/src/main/java/io/agentscope/core/message/ToolResultBlock.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/message/ToolResultBlock.java
@@ -41,17 +41,25 @@ public final class ToolResultBlock extends ContentBlock {
     private final String name;
     private final List<ContentBlock> output;
     private final Map<String, Object> metadata;
+    private final ToolResultState state;
 
     @JsonCreator
     public ToolResultBlock(
             @JsonProperty("id") String id,
             @JsonProperty("name") String name,
             @JsonProperty("output") List<ContentBlock> output,
-            @JsonProperty("metadata") Map<String, Object> metadata) {
+            @JsonProperty("metadata") Map<String, Object> metadata,
+            @JsonProperty("state") ToolResultState state) {
         this.id = id;
         this.name = name;
         this.output = output != null ? List.copyOf(output) : List.of();
         this.metadata = metadata != null ? Map.copyOf(metadata) : Map.of();
+        this.state = state != null ? state : ToolResultState.RUNNING;
+    }
+
+    public ToolResultBlock(
+            String id, String name, List<ContentBlock> output, Map<String, Object> metadata) {
+        this(id, name, output, metadata, null);
     }
 
     /**
@@ -62,7 +70,7 @@ public final class ToolResultBlock extends ContentBlock {
      * @param output Single content block as output
      */
     public ToolResultBlock(String id, String name, ContentBlock output) {
-        this(id, name, List.of(output), null);
+        this(id, name, List.of(output), null, null);
     }
 
     /**
@@ -73,7 +81,7 @@ public final class ToolResultBlock extends ContentBlock {
      * @param output List of content blocks as output
      */
     public ToolResultBlock(String id, String name, List<ContentBlock> output) {
-        this(id, name, output, null);
+        this(id, name, output, null, null);
     }
 
     /**
@@ -110,6 +118,25 @@ public final class ToolResultBlock extends ContentBlock {
      */
     public Map<String, Object> getMetadata() {
         return metadata;
+    }
+
+    /**
+     * Gets the tool result state.
+     *
+     * @return The tool result state
+     */
+    public ToolResultState getState() {
+        return state;
+    }
+
+    /**
+     * Returns a copy of this block with the given state.
+     *
+     * @param state The new state
+     * @return A new ToolResultBlock with the updated state
+     */
+    public ToolResultBlock withState(ToolResultState state) {
+        return new ToolResultBlock(this.id, this.name, this.output, this.metadata, state);
     }
 
     /**
@@ -286,7 +313,7 @@ public final class ToolResultBlock extends ContentBlock {
      * @return New ToolResultBlock with id and name set
      */
     public ToolResultBlock withIdAndName(String id, String name) {
-        return new ToolResultBlock(id, name, this.output, this.metadata);
+        return new ToolResultBlock(id, name, this.output, this.metadata, this.state);
     }
 
     /**
@@ -306,6 +333,7 @@ public final class ToolResultBlock extends ContentBlock {
         private String name;
         private List<ContentBlock> output;
         private Map<String, Object> metadata;
+        private ToolResultState state;
 
         /**
          * Sets the tool call ID.
@@ -363,12 +391,23 @@ public final class ToolResultBlock extends ContentBlock {
         }
 
         /**
+         * Sets the tool result state.
+         *
+         * @param state The tool result state
+         * @return This builder for chaining
+         */
+        public Builder state(ToolResultState state) {
+            this.state = state;
+            return this;
+        }
+
+        /**
          * Builds a new ToolResultBlock with the configured properties.
          *
          * @return A new ToolResultBlock instance
          */
         public ToolResultBlock build() {
-            return new ToolResultBlock(id, name, output, metadata);
+            return new ToolResultBlock(id, name, output, metadata, state);
         }
     }
 }

--- a/agentscope-core/src/main/java/io/agentscope/core/message/ToolResultState.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/message/ToolResultState.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.core.message;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+
+public enum ToolResultState {
+    SUCCESS("success"),
+
+    ERROR("error"),
+
+    INTERRUPTED("interrupted"),
+
+    DENIED("denied"),
+
+    RUNNING("running");
+
+    private final String value;
+
+    ToolResultState(String value) {
+        this.value = value;
+    }
+
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
+}

--- a/agentscope-core/src/main/java/io/agentscope/core/message/ToolUseBlock.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/message/ToolUseBlock.java
@@ -41,6 +41,7 @@ public final class ToolUseBlock extends ContentBlock {
     private final Map<String, Object> input;
     private final String content; // Raw content for streaming tool calls
     private final Map<String, Object> metadata; // Provider-specific metadata
+    private final ToolCallState state;
 
     /**
      * Creates a new tool use block for JSON deserialization.
@@ -52,7 +53,7 @@ public final class ToolUseBlock extends ContentBlock {
      */
     public ToolUseBlock(
             String id, String name, Map<String, Object> input, Map<String, Object> metadata) {
-        this(id, name, input, null, metadata);
+        this(id, name, input, null, metadata, null);
     }
 
     /**
@@ -63,7 +64,7 @@ public final class ToolUseBlock extends ContentBlock {
      * @param input Input parameters for the tool (will be defensively copied)
      */
     public ToolUseBlock(String id, String name, Map<String, Object> input) {
-        this(id, name, input, null, null);
+        this(id, name, input, null, null, null);
     }
 
     /**
@@ -75,13 +76,33 @@ public final class ToolUseBlock extends ContentBlock {
      * @param content Raw content for streaming tool calls
      * @param metadata Provider-specific metadata (will be defensively copied)
      */
+    public ToolUseBlock(
+            String id,
+            String name,
+            Map<String, Object> input,
+            String content,
+            Map<String, Object> metadata) {
+        this(id, name, input, content, metadata, null);
+    }
+
+    /**
+     * Creates a new tool use block with all fields.
+     *
+     * @param id Unique identifier for this tool call
+     * @param name Name of the tool to execute
+     * @param input Input parameters for the tool (will be defensively copied)
+     * @param content Raw content for streaming tool calls
+     * @param metadata Provider-specific metadata (will be defensively copied)
+     * @param state The tool call state, defaults to PENDING if null
+     */
     @JsonCreator
     public ToolUseBlock(
             @JsonProperty("id") String id,
             @JsonProperty("name") String name,
             @JsonProperty("input") Map<String, Object> input,
             @JsonProperty("content") String content,
-            @JsonProperty("metadata") Map<String, Object> metadata) {
+            @JsonProperty("metadata") Map<String, Object> metadata,
+            @JsonProperty("state") ToolCallState state) {
         this.id = id;
         this.name = name;
         // Defensive copy to prevent external modifications
@@ -94,6 +115,7 @@ public final class ToolUseBlock extends ContentBlock {
                 metadata == null
                         ? Collections.emptyMap()
                         : Collections.unmodifiableMap(new HashMap<>(metadata));
+        this.state = state != null ? state : ToolCallState.PENDING;
     }
 
     /**
@@ -145,6 +167,25 @@ public final class ToolUseBlock extends ContentBlock {
     }
 
     /**
+     * Gets the tool call state.
+     *
+     * @return The tool call state
+     */
+    public ToolCallState getState() {
+        return state;
+    }
+
+    /**
+     * Returns a copy of this block with the given state.
+     *
+     * @param state The new state
+     * @return A new ToolUseBlock with the updated state
+     */
+    public ToolUseBlock withState(ToolCallState state) {
+        return new ToolUseBlock(this.id, this.name, this.input, this.content, this.metadata, state);
+    }
+
+    /**
      * Creates a new builder for constructing a ToolUseBlock.
      *
      * @return A new builder instance
@@ -162,6 +203,7 @@ public final class ToolUseBlock extends ContentBlock {
         private Map<String, Object> input;
         private String content;
         private Map<String, Object> metadata;
+        private ToolCallState state;
 
         /**
          * Sets the unique identifier for the tool call.
@@ -222,12 +264,23 @@ public final class ToolUseBlock extends ContentBlock {
         }
 
         /**
+         * Sets the tool call state.
+         *
+         * @param state The tool call state
+         * @return This builder for chaining
+         */
+        public Builder state(ToolCallState state) {
+            this.state = state;
+            return this;
+        }
+
+        /**
          * Builds a new ToolUseBlock with the configured properties.
          *
          * @return A new ToolUseBlock instance
          */
         public ToolUseBlock build() {
-            return new ToolUseBlock(id, name, input, content, metadata);
+            return new ToolUseBlock(id, name, input, content, metadata, state);
         }
     }
 }

--- a/agentscope-core/src/main/java/io/agentscope/core/middleware/ActingInput.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/middleware/ActingInput.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.core.middleware;
+
+import io.agentscope.core.message.ToolUseBlock;
+import java.util.List;
+
+/**
+ * Input context for {@link Middleware#onActing}.
+ *
+ * @param toolCalls the tool calls to execute
+ */
+public record ActingInput(List<ToolUseBlock> toolCalls) {}

--- a/agentscope-core/src/main/java/io/agentscope/core/middleware/Middleware.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/middleware/Middleware.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.core.middleware;
+
+import io.agentscope.core.agent.Agent;
+import io.agentscope.core.event.AgentEvent;
+import java.util.function.Function;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+/**
+ * Middleware provides interception mechanisms at 5 key execution points
+ * in the Agent lifecycle.
+ *
+ * <p><b>Onion Pattern</b> (4 hooks — wrap execution with before/after logic):
+ * <ul>
+ *   <li>{@link #onReply} — intercepts the entire reply process</li>
+ *   <li>{@link #onReasoning} — intercepts the reasoning/model-call phase</li>
+ *   <li>{@link #onActing} — intercepts individual tool-call execution</li>
+ *   <li>{@link #onModelCall} — intercepts the raw model API call</li>
+ * </ul>
+ *
+ * <p><b>Transformer/Pipeline Pattern</b> (1 hook — sequential transform):
+ * <ul>
+ *   <li>{@link #onSystemPrompt} — transforms the system prompt string</li>
+ * </ul>
+ *
+ * <p>Each hook has a default implementation that delegates directly to
+ * {@code next}, so subclasses only need to override the hooks they care about.
+ *
+ * <p><b>Example:</b>
+ * <pre>{@code
+ * Middleware logging = new Middleware() {
+ *     @Override
+ *     public Flux<AgentEvent> onReasoning(
+ *             Agent agent, ReasoningInput input,
+ *             Function<ReasoningInput, Flux<AgentEvent>> next) {
+ *         System.out.println("Before reasoning");
+ *         return next.apply(input)
+ *             .doOnComplete(() -> System.out.println("After reasoning"));
+ *     }
+ * };
+ *
+ * ReActAgent agent = ReActAgent.builder()
+ *     .middleware(logging)
+ *     .build();
+ * }</pre>
+ */
+public interface Middleware {
+
+    /**
+     * Intercept the entire reply process.
+     *
+     * @param agent the agent instance
+     * @param input reply input (messages)
+     * @param next  calls the next middleware or the core reply logic
+     * @return event stream from the reply
+     */
+    default Flux<AgentEvent> onReply(
+            Agent agent, ReplyInput input, Function<ReplyInput, Flux<AgentEvent>> next) {
+        return next.apply(input);
+    }
+
+    /**
+     * Intercept the reasoning phase (LLM call + streaming output parsing).
+     *
+     * @param agent the agent instance
+     * @param input reasoning input (messages, tools, options)
+     * @param next  calls the next middleware or the core reasoning logic
+     * @return event stream from reasoning
+     */
+    default Flux<AgentEvent> onReasoning(
+            Agent agent, ReasoningInput input, Function<ReasoningInput, Flux<AgentEvent>> next) {
+        return next.apply(input);
+    }
+
+    /**
+     * Intercept the tool-call execution phase.
+     *
+     * @param agent the agent instance
+     * @param input acting input (the tool calls)
+     * @param next  calls the next middleware or the core acting logic
+     * @return event stream from acting
+     */
+    default Flux<AgentEvent> onActing(
+            Agent agent, ActingInput input, Function<ActingInput, Flux<AgentEvent>> next) {
+        return next.apply(input);
+    }
+
+    /**
+     * Intercept the raw model API call.
+     *
+     * @param agent the agent instance
+     * @param input model-call input (messages, tools, options, model)
+     * @param next  calls the next middleware or the actual model invocation
+     * @return event stream from the model call
+     */
+    default Flux<AgentEvent> onModelCall(
+            Agent agent, ModelCallInput input, Function<ModelCallInput, Flux<AgentEvent>> next) {
+        return next.apply(input);
+    }
+
+    /**
+     * Transform the system prompt string (pipeline pattern).
+     *
+     * <p>Multiple middlewares are applied sequentially; each receives the
+     * output of the previous one.
+     *
+     * @param agent         the agent instance
+     * @param currentPrompt the current system prompt
+     * @return the (possibly transformed) system prompt
+     */
+    default Mono<String> onSystemPrompt(Agent agent, String currentPrompt) {
+        return Mono.just(currentPrompt);
+    }
+}

--- a/agentscope-core/src/main/java/io/agentscope/core/middleware/MiddlewareChain.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/middleware/MiddlewareChain.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.core.middleware;
+
+import io.agentscope.core.agent.Agent;
+import io.agentscope.core.event.AgentEvent;
+import java.util.List;
+import java.util.function.Function;
+import reactor.core.publisher.Flux;
+
+/**
+ * Builds an onion-style middleware chain for a given interception point.
+ *
+ * <p>The chain is constructed back-to-front: the last middleware wraps
+ * the core logic, and the first middleware is the outermost wrapper.
+ */
+public final class MiddlewareChain {
+
+    private MiddlewareChain() {}
+
+    /**
+     * Build a middleware chain that produces {@code Flux<AgentEvent>}.
+     *
+     * @param middlewares ordered list of middlewares (first = outermost)
+     * @param agent      the agent instance passed to each middleware
+     * @param method     reference to the middleware hook method
+     * @param core       the innermost logic to execute when all middlewares delegate
+     * @param <I>        the input type for the interception point
+     * @return a function that, when applied to an input, runs the full chain
+     */
+    public static <I> Function<I, Flux<AgentEvent>> build(
+            List<Middleware> middlewares,
+            Agent agent,
+            MiddlewareMethod<I> method,
+            Function<I, Flux<AgentEvent>> core) {
+        if (middlewares == null || middlewares.isEmpty()) {
+            return core;
+        }
+        Function<I, Flux<AgentEvent>> chain = core;
+        for (int i = middlewares.size() - 1; i >= 0; i--) {
+            Middleware mw = middlewares.get(i);
+            Function<I, Flux<AgentEvent>> next = chain;
+            chain = input -> method.apply(mw, agent, input, next);
+        }
+        return chain;
+    }
+
+    /**
+     * Functional interface representing one of the onion-pattern middleware hooks.
+     *
+     * @param <I> the input type
+     */
+    @FunctionalInterface
+    public interface MiddlewareMethod<I> {
+        Flux<AgentEvent> apply(
+                Middleware mw, Agent agent, I input, Function<I, Flux<AgentEvent>> next);
+    }
+}

--- a/agentscope-core/src/main/java/io/agentscope/core/middleware/ModelCallInput.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/middleware/ModelCallInput.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.core.middleware;
+
+import io.agentscope.core.message.Msg;
+import io.agentscope.core.model.GenerateOptions;
+import io.agentscope.core.model.Model;
+import io.agentscope.core.model.ToolSchema;
+import java.util.List;
+
+/**
+ * Input context for {@link Middleware#onModelCall}.
+ *
+ * @param messages the messages to send to the model
+ * @param tools    the tool schemas
+ * @param options  generation options
+ * @param model    the model instance to call
+ */
+public record ModelCallInput(
+        List<Msg> messages, List<ToolSchema> tools, GenerateOptions options, Model model) {}

--- a/agentscope-core/src/main/java/io/agentscope/core/middleware/ReasoningInput.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/middleware/ReasoningInput.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.core.middleware;
+
+import io.agentscope.core.message.Msg;
+import io.agentscope.core.model.GenerateOptions;
+import io.agentscope.core.model.ToolSchema;
+import java.util.List;
+
+/**
+ * Input context for {@link Middleware#onReasoning}.
+ *
+ * @param messages  the messages to send to the model
+ * @param tools     the tool schemas available to the model
+ * @param options   generation options
+ */
+public record ReasoningInput(List<Msg> messages, List<ToolSchema> tools, GenerateOptions options) {}

--- a/agentscope-core/src/main/java/io/agentscope/core/middleware/ReplyInput.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/middleware/ReplyInput.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.core.middleware;
+
+import io.agentscope.core.message.Msg;
+import java.util.List;
+
+/**
+ * Input context for {@link Middleware#onReply}.
+ *
+ * @param msgs the input messages to the agent
+ */
+public record ReplyInput(List<Msg> msgs) {}


### PR DESCRIPTION
## Summary

Aligns AgentScope Java with Python 2.0 by adding a fine-grained event system and middleware framework, while refactoring Agent internals to emit `Flux<AgentEvent>` event streams.

### Phase 1 — Event system
- **25 AgentEvent types** in `io.agentscope.core.event` package: ReplyStart/End, ModelCallStart/End, TextBlock/ThinkingBlock/ToolCall/ToolResult Start/Delta/End, ExceedMaxIters, RequireUserConfirm, RequireExternalExecution, etc.
- **New message types**: `ToolCallState`, `ToolResultState` enums, `HintBlock` content block
- **ContentBlock / ToolResultBlock / ToolUseBlock**: added state fields for event tracking

### Phase 2 — Middleware framework
- **`Middleware` interface** with 5 interception points:
  - Onion pattern (4): `onReply`, `onReasoning`, `onActing`, `onModelCall`
  - Pipeline pattern (1): `onSystemPrompt`
- **`MiddlewareChain`** utility: builds back-to-front onion chains via `MiddlewareChain.build()`
- **Input records**: `ReplyInput`, `ReasoningInput`, `ActingInput`, `ModelCallInput`
- **Builder support**: `ReActAgent.builder().middleware(mw).build()`

### Phase 3 — Agent event stream refactoring
- `ReActAgent` internals refactored: `reasoning()` / `acting()` / `summarizing()` now produce `Flux<AgentEvent>` via `reasoningStream()` / `actingStream()` / `summaryStream()`
- New `replyImpl()` orchestrates the full ReAct loop as an event stream (ReplyStart → reasoning/acting events → ReplyEnd)
- Middleware wired at all 5 interception points using `MiddlewareChain.build()`
- New public API: `ReActAgent.streamEvents(msgs)` → `Flux<AgentEvent>`

### Backward compatibility
- `call()` → `Mono<Msg>` signature **unchanged**
- `stream()` → `Flux<Event>` signature **unchanged**
- Hook system fully preserved and still called alongside new event stream
- All **3807 existing tests pass** with 0 failures

## Test plan

- [x] `mvn compile -pl agentscope-core` — compiles clean
- [x] `mvn test -pl agentscope-core` — 3807 tests pass, 0 failures, 0 errors
- [x] Full project compile (all modules except pre-existing `graceful-shutdown` issue) — passes
- [ ] Manual verification with middleware example (logging middleware wrapping reasoning)