### PR TITLE
fix: preserve typed RuntimeContext attributes in HarnessAgent

### DIFF
--- a/agentscope-core/src/main/java/io/agentscope/core/agent/RuntimeContext.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/agent/RuntimeContext.java
@@ -292,6 +292,27 @@ public class RuntimeContext {
         }
 
         /**
+         * Copies singleton typed attributes from an existing {@link RuntimeContext}.
+         *
+         * <p>Only default-keyed typed values exposed via {@link RuntimeContext#get(Class)} are
+         * copied. Keyed typed entries are intentionally not included because the builder currently
+         * models singleton typed registrations only.
+         */
+        public Builder typedFrom(RuntimeContext source) {
+            if (source == null || source.typedAttributes == null) {
+                return this;
+            }
+            for (Map.Entry<Class<?>, ConcurrentMap<String, Object>> e :
+                    source.typedAttributes.entrySet()) {
+                Object value = e.getValue().get(TYPED_DEFAULT_KEY);
+                if (value != null) {
+                    this.typedSingletons.put(e.getKey(), value);
+                }
+            }
+            return this;
+        }
+
+        /**
          * Nests a {@link ToolExecutionContext} (e.g. agent builder-level tool DI) that will be
          * visible at lower priority than runtime attributes in {@link #asToolExecutionContext()}.
          */

--- a/agentscope-core/src/test/java/io/agentscope/core/agent/RuntimeContextTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/agent/RuntimeContextTest.java
@@ -90,6 +90,21 @@ class RuntimeContextTest {
     }
 
     @Test
+    @DisplayName("builder typedFrom copies singleton typed attributes")
+    void builderTypedFromCopiesSingletonTypedAttributes() {
+        PojoA a = new PojoA("a");
+        PojoB keyed = new PojoB(7);
+        RuntimeContext source = RuntimeContext.builder().put(PojoA.class, a).build();
+        source.put("keyed", PojoB.class, keyed);
+
+        RuntimeContext copy = RuntimeContext.builder().put("extra", 42).typedFrom(source).build();
+
+        assertSame(a, copy.get(PojoA.class));
+        assertNull(copy.get("keyed", PojoB.class));
+        assertEquals(Integer.valueOf(42), copy.get("extra"));
+    }
+
+    @Test
     @DisplayName("get(Class) for RuntimeContext returns the instance")
     void selfTypedAccess() {
         RuntimeContext ctx = RuntimeContext.empty();

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/HarnessAgent.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/HarnessAgent.java
@@ -322,25 +322,27 @@ public class HarnessAgent implements Agent, StateModule {
                 sessionKey = SimpleSessionKey.of(delegate.getName());
             }
         }
+        SandboxContext callerSandbox = ctx.get(SandboxContext.class);
         // Inject default sandbox context if the call doesn't provide one
-        SandboxContext sandboxCtx =
-                ctx.get(SandboxContext.class) != null
-                        ? ctx.get(SandboxContext.class)
-                        : defaultSandboxContext;
+        SandboxContext sandboxCtx = callerSandbox != null ? callerSandbox : defaultSandboxContext;
 
         if (session == ctx.getSession()
                 && sessionKey == ctx.getSessionKey()
                 && sandboxCtx == ctx.get(SandboxContext.class)) {
             return ctx;
         }
-        return RuntimeContext.builder()
-                .sessionId(ctx.getSessionId())
-                .userId(ctx.getUserId())
-                .session(session)
-                .sessionKey(sessionKey)
-                .putAll(ctx.getExtra())
-                .put(SandboxContext.class, sandboxCtx)
-                .build();
+        RuntimeContext.Builder builder =
+                RuntimeContext.builder()
+                        .sessionId(ctx.getSessionId())
+                        .userId(ctx.getUserId())
+                        .session(session)
+                        .sessionKey(sessionKey)
+                        .putAll(ctx.getExtra())
+                        .typedFrom(ctx);
+        if (callerSandbox == null && defaultSandboxContext != null) {
+            builder.put(SandboxContext.class, defaultSandboxContext);
+        }
+        return builder.build();
     }
 
     // ==================== Agent interface delegation ====================

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/HarnessAgentTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/HarnessAgentTest.java
@@ -36,15 +36,18 @@ import io.agentscope.core.model.ToolSchema;
 import io.agentscope.core.session.Session;
 import io.agentscope.core.tool.AgentTool;
 import io.agentscope.core.tool.Toolkit;
+import io.agentscope.harness.agent.example.support.InMemorySandboxFilesystemSpec;
 import io.agentscope.harness.agent.filesystem.local.LocalFilesystem;
 import io.agentscope.harness.agent.filesystem.spec.RemoteFilesystemSpec;
 import io.agentscope.harness.agent.hook.SubagentsHook.SubagentEntry;
 import io.agentscope.harness.agent.memory.compaction.CompactionConfig;
+import io.agentscope.harness.agent.sandbox.SandboxDistributedOptions;
 import io.agentscope.harness.agent.store.InMemoryStore;
 import io.agentscope.harness.agent.subagent.AgentSpecLoader;
 import io.agentscope.harness.agent.subagent.SubagentDeclaration;
 import io.agentscope.harness.agent.subagent.WorkspaceMode;
 import io.agentscope.harness.agent.workspace.WorkspaceConstants;
+import java.lang.reflect.Method;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
@@ -62,6 +65,14 @@ import reactor.core.publisher.Flux;
 class HarnessAgentTest {
 
     @TempDir Path workspace;
+
+    private static final class HarnessContext {
+        final String value;
+
+        private HarnessContext(String value) {
+            this.value = value;
+        }
+    }
 
     @Test
     void workspaceAgentsMd_readableViaWorkspaceManager() throws Exception {
@@ -337,6 +348,40 @@ class HarnessAgentTest {
 
         assertTrue(
                 store.get(List.of("agents", "agent-a", "users", "_default"), "/MEMORY.md") != null);
+    }
+
+    @Test
+    void ensureSessionDefaults_preservesTypedAttributesWhenInjectingDefaultSandbox()
+            throws Exception {
+        Files.createDirectories(workspace);
+        HarnessAgent agent =
+                HarnessAgent.builder()
+                        .name("t")
+                        .model(stubModel("ok"))
+                        .workspace(workspace)
+                        .filesystem(new InMemorySandboxFilesystemSpec())
+                        .session(mock(Session.class))
+                        .sandboxDistributed(
+                                SandboxDistributedOptions.builder()
+                                        .requireDistributed(false)
+                                        .build())
+                        .build();
+
+        HarnessContext typed = new HarnessContext("typed-value");
+        RuntimeContext input =
+                RuntimeContext.builder()
+                        .sessionId("sid-typed")
+                        .session(mock(Session.class))
+                        .sessionKey(io.agentscope.core.state.SimpleSessionKey.of("sid-typed"))
+                        .put(HarnessContext.class, typed)
+                        .build();
+
+        Method method =
+                HarnessAgent.class.getDeclaredMethod("ensureSessionDefaults", RuntimeContext.class);
+        method.setAccessible(true);
+        RuntimeContext effective = (RuntimeContext) method.invoke(agent, input);
+
+        assertEquals("typed-value", effective.get(HarnessContext.class).value);
     }
 
     private static Msg userText(String text) {


### PR DESCRIPTION
## AgentScope-Java Version

[The version of AgentScope-Java you are working on, e.g. 1.0.12, check your pom.xml dependency version or run `mvn dependency:tree | grep agentscope-parent:pom`(only mac/linux)]

## Description

[Please describe the background, purpose, changes made, and how to test this PR]

## Checklist

Please check the following items before code is ready to be reviewed.

- [ ]  Code has been formatted with `mvn spotless:apply`
- [ ]  All tests are passing (`mvn test`)
- [ ]  Javadoc comments are complete and follow project conventions
- [ ]  Related documentation has been updated (e.g. links, examples, etc.)
- [ ]  Code is ready for review
