### PR TITLE
feat(harness): add projectWorkspace for filesystem tools

### DIFF
--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/HarnessAgent.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/HarnessAgent.java
@@ -51,6 +51,7 @@ import io.agentscope.core.tool.ToolExecutionContext;
 import io.agentscope.core.tool.Toolkit;
 import io.agentscope.harness.agent.filesystem.AbstractFilesystem;
 import io.agentscope.harness.agent.filesystem.BakedContextFilesystem;
+import io.agentscope.harness.agent.filesystem.local.LocalFilesystem;
 import io.agentscope.harness.agent.filesystem.local.LocalFilesystemWithShell;
 import io.agentscope.harness.agent.filesystem.sandbox.AbstractSandboxFilesystem;
 import io.agentscope.harness.agent.filesystem.sandbox.SandboxBackedFilesystem;
@@ -669,6 +670,7 @@ public class HarnessAgent implements Agent, StateModule, AutoCloseable {
 
         // Harness-specific params
         private Path workspace;
+        private Path projectWorkspace;
         private String environmentMemory;
         private AbstractFilesystem abstractFilesystem;
         private Session session;
@@ -1086,6 +1088,24 @@ public class HarnessAgent implements Agent, StateModule, AutoCloseable {
          */
         public Builder workspace(Path workspace) {
             this.workspace = workspace;
+            return this;
+        }
+
+        /**
+         * Sets the project workspace directory exposed to the built-in file tools.
+         *
+         * <p>{@link #workspace(Path)} remains the harness workspace used for {@code AGENTS.md},
+         * memory, sessions, skills, and other agent state. When this option is set, built-in file
+         * tools such as {@code read_file}, {@code write_file}, {@code edit_file},
+         * {@code list_files}, {@code grep_files}, and {@code glob_files} operate against this
+         * project directory instead, without applying the per-user namespace used by the harness
+         * workspace backend.
+         *
+         * <p>This is useful for applications that keep agent state in one stable directory but need
+         * the agent to work on arbitrary project folders.
+         */
+        public Builder projectWorkspace(Path projectWorkspace) {
+            this.projectWorkspace = projectWorkspace;
             return this;
         }
 
@@ -1530,6 +1550,8 @@ public class HarnessAgent implements Agent, StateModule, AutoCloseable {
             AbstractFilesystem filesystem =
                     resolveFilesystem(
                             resolvedWorkspace, resolvedAgentId, workspaceIndex, nsFactory);
+            AbstractFilesystem toolFilesystem =
+                    resolveProjectFilesystem(projectWorkspace, filesystem);
 
             // ---- Sandbox integration ----
             SandboxLifecycleHook sandboxLifecycleHook = null;
@@ -1542,6 +1564,7 @@ public class HarnessAgent implements Agent, StateModule, AutoCloseable {
                 }
                 capturedSandboxFs = new SandboxBackedFilesystem();
                 filesystem = capturedSandboxFs;
+                toolFilesystem = resolveProjectFilesystem(projectWorkspace, filesystem);
 
                 defaultSandboxContext = sandboxFilesystemSpec.toSandboxContext(resolvedWorkspace);
                 // Mode 2 (SandboxFilesystemSpec) always validates distributed prerequisites unless
@@ -1662,7 +1685,7 @@ public class HarnessAgent implements Agent, StateModule, AutoCloseable {
             }
 
             if (toolResultEvictionConfig != null) {
-                allHooks.add(new ToolResultEvictionHook(filesystem, toolResultEvictionConfig));
+                allHooks.add(new ToolResultEvictionHook(toolFilesystem, toolResultEvictionConfig));
             }
 
             if (!disableSessionPersistence) {
@@ -1696,7 +1719,7 @@ public class HarnessAgent implements Agent, StateModule, AutoCloseable {
             }
 
             if (!disableFilesystemTools) {
-                agentToolkit.registerTool(new FilesystemTool(filesystem));
+                agentToolkit.registerTool(new FilesystemTool(toolFilesystem));
             }
 
             if (!disableShellTool && filesystem instanceof AbstractSandboxFilesystem sandbox) {
@@ -1909,6 +1932,14 @@ public class HarnessAgent implements Agent, StateModule, AutoCloseable {
             return new LocalFilesystemWithShell(workspace, nsFactory);
         }
 
+        private AbstractFilesystem resolveProjectFilesystem(
+                Path projectWorkspace, AbstractFilesystem workspaceFilesystem) {
+            if (projectWorkspace == null) {
+                return workspaceFilesystem;
+            }
+            return new LocalFilesystem(projectWorkspace, true, 10);
+        }
+
         private void validateDistributedSandboxConfig(
                 Session effectiveSession, SandboxContext sandboxContext) {
             if (sandboxFilesystemSpec.getSandboxStateStore() == null
@@ -2092,6 +2123,7 @@ public class HarnessAgent implements Agent, StateModule, AutoCloseable {
                     List.copyOf(this.skillRepositories);
             final Path capturedProjectGlobalSkillsDir = this.projectGlobalSkillsDir;
             final boolean capturedUseLegacyXmlWorkspaceContext = this.useLegacyXmlWorkspaceContext;
+            final Path capturedProjectWorkspace = this.projectWorkspace;
             final boolean capturedDisableFilesystemTools = this.disableFilesystemTools;
             final boolean capturedDisableShellTool = this.disableShellTool;
             final boolean capturedDisableMemoryTools = this.disableMemoryTools;
@@ -2135,6 +2167,9 @@ public class HarnessAgent implements Agent, StateModule, AutoCloseable {
                 if (capturedProjectGlobalSkillsDir != null) {
                     sub.projectGlobalSkillsDir(capturedProjectGlobalSkillsDir);
                 }
+                if (capturedProjectWorkspace != null) {
+                    sub.projectWorkspace(capturedProjectWorkspace);
+                }
                 if (capturedBackend != null) sub.abstractFilesystem(capturedBackend);
                 if (capturedModelExec != null) sub.modelExecutionConfig(capturedModelExec);
                 if (capturedToolExec != null) sub.toolExecutionConfig(capturedToolExec);
@@ -2167,6 +2202,7 @@ public class HarnessAgent implements Agent, StateModule, AutoCloseable {
             final Function<String, Model> capturedResolver = this.modelResolver;
             final AbstractFilesystem capturedSharedBackend =
                     sandboxFs != null ? sandboxFs : this.abstractFilesystem;
+            final Path capturedProjectWorkspace = this.projectWorkspace;
             final boolean capturedUseLegacyXmlWorkspaceContext = this.useLegacyXmlWorkspaceContext;
             final boolean capturedDisableFilesystemTools = this.disableFilesystemTools;
             final boolean capturedDisableShellTool = this.disableShellTool;
@@ -2210,6 +2246,10 @@ public class HarnessAgent implements Agent, StateModule, AutoCloseable {
                 if (decl.getWorkspaceMode() == WorkspaceMode.SHARED
                         && capturedSharedBackend != null) {
                     sub.abstractFilesystem(capturedSharedBackend);
+                }
+                if (decl.getWorkspaceMode() == WorkspaceMode.SHARED
+                        && capturedProjectWorkspace != null) {
+                    sub.projectWorkspace(capturedProjectWorkspace);
                 }
 
                 // Propagate disable flags so the declared subagent respects the same capability

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/HarnessAgentTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/HarnessAgentTest.java
@@ -26,20 +26,27 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import io.agentscope.core.agent.Agent;
 import io.agentscope.core.agent.RuntimeContext;
 import io.agentscope.core.message.Msg;
 import io.agentscope.core.message.MsgRole;
 import io.agentscope.core.message.TextBlock;
+import io.agentscope.core.message.ToolResultBlock;
+import io.agentscope.core.message.ToolUseBlock;
 import io.agentscope.core.model.ChatResponse;
 import io.agentscope.core.model.Model;
 import io.agentscope.core.model.ToolSchema;
 import io.agentscope.core.session.Session;
 import io.agentscope.core.tool.AgentTool;
+import io.agentscope.core.tool.ToolCallParam;
 import io.agentscope.core.tool.Toolkit;
+import io.agentscope.core.util.JsonUtils;
 import io.agentscope.harness.agent.filesystem.local.LocalFilesystem;
+import io.agentscope.harness.agent.filesystem.spec.DockerFilesystemSpec;
 import io.agentscope.harness.agent.filesystem.spec.RemoteFilesystemSpec;
 import io.agentscope.harness.agent.hook.SubagentsHook.SubagentEntry;
 import io.agentscope.harness.agent.memory.compaction.CompactionConfig;
+import io.agentscope.harness.agent.sandbox.SandboxDistributedOptions;
 import io.agentscope.harness.agent.store.InMemoryStore;
 import io.agentscope.harness.agent.subagent.AgentSpecLoader;
 import io.agentscope.harness.agent.subagent.SubagentDeclaration;
@@ -346,6 +353,107 @@ class HarnessAgentTest {
         }
     }
 
+    @Test
+    void projectWorkspace_fileToolsUseProjectDirectory() throws Exception {
+        Files.createDirectories(workspace);
+        Path projectWorkspace = Files.createTempDirectory("agentscope-project-workspace");
+        Path projectTarget = projectWorkspace.resolve("from-file-tool.txt");
+        Path stateWorkspaceTarget = workspace.resolve("from-file-tool.txt");
+
+        try (HarnessAgent agent =
+                HarnessAgent.builder()
+                        .name("agent")
+                        .model(stubModel("ok"))
+                        .workspace(workspace)
+                        .projectWorkspace(projectWorkspace)
+                        .build()) {
+            Map<String, Object> writeInput =
+                    Map.of("path", "/from-file-tool.txt", "content", "project-only");
+
+            ToolResultBlock result = callTool(agent, "write_file", writeInput);
+
+            assertTrue(
+                    joinToolResultText(result).contains("Written to /from-file-tool.txt"),
+                    "file tool should write successfully: " + joinToolResultText(result));
+            assertTrue(
+                    Files.readString(projectTarget).contains("project-only"),
+                    "file tool should use projectWorkspace");
+            assertTrue(
+                    Files.notExists(stateWorkspaceTarget),
+                    "file tool must not write into the Harness state workspace");
+        }
+    }
+
+    @Test
+    void sandboxFilesystemMode_fileToolsUseSandboxBackendByDefault() throws Exception {
+        Files.createDirectories(workspace);
+        Path localTarget = workspace.resolve("should-not-be-local.txt");
+
+        HarnessAgent agent =
+                HarnessAgent.builder()
+                        .name("agent")
+                        .model(stubModel("ok"))
+                        .workspace(workspace)
+                        .filesystem(new DockerFilesystemSpec())
+                        .sandboxDistributed(
+                                SandboxDistributedOptions.builder()
+                                        .requireDistributed(false)
+                                        .build())
+                        .build();
+        Map<String, Object> writeInput =
+                Map.of("path", "/should-not-be-local.txt", "content", "sandbox-only");
+
+        ToolResultBlock result = callTool(agent, "write_file", writeInput);
+
+        String text = joinToolResultText(result);
+        assertTrue(
+                text.contains("No active sandbox") || text.contains("sandbox filesystem"),
+                "file tool should use the sandbox proxy outside a sandbox call context: " + text);
+        assertTrue(
+                Files.notExists(localTarget),
+                "sandbox file tool must not fall back to the local workspace");
+    }
+
+    @Test
+    void generalPurposeSubagent_inheritsProjectWorkspaceForFileTools() throws Exception {
+        Files.createDirectories(workspace);
+        Path projectWorkspace = Files.createTempDirectory("agentscope-project-workspace");
+        Path projectTarget = projectWorkspace.resolve("from-subagent.txt");
+        Path stateWorkspaceTarget = workspace.resolve("from-subagent.txt");
+
+        List<SubagentEntry> entries =
+                HarnessAgent.builder()
+                        .name("main")
+                        .model(stubModel("ok"))
+                        .workspace(workspace)
+                        .projectWorkspace(projectWorkspace)
+                        .buildSubagentEntries(workspace);
+
+        Agent createdAgent =
+                entries.stream()
+                        .filter(entry -> entry.name().equals("general-purpose"))
+                        .findFirst()
+                        .orElseThrow()
+                        .factory()
+                        .create();
+        assertTrue(createdAgent instanceof HarnessAgent);
+        HarnessAgent subagent = (HarnessAgent) createdAgent;
+
+        Map<String, Object> writeInput =
+                Map.of("path", "/from-subagent.txt", "content", "subagent-project");
+        ToolResultBlock result = callTool(subagent, "write_file", writeInput);
+
+        assertTrue(
+                joinToolResultText(result).contains("Written to /from-subagent.txt"),
+                "subagent file tool should write successfully: " + joinToolResultText(result));
+        assertTrue(
+                Files.readString(projectTarget).contains("subagent-project"),
+                "subagent file tool should use inherited projectWorkspace");
+        assertTrue(
+                Files.notExists(stateWorkspaceTarget),
+                "subagent file tool must not write into the Harness state workspace");
+    }
+
     private static Msg userText(String text) {
         return Msg.builder()
                 .role(MsgRole.USER)
@@ -355,6 +463,35 @@ class HarnessAgentTest {
 
     private static String joinAllText(List<Msg> msgs) {
         return msgs.stream().map(Msg::getTextContent).collect(Collectors.joining("\n"));
+    }
+
+    private static ToolResultBlock callTool(
+            HarnessAgent agent, String toolName, Map<String, Object> input) {
+        return agent.getDelegate()
+                .getToolkit()
+                .callTool(
+                        ToolCallParam.builder()
+                                .toolUseBlock(
+                                        ToolUseBlock.builder()
+                                                .id("call-" + toolName)
+                                                .name(toolName)
+                                                .input(input)
+                                                .content(JsonUtils.getJsonCodec().toJson(input))
+                                                .build())
+                                .input(input)
+                                .build())
+                .block();
+    }
+
+    private static String joinToolResultText(ToolResultBlock result) {
+        if (result == null) {
+            return "";
+        }
+        return result.getOutput().stream()
+                .filter(TextBlock.class::isInstance)
+                .map(TextBlock.class::cast)
+                .map(TextBlock::getText)
+                .collect(Collectors.joining("\n"));
     }
 
     // =========================================================================


### PR DESCRIPTION
## Summary

Revives and retargets the closed #1348 work onto the current `main` branch.

- Adds `HarnessAgent.Builder.projectWorkspace(Path)` so built-in file tools can operate on a project directory that is separate from the Harness state workspace.
- Keeps `workspace(...)` responsible for `AGENTS.md`, memory, sessions, skills, workspace context, and other Harness state.
- Uses a virtual `LocalFilesystem` rooted at `projectWorkspace` for file tools without the per-user namespace.
- Preserves sandbox-backed file tool behavior by default when `projectWorkspace` is not configured.
- Propagates `projectWorkspace` to shared/general-purpose subagents so their file tools use the same project directory.

## Why

The old PR targeted the deleted `harness` branch, so it was closed without merging. This reapplies the feature against current `main` and adapts it to the newer HarnessAgent/subagent structure.

## Validation

- `mvn -pl agentscope-harness spotless:apply`
- `mvn -pl agentscope-harness -am -Dtest=HarnessAgentTest test`