### PR TITLE
Add PostgreSQL session storage

### DIFF
--- a/agentscope-distribution/agentscope-all/pom.xml
+++ b/agentscope-distribution/agentscope-all/pom.xml
@@ -194,6 +194,13 @@
 
         <dependency>
             <groupId>io.agentscope</groupId>
+            <artifactId>agentscope-extensions-session-postgresql</artifactId>
+            <scope>compile</scope>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
+            <groupId>io.agentscope</groupId>
             <artifactId>agentscope-extensions-session-redis</artifactId>
             <scope>compile</scope>
             <optional>true</optional>

--- a/agentscope-distribution/agentscope-bom/pom.xml
+++ b/agentscope-distribution/agentscope-bom/pom.xml
@@ -225,6 +225,13 @@
                 <version>${project.version}</version>
             </dependency>
 
+            <!-- AgentScope Extensions Session PostgreSQL -->
+            <dependency>
+                <groupId>io.agentscope</groupId>
+                <artifactId>agentscope-extensions-session-postgresql</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
             <!-- AgentScope Extensions Session Redis -->
             <dependency>
                 <groupId>io.agentscope</groupId>

--- a/agentscope-extensions/agentscope-extensions-session-postgresql/pom.xml
+++ b/agentscope-extensions/agentscope-extensions-session-postgresql/pom.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2024-2026 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.agentscope</groupId>
+        <artifactId>agentscope-extensions</artifactId>
+        <version>${revision}</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <name>AgentScope Java - Extensions - Session PostgreSQL</name>
+    <description>AgentScope Extensions - PostgreSQL Session Storage</description>
+    <artifactId>agentscope-extensions-session-postgresql</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.agentscope</groupId>
+            <artifactId>agentscope-core</artifactId>
+            <optional>true</optional>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- PostgreSQL JDBC Driver -->
+        <dependency>
+            <groupId>org.postgresql</groupId>
+            <artifactId>postgresql</artifactId>
+        </dependency>
+
+        <!-- In-memory database for E2E tests (run without a real PostgreSQL instance in CI) -->
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <version>2.4.240</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/agentscope-extensions/agentscope-extensions-session-postgresql/src/main/java/io/agentscope/core/session/postgresql/PostgresSession.java
+++ b/agentscope-extensions/agentscope-extensions-session-postgresql/src/main/java/io/agentscope/core/session/postgresql/PostgresSession.java
@@ -1,0 +1,900 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.core.session.postgresql;
+
+import io.agentscope.core.session.ListHashUtil;
+import io.agentscope.core.session.Session;
+import io.agentscope.core.state.SessionKey;
+import io.agentscope.core.state.SimpleSessionKey;
+import io.agentscope.core.state.State;
+import io.agentscope.core.util.JsonUtils;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.regex.Pattern;
+import javax.sql.DataSource;
+
+/**
+ * PostgreSQL database-based session implementation.
+ *
+ * <p>This implementation stores session state in PostgreSQL tables with the following
+ * structure:
+ *
+ * <ul>
+ *   <li>Single state: stored as JSON with item_index = 0
+ *   <li>List state: each item stored in a separate row with item_index = 0, 1, 2, ...
+ * </ul>
+ *
+ * <p>Table Schema (auto-created if createIfNotExist=true):
+ *
+ * <pre>
+ * CREATE TABLE IF NOT EXISTS "public"."agentscope_sessions" (
+ *     session_id VARCHAR(255) NOT NULL,
+ *     state_key VARCHAR(255) NOT NULL,
+ *     item_index INTEGER NOT NULL DEFAULT 0,
+ *     state_data TEXT NOT NULL,
+ *     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+ *     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+ *     PRIMARY KEY (session_id, state_key, item_index)
+ * );
+ * </pre>
+ *
+ * <p>Features:
+ *
+ * <ul>
+ *   <li>True incremental list storage (only INSERTs new items, no read-modify-write)
+ *   <li>Type-safe state serialization using Jackson
+ *   <li>Automatic table creation
+ *   <li>SQL injection prevention through parameterized queries
+ * </ul>
+ */
+public class PostgresSession implements Session {
+
+    private static final String DEFAULT_SCHEMA_NAME = "public";
+    private static final String DEFAULT_TABLE_NAME = "agentscope_sessions";
+
+    /** Suffix for hash storage keys. */
+    private static final String HASH_KEY_SUFFIX = ":_hash";
+
+    /** item_index value for single state values. */
+    private static final int SINGLE_STATE_INDEX = 0;
+
+    /**
+     * Pattern for validating schema and table names. Only allows alphanumeric characters,
+     * underscores, and hyphens, must start with letter or underscore. This prevents SQL injection
+     * attacks through malicious schema/table names.
+     *
+     * <p>Note: Identifiers containing hyphens require double-quote escaping in SQL queries.
+     */
+    private static final Pattern IDENTIFIER_PATTERN = Pattern.compile("^[a-zA-Z_][a-zA-Z0-9_-]*$");
+
+    private static final int MAX_IDENTIFIER_LENGTH = 63; // PostgreSQL identifier length limit
+
+    private final DataSource dataSource;
+    private final String schemaName;
+    private final String tableName;
+
+    @FunctionalInterface
+    private interface SqlOperation {
+        void execute() throws Exception;
+    }
+
+    /**
+     * Create a PostgresSession with default settings.
+     *
+     * <p>This constructor uses default schema name ({@code public}) and table name ({@code
+     * agentscope_sessions}), and does NOT auto-create the schema or table. If the schema or
+     * table does not exist, an {@link IllegalStateException} will be thrown.
+     *
+     * @param dataSource DataSource for database connections
+     * @throws IllegalArgumentException if dataSource is null
+     * @throws IllegalStateException if schema or table does not exist
+     */
+    public PostgresSession(DataSource dataSource) {
+        this(dataSource, DEFAULT_SCHEMA_NAME, DEFAULT_TABLE_NAME, false);
+    }
+
+    /**
+     * Create a PostgresSession with optional auto-creation of schema and table.
+     *
+     * <p>This constructor uses default schema name ({@code public}) and table name ({@code
+     * agentscope_sessions}). If {@code createIfNotExist} is true, the schema and table will be
+     * created automatically if they don't exist. If false and the schema or table doesn't exist,
+     * an {@link IllegalStateException} will be thrown.
+     *
+     * @param dataSource DataSource for database connections
+     * @param createIfNotExist If true, auto-create schema and table; if false, require existing
+     * @throws IllegalArgumentException if dataSource is null
+     * @throws IllegalStateException if createIfNotExist is false and schema/table does not exist
+     */
+    public PostgresSession(DataSource dataSource, boolean createIfNotExist) {
+        this(dataSource, DEFAULT_SCHEMA_NAME, DEFAULT_TABLE_NAME, createIfNotExist);
+    }
+
+    /**
+     * Create a PostgresSession with custom schema name, table name, and optional auto-creation.
+     *
+     * <p>If {@code createIfNotExist} is true, the schema and table will be created automatically
+     * if they don't exist. If false and the schema or table doesn't exist, an {@link
+     * IllegalStateException} will be thrown.
+     *
+     * @param dataSource DataSource for database connections
+     * @param schemaName Custom schema name (uses default if null or empty)
+     * @param tableName Custom table name (uses default if null or empty)
+     * @param createIfNotExist If true, auto-create schema and table; if false, require existing
+     * @throws IllegalArgumentException if dataSource is null
+     * @throws IllegalStateException if createIfNotExist is false and schema/table does not exist
+     */
+    public PostgresSession(
+            DataSource dataSource, String schemaName, String tableName, boolean createIfNotExist) {
+        if (dataSource == null) {
+            throw new IllegalArgumentException("DataSource cannot be null");
+        }
+
+        this.dataSource = dataSource;
+        this.schemaName =
+                (schemaName == null || schemaName.trim().isEmpty())
+                        ? DEFAULT_SCHEMA_NAME
+                        : schemaName.trim();
+        this.tableName =
+                (tableName == null || tableName.trim().isEmpty())
+                        ? DEFAULT_TABLE_NAME
+                        : tableName.trim();
+
+        // Validate schema and table names to prevent SQL injection
+        validateIdentifier(this.schemaName, "Schema name");
+        validateIdentifier(this.tableName, "Table name");
+
+        if (createIfNotExist) {
+            // Create schema and table if they don't exist
+            createSchemaIfNotExist();
+            createTableIfNotExist();
+        } else {
+            // Verify schema and table exist
+            verifySchemaExists();
+            verifyTableExists();
+        }
+    }
+
+    /**
+     * Create the schema if it doesn't exist.
+     *
+     * <p>PostgreSQL databases are selected by the JDBC URL, so this implementation creates a
+     * schema inside that database instead of trying to create a database.
+     */
+    private void createSchemaIfNotExist() {
+        String createSchemaSql = "CREATE SCHEMA IF NOT EXISTS " + quoteIdentifier(schemaName);
+
+        try (Connection conn = dataSource.getConnection()) {
+            executeInWriteTransaction(
+                    conn,
+                    () -> {
+                        try (PreparedStatement stmt = conn.prepareStatement(createSchemaSql)) {
+                            stmt.execute();
+                        }
+                    });
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to create schema: " + schemaName, e);
+        }
+    }
+
+    /**
+     * Create the sessions table if it doesn't exist.
+     *
+     * <p>Uses double-quote escaping for the table name to safely handle identifiers with special
+     * characters like hyphens.
+     */
+    private void createTableIfNotExist() {
+        String createTableSql =
+                "CREATE TABLE IF NOT EXISTS "
+                        + getFullTableName()
+                        + " (session_id VARCHAR(255) NOT NULL, state_key VARCHAR(255) NOT NULL,"
+                        + " item_index INTEGER NOT NULL DEFAULT 0, state_data TEXT NOT NULL,"
+                        + " created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP, updated_at TIMESTAMP"
+                        + " DEFAULT CURRENT_TIMESTAMP, PRIMARY KEY"
+                        + " (session_id, state_key, item_index))";
+
+        try (Connection conn = dataSource.getConnection()) {
+            executeInWriteTransaction(
+                    conn,
+                    () -> {
+                        try (PreparedStatement stmt = conn.prepareStatement(createTableSql)) {
+                            stmt.execute();
+                        }
+                    });
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to create session table: " + tableName, e);
+        }
+    }
+
+    /**
+     * Verify that the schema exists.
+     *
+     * @throws IllegalStateException if schema does not exist
+     */
+    private void verifySchemaExists() {
+        String checkSql =
+                "SELECT SCHEMA_NAME FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = ?";
+
+        try (Connection conn = dataSource.getConnection();
+                PreparedStatement stmt = conn.prepareStatement(checkSql)) {
+            stmt.setString(1, schemaName);
+            try (ResultSet rs = stmt.executeQuery()) {
+                if (!rs.next()) {
+                    throw new IllegalStateException(
+                            "Schema does not exist: "
+                                    + schemaName
+                                    + ". Use PostgresSession(dataSource, true) to auto-create.");
+                }
+            }
+        } catch (SQLException e) {
+            throw new RuntimeException("Failed to check schema existence: " + schemaName, e);
+        }
+    }
+
+    /**
+     * Verify that the sessions table exists.
+     *
+     * @throws IllegalStateException if table does not exist
+     */
+    private void verifyTableExists() {
+        String checkSql =
+                "SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES "
+                        + "WHERE TABLE_SCHEMA = ? AND TABLE_NAME = ?";
+
+        try (Connection conn = dataSource.getConnection();
+                PreparedStatement stmt = conn.prepareStatement(checkSql)) {
+            stmt.setString(1, schemaName);
+            stmt.setString(2, tableName);
+            try (ResultSet rs = stmt.executeQuery()) {
+                if (!rs.next()) {
+                    throw new IllegalStateException(
+                            "Table does not exist: "
+                                    + schemaName
+                                    + "."
+                                    + tableName
+                                    + ". Use PostgresSession(dataSource, true) to auto-create.");
+                }
+            }
+        } catch (SQLException e) {
+            throw new RuntimeException("Failed to check table existence: " + tableName, e);
+        }
+    }
+
+    /**
+     * Get the full table name with schema prefix, properly escaped with double quotes.
+     *
+     * <p>Uses double quotes to escape identifiers that may contain special characters like hyphens.
+     *
+     * @return The full table name with double-quote escaping ("schema"."table")
+     */
+    private String getFullTableName() {
+        return quoteIdentifier(schemaName) + "." + quoteIdentifier(tableName);
+    }
+
+    private String quoteIdentifier(String identifier) {
+        return "\"" + identifier + "\"";
+    }
+
+    private String getUpsertSql(Connection conn) {
+        if (isH2(conn)) {
+            return "MERGE INTO "
+                    + getFullTableName()
+                    + " (session_id, state_key, item_index, state_data, updated_at)"
+                    + " KEY(session_id, state_key, item_index)"
+                    + " VALUES (?, ?, ?, ?, CURRENT_TIMESTAMP)";
+        }
+        return "INSERT INTO "
+                + getFullTableName()
+                + " (session_id, state_key, item_index, state_data)"
+                + " VALUES (?, ?, ?, ?)"
+                + " ON CONFLICT (session_id, state_key, item_index) DO UPDATE SET"
+                + " state_data = EXCLUDED.state_data,"
+                + " updated_at = CURRENT_TIMESTAMP";
+    }
+
+    private boolean isH2(Connection conn) {
+        try {
+            var metadata = conn.getMetaData();
+            if (metadata == null) {
+                return false;
+            }
+            String productName = metadata.getDatabaseProductName();
+            return "H2".equalsIgnoreCase(productName);
+        } catch (SQLException | RuntimeException e) {
+            return false;
+        }
+    }
+
+    /**
+     * Execute a write operation in an explicit transaction.
+     *
+     * <p>PostgresSession obtains and owns a fresh JDBC connection for each write method call. This
+     * helper makes write semantics consistent even when the underlying DataSource defaults to
+     * {@code autoCommit=false}, and restores the connection's original auto-commit mode before
+     * returning it to the pool.
+     */
+    private void executeInWriteTransaction(Connection conn, SqlOperation operation)
+            throws Exception {
+        boolean originalAutoCommit = conn.getAutoCommit();
+        if (originalAutoCommit) {
+            conn.setAutoCommit(false);
+        }
+
+        try {
+            operation.execute();
+            conn.commit();
+        } catch (Exception e) {
+            try {
+                conn.rollback();
+            } catch (SQLException rollbackException) {
+                e.addSuppressed(rollbackException);
+            }
+            throw e;
+        } finally {
+            if (conn.getAutoCommit() != originalAutoCommit) {
+                conn.setAutoCommit(originalAutoCommit);
+            }
+        }
+    }
+
+    @Override
+    public void save(SessionKey sessionKey, String key, State value) {
+        String sessionId = sessionKey.toIdentifier();
+        validateSessionId(sessionId);
+        validateStateKey(key);
+
+        try (Connection conn = dataSource.getConnection()) {
+            executeInWriteTransaction(
+                    conn,
+                    () -> {
+                        String upsertSql = getUpsertSql(conn);
+                        try (PreparedStatement stmt = conn.prepareStatement(upsertSql)) {
+                            String json = JsonUtils.getJsonCodec().toJson(value);
+
+                            stmt.setString(1, sessionId);
+                            stmt.setString(2, key);
+                            stmt.setInt(3, SINGLE_STATE_INDEX);
+                            stmt.setString(4, json);
+
+                            stmt.executeUpdate();
+                        }
+                    });
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to save state: " + key, e);
+        }
+    }
+
+    /**
+     * Save a list of state values with hash-based change detection.
+     *
+     * <p>This method uses hash-based change detection to handle both append-only and mutable lists:
+     *
+     * <ul>
+     *   <li>If the hash changes (list was modified), all existing items are deleted and rewritten
+     *   <li>If the list shrinks, all existing items are deleted and rewritten
+     *   <li>If the list only grows (append-only), only new items are inserted
+     *   <li>If nothing changes, the operation is skipped
+     * </ul>
+     *
+     * @param sessionKey the session identifier
+     * @param key the state key (e.g., "memory_messages")
+     * @param values the list of state values to save
+     */
+    @Override
+    public void save(SessionKey sessionKey, String key, List<? extends State> values) {
+        String sessionId = sessionKey.toIdentifier();
+        validateSessionId(sessionId);
+        validateStateKey(key);
+
+        if (values.isEmpty()) {
+            return;
+        }
+
+        String hashKey = key + HASH_KEY_SUFFIX;
+
+        try (Connection conn = dataSource.getConnection()) {
+            executeInWriteTransaction(
+                    conn,
+                    () -> {
+                        // Compute current hash
+                        String currentHash = ListHashUtil.computeHash(values);
+
+                        // Get stored hash
+                        String storedHash = getStoredHash(conn, sessionId, hashKey);
+
+                        // Get existing count
+                        int existingCount = getListCount(conn, sessionId, key);
+
+                        // Determine if full rewrite is needed
+                        boolean needsFullRewrite =
+                                ListHashUtil.needsFullRewrite(values, storedHash, existingCount);
+
+                        if (needsFullRewrite) {
+                            deleteListItems(conn, sessionId, key);
+                            insertAllItems(conn, sessionId, key, values);
+                            saveHash(conn, sessionId, hashKey, currentHash);
+                        } else if (values.size() > existingCount) {
+                            List<? extends State> newItems =
+                                    values.subList(existingCount, values.size());
+                            insertItems(conn, sessionId, key, newItems, existingCount);
+                            saveHash(conn, sessionId, hashKey, currentHash);
+                        }
+                        // else: no change, skip
+                    });
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to save list: " + key, e);
+        }
+    }
+
+    /**
+     * Get stored hash value for a list.
+     *
+     * @param conn database connection
+     * @param sessionId session identifier
+     * @param hashKey the hash key (e.g., "memory_messages:_hash")
+     * @return the stored hash, or null if not found
+     */
+    private String getStoredHash(Connection conn, String sessionId, String hashKey)
+            throws SQLException {
+        String selectSql =
+                "SELECT state_data FROM "
+                        + getFullTableName()
+                        + " WHERE session_id = ? AND state_key = ? AND item_index = ?";
+
+        PreparedStatement stmt = conn.prepareStatement(selectSql);
+        try {
+            stmt.setString(1, sessionId);
+            stmt.setString(2, hashKey);
+            stmt.setInt(3, SINGLE_STATE_INDEX);
+
+            ResultSet rs = stmt.executeQuery();
+            try {
+                if (rs.next()) {
+                    return rs.getString("state_data");
+                }
+                return null;
+            } finally {
+                rs.close();
+            }
+        } finally {
+            stmt.close();
+        }
+    }
+
+    /**
+     * Save hash value for a list.
+     *
+     * @param conn database connection
+     * @param sessionId session identifier
+     * @param hashKey the hash key
+     * @param hash the hash value to save
+     */
+    private void saveHash(Connection conn, String sessionId, String hashKey, String hash)
+            throws SQLException {
+        String upsertSql = getUpsertSql(conn);
+
+        try (PreparedStatement stmt = conn.prepareStatement(upsertSql)) {
+            stmt.setString(1, sessionId);
+            stmt.setString(2, hashKey);
+            stmt.setInt(3, SINGLE_STATE_INDEX);
+            stmt.setString(4, hash);
+            stmt.executeUpdate();
+        }
+    }
+
+    /**
+     * Delete all items for a list state.
+     *
+     * @param conn database connection
+     * @param sessionId session identifier
+     * @param key the state key
+     */
+    private void deleteListItems(Connection conn, String sessionId, String key)
+            throws SQLException {
+        String deleteSql =
+                "DELETE FROM " + getFullTableName() + " WHERE session_id = ? AND state_key = ?";
+
+        try (PreparedStatement stmt = conn.prepareStatement(deleteSql)) {
+            stmt.setString(1, sessionId);
+            stmt.setString(2, key);
+            stmt.executeUpdate();
+        }
+    }
+
+    /**
+     * Insert all items for a list state.
+     *
+     * @param conn database connection
+     * @param sessionId session identifier
+     * @param key the state key
+     * @param values the values to insert
+     */
+    private void insertAllItems(
+            Connection conn, String sessionId, String key, List<? extends State> values)
+            throws Exception {
+        insertItems(conn, sessionId, key, values, 0);
+    }
+
+    /**
+     * Insert items for a list state starting at a given index.
+     *
+     * @param conn database connection
+     * @param sessionId session identifier
+     * @param key the state key
+     * @param items the items to insert
+     * @param startIndex the starting index for item_index
+     */
+    private void insertItems(
+            Connection conn,
+            String sessionId,
+            String key,
+            List<? extends State> items,
+            int startIndex)
+            throws Exception {
+        String insertSql =
+                "INSERT INTO "
+                        + getFullTableName()
+                        + " (session_id, state_key, item_index, state_data)"
+                        + " VALUES (?, ?, ?, ?)";
+
+        try (PreparedStatement stmt = conn.prepareStatement(insertSql)) {
+            int index = startIndex;
+            for (State item : items) {
+                String json = JsonUtils.getJsonCodec().toJson(item);
+                stmt.setString(1, sessionId);
+                stmt.setString(2, key);
+                stmt.setInt(3, index);
+                stmt.setString(4, json);
+                stmt.addBatch();
+                index++;
+            }
+            stmt.executeBatch();
+        }
+    }
+
+    /**
+     * Get the count of items in a list state (max index + 1).
+     */
+    private int getListCount(Connection conn, String sessionId, String key) throws SQLException {
+        String selectSql =
+                "SELECT MAX(item_index) as max_index FROM "
+                        + getFullTableName()
+                        + " WHERE session_id = ? AND state_key = ?";
+
+        PreparedStatement stmt = conn.prepareStatement(selectSql);
+        try {
+            stmt.setString(1, sessionId);
+            stmt.setString(2, key);
+
+            ResultSet rs = stmt.executeQuery();
+            try {
+                if (rs.next()) {
+                    int maxIndex = rs.getInt("max_index");
+                    if (rs.wasNull()) {
+                        return 0;
+                    }
+                    return maxIndex + 1;
+                }
+                return 0;
+            } finally {
+                rs.close();
+            }
+        } finally {
+            stmt.close();
+        }
+    }
+
+    @Override
+    public <T extends State> Optional<T> get(SessionKey sessionKey, String key, Class<T> type) {
+        String sessionId = sessionKey.toIdentifier();
+        validateSessionId(sessionId);
+        validateStateKey(key);
+
+        String selectSql =
+                "SELECT state_data FROM "
+                        + getFullTableName()
+                        + " WHERE session_id = ? AND state_key = ? AND item_index = ?";
+
+        try {
+            Connection conn = dataSource.getConnection();
+            try {
+                PreparedStatement stmt = conn.prepareStatement(selectSql);
+                try {
+
+                    stmt.setString(1, sessionId);
+                    stmt.setString(2, key);
+                    stmt.setInt(3, SINGLE_STATE_INDEX);
+
+                    ResultSet rs = stmt.executeQuery();
+                    try {
+                        if (rs.next()) {
+                            String json = rs.getString("state_data");
+                            return Optional.of(JsonUtils.getJsonCodec().fromJson(json, type));
+                        }
+                        return Optional.empty();
+                    } finally {
+                        rs.close();
+                    }
+                } finally {
+                    stmt.close();
+                }
+            } finally {
+                conn.close();
+            }
+
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to get state: " + key, e);
+        }
+    }
+
+    @Override
+    public <T extends State> List<T> getList(SessionKey sessionKey, String key, Class<T> itemType) {
+        String sessionId = sessionKey.toIdentifier();
+        validateSessionId(sessionId);
+        validateStateKey(key);
+
+        String selectSql =
+                "SELECT state_data FROM "
+                        + getFullTableName()
+                        + " WHERE session_id = ? AND state_key = ?"
+                        + " ORDER BY item_index";
+
+        try (Connection conn = dataSource.getConnection();
+                PreparedStatement stmt = conn.prepareStatement(selectSql)) {
+
+            stmt.setString(1, sessionId);
+            stmt.setString(2, key);
+
+            try (ResultSet rs = stmt.executeQuery()) {
+                List<T> result = new ArrayList<>();
+                while (rs.next()) {
+                    String json = rs.getString("state_data");
+                    result.add(JsonUtils.getJsonCodec().fromJson(json, itemType));
+                }
+                return result;
+            }
+
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to get list: " + key, e);
+        }
+    }
+
+    @Override
+    public boolean exists(SessionKey sessionKey) {
+        String sessionId = sessionKey.toIdentifier();
+        validateSessionId(sessionId);
+
+        String existsSql = "SELECT 1 FROM " + getFullTableName() + " WHERE session_id = ? LIMIT 1";
+
+        try (Connection conn = dataSource.getConnection();
+                PreparedStatement stmt = conn.prepareStatement(existsSql)) {
+
+            stmt.setString(1, sessionId);
+            try (ResultSet rs = stmt.executeQuery()) {
+                return rs.next();
+            }
+
+        } catch (SQLException e) {
+            throw new RuntimeException("Failed to check session existence: " + sessionId, e);
+        }
+    }
+
+    @Override
+    public void delete(SessionKey sessionKey) {
+        String sessionId = sessionKey.toIdentifier();
+        validateSessionId(sessionId);
+
+        String deleteSql = "DELETE FROM " + getFullTableName() + " WHERE session_id = ?";
+
+        try (Connection conn = dataSource.getConnection()) {
+            executeInWriteTransaction(
+                    conn,
+                    () -> {
+                        try (PreparedStatement stmt = conn.prepareStatement(deleteSql)) {
+                            stmt.setString(1, sessionId);
+                            stmt.executeUpdate();
+                        }
+                    });
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to delete session: " + sessionId, e);
+        }
+    }
+
+    @Override
+    public Set<SessionKey> listSessionKeys() {
+        String listSql =
+                "SELECT DISTINCT session_id FROM " + getFullTableName() + " ORDER BY session_id";
+
+        try (Connection conn = dataSource.getConnection();
+                PreparedStatement stmt = conn.prepareStatement(listSql);
+                ResultSet rs = stmt.executeQuery()) {
+
+            Set<SessionKey> sessionKeys = new HashSet<>();
+            while (rs.next()) {
+                sessionKeys.add(SimpleSessionKey.of(rs.getString("session_id")));
+            }
+            return sessionKeys;
+
+        } catch (SQLException e) {
+            throw new RuntimeException("Failed to list sessions", e);
+        }
+    }
+
+    /**
+     * Close the session and release any resources.
+     *
+     * <p>Note: This implementation does not close the DataSource as it may be shared across
+     * multiple sessions. The caller is responsible for managing the DataSource lifecycle.
+     */
+    @Override
+    public void close() {
+        // DataSource is managed externally, so we don't close it here
+    }
+
+    /**
+     * Get the schema name used for storing sessions.
+     *
+     * @return The schema name
+     */
+    public String getSchemaName() {
+        return schemaName;
+    }
+
+    /**
+     * Get the table name used for storing sessions.
+     *
+     * @return The table name
+     */
+    public String getTableName() {
+        return tableName;
+    }
+
+    /**
+     * Get the DataSource used for database connections.
+     *
+     * @return The DataSource instance
+     */
+    public DataSource getDataSource() {
+        return dataSource;
+    }
+
+    /**
+     * Clear all sessions from the database (for testing or cleanup).
+     *
+     * @return Number of rows deleted
+     * @deprecated Use {@link #truncateAllSessions()} instead
+     */
+    @Deprecated
+    public int clearAllSessions() {
+        String clearSql = "DELETE FROM " + getFullTableName();
+
+        try (Connection conn = dataSource.getConnection()) {
+            int[] deletedRows = new int[1];
+            executeInWriteTransaction(
+                    conn,
+                    () -> {
+                        try (PreparedStatement stmt = conn.prepareStatement(clearSql)) {
+                            deletedRows[0] = stmt.executeUpdate();
+                        }
+                    });
+            return deletedRows[0];
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to clear sessions", e);
+        }
+    }
+
+    /**
+     * Truncate session table from the database (for testing or cleanup).
+     *
+     * <p>This method clears all session records by executing a TRUNCATE TABLE statement on the
+     * sessions table. TRUNCATE is faster than DELETE as it resets the table without logging
+     * individual row deletions and reclaims storage space immediately.
+     *
+     * <p><strong>Note:</strong> In PostgreSQL, {@code TRUNCATE TABLE} is transactional. This method
+     * routes the statement through {@link #executeInWriteTransaction(Connection, SqlOperation)} so
+     * it persists even when the DataSource returns connections with {@code autoCommit=false}.
+     *
+     * <p><strong>Note:</strong> The TRUNCATE operation requires TRUNCATE privileges in PostgreSQL.
+     *
+     * @return typically 0 if successful
+     */
+    public int truncateAllSessions() {
+        String clearSql = "TRUNCATE TABLE " + getFullTableName();
+
+        try (Connection conn = dataSource.getConnection()) {
+            int[] deletedRows = new int[1];
+            executeInWriteTransaction(
+                    conn,
+                    () -> {
+                        try (PreparedStatement stmt = conn.prepareStatement(clearSql)) {
+                            deletedRows[0] = stmt.executeUpdate();
+                        }
+                    });
+            return deletedRows[0];
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to truncate sessions", e);
+        }
+    }
+
+    /**
+     * Validate a session ID format.
+     *
+     * @param sessionId Session ID to validate
+     * @throws IllegalArgumentException if session ID is invalid
+     */
+    protected void validateSessionId(String sessionId) {
+        if (sessionId == null || sessionId.trim().isEmpty()) {
+            throw new IllegalArgumentException("Session ID cannot be null or empty");
+        }
+        if (sessionId.contains("/") || sessionId.contains("\\")) {
+            throw new IllegalArgumentException("Session ID cannot contain path separators");
+        }
+        if (sessionId.length() > 255) {
+            throw new IllegalArgumentException("Session ID cannot exceed 255 characters");
+        }
+    }
+
+    /**
+     * Validate a state key format.
+     *
+     * @param key State key to validate
+     * @throws IllegalArgumentException if state key is invalid
+     */
+    private void validateStateKey(String key) {
+        if (key == null || key.trim().isEmpty()) {
+            throw new IllegalArgumentException("State key cannot be null or empty");
+        }
+        if (key.length() > 255) {
+            throw new IllegalArgumentException("State key cannot exceed 255 characters");
+        }
+    }
+
+    /**
+     * Validate a schema or table identifier to prevent SQL injection.
+     *
+     * <p>This method ensures that identifiers only contain safe characters (alphanumeric,
+     * underscores, and hyphens) and start with a letter or underscore. This is critical for
+     * security since schema and table names cannot be parameterized in prepared statements.
+     *
+     * @param identifier The identifier to validate (schema name or table name)
+     * @param identifierType Description of the identifier type for error messages
+     * @throws IllegalArgumentException if the identifier is invalid or contains unsafe characters
+     */
+    private void validateIdentifier(String identifier, String identifierType) {
+        if (identifier == null || identifier.isEmpty()) {
+            throw new IllegalArgumentException(identifierType + " cannot be null or empty");
+        }
+        if (identifier.length() > MAX_IDENTIFIER_LENGTH) {
+            throw new IllegalArgumentException(
+                    identifierType + " cannot exceed " + MAX_IDENTIFIER_LENGTH + " characters");
+        }
+        if (!IDENTIFIER_PATTERN.matcher(identifier).matches()) {
+            throw new IllegalArgumentException(
+                    identifierType
+                            + " contains invalid characters. Only alphanumeric characters,"
+                            + " underscores, and hyphens are allowed, and it must start with a"
+                            + " letter or underscore. Invalid value: "
+                            + identifier);
+        }
+    }
+}

--- a/agentscope-extensions/agentscope-extensions-session-postgresql/src/test/java/io/agentscope/core/session/postgresql/PostgresSessionTest.java
+++ b/agentscope-extensions/agentscope-extensions-session-postgresql/src/test/java/io/agentscope/core/session/postgresql/PostgresSessionTest.java
@@ -1,0 +1,1283 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.core.session.postgresql;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.atLeast;
+import static org.mockito.Mockito.clearInvocations;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.agentscope.core.session.ListHashUtil;
+import io.agentscope.core.state.SessionKey;
+import io.agentscope.core.state.SimpleSessionKey;
+import io.agentscope.core.state.State;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import javax.sql.DataSource;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+/**
+ * Unit tests for PostgresSession.
+ *
+ * <p>These tests use mocked DataSource and Connection to verify the behavior of PostgresSession
+ * without requiring an actual PostgreSQL database.
+ */
+@DisplayName("PostgresSession Tests")
+public class PostgresSessionTest {
+
+    @Mock private DataSource mockDataSource;
+
+    @Mock private Connection mockConnection;
+
+    @Mock private PreparedStatement mockStatement;
+
+    @Mock private ResultSet mockResultSet;
+
+    private AutoCloseable mockitoCloseable;
+
+    @BeforeEach
+    void setUp() throws SQLException {
+        mockitoCloseable = MockitoAnnotations.openMocks(this);
+        when(mockDataSource.getConnection()).thenReturn(mockConnection);
+        when(mockConnection.prepareStatement(anyString())).thenReturn(mockStatement);
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        if (mockitoCloseable != null) {
+            mockitoCloseable.close();
+        }
+    }
+
+    @Test
+    @DisplayName("Should throw exception when DataSource is null")
+    void testConstructorWithNullDataSource() {
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> new PostgresSession(null),
+                "DataSource cannot be null");
+    }
+
+    @Test
+    @DisplayName("Should throw exception when DataSource is null with createIfNotExist flag")
+    void testConstructorWithNullDataSourceAndCreateIfNotExist() {
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> new PostgresSession(null, true),
+                "DataSource cannot be null");
+    }
+
+    @Test
+    @DisplayName("Should create session with createIfNotExist=true")
+    void testConstructorWithCreateIfNotExistTrue() throws SQLException {
+        when(mockStatement.execute()).thenReturn(true);
+
+        PostgresSession session = new PostgresSession(mockDataSource, true);
+
+        assertEquals("public", session.getSchemaName());
+        assertEquals("agentscope_sessions", session.getTableName());
+        assertEquals(mockDataSource, session.getDataSource());
+    }
+
+    @Test
+    @DisplayName("Should throw exception when schema does not exist and createIfNotExist=false")
+    void testConstructorWithCreateIfNotExistFalseAndSchemaNotExist() throws SQLException {
+        when(mockStatement.executeQuery()).thenReturn(mockResultSet);
+        when(mockResultSet.next()).thenReturn(false);
+
+        assertThrows(
+                IllegalStateException.class,
+                () -> new PostgresSession(mockDataSource, false),
+                "Schema does not exist");
+    }
+
+    @Test
+    @DisplayName("Should throw exception when table does not exist and createIfNotExist=false")
+    void testConstructorWithCreateIfNotExistFalseAndTableNotExist() throws SQLException {
+        when(mockStatement.executeQuery()).thenReturn(mockResultSet);
+        when(mockResultSet.next()).thenReturn(true, false);
+
+        assertThrows(
+                IllegalStateException.class,
+                () -> new PostgresSession(mockDataSource, false),
+                "Table does not exist");
+    }
+
+    @Test
+    @DisplayName("Should create session when both schema and table exist")
+    void testConstructorWithCreateIfNotExistFalseAndBothExist() throws SQLException {
+        when(mockStatement.executeQuery()).thenReturn(mockResultSet);
+        when(mockResultSet.next()).thenReturn(true, true);
+
+        PostgresSession session = new PostgresSession(mockDataSource, false);
+
+        assertEquals("public", session.getSchemaName());
+        assertEquals("agentscope_sessions", session.getTableName());
+    }
+
+    @Test
+    @DisplayName("Default constructor should require existing schema and table")
+    void testDefaultConstructorRequiresExistingSchemaAndTable() throws SQLException {
+        when(mockStatement.executeQuery()).thenReturn(mockResultSet);
+        when(mockResultSet.next()).thenReturn(true, true);
+
+        PostgresSession session = new PostgresSession(mockDataSource);
+
+        assertEquals("public", session.getSchemaName());
+        assertEquals("agentscope_sessions", session.getTableName());
+    }
+
+    @Test
+    @DisplayName("Should wrap schema creation failures")
+    void testConstructorWrapsSchemaCreationFailure() throws SQLException {
+        when(mockConnection.prepareStatement(anyString()))
+                .thenThrow(new SQLException("create schema failed"));
+
+        RuntimeException exception =
+                assertThrows(
+                        RuntimeException.class, () -> new PostgresSession(mockDataSource, true));
+
+        assertTrue(exception.getMessage().contains("Failed to create schema"));
+    }
+
+    @Test
+    @DisplayName("Should wrap table creation failures")
+    void testConstructorWrapsTableCreationFailure() throws SQLException {
+        when(mockConnection.prepareStatement(anyString()))
+                .thenReturn(mockStatement)
+                .thenThrow(new SQLException("create table failed"));
+        when(mockStatement.execute()).thenReturn(true);
+
+        RuntimeException exception =
+                assertThrows(
+                        RuntimeException.class, () -> new PostgresSession(mockDataSource, true));
+
+        assertTrue(exception.getMessage().contains("Failed to create session table"));
+    }
+
+    @Test
+    @DisplayName("Should wrap schema verification query failures")
+    void testConstructorWrapsSchemaVerificationFailure() throws SQLException {
+        when(mockConnection.prepareStatement(anyString()))
+                .thenThrow(new SQLException("schema check failed"));
+
+        RuntimeException exception =
+                assertThrows(RuntimeException.class, () -> new PostgresSession(mockDataSource));
+
+        assertTrue(exception.getMessage().contains("Failed to check schema existence"));
+    }
+
+    @Test
+    @DisplayName("Should wrap table verification query failures")
+    void testConstructorWrapsTableVerificationFailure() throws SQLException {
+        when(mockConnection.prepareStatement(anyString()))
+                .thenReturn(mockStatement)
+                .thenThrow(new SQLException("table check failed"));
+        when(mockStatement.executeQuery()).thenReturn(mockResultSet);
+        when(mockResultSet.next()).thenReturn(true);
+
+        RuntimeException exception =
+                assertThrows(RuntimeException.class, () -> new PostgresSession(mockDataSource));
+
+        assertTrue(exception.getMessage().contains("Failed to check table existence"));
+    }
+
+    @Test
+    @DisplayName("Should create session with custom schema and table name")
+    void testConstructorWithCustomSchemaAndTableName() throws SQLException {
+        when(mockStatement.execute()).thenReturn(true);
+
+        PostgresSession session =
+                new PostgresSession(mockDataSource, "custom_db", "custom_table", true);
+
+        assertEquals("custom_db", session.getSchemaName());
+        assertEquals("custom_table", session.getTableName());
+    }
+
+    @Test
+    @DisplayName("Should use default schema name when null is provided")
+    void testConstructorWithNullSchemaNameUsesDefault() throws SQLException {
+        when(mockStatement.execute()).thenReturn(true);
+
+        PostgresSession session = new PostgresSession(mockDataSource, null, "custom_table", true);
+
+        assertEquals("public", session.getSchemaName());
+        assertEquals("custom_table", session.getTableName());
+    }
+
+    @Test
+    @DisplayName("Should use default schema name when empty string is provided")
+    void testConstructorWithEmptySchemaNameUsesDefault() throws SQLException {
+        when(mockStatement.execute()).thenReturn(true);
+
+        PostgresSession session = new PostgresSession(mockDataSource, "  ", "custom_table", true);
+
+        assertEquals("public", session.getSchemaName());
+        assertEquals("custom_table", session.getTableName());
+    }
+
+    @Test
+    @DisplayName("Should use default table name when null is provided")
+    void testConstructorWithNullTableNameUsesDefault() throws SQLException {
+        when(mockStatement.execute()).thenReturn(true);
+
+        PostgresSession session = new PostgresSession(mockDataSource, "custom_db", null, true);
+
+        assertEquals("custom_db", session.getSchemaName());
+        assertEquals("agentscope_sessions", session.getTableName());
+    }
+
+    @Test
+    @DisplayName("Should use default table name when empty string is provided")
+    void testConstructorWithEmptyTableNameUsesDefault() throws SQLException {
+        when(mockStatement.execute()).thenReturn(true);
+
+        PostgresSession session = new PostgresSession(mockDataSource, "custom_db", "", true);
+
+        assertEquals("custom_db", session.getSchemaName());
+        assertEquals("agentscope_sessions", session.getTableName());
+    }
+
+    @Test
+    @DisplayName("Should get DataSource correctly")
+    void testGetDataSource() throws SQLException {
+        when(mockStatement.execute()).thenReturn(true);
+
+        PostgresSession session = new PostgresSession(mockDataSource, true);
+        assertEquals(mockDataSource, session.getDataSource());
+    }
+
+    @Test
+    @DisplayName("Should save and get single state correctly")
+    void testSaveAndGetSingleState() throws SQLException {
+        when(mockStatement.execute()).thenReturn(true);
+        when(mockStatement.executeUpdate()).thenReturn(1);
+        when(mockStatement.executeQuery()).thenReturn(mockResultSet);
+        when(mockResultSet.next()).thenReturn(true);
+        when(mockResultSet.getString("state_data"))
+                .thenReturn("{\"value\":\"test_value\",\"count\":42}");
+
+        PostgresSession session = new PostgresSession(mockDataSource, true);
+        clearInvocations(mockConnection);
+        SessionKey sessionKey = SimpleSessionKey.of("session1");
+        TestState state = new TestState("test_value", 42);
+
+        // Save state
+        session.save(sessionKey, "testModule", state);
+
+        // Verify save operations
+        verify(mockStatement, atLeast(1)).executeUpdate();
+
+        // Get state
+        Optional<TestState> loaded = session.get(sessionKey, "testModule", TestState.class);
+        assertTrue(loaded.isPresent());
+        assertEquals("test_value", loaded.get().value());
+        assertEquals(42, loaded.get().count());
+    }
+
+    @Test
+    @DisplayName("Should commit single state save when connection auto-commit is disabled")
+    void testSaveSingleStateCommitsWhenAutoCommitDisabled() throws SQLException {
+        when(mockConnection.getAutoCommit()).thenReturn(false);
+        when(mockStatement.execute()).thenReturn(true);
+        when(mockStatement.executeUpdate()).thenReturn(1);
+
+        PostgresSession session = new PostgresSession(mockDataSource, true);
+        clearInvocations(mockConnection);
+        SessionKey sessionKey = SimpleSessionKey.of("session_auto_commit_off");
+
+        session.save(sessionKey, "testModule", new TestState("test_value", 42));
+
+        verify(mockConnection).commit();
+        verify(mockConnection, never()).setAutoCommit(true);
+    }
+
+    @Test
+    @DisplayName("Should save single state when database metadata lookup fails")
+    void testSaveSingleStateWhenMetadataLookupFails() throws SQLException {
+        when(mockConnection.getMetaData()).thenThrow(new SQLException("metadata failed"));
+        when(mockStatement.execute()).thenReturn(true);
+        when(mockStatement.executeUpdate()).thenReturn(1);
+
+        PostgresSession session = new PostgresSession(mockDataSource, true);
+
+        session.save(
+                SimpleSessionKey.of("session_metadata_lookup_failed"),
+                "testModule",
+                new TestState("test_value", 42));
+
+        verify(mockStatement, atLeast(1)).executeUpdate();
+    }
+
+    @Test
+    @DisplayName("Should save and get list state correctly")
+    void testSaveAndGetListState() throws SQLException {
+        when(mockStatement.execute()).thenReturn(true);
+        when(mockStatement.executeUpdate()).thenReturn(1);
+        when(mockStatement.executeQuery()).thenReturn(mockResultSet);
+
+        // Mock sequence for save():
+        // 1. getStoredHash() query - no hash found (next=false)
+        // 2. getListCount() query - no items (next=true, wasNull=true)
+        // Then for getList():
+        // 3. getList() query - 2 rows (next=true, true, false)
+        when(mockResultSet.next()).thenReturn(false, true, true, true, false);
+        when(mockResultSet.getInt("max_index")).thenReturn(0);
+        when(mockResultSet.wasNull()).thenReturn(true);
+        when(mockResultSet.getString("state_data"))
+                .thenReturn("{\"value\":\"value1\",\"count\":1}")
+                .thenReturn("{\"value\":\"value2\",\"count\":2}");
+
+        PostgresSession session = new PostgresSession(mockDataSource, true);
+        SessionKey sessionKey = SimpleSessionKey.of("session1");
+        List<TestState> states = List.of(new TestState("value1", 1), new TestState("value2", 2));
+
+        // Save list state
+        session.save(sessionKey, "testList", states);
+
+        // Get list state
+        List<TestState> loaded = session.getList(sessionKey, "testList", TestState.class);
+        assertEquals(2, loaded.size());
+        assertEquals("value1", loaded.get(0).value());
+        assertEquals("value2", loaded.get(1).value());
+    }
+
+    @Test
+    @DisplayName("Should skip saving empty lists")
+    void testSaveEmptyListDoesNothing() throws SQLException {
+        when(mockStatement.execute()).thenReturn(true);
+
+        PostgresSession session = new PostgresSession(mockDataSource, true);
+        clearInvocations(mockStatement);
+
+        session.save(SimpleSessionKey.of("session_empty_list"), "testList", List.of());
+
+        verify(mockStatement, never()).executeUpdate();
+        verify(mockStatement, never()).executeBatch();
+    }
+
+    @Test
+    @DisplayName("Should skip unchanged list state")
+    void testSaveUnchangedListDoesNothing() throws SQLException {
+        when(mockStatement.execute()).thenReturn(true);
+        when(mockStatement.executeQuery()).thenReturn(mockResultSet);
+        List<TestState> states = List.of(new TestState("value1", 1), new TestState("value2", 2));
+        when(mockResultSet.next()).thenReturn(true, true);
+        when(mockResultSet.getString("state_data")).thenReturn(ListHashUtil.computeHash(states));
+        when(mockResultSet.getInt("max_index")).thenReturn(states.size() - 1);
+        when(mockResultSet.wasNull()).thenReturn(false);
+
+        PostgresSession session = new PostgresSession(mockDataSource, true);
+        clearInvocations(mockStatement);
+
+        session.save(SimpleSessionKey.of("session_unchanged_list"), "testList", states);
+
+        verify(mockStatement, never()).executeUpdate();
+        verify(mockStatement, never()).executeBatch();
+    }
+
+    @Test
+    @DisplayName("Should commit incremental list save when connection auto-commit is disabled")
+    void testSaveListIncrementalAppendCommitsWhenAutoCommitDisabled() throws SQLException {
+        when(mockConnection.getAutoCommit()).thenReturn(false);
+        when(mockStatement.execute()).thenReturn(true);
+        when(mockStatement.executeQuery()).thenReturn(mockResultSet);
+        when(mockResultSet.next()).thenReturn(false, true);
+        when(mockResultSet.getInt("max_index")).thenReturn(0);
+        when(mockResultSet.wasNull()).thenReturn(true);
+
+        PostgresSession session = new PostgresSession(mockDataSource, true);
+        clearInvocations(mockConnection);
+        SessionKey sessionKey = SimpleSessionKey.of("session_list_auto_commit_off");
+        List<TestState> states = List.of(new TestState("value1", 1), new TestState("value2", 2));
+
+        session.save(sessionKey, "testList", states);
+
+        verify(mockConnection).commit();
+        verify(mockConnection, never()).setAutoCommit(true);
+    }
+
+    @Test
+    @DisplayName("Should save list when count query returns no rows")
+    void testSaveListWhenCountQueryReturnsNoRows() throws SQLException {
+        when(mockStatement.execute()).thenReturn(true);
+        when(mockStatement.executeQuery()).thenReturn(mockResultSet);
+        when(mockStatement.executeUpdate()).thenReturn(1);
+        when(mockResultSet.next()).thenReturn(false, false);
+
+        PostgresSession session = new PostgresSession(mockDataSource, true);
+        List<TestState> states = List.of(new TestState("value1", 1));
+
+        session.save(SimpleSessionKey.of("session_list_no_count_row"), "testList", states);
+
+        verify(mockStatement, atLeast(1)).executeBatch();
+    }
+
+    @Test
+    @DisplayName(
+            "Should not force auto-commit true after full rewrite when connection starts disabled")
+    void testSaveListFullRewriteRestoresOriginalAutoCommitState() throws SQLException {
+        when(mockConnection.getAutoCommit()).thenReturn(false);
+        when(mockStatement.execute()).thenReturn(true);
+        when(mockStatement.executeQuery()).thenReturn(mockResultSet);
+        when(mockResultSet.next()).thenReturn(true, true);
+        when(mockResultSet.getString("state_data")).thenReturn("stale_hash");
+        when(mockResultSet.getInt("max_index")).thenReturn(0);
+        when(mockResultSet.wasNull()).thenReturn(false);
+        when(mockStatement.executeUpdate()).thenReturn(1);
+
+        PostgresSession session = new PostgresSession(mockDataSource, true);
+        clearInvocations(mockConnection);
+        SessionKey sessionKey = SimpleSessionKey.of("session_full_rewrite_auto_commit_off");
+        List<TestState> states = List.of(new TestState("value1", 1));
+
+        session.save(sessionKey, "testList", states);
+
+        verify(mockConnection).commit();
+        verify(mockConnection, never()).setAutoCommit(true);
+    }
+
+    @Test
+    @DisplayName("Should return empty for non-existent state")
+    void testGetNonExistentState() throws SQLException {
+        when(mockStatement.execute()).thenReturn(true);
+        when(mockStatement.executeQuery()).thenReturn(mockResultSet);
+        when(mockResultSet.next()).thenReturn(false);
+
+        PostgresSession session = new PostgresSession(mockDataSource, true);
+        SessionKey sessionKey = SimpleSessionKey.of("non_existent");
+
+        Optional<TestState> state = session.get(sessionKey, "testModule", TestState.class);
+        assertFalse(state.isPresent());
+    }
+
+    @Test
+    @DisplayName("Should return empty list for non-existent list state")
+    void testGetNonExistentListState() throws SQLException {
+        when(mockStatement.execute()).thenReturn(true);
+        when(mockStatement.executeQuery()).thenReturn(mockResultSet);
+        when(mockResultSet.next()).thenReturn(false);
+
+        PostgresSession session = new PostgresSession(mockDataSource, true);
+        SessionKey sessionKey = SimpleSessionKey.of("non_existent");
+
+        List<TestState> states = session.getList(sessionKey, "testList", TestState.class);
+        assertTrue(states.isEmpty());
+    }
+
+    @Test
+    @DisplayName("Should return true when session exists")
+    void testSessionExists() throws SQLException {
+        when(mockStatement.execute()).thenReturn(true);
+        when(mockStatement.executeQuery()).thenReturn(mockResultSet);
+        when(mockResultSet.next()).thenReturn(true);
+
+        PostgresSession session = new PostgresSession(mockDataSource, true);
+        clearInvocations(mockConnection);
+        SessionKey sessionKey = SimpleSessionKey.of("session1");
+
+        assertTrue(session.exists(sessionKey));
+    }
+
+    @Test
+    @DisplayName("Should return false when session does not exist")
+    void testSessionDoesNotExist() throws SQLException {
+        when(mockStatement.execute()).thenReturn(true);
+        when(mockStatement.executeQuery()).thenReturn(mockResultSet);
+        when(mockResultSet.next()).thenReturn(false);
+
+        PostgresSession session = new PostgresSession(mockDataSource, true);
+        SessionKey sessionKey = SimpleSessionKey.of("non_existent");
+
+        assertFalse(session.exists(sessionKey));
+    }
+
+    @Test
+    @DisplayName("Should delete session correctly")
+    void testDeleteSession() throws SQLException {
+        when(mockStatement.execute()).thenReturn(true);
+        when(mockStatement.executeUpdate()).thenReturn(1);
+
+        PostgresSession session = new PostgresSession(mockDataSource, true);
+        clearInvocations(mockConnection);
+        SessionKey sessionKey = SimpleSessionKey.of("session1");
+
+        session.delete(sessionKey);
+
+        verify(mockStatement).setString(1, "session1");
+        verify(mockStatement).executeUpdate();
+    }
+
+    @Test
+    @DisplayName("Should commit delete when connection auto-commit is disabled")
+    void testDeleteSessionCommitsWhenAutoCommitDisabled() throws SQLException {
+        when(mockConnection.getAutoCommit()).thenReturn(false);
+        when(mockStatement.execute()).thenReturn(true);
+        when(mockStatement.executeUpdate()).thenReturn(1);
+
+        PostgresSession session = new PostgresSession(mockDataSource, true);
+        clearInvocations(mockConnection);
+        SessionKey sessionKey = SimpleSessionKey.of("session1");
+
+        session.delete(sessionKey);
+
+        verify(mockConnection).commit();
+        verify(mockConnection, never()).setAutoCommit(true);
+    }
+
+    @Test
+    @DisplayName("Should list all session keys when empty")
+    void testListSessionKeysEmpty() throws SQLException {
+        when(mockStatement.execute()).thenReturn(true);
+        when(mockStatement.executeQuery()).thenReturn(mockResultSet);
+        when(mockResultSet.next()).thenReturn(false);
+
+        PostgresSession session = new PostgresSession(mockDataSource, true);
+        Set<SessionKey> sessionKeys = session.listSessionKeys();
+
+        assertTrue(sessionKeys.isEmpty());
+    }
+
+    @Test
+    @DisplayName("Should list all session keys")
+    void testListSessionKeysWithResults() throws SQLException {
+        when(mockStatement.execute()).thenReturn(true);
+        when(mockStatement.executeQuery()).thenReturn(mockResultSet);
+        when(mockResultSet.next()).thenReturn(true, true, false);
+        when(mockResultSet.getString("session_id")).thenReturn("session1", "session2");
+
+        PostgresSession session = new PostgresSession(mockDataSource, true);
+        Set<SessionKey> sessionKeys = session.listSessionKeys();
+
+        assertEquals(2, sessionKeys.size());
+        assertTrue(sessionKeys.contains(SimpleSessionKey.of("session1")));
+        assertTrue(sessionKeys.contains(SimpleSessionKey.of("session2")));
+    }
+
+    @Test
+    @DisplayName("Should clear all sessions")
+    void testClearAllSessions() throws SQLException {
+        when(mockStatement.execute()).thenReturn(true);
+        when(mockStatement.executeUpdate()).thenReturn(5);
+
+        PostgresSession session = new PostgresSession(mockDataSource, true);
+        clearInvocations(mockConnection);
+        int deleted = session.clearAllSessions();
+
+        assertEquals(5, deleted);
+    }
+
+    @Test
+    @DisplayName("Should commit clearAllSessions when connection auto-commit is disabled")
+    void testClearAllSessionsCommitsWhenAutoCommitDisabled() throws SQLException {
+        when(mockConnection.getAutoCommit()).thenReturn(false);
+        when(mockStatement.execute()).thenReturn(true);
+        when(mockStatement.executeUpdate()).thenReturn(5);
+
+        PostgresSession session = new PostgresSession(mockDataSource, true);
+        clearInvocations(mockConnection);
+        int deleted = session.clearAllSessions();
+
+        assertEquals(5, deleted);
+        verify(mockConnection).commit();
+        verify(mockConnection, never()).setAutoCommit(true);
+    }
+
+    @Test
+    @DisplayName("Should truncate session table")
+    void testTruncateAllSessions() throws SQLException {
+        when(mockStatement.execute()).thenReturn(true);
+        when(mockStatement.executeUpdate()).thenReturn(0);
+
+        PostgresSession session = new PostgresSession(mockDataSource, true);
+        clearInvocations(mockConnection);
+        int success = session.truncateAllSessions();
+
+        assertEquals(0, success);
+    }
+
+    @Test
+    @DisplayName("Should commit truncateAllSessions when connection auto-commit is disabled")
+    void testTruncateAllSessionsCommitsWhenAutoCommitDisabled() throws SQLException {
+        when(mockConnection.getAutoCommit()).thenReturn(false);
+        when(mockStatement.execute()).thenReturn(true);
+        when(mockStatement.executeUpdate()).thenReturn(0);
+
+        PostgresSession session = new PostgresSession(mockDataSource, true);
+        clearInvocations(mockConnection);
+        int success = session.truncateAllSessions();
+
+        assertEquals(0, success);
+        verify(mockConnection).commit();
+        verify(mockConnection, never()).setAutoCommit(true);
+    }
+
+    @Test
+    @DisplayName("Should not close DataSource when closing session")
+    void testClose() throws SQLException {
+        when(mockStatement.execute()).thenReturn(true);
+
+        PostgresSession session = new PostgresSession(mockDataSource, true);
+        session.close();
+        assertEquals(mockDataSource, session.getDataSource());
+    }
+
+    @Test
+    @DisplayName("Should reject invalid session identifiers")
+    void testRejectsInvalidSessionIdentifiers() throws SQLException {
+        when(mockStatement.execute()).thenReturn(true);
+
+        PostgresSession session = new PostgresSession(mockDataSource, true);
+        TestState state = new TestState("value", 1);
+
+        assertThrows(
+                IllegalArgumentException.class,
+                () ->
+                        session.save(
+                                new SessionKey() {
+                                    @Override
+                                    public String toIdentifier() {
+                                        return null;
+                                    }
+                                },
+                                "module",
+                                state));
+        assertThrows(
+                IllegalArgumentException.class,
+                () ->
+                        session.save(
+                                new SessionKey() {
+                                    @Override
+                                    public String toIdentifier() {
+                                        return "   ";
+                                    }
+                                },
+                                "module",
+                                state));
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> session.save(SimpleSessionKey.of("bad/path"), "module", state));
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> session.save(SimpleSessionKey.of("bad\\path"), "module", state));
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> session.save(SimpleSessionKey.of("a".repeat(256)), "module", state));
+    }
+
+    @Test
+    @DisplayName("Should reject invalid state keys")
+    void testRejectsInvalidStateKeys() throws SQLException {
+        when(mockStatement.execute()).thenReturn(true);
+
+        PostgresSession session = new PostgresSession(mockDataSource, true);
+        SessionKey sessionKey = SimpleSessionKey.of("session_invalid_state_key");
+        TestState state = new TestState("value", 1);
+
+        assertThrows(IllegalArgumentException.class, () -> session.save(sessionKey, null, state));
+        assertThrows(IllegalArgumentException.class, () -> session.save(sessionKey, "   ", state));
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> session.save(sessionKey, "a".repeat(256), state));
+    }
+
+    @Test
+    @DisplayName("Should wrap save failures and include rollback failures as suppressed")
+    void testSaveWrapsWriteFailureAndSuppressedRollbackFailure() throws SQLException {
+        when(mockStatement.execute()).thenReturn(true);
+        when(mockStatement.executeUpdate()).thenThrow(new SQLException("write failed"));
+        doThrow(new SQLException("rollback failed")).when(mockConnection).rollback();
+
+        PostgresSession session = new PostgresSession(mockDataSource, true);
+
+        RuntimeException exception =
+                assertThrows(
+                        RuntimeException.class,
+                        () ->
+                                session.save(
+                                        SimpleSessionKey.of("session_save_failure"),
+                                        "module",
+                                        new TestState("value", 1)));
+
+        assertTrue(exception.getMessage().contains("Failed to save state"));
+        assertEquals(1, exception.getCause().getSuppressed().length);
+    }
+
+    @Test
+    @DisplayName("Should wrap list save failures")
+    void testSaveListWrapsQueryFailure() throws SQLException {
+        when(mockStatement.execute()).thenReturn(true);
+        when(mockStatement.executeQuery()).thenThrow(new SQLException("hash read failed"));
+
+        PostgresSession session = new PostgresSession(mockDataSource, true);
+
+        RuntimeException exception =
+                assertThrows(
+                        RuntimeException.class,
+                        () ->
+                                session.save(
+                                        SimpleSessionKey.of("session_list_failure"),
+                                        "testList",
+                                        List.of(new TestState("value", 1))));
+
+        assertTrue(exception.getMessage().contains("Failed to save list"));
+    }
+
+    @Test
+    @DisplayName("Should wrap list save when hash cursor fails")
+    void testSaveListWrapsHashCursorFailure() throws SQLException {
+        when(mockStatement.execute()).thenReturn(true);
+        when(mockStatement.executeQuery()).thenReturn(mockResultSet);
+        when(mockResultSet.next()).thenThrow(new SQLException("hash cursor failed"));
+
+        PostgresSession session = new PostgresSession(mockDataSource, true);
+
+        RuntimeException exception =
+                assertThrows(
+                        RuntimeException.class,
+                        () ->
+                                session.save(
+                                        SimpleSessionKey.of("session_hash_cursor_failure"),
+                                        "testList",
+                                        List.of(new TestState("value", 1))));
+
+        assertTrue(exception.getMessage().contains("Failed to save list"));
+    }
+
+    @Test
+    @DisplayName("Should wrap list save when hash result close fails")
+    void testSaveListWrapsHashResultCloseFailure() throws SQLException {
+        when(mockStatement.execute()).thenReturn(true);
+        when(mockStatement.executeQuery()).thenReturn(mockResultSet);
+        when(mockResultSet.next()).thenReturn(false);
+
+        PostgresSession session = new PostgresSession(mockDataSource, true);
+        doThrow(new SQLException("hash result close failed")).when(mockResultSet).close();
+
+        RuntimeException exception =
+                assertThrows(
+                        RuntimeException.class,
+                        () ->
+                                session.save(
+                                        SimpleSessionKey.of("session_hash_result_close_failure"),
+                                        "testList",
+                                        List.of(new TestState("value", 1))));
+
+        assertTrue(exception.getMessage().contains("Failed to save list"));
+    }
+
+    @Test
+    @DisplayName("Should wrap list save when hash statement close fails")
+    void testSaveListWrapsHashStatementCloseFailure() throws SQLException {
+        when(mockStatement.execute()).thenReturn(true);
+        when(mockStatement.executeQuery()).thenReturn(mockResultSet);
+        when(mockResultSet.next()).thenReturn(false);
+
+        PostgresSession session = new PostgresSession(mockDataSource, true);
+        doThrow(new SQLException("hash statement close failed")).when(mockStatement).close();
+
+        RuntimeException exception =
+                assertThrows(
+                        RuntimeException.class,
+                        () ->
+                                session.save(
+                                        SimpleSessionKey.of("session_hash_statement_close_failure"),
+                                        "testList",
+                                        List.of(new TestState("value", 1))));
+
+        assertTrue(exception.getMessage().contains("Failed to save list"));
+    }
+
+    @Test
+    @DisplayName("Should wrap list save when count result close fails")
+    void testSaveListWrapsCountResultCloseFailure() throws SQLException {
+        when(mockStatement.execute()).thenReturn(true);
+        when(mockStatement.executeQuery()).thenReturn(mockResultSet);
+        when(mockResultSet.next()).thenReturn(false, true);
+        when(mockResultSet.getInt("max_index")).thenReturn(0);
+        when(mockResultSet.wasNull()).thenReturn(true);
+
+        PostgresSession session = new PostgresSession(mockDataSource, true);
+        doNothing()
+                .doThrow(new SQLException("count result close failed"))
+                .when(mockResultSet)
+                .close();
+
+        RuntimeException exception =
+                assertThrows(
+                        RuntimeException.class,
+                        () ->
+                                session.save(
+                                        SimpleSessionKey.of("session_count_result_close_failure"),
+                                        "testList",
+                                        List.of(new TestState("value", 1))));
+
+        assertTrue(exception.getMessage().contains("Failed to save list"));
+    }
+
+    @Test
+    @DisplayName("Should wrap list save when count cursor fails")
+    void testSaveListWrapsCountCursorFailure() throws SQLException {
+        when(mockStatement.execute()).thenReturn(true);
+        PreparedStatement hashStatement = mock(PreparedStatement.class);
+        PreparedStatement countStatement = mock(PreparedStatement.class);
+        ResultSet hashResultSet = mock(ResultSet.class);
+        ResultSet countResultSet = mock(ResultSet.class);
+        when(hashStatement.executeQuery()).thenReturn(hashResultSet);
+        when(hashResultSet.next()).thenReturn(false);
+        when(countStatement.executeQuery()).thenReturn(countResultSet);
+        when(countResultSet.next()).thenThrow(new SQLException("count cursor failed"));
+
+        PostgresSession session = new PostgresSession(mockDataSource, true);
+        when(mockConnection.prepareStatement(anyString()))
+                .thenReturn(hashStatement, countStatement);
+
+        RuntimeException exception =
+                assertThrows(
+                        RuntimeException.class,
+                        () ->
+                                session.save(
+                                        SimpleSessionKey.of("session_count_cursor_failure"),
+                                        "testList",
+                                        List.of(new TestState("value", 1))));
+
+        assertTrue(exception.getMessage().contains("Failed to save list"));
+    }
+
+    @Test
+    @DisplayName("Should wrap list save when count statement close fails")
+    void testSaveListWrapsCountStatementCloseFailure() throws SQLException {
+        when(mockStatement.execute()).thenReturn(true);
+        when(mockStatement.executeQuery()).thenReturn(mockResultSet);
+        when(mockResultSet.next()).thenReturn(false, true);
+        when(mockResultSet.getInt("max_index")).thenReturn(0);
+        when(mockResultSet.wasNull()).thenReturn(true);
+
+        PostgresSession session = new PostgresSession(mockDataSource, true);
+        doNothing()
+                .doThrow(new SQLException("count statement close failed"))
+                .when(mockStatement)
+                .close();
+
+        RuntimeException exception =
+                assertThrows(
+                        RuntimeException.class,
+                        () ->
+                                session.save(
+                                        SimpleSessionKey.of(
+                                                "session_count_statement_close_failure"),
+                                        "testList",
+                                        List.of(new TestState("value", 1))));
+
+        assertTrue(exception.getMessage().contains("Failed to save list"));
+    }
+
+    @Test
+    @DisplayName("Should wrap single state read failures")
+    void testGetWrapsQueryFailure() throws SQLException {
+        when(mockStatement.execute()).thenReturn(true);
+        when(mockStatement.executeQuery()).thenThrow(new SQLException("read failed"));
+
+        PostgresSession session = new PostgresSession(mockDataSource, true);
+
+        RuntimeException exception =
+                assertThrows(
+                        RuntimeException.class,
+                        () ->
+                                session.get(
+                                        SimpleSessionKey.of("session_get_failure"),
+                                        "module",
+                                        TestState.class));
+
+        assertTrue(exception.getMessage().contains("Failed to get state"));
+    }
+
+    @Test
+    @DisplayName("Should wrap single state read when cursor fails")
+    void testGetWrapsCursorFailure() throws SQLException {
+        when(mockStatement.execute()).thenReturn(true);
+        when(mockStatement.executeQuery()).thenReturn(mockResultSet);
+        when(mockResultSet.next()).thenThrow(new SQLException("read cursor failed"));
+
+        PostgresSession session = new PostgresSession(mockDataSource, true);
+
+        RuntimeException exception =
+                assertThrows(
+                        RuntimeException.class,
+                        () ->
+                                session.get(
+                                        SimpleSessionKey.of("session_get_cursor_failure"),
+                                        "module",
+                                        TestState.class));
+
+        assertTrue(exception.getMessage().contains("Failed to get state"));
+    }
+
+    @Test
+    @DisplayName("Should wrap single state read when result close fails")
+    void testGetWrapsResultCloseFailure() throws SQLException {
+        when(mockStatement.execute()).thenReturn(true);
+        when(mockStatement.executeQuery()).thenReturn(mockResultSet);
+        when(mockResultSet.next()).thenReturn(false);
+
+        PostgresSession session = new PostgresSession(mockDataSource, true);
+        doThrow(new SQLException("read result close failed")).when(mockResultSet).close();
+
+        RuntimeException exception =
+                assertThrows(
+                        RuntimeException.class,
+                        () ->
+                                session.get(
+                                        SimpleSessionKey.of("session_get_result_close_failure"),
+                                        "module",
+                                        TestState.class));
+
+        assertTrue(exception.getMessage().contains("Failed to get state"));
+    }
+
+    @Test
+    @DisplayName("Should wrap single state read when statement close fails")
+    void testGetWrapsStatementCloseFailure() throws SQLException {
+        when(mockStatement.execute()).thenReturn(true);
+        when(mockStatement.executeQuery()).thenReturn(mockResultSet);
+        when(mockResultSet.next()).thenReturn(false);
+
+        PostgresSession session = new PostgresSession(mockDataSource, true);
+        doThrow(new SQLException("read statement close failed")).when(mockStatement).close();
+
+        RuntimeException exception =
+                assertThrows(
+                        RuntimeException.class,
+                        () ->
+                                session.get(
+                                        SimpleSessionKey.of("session_get_statement_close_failure"),
+                                        "module",
+                                        TestState.class));
+
+        assertTrue(exception.getMessage().contains("Failed to get state"));
+    }
+
+    @Test
+    @DisplayName("Should wrap list read failures")
+    void testGetListWrapsQueryFailure() throws SQLException {
+        when(mockStatement.execute()).thenReturn(true);
+        when(mockStatement.executeQuery()).thenThrow(new SQLException("read list failed"));
+
+        PostgresSession session = new PostgresSession(mockDataSource, true);
+
+        RuntimeException exception =
+                assertThrows(
+                        RuntimeException.class,
+                        () ->
+                                session.getList(
+                                        SimpleSessionKey.of("session_get_list_failure"),
+                                        "testList",
+                                        TestState.class));
+
+        assertTrue(exception.getMessage().contains("Failed to get list"));
+    }
+
+    @Test
+    @DisplayName("Should wrap exists query failures")
+    void testExistsWrapsQueryFailure() throws SQLException {
+        when(mockStatement.execute()).thenReturn(true);
+        when(mockStatement.executeQuery()).thenThrow(new SQLException("exists failed"));
+
+        PostgresSession session = new PostgresSession(mockDataSource, true);
+
+        RuntimeException exception =
+                assertThrows(
+                        RuntimeException.class,
+                        () -> session.exists(SimpleSessionKey.of("session_exists_failure")));
+
+        assertTrue(exception.getMessage().contains("Failed to check session existence"));
+    }
+
+    @Test
+    @DisplayName("Should wrap delete failures")
+    void testDeleteWrapsWriteFailure() throws SQLException {
+        when(mockStatement.execute()).thenReturn(true);
+        when(mockStatement.executeUpdate()).thenThrow(new SQLException("delete failed"));
+
+        PostgresSession session = new PostgresSession(mockDataSource, true);
+
+        RuntimeException exception =
+                assertThrows(
+                        RuntimeException.class,
+                        () -> session.delete(SimpleSessionKey.of("session_delete_failure")));
+
+        assertTrue(exception.getMessage().contains("Failed to delete session"));
+    }
+
+    @Test
+    @DisplayName("Should wrap session listing failures")
+    void testListSessionKeysWrapsQueryFailure() throws SQLException {
+        when(mockStatement.execute()).thenReturn(true);
+        when(mockStatement.executeQuery()).thenThrow(new SQLException("list failed"));
+
+        PostgresSession session = new PostgresSession(mockDataSource, true);
+
+        RuntimeException exception = assertThrows(RuntimeException.class, session::listSessionKeys);
+
+        assertTrue(exception.getMessage().contains("Failed to list sessions"));
+    }
+
+    @Test
+    @DisplayName("Should wrap clear failures")
+    void testClearAllSessionsWrapsWriteFailure() throws SQLException {
+        when(mockStatement.execute()).thenReturn(true);
+        when(mockStatement.executeUpdate()).thenThrow(new SQLException("clear failed"));
+
+        PostgresSession session = new PostgresSession(mockDataSource, true);
+
+        RuntimeException exception =
+                assertThrows(RuntimeException.class, session::clearAllSessions);
+
+        assertTrue(exception.getMessage().contains("Failed to clear sessions"));
+    }
+
+    @Test
+    @DisplayName("Should wrap truncate failures")
+    void testTruncateAllSessionsWrapsWriteFailure() throws SQLException {
+        when(mockStatement.execute()).thenReturn(true);
+        when(mockStatement.executeUpdate()).thenThrow(new SQLException("truncate failed"));
+
+        PostgresSession session = new PostgresSession(mockDataSource, true);
+
+        RuntimeException exception =
+                assertThrows(RuntimeException.class, session::truncateAllSessions);
+
+        assertTrue(exception.getMessage().contains("Failed to truncate sessions"));
+    }
+
+    // ==================== SQL Injection Prevention Tests ====================
+
+    @Test
+    @DisplayName("Should reject schema name with semicolon (SQL injection)")
+    void testConstructorRejectsSchemaNameWithSemicolon() {
+        assertThrows(
+                IllegalArgumentException.class,
+                () ->
+                        new PostgresSession(
+                                mockDataSource, "db; DROP SCHEMA public; --", "table", true),
+                "Schema name contains invalid characters");
+    }
+
+    @Test
+    @DisplayName("Should reject table name with semicolon (SQL injection)")
+    void testConstructorRejectsTableNameWithSemicolon() {
+        assertThrows(
+                IllegalArgumentException.class,
+                () ->
+                        new PostgresSession(
+                                mockDataSource, "valid_db", "table; DROP TABLE users; --", true),
+                "Table name contains invalid characters");
+    }
+
+    @Test
+    @DisplayName("Should reject schema name with space")
+    void testConstructorRejectsSchemaNameWithSpace() {
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> new PostgresSession(mockDataSource, "db name", "table", true),
+                "Schema name contains invalid characters");
+    }
+
+    @Test
+    @DisplayName("Should reject table name with space")
+    void testConstructorRejectsTableNameWithSpace() {
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> new PostgresSession(mockDataSource, "valid_db", "table name", true),
+                "Table name contains invalid characters");
+    }
+
+    @Test
+    @DisplayName("Should reject schema name starting with number")
+    void testConstructorRejectsSchemaNameStartingWithNumber() {
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> new PostgresSession(mockDataSource, "123db", "table", true),
+                "Schema name contains invalid characters");
+    }
+
+    @Test
+    @DisplayName("Should reject table name starting with number")
+    void testConstructorRejectsTableNameStartingWithNumber() {
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> new PostgresSession(mockDataSource, "valid_db", "123table", true),
+                "Table name contains invalid characters");
+    }
+
+    @Test
+    @DisplayName("Should reject schema name exceeding max length")
+    void testConstructorRejectsSchemaNameExceedingMaxLength() {
+        String longName = "a".repeat(64);
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> new PostgresSession(mockDataSource, longName, "table", true),
+                "Schema name cannot exceed 63 characters");
+    }
+
+    @Test
+    @DisplayName("Should reject table name exceeding max length")
+    void testConstructorRejectsTableNameExceedingMaxLength() {
+        String longName = "a".repeat(64);
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> new PostgresSession(mockDataSource, "valid_db", longName, true),
+                "Table name cannot exceed 63 characters");
+    }
+
+    @Test
+    @DisplayName("Should accept valid schema and table names")
+    void testConstructorAcceptsValidSchemaAndTableNames() throws SQLException {
+        when(mockStatement.execute()).thenReturn(true);
+
+        PostgresSession session =
+                new PostgresSession(mockDataSource, "my_schema_123", "my_table_456", true);
+
+        assertEquals("my_schema_123", session.getSchemaName());
+        assertEquals("my_table_456", session.getTableName());
+    }
+
+    @Test
+    @DisplayName("Should accept names starting with underscore")
+    void testConstructorAcceptsNameStartingWithUnderscore() throws SQLException {
+        when(mockStatement.execute()).thenReturn(true);
+
+        PostgresSession session =
+                new PostgresSession(mockDataSource, "_private_db", "_private_table", true);
+
+        assertEquals("_private_db", session.getSchemaName());
+        assertEquals("_private_table", session.getTableName());
+    }
+
+    @Test
+    @DisplayName("Should accept max length names")
+    void testConstructorAcceptsMaxLengthNames() throws SQLException {
+        when(mockStatement.execute()).thenReturn(true);
+
+        String maxLengthName = "a".repeat(63);
+        PostgresSession session =
+                new PostgresSession(mockDataSource, maxLengthName, maxLengthName, true);
+
+        assertEquals(maxLengthName, session.getSchemaName());
+        assertEquals(maxLengthName, session.getTableName());
+    }
+
+    @Test
+    @DisplayName("Should reject null and empty identifiers")
+    void testRejectsNullAndEmptyIdentifiers() throws Exception {
+        when(mockStatement.execute()).thenReturn(true);
+        PostgresSession session = new PostgresSession(mockDataSource, true);
+        java.lang.reflect.Method validateIdentifier =
+                PostgresSession.class.getDeclaredMethod(
+                        "validateIdentifier", String.class, String.class);
+        validateIdentifier.setAccessible(true);
+
+        java.lang.reflect.InvocationTargetException nullException =
+                assertThrows(
+                        java.lang.reflect.InvocationTargetException.class,
+                        () -> validateIdentifier.invoke(session, null, "Identifier"));
+        java.lang.reflect.InvocationTargetException emptyException =
+                assertThrows(
+                        java.lang.reflect.InvocationTargetException.class,
+                        () -> validateIdentifier.invoke(session, "", "Identifier"));
+
+        assertTrue(
+                nullException
+                        .getCause()
+                        .getMessage()
+                        .contains("Identifier cannot be null or empty"));
+        assertTrue(
+                emptyException
+                        .getCause()
+                        .getMessage()
+                        .contains("Identifier cannot be null or empty"));
+    }
+
+    @Test
+    @DisplayName("Should accept schema name with hyphens")
+    void testConstructorAcceptsSchemaNameWithHyphens() throws SQLException {
+        when(mockStatement.execute()).thenReturn(true);
+
+        PostgresSession session =
+                new PostgresSession(mockDataSource, "my-test-schema", "my_table", true);
+
+        assertEquals("my-test-schema", session.getSchemaName());
+        assertEquals("my_table", session.getTableName());
+    }
+
+    @Test
+    @DisplayName("Should accept table name with hyphens")
+    void testConstructorAcceptsTableNameWithHyphens() throws SQLException {
+        when(mockStatement.execute()).thenReturn(true);
+
+        PostgresSession session =
+                new PostgresSession(mockDataSource, "my_db", "my-test-table", true);
+
+        assertEquals("my_db", session.getSchemaName());
+        assertEquals("my-test-table", session.getTableName());
+    }
+
+    @Test
+    @DisplayName("Should accept schema and table names with hyphens")
+    void testConstructorAcceptsSchemaAndTableNamesWithHyphens() throws SQLException {
+        when(mockStatement.execute()).thenReturn(true);
+
+        PostgresSession session =
+                new PostgresSession(mockDataSource, "xxx-xxx-xx", "test-table", true);
+
+        assertEquals("xxx-xxx-xx", session.getSchemaName());
+        assertEquals("test-table", session.getTableName());
+    }
+
+    @Test
+    @DisplayName("Should accept name with underscore and hyphen")
+    void testConstructorAcceptsNameWithUnderscoreAndHyphen() throws SQLException {
+        when(mockStatement.execute()).thenReturn(true);
+
+        PostgresSession session =
+                new PostgresSession(mockDataSource, "my_test-db", "my_table-test", true);
+
+        assertEquals("my_test-db", session.getSchemaName());
+        assertEquals("my_table-test", session.getTableName());
+    }
+
+    /** Simple test state record for testing. */
+    public record TestState(String value, int count) implements State {}
+}

--- a/agentscope-extensions/agentscope-extensions-session-postgresql/src/test/java/io/agentscope/core/session/postgresql/e2e/PostgresSessionE2ETest.java
+++ b/agentscope-extensions/agentscope-extensions-session-postgresql/src/test/java/io/agentscope/core/session/postgresql/e2e/PostgresSessionE2ETest.java
@@ -1,0 +1,422 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.core.session.postgresql.e2e;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.agentscope.core.session.postgresql.PostgresSession;
+import io.agentscope.core.state.SessionKey;
+import io.agentscope.core.state.SimpleSessionKey;
+import io.agentscope.core.state.State;
+import java.io.PrintWriter;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.SQLFeatureNotSupportedException;
+import java.sql.Statement;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import java.util.logging.Logger;
+import javax.sql.DataSource;
+import org.h2.jdbcx.JdbcDataSource;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+
+/**
+ * End-to-end tests for {@link PostgresSession} using an in-memory H2 database in PostgreSQL
+ * compatibility mode.
+ *
+ * <p>This makes the E2E tests runnable in CI without provisioning a real PostgreSQL instance and
+ * without requiring any environment variables.
+ */
+@Tag("e2e")
+@Execution(ExecutionMode.CONCURRENT)
+@DisplayName("Session PostgreSQL Storage E2E Tests")
+class PostgresSessionE2ETest {
+
+    private String createdSchemaName;
+    private DataSource dataSource;
+
+    @AfterEach
+    void cleanupDatabase() {
+        if (dataSource == null || createdSchemaName == null) {
+            return;
+        }
+        try (Connection conn = dataSource.getConnection();
+                Statement stmt = conn.createStatement()) {
+            stmt.execute("DROP SCHEMA IF EXISTS " + createdSchemaName + " CASCADE");
+        } catch (SQLException e) {
+            // best-effort cleanup
+            System.err.println(
+                    "Failed to drop e2e schema " + createdSchemaName + ": " + e.getMessage());
+        } finally {
+            createdSchemaName = null;
+            dataSource = null;
+        }
+    }
+
+    @Test
+    @DisplayName("Auto-create schema/table when createIfNotExist=true")
+    void testAutoCreateSchemaAndTable() {
+        System.out.println("\n=== Test: Auto-Create Schema And Table ===");
+
+        dataSource = createH2DataSource();
+        String schemaName = generateSafeIdentifier("AGENTSCOPE_E2E_AUTOCREATE").toUpperCase();
+        String tableName = generateSafeIdentifier("AGENTSCOPE_SESSIONS").toUpperCase();
+        createdSchemaName = schemaName;
+
+        PostgresSession session = new PostgresSession(dataSource, schemaName, tableName, true);
+        SessionKey sessionKey = SimpleSessionKey.of("postgresql_e2e_auto_" + UUID.randomUUID());
+
+        session.save(sessionKey, "moduleA", new TestState("hello", 1));
+
+        Optional<TestState> loadedState = session.get(sessionKey, "moduleA", TestState.class);
+        assertTrue(loadedState.isPresent());
+        assertEquals("hello", loadedState.get().value());
+    }
+
+    @Test
+    @DisplayName("Smoke: save/load/list/delete flow")
+    void testPostgresSessionEndToEndFlow() {
+        System.out.println("\n=== Test: PostgresSession E2E Flow ===");
+
+        dataSource = createH2DataSource();
+        String schemaName = generateSafeIdentifier("AGENTSCOPE_E2E").toUpperCase();
+        String tableName = generateSafeIdentifier("AGENTSCOPE_SESSIONS").toUpperCase();
+        createdSchemaName = schemaName;
+
+        initSchemaAndTable(dataSource, schemaName, tableName);
+        PostgresSession session = new PostgresSession(dataSource, schemaName, tableName, false);
+
+        // Prepare test states
+        TestState stateA = new TestState("hello", 1);
+        TestState stateB = new TestState("world", 2);
+
+        String sessionIdStr = "postgresql_e2e_session_" + UUID.randomUUID();
+        SessionKey sessionKey = SimpleSessionKey.of(sessionIdStr);
+
+        // Save single states
+        session.save(sessionKey, "moduleA", stateA);
+        session.save(sessionKey, "moduleB", stateB);
+        assertTrue(session.exists(sessionKey));
+
+        // Load states
+        Optional<TestState> loadedA = session.get(sessionKey, "moduleA", TestState.class);
+        Optional<TestState> loadedB = session.get(sessionKey, "moduleB", TestState.class);
+
+        assertTrue(loadedA.isPresent());
+        assertTrue(loadedB.isPresent());
+        assertEquals("hello", loadedA.get().value());
+        assertEquals("world", loadedB.get().value());
+        assertEquals(1, loadedA.get().count());
+        assertEquals(2, loadedB.get().count());
+
+        // listSessionKeys
+        Set<SessionKey> sessionKeys = session.listSessionKeys();
+        assertTrue(
+                sessionKeys.contains(sessionKey), "listSessionKeys should contain saved session");
+
+        // delete session
+        session.delete(sessionKey);
+        assertFalse(session.exists(sessionKey));
+    }
+
+    @Test
+    @DisplayName("Save and load list state correctly")
+    void testSaveAndLoadListState() {
+        System.out.println("\n=== Test: Save and Load List State ===");
+
+        dataSource = createH2DataSource();
+        String schemaName = generateSafeIdentifier("AGENTSCOPE_E2E").toUpperCase();
+        String tableName = generateSafeIdentifier("AGENTSCOPE_SESSIONS").toUpperCase();
+        createdSchemaName = schemaName;
+
+        initSchemaAndTable(dataSource, schemaName, tableName);
+        PostgresSession session = new PostgresSession(dataSource, schemaName, tableName, false);
+
+        String sessionIdStr = "postgresql_e2e_list_" + UUID.randomUUID();
+        SessionKey sessionKey = SimpleSessionKey.of(sessionIdStr);
+
+        // Save list state
+        List<TestState> states = List.of(new TestState("item1", 1), new TestState("item2", 2));
+        session.save(sessionKey, "stateList", states);
+
+        // Load list state
+        List<TestState> loaded = session.getList(sessionKey, "stateList", TestState.class);
+        assertEquals(2, loaded.size());
+        assertEquals("item1", loaded.get(0).value());
+        assertEquals("item2", loaded.get(1).value());
+
+        // Add more items incrementally
+        List<TestState> moreStates =
+                List.of(
+                        new TestState("item1", 1),
+                        new TestState("item2", 2),
+                        new TestState("item3", 3));
+        session.save(sessionKey, "stateList", moreStates);
+
+        // Verify all items
+        List<TestState> allLoaded = session.getList(sessionKey, "stateList", TestState.class);
+        assertEquals(3, allLoaded.size());
+        assertEquals("item3", allLoaded.get(2).value());
+    }
+
+    @Test
+    @DisplayName("Save persists when DataSource connections default to auto-commit false")
+    void testSavePersistsWithAutoCommitDisabledConnections() {
+        System.out.println("\n=== Test: Save With Auto-Commit Disabled Connections ===");
+
+        DataSource baseDataSource = createH2DataSource();
+        dataSource = baseDataSource;
+        String schemaName = generateSafeIdentifier("AGENTSCOPE_E2E").toUpperCase();
+        String tableName = generateSafeIdentifier("AGENTSCOPE_SESSIONS").toUpperCase();
+        createdSchemaName = schemaName;
+
+        initSchemaAndTable(baseDataSource, schemaName, tableName);
+
+        PostgresSession session =
+                new PostgresSession(
+                        wrapWithAutoCommit(baseDataSource, false), schemaName, tableName, false);
+
+        SessionKey sessionKey =
+                SimpleSessionKey.of("postgresql_e2e_autocommit_off_" + UUID.randomUUID());
+
+        session.save(sessionKey, "moduleA", new TestState("hello", 1));
+        session.save(
+                sessionKey,
+                "stateList",
+                List.of(new TestState("item1", 1), new TestState("item2", 2)));
+
+        assertTrue(session.exists(sessionKey));
+
+        Optional<TestState> loadedState = session.get(sessionKey, "moduleA", TestState.class);
+        assertTrue(loadedState.isPresent());
+        assertEquals("hello", loadedState.get().value());
+
+        List<TestState> loadedList = session.getList(sessionKey, "stateList", TestState.class);
+        assertEquals(2, loadedList.size());
+        assertEquals("item1", loadedList.get(0).value());
+        assertEquals("item2", loadedList.get(1).value());
+    }
+
+    @Test
+    @DisplayName(
+            "Delete and cleanup persist when DataSource connections default to auto-commit false")
+    void testDeleteAndCleanupPersistWithAutoCommitDisabledConnections() {
+        System.out.println(
+                "\n=== Test: Delete And Cleanup With Auto-Commit Disabled Connections ===");
+
+        DataSource baseDataSource = createH2DataSource();
+        dataSource = baseDataSource;
+        String schemaName = generateSafeIdentifier("AGENTSCOPE_E2E").toUpperCase();
+        String tableName = generateSafeIdentifier("AGENTSCOPE_SESSIONS").toUpperCase();
+        createdSchemaName = schemaName;
+
+        initSchemaAndTable(baseDataSource, schemaName, tableName);
+
+        PostgresSession session =
+                new PostgresSession(
+                        wrapWithAutoCommit(baseDataSource, false), schemaName, tableName, false);
+
+        SessionKey sessionKey1 = SimpleSessionKey.of("postgresql_e2e_delete_" + UUID.randomUUID());
+        SessionKey sessionKey2 = SimpleSessionKey.of("postgresql_e2e_clear_" + UUID.randomUUID());
+
+        session.save(sessionKey1, "moduleA", new TestState("hello", 1));
+        session.save(sessionKey2, "moduleA", new TestState("world", 2));
+
+        session.delete(sessionKey1);
+        assertFalse(session.exists(sessionKey1));
+        assertTrue(session.exists(sessionKey2));
+
+        session.clearAllSessions();
+        assertTrue(session.listSessionKeys().isEmpty());
+
+        session.save(sessionKey1, "moduleA", new TestState("hello_again", 3));
+        assertTrue(session.exists(sessionKey1));
+
+        session.truncateAllSessions();
+        assertTrue(session.listSessionKeys().isEmpty());
+    }
+
+    @Test
+    @DisplayName("Session does not exist should return false")
+    void testSessionNotExists() {
+        System.out.println("\n=== Test: Session Not Exists ===");
+
+        dataSource = createH2DataSource();
+        String schemaName = generateSafeIdentifier("AGENTSCOPE_E2E").toUpperCase();
+        String tableName = generateSafeIdentifier("AGENTSCOPE_SESSIONS").toUpperCase();
+        createdSchemaName = schemaName;
+
+        initSchemaAndTable(dataSource, schemaName, tableName);
+        PostgresSession session = new PostgresSession(dataSource, schemaName, tableName, false);
+
+        SessionKey sessionKey = SimpleSessionKey.of("non_existent_" + UUID.randomUUID());
+        assertFalse(session.exists(sessionKey));
+    }
+
+    @Test
+    @DisplayName("Get non-existent state should return empty")
+    void testGetNonExistentState() {
+        System.out.println("\n=== Test: Get Non-Existent State ===");
+
+        dataSource = createH2DataSource();
+        String schemaName = generateSafeIdentifier("AGENTSCOPE_E2E").toUpperCase();
+        String tableName = generateSafeIdentifier("AGENTSCOPE_SESSIONS").toUpperCase();
+        createdSchemaName = schemaName;
+
+        initSchemaAndTable(dataSource, schemaName, tableName);
+        PostgresSession session = new PostgresSession(dataSource, schemaName, tableName, false);
+
+        SessionKey sessionKey = SimpleSessionKey.of("missing_" + UUID.randomUUID());
+        Optional<TestState> result = session.get(sessionKey, "moduleA", TestState.class);
+        assertFalse(result.isPresent());
+    }
+
+    @Test
+    @DisplayName("createIfNotExist=false should fail fast when schema/table do not exist")
+    void testCreateIfNotExistFalseFailsWhenMissing() {
+        System.out.println("\n=== Test: createIfNotExist=false with missing schema ===");
+
+        dataSource = createH2DataSource();
+        String schemaName = generateSafeIdentifier("AGENTSCOPE_E2E_MISSING").toUpperCase();
+        String tableName = generateSafeIdentifier("AGENTSCOPE_SESSIONS_MISSING").toUpperCase();
+
+        assertThrows(
+                IllegalStateException.class,
+                () -> new PostgresSession(dataSource, schemaName, tableName, false));
+    }
+
+    private static DataSource createH2DataSource() {
+        String dbName = "postgresql_session_e2e_" + UUID.randomUUID().toString().replace("-", "");
+        JdbcDataSource ds = new JdbcDataSource();
+        ds.setURL(
+                "jdbc:h2:mem:"
+                        + dbName
+                        + ";MODE=PostgreSQL;DATABASE_TO_UPPER=false;DB_CLOSE_DELAY=-1");
+        ds.setUser("sa");
+        ds.setPassword("");
+        return ds;
+    }
+
+    private static DataSource wrapWithAutoCommit(DataSource delegate, boolean autoCommit) {
+        return new DataSource() {
+            @Override
+            public Connection getConnection() throws SQLException {
+                Connection conn = delegate.getConnection();
+                conn.setAutoCommit(autoCommit);
+                return conn;
+            }
+
+            @Override
+            public Connection getConnection(String username, String password) throws SQLException {
+                Connection conn = delegate.getConnection(username, password);
+                conn.setAutoCommit(autoCommit);
+                return conn;
+            }
+
+            @Override
+            public PrintWriter getLogWriter() throws SQLException {
+                return delegate.getLogWriter();
+            }
+
+            @Override
+            public void setLogWriter(PrintWriter out) throws SQLException {
+                delegate.setLogWriter(out);
+            }
+
+            @Override
+            public void setLoginTimeout(int seconds) throws SQLException {
+                delegate.setLoginTimeout(seconds);
+            }
+
+            @Override
+            public int getLoginTimeout() throws SQLException {
+                return delegate.getLoginTimeout();
+            }
+
+            @Override
+            public Logger getParentLogger() throws SQLFeatureNotSupportedException {
+                return delegate.getParentLogger();
+            }
+
+            @Override
+            public <T> T unwrap(Class<T> iface) throws SQLException {
+                return delegate.unwrap(iface);
+            }
+
+            @Override
+            public boolean isWrapperFor(Class<?> iface) throws SQLException {
+                return delegate.isWrapperFor(iface);
+            }
+        };
+    }
+
+    /**
+     * Generates a safe PostgreSQL identifier (letters/numbers/underscore) and keeps it <= 63 chars.
+     */
+    private static String generateSafeIdentifier(String prefix) {
+        String suffix = UUID.randomUUID().toString().replace("-", "_");
+        String raw = prefix + "_" + suffix;
+        if (!Character.isLetter(raw.charAt(0)) && raw.charAt(0) != '_') {
+            raw = "_" + raw;
+        }
+        if (raw.length() > 63) {
+            raw = raw.substring(0, 63);
+        }
+        raw = raw.replaceAll("_+$", "_e2e");
+        if (raw.length() > 63) {
+            raw = raw.substring(0, 63);
+        }
+        return raw;
+    }
+
+    private static void initSchemaAndTable(
+            DataSource dataSource, String schemaName, String tableName) throws RuntimeException {
+        try (Connection conn = dataSource.getConnection();
+                Statement stmt = conn.createStatement()) {
+            stmt.execute("CREATE SCHEMA IF NOT EXISTS " + schemaName);
+            stmt.execute("SET SCHEMA " + schemaName);
+            stmt.execute("DROP TABLE IF EXISTS " + tableName);
+            // Table structure with item_index for incremental list storage
+            stmt.execute(
+                    "CREATE TABLE "
+                            + tableName
+                            + " ("
+                            + "session_id VARCHAR(255) NOT NULL, "
+                            + "state_key VARCHAR(255) NOT NULL, "
+                            + "item_index INTEGER NOT NULL DEFAULT 0, "
+                            + "state_data TEXT NOT NULL, "
+                            + "created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP, "
+                            + "updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP, "
+                            + "PRIMARY KEY (session_id, state_key, item_index)"
+                            + ")");
+        } catch (SQLException e) {
+            throw new RuntimeException("Failed to init schema/table for H2 e2e", e);
+        }
+    }
+
+    /** Simple test state record for testing. */
+    public record TestState(String value, int count) implements State {}
+}

--- a/agentscope-extensions/pom.xml
+++ b/agentscope-extensions/pom.xml
@@ -46,6 +46,7 @@
         <module>agentscope-extensions-scheduler</module>
         <module>agentscope-extensions-session-redis</module>
         <module>agentscope-extensions-session-mysql</module>
+        <module>agentscope-extensions-session-postgresql</module>
         <module>agentscope-extensions-training</module>
         <module>agentscope-micronaut-extensions</module>
         <module>agentscope-quarkus-extensions</module>

--- a/docs/en/quickstart/installation.md
+++ b/docs/en/quickstart/installation.md
@@ -59,6 +59,7 @@ When using other models or features, add the corresponding dependencies:
 | **HayStack RAG**          | [OkHttp](https://central.sonatype.com/artifact/com.squareup.okhttp3/okhttp)              | `com.squareup.okhttp3:okhttp`    |
 | **Elasticsearch RAG** | [Elasticsearch Java Client](https://www.elastic.co/docs/reference/elasticsearch/clients/java)   |`co.elastic.clients:elasticsearch-java` |
 | **MySQL Session**         | [MySQL Connector](https://central.sonatype.com/artifact/com.mysql/mysql-connector-j)     | `com.mysql:mysql-connector-j`    |
+| **PostgreSQL Session**    | [PostgreSQL Driver](https://central.sonatype.com/artifact/org.postgresql/postgresql)     | `org.postgresql:postgresql`     |
 | **Redis Session**         | [Jedis](https://central.sonatype.com/artifact/redis.clients/jedis)                       | `redis.clients:jedis`            |
 | **PDF Processing**        | [Apache PDFBox](https://central.sonatype.com/artifact/org.apache.pdfbox/pdfbox)          | `org.apache.pdfbox:pdfbox`       |
 | **Word Processing**       | [Apache POI](https://central.sonatype.com/artifact/org.apache.poi/poi-ooxml)             | `org.apache.poi:poi-ooxml`       |
@@ -170,6 +171,7 @@ implementation 'io.agentscope:agentscope-core:1.0.12'
 | Module | Feature | Maven Coordinates |
 |--------|---------|-------------------|
 | [agentscope-extensions-session-mysql](https://central.sonatype.com/artifact/io.agentscope/agentscope-extensions-session-mysql) | MySQL Session | `io.agentscope:agentscope-extensions-session-mysql` |
+| [agentscope-extensions-session-postgresql](https://central.sonatype.com/artifact/io.agentscope/agentscope-extensions-session-postgresql) | PostgreSQL Session | `io.agentscope:agentscope-extensions-session-postgresql` |
 | [agentscope-extensions-session-redis](https://central.sonatype.com/artifact/io.agentscope/agentscope-extensions-session-redis) | Redis Session | `io.agentscope:agentscope-extensions-session-redis` |
 
 #### Multi-Agent Collaboration

--- a/docs/zh/quickstart/installation.md
+++ b/docs/zh/quickstart/installation.md
@@ -61,6 +61,7 @@ All-in-one 包默认带以下依赖，不用额外配置：
 | **HayStack RAG**     | [OkHttp](https://central.sonatype.com/artifact/com.squareup.okhttp3/okhttp)              | `com.squareup.okhttp3:okhttp`    |
 | **Elasticsearch RAG** | [Elasticsearch Java Client](https://www.elastic.co/docs/reference/elasticsearch/clients/java)   |`co.elastic.clients:elasticsearch-java` |
 | **MySQL Session**    | [MySQL Connector](https://central.sonatype.com/artifact/com.mysql/mysql-connector-j)     | `com.mysql:mysql-connector-j`    |
+| **PostgreSQL Session** | [PostgreSQL Driver](https://central.sonatype.com/artifact/org.postgresql/postgresql) | `org.postgresql:postgresql` |
 | **Redis Session**    | [Jedis](https://central.sonatype.com/artifact/redis.clients/jedis)                       | `redis.clients:jedis`            |
 | **PDF 处理**           | [Apache PDFBox](https://central.sonatype.com/artifact/org.apache.pdfbox/pdfbox)          | `org.apache.pdfbox:pdfbox`       |
 | **Word 处理**          | [Apache POI](https://central.sonatype.com/artifact/org.apache.poi/poi-ooxml)             | `org.apache.poi:poi-ooxml`       |
@@ -174,6 +175,7 @@ implementation 'io.agentscope:agentscope-core:1.0.12'
 | 模块 | 功能 | Maven 坐标 |
 |-----|------|-----------|
 | [agentscope-extensions-session-mysql](https://central.sonatype.com/artifact/io.agentscope/agentscope-extensions-session-mysql) | MySQL Session | `io.agentscope:agentscope-extensions-session-mysql` |
+| [agentscope-extensions-session-postgresql](https://central.sonatype.com/artifact/io.agentscope/agentscope-extensions-session-postgresql) | PostgreSQL Session | `io.agentscope:agentscope-extensions-session-postgresql` |
 | [agentscope-extensions-session-redis](https://central.sonatype.com/artifact/io.agentscope/agentscope-extensions-session-redis) | Redis Session | `io.agentscope:agentscope-extensions-session-redis` |
 
 #### 多智能体协作


### PR DESCRIPTION
## Summary
- Add a PostgreSQL-backed session storage extension.
- Register the module in extensions, BOM, and all-in-one distribution.
- Document the new PostgreSQL session dependency.

## Validation
- `mvn -pl agentscope-extensions/agentscope-extensions-session-postgresql spotless:apply test`
- Real PostgreSQL smoke test against `postgres:16-alpine` in Docker
- `mvn -pl agentscope-distribution/agentscope-bom -DskipTests package`
- `mvn -pl agentscope-distribution/agentscope-all -am -DskipTests package`