### PR TITLE
fix(harness): prevent local shell output deadlock

### DIFF
--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/filesystem/local/LocalFilesystemWithShell.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/filesystem/local/LocalFilesystemWithShell.java
@@ -22,13 +22,20 @@ import io.agentscope.harness.agent.filesystem.sandbox.AbstractSandboxFilesystem;
 import io.agentscope.harness.agent.workspace.LocalFsMode;
 import io.agentscope.harness.agent.workspace.PathPolicy;
 import java.io.IOException;
+import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -46,6 +53,25 @@ import org.slf4j.LoggerFactory;
 public class LocalFilesystemWithShell extends LocalFilesystem implements AbstractSandboxFilesystem {
 
     private static final Logger log = LoggerFactory.getLogger(LocalFilesystemWithShell.class);
+
+    private static final int STREAM_DRAIN_TIMEOUT_SECONDS = 5;
+    private static final int TIMEOUT_STREAM_DRAIN_SECONDS = 1;
+    private static final AtomicInteger STREAM_READER_THREAD_ID = new AtomicInteger();
+
+    /**
+     * Shared cached pool for asynchronous stream reading, matching {@code ShellCommandTool}.
+     */
+    private static final ExecutorService STREAM_READER_POOL =
+            Executors.newCachedThreadPool(
+                    runnable -> {
+                        Thread thread =
+                                new Thread(
+                                        runnable,
+                                        "local-filesystem-shell-stream-reader-"
+                                                + STREAM_READER_THREAD_ID.incrementAndGet());
+                        thread.setDaemon(true);
+                        return thread;
+                    });
 
     /** Default timeout in seconds for shell command execution. */
     public static final int DEFAULT_EXECUTE_TIMEOUT = 120;
@@ -250,7 +276,6 @@ public class LocalFilesystemWithShell extends LocalFilesystem implements Abstrac
         if (timeout <= 0) {
             throw new IllegalArgumentException("timeout must be positive, got " + timeout);
         }
-
         this.defaultTimeout = timeout;
         this.maxOutputBytes = maxOutputBytes;
         this.sandboxId = "local-" + UUID.randomUUID().toString().substring(0, 8);
@@ -316,6 +341,10 @@ public class LocalFilesystemWithShell extends LocalFilesystem implements Abstrac
             throw new IllegalArgumentException("timeout must be positive, got " + effectiveTimeout);
         }
 
+        Process proc = null;
+        Future<String> stdoutFuture = null;
+        Future<String> stderrFuture = null;
+
         try {
             Path workDir = resolveExecuteCwd(runtimeContext);
             String osName = System.getProperty("os.name").toLowerCase();
@@ -331,17 +360,21 @@ public class LocalFilesystemWithShell extends LocalFilesystem implements Abstrac
                 pb.environment().putAll(env);
             }
 
-            Process proc = pb.start();
+            proc = pb.start();
+            Process startedProc = proc;
+            stdoutFuture =
+                    STREAM_READER_POOL.submit(() -> readStream(startedProc.getInputStream()));
+            stderrFuture =
+                    STREAM_READER_POOL.submit(() -> readStream(startedProc.getErrorStream()));
 
             boolean finished = proc.waitFor(effectiveTimeout, TimeUnit.SECONDS);
 
-            String stdout =
-                    new String(proc.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
-            String stderr =
-                    new String(proc.getErrorStream().readAllBytes(), StandardCharsets.UTF_8);
-
             if (!finished) {
                 proc.destroyForcibly();
+                // Allow readers to observe EOF before cleanup, while preserving the existing
+                // timeout response format.
+                getOutputWithTimeout(stdoutFuture, TIMEOUT_STREAM_DRAIN_SECONDS, TimeUnit.SECONDS);
+                getOutputWithTimeout(stderrFuture, TIMEOUT_STREAM_DRAIN_SECONDS, TimeUnit.SECONDS);
                 String msg;
                 if (timeoutSeconds != null) {
                     msg =
@@ -358,6 +391,13 @@ public class LocalFilesystemWithShell extends LocalFilesystem implements Abstrac
                 }
                 return new ExecuteResponse(msg, 124, false);
             }
+
+            String stdout =
+                    getOutputWithTimeout(
+                            stdoutFuture, STREAM_DRAIN_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+            String stderr =
+                    getOutputWithTimeout(
+                            stderrFuture, STREAM_DRAIN_TIMEOUT_SECONDS, TimeUnit.SECONDS);
 
             StringBuilder output = new StringBuilder();
             if (stdout != null && !stdout.isEmpty()) {
@@ -404,6 +444,43 @@ public class LocalFilesystemWithShell extends LocalFilesystem implements Abstrac
                             + e.getMessage(),
                     1,
                     false);
+        } finally {
+            if (proc != null && proc.isAlive()) {
+                proc.destroyForcibly();
+            }
+            cancelStreamReader(stdoutFuture);
+            cancelStreamReader(stderrFuture);
+        }
+    }
+
+    private static String getOutputWithTimeout(
+            Future<String> future, long timeout, TimeUnit timeUnit) {
+        try {
+            return future.get(timeout, timeUnit);
+        } catch (TimeoutException e) {
+            log.warn("Timeout waiting for process stream reader to complete");
+            cancelStreamReader(future);
+            return "";
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            log.warn("Interrupted while waiting for process stream reader");
+            cancelStreamReader(future);
+            return "";
+        } catch (ExecutionException e) {
+            log.warn("Failed to read process output", e.getCause());
+            return "";
+        }
+    }
+
+    private static String readStream(InputStream stream) throws IOException {
+        try (InputStream input = stream) {
+            return new String(input.readAllBytes(), StandardCharsets.UTF_8);
+        }
+    }
+
+    private static void cancelStreamReader(Future<String> future) {
+        if (future != null && !future.isDone()) {
+            future.cancel(true);
         }
     }
 

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/filesystem/local/LocalFilesystemWithShell.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/filesystem/local/LocalFilesystemWithShell.java
@@ -20,13 +20,19 @@ import io.agentscope.harness.agent.filesystem.model.ExecuteResponse;
 import io.agentscope.harness.agent.filesystem.sandbox.AbstractSandboxFilesystem;
 import io.agentscope.harness.agent.store.NamespaceFactory;
 import java.io.IOException;
+import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -44,6 +50,14 @@ import org.slf4j.LoggerFactory;
 public class LocalFilesystemWithShell extends LocalFilesystem implements AbstractSandboxFilesystem {
 
     private static final Logger log = LoggerFactory.getLogger(LocalFilesystemWithShell.class);
+
+    private static final ExecutorService STREAM_READER_POOL =
+            Executors.newCachedThreadPool(
+                    r -> {
+                        Thread thread = new Thread(r, "local-filesystem-shell-stream-reader");
+                        thread.setDaemon(true);
+                        return thread;
+                    });
 
     /** Default timeout in seconds for shell command execution. */
     public static final int DEFAULT_EXECUTE_TIMEOUT = 120;
@@ -223,6 +237,10 @@ public class LocalFilesystemWithShell extends LocalFilesystem implements Abstrac
             throw new IllegalArgumentException("timeout must be positive, got " + effectiveTimeout);
         }
 
+        Process proc = null;
+        Future<String> stdoutFuture = null;
+        Future<String> stderrFuture = null;
+
         try {
             Path workDir = resolveExecuteCwd(runtimeContext);
             ProcessBuilder pb =
@@ -235,17 +253,20 @@ public class LocalFilesystemWithShell extends LocalFilesystem implements Abstrac
                 pb.environment().putAll(env);
             }
 
-            Process proc = pb.start();
+            proc = pb.start();
+            Process startedProc = proc;
+
+            stdoutFuture =
+                    STREAM_READER_POOL.submit(() -> readStream(startedProc.getInputStream()));
+            stderrFuture =
+                    STREAM_READER_POOL.submit(() -> readStream(startedProc.getErrorStream()));
 
             boolean finished = proc.waitFor(effectiveTimeout, TimeUnit.SECONDS);
 
-            String stdout =
-                    new String(proc.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
-            String stderr =
-                    new String(proc.getErrorStream().readAllBytes(), StandardCharsets.UTF_8);
-
             if (!finished) {
                 proc.destroyForcibly();
+                cancelStreamReader(stdoutFuture);
+                cancelStreamReader(stderrFuture);
                 String msg;
                 if (timeoutSeconds != null) {
                     msg =
@@ -262,6 +283,9 @@ public class LocalFilesystemWithShell extends LocalFilesystem implements Abstrac
                 }
                 return new ExecuteResponse(msg, 124, false);
             }
+
+            String stdout = getStreamOutput(stdoutFuture);
+            String stderr = getStreamOutput(stderrFuture);
 
             StringBuilder output = new StringBuilder();
             if (stdout != null && !stdout.isEmpty()) {
@@ -300,6 +324,11 @@ public class LocalFilesystemWithShell extends LocalFilesystem implements Abstrac
             if (e instanceof InterruptedException) {
                 Thread.currentThread().interrupt();
             }
+            if (proc != null && proc.isAlive()) {
+                proc.destroyForcibly();
+            }
+            cancelStreamReader(stdoutFuture);
+            cancelStreamReader(stderrFuture);
             log.error("Command execution failed: {}", e.getMessage(), e);
             return new ExecuteResponse(
                     "Error executing command ("
@@ -308,6 +337,31 @@ public class LocalFilesystemWithShell extends LocalFilesystem implements Abstrac
                             + e.getMessage(),
                     1,
                     false);
+        }
+    }
+
+    private static String readStream(InputStream stream) throws IOException {
+        return new String(stream.readAllBytes(), StandardCharsets.UTF_8);
+    }
+
+    private static String getStreamOutput(Future<String> future)
+            throws IOException, InterruptedException {
+        try {
+            return future != null ? future.get(5, TimeUnit.SECONDS) : "";
+        } catch (TimeoutException e) {
+            throw new IOException("Timed out while reading process output", e);
+        } catch (ExecutionException e) {
+            Throwable cause = e.getCause();
+            if (cause instanceof IOException ioException) {
+                throw ioException;
+            }
+            throw new IOException("Failed to read process output", cause);
+        }
+    }
+
+    private static void cancelStreamReader(Future<String> future) {
+        if (future != null && !future.isDone()) {
+            future.cancel(true);
         }
     }
 

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/filesystem/local/LocalFilesystemWithShellTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/filesystem/local/LocalFilesystemWithShellTest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.harness.agent.filesystem.local;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.agentscope.core.agent.RuntimeContext;
+import io.agentscope.harness.agent.filesystem.model.ExecuteResponse;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class LocalFilesystemWithShellTest {
+
+    @Test
+    void executeDrainsLargeStdoutWhileWaiting(@TempDir Path tmp) {
+        LocalFilesystemWithShell fs =
+                new LocalFilesystemWithShell(tmp, false, 2, 300_000, null, false);
+
+        ExecuteResponse response = fs.execute(RuntimeContext.empty(), "yes x | head -c 200000", 2);
+
+        assertEquals(0, response.exitCode());
+        assertFalse(response.truncated());
+        assertTrue(response.output().length() >= 200_000);
+    }
+}

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/filesystem/local/LocalFilesystemWithShellTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/filesystem/local/LocalFilesystemWithShellTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.harness.agent.filesystem.local;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.agentscope.core.agent.RuntimeContext;
+import io.agentscope.harness.agent.filesystem.model.ExecuteResponse;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+import org.junit.jupiter.api.io.TempDir;
+
+@EnabledOnOs({OS.LINUX, OS.MAC})
+class LocalFilesystemWithShellTest {
+
+    private static final int LARGE_OUTPUT_BYTES = 200_000;
+
+    @Test
+    @Timeout(20)
+    void executeDrainsLargeStdoutWhileWaiting(@TempDir Path tmp) {
+        LocalFilesystemWithShell fs =
+                new LocalFilesystemWithShell(tmp, false, 10, 300_000, null, false);
+
+        ExecuteResponse response =
+                fs.execute(RuntimeContext.empty(), "yes x | head -c " + LARGE_OUTPUT_BYTES, 10);
+
+        assertEquals(0, response.exitCode());
+        assertFalse(response.truncated());
+        assertTrue(response.output().length() >= LARGE_OUTPUT_BYTES);
+    }
+
+    @Test
+    @Timeout(20)
+    void executeDrainsLargeStderrWhileWaiting(@TempDir Path tmp) {
+        LocalFilesystemWithShell fs =
+                new LocalFilesystemWithShell(tmp, false, 10, 300_000, null, false);
+
+        ExecuteResponse response =
+                fs.execute(
+                        RuntimeContext.empty(),
+                        "yes e | tr -d '\\n' | head -c " + LARGE_OUTPUT_BYTES + " >&2",
+                        10);
+
+        assertEquals(0, response.exitCode());
+        assertFalse(response.truncated());
+        assertTrue(response.output().startsWith("[stderr] "));
+        assertTrue(response.output().length() >= LARGE_OUTPUT_BYTES);
+    }
+}


### PR DESCRIPTION
Prevent `LocalFilesystemWithShell` from deadlocking when commands emit output larger than the OS pipe buffer.

## AgentScope-Java Version

2.0.1-SNAPSHOT

## Description

`LocalFilesystemWithShell.execute` previously waited for the child process to exit before draining stdout and stderr. When either pipe filled up, the child process blocked while Java remained in `Process.waitFor(...)`, resulting in a deadlock.

This refreshes the original fix against the current 2.0 `main` branch and follows the existing `ShellCommandTool#executeCommand` pattern:

- Start asynchronous stdout and stderr readers immediately after process launch.
- Drain both process pipes while waiting for completion.
- Use bounded waits and cancel unfinished readers during cleanup.
- Preserve the existing Harness output merging, truncation, timeout message, and exit-code behavior.

Regression tests cover commands producing 200 KB of stdout and stderr on Linux and macOS. No user-facing documentation changes are required.

Closes #1519

Related alternative implementation: #2151.

## Checklist

Please check the following items before code is ready to be reviewed.

- [x] Code has been formatted with `mvn spotless:apply`
- [x] All tests are passing (`mvn test`)
- [x] Javadoc comments are complete and follow project conventions
- [ ] Related documentation has been updated (e.g. links, examples, etc.)
- [x] Code is ready for review