### PR TITLE
fix(rag): respect RAGFlowConfig topK/similarityThreshold over framewo…

### DIFF
--- a/agentscope-extensions/agentscope-extensions-rag-ragflow/src/main/java/io/agentscope/core/rag/integration/ragflow/RAGFlowKnowledge.java
+++ b/agentscope-extensions/agentscope-extensions-rag-ragflow/src/main/java/io/agentscope/core/rag/integration/ragflow/RAGFlowKnowledge.java
@@ -131,9 +131,17 @@ public class RAGFlowKnowledge implements Knowledge {
 
         logger.debug("RAGFlow retrieve: query={}, config={}", query, config);
 
-        // Extract retrieval parameters
-        Integer topK = config != null ? config.getLimit() : null;
-        Double similarityThreshold = config != null ? config.getScoreThreshold() : null;
+        // Prefer user-explicit RAGFlowConfig values over the framework-supplied RetrieveConfig,
+        // which is auto-populated with defaults by ReActAgent.Builder and would otherwise mask
+        // RAGFlow-specific settings.
+        Integer topK =
+                this.config.getTopK() != null
+                        ? this.config.getTopK()
+                        : (config != null ? config.getLimit() : null);
+        Double similarityThreshold =
+                this.config.getSimilarityThreshold() != null
+                        ? this.config.getSimilarityThreshold()
+                        : (config != null ? config.getScoreThreshold() : null);
 
         // Call RAGFlow API (metadata condition from config)
         return client.retrieve(query, topK, similarityThreshold, null)

--- a/agentscope-extensions/agentscope-extensions-rag-ragflow/src/test/java/io/agentscope/core/rag/integration/ragflow/RAGFlowKnowledgeTest.java
+++ b/agentscope-extensions/agentscope-extensions-rag-ragflow/src/test/java/io/agentscope/core/rag/integration/ragflow/RAGFlowKnowledgeTest.java
@@ -20,12 +20,16 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.fasterxml.jackson.core.type.TypeReference;
 import io.agentscope.core.rag.model.Document;
 import io.agentscope.core.rag.model.RetrieveConfig;
+import io.agentscope.core.util.JsonUtils;
 import java.io.IOException;
 import java.util.List;
+import java.util.Map;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -237,6 +241,42 @@ class RAGFlowKnowledgeTest {
 
         assertNotNull(documents);
         assertTrue(documents.isEmpty());
+    }
+
+    @Test
+    void testRagFlowConfigTakesPrecedenceOverFrameworkRetrieveConfig() throws Exception {
+        // Regression for #1516: ReActAgent.Builder seeds RetrieveConfig with
+        // limit=5/scoreThreshold=0.5.
+        // RAGFlowConfig values must win so the user's RAGFlow-specific settings are not silently
+        // dropped.
+        mockWebServer.enqueue(createSuccessResponse());
+
+        RAGFlowConfig ragFlowConfig =
+                RAGFlowConfig.builder()
+                        .apiKey("test-api-key")
+                        .baseUrl(mockWebServer.url("").toString().replaceAll("/$", ""))
+                        .addDatasetId("dataset-123")
+                        .topK(10)
+                        .similarityThreshold(0.3)
+                        .maxRetries(0)
+                        .build();
+
+        RAGFlowKnowledge knowledge = RAGFlowKnowledge.builder().config(ragFlowConfig).build();
+
+        RetrieveConfig frameworkDefaults =
+                RetrieveConfig.builder().limit(5).scoreThreshold(0.5).build();
+
+        knowledge.retrieve("query", frameworkDefaults).block();
+
+        RecordedRequest request = mockWebServer.takeRequest();
+        Map<String, Object> body =
+                JsonUtils.getJsonCodec()
+                        .fromJson(
+                                request.getBody().readUtf8(),
+                                new TypeReference<Map<String, Object>>() {});
+
+        assertEquals(10, body.get("top_k"));
+        assertEquals(0.3, body.get("similarity_threshold"));
     }
 
     // === AddDocuments Tests ===


### PR DESCRIPTION
…rk defaults (#1516)

ReActAgent.Builder seeds a default RetrieveConfig(limit=5, scoreThreshold=0.5) that masked the user-configured values on RAGFlowConfig. RAGFlowKnowledge now prefers RAGFlowConfig's topK/similarityThreshold and only falls back to the per-call RetrieveConfig when they are unset.
