### PR TITLE
fix(harness): fix zero file sizes in sandbox ls and glob results

### DIFF
--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/filesystem/sandbox/BaseSandboxFilesystem.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/filesystem/sandbox/BaseSandboxFilesystem.java
@@ -72,23 +72,27 @@ public abstract class BaseSandboxFilesystem implements AbstractSandboxFilesystem
     @Override
     public LsResult ls(RuntimeContext runtimeContext, String path) {
         String escapedPath = FilesystemUtils.shellQuote(path);
+        // Use tab-separated output: DIR\t<path> or FILE\t<path>\t<size>
+        // stat -c%s reads inode metadata only (O(1)), never reads file content.
+        // The sandbox runs on Docker Linux where GNU coreutils are always available.
         String cmd =
                 "for f in "
                         + escapedPath
-                        + "/*; do "
-                        + "  if [ -d \"$f\" ]; then echo \"DIR:$f\"; "
-                        + "  elif [ -f \"$f\" ]; then echo \"FILE:$f\"; fi; "
-                        + "done 2>/dev/null";
+                        + "/*; do   if [ -d \"$f\" ]; then printf 'DIR\\t%s\\n"
+                        + "' \"$f\";   elif [ -f \"$f\" ]; then printf 'FILE\\t%s\\t%s\\n"
+                        + "' \"$f\" \"$(stat -c%s \"$f\" 2>/dev/null || echo 0)\"; fi; done"
+                        + " 2>/dev/null";
 
         ExecuteResponse result = execute(runtimeContext, cmd, null);
         List<FileInfo> entries = new ArrayList<>();
 
         if (result.output() != null && !result.output().isBlank()) {
             for (String line : result.output().strip().split("\n")) {
-                if (line.startsWith("DIR:")) {
-                    entries.add(FileInfo.ofDir(line.substring(4), ""));
-                } else if (line.startsWith("FILE:")) {
-                    entries.add(FileInfo.ofFile(line.substring(5), 0, ""));
+                String[] parts = line.split("\t", 3);
+                if (parts.length >= 2 && "DIR".equals(parts[0])) {
+                    entries.add(FileInfo.ofDir(parts[1], ""));
+                } else if (parts.length >= 3 && "FILE".equals(parts[0])) {
+                    entries.add(FileInfo.ofFile(parts[1], parseFileSize(parts[2]), ""));
                 }
             }
         }
@@ -321,8 +325,15 @@ public abstract class BaseSandboxFilesystem implements AbstractSandboxFilesystem
         String escapedPath = FilesystemUtils.shellQuote(path != null ? path : "/");
         String escapedPattern = FilesystemUtils.shellQuote(pattern);
 
+        // Use find -printf to emit "<size>\t<path>" per match in a single pass.
+        // -printf '%s\t%p\n' reads inode metadata only (O(1) per file, no file I/O).
+        // The sandbox runs on Docker Linux where GNU find is always available.
         String cmd =
-                "find " + escapedPath + " -type f -name " + escapedPattern + " 2>/dev/null | sort";
+                "find "
+                        + escapedPath
+                        + " -type f -name "
+                        + escapedPattern
+                        + " -printf '%s\\t%p\\n' 2>/dev/null | sort";
 
         ExecuteResponse result = execute(runtimeContext, cmd, null);
         String output = result.output() != null ? result.output().strip() : "";
@@ -334,11 +345,23 @@ public abstract class BaseSandboxFilesystem implements AbstractSandboxFilesystem
         List<FileInfo> entries = new ArrayList<>();
         for (String line : output.split("\n")) {
             if (!line.isBlank()) {
-                entries.add(FileInfo.ofFile(line.trim(), 0, ""));
+                String[] parts = line.split("\t", 2);
+                if (parts.length == 2) {
+                    // find -printf '%s\t%p\n': parts[0]=size, parts[1]=path
+                    entries.add(FileInfo.ofFile(parts[1].trim(), parseFileSize(parts[0]), ""));
+                }
             }
         }
 
         return GlobResult.success(entries);
+    }
+
+    private static long parseFileSize(String raw) {
+        try {
+            return Long.parseLong(raw.trim());
+        } catch (NumberFormatException e) {
+            return 0L;
+        }
     }
 
     @Override

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/filesystem/sandbox/BaseSandboxFilesystemTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/filesystem/sandbox/BaseSandboxFilesystemTest.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.harness.agent.filesystem.sandbox;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import io.agentscope.core.agent.RuntimeContext;
+import io.agentscope.harness.agent.filesystem.model.ExecuteResponse;
+import io.agentscope.harness.agent.filesystem.model.FileDownloadResponse;
+import io.agentscope.harness.agent.filesystem.model.FileUploadResponse;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class BaseSandboxFilesystemTest {
+
+    @Test
+    void ls_parsesFileSizesFromSandboxOutput() {
+        TestSandboxFilesystem filesystem = new TestSandboxFilesystem();
+        filesystem.nextExecuteResponse =
+                new ExecuteResponse(
+                        "DIR\t/workspace/session/uploads/subdir\n"
+                                + "FILE\t/workspace/session/uploads/a.pdf\t1234\n",
+                        0,
+                        false);
+
+        var result = filesystem.ls(RuntimeContext.empty(), "/workspace/session/uploads");
+
+        assertFalse(result.entries().isEmpty());
+        assertEquals(2, result.entries().size());
+        assertEquals("/workspace/session/uploads/subdir", result.entries().get(0).path());
+        assertEquals("/workspace/session/uploads/a.pdf", result.entries().get(1).path());
+        assertEquals(1234L, result.entries().get(1).size());
+    }
+
+    @Test
+    void glob_parsesFileSizesFromSandboxOutput() {
+        TestSandboxFilesystem filesystem = new TestSandboxFilesystem();
+        filesystem.nextExecuteResponse =
+                new ExecuteResponse(
+                        "128\t/workspace/session/uploads/a.pdf\n"
+                                + "2048\t/workspace/session/uploads/b.xlsx\n",
+                        0,
+                        false);
+
+        var result = filesystem.glob(RuntimeContext.empty(), "*.pdf", "/workspace/session/uploads");
+
+        assertEquals(2, result.matches().size());
+        assertEquals("/workspace/session/uploads/a.pdf", result.matches().get(0).path());
+        assertEquals(128L, result.matches().get(0).size());
+        assertEquals("/workspace/session/uploads/b.xlsx", result.matches().get(1).path());
+        assertEquals(2048L, result.matches().get(1).size());
+    }
+
+    private static final class TestSandboxFilesystem extends BaseSandboxFilesystem {
+        private ExecuteResponse nextExecuteResponse = new ExecuteResponse("", 0, false);
+
+        @Override
+        public String id() {
+            return "test";
+        }
+
+        @Override
+        public ExecuteResponse execute(
+                RuntimeContext runtimeContext, String command, Integer timeoutSeconds) {
+            return nextExecuteResponse;
+        }
+
+        @Override
+        public List<FileUploadResponse> uploadFiles(
+                RuntimeContext runtimeContext, List<Map.Entry<String, byte[]>> files) {
+            throw new UnsupportedOperationException("Not needed for this test");
+        }
+
+        @Override
+        public List<FileDownloadResponse> downloadFiles(
+                RuntimeContext runtimeContext, List<String> paths) {
+            throw new UnsupportedOperationException("Not needed for this test");
+        }
+    }
+}


### PR DESCRIPTION
## Problem

Both `ls()` and `glob()` in `BaseSandboxFilesystem` were constructing
`FileInfo` entries with size `0`, so sandbox-backed file listings always
reported `0 bytes` regardless of the actual file size.

## Fix

- update `ls()` to emit tab-separated entries with real file sizes
- update `glob()` to return `"<size>\t<path>"` records so `FileInfo.size`
  is populated correctly
- use GNU file utilities available in the Debian-based sandbox:
  `stat -c%s` for `ls()` and `find -printf` for `glob()`
- add regression tests covering file size parsing for both code paths

## Testing

```bash
mvn -pl agentscope-harness -Dtest=BaseSandboxFilesystemTest test