### PR TITLE
chore(ci): bump skywalking-eyes to fix license job Go download

### DIFF
--- a/.github/workflows/maven-ci.yml
+++ b/.github/workflows/maven-ci.yml
@@ -18,11 +18,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: "Check License"
-        uses: apache/skywalking-eyes@e1a02359b239bd28de3f6d35fdc870250fa513d5
+        uses: apache/skywalking-eyes@ab3d1fe50d23f9c82eff489297167e2dde8ba6cb
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: "Check Dependencies' License"
-        uses: apache/skywalking-eyes/dependency@e1a02359b239bd28de3f6d35fdc870250fa513d5
+        uses: apache/skywalking-eyes/dependency@ab3d1fe50d23f9c82eff489297167e2dde8ba6cb
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:


### PR DESCRIPTION
Bump the pinned `apache/skywalking-eyes` commit so the license CI job no longer fails while downloading Go 1.18.

## AgentScope-Java Version

1.1.0-SNAPSHOT

## Description

The `license` job in `maven-ci.yml` uses `apache/skywalking-eyes`, which internally runs `actions/setup-go`. The previously pinned commit (`e1a02359`) installs Go via `actions/setup-go@v2` with `go-version: 1.18`. When that version is missing from the toolcache manifest, setup-go falls back to the deprecated `storage.googleapis.com/golang` URL and fails with HTTP 403.

This PR updates both `apache/skywalking-eyes` and `apache/skywalking-eyes/dependency` to commit `ab3d1fe50d23f9c82eff489297167e2dde8ba6cb` on `main`, which includes [apache/skywalking-eyes#265](https://github.com/apache/skywalking-eyes/pull/265) (`actions/setup-go@v6`, Go 1.25, downloads from `go.dev/dl`).

**How to test:** Re-run the `Java CI with Maven` workflow; the `Check License` step should pass the Go setup phase.

No application code changes. Maven/Spotless checks were not run (workflow-only change).

## Checklist

Please check the following items before code is ready to be reviewed.

- [ ]  Code has been formatted with `mvn spotless:apply`
- [ ]  All tests are passing (`mvn test`)
- [ ]  Javadoc comments are complete and follow project conventions
- [ ]  Related documentation has been updated (e.g. links, examples, etc.)
- [x]  Code is ready for review

Made with [Cursor](https://cursor.com)