### PR TITLE
fix/localfilesystem-glob-direct-files

### DIFF
--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/memory/MemoryConsolidatorFilesystemTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/memory/MemoryConsolidatorFilesystemTest.java
@@ -18,7 +18,15 @@ package io.agentscope.harness.agent.memory;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
+import io.agentscope.core.message.TextBlock;
+import io.agentscope.core.model.ChatResponse;
+import io.agentscope.core.model.Model;
+import io.agentscope.harness.agent.filesystem.local.LocalFilesystem;
 import io.agentscope.harness.agent.filesystem.remote.RemoteFilesystem;
 import io.agentscope.harness.agent.store.InMemoryStore;
 import io.agentscope.harness.agent.workspace.WorkspaceManager;
@@ -29,11 +37,11 @@ import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import reactor.core.publisher.Flux;
 
 /**
  * Verifies that {@link MemoryConsolidator} reads daily ledgers and writes watermark / MEMORY.md
- * entirely through {@link io.agentscope.harness.agent.filesystem.AbstractFilesystem}, making it
- * backend-agnostic.
+ * through the filesystem layer.
  */
 class MemoryConsolidatorFilesystemTest {
 
@@ -50,10 +58,6 @@ class MemoryConsolidatorFilesystemTest {
         store.put(ns, path, value);
     }
 
-    // ======================================================================
-    // readWatermark: returns EPOCH when state file absent
-    // ======================================================================
-
     @Test
     void readWatermark_returnsEpochWhenStateAbsent(@TempDir Path tmp) {
         InMemoryStore store = new InMemoryStore();
@@ -65,10 +69,6 @@ class MemoryConsolidatorFilesystemTest {
 
         assertEquals(Instant.EPOCH, consolidator.readWatermark());
     }
-
-    // ======================================================================
-    // readWatermark / writeWatermark round-trip through filesystem
-    // ======================================================================
 
     @Test
     void watermark_roundTripThroughFilesystem(@TempDir Path tmp) {
@@ -85,10 +85,6 @@ class MemoryConsolidatorFilesystemTest {
         assertEquals(ts, consolidator.readWatermark());
     }
 
-    // ======================================================================
-    // readWatermark: no local file is touched — only the filesystem
-    // ======================================================================
-
     @Test
     void watermark_doesNotCreateLocalFile(@TempDir Path tmp) {
         InMemoryStore store = new InMemoryStore();
@@ -101,28 +97,34 @@ class MemoryConsolidatorFilesystemTest {
         Instant ts = Instant.now();
         wsm.writeUtf8WorkspaceRelative(MemoryConsolidator.STATE_REL_PATH, ts.toString());
 
-        // local disk must NOT have the state file — it lives only in the store
         Path localState = tmp.resolve("memory").resolve(MemoryConsolidator.STATE_FILE);
         assertFalse(
                 Files.exists(localState),
                 "state file should not be written to local disk when using RemoteFilesystem");
 
-        // but consolidator reads it correctly from the store
         assertEquals(ts, consolidator.readWatermark());
     }
-
-    // ======================================================================
-    // STATE_FILE constant is preserved
-    // ======================================================================
 
     @Test
     void stateFileRelPath_matchesConstant() {
         assertEquals("memory/" + MemoryConsolidator.STATE_FILE, MemoryConsolidator.STATE_REL_PATH);
     }
 
-    // ======================================================================
-    // Local filesystem (no store) — watermark uses local disk via WorkspaceManager
-    // ======================================================================
+    @Test
+    void consolidate_readsRootDailyLedgerAndWritesMemoryMd(@TempDir Path tmp) throws Exception {
+        LocalFilesystem fs = new LocalFilesystem(tmp);
+        WorkspaceManager wsm = new WorkspaceManager(tmp, fs);
+
+        Path memoryDir = Files.createDirectories(tmp.resolve("memory"));
+        Files.writeString(memoryDir.resolve("2026-05-20.md"), "root daily entry");
+
+        MemoryConsolidator consolidator = new MemoryConsolidator(wsm, stubModel("updated memory"));
+
+        consolidator.consolidate().block();
+
+        assertEquals("updated memory", wsm.readMemoryMd());
+        assertTrue(consolidator.readWatermark().isAfter(Instant.EPOCH));
+    }
 
     @Test
     void watermark_localFallback_whenNoFilesystem(@TempDir Path tmp) throws Exception {
@@ -130,19 +132,30 @@ class MemoryConsolidatorFilesystemTest {
 
         MemoryConsolidator consolidator = new MemoryConsolidator(wsm, null);
 
-        // No file → EPOCH
         assertEquals(Instant.EPOCH, consolidator.readWatermark());
 
-        // Write via WorkspaceManager (falls to local disk)
         Instant ts = Instant.parse("2025-03-10T09:00:00Z");
         wsm.writeUtf8WorkspaceRelative(MemoryConsolidator.STATE_REL_PATH, ts.toString());
 
         assertEquals(ts, consolidator.readWatermark());
 
-        // Verify the local file actually exists
         Path localState = tmp.resolve("memory").resolve(MemoryConsolidator.STATE_FILE);
         assertTrue(
                 Files.exists(localState),
                 "state file should be written to local disk when no filesystem is configured");
+    }
+
+    private static Model stubModel(String assistantText) {
+        Model model = mock(Model.class);
+        when(model.getModelName()).thenReturn("stub-model");
+        ChatResponse chunk =
+                new ChatResponse(
+                        "stub-id",
+                        List.of(TextBlock.builder().text(assistantText).build()),
+                        null,
+                        Map.of(),
+                        "stop");
+        when(model.stream(anyList(), any(), any())).thenReturn(Flux.just(chunk));
+        return model;
     }
 }


### PR DESCRIPTION
## PR 标题
test(harness): add regression test for memory consolidation glob

## 背景
issue #1458 里，`MemoryConsolidator` 处理 `memory/*.md` 时需要确保根目录下的日记文件也能被正确读取，避免后续 `glob` 行为变化引入回归。

## 修改内容
- 在 `agentscope-harness/src/test/java/io/agentscope/harness/agent/memory/MemoryConsolidatorFilesystemTest.java` 中新增回归测试 `consolidate_readsRootDailyLedgerAndWritesMemoryMd`
- 使用 `LocalFilesystem + WorkspaceManager` 直接创建 `memory/2026-05-20.md`
- 验证 `consolidate()` 能读取根目录日记并写出 `MEMORY.md`
- 本次仅补充测试，不修改运行时代码

## 验证
- `mvn -gs <temp-settings> -pl agentscope-harness -am -Dtest=MemoryConsolidatorFilesystemTest test`
- `spotless:apply`
