### PR TITLE
fix(agent): 对齐 EventType.ALL 的文档与流式行为

### DIFF
--- a/agentscope-core/src/main/java/io/agentscope/core/agent/EventType.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/agent/EventType.java
@@ -67,7 +67,10 @@ public enum EventType {
      * Final result event - The agent's complete response.
      *
      * <p>This is the message returned by {@link Agent#call(io.agentscope.core.message.Msg)}.
-     * By default, this event is NOT included in the stream to avoid duplication since it's the return value.
+     * In streaming APIs, this event is emitted whenever {@link StreamOptions} includes
+     * {@link #AGENT_RESULT} explicitly or uses {@link #ALL}. Since the default
+     * {@link StreamOptions} configuration uses {@link #ALL}, {@code AGENT_RESULT} is streamed
+     * by default.
      *
      * <p>Characteristics:
      * <ul>

--- a/agentscope-core/src/main/java/io/agentscope/core/agent/EventType.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/agent/EventType.java
@@ -76,7 +76,8 @@ public enum EventType {
      * <ul>
      *   <li>Message role: {@link io.agentscope.core.message.MsgRole#ASSISTANT}</li>
      *   <li>Content: Final response text</li>
-     *   <li>Streaming: Not applicable</li>
+     *   <li>Streaming: Included when {@link StreamOptions} contains {@link #AGENT_RESULT}
+     *       or {@link #ALL} (the default)</li>
      * </ul>
      */
     AGENT_RESULT,
@@ -94,7 +95,7 @@ public enum EventType {
     SUMMARY,
 
     /**
-     * Special value to stream all event types (except {@link #AGENT_RESULT}).
+     * Special value to stream all event types, including {@link #AGENT_RESULT}.
      *
      * <p>Use this in {@link StreamOptions} to receive all events without filtering.
      */

--- a/agentscope-core/src/test/java/io/agentscope/core/agent/AgentStreamingTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/agent/AgentStreamingTest.java
@@ -115,6 +115,29 @@ class AgentStreamingTest {
     }
 
     @Test
+    void testStreamWithAllIncludesAgentResult() {
+        TestStreamingAgent agent = new TestStreamingAgent("test-agent");
+        agent.setResponseText("Response");
+
+        Msg inputMsg =
+                Msg.builder()
+                        .name("user")
+                        .role(MsgRole.USER)
+                        .content(List.of(TextBlock.builder().text("Test").build()))
+                        .build();
+
+        StreamOptions options = StreamOptions.builder().eventTypes(EventType.ALL).build();
+
+        List<Event> events = new ArrayList<>();
+        agent.stream(inputMsg, options).doOnNext(events::add).blockLast();
+
+        assertFalse(events.isEmpty());
+        Event lastEvent = events.get(events.size() - 1);
+        assertEquals(EventType.AGENT_RESULT, lastEvent.getType());
+        assertTrue(lastEvent.isLast());
+    }
+
+    @Test
     void testStreamWithSpecificEventTypes() {
         TestStreamingAgent agent = new TestStreamingAgent("test-agent");
         agent.setResponseText("Response");

--- a/docs/v1/en/docs/task/streaming.md
+++ b/docs/v1/en/docs/task/streaming.md
@@ -43,8 +43,8 @@ Flux<Event> events = agent.stream(msgs, StreamOptions.defaults(), ctx);
 | `TOOL_RESULT` | After each tool execution | `ToolResultBlock` (tool name, id, output) |
 | `HINT` | After RAG / memory retrieval | Context text injected into the model |
 | `SUMMARY` | When `maxIters` is reached | Iteration summary text |
-| `AGENT_RESULT` | Final reply ready | Same as `call()` return value; **not included** in stream by default |
-| `ALL` | Placeholder for all the above (except `AGENT_RESULT`) | — |
+| `AGENT_RESULT` | Final reply ready | Same as `call()` return value |
+| `ALL` | Placeholder for all event types | - |
 
 ### Subscribe to specific types only
 
@@ -153,7 +153,7 @@ serialize `event.getSource()` as well — see [Harness Subagent Streaming](../ha
 
 ```java
 StreamOptions options = StreamOptions.builder()
-        // Event types to receive (default: ALL, excluding AGENT_RESULT)
+        // Event types to receive (default: ALL)
         .eventTypes(EventType.REASONING, EventType.TOOL_RESULT, EventType.AGENT_RESULT)
 
         // Incremental mode: true = push deltas (default), false = push full accumulated text

--- a/docs/v1/zh/docs/task/streaming.md
+++ b/docs/v1/zh/docs/task/streaming.md
@@ -43,8 +43,8 @@ Flux<Event> events = agent.stream(msgs, StreamOptions.defaults(), ctx);
 | `TOOL_RESULT` | 每次工具执行完毕后 | `ToolResultBlock`（含工具名、id、输出） |
 | `HINT` | RAG / 记忆检索注入后 | 注入模型的上下文文本 |
 | `SUMMARY` | 达到 `maxIters` 上限时 | 迭代摘要文本 |
-| `AGENT_RESULT` | 最终回复就绪 | 与 `call()` 返回值相同，默认**不在**流中 |
-| `ALL` | 占位符，代表全部（不含 `AGENT_RESULT`） | — |
+| `AGENT_RESULT` | 最终回复就绪 | 与 `call()` 返回值相同 |
+| `ALL` | 占位符，代表全部事件类型 | - |
 
 ### 只订阅指定类型
 
@@ -151,7 +151,7 @@ public Flux<ServerSentEvent<String>> chat(@RequestParam String message) {
 
 ```java
 StreamOptions options = StreamOptions.builder()
-        // 订阅的事件类型（默认 ALL，不含 AGENT_RESULT）
+        // 订阅的事件类型（默认 ALL）
         .eventTypes(EventType.REASONING, EventType.TOOL_RESULT, EventType.AGENT_RESULT)
 
         // 增量模式（默认 true）


### PR DESCRIPTION
## 做了什么
- 明确 `EventType.ALL` 和 `StreamOptions#getEventTypes()` 实际会包含 `AGENT_RESULT`
- 同步更新英文/中文流式文档，和真实行为保持一致
- 补充回归测试，验证 `EventType.ALL` 会流式输出 `AGENT_RESULT`

## 原因
- Issue #1439 指出注释/文档与实现不一致
- 这次只统一说明与测试，不修改运行时逻辑

## 验证
- `mvn -pl agentscope-core spotless:apply`
- `mvn -pl agentscope-core -Dtest=StreamOptionsTest test`

Fixes #1439
