### PR TITLE
fix(hook): PendingToolRecoveryHook skips patching when memory has historical ToolResults

### DIFF
--- a/agentscope-core/src/main/java/io/agentscope/core/hook/PendingToolRecoveryHook.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/hook/PendingToolRecoveryHook.java
@@ -98,17 +98,25 @@ public class PendingToolRecoveryHook implements Hook {
             return Mono.just(event);
         }
 
-        // Check if user already provided tool results in the input
+        // event.getInputMessages() = memory snapshot + user callArgs
+        // (see AgentBase.notifyPreCall). Extract just the callArgs portion so we only
+        // check the user's current input for ToolResultBlocks, not the entire memory
+        // history which naturally contains ToolResultBlocks from previous tool calls.
         List<Msg> inputMessages = event.getInputMessages();
+        int memorySize = memory.getMessages().size();
+        List<Msg> callArgs =
+                (inputMessages != null && inputMessages.size() > memorySize)
+                        ? inputMessages.subList(memorySize, inputMessages.size())
+                        : List.of();
 
-        // If input is empty/null, the user is resuming (wants to continue acting).
+        // If callArgs is empty, the user is resuming (wants to continue acting).
         // Do NOT patch — let ReActAgent's doCall handle the resume flow.
-        if (inputMessages == null || inputMessages.isEmpty()) {
+        if (callArgs.isEmpty()) {
             return Mono.just(event);
         }
 
         boolean userProvidedResults =
-                inputMessages.stream().anyMatch(m -> m.hasContentBlocks(ToolResultBlock.class));
+                callArgs.stream().anyMatch(m -> m.hasContentBlocks(ToolResultBlock.class));
         if (userProvidedResults) {
             return Mono.just(event);
         }

--- a/agentscope-core/src/test/java/io/agentscope/core/hook/HookStopAgentTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/hook/HookStopAgentTest.java
@@ -420,6 +420,101 @@ class HookStopAgentTest {
                     "Memory should contain an error ToolResultBlock for the pending tool call"
                             + " id='tool1'");
         }
+
+        @Test
+        @DisplayName("Auto-recovery works when memory already contains historical ToolResultBlocks")
+        void testAutoRecoveryWithHistoricalToolResults() {
+            // Pre-populate memory with historical tool call + result pairs.
+            // This simulates a conversation that has used tools before.
+            Msg historicalToolUse = createToolUseMsg("old_tool_1", "odps_query", Map.of());
+            memory.addMessage(historicalToolUse);
+            Msg historicalToolResult =
+                    Msg.builder()
+                            .name("test-agent")
+                            .role(MsgRole.TOOL)
+                            .content(
+                                    ToolResultBlock.builder()
+                                            .id("old_tool_1")
+                                            .output(
+                                                    List.of(
+                                                            TextBlock.builder()
+                                                                    .text("query result")
+                                                                    .build()))
+                                            .build())
+                            .build();
+            memory.addMessage(historicalToolResult);
+            Msg historicalAssistantReply = createAssistantTextMsg("Here is the query result.");
+            memory.addMessage(historicalAssistantReply);
+
+            // Now set up the current scenario: agent makes a new tool call that gets stopped
+            Msg newToolUseMsg = createToolUseMsg("new_tool_1", "test_tool", Map.of());
+            Msg recoveryResponse = createAssistantTextMsg("Recovered successfully");
+
+            when(mockModel.stream(anyList(), anyList(), any()))
+                    .thenReturn(createFluxFromMsg(newToolUseMsg))
+                    .thenReturn(createFluxFromMsg(recoveryResponse));
+
+            Hook stopHook = createPostReasoningStopHook();
+
+            ReActAgent agent =
+                    ReActAgent.builder()
+                            .name("test-agent")
+                            .model(mockModel)
+                            .toolkit(toolkit)
+                            .memory(memory)
+                            .checkRunning(false)
+                            .hook(stopHook)
+                            .enablePendingToolRecovery(true)
+                            .build();
+
+            // First call - agent reasons a tool call, gets stopped by hook
+            Msg result1 = agent.call(createUserMsg("do something")).block(TEST_TIMEOUT);
+            assertTrue(
+                    result1.hasContentBlocks(ToolUseBlock.class),
+                    "First call should return ToolUse message (stopped by hook)");
+
+            // At this point, memory has:
+            //   - historical ASSISTANT msg with ToolUseBlock(id=old_tool_1)
+            //   - historical TOOL msg with ToolResultBlock(id=old_tool_1) ← THIS IS THE KEY
+            //   - historical ASSISTANT text msg
+            //   - user msg
+            //   - new ASSISTANT msg with ToolUseBlock(id=new_tool_1) ← PENDING (no result)
+            //
+            // Bug scenario: the hook's userProvidedResults check scanned the full
+            // inputMessages (memory snapshot + callArgs). The historical ToolResultBlock
+            // for old_tool_1 caused the hook to think "user provided results" and skip
+            // patching. Then doCall threw IllegalStateException.
+
+            // Second call - should auto-recover, NOT throw IllegalStateException
+            Msg result2 = agent.call(createUserMsg("continue")).block(TEST_TIMEOUT);
+
+            assertNotNull(result2, "Agent should auto-recover even with historical ToolResults");
+            assertTrue(
+                    result2.hasContentBlocks(TextBlock.class),
+                    "Recovery result should contain text content");
+
+            // Verify error ToolResultBlock was written for the PENDING tool call
+            List<Msg> memoryMsgs = memory.getMessages();
+            boolean hasErrorResultForNewTool =
+                    memoryMsgs.stream()
+                            .flatMap(m -> m.getContentBlocks(ToolResultBlock.class).stream())
+                            .anyMatch(
+                                    tr ->
+                                            "new_tool_1".equals(tr.getId())
+                                                    && tr.getOutput().stream()
+                                                            .anyMatch(
+                                                                    cb ->
+                                                                            cb instanceof TextBlock
+                                                                                    && ((TextBlock)
+                                                                                                    cb)
+                                                                                            .getText()
+                                                                                            .contains(
+                                                                                                    "[ERROR]")));
+            assertTrue(
+                    hasErrorResultForNewTool,
+                    "Memory should contain an error ToolResultBlock for the PENDING tool call"
+                            + " (new_tool_1), not be confused by historical ToolResults");
+        }
     }
 
     // ==================== E. Hook Integration Tests ====================

--- a/agentscope-core/src/test/java/io/agentscope/core/hook/PendingToolRecoveryHookTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/hook/PendingToolRecoveryHookTest.java
@@ -1,0 +1,190 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.core.hook;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.agentscope.core.ReActAgent;
+import io.agentscope.core.memory.InMemoryMemory;
+import io.agentscope.core.memory.Memory;
+import io.agentscope.core.message.Msg;
+import io.agentscope.core.message.MsgRole;
+import io.agentscope.core.message.TextBlock;
+import io.agentscope.core.message.ToolResultBlock;
+import io.agentscope.core.message.ToolUseBlock;
+import io.agentscope.core.util.JsonUtils;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for {@link PendingToolRecoveryHook}, focusing on the callArgs extraction logic that
+ * separates user input from the memory snapshot in {@code event.getInputMessages()}.
+ */
+class PendingToolRecoveryHookTest {
+
+    private final PendingToolRecoveryHook hook = new PendingToolRecoveryHook();
+
+    @Test
+    @DisplayName("Patches pending tool calls when memory has historical ToolResultBlocks")
+    void patchesDespiteHistoricalToolResults() {
+        Memory memory = new InMemoryMemory();
+
+        // Historical tool call + result (completed in a previous turn)
+        memory.addMessage(assistantToolUse("old_call", "old_tool"));
+        memory.addMessage(toolResult("old_call", "old result"));
+        memory.addMessage(assistantText("Done with old tool."));
+
+        // Pending tool call (no result)
+        memory.addMessage(assistantToolUse("pending_call", "new_tool"));
+
+        ReActAgent agent = mockReActAgent(memory);
+
+        // event.getInputMessages() = memory snapshot (4 msgs) + user callArgs (1 msg)
+        List<Msg> fullInput =
+                List.of(
+                        memory.getMessages().get(0),
+                        memory.getMessages().get(1),
+                        memory.getMessages().get(2),
+                        memory.getMessages().get(3),
+                        userMsg("continue please"));
+
+        PreCallEvent event = new PreCallEvent(agent, fullInput);
+        hook.onEvent(event).block();
+
+        // Verify the hook patched: memory should now have a ToolResultBlock for "pending_call"
+        boolean patched =
+                memory.getMessages().stream()
+                        .flatMap(m -> m.getContentBlocks(ToolResultBlock.class).stream())
+                        .anyMatch(tr -> "pending_call".equals(tr.getId()));
+        assertTrue(patched, "Hook should patch the pending tool call despite historical results");
+    }
+
+    @Test
+    @DisplayName("Skips when callArgs is empty (resume scenario)")
+    void skipsWhenCallArgsEmpty() {
+        Memory memory = new InMemoryMemory();
+        memory.addMessage(assistantToolUse("pending_call", "some_tool"));
+
+        ReActAgent agent = mockReActAgent(memory);
+
+        // inputMessages = memory snapshot only, no callArgs (resume scenario)
+        List<Msg> fullInput = List.of(memory.getMessages().get(0));
+
+        PreCallEvent event = new PreCallEvent(agent, fullInput);
+        hook.onEvent(event).block();
+
+        // Should NOT patch — resume flow handled by doCall
+        boolean patched =
+                memory.getMessages().stream()
+                        .flatMap(m -> m.getContentBlocks(ToolResultBlock.class).stream())
+                        .anyMatch(tr -> "pending_call".equals(tr.getId()));
+        assertFalse(patched, "Hook should skip when callArgs is empty (resume scenario)");
+    }
+
+    @Test
+    @DisplayName("Skips when user provides ToolResultBlock in callArgs")
+    void skipsWhenUserProvidesToolResult() {
+        Memory memory = new InMemoryMemory();
+        memory.addMessage(assistantToolUse("pending_call", "some_tool"));
+
+        ReActAgent agent = mockReActAgent(memory);
+
+        // User provides a ToolResultBlock in callArgs (HITL / clarify scenario)
+        Msg userResult =
+                Msg.builder()
+                        .name("user")
+                        .role(MsgRole.TOOL)
+                        .content(
+                                ToolResultBlock.builder()
+                                        .id("pending_call")
+                                        .output(
+                                                List.of(
+                                                        TextBlock.builder()
+                                                                .text("user answer")
+                                                                .build()))
+                                        .build())
+                        .build();
+
+        List<Msg> fullInput = List.of(memory.getMessages().get(0), userResult);
+
+        PreCallEvent event = new PreCallEvent(agent, fullInput);
+        hook.onEvent(event).block();
+
+        // Should NOT patch — user is providing results themselves
+        assertEquals(
+                1,
+                memory.getMessages().size(),
+                "Hook should not add anything when user provides ToolResultBlock");
+    }
+
+    // ==================== Helpers ====================
+
+    private static ReActAgent mockReActAgent(Memory memory) {
+        ReActAgent agent = mock(ReActAgent.class);
+        when(agent.getMemory()).thenReturn(memory);
+        when(agent.getName()).thenReturn("test-agent");
+        return agent;
+    }
+
+    private static Msg userMsg(String text) {
+        return Msg.builder()
+                .name("user")
+                .role(MsgRole.USER)
+                .content(TextBlock.builder().text(text).build())
+                .build();
+    }
+
+    private static Msg assistantText(String text) {
+        return Msg.builder()
+                .name("assistant")
+                .role(MsgRole.ASSISTANT)
+                .content(TextBlock.builder().text(text).build())
+                .build();
+    }
+
+    private static Msg assistantToolUse(String id, String name) {
+        Map<String, Object> input = Map.of();
+        return Msg.builder()
+                .name("assistant")
+                .role(MsgRole.ASSISTANT)
+                .content(
+                        ToolUseBlock.builder()
+                                .id(id)
+                                .name(name)
+                                .input(input)
+                                .content(JsonUtils.getJsonCodec().toJson(input))
+                                .build())
+                .build();
+    }
+
+    private static Msg toolResult(String id, String text) {
+        return Msg.builder()
+                .name("test-agent")
+                .role(MsgRole.TOOL)
+                .content(
+                        ToolResultBlock.builder()
+                                .id(id)
+                                .output(List.of(TextBlock.builder().text(text).build()))
+                                .build())
+                .build();
+    }
+}


### PR DESCRIPTION
## Summary

`PendingToolRecoveryHook.handlePreCall` checks `event.getInputMessages()` for `ToolResultBlock`s to decide whether the user is providing tool results (HITL/Clarify scenario). However, `event.getInputMessages()` includes the **full memory snapshot** + user callArgs (constructed in `AgentBase.notifyPreCall`). 

Any historical `ToolResultBlock` from previous tool calls in memory causes `userProvidedResults = true`, silently skipping the auto-recovery patch. This makes the hook ineffective in **any conversation that has previously used tools** — which is essentially all real-world conversations.

### Root Cause

```java
// Before (bug): scans full memory history + user input
List<Msg> inputMessages = event.getInputMessages(); // = memory snapshot + callArgs
boolean userProvidedResults =
    inputMessages.stream().anyMatch(m -> m.hasContentBlocks(ToolResultBlock.class));
// → always true when memory has historical tool results → skip patch
```

### Fix

Extract only the callArgs portion (beyond the memory snapshot boundary) before checking:

```java
// After (fix): scans only user's current input
int memorySize = memory.getMessages().size();
List<Msg> callArgs = inputMessages.subList(memorySize, inputMessages.size());
boolean userProvidedResults =
    callArgs.stream().anyMatch(m -> m.hasContentBlocks(ToolResultBlock.class));
```

### Reproduction

1. Conversation with 250+ historical tool calls (memory contains many `ToolResultBlock`s)
2. Agent calls a new tool → execution crashes/interrupts → orphan `ToolUseBlock` in memory
3. User retries → hook detects pending IDs, but `userProvidedResults` is `true` due to historical results → **skips patch**
4. `ReActAgent.doCall` throws `IllegalStateException: Pending tool calls exist without results`
5. Error saved to MySQL → same state on next retry → **infinite error loop**

## Test plan

- [x] Added `testAutoRecoveryWithHistoricalToolResults` — pre-populates memory with historical tool call + result pairs, then verifies the hook still patches pending tool calls
- [x] All 17 existing `HookStopAgentTest` tests pass (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)