### PR TITLE
feat(tool): add copy builder to ToolCallParam

### DIFF
--- a/agentscope-core/src/main/java/io/agentscope/core/tool/ToolCallParam.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/tool/ToolCallParam.java
@@ -115,6 +115,32 @@ public class ToolCallParam {
     }
 
     /**
+     * Creates a new builder initialized with values from an existing ToolCallParam.
+     *
+     * <p>This is useful for creating a modified copy of an existing parameter object.
+     * The builder copies all values from the source object, allowing selective
+     * modifications before building a new instance.
+     *
+     * <p><b>Example usage:</b>
+     * <pre>{@code
+     * ToolCallParam original = ...;
+     * ToolCallParam modified = ToolCallParam.builder(original)
+     *     .input(Map.of("newKey", "newValue"))
+     *     .build();
+     * }</pre>
+     *
+     * <p>Note: Mutable fields (such as the input map) are deep-copied to ensure
+     * the new instance is independent of the source. Immutable fields are shared.
+     *
+     * @param source The existing ToolCallParam to copy values from
+     * @return A new builder pre-populated with the source's values
+     * @throws NullPointerException if source is null
+     */
+    public static Builder builder(ToolCallParam source) {
+        return new Builder(source);
+    }
+
+    /**
      * Builder for ToolCallParam.
      */
     public static class Builder {
@@ -125,6 +151,14 @@ public class ToolCallParam {
         private ToolEmitter emitter;
 
         private Builder() {}
+
+        private Builder(ToolCallParam source) {
+            this.toolUseBlock = source.toolUseBlock;
+            this.input = source.input.isEmpty() ? null : new HashMap<>(source.input);
+            this.agent = source.agent;
+            this.context = source.context;
+            this.emitter = source.emitter;
+        }
 
         /**
          * Sets the tool use block.

--- a/agentscope-core/src/main/java/io/agentscope/core/tool/ToolCallParam.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/tool/ToolCallParam.java
@@ -20,6 +20,7 @@ import io.agentscope.core.message.ToolUseBlock;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * Parameters for tool invocation.
@@ -129,14 +130,16 @@ public class ToolCallParam {
      *     .build();
      * }</pre>
      *
-     * <p>Note: Mutable fields (such as the input map) are deep-copied to ensure
-     * the new instance is independent of the source. Immutable fields are shared.
+     * <p>Note: The input map structure is copied so that entries can be modified
+     * independently, but nested values (typed as Object) remain shared.
+     * Immutable fields (toolUseBlock, agent, context, emitter) are shared by reference.
      *
      * @param source The existing ToolCallParam to copy values from
      * @return A new builder pre-populated with the source's values
      * @throws NullPointerException if source is null
      */
     public static Builder builder(ToolCallParam source) {
+        Objects.requireNonNull(source, "source must not be null");
         return new Builder(source);
     }
 
@@ -154,7 +157,7 @@ public class ToolCallParam {
 
         private Builder(ToolCallParam source) {
             this.toolUseBlock = source.toolUseBlock;
-            this.input = source.input.isEmpty() ? null : new HashMap<>(source.input);
+            this.input = source.input.isEmpty() ? null : source.input;
             this.agent = source.agent;
             this.context = source.context;
             this.emitter = source.emitter;

--- a/agentscope-core/src/test/java/io/agentscope/core/tool/ToolCallParamTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/tool/ToolCallParamTest.java
@@ -194,30 +194,43 @@ class ToolCallParamTest {
         }
 
         @Test
-        @DisplayName("Should deep copy input map")
-        void testDeepCopyInputMap() {
+        @DisplayName("Should shallow copy input map (entries independent, nested values shared)")
+        @SuppressWarnings("unchecked")
+        void testShallowCopyInputMap() {
             ToolUseBlock toolUseBlock =
                     ToolUseBlock.builder().id("id").name("tool").input(Map.of()).build();
 
+            // Use a nested mutable value to verify shallow copy semantics
+            List<String> nestedList = new ArrayList<>(List.of("a", "b"));
             Map<String, Object> input = new HashMap<>();
-            input.put("key", "value");
+            input.put("list", nestedList);
 
             ToolCallParam original =
                     ToolCallParam.builder().toolUseBlock(toolUseBlock).input(input).build();
 
-            // Create copy
+            // Create copy (no input override)
             ToolCallParam copy = ToolCallParam.builder(original).build();
 
-            // Modify the copy's input (by building a new param with different input)
+            // Input maps should be equal
+            assertEquals(original.getInput(), copy.getInput());
+
+            // Nested mutable value should be the SAME reference (shallow copy)
+            assertSame(
+                    original.getInput().get("list"),
+                    copy.getInput().get("list"),
+                    "Nested values should be shared (shallow copy)");
+
+            // But top-level entries should be independent:
+            // adding a new top-level key to copy's input should NOT affect original
+            // (because ToolCallParam constructor does new HashMap<>(builder.input))
             Map<String, Object> modifiedInput = new HashMap<>(copy.getInput());
-            modifiedInput.put("key", "modified");
+            modifiedInput.put("newKey", "newValue");
             ToolCallParam modified = ToolCallParam.builder(original).input(modifiedInput).build();
 
-            // Original should be unchanged
-            assertEquals("value", original.getInput().get("key"));
-
-            // Modified should have new value
-            assertEquals("modified", modified.getInput().get("key"));
+            assertNull(
+                    original.getInput().get("newKey"),
+                    "Original should not have the new key added to the modified copy");
+            assertEquals("newValue", modified.getInput().get("newKey"));
         }
 
         @Test

--- a/agentscope-core/src/test/java/io/agentscope/core/tool/ToolCallParamTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/tool/ToolCallParamTest.java
@@ -118,6 +118,189 @@ class ToolCallParamTest {
     }
 
     @Nested
+    @DisplayName("Copy Builder pattern")
+    class CopyBuilderTests {
+
+        @Test
+        @DisplayName("Should copy all fields from source")
+        void testCopyAllFields() {
+            ToolUseBlock toolUseBlock =
+                    ToolUseBlock.builder()
+                            .id("test-id")
+                            .name("test_tool")
+                            .input(Map.of("key", "value"))
+                            .build();
+
+            Agent mockAgent = mock(Agent.class);
+            when(mockAgent.getName()).thenReturn("TestAgent");
+
+            ToolExecutionContext context =
+                    ToolExecutionContext.builder().register("testContext").build();
+
+            List<ToolResultBlock> emittedChunks = new ArrayList<>();
+            ToolEmitter emitter = emittedChunks::add;
+
+            Map<String, Object> input = new HashMap<>();
+            input.put("param1", "value1");
+
+            ToolCallParam original =
+                    ToolCallParam.builder()
+                            .toolUseBlock(toolUseBlock)
+                            .input(input)
+                            .agent(mockAgent)
+                            .context(context)
+                            .emitter(emitter)
+                            .build();
+
+            // Create copy
+            ToolCallParam copy = ToolCallParam.builder(original).build();
+
+            assertNotNull(copy);
+            assertEquals(original.getToolUseBlock(), copy.getToolUseBlock());
+            assertEquals(original.getInput(), copy.getInput());
+            assertEquals(original.getAgent(), copy.getAgent());
+            assertEquals(original.getContext(), copy.getContext());
+            assertSame(original.getEmitter(), copy.getEmitter());
+        }
+
+        @Test
+        @DisplayName("Should allow modifying copied fields")
+        void testModifyCopiedFields() {
+            ToolUseBlock toolUseBlock =
+                    ToolUseBlock.builder()
+                            .id("test-id")
+                            .name("test_tool")
+                            .input(Map.of("key", "value"))
+                            .build();
+
+            Map<String, Object> input = new HashMap<>();
+            input.put("param1", "value1");
+
+            ToolCallParam original =
+                    ToolCallParam.builder().toolUseBlock(toolUseBlock).input(input).build();
+
+            // Create copy with modified input
+            Map<String, Object> newInput = new HashMap<>();
+            newInput.put("param2", "value2");
+            ToolCallParam modified = ToolCallParam.builder(original).input(newInput).build();
+
+            // Original should be unchanged
+            assertEquals("value1", original.getInput().get("param1"));
+            assertNull(original.getInput().get("param2"));
+
+            // Modified should have new value
+            assertEquals("value2", modified.getInput().get("param2"));
+            assertNull(modified.getInput().get("param1"));
+        }
+
+        @Test
+        @DisplayName("Should deep copy input map")
+        void testDeepCopyInputMap() {
+            ToolUseBlock toolUseBlock =
+                    ToolUseBlock.builder().id("id").name("tool").input(Map.of()).build();
+
+            Map<String, Object> input = new HashMap<>();
+            input.put("key", "value");
+
+            ToolCallParam original =
+                    ToolCallParam.builder().toolUseBlock(toolUseBlock).input(input).build();
+
+            // Create copy
+            ToolCallParam copy = ToolCallParam.builder(original).build();
+
+            // Modify the copy's input (by building a new param with different input)
+            Map<String, Object> modifiedInput = new HashMap<>(copy.getInput());
+            modifiedInput.put("key", "modified");
+            ToolCallParam modified = ToolCallParam.builder(original).input(modifiedInput).build();
+
+            // Original should be unchanged
+            assertEquals("value", original.getInput().get("key"));
+
+            // Modified should have new value
+            assertEquals("modified", modified.getInput().get("key"));
+        }
+
+        @Test
+        @DisplayName("Should copy with null fields")
+        void testCopyWithNullFields() {
+            ToolUseBlock toolUseBlock =
+                    ToolUseBlock.builder().id("id").name("tool").input(Map.of()).build();
+
+            ToolCallParam original = ToolCallParam.builder().toolUseBlock(toolUseBlock).build();
+
+            // Create copy
+            ToolCallParam copy = ToolCallParam.builder(original).build();
+
+            assertNotNull(copy);
+            assertEquals(original.getToolUseBlock(), copy.getToolUseBlock());
+            assertTrue(copy.getInput().isEmpty());
+            assertNull(copy.getAgent());
+            assertNull(copy.getContext());
+        }
+
+        @Test
+        @DisplayName("Should throw NPE when source is null")
+        void testCopyWithNullSource() {
+            org.junit.jupiter.api.Assertions.assertThrows(
+                    NullPointerException.class, () -> ToolCallParam.builder((ToolCallParam) null));
+        }
+
+        @Test
+        @DisplayName("Should preserve immutable fields as references")
+        void testPreserveImmutableFields() {
+            ToolUseBlock toolUseBlock =
+                    ToolUseBlock.builder()
+                            .id("test-id")
+                            .name("test_tool")
+                            .input(Map.of("key", "value"))
+                            .build();
+
+            Agent mockAgent = mock(Agent.class);
+            when(mockAgent.getName()).thenReturn("TestAgent");
+
+            ToolExecutionContext context =
+                    ToolExecutionContext.builder().register("testContext").build();
+
+            ToolCallParam original =
+                    ToolCallParam.builder()
+                            .toolUseBlock(toolUseBlock)
+                            .agent(mockAgent)
+                            .context(context)
+                            .build();
+
+            ToolCallParam copy = ToolCallParam.builder(original).build();
+
+            // Immutable fields should be the same references
+            assertSame(original.getToolUseBlock(), copy.getToolUseBlock());
+            assertSame(original.getAgent(), copy.getAgent());
+            assertSame(original.getContext(), copy.getContext());
+        }
+
+        @Test
+        @DisplayName("Should allow replacing immutable fields in copy")
+        void testReplaceImmutableFieldsInCopy() {
+            ToolUseBlock originalToolUseBlock =
+                    ToolUseBlock.builder().id("id1").name("tool1").input(Map.of()).build();
+            ToolUseBlock newToolUseBlock =
+                    ToolUseBlock.builder().id("id2").name("tool2").input(Map.of()).build();
+
+            ToolCallParam original =
+                    ToolCallParam.builder().toolUseBlock(originalToolUseBlock).build();
+
+            ToolCallParam modified =
+                    ToolCallParam.builder(original).toolUseBlock(newToolUseBlock).build();
+
+            // Original should be unchanged
+            assertEquals("id1", original.getToolUseBlock().getId());
+            assertEquals("tool1", original.getToolUseBlock().getName());
+
+            // Modified should have new values
+            assertEquals("id2", modified.getToolUseBlock().getId());
+            assertEquals("tool2", modified.getToolUseBlock().getName());
+        }
+    }
+
+    @Nested
     @DisplayName("Emitter functionality")
     class EmitterTests {
 


### PR DESCRIPTION
Add builder(ToolCallParam) factory method to create a builder initialized with values from an existing instance. Mutable fields such as the input map are deep-copied to ensure independence.

Closes #1517

## AgentScope-Java Version

[The version of AgentScope-Java you are working on, e.g. 1.0.12, check your pom.xml dependency version or run `mvn dependency:tree | grep agentscope-parent:pom`(only mac/linux)]

## Description

[Please describe the background, purpose, changes made, and how to test this PR]

## Checklist

Please check the following items before code is ready to be reviewed.

- [X]  Code has been formatted with `mvn spotless:apply`
- [X]  All tests are passing (`mvn test`)
- [X]  Javadoc comments are complete and follow project conventions
- [X]  Related documentation has been updated (e.g. links, examples, etc.)
- [X]  Code is ready for review
