### PR TITLE
chore: add .gitattributes to enforce LF line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,20 @@
+# Normalize line endings to LF on checkin; check out as LF on all platforms.
+# Prevents Windows CRLF from fighting Spotless (googleJavaFormat enforces LF).
+* text=auto eol=lf
+
+# Windows-only script files keep CRLF.
+*.bat text eol=crlf
+*.cmd text eol=crlf
+
+# Common binary types — never touch them.
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.ico binary
+*.pdf binary
+*.zip binary
+*.gz binary
+*.tar binary
+*.jar binary
+*.class binary

--- a/.licenserc.yaml
+++ b/.licenserc.yaml
@@ -60,6 +60,7 @@ header:
     - '.git/'
     - '.github/**'
     - '**/.gitignore'
+    - '**/.gitattributes'
     - '**/.helmignore'
     - '.repository/'
     - 'compiler/**'


### PR DESCRIPTION
## Summary

- Add a top-level `.gitattributes` to normalize text files to **LF** on checkin and checkout, regardless of OS.
- Keep `.bat`/`.cmd` as **CRLF** so Windows shells parse them correctly.
- Mark common binary types as `binary` to disable diff/eol munging.

## Why

On Windows, Git's default `core.autocrlf=true` rewrites LF to CRLF at checkout. Spotless's `googleJavaFormat` step normalizes Java sources to LF, so the two fight each other and `mvn spotless:check` fails on Windows even though the same tree is clean on macOS/Linux. A repo-level `.gitattributes` with `* text=auto eol=lf` overrides the per-user `core.autocrlf` setting and makes line endings consistent for every contributor.

A real failure observed on Windows:

```
Error:  Failed to execute goal com.diffplug.spotless:spotless-maven-plugin:3.4.0:check
Error:      src\main\java\io\agentscope\dataagent\web\session\SessionReadStateStore.java
Error:      ... (diff shows the file checked out as CRLF while Spotless wants LF)
```

## Test plan

- [x] `mvn spotless:check` still passes on macOS (no behavior change for existing LF tree)
- [ ] Verify on Windows that a fresh clone + `mvn spotless:check` no longer reports CRLF/LF violations
- [ ] Existing CRLF files (if any) can be normalized in a follow-up via `git add --renormalize . && git commit -m "chore: renormalize line endings"`

## Notes

- This change does not modify any existing tracked file's contents — `.gitattributes` only affects future checkins/checkouts. Pre-existing CRLF files in the repo will remain CRLF until someone runs `git add --renormalize .`.
- Considered also adding `<lineEndings>UNIX</lineEndings>` to the Spotless plugin config as defense-in-depth; happy to follow up with that if maintainers prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)