### PR TITLE
fix(harness): align subagent task output timeout

### DIFF
--- a/agentscope-core/src/main/java/io/agentscope/core/tool/ToolExecutor.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/tool/ToolExecutor.java
@@ -358,9 +358,16 @@ class ToolExecutor {
         Duration timeout = config.getTimeout();
         logger.debug("Applied timeout: {} for tool: {}", timeout, toolCall.getName());
 
-        return execution.timeout(
-                timeout,
-                Mono.error(new RuntimeException("Tool execution timeout after " + timeout)));
+        return execution.timeout(timeout, Mono.error(toolExecutionTimeoutError(timeout, toolCall)));
+    }
+
+    private static RuntimeException toolExecutionTimeoutError(
+            Duration timeout, ToolUseBlock toolCall) {
+        String toolName = toolCall.getName() != null ? toolCall.getName() : "unknown";
+        String toolId = toolCall.getId() != null ? toolCall.getId() : "unknown";
+        return new RuntimeException(
+                String.format(
+                        "Tool '%s' (id=%s) execution timeout after %s", toolName, toolId, timeout));
     }
 
     private Mono<ToolResultBlock> applyRetry(

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/HarnessAgent.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/HarnessAgent.java
@@ -93,10 +93,12 @@ import io.agentscope.harness.agent.tool.MemoryGetTool;
 import io.agentscope.harness.agent.tool.MemorySearchTool;
 import io.agentscope.harness.agent.tool.SessionSearchTool;
 import io.agentscope.harness.agent.tool.ShellExecuteTool;
+import io.agentscope.harness.agent.tool.TaskTool;
 import io.agentscope.harness.agent.workspace.WorkspaceManager;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
@@ -145,6 +147,9 @@ import reactor.core.publisher.Mono;
 public class HarnessAgent implements Agent, StateModule {
 
     private static final Logger log = LoggerFactory.getLogger(HarnessAgent.class);
+
+    private static final Duration SUBAGENT_TOOL_EXECUTION_TIMEOUT =
+            TaskTool.MAX_BLOCK_WAIT.plusMinutes(1);
 
     private final ReActAgent delegate;
     private final WorkspaceManager workspaceManager;
@@ -1380,7 +1385,11 @@ public class HarnessAgent implements Agent, StateModule {
                 allHooks.add(new SessionPersistenceHook());
             }
 
-            if (!leafSubagent && !disableSubagents && model != null) {
+            boolean subagentsEnabled = !leafSubagent && !disableSubagents && model != null;
+            ExecutionConfig effectiveToolExecutionConfig = toolExecutionConfig;
+            if (subagentsEnabled) {
+                effectiveToolExecutionConfig =
+                        withSubagentToolExecutionTimeout(toolExecutionConfig);
                 SubagentsHook subagentsHook =
                         buildSubagentsHook(
                                 wsManager, resolvedWorkspace, capturedSandboxFs, userIdRef);
@@ -1425,8 +1434,8 @@ public class HarnessAgent implements Agent, StateModule {
             if (modelExecutionConfig != null) {
                 reactBuilder.modelExecutionConfig(modelExecutionConfig);
             }
-            if (toolExecutionConfig != null) {
-                reactBuilder.toolExecutionConfig(toolExecutionConfig);
+            if (effectiveToolExecutionConfig != null) {
+                reactBuilder.toolExecutionConfig(effectiveToolExecutionConfig);
             }
             if (generateOptions != null) {
                 reactBuilder.generateOptions(generateOptions);
@@ -1470,7 +1479,7 @@ public class HarnessAgent implements Agent, StateModule {
                     name,
                     resolvedWorkspace,
                     filesystem.getClass().getSimpleName(),
-                    !leafSubagent && !disableSubagents && model != null);
+                    subagentsEnabled);
 
             return new HarnessAgent(
                     delegate,
@@ -1594,6 +1603,20 @@ public class HarnessAgent implements Agent, StateModule {
                 }
                 return List.of(userId);
             };
+        }
+
+        private static ExecutionConfig withSubagentToolExecutionTimeout(
+                ExecutionConfig configured) {
+            ExecutionConfig timeoutOverride =
+                    ExecutionConfig.builder().timeout(SUBAGENT_TOOL_EXECUTION_TIMEOUT).build();
+            if (configured == null) {
+                return timeoutOverride;
+            }
+            Duration timeout = configured.getTimeout();
+            if (timeout == null || timeout.compareTo(TaskTool.MAX_BLOCK_WAIT) <= 0) {
+                return ExecutionConfig.mergeConfigs(timeoutOverride, configured);
+            }
+            return configured;
         }
 
         // -----------------------------------------------------------------

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/tool/TaskTool.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/tool/TaskTool.java
@@ -21,6 +21,7 @@ import io.agentscope.core.tool.ToolParam;
 import io.agentscope.harness.agent.subagent.task.BackgroundTask;
 import io.agentscope.harness.agent.subagent.task.TaskRepository;
 import io.agentscope.harness.agent.subagent.task.TaskStatus;
+import java.time.Duration;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.util.Collection;
@@ -40,6 +41,9 @@ import java.util.Collection;
  * exists (cross-node or post-restart scenarios).
  */
 public class TaskTool {
+
+    public static final long MAX_BLOCK_WAIT_MILLIS = 600_000L;
+    public static final Duration MAX_BLOCK_WAIT = Duration.ofMillis(MAX_BLOCK_WAIT_MILLIS);
 
     private static final DateTimeFormatter ISO_FORMATTER =
             DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss'Z'").withZone(ZoneOffset.UTC);
@@ -96,7 +100,7 @@ public class TaskTool {
         bgTask.updateLastCheckedAt();
 
         boolean shouldBlock = block == null || block;
-        long timeoutMs = timeout != null ? Math.min(timeout, 600_000) : 30_000;
+        long timeoutMs = timeout != null ? Math.min(timeout, MAX_BLOCK_WAIT_MILLIS) : 30_000;
 
         if (shouldBlock && !bgTask.isCompleted()) {
             // If the task has no local future (cross-node or post-restart), degrade gracefully


### PR DESCRIPTION
Fixes #1451

Ensure HarnessAgent tool execution timeout exceeds task_output blocking waits and include tool identifiers in timeout errors.

## AgentScope-Java Version

1.1.0-SNAPSHOT

## Description

### Background

When `HarnessAgent` enables subagent orchestration, `task_output` supports blocking up to 10 minutes via its `timeout` parameter (`max: 600000` ms). However, the default tool execution configuration (`ExecutionConfig.TOOL_DEFAULTS`) applies a 5-minute timeout at the framework level.

As a result, a long-running `task_output(block=true, timeout=600000)` call can be interrupted by the tool executor before the tool's own wait limit is reached.

### Changes

1. **`TaskTool`**
   - Introduce shared constants `MAX_BLOCK_WAIT_MILLIS` / `MAX_BLOCK_WAIT` (10 minutes) and reuse them in `task_output` timeout clamping.

2. **`HarnessAgent`**
   - When subagents are enabled, raise the effective tool execution timeout to `TaskTool.MAX_BLOCK_WAIT + 1 minute` (11 minutes) if the user config is unset or not greater than 10 minutes.
   - Apply subagent hook registration and timeout adjustment in the same code path.

3. **`ToolExecutor`**
   - Improve timeout error messages to include tool name and tool call id, e.g.  
     `Tool 'task_output' (id=...) execution timeout after PT5M`.


## Checklist

Please check the following items before code is ready to be reviewed.

- [x] Code has been formatted with `mvn spotless:apply`
- [x] All tests are passing (`mvn test`)
- [x] Javadoc comments are complete and follow project conventions
- [x] Related documentation has been updated (e.g. links, examples, etc.)
- [x] Code is ready for review
