### PR TITLE
fix(models): exclude qwen3.6-max-preview from multimodal detection

### DIFF
--- a/agentscope-core/src/main/java/io/agentscope/core/model/DashScopeHttpClient.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/model/DashScopeHttpClient.java
@@ -374,6 +374,12 @@ public class DashScopeHttpClient {
      *   <li>Models containing "kimi-k2.5"/"kimi-k2.6" (e.g., kimi-k2.6, kimi/kimi-k2.5)</li>
      * </ul>
      *
+     * <p>Reverse exclusion rules (models matching the patterns above but treated as non-multimodal):
+     * <ul>
+     *   <li>Models starting with "qwen3.6": currently excludes "qwen3.6-max-preview",
+     *       which is a text-only model and should not be routed to the multimodal API.</li>
+     * </ul>
+     *
      * @param modelName the model name
      * @return true if the model is a multimodal model
      */
@@ -382,6 +388,10 @@ public class DashScopeHttpClient {
             return false;
         }
         String lowerModelName = modelName.toLowerCase();
+        // Reverse exclusion: certain qwen3.6-prefixed models are text-only.
+        if (lowerModelName.equals("qwen3.6-max-preview")) {
+            return false;
+        }
         return lowerModelName.startsWith("qvq")
                 || lowerModelName.contains("-vl")
                 || lowerModelName.contains("-asr")


### PR DESCRIPTION
qwen3.6-max-preview is a text-only model and should not be routed to the multimodal-generation API. Add a reverse exclusion in DashScopeHttpClient#isMultimodalModel and document the qwen3.6 reverse-exclusion rule in the method Javadoc.

## AgentScope-Java Version

[The version of AgentScope-Java you are working on, e.g. 1.0.12, check your pom.xml dependency version or run `mvn dependency:tree | grep agentscope-parent:pom`(only mac/linux)]

## Description

[Please describe the background, purpose, changes made, and how to test this PR]

## Checklist

Please check the following items before code is ready to be reviewed.

- [x]  Code has been formatted with `mvn spotless:apply`
- [x]  All tests are passing (`mvn test`)
- [x]  Javadoc comments are complete and follow project conventions
- [x]  Related documentation has been updated (e.g. links, examples, etc.)
- [x]  Code is ready for review
