### PR TITLE
fix(a2a): preserve streaming tool use content

### DIFF
--- a/agentscope-extensions/agentscope-extensions-a2a/agentscope-extensions-a2a-client/src/main/java/io/agentscope/core/a2a/agent/message/DataPartParser.java
+++ b/agentscope-extensions/agentscope-extensions-a2a/agentscope-extensions-a2a-client/src/main/java/io/agentscope/core/a2a/agent/message/DataPartParser.java
@@ -73,7 +73,12 @@ public class DataPartParser implements PartParser<DataPart> {
         ToolUseBlock.Builder builder = ToolUseBlock.builder();
         builder.id(getToolCallId(part)).name(getToolName(part));
         builder.metadata(getOriginalMetadata(part));
-        builder.input(part.getData());
+        Map<String, Object> input = new HashMap<>(part.getData());
+        Object content = input.remove(MessageConstants.TOOL_USE_CONTENT_DATA_KEY);
+        builder.input(input);
+        if (content != null) {
+            builder.content(content.toString());
+        }
         return builder.build();
     }
 

--- a/agentscope-extensions/agentscope-extensions-a2a/agentscope-extensions-a2a-client/src/main/java/io/agentscope/core/a2a/agent/message/MessageConstants.java
+++ b/agentscope-extensions/agentscope-extensions-a2a/agentscope-extensions-a2a-client/src/main/java/io/agentscope/core/a2a/agent/message/MessageConstants.java
@@ -48,5 +48,7 @@ public class MessageConstants {
 
     public static final String TOOL_CALL_ID_METADATA_KEY = "_agentscope_tool_call_id";
 
+    public static final String TOOL_USE_CONTENT_DATA_KEY = "_agentscope_tool_content";
+
     public static final String TOOL_RESULT_OUTPUT_METADATA_KEY = "_agentscope_tool_output";
 }

--- a/agentscope-extensions/agentscope-extensions-a2a/agentscope-extensions-a2a-client/src/main/java/io/agentscope/core/a2a/agent/message/ToolUseBlockParser.java
+++ b/agentscope-extensions/agentscope-extensions-a2a/agentscope-extensions-a2a-client/src/main/java/io/agentscope/core/a2a/agent/message/ToolUseBlockParser.java
@@ -20,6 +20,7 @@ import io.a2a.spec.DataPart;
 import io.a2a.spec.Part;
 import io.agentscope.core.a2a.agent.utils.MessageConvertUtil;
 import io.agentscope.core.message.ToolUseBlock;
+import java.util.HashMap;
 import java.util.Map;
 
 /**
@@ -34,6 +35,11 @@ public class ToolUseBlockParser implements ContentBlockParser<ToolUseBlock> {
         metadata.put(MessageConstants.TOOL_NAME_METADATA_KEY, contentBlock.getName());
         metadata.put(MessageConstants.TOOL_CALL_ID_METADATA_KEY, contentBlock.getId());
         metadata.putAll(contentBlock.getMetadata());
-        return new DataPart(contentBlock.getInput(), metadata);
+
+        Map<String, Object> data = new HashMap<>(contentBlock.getInput());
+        if (contentBlock.getContent() != null) {
+            data.put(MessageConstants.TOOL_USE_CONTENT_DATA_KEY, contentBlock.getContent());
+        }
+        return new DataPart(data, metadata);
     }
 }

--- a/agentscope-extensions/agentscope-extensions-a2a/agentscope-extensions-a2a-client/src/test/java/io/agentscope/core/a2a/agent/message/DataPartParserTest.java
+++ b/agentscope-extensions/agentscope-extensions-a2a/agentscope-extensions-a2a-client/src/test/java/io/agentscope/core/a2a/agent/message/DataPartParserTest.java
@@ -86,6 +86,30 @@ class DataPartParserTest {
     }
 
     @Test
+    @DisplayName("Should parse streaming tool use content")
+    void testParseDataPartWithStreamingToolUseContent() {
+        Map<String, Object> metadata =
+                Map.of(
+                        "_agentscope_block_type", "tool_use",
+                        "_agentscope_tool_name", "__fragment__",
+                        "_agentscope_tool_call_id", "call-123");
+        DataPart part =
+                new DataPart(
+                        Map.of(MessageConstants.TOOL_USE_CONTENT_DATA_KEY, "{\"productName\": \""),
+                        metadata);
+
+        ContentBlock result = parser.parse(part);
+
+        assertNotNull(result);
+        assertEquals(ToolUseBlock.class, result.getClass());
+        ToolUseBlock toolUseBlock = (ToolUseBlock) result;
+        assertEquals("__fragment__", toolUseBlock.getName());
+        assertEquals("call-123", toolUseBlock.getId());
+        assertEquals("{\"productName\": \"", toolUseBlock.getContent());
+        assertTrue(toolUseBlock.getInput().isEmpty());
+    }
+
+    @Test
     @DisplayName("Should parse DataPart with tool_result metadata to ToolResultBlock")
     void testParseDataPartWithToolResultMetadata() {
         Map<String, Object> metadata =

--- a/agentscope-extensions/agentscope-extensions-a2a/agentscope-extensions-a2a-client/src/test/java/io/agentscope/core/a2a/agent/message/ToolUseBlockParserTest.java
+++ b/agentscope-extensions/agentscope-extensions-a2a/agentscope-extensions-a2a-client/src/test/java/io/agentscope/core/a2a/agent/message/ToolUseBlockParserTest.java
@@ -65,6 +65,26 @@ class ToolUseBlockParserTest {
     }
 
     @Test
+    @DisplayName("Should preserve streaming tool use content")
+    void testParseStreamingToolUseContent() {
+        ToolUseBlock block =
+                ToolUseBlock.builder()
+                        .name("__fragment__")
+                        .id("call-123")
+                        .content("{\"productName\": \"")
+                        .build();
+
+        Part<?> result = parser.parse(block);
+
+        assertNotNull(result);
+        assertEquals(DataPart.class, result.getClass());
+        DataPart dataPart = (DataPart) result;
+        assertEquals(
+                "{\"productName\": \"",
+                dataPart.getData().get(MessageConstants.TOOL_USE_CONTENT_DATA_KEY));
+    }
+
+    @Test
     @DisplayName("Should have correct metadata")
     void testMetadata() {
         ToolUseBlock block =


### PR DESCRIPTION
## AgentScope-Java Version

1.1.0-SNAPSHOT

## Description

This PR fixes A2A conversion for streaming `ToolUseBlock` fragments.

Previously, `ToolUseBlockParser` serialized only `ToolUseBlock#getInput()` into `DataPart.data`. Streaming tool-call fragments can carry argument deltas in `ToolUseBlock#getContent()` while `input` and `metadata` are empty, so the raw content was dropped during A2A conversion.

Changes made:

- Add an internal `DataPart.data` key for raw streaming tool-use content.
- Preserve `ToolUseBlock.content` when converting `ToolUseBlock` to `DataPart`.
- Restore that content when converting `DataPart` back to `ToolUseBlock`.
- Keep the internal content key out of `ToolUseBlock.input`.
- Add regression tests for both conversion directions.

Test commands:

```bash
mvn -pl agentscope-extensions/agentscope-extensions-a2a/agentscope-extensions-a2a-client -am "-Dtest=ToolUseBlockParserTest#testParseStreamingToolUseContent,DataPartParserTest#testParseDataPartWithStreamingToolUseContent" test

mvn -pl agentscope-extensions/agentscope-extensions-a2a/agentscope-extensions-a2a-client -am test
```

Local results:
```bash
Tests run: 106, Failures: 0, Errors: 0, Skipped: 0
BUILD SUCCESS
```

Fixes #1526

## Checklist
Please check the following items before code is ready to be reviewed.

- [x] Code has been formatted with mvn spotless:apply
- [x] All related tests are passing
- [x] Javadoc comments are complete and follow project conventions
- [x] Related documentation has been updated (not needed for this bug fix)
- [x] Code is ready for review