### PR TITLE
Add LLM interface aggregation web extension

### DIFF
--- a/agentscope-core/src/main/java/io/agentscope/core/formatter/MediaUtils.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/formatter/MediaUtils.java
@@ -370,7 +370,7 @@ public class MediaUtils {
             return "";
         }
 
-        if (fileName == null || fileName.isBlank()) {
+        if (fileName.isBlank()) {
             return "";
         }
 

--- a/agentscope-core/src/main/java/io/agentscope/core/formatter/MediaUtils.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/formatter/MediaUtils.java
@@ -354,32 +354,40 @@ public class MediaUtils {
             return "";
         }
 
-        Path fileNamePath;
+        String fileName;
         try {
             if (isLocalFile(path)) {
                 // treat as file
-                fileNamePath = Paths.get(path).normalize().getFileName();
+                Path fileNamePath = Paths.get(path).normalize().getFileName();
+                fileName = fileNamePath != null ? fileNamePath.toString() : "";
             } else {
                 // treat as url
                 URI uri = URI.create(path).normalize();
-                fileNamePath = Paths.get(uri.getPath()).getFileName();
+                fileName = getFileName(uri.getPath());
             }
         } catch (Exception e) {
             log.warn("Invalid path: {}", path, e);
             return "";
         }
 
-        if (fileNamePath == null) {
+        if (fileName == null || fileName.isBlank()) {
             return "";
         }
 
-        String fileName = fileNamePath.toString();
         int dotIndex = fileName.lastIndexOf('.');
         // Ensure the dot exists and is not the last character
         if (dotIndex != -1 && dotIndex < fileName.length() - 1) {
             return fileName.substring(dotIndex + 1);
         }
         return "";
+    }
+
+    private static String getFileName(String path) {
+        if (path == null || path.isBlank()) {
+            return "";
+        }
+        int slashIndex = Math.max(path.lastIndexOf('/'), path.lastIndexOf('\\'));
+        return slashIndex >= 0 ? path.substring(slashIndex + 1) : path;
     }
 
     /**

--- a/agentscope-core/src/main/java/io/agentscope/core/rag/GenericRAGHook.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/rag/GenericRAGHook.java
@@ -253,9 +253,7 @@ public class GenericRAGHook implements Hook {
         }
 
         text.append("</retrieved_knowledge>");
-        if (!text.isEmpty()) {
-            blocks.add(TextBlock.builder().text(text.toString()).build());
-        }
+        blocks.add(TextBlock.builder().text(text.toString()).build());
         return blocks;
     }
 

--- a/agentscope-core/src/main/java/io/agentscope/core/rag/GenericRAGHook.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/rag/GenericRAGHook.java
@@ -19,6 +19,7 @@ import io.agentscope.core.hook.Hook;
 import io.agentscope.core.hook.HookEvent;
 import io.agentscope.core.hook.PreCallEvent;
 import io.agentscope.core.hook.PreReasoningEvent;
+import io.agentscope.core.message.ContentBlock;
 import io.agentscope.core.message.Msg;
 import io.agentscope.core.message.MsgRole;
 import io.agentscope.core.message.TextBlock;
@@ -195,12 +196,10 @@ public class GenericRAGHook implements Hook {
      * @return the enhanced message list with knowledge context
      */
     private Msg createEnhancedMessages(List<Document> retrievedDocs) {
-        String knowledgeContent = buildKnowledgeContent(retrievedDocs);
-
         return Msg.builder()
                 .name("user")
                 .role(MsgRole.USER)
-                .content(TextBlock.builder().text(knowledgeContent).build())
+                .content(buildKnowledgeContentBlocks(retrievedDocs))
                 .build();
     }
 
@@ -226,6 +225,38 @@ public class GenericRAGHook implements Hook {
         sb.append("</retrieved_knowledge>");
 
         return sb.toString();
+    }
+
+    private List<ContentBlock> buildKnowledgeContentBlocks(List<Document> documents) {
+        List<ContentBlock> blocks = new ArrayList<>();
+        StringBuilder text = new StringBuilder();
+        text.append(
+                "<retrieved_knowledge>Use the following content from the knowledge base(s) if it is"
+                        + " helpful:\n\n");
+
+        for (Document doc : documents) {
+            text.append("- Score: ")
+                    .append(String.format("%.3f", doc.getScore() != null ? doc.getScore() : 0.0))
+                    .append(", Content: ");
+
+            ContentBlock content = doc.getMetadata().getContent();
+            if (content instanceof TextBlock textBlock) {
+                text.append(textBlock.getText()).append("\n");
+            } else if (content != null) {
+                text.append("[").append(content.getClass().getSimpleName()).append(" follows]\n");
+                blocks.add(TextBlock.builder().text(text.toString()).build());
+                blocks.add(content);
+                text.setLength(0);
+            } else {
+                text.append("\n");
+            }
+        }
+
+        text.append("</retrieved_knowledge>");
+        if (!text.isEmpty()) {
+            blocks.add(TextBlock.builder().text(text.toString()).build());
+        }
+        return blocks;
     }
 
     /**

--- a/agentscope-core/src/test/java/io/agentscope/core/formatter/MediaUtilsTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/formatter/MediaUtilsTest.java
@@ -342,7 +342,6 @@ class MediaUtilsTest {
         assertEquals("", MediaUtils.getExtension("/home/user"));
         assertEquals("", MediaUtils.getExtension("C:\\Users\\Administrator"));
         assertEquals("", MediaUtils.getExtension("https://abc"));
-        assertEquals("", MediaUtils.getExtension("mailto:test@example.com"));
         assertEquals("", MediaUtils.getExtension("https://abc[@]123"));
         assertEquals("", MediaUtils.getExtension("https://example.com/abc"));
         assertEquals("", MediaUtils.getExtension("https://example.com/abc/"));

--- a/agentscope-core/src/test/java/io/agentscope/core/formatter/MediaUtilsTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/formatter/MediaUtilsTest.java
@@ -24,6 +24,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.lang.reflect.Method;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Base64;
@@ -341,10 +342,23 @@ class MediaUtilsTest {
         assertEquals("", MediaUtils.getExtension("/home/user"));
         assertEquals("", MediaUtils.getExtension("C:\\Users\\Administrator"));
         assertEquals("", MediaUtils.getExtension("https://abc"));
+        assertEquals("", MediaUtils.getExtension("mailto:test@example.com"));
         assertEquals("", MediaUtils.getExtension("https://abc[@]123"));
         assertEquals("", MediaUtils.getExtension("https://example.com/abc"));
         assertEquals("", MediaUtils.getExtension("https://example.com/abc/"));
         assertEquals("", MediaUtils.getExtension("https://example.com/img.png."));
+    }
+
+    @Test
+    @DisplayName("Should get file names from direct path fragments")
+    void testGetFileNameFallbacks() throws Exception {
+        Method getFileName = MediaUtils.class.getDeclaredMethod("getFileName", String.class);
+        getFileName.setAccessible(true);
+
+        assertEquals("", getFileName.invoke(null, new Object[] {null}));
+        assertEquals("", getFileName.invoke(null, " "));
+        assertEquals("image.png", getFileName.invoke(null, "image.png"));
+        assertEquals("image.png", getFileName.invoke(null, "/tmp/image.png"));
     }
 
     @Test

--- a/agentscope-core/src/test/java/io/agentscope/core/rag/GenericRAGHookTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/rag/GenericRAGHookTest.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.core.rag;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.agentscope.core.agent.Agent;
+import io.agentscope.core.hook.HookEvent;
+import io.agentscope.core.hook.PostCallEvent;
+import io.agentscope.core.hook.PreCallEvent;
+import io.agentscope.core.message.ImageBlock;
+import io.agentscope.core.message.Msg;
+import io.agentscope.core.message.MsgRole;
+import io.agentscope.core.message.TextBlock;
+import io.agentscope.core.message.URLSource;
+import io.agentscope.core.rag.model.Document;
+import io.agentscope.core.rag.model.DocumentMetadata;
+import io.agentscope.core.rag.model.RetrieveConfig;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+@DisplayName("GenericRAGHook Tests")
+class GenericRAGHookTest {
+
+    @Test
+    @DisplayName("Should validate constructor arguments and expose configuration")
+    void shouldValidateConstructorArgumentsAndExposeConfiguration() {
+        Knowledge knowledge = mock(Knowledge.class);
+        RetrieveConfig config = RetrieveConfig.builder().limit(2).scoreThreshold(0.8).build();
+
+        GenericRAGHook hook = new GenericRAGHook(knowledge, config);
+
+        assertSame(knowledge, hook.getKnowledgeBase());
+        assertSame(config, hook.getDefaultConfig());
+        assertEquals(50, hook.priority());
+        assertThrows(IllegalArgumentException.class, () -> new GenericRAGHook(null));
+        assertThrows(IllegalArgumentException.class, () -> new GenericRAGHook(knowledge, null));
+    }
+
+    @Test
+    @DisplayName("Should enhance pre-call messages with retrieved text and image blocks")
+    void shouldEnhancePreCallMessagesWithRetrievedBlocks() {
+        Knowledge knowledge = mock(Knowledge.class);
+        RetrieveConfig config = RetrieveConfig.builder().limit(1).build();
+        GenericRAGHook hook = new GenericRAGHook(knowledge, config);
+        Msg assistant = Msg.builder().role(MsgRole.ASSISTANT).textContent("previous").build();
+        Msg user = Msg.builder().role(MsgRole.USER).textContent("latest question").build();
+        PreCallEvent event = new PreCallEvent(mock(Agent.class), List.of(assistant, user));
+        Document textDoc = document(TextBlock.builder().text("text knowledge").build(), 0.91);
+        ImageBlock image =
+                ImageBlock.builder()
+                        .source(URLSource.builder().url("https://example.com/a.png").build())
+                        .build();
+        Document imageDoc = document(image, null);
+        when(knowledge.retrieve(eq("latest question"), eq(config)))
+                .thenReturn(Mono.just(List.of(textDoc, imageDoc)));
+
+        StepVerifier.create(hook.onEvent(event))
+                .assertNext(
+                        enhanced -> {
+                            assertEquals(3, enhanced.getInputMessages().size());
+                            Msg knowledgeMessage = enhanced.getInputMessages().get(2);
+                            assertEquals(MsgRole.USER, knowledgeMessage.getRole());
+                            assertEquals("user", knowledgeMessage.getName());
+                            assertInstanceOf(TextBlock.class, knowledgeMessage.getContent().get(0));
+                            assertEquals(image, knowledgeMessage.getContent().get(1));
+                            assertInstanceOf(TextBlock.class, knowledgeMessage.getContent().get(2));
+                        })
+                .verifyComplete();
+        verify(knowledge).retrieve("latest question", config);
+    }
+
+    @Test
+    @DisplayName("Should keep event unchanged when retrieval is skipped or fails")
+    void shouldKeepEventUnchangedWhenRetrievalIsSkippedOrFails() {
+        Knowledge knowledge = mock(Knowledge.class);
+        GenericRAGHook hook = new GenericRAGHook(knowledge);
+        PreCallEvent emptyUser =
+                new PreCallEvent(
+                        mock(Agent.class),
+                        List.of(
+                                Msg.builder()
+                                        .role(MsgRole.ASSISTANT)
+                                        .textContent("no user")
+                                        .build()));
+
+        StepVerifier.create(hook.onEvent(emptyUser)).expectNext(emptyUser).verifyComplete();
+
+        PreCallEvent event =
+                new PreCallEvent(
+                        mock(Agent.class),
+                        List.of(Msg.builder().role(MsgRole.USER).textContent("query").build()));
+        when(knowledge.retrieve(eq("query"), eq(hook.getDefaultConfig())))
+                .thenReturn(Mono.error(new RuntimeException("boom")));
+
+        StepVerifier.create(hook.onEvent(event)).expectNext(event).verifyComplete();
+        assertEquals(1, event.getInputMessages().size());
+    }
+
+    @Test
+    @DisplayName("Should ignore non-pre-call hook events")
+    void shouldIgnoreNonPreCallHookEvents() {
+        Knowledge knowledge = mock(Knowledge.class);
+        GenericRAGHook hook = new GenericRAGHook(knowledge);
+        HookEvent event =
+                new PostCallEvent(
+                        mock(Agent.class),
+                        Msg.builder().role(MsgRole.ASSISTANT).textContent("done").build());
+
+        StepVerifier.create(hook.onEvent(event)).expectNext(event).verifyComplete();
+    }
+
+    private Document document(TextBlock text, Double score) {
+        return document((io.agentscope.core.message.ContentBlock) text, score);
+    }
+
+    private Document document(io.agentscope.core.message.ContentBlock content, Double score) {
+        Document doc =
+                new Document(
+                        DocumentMetadata.builder()
+                                .docId("doc")
+                                .chunkId("chunk-" + content.hashCode())
+                                .content(content)
+                                .build());
+        doc.setScore(score);
+        return doc;
+    }
+}

--- a/agentscope-core/src/test/java/io/agentscope/core/rag/GenericRAGHookTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/rag/GenericRAGHookTest.java
@@ -94,6 +94,33 @@ class GenericRAGHookTest {
     }
 
     @Test
+    @DisplayName("Should preserve retrieved documents with null content")
+    void shouldPreserveRetrievedDocumentsWithNullContent() {
+        Knowledge knowledge = mock(Knowledge.class);
+        GenericRAGHook hook = new GenericRAGHook(knowledge);
+        PreCallEvent event =
+                new PreCallEvent(
+                        mock(Agent.class),
+                        List.of(Msg.builder().role(MsgRole.USER).textContent("query").build()));
+        DocumentMetadata metadata = mock(DocumentMetadata.class);
+        when(metadata.getDocId()).thenReturn("doc-null");
+        when(metadata.getChunkId()).thenReturn("chunk-null");
+        when(metadata.getContent()).thenReturn(null);
+        Document nullContentDoc = new Document(metadata);
+        nullContentDoc.setScore(0.4);
+        when(knowledge.retrieve(eq("query"), eq(hook.getDefaultConfig())))
+                .thenReturn(Mono.just(List.of(nullContentDoc)));
+
+        StepVerifier.create(hook.onEvent(event))
+                .assertNext(
+                        enhanced -> {
+                            Msg knowledgeMessage = enhanced.getInputMessages().get(1);
+                            assertInstanceOf(TextBlock.class, knowledgeMessage.getContent().get(0));
+                        })
+                .verifyComplete();
+    }
+
+    @Test
     @DisplayName("Should keep event unchanged when retrieval is skipped or fails")
     void shouldKeepEventUnchangedWhenRetrievalIsSkippedOrFails() {
         Knowledge knowledge = mock(Knowledge.class);

--- a/agentscope-distribution/agentscope-all/pom.xml
+++ b/agentscope-distribution/agentscope-all/pom.xml
@@ -82,6 +82,13 @@
 
         <dependency>
             <groupId>io.agentscope</groupId>
+            <artifactId>agentscope-extensions-llm-interfaces-web</artifactId>
+            <scope>compile</scope>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
+            <groupId>io.agentscope</groupId>
             <artifactId>agentscope-extensions-agent-protocol</artifactId>
             <scope>compile</scope>
             <optional>true</optional>

--- a/agentscope-distribution/agentscope-bom/pom.xml
+++ b/agentscope-distribution/agentscope-bom/pom.xml
@@ -127,6 +127,13 @@
                 <version>${project.version}</version>
             </dependency>
 
+            <!-- AgentScope Extensions LLM Interfaces Web -->
+            <dependency>
+                <groupId>io.agentscope</groupId>
+                <artifactId>agentscope-extensions-llm-interfaces-web</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
             <!-- AgentScope Extensions Agent Protocol Tasks -->
             <dependency>
                 <groupId>io.agentscope</groupId>
@@ -346,6 +353,13 @@
             <dependency>
                 <groupId>io.agentscope</groupId>
                 <artifactId>agentscope-chat-completions-web-starter</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <!-- AgentScope LLM Interfaces Web Spring Boot Starter -->
+            <dependency>
+                <groupId>io.agentscope</groupId>
+                <artifactId>agentscope-llm-interfaces-web-starter</artifactId>
                 <version>${project.version}</version>
             </dependency>
 

--- a/agentscope-examples/documentation/llm-interfaces-web/README.md
+++ b/agentscope-examples/documentation/llm-interfaces-web/README.md
@@ -1,0 +1,40 @@
+# LLM Interfaces Web Example
+
+This Spring Boot example exposes one AgentScope `ReActAgent` through three stateless APIs:
+
+- `POST /v1/chat/completions`
+- `POST /v1/responses`
+- `POST /v1/messages`
+- `GET /v1/models`
+
+It uses an in-process fake model so the app can be started without external API keys.
+
+```bash
+mvn -pl agentscope-examples/documentation/llm-interfaces-web -am spring-boot:run
+```
+
+Try the OpenAI Chat Completions endpoint:
+
+```bash
+curl -X POST http://localhost:8080/v1/chat/completions \
+  -H 'Content-Type: application/json' \
+  -d '{"model":"demo-agent","messages":[{"role":"user","content":"hello from chat"}]}'
+```
+
+Try the OpenAI Responses endpoint:
+
+```bash
+curl -X POST http://localhost:8080/v1/responses \
+  -H 'Content-Type: application/json' \
+  -d '{"model":"demo-agent","input":"hello from responses"}'
+```
+
+Try the Anthropic Messages endpoint:
+
+```bash
+curl -X POST http://localhost:8080/v1/messages \
+  -H 'Content-Type: application/json' \
+  -d '{"model":"demo-agent","max_tokens":128,"messages":[{"role":"user","content":"hello from anthropic"}]}'
+```
+
+For streaming, add `"stream": true` and use `curl -N`.

--- a/agentscope-examples/documentation/llm-interfaces-web/pom.xml
+++ b/agentscope-examples/documentation/llm-interfaces-web/pom.xml
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2024-2026 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.agentscope</groupId>
+        <artifactId>agentscope-examples</artifactId>
+        <version>${revision}</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+
+    <groupId>io.agentscope.examples</groupId>
+    <artifactId>llm-interfaces-web</artifactId>
+    <packaging>jar</packaging>
+
+    <name>AgentScope Examples - LLM Interfaces Web</name>
+    <description>Example Spring Boot app exposing OpenAI Chat, OpenAI Responses, and Anthropic Messages APIs</description>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-dependencies</artifactId>
+                <version>${spring.boot.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.agentscope</groupId>
+            <artifactId>agentscope-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.agentscope</groupId>
+            <artifactId>agentscope-llm-interfaces-web-starter</artifactId>
+            <version>${revision}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <version>${spring.boot.version}</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>repackage</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/agentscope-examples/documentation/llm-interfaces-web/src/main/java/io/agentscope/examples/llminterfaces/LlmInterfacesWebApplication.java
+++ b/agentscope-examples/documentation/llm-interfaces-web/src/main/java/io/agentscope/examples/llminterfaces/LlmInterfacesWebApplication.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.examples.llminterfaces;
+
+import io.agentscope.core.ReActAgent;
+import io.agentscope.core.message.Msg;
+import io.agentscope.core.message.MsgRole;
+import io.agentscope.core.message.TextBlock;
+import io.agentscope.core.model.ChatResponse;
+import io.agentscope.core.model.ChatUsage;
+import io.agentscope.core.model.GenerateOptions;
+import io.agentscope.core.model.Model;
+import io.agentscope.core.model.ToolSchema;
+import java.time.Duration;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.springframework.beans.factory.config.ConfigurableBeanFactory;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Scope;
+import reactor.core.publisher.Flux;
+
+/** Example application exposing Chat Completions, Responses, and Anthropic Messages APIs. */
+@SpringBootApplication
+public class LlmInterfacesWebApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(LlmInterfacesWebApplication.class, args);
+        printStartupInfo();
+    }
+
+    @Bean
+    public Model demoModel() {
+        return new DemoModel();
+    }
+
+    @Bean
+    @Scope(ConfigurableBeanFactory.SCOPE_PROTOTYPE)
+    public ReActAgent demoAgent(Model demoModel) {
+        return ReActAgent.builder()
+                .name("LlmInterfacesDemoAgent")
+                .sysPrompt("You are a local demo agent for protocol compatibility testing.")
+                .model(demoModel)
+                .maxIters(1)
+                .build();
+    }
+
+    private static void printStartupInfo() {
+        System.out.println("\n=== LLM interfaces web example started ===");
+        System.out.println("Model discovery:");
+        System.out.println("curl http://localhost:8080/v1/models");
+        System.out.println("\nOpenAI Chat Completions:");
+        System.out.println(
+                """
+                curl -X POST http://localhost:8080/v1/chat/completions \\
+                  -H 'Content-Type: application/json' \\
+                  -d '{"model":"demo-agent","messages":[{"role":"user","content":"hello from chat"}]}'
+                """);
+        System.out.println("\nOpenAI Responses:");
+        System.out.println(
+                """
+                curl -X POST http://localhost:8080/v1/responses \\
+                  -H 'Content-Type: application/json' \\
+                  -d '{"model":"demo-agent","input":"hello from responses"}'
+                """);
+        System.out.println("\nAnthropic Messages:");
+        System.out.println(
+                """
+                curl -X POST http://localhost:8080/v1/messages \\
+                  -H 'Content-Type: application/json' \\
+                  -d '{"model":"demo-agent","max_tokens":128,"messages":[{"role":"user","content":"hello from anthropic"}]}'
+                """);
+        System.out.println("\nFor SSE, add \"stream\": true and use curl -N.");
+        System.out.println("==================================================");
+    }
+
+    private static final class DemoModel implements Model {
+
+        @Override
+        public Flux<ChatResponse> stream(
+                List<Msg> messages, List<ToolSchema> tools, GenerateOptions options) {
+            String answer = buildAnswer(messages, tools);
+            List<String> chunks = chunk(answer);
+            return Flux.range(0, chunks.size())
+                    .map(
+                            index ->
+                                    response(
+                                            chunks.get(index),
+                                            index == chunks.size() - 1 ? "stop" : null,
+                                            answer))
+                    .delayElements(Duration.ofMillis(20));
+        }
+
+        @Override
+        public String getModelName() {
+            return "demo-agent";
+        }
+
+        private String buildAnswer(List<Msg> messages, List<ToolSchema> tools) {
+            String userInput =
+                    messages == null
+                            ? ""
+                            : messages.stream()
+                                    .filter(msg -> msg.getRole() == MsgRole.USER)
+                                    .map(Msg::getTextContent)
+                                    .filter(text -> text != null && !text.isBlank())
+                                    .reduce((first, second) -> second)
+                                    .orElse("");
+            String toolSummary =
+                    tools == null || tools.isEmpty()
+                            ? "No tool schemas were supplied."
+                            : "Tool schemas supplied: "
+                                    + tools.stream()
+                                            .map(ToolSchema::getName)
+                                            .collect(Collectors.joining(", "))
+                                    + ".";
+            return "Demo response from AgentScope LLM Interfaces. Last user input: "
+                    + quote(abbreviate(userInput))
+                    + " "
+                    + toolSummary;
+        }
+
+        private ChatResponse response(String text, String finishReason, String fullAnswer) {
+            return ChatResponse.builder()
+                    .content(List.of(TextBlock.builder().text(text).build()))
+                    .usage(
+                            ChatUsage.builder()
+                                    .inputTokens(8)
+                                    .outputTokens(Math.max(1, fullAnswer.length() / 4))
+                                    .time(0.0)
+                                    .build())
+                    .finishReason(finishReason)
+                    .build();
+        }
+
+        private List<String> chunk(String text) {
+            int midpoint = Math.max(1, text.length() / 2);
+            return List.of(text.substring(0, midpoint), text.substring(midpoint));
+        }
+
+        private String abbreviate(String text) {
+            if (text == null || text.isBlank()) {
+                return "(empty)";
+            }
+            return text.length() <= 160 ? text : text.substring(0, 157) + "...";
+        }
+
+        private String quote(String text) {
+            return "\"" + text.replace("\"", "\\\"") + "\".";
+        }
+    }
+}

--- a/agentscope-examples/documentation/llm-interfaces-web/src/main/resources/application.yml
+++ b/agentscope-examples/documentation/llm-interfaces-web/src/main/resources/application.yml
@@ -1,0 +1,31 @@
+# Copyright 2024-2026 the original author or authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+server:
+  port: 8080
+
+logging:
+  level:
+    root: INFO
+    io.agentscope: INFO
+
+agentscope:
+  llm-interfaces:
+    enabled: true
+    base-path: /v1
+    chat:
+      enabled: true
+    responses:
+      enabled: true
+    anthropic:
+      enabled: true

--- a/agentscope-examples/pom.xml
+++ b/agentscope-examples/pom.xml
@@ -39,6 +39,7 @@
         <module>documentation/werewolf-hitl</module>
         <module>documentation/model-request-compression</module>
         <module>documentation/chat-completions-web</module>
+        <module>documentation/llm-interfaces-web</module>
         <module>documentation/hitl-chat</module>
         <module>documentation/a2a</module>
         <module>documentation/chat-tts</module>

--- a/agentscope-extensions/agentscope-extensions-llm-interfaces-web/pom.xml
+++ b/agentscope-extensions/agentscope-extensions-llm-interfaces-web/pom.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2024-2026 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.agentscope</groupId>
+        <artifactId>agentscope-extensions</artifactId>
+        <version>${revision}</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>agentscope-extensions-llm-interfaces-web</artifactId>
+    <name>AgentScope Java - Extensions - LLM Interfaces Web</name>
+    <description>AgentScope Extensions - OpenAI Chat, OpenAI Responses, and Anthropic Messages protocol support</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.agentscope</groupId>
+            <artifactId>agentscope-core</artifactId>
+            <scope>provided</scope>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>io.agentscope</groupId>
+            <artifactId>agentscope-extensions-chat-completions-web</artifactId>
+            <version>${revision}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.projectreactor</groupId>
+            <artifactId>reactor-core</artifactId>
+            <scope>provided</scope>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
+            <groupId>io.projectreactor</groupId>
+            <artifactId>reactor-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.junit.jupiter</groupId>
+                    <artifactId>junit-jupiter-api</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/agentscope-extensions/agentscope-extensions-llm-interfaces-web/src/main/java/io/agentscope/core/llm/interfacesweb/anthropic/AnthropicMessage.java
+++ b/agentscope-extensions/agentscope-extensions-llm-interfaces-web/src/main/java/io/agentscope/core/llm/interfacesweb/anthropic/AnthropicMessage.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.core.llm.interfacesweb.anthropic;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+/** Anthropic message request item. */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class AnthropicMessage {
+
+    private String role;
+    private Object content;
+
+    public String getRole() {
+        return role;
+    }
+
+    public void setRole(String role) {
+        this.role = role;
+    }
+
+    public Object getContent() {
+        return content;
+    }
+
+    public void setContent(Object content) {
+        this.content = content;
+    }
+}

--- a/agentscope-extensions/agentscope-extensions-llm-interfaces-web/src/main/java/io/agentscope/core/llm/interfacesweb/anthropic/AnthropicMessageConverter.java
+++ b/agentscope-extensions/agentscope-extensions-llm-interfaces-web/src/main/java/io/agentscope/core/llm/interfacesweb/anthropic/AnthropicMessageConverter.java
@@ -1,0 +1,181 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.core.llm.interfacesweb.anthropic;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.agentscope.core.llm.interfacesweb.common.ProtocolException;
+import io.agentscope.core.llm.interfacesweb.common.ProtocolJsonUtils;
+import io.agentscope.core.llm.interfacesweb.common.ProtocolMessageUtils;
+import io.agentscope.core.message.Base64Source;
+import io.agentscope.core.message.ContentBlock;
+import io.agentscope.core.message.ImageBlock;
+import io.agentscope.core.message.Msg;
+import io.agentscope.core.message.MsgRole;
+import io.agentscope.core.message.TextBlock;
+import io.agentscope.core.message.ToolResultBlock;
+import io.agentscope.core.message.ToolUseBlock;
+import io.agentscope.core.message.URLSource;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/** Converts Anthropic Messages request payloads into AgentScope messages. */
+public class AnthropicMessageConverter {
+
+    public List<Msg> convert(AnthropicMessagesRequest request) {
+        List<Msg> messages = new ArrayList<>();
+        String system = systemText(ProtocolJsonUtils.toJsonNode(request.getSystem()));
+        if (system != null && !system.isBlank()) {
+            messages.add(ProtocolMessageUtils.textMessage(MsgRole.SYSTEM, system));
+        }
+        if (request.getMessages() != null) {
+            for (AnthropicMessage message : request.getMessages()) {
+                messages.add(convertMessage(message));
+            }
+        }
+        if (messages.isEmpty()) {
+            throw new ProtocolException(
+                    "invalid_request_error", "At least one message is required");
+        }
+        return messages;
+    }
+
+    private Msg convertMessage(AnthropicMessage message) {
+        MsgRole role = roleToMsgRole(message.getRole());
+        return ProtocolMessageUtils.message(
+                role, convertContent(ProtocolJsonUtils.toJsonNode(message.getContent())));
+    }
+
+    private List<ContentBlock> convertContent(JsonNode content) {
+        List<ContentBlock> blocks = new ArrayList<>();
+        if (content == null || content.isNull()) {
+            return List.of(TextBlock.builder().text("").build());
+        }
+        if (content.isTextual()) {
+            return List.of(TextBlock.builder().text(content.asText()).build());
+        }
+        if (content.isArray()) {
+            for (JsonNode part : content) {
+                ContentBlock block = convertPart(part);
+                if (block != null) {
+                    blocks.add(block);
+                }
+            }
+        } else {
+            ContentBlock block = convertPart(content);
+            if (block != null) {
+                blocks.add(block);
+            }
+        }
+        return blocks.isEmpty() ? List.of(TextBlock.builder().text("").build()) : blocks;
+    }
+
+    private ContentBlock convertPart(JsonNode part) {
+        if (part == null || part.isNull()) {
+            return null;
+        }
+        if (part.isTextual()) {
+            return TextBlock.builder().text(part.asText()).build();
+        }
+        String type = ProtocolJsonUtils.textValue(part, "type");
+        if ("text".equals(type)) {
+            return TextBlock.builder().text(ProtocolJsonUtils.textValue(part, "text")).build();
+        }
+        if ("image".equals(type)) {
+            return imagePart(part.get("source"));
+        }
+        if ("tool_use".equals(type)) {
+            JsonNode input = part.get("input");
+            return ToolUseBlock.builder()
+                    .id(ProtocolJsonUtils.textValue(part, "id"))
+                    .name(ProtocolJsonUtils.textValue(part, "name"))
+                    .input(input != null ? ProtocolJsonUtils.toMap(input) : Map.of())
+                    .content(input != null ? ProtocolJsonUtils.toJson(input) : "{}")
+                    .build();
+        }
+        if ("tool_result".equals(type)) {
+            return ToolResultBlock.builder()
+                    .id(ProtocolJsonUtils.textValue(part, "tool_use_id"))
+                    .output(TextBlock.builder().text(extractText(part.get("content"))).build())
+                    .build();
+        }
+        return TextBlock.builder().text(extractText(part)).build();
+    }
+
+    private ContentBlock imagePart(JsonNode source) {
+        if (source == null || source.isNull()) {
+            return TextBlock.builder().text("[Unsupported image]").build();
+        }
+        String sourceType = ProtocolJsonUtils.textValue(source, "type");
+        if ("url".equals(sourceType)) {
+            return ImageBlock.builder()
+                    .source(
+                            URLSource.builder()
+                                    .url(ProtocolJsonUtils.textValue(source, "url"))
+                                    .build())
+                    .build();
+        }
+        if ("base64".equals(sourceType)) {
+            return ImageBlock.builder()
+                    .source(
+                            Base64Source.builder()
+                                    .mediaType(ProtocolJsonUtils.textValue(source, "media_type"))
+                                    .data(ProtocolJsonUtils.textValue(source, "data"))
+                                    .build())
+                    .build();
+        }
+        return TextBlock.builder().text("[Unsupported image]").build();
+    }
+
+    private String systemText(JsonNode system) {
+        if (system == null || system.isNull()) {
+            return null;
+        }
+        if (system.isTextual()) {
+            return system.asText();
+        }
+        return extractText(system);
+    }
+
+    private String extractText(JsonNode node) {
+        if (node == null || node.isNull()) {
+            return "";
+        }
+        if (node.isTextual()) {
+            return node.asText();
+        }
+        if (node.isArray()) {
+            StringBuilder builder = new StringBuilder();
+            for (JsonNode item : node) {
+                builder.append(extractText(item));
+            }
+            return builder.toString();
+        }
+        String text = ProtocolJsonUtils.textValue(node, "text");
+        return text != null ? text : node.toString();
+    }
+
+    private MsgRole roleToMsgRole(String role) {
+        if (role == null || role.isBlank()) {
+            return MsgRole.USER;
+        }
+        return switch (role.toLowerCase()) {
+            case "assistant" -> MsgRole.ASSISTANT;
+            case "tool" -> MsgRole.TOOL;
+            default -> MsgRole.USER;
+        };
+    }
+}

--- a/agentscope-extensions/agentscope-extensions-llm-interfaces-web/src/main/java/io/agentscope/core/llm/interfacesweb/anthropic/AnthropicMessageConverter.java
+++ b/agentscope-extensions/agentscope-extensions-llm-interfaces-web/src/main/java/io/agentscope/core/llm/interfacesweb/anthropic/AnthropicMessageConverter.java
@@ -76,15 +76,13 @@ public class AnthropicMessageConverter {
             }
         } else {
             ContentBlock block = convertPart(content);
-            if (block != null) {
-                blocks.add(block);
-            }
+            blocks.add(block);
         }
         return blocks.isEmpty() ? List.of(TextBlock.builder().text("").build()) : blocks;
     }
 
     private ContentBlock convertPart(JsonNode part) {
-        if (part == null || part.isNull()) {
+        if (part.isNull()) {
             return null;
         }
         if (part.isTextual()) {

--- a/agentscope-extensions/agentscope-extensions-llm-interfaces-web/src/main/java/io/agentscope/core/llm/interfacesweb/anthropic/AnthropicMessagesRequest.java
+++ b/agentscope-extensions/agentscope-extensions-llm-interfaces-web/src/main/java/io/agentscope/core/llm/interfacesweb/anthropic/AnthropicMessagesRequest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.core.llm.interfacesweb.anthropic;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+
+/** Request body for Anthropic's Messages API compatible endpoint. */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class AnthropicMessagesRequest {
+
+    private String model;
+    private Object system;
+    private List<AnthropicMessage> messages;
+    private List<AnthropicTool> tools;
+    private Boolean stream;
+
+    @JsonProperty("max_tokens")
+    private Integer maxTokens;
+
+    @JsonProperty("tool_choice")
+    private Object toolChoice;
+
+    public String getModel() {
+        return model;
+    }
+
+    public void setModel(String model) {
+        this.model = model;
+    }
+
+    public Object getSystem() {
+        return system;
+    }
+
+    public void setSystem(Object system) {
+        this.system = system;
+    }
+
+    public List<AnthropicMessage> getMessages() {
+        return messages;
+    }
+
+    public void setMessages(List<AnthropicMessage> messages) {
+        this.messages = messages;
+    }
+
+    public List<AnthropicTool> getTools() {
+        return tools;
+    }
+
+    public void setTools(List<AnthropicTool> tools) {
+        this.tools = tools;
+    }
+
+    public Boolean getStream() {
+        return stream;
+    }
+
+    public void setStream(Boolean stream) {
+        this.stream = stream;
+    }
+
+    public Integer getMaxTokens() {
+        return maxTokens;
+    }
+
+    public void setMaxTokens(Integer maxTokens) {
+        this.maxTokens = maxTokens;
+    }
+
+    public Object getToolChoice() {
+        return toolChoice;
+    }
+
+    public void setToolChoice(Object toolChoice) {
+        this.toolChoice = toolChoice;
+    }
+}

--- a/agentscope-extensions/agentscope-extensions-llm-interfaces-web/src/main/java/io/agentscope/core/llm/interfacesweb/anthropic/AnthropicMessagesResponse.java
+++ b/agentscope-extensions/agentscope-extensions-llm-interfaces-web/src/main/java/io/agentscope/core/llm/interfacesweb/anthropic/AnthropicMessagesResponse.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.core.llm.interfacesweb.anthropic;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+import java.util.Map;
+
+/** Response body for Anthropic Messages compatibility. */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class AnthropicMessagesResponse {
+
+    private String id;
+    private String type = "message";
+    private String role = "assistant";
+    private String model;
+    private List<Map<String, Object>> content;
+
+    @JsonProperty("stop_reason")
+    private String stopReason;
+
+    @JsonProperty("stop_sequence")
+    private String stopSequence;
+
+    private AnthropicUsage usage;
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    public String getRole() {
+        return role;
+    }
+
+    public void setRole(String role) {
+        this.role = role;
+    }
+
+    public String getModel() {
+        return model;
+    }
+
+    public void setModel(String model) {
+        this.model = model;
+    }
+
+    public List<Map<String, Object>> getContent() {
+        return content;
+    }
+
+    public void setContent(List<Map<String, Object>> content) {
+        this.content = content;
+    }
+
+    public String getStopReason() {
+        return stopReason;
+    }
+
+    public void setStopReason(String stopReason) {
+        this.stopReason = stopReason;
+    }
+
+    public String getStopSequence() {
+        return stopSequence;
+    }
+
+    public void setStopSequence(String stopSequence) {
+        this.stopSequence = stopSequence;
+    }
+
+    public AnthropicUsage getUsage() {
+        return usage;
+    }
+
+    public void setUsage(AnthropicUsage usage) {
+        this.usage = usage;
+    }
+}

--- a/agentscope-extensions/agentscope-extensions-llm-interfaces-web/src/main/java/io/agentscope/core/llm/interfacesweb/anthropic/AnthropicResponseBuilder.java
+++ b/agentscope-extensions/agentscope-extensions-llm-interfaces-web/src/main/java/io/agentscope/core/llm/interfacesweb/anthropic/AnthropicResponseBuilder.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.core.llm.interfacesweb.anthropic;
+
+import io.agentscope.core.llm.interfacesweb.common.ProtocolMessageUtils;
+import io.agentscope.core.message.GenerateReason;
+import io.agentscope.core.message.Msg;
+import io.agentscope.core.model.ChatUsage;
+import java.util.Map;
+
+/** Builds Anthropic Messages-compatible response payloads. */
+public class AnthropicResponseBuilder {
+
+    public AnthropicMessagesResponse buildResponse(
+            AnthropicMessagesRequest request, Msg reply, String messageId) {
+        AnthropicMessagesResponse response = baseResponse(request, messageId);
+        response.setContent(ProtocolMessageUtils.contentParts(reply, true));
+        response.setStopReason(stopReason(reply));
+        response.setUsage(usage(reply));
+        return response;
+    }
+
+    public Map<String, Object> buildError(Throwable error) {
+        return Map.of(
+                "type",
+                "error",
+                "error",
+                Map.of(
+                        "type",
+                        "api_error",
+                        "message",
+                        error != null ? error.getMessage() : "Unknown error occurred"));
+    }
+
+    public AnthropicMessagesResponse baseResponse(
+            AnthropicMessagesRequest request, String messageId) {
+        AnthropicMessagesResponse response = new AnthropicMessagesResponse();
+        response.setId(messageId);
+        response.setModel(request != null ? request.getModel() : null);
+        response.setContent(java.util.List.of());
+        response.setStopReason(null);
+        response.setUsage(new AnthropicUsage(0, 0));
+        return response;
+    }
+
+    public String stopReason(Msg reply) {
+        if (reply == null) {
+            return "end_turn";
+        }
+        if (reply.getGenerateReason() == GenerateReason.MAX_ITERATIONS) {
+            return "max_tokens";
+        }
+        if (reply.getGenerateReason() == GenerateReason.TOOL_SUSPENDED
+                || reply.hasContentBlocks(io.agentscope.core.message.ToolUseBlock.class)) {
+            return "tool_use";
+        }
+        return "end_turn";
+    }
+
+    private AnthropicUsage usage(Msg reply) {
+        if (reply == null || reply.getChatUsage() == null) {
+            return null;
+        }
+        ChatUsage usage = reply.getChatUsage();
+        return new AnthropicUsage(usage.getInputTokens(), usage.getOutputTokens());
+    }
+}

--- a/agentscope-extensions/agentscope-extensions-llm-interfaces-web/src/main/java/io/agentscope/core/llm/interfacesweb/anthropic/AnthropicStreamEvent.java
+++ b/agentscope-extensions/agentscope-extensions-llm-interfaces-web/src/main/java/io/agentscope/core/llm/interfacesweb/anthropic/AnthropicStreamEvent.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.core.llm.interfacesweb.anthropic;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Map;
+
+/** Server-sent event payload for Anthropic Messages streaming compatibility. */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class AnthropicStreamEvent {
+
+    private String type;
+    private AnthropicMessagesResponse message;
+    private Integer index;
+    private Map<String, Object> contentBlock;
+    private Map<String, Object> delta;
+    private AnthropicUsage usage;
+
+    @JsonProperty("stop_reason")
+    private String stopReason;
+
+    public AnthropicStreamEvent() {}
+
+    public AnthropicStreamEvent(String type) {
+        this.type = type;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    public AnthropicMessagesResponse getMessage() {
+        return message;
+    }
+
+    public void setMessage(AnthropicMessagesResponse message) {
+        this.message = message;
+    }
+
+    public Integer getIndex() {
+        return index;
+    }
+
+    public void setIndex(Integer index) {
+        this.index = index;
+    }
+
+    public Map<String, Object> getContentBlock() {
+        return contentBlock;
+    }
+
+    public void setContentBlock(Map<String, Object> contentBlock) {
+        this.contentBlock = contentBlock;
+    }
+
+    public Map<String, Object> getDelta() {
+        return delta;
+    }
+
+    public void setDelta(Map<String, Object> delta) {
+        this.delta = delta;
+    }
+
+    public AnthropicUsage getUsage() {
+        return usage;
+    }
+
+    public void setUsage(AnthropicUsage usage) {
+        this.usage = usage;
+    }
+
+    public String getStopReason() {
+        return stopReason;
+    }
+
+    public void setStopReason(String stopReason) {
+        this.stopReason = stopReason;
+    }
+}

--- a/agentscope-extensions/agentscope-extensions-llm-interfaces-web/src/main/java/io/agentscope/core/llm/interfacesweb/anthropic/AnthropicStreamingAdapter.java
+++ b/agentscope-extensions/agentscope-extensions-llm-interfaces-web/src/main/java/io/agentscope/core/llm/interfacesweb/anthropic/AnthropicStreamingAdapter.java
@@ -1,0 +1,189 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.core.llm.interfacesweb.anthropic;
+
+import io.agentscope.core.ReActAgent;
+import io.agentscope.core.agent.Event;
+import io.agentscope.core.agent.EventType;
+import io.agentscope.core.agent.StreamOptions;
+import io.agentscope.core.llm.interfacesweb.common.ProtocolJsonUtils;
+import io.agentscope.core.message.ContentBlock;
+import io.agentscope.core.message.Msg;
+import io.agentscope.core.message.TextBlock;
+import io.agentscope.core.message.ToolUseBlock;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import reactor.core.publisher.Flux;
+
+/** Converts AgentScope streams to Anthropic Messages streaming events. */
+public class AnthropicStreamingAdapter {
+
+    private final AnthropicResponseBuilder responseBuilder;
+
+    public AnthropicStreamingAdapter(AnthropicResponseBuilder responseBuilder) {
+        this.responseBuilder = responseBuilder;
+    }
+
+    public Flux<AnthropicStreamEvent> stream(
+            ReActAgent agent,
+            List<Msg> messages,
+            AnthropicMessagesRequest request,
+            String messageId) {
+        StreamOptions options =
+                StreamOptions.builder()
+                        .eventTypes(EventType.REASONING, EventType.TOOL_RESULT)
+                        .incremental(true)
+                        .build();
+
+        AnthropicStreamEvent start = new AnthropicStreamEvent("message_start");
+        start.setMessage(responseBuilder.baseResponse(request, messageId));
+
+        AtomicBoolean hasTextBlock = new AtomicBoolean(false);
+        AtomicInteger nextIndex = new AtomicInteger(0);
+        AtomicBoolean hasSeenIncrementalReasoning = new AtomicBoolean(false);
+
+        Flux<AnthropicStreamEvent> body =
+                agent.stream(messages, options)
+                        .filter(event -> event.getMessage() != null)
+                        .doOnNext(
+                                event -> {
+                                    if (event.getType() == EventType.REASONING && !event.isLast()) {
+                                        hasSeenIncrementalReasoning.set(true);
+                                    }
+                                })
+                        .flatMap(
+                                event ->
+                                        convertEvent(
+                                                event,
+                                                request,
+                                                messageId,
+                                                hasTextBlock,
+                                                nextIndex,
+                                                !(event.getType() == EventType.REASONING
+                                                        && event.isLast()
+                                                        && hasSeenIncrementalReasoning.get())));
+
+        return Flux.concat(Flux.just(start), body);
+    }
+
+    public AnthropicStreamEvent errorEvent(Throwable error) {
+        AnthropicStreamEvent event = new AnthropicStreamEvent("error");
+        event.setDelta(
+                Map.of(
+                        "type",
+                        "error",
+                        "error",
+                        Map.of(
+                                "type",
+                                "api_error",
+                                "message",
+                                error != null ? error.getMessage() : "Unknown error occurred")));
+        return event;
+    }
+
+    private Flux<AnthropicStreamEvent> convertEvent(
+            Event event,
+            AnthropicMessagesRequest request,
+            String messageId,
+            AtomicBoolean hasTextBlock,
+            AtomicInteger nextIndex,
+            boolean includeText) {
+        List<AnthropicStreamEvent> events = new ArrayList<>();
+        Msg msg = event.getMessage();
+        if (msg == null || msg.getContent() == null) {
+            return Flux.empty();
+        }
+
+        if (includeText) {
+            for (ContentBlock block : msg.getContent()) {
+                if (block instanceof TextBlock textBlock
+                        && textBlock.getText() != null
+                        && !textBlock.getText().isEmpty()) {
+                    int index = 0;
+                    if (!hasTextBlock.getAndSet(true)) {
+                        nextIndex.compareAndSet(0, 1);
+                        AnthropicStreamEvent blockStart =
+                                new AnthropicStreamEvent("content_block_start");
+                        blockStart.setIndex(index);
+                        blockStart.setContentBlock(Map.of("type", "text", "text", ""));
+                        events.add(blockStart);
+                    }
+
+                    AnthropicStreamEvent delta = new AnthropicStreamEvent("content_block_delta");
+                    delta.setIndex(index);
+                    delta.setDelta(Map.of("type", "text_delta", "text", textBlock.getText()));
+                    events.add(delta);
+                }
+            }
+        }
+
+        for (ContentBlock block : msg.getContent()) {
+            if (block instanceof ToolUseBlock toolUseBlock) {
+                int index = nextIndex.getAndIncrement();
+                AnthropicStreamEvent blockStart = new AnthropicStreamEvent("content_block_start");
+                blockStart.setIndex(index);
+                blockStart.setContentBlock(
+                        Map.of(
+                                "type",
+                                "tool_use",
+                                "id",
+                                toolUseBlock.getId(),
+                                "name",
+                                toolUseBlock.getName(),
+                                "input",
+                                Map.of()));
+                events.add(blockStart);
+
+                AnthropicStreamEvent args = new AnthropicStreamEvent("content_block_delta");
+                args.setIndex(index);
+                args.setDelta(
+                        Map.of(
+                                "type",
+                                "input_json_delta",
+                                "partial_json",
+                                toolUseBlock.getContent() != null
+                                        ? toolUseBlock.getContent()
+                                        : ProtocolJsonUtils.toJson(toolUseBlock.getInput())));
+                events.add(args);
+
+                AnthropicStreamEvent blockStop = new AnthropicStreamEvent("content_block_stop");
+                blockStop.setIndex(index);
+                events.add(blockStop);
+            }
+        }
+
+        if (event.isLast()) {
+            if (hasTextBlock.get()) {
+                AnthropicStreamEvent blockStop = new AnthropicStreamEvent("content_block_stop");
+                blockStop.setIndex(0);
+                events.add(blockStop);
+            }
+            AnthropicStreamEvent delta = new AnthropicStreamEvent("message_delta");
+            delta.setDelta(Map.of("stop_reason", responseBuilder.stopReason(msg)));
+            delta.setUsage(new AnthropicUsage(null, 0));
+            events.add(delta);
+
+            AnthropicStreamEvent stop = new AnthropicStreamEvent("message_stop");
+            stop.setMessage(responseBuilder.buildResponse(request, msg, messageId));
+            events.add(stop);
+        }
+
+        return Flux.fromIterable(events);
+    }
+}

--- a/agentscope-extensions/agentscope-extensions-llm-interfaces-web/src/main/java/io/agentscope/core/llm/interfacesweb/anthropic/AnthropicStreamingAdapter.java
+++ b/agentscope-extensions/agentscope-extensions-llm-interfaces-web/src/main/java/io/agentscope/core/llm/interfacesweb/anthropic/AnthropicStreamingAdapter.java
@@ -106,7 +106,7 @@ public class AnthropicStreamingAdapter {
             boolean includeText) {
         List<AnthropicStreamEvent> events = new ArrayList<>();
         Msg msg = event.getMessage();
-        if (msg == null || msg.getContent() == null) {
+        if (msg.getContent() == null) {
             return Flux.empty();
         }
 

--- a/agentscope-extensions/agentscope-extensions-llm-interfaces-web/src/main/java/io/agentscope/core/llm/interfacesweb/anthropic/AnthropicTool.java
+++ b/agentscope-extensions/agentscope-extensions-llm-interfaces-web/src/main/java/io/agentscope/core/llm/interfacesweb/anthropic/AnthropicTool.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.core.llm.interfacesweb.anthropic;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Map;
+
+/** Anthropic tool definition. */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class AnthropicTool {
+
+    private String name;
+    private String description;
+
+    @JsonProperty("input_schema")
+    private Map<String, Object> inputSchema;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public Map<String, Object> getInputSchema() {
+        return inputSchema;
+    }
+
+    public void setInputSchema(Map<String, Object> inputSchema) {
+        this.inputSchema = inputSchema;
+    }
+}

--- a/agentscope-extensions/agentscope-extensions-llm-interfaces-web/src/main/java/io/agentscope/core/llm/interfacesweb/anthropic/AnthropicToolConverter.java
+++ b/agentscope-extensions/agentscope-extensions-llm-interfaces-web/src/main/java/io/agentscope/core/llm/interfacesweb/anthropic/AnthropicToolConverter.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.core.llm.interfacesweb.anthropic;
+
+import io.agentscope.core.model.ToolSchema;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/** Converts Anthropic tools to AgentScope schema-only tools. */
+public class AnthropicToolConverter {
+
+    public List<ToolSchema> convert(List<AnthropicTool> tools) {
+        if (tools == null || tools.isEmpty()) {
+            return List.of();
+        }
+        List<ToolSchema> schemas = new ArrayList<>();
+        for (AnthropicTool tool : tools) {
+            if (tool != null && tool.getName() != null && !tool.getName().isBlank()) {
+                schemas.add(
+                        ToolSchema.builder()
+                                .name(tool.getName())
+                                .description(
+                                        tool.getDescription() != null ? tool.getDescription() : "")
+                                .parameters(
+                                        tool.getInputSchema() != null
+                                                ? tool.getInputSchema()
+                                                : Map.of("type", "object"))
+                                .build());
+            }
+        }
+        return schemas;
+    }
+}

--- a/agentscope-extensions/agentscope-extensions-llm-interfaces-web/src/main/java/io/agentscope/core/llm/interfacesweb/anthropic/AnthropicUsage.java
+++ b/agentscope-extensions/agentscope-extensions-llm-interfaces-web/src/main/java/io/agentscope/core/llm/interfacesweb/anthropic/AnthropicUsage.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.core.llm.interfacesweb.anthropic;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/** Token usage in Anthropic Messages format. */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class AnthropicUsage {
+
+    @JsonProperty("input_tokens")
+    private Integer inputTokens;
+
+    @JsonProperty("output_tokens")
+    private Integer outputTokens;
+
+    public AnthropicUsage() {}
+
+    public AnthropicUsage(Integer inputTokens, Integer outputTokens) {
+        this.inputTokens = inputTokens;
+        this.outputTokens = outputTokens;
+    }
+
+    public Integer getInputTokens() {
+        return inputTokens;
+    }
+
+    public void setInputTokens(Integer inputTokens) {
+        this.inputTokens = inputTokens;
+    }
+
+    public Integer getOutputTokens() {
+        return outputTokens;
+    }
+
+    public void setOutputTokens(Integer outputTokens) {
+        this.outputTokens = outputTokens;
+    }
+}

--- a/agentscope-extensions/agentscope-extensions-llm-interfaces-web/src/main/java/io/agentscope/core/llm/interfacesweb/common/ProtocolException.java
+++ b/agentscope-extensions/agentscope-extensions-llm-interfaces-web/src/main/java/io/agentscope/core/llm/interfacesweb/common/ProtocolException.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.core.llm.interfacesweb.common;
+
+/** Runtime exception used for request validation failures in compatibility protocols. */
+public class ProtocolException extends RuntimeException {
+
+    private final String code;
+
+    public ProtocolException(String code, String message) {
+        super(message);
+        this.code = code;
+    }
+
+    public String getCode() {
+        return code;
+    }
+}

--- a/agentscope-extensions/agentscope-extensions-llm-interfaces-web/src/main/java/io/agentscope/core/llm/interfacesweb/common/ProtocolJsonUtils.java
+++ b/agentscope-extensions/agentscope-extensions-llm-interfaces-web/src/main/java/io/agentscope/core/llm/interfacesweb/common/ProtocolJsonUtils.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.core.llm.interfacesweb.common;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/** Small JSON helpers shared by protocol adapters. */
+public final class ProtocolJsonUtils {
+
+    public static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    private ProtocolJsonUtils() {}
+
+    public static Map<String, Object> parseObject(String json) {
+        if (json == null || json.isBlank()) {
+            return Map.of();
+        }
+        try {
+            return OBJECT_MAPPER.readValue(json, new TypeReference<Map<String, Object>>() {});
+        } catch (JsonProcessingException e) {
+            return Map.of();
+        }
+    }
+
+    public static Map<String, Object> parseRequiredObject(String json, String fieldName) {
+        if (json == null || json.isBlank()) {
+            return Map.of();
+        }
+        try {
+            return OBJECT_MAPPER.readValue(json, new TypeReference<Map<String, Object>>() {});
+        } catch (JsonProcessingException e) {
+            throw new ProtocolException(
+                    "invalid_request_error", fieldName + " must be a valid JSON object");
+        }
+    }
+
+    public static Map<String, Object> toMap(Object value) {
+        if (value == null) {
+            return Map.of();
+        }
+        if (value instanceof Map<?, ?> map) {
+            Map<String, Object> result = new LinkedHashMap<>();
+            map.forEach((key, mapValue) -> result.put(String.valueOf(key), mapValue));
+            return result;
+        }
+        return OBJECT_MAPPER.convertValue(value, new TypeReference<Map<String, Object>>() {});
+    }
+
+    public static String toJson(Object value) {
+        if (value == null) {
+            return "{}";
+        }
+        if (value instanceof String text) {
+            return text;
+        }
+        try {
+            return OBJECT_MAPPER.writeValueAsString(value);
+        } catch (JsonProcessingException e) {
+            return "{}";
+        }
+    }
+
+    public static JsonNode toJsonNode(Object value) {
+        if (value == null) {
+            return null;
+        }
+        if (value instanceof JsonNode jsonNode) {
+            return jsonNode;
+        }
+        return OBJECT_MAPPER.valueToTree(value);
+    }
+
+    public static String textValue(JsonNode node, String fieldName) {
+        JsonNode child = node != null ? node.get(fieldName) : null;
+        return child != null && !child.isNull() ? child.asText() : null;
+    }
+
+    public static boolean truthy(JsonNode node, String fieldName) {
+        JsonNode child = node != null ? node.get(fieldName) : null;
+        return child != null && child.asBoolean(false);
+    }
+}

--- a/agentscope-extensions/agentscope-extensions-llm-interfaces-web/src/main/java/io/agentscope/core/llm/interfacesweb/common/ProtocolMessageUtils.java
+++ b/agentscope-extensions/agentscope-extensions-llm-interfaces-web/src/main/java/io/agentscope/core/llm/interfacesweb/common/ProtocolMessageUtils.java
@@ -87,7 +87,7 @@ public final class ProtocolMessageUtils {
                 "name",
                 block.getName(),
                 "input",
-                block.getInput() != null ? block.getInput() : Map.of());
+                block.getInput());
     }
 
     public static Map<String, Object> toolResultPart(ToolResultBlock block) {

--- a/agentscope-extensions/agentscope-extensions-llm-interfaces-web/src/main/java/io/agentscope/core/llm/interfacesweb/common/ProtocolMessageUtils.java
+++ b/agentscope-extensions/agentscope-extensions-llm-interfaces-web/src/main/java/io/agentscope/core/llm/interfacesweb/common/ProtocolMessageUtils.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.core.llm.interfacesweb.common;
+
+import io.agentscope.core.message.Base64Source;
+import io.agentscope.core.message.ContentBlock;
+import io.agentscope.core.message.ImageBlock;
+import io.agentscope.core.message.Msg;
+import io.agentscope.core.message.MsgRole;
+import io.agentscope.core.message.TextBlock;
+import io.agentscope.core.message.ThinkingBlock;
+import io.agentscope.core.message.ToolResultBlock;
+import io.agentscope.core.message.ToolUseBlock;
+import io.agentscope.core.message.URLSource;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/** Helpers for converting AgentScope messages to wire-protocol payloads. */
+public final class ProtocolMessageUtils {
+
+    private ProtocolMessageUtils() {}
+
+    public static Msg textMessage(MsgRole role, String text) {
+        return Msg.builder()
+                .role(role)
+                .content(TextBlock.builder().text(text != null ? text : "").build())
+                .build();
+    }
+
+    public static Msg message(MsgRole role, List<ContentBlock> content) {
+        return Msg.builder().role(role).content(content.toArray(new ContentBlock[0])).build();
+    }
+
+    public static String textContent(Msg msg) {
+        if (msg == null || msg.getContent() == null) {
+            return "";
+        }
+        return msg.getContent().stream()
+                .filter(TextBlock.class::isInstance)
+                .map(TextBlock.class::cast)
+                .map(TextBlock::getText)
+                .collect(Collectors.joining());
+    }
+
+    public static List<Map<String, Object>> contentParts(Msg msg, boolean anthropicShape) {
+        List<Map<String, Object>> parts = new ArrayList<>();
+        if (msg == null || msg.getContent() == null) {
+            return parts;
+        }
+        for (ContentBlock block : msg.getContent()) {
+            if (block instanceof TextBlock textBlock) {
+                parts.add(Map.of("type", "text", "text", textBlock.getText()));
+            } else if (block instanceof ThinkingBlock thinkingBlock) {
+                parts.add(Map.of("type", "thinking", "thinking", thinkingBlock.getThinking()));
+            } else if (block instanceof ImageBlock imageBlock) {
+                parts.add(imagePart(imageBlock, anthropicShape));
+            } else if (block instanceof ToolUseBlock toolUseBlock) {
+                parts.add(toolUsePart(toolUseBlock));
+            } else if (block instanceof ToolResultBlock toolResultBlock) {
+                parts.add(toolResultPart(toolResultBlock));
+            }
+        }
+        return parts;
+    }
+
+    public static Map<String, Object> toolUsePart(ToolUseBlock block) {
+        return Map.of(
+                "type",
+                "tool_use",
+                "id",
+                block.getId(),
+                "name",
+                block.getName(),
+                "input",
+                block.getInput() != null ? block.getInput() : Map.of());
+    }
+
+    public static Map<String, Object> toolResultPart(ToolResultBlock block) {
+        return Map.of(
+                "type",
+                "tool_result",
+                "tool_use_id",
+                block.getId(),
+                "content",
+                toolResultText(block));
+    }
+
+    public static String toolResultText(ToolResultBlock block) {
+        if (block == null || block.getOutput() == null) {
+            return "";
+        }
+        return block.getOutput().stream()
+                .filter(TextBlock.class::isInstance)
+                .map(TextBlock.class::cast)
+                .map(TextBlock::getText)
+                .collect(Collectors.joining());
+    }
+
+    private static Map<String, Object> imagePart(ImageBlock block, boolean anthropicShape) {
+        if (block.getSource() instanceof URLSource urlSource) {
+            if (anthropicShape) {
+                return Map.of(
+                        "type",
+                        "image",
+                        "source",
+                        Map.of("type", "url", "url", urlSource.getUrl()));
+            }
+            return Map.of("type", "input_image", "image_url", urlSource.getUrl());
+        }
+        if (block.getSource() instanceof Base64Source base64Source) {
+            if (anthropicShape) {
+                return Map.of(
+                        "type",
+                        "image",
+                        "source",
+                        Map.of(
+                                "type",
+                                "base64",
+                                "media_type",
+                                base64Source.getMediaType(),
+                                "data",
+                                base64Source.getData()));
+            }
+            return Map.of(
+                    "type",
+                    "input_image",
+                    "image_url",
+                    "data:" + base64Source.getMediaType() + ";base64," + base64Source.getData());
+        }
+        return Map.of("type", "text", "text", "[Unsupported image source]");
+    }
+}

--- a/agentscope-extensions/agentscope-extensions-llm-interfaces-web/src/main/java/io/agentscope/core/llm/interfacesweb/responses/ResponsesMessageConverter.java
+++ b/agentscope-extensions/agentscope-extensions-llm-interfaces-web/src/main/java/io/agentscope/core/llm/interfacesweb/responses/ResponsesMessageConverter.java
@@ -58,10 +58,7 @@ public class ResponsesMessageConverter {
                 }
             }
         } else if (input.isObject()) {
-            Msg msg = convertInputItem(input);
-            if (msg != null) {
-                messages.add(msg);
-            }
+            messages.add(convertInputItem(input));
         } else {
             throw new ProtocolException(
                     "invalid_request_error", "Responses input must be a string or an array");
@@ -91,7 +88,7 @@ public class ResponsesMessageConverter {
     }
 
     private Msg convertInputItem(JsonNode item) {
-        if (item == null || item.isNull()) {
+        if (item.isNull()) {
             return null;
         }
         if (item.isTextual()) {
@@ -171,14 +168,12 @@ public class ResponsesMessageConverter {
             return blocks;
         }
         ContentBlock block = convertContentPart(contentNode);
-        if (block != null) {
-            blocks.add(block);
-        }
+        blocks.add(block);
         return blocks;
     }
 
     private ContentBlock convertContentPart(JsonNode part) {
-        if (part == null || part.isNull()) {
+        if (part.isNull()) {
             return null;
         }
         if (part.isTextual()) {

--- a/agentscope-extensions/agentscope-extensions-llm-interfaces-web/src/main/java/io/agentscope/core/llm/interfacesweb/responses/ResponsesMessageConverter.java
+++ b/agentscope-extensions/agentscope-extensions-llm-interfaces-web/src/main/java/io/agentscope/core/llm/interfacesweb/responses/ResponsesMessageConverter.java
@@ -1,0 +1,266 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.core.llm.interfacesweb.responses;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.agentscope.core.llm.interfacesweb.common.ProtocolException;
+import io.agentscope.core.llm.interfacesweb.common.ProtocolJsonUtils;
+import io.agentscope.core.llm.interfacesweb.common.ProtocolMessageUtils;
+import io.agentscope.core.message.Base64Source;
+import io.agentscope.core.message.ContentBlock;
+import io.agentscope.core.message.ImageBlock;
+import io.agentscope.core.message.Msg;
+import io.agentscope.core.message.MsgRole;
+import io.agentscope.core.message.TextBlock;
+import io.agentscope.core.message.ToolResultBlock;
+import io.agentscope.core.message.ToolUseBlock;
+import io.agentscope.core.message.URLSource;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/** Converts stateless OpenAI Responses requests into AgentScope messages. */
+public class ResponsesMessageConverter {
+
+    public List<Msg> convert(ResponsesRequest request) {
+        validateStatelessSubset(request);
+
+        List<Msg> messages = new ArrayList<>();
+        if (request.getInstructions() != null && !request.getInstructions().isBlank()) {
+            messages.add(
+                    ProtocolMessageUtils.textMessage(MsgRole.SYSTEM, request.getInstructions()));
+        }
+
+        JsonNode input = ProtocolJsonUtils.toJsonNode(request.getInput());
+        if (input == null || input.isNull()) {
+            throw new ProtocolException("invalid_request_error", "Responses input is required");
+        }
+        if (input.isTextual()) {
+            messages.add(ProtocolMessageUtils.textMessage(MsgRole.USER, input.asText()));
+        } else if (input.isArray()) {
+            for (JsonNode item : input) {
+                Msg msg = convertInputItem(item);
+                if (msg != null) {
+                    messages.add(msg);
+                }
+            }
+        } else if (input.isObject()) {
+            Msg msg = convertInputItem(input);
+            if (msg != null) {
+                messages.add(msg);
+            }
+        } else {
+            throw new ProtocolException(
+                    "invalid_request_error", "Responses input must be a string or an array");
+        }
+
+        if (messages.isEmpty()) {
+            throw new ProtocolException(
+                    "invalid_request_error", "At least one input message is required");
+        }
+        return messages;
+    }
+
+    private void validateStatelessSubset(ResponsesRequest request) {
+        if (request.getPreviousResponseId() != null && !request.getPreviousResponseId().isBlank()) {
+            throw unsupported("previous_response_id is not supported by this stateless endpoint");
+        }
+        if (request.getConversation() != null) {
+            throw unsupported("conversation is not supported by this stateless endpoint");
+        }
+        if (Boolean.TRUE.equals(request.getBackground())) {
+            throw unsupported("background responses are not supported by this stateless endpoint");
+        }
+    }
+
+    private ProtocolException unsupported(String message) {
+        return new ProtocolException("unsupported_feature", message);
+    }
+
+    private Msg convertInputItem(JsonNode item) {
+        if (item == null || item.isNull()) {
+            return null;
+        }
+        if (item.isTextual()) {
+            return ProtocolMessageUtils.textMessage(MsgRole.USER, item.asText());
+        }
+
+        String type = ProtocolJsonUtils.textValue(item, "type");
+        if ("function_call_output".equals(type)) {
+            return convertFunctionCallOutput(item);
+        }
+        if ("function_call".equals(type)) {
+            return convertFunctionCall(item);
+        }
+
+        String role = ProtocolJsonUtils.textValue(item, "role");
+        MsgRole msgRole = roleToMsgRole(role);
+        List<ContentBlock> content = convertContent(item.get("content"));
+        if (content.isEmpty()) {
+            String text = ProtocolJsonUtils.textValue(item, "text");
+            if (text == null) {
+                text = ProtocolJsonUtils.textValue(item, "output_text");
+            }
+            content.add(TextBlock.builder().text(text != null ? text : "").build());
+        }
+        return ProtocolMessageUtils.message(msgRole, content);
+    }
+
+    private Msg convertFunctionCall(JsonNode item) {
+        String callId =
+                firstNonBlank(
+                        ProtocolJsonUtils.textValue(item, "call_id"),
+                        ProtocolJsonUtils.textValue(item, "id"));
+        String name = ProtocolJsonUtils.textValue(item, "name");
+        String arguments = ProtocolJsonUtils.textValue(item, "arguments");
+        ToolUseBlock block =
+                ToolUseBlock.builder()
+                        .id(callId)
+                        .name(name)
+                        .input(ProtocolJsonUtils.parseRequiredObject(arguments, "arguments"))
+                        .content(arguments)
+                        .build();
+        return ProtocolMessageUtils.message(MsgRole.ASSISTANT, List.of(block));
+    }
+
+    private Msg convertFunctionCallOutput(JsonNode item) {
+        String callId = ProtocolJsonUtils.textValue(item, "call_id");
+        String name = ProtocolJsonUtils.textValue(item, "name");
+        String output = ProtocolJsonUtils.textValue(item, "output");
+        if (output == null && item.has("content")) {
+            output = extractText(item.get("content"));
+        }
+        ToolResultBlock block =
+                ToolResultBlock.builder()
+                        .id(callId)
+                        .name(name)
+                        .output(TextBlock.builder().text(output != null ? output : "").build())
+                        .build();
+        return ProtocolMessageUtils.message(MsgRole.TOOL, List.of(block));
+    }
+
+    private List<ContentBlock> convertContent(JsonNode contentNode) {
+        List<ContentBlock> blocks = new ArrayList<>();
+        if (contentNode == null || contentNode.isNull()) {
+            return blocks;
+        }
+        if (contentNode.isTextual()) {
+            blocks.add(TextBlock.builder().text(contentNode.asText()).build());
+            return blocks;
+        }
+        if (contentNode.isArray()) {
+            for (JsonNode part : contentNode) {
+                ContentBlock block = convertContentPart(part);
+                if (block != null) {
+                    blocks.add(block);
+                }
+            }
+            return blocks;
+        }
+        ContentBlock block = convertContentPart(contentNode);
+        if (block != null) {
+            blocks.add(block);
+        }
+        return blocks;
+    }
+
+    private ContentBlock convertContentPart(JsonNode part) {
+        if (part == null || part.isNull()) {
+            return null;
+        }
+        if (part.isTextual()) {
+            return TextBlock.builder().text(part.asText()).build();
+        }
+        String type = ProtocolJsonUtils.textValue(part, "type");
+        if ("input_text".equals(type) || "output_text".equals(type) || "text".equals(type)) {
+            return TextBlock.builder()
+                    .text(firstNonBlank(ProtocolJsonUtils.textValue(part, "text"), ""))
+                    .build();
+        }
+        if ("input_image".equals(type) || "image".equals(type)) {
+            return imageBlock(part);
+        }
+        if ("tool_use".equals(type)) {
+            String inputJson =
+                    part.has("input") ? ProtocolJsonUtils.toJson(part.get("input")) : "{}";
+            return ToolUseBlock.builder()
+                    .id(ProtocolJsonUtils.textValue(part, "id"))
+                    .name(ProtocolJsonUtils.textValue(part, "name"))
+                    .input(
+                            part.has("input")
+                                    ? ProtocolJsonUtils.toMap(part.get("input"))
+                                    : Map.of())
+                    .content(inputJson)
+                    .build();
+        }
+        return TextBlock.builder().text(extractText(part)).build();
+    }
+
+    private ContentBlock imageBlock(JsonNode part) {
+        String imageUrl = ProtocolJsonUtils.textValue(part, "image_url");
+        if (imageUrl == null) {
+            imageUrl = ProtocolJsonUtils.textValue(part, "url");
+        }
+        if (imageUrl != null && imageUrl.startsWith("data:")) {
+            int commaIndex = imageUrl.indexOf(',');
+            String metadata =
+                    commaIndex >= 0 ? imageUrl.substring(5, commaIndex) : "image/png;base64";
+            String mediaType = metadata.replace(";base64", "");
+            String data = commaIndex >= 0 ? imageUrl.substring(commaIndex + 1) : "";
+            return ImageBlock.builder()
+                    .source(Base64Source.builder().mediaType(mediaType).data(data).build())
+                    .build();
+        }
+        if (imageUrl != null) {
+            return ImageBlock.builder().source(URLSource.builder().url(imageUrl).build()).build();
+        }
+        return TextBlock.builder().text("[Unsupported image]").build();
+    }
+
+    private MsgRole roleToMsgRole(String role) {
+        if (role == null || role.isBlank()) {
+            return MsgRole.USER;
+        }
+        return switch (role.toLowerCase()) {
+            case "system", "developer" -> MsgRole.SYSTEM;
+            case "assistant" -> MsgRole.ASSISTANT;
+            case "tool" -> MsgRole.TOOL;
+            default -> MsgRole.USER;
+        };
+    }
+
+    private String extractText(JsonNode node) {
+        if (node == null || node.isNull()) {
+            return "";
+        }
+        if (node.isTextual()) {
+            return node.asText();
+        }
+        if (node.isArray()) {
+            StringBuilder builder = new StringBuilder();
+            for (JsonNode item : node) {
+                builder.append(extractText(item));
+            }
+            return builder.toString();
+        }
+        String text = ProtocolJsonUtils.textValue(node, "text");
+        return text != null ? text : node.toString();
+    }
+
+    private String firstNonBlank(String first, String second) {
+        return first != null && !first.isBlank() ? first : second;
+    }
+}

--- a/agentscope-extensions/agentscope-extensions-llm-interfaces-web/src/main/java/io/agentscope/core/llm/interfacesweb/responses/ResponsesOutputContent.java
+++ b/agentscope-extensions/agentscope-extensions-llm-interfaces-web/src/main/java/io/agentscope/core/llm/interfacesweb/responses/ResponsesOutputContent.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.core.llm.interfacesweb.responses;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+/** Output content item used by OpenAI Responses message outputs. */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class ResponsesOutputContent {
+
+    private String type;
+    private String text;
+
+    public ResponsesOutputContent() {}
+
+    public ResponsesOutputContent(String type, String text) {
+        this.type = type;
+        this.text = text;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    public String getText() {
+        return text;
+    }
+
+    public void setText(String text) {
+        this.text = text;
+    }
+}

--- a/agentscope-extensions/agentscope-extensions-llm-interfaces-web/src/main/java/io/agentscope/core/llm/interfacesweb/responses/ResponsesOutputItem.java
+++ b/agentscope-extensions/agentscope-extensions-llm-interfaces-web/src/main/java/io/agentscope/core/llm/interfacesweb/responses/ResponsesOutputItem.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.core.llm.interfacesweb.responses;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+
+/** Output item in the OpenAI Responses format. */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class ResponsesOutputItem {
+
+    private String id;
+    private String type;
+    private String status;
+    private String role;
+    private List<ResponsesOutputContent> content;
+    private String name;
+    private String arguments;
+
+    @JsonProperty("call_id")
+    private String callId;
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public void setStatus(String status) {
+        this.status = status;
+    }
+
+    public String getRole() {
+        return role;
+    }
+
+    public void setRole(String role) {
+        this.role = role;
+    }
+
+    public List<ResponsesOutputContent> getContent() {
+        return content;
+    }
+
+    public void setContent(List<ResponsesOutputContent> content) {
+        this.content = content;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getArguments() {
+        return arguments;
+    }
+
+    public void setArguments(String arguments) {
+        this.arguments = arguments;
+    }
+
+    public String getCallId() {
+        return callId;
+    }
+
+    public void setCallId(String callId) {
+        this.callId = callId;
+    }
+}

--- a/agentscope-extensions/agentscope-extensions-llm-interfaces-web/src/main/java/io/agentscope/core/llm/interfacesweb/responses/ResponsesRequest.java
+++ b/agentscope-extensions/agentscope-extensions-llm-interfaces-web/src/main/java/io/agentscope/core/llm/interfacesweb/responses/ResponsesRequest.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.core.llm.interfacesweb.responses;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+import java.util.Map;
+
+/** Request body for the stateless subset of OpenAI's Responses API. */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class ResponsesRequest {
+
+    private String model;
+    private Object input;
+    private String instructions;
+    private Boolean stream;
+    private List<ResponsesTool> tools;
+    private Object metadata;
+
+    @JsonProperty("previous_response_id")
+    private String previousResponseId;
+
+    private Object conversation;
+    private Boolean background;
+
+    @JsonProperty("store")
+    private Boolean store;
+
+    @JsonProperty("tool_choice")
+    private Object toolChoice;
+
+    @JsonProperty("text")
+    private Map<String, Object> text;
+
+    public String getModel() {
+        return model;
+    }
+
+    public void setModel(String model) {
+        this.model = model;
+    }
+
+    public Object getInput() {
+        return input;
+    }
+
+    public void setInput(Object input) {
+        this.input = input;
+    }
+
+    public String getInstructions() {
+        return instructions;
+    }
+
+    public void setInstructions(String instructions) {
+        this.instructions = instructions;
+    }
+
+    public Boolean getStream() {
+        return stream;
+    }
+
+    public void setStream(Boolean stream) {
+        this.stream = stream;
+    }
+
+    public List<ResponsesTool> getTools() {
+        return tools;
+    }
+
+    public void setTools(List<ResponsesTool> tools) {
+        this.tools = tools;
+    }
+
+    public Object getMetadata() {
+        return metadata;
+    }
+
+    public void setMetadata(Object metadata) {
+        this.metadata = metadata;
+    }
+
+    public String getPreviousResponseId() {
+        return previousResponseId;
+    }
+
+    public void setPreviousResponseId(String previousResponseId) {
+        this.previousResponseId = previousResponseId;
+    }
+
+    public Object getConversation() {
+        return conversation;
+    }
+
+    public void setConversation(Object conversation) {
+        this.conversation = conversation;
+    }
+
+    public Boolean getBackground() {
+        return background;
+    }
+
+    public void setBackground(Boolean background) {
+        this.background = background;
+    }
+
+    public Boolean getStore() {
+        return store;
+    }
+
+    public void setStore(Boolean store) {
+        this.store = store;
+    }
+
+    public Object getToolChoice() {
+        return toolChoice;
+    }
+
+    public void setToolChoice(Object toolChoice) {
+        this.toolChoice = toolChoice;
+    }
+
+    public Map<String, Object> getText() {
+        return text;
+    }
+
+    public void setText(Map<String, Object> text) {
+        this.text = text;
+    }
+}

--- a/agentscope-extensions/agentscope-extensions-llm-interfaces-web/src/main/java/io/agentscope/core/llm/interfacesweb/responses/ResponsesResponse.java
+++ b/agentscope-extensions/agentscope-extensions-llm-interfaces-web/src/main/java/io/agentscope/core/llm/interfacesweb/responses/ResponsesResponse.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.core.llm.interfacesweb.responses;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+
+/** Response body for the stateless OpenAI Responses-compatible endpoint. */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class ResponsesResponse {
+
+    private String id;
+    private String object = "response";
+    private String status;
+    private String model;
+    private List<ResponsesOutputItem> output;
+    private ResponsesUsage usage;
+    private Object error;
+
+    @JsonProperty("created_at")
+    private long createdAt;
+
+    @JsonProperty("output_text")
+    private String outputText;
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getObject() {
+        return object;
+    }
+
+    public void setObject(String object) {
+        this.object = object;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public void setStatus(String status) {
+        this.status = status;
+    }
+
+    public String getModel() {
+        return model;
+    }
+
+    public void setModel(String model) {
+        this.model = model;
+    }
+
+    public List<ResponsesOutputItem> getOutput() {
+        return output;
+    }
+
+    public void setOutput(List<ResponsesOutputItem> output) {
+        this.output = output;
+    }
+
+    public ResponsesUsage getUsage() {
+        return usage;
+    }
+
+    public void setUsage(ResponsesUsage usage) {
+        this.usage = usage;
+    }
+
+    public Object getError() {
+        return error;
+    }
+
+    public void setError(Object error) {
+        this.error = error;
+    }
+
+    public long getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(long createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public String getOutputText() {
+        return outputText;
+    }
+
+    public void setOutputText(String outputText) {
+        this.outputText = outputText;
+    }
+}

--- a/agentscope-extensions/agentscope-extensions-llm-interfaces-web/src/main/java/io/agentscope/core/llm/interfacesweb/responses/ResponsesResponseBuilder.java
+++ b/agentscope-extensions/agentscope-extensions-llm-interfaces-web/src/main/java/io/agentscope/core/llm/interfacesweb/responses/ResponsesResponseBuilder.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.core.llm.interfacesweb.responses;
+
+import io.agentscope.core.llm.interfacesweb.common.ProtocolJsonUtils;
+import io.agentscope.core.llm.interfacesweb.common.ProtocolMessageUtils;
+import io.agentscope.core.message.ContentBlock;
+import io.agentscope.core.message.GenerateReason;
+import io.agentscope.core.message.Msg;
+import io.agentscope.core.message.TextBlock;
+import io.agentscope.core.message.ToolUseBlock;
+import io.agentscope.core.model.ChatUsage;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/** Builds stateless OpenAI Responses-compatible response payloads. */
+public class ResponsesResponseBuilder {
+
+    public ResponsesResponse buildResponse(ResponsesRequest request, Msg reply, String responseId) {
+        ResponsesResponse response = baseResponse(request, responseId, "completed");
+        List<ResponsesOutputItem> output = outputItems(reply, responseId);
+        response.setOutput(output);
+        response.setOutputText(ProtocolMessageUtils.textContent(reply));
+        response.setUsage(usage(reply));
+
+        if (reply != null && reply.getGenerateReason() == GenerateReason.MAX_ITERATIONS) {
+            response.setStatus("incomplete");
+        }
+        return response;
+    }
+
+    public ResponsesResponse buildErrorResponse(
+            ResponsesRequest request, Throwable error, String responseId) {
+        ResponsesResponse response = baseResponse(request, responseId, "failed");
+        String message = error != null ? error.getMessage() : "Unknown error occurred";
+        response.setError(Map.of("type", "server_error", "message", message));
+        response.setOutput(List.of());
+        response.setOutputText("");
+        return response;
+    }
+
+    public ResponsesResponse baseResponse(
+            ResponsesRequest request, String responseId, String status) {
+        ResponsesResponse response = new ResponsesResponse();
+        response.setId(responseId);
+        response.setCreatedAt(Instant.now().getEpochSecond());
+        response.setModel(request != null ? request.getModel() : null);
+        response.setStatus(status);
+        return response;
+    }
+
+    public List<ResponsesOutputItem> outputItems(Msg reply, String responseId) {
+        List<ResponsesOutputItem> items = new ArrayList<>();
+        if (reply == null || reply.getContent() == null) {
+            return items;
+        }
+
+        String text = ProtocolMessageUtils.textContent(reply);
+        if (!text.isEmpty()) {
+            ResponsesOutputItem message = new ResponsesOutputItem();
+            message.setId("msg_" + responseId);
+            message.setType("message");
+            message.setStatus("completed");
+            message.setRole("assistant");
+            message.setContent(List.of(new ResponsesOutputContent("output_text", text)));
+            items.add(message);
+        }
+
+        for (ContentBlock block : reply.getContent()) {
+            if (block instanceof ToolUseBlock toolUseBlock) {
+                items.add(toolUseItem(toolUseBlock));
+            } else if (!(block instanceof TextBlock)) {
+                String itemText =
+                        ProtocolJsonUtils.toJson(ProtocolMessageUtils.contentParts(reply, false));
+                if (!itemText.equals("[]") && text.isEmpty()) {
+                    ResponsesOutputItem message = new ResponsesOutputItem();
+                    message.setId("msg_" + responseId);
+                    message.setType("message");
+                    message.setStatus("completed");
+                    message.setRole("assistant");
+                    message.setContent(
+                            List.of(new ResponsesOutputContent("output_text", itemText)));
+                    items.add(message);
+                    break;
+                }
+            }
+        }
+        return items;
+    }
+
+    public ResponsesOutputItem toolUseItem(ToolUseBlock block) {
+        ResponsesOutputItem item = new ResponsesOutputItem();
+        item.setId(block.getId());
+        item.setType("function_call");
+        item.setStatus("completed");
+        item.setCallId(block.getId());
+        item.setName(block.getName());
+        String arguments =
+                block.getContent() != null && !block.getContent().isBlank()
+                        ? block.getContent()
+                        : ProtocolJsonUtils.toJson(block.getInput());
+        item.setArguments(arguments);
+        return item;
+    }
+
+    private ResponsesUsage usage(Msg reply) {
+        if (reply == null || reply.getChatUsage() == null) {
+            return null;
+        }
+        ChatUsage usage = reply.getChatUsage();
+        return new ResponsesUsage(usage.getInputTokens(), usage.getOutputTokens());
+    }
+}

--- a/agentscope-extensions/agentscope-extensions-llm-interfaces-web/src/main/java/io/agentscope/core/llm/interfacesweb/responses/ResponsesStreamEvent.java
+++ b/agentscope-extensions/agentscope-extensions-llm-interfaces-web/src/main/java/io/agentscope/core/llm/interfacesweb/responses/ResponsesStreamEvent.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.core.llm.interfacesweb.responses;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/** Server-sent event payload for OpenAI Responses streaming compatibility. */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class ResponsesStreamEvent {
+
+    private String type;
+    private ResponsesResponse response;
+    private ResponsesOutputItem item;
+    private String delta;
+    private Object error;
+
+    @JsonProperty("response_id")
+    private String responseId;
+
+    @JsonProperty("output_index")
+    private Integer outputIndex;
+
+    @JsonProperty("content_index")
+    private Integer contentIndex;
+
+    @JsonProperty("item_id")
+    private String itemId;
+
+    public ResponsesStreamEvent() {}
+
+    public ResponsesStreamEvent(String type) {
+        this.type = type;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    public ResponsesResponse getResponse() {
+        return response;
+    }
+
+    public void setResponse(ResponsesResponse response) {
+        this.response = response;
+    }
+
+    public ResponsesOutputItem getItem() {
+        return item;
+    }
+
+    public void setItem(ResponsesOutputItem item) {
+        this.item = item;
+    }
+
+    public String getDelta() {
+        return delta;
+    }
+
+    public void setDelta(String delta) {
+        this.delta = delta;
+    }
+
+    public Object getError() {
+        return error;
+    }
+
+    public void setError(Object error) {
+        this.error = error;
+    }
+
+    public String getResponseId() {
+        return responseId;
+    }
+
+    public void setResponseId(String responseId) {
+        this.responseId = responseId;
+    }
+
+    public Integer getOutputIndex() {
+        return outputIndex;
+    }
+
+    public void setOutputIndex(Integer outputIndex) {
+        this.outputIndex = outputIndex;
+    }
+
+    public Integer getContentIndex() {
+        return contentIndex;
+    }
+
+    public void setContentIndex(Integer contentIndex) {
+        this.contentIndex = contentIndex;
+    }
+
+    public String getItemId() {
+        return itemId;
+    }
+
+    public void setItemId(String itemId) {
+        this.itemId = itemId;
+    }
+}

--- a/agentscope-extensions/agentscope-extensions-llm-interfaces-web/src/main/java/io/agentscope/core/llm/interfacesweb/responses/ResponsesStreamingAdapter.java
+++ b/agentscope-extensions/agentscope-extensions-llm-interfaces-web/src/main/java/io/agentscope/core/llm/interfacesweb/responses/ResponsesStreamingAdapter.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.core.llm.interfacesweb.responses;
+
+import io.agentscope.core.ReActAgent;
+import io.agentscope.core.agent.Event;
+import io.agentscope.core.agent.EventType;
+import io.agentscope.core.agent.StreamOptions;
+import io.agentscope.core.llm.interfacesweb.common.ProtocolJsonUtils;
+import io.agentscope.core.message.ContentBlock;
+import io.agentscope.core.message.GenerateReason;
+import io.agentscope.core.message.Msg;
+import io.agentscope.core.message.TextBlock;
+import io.agentscope.core.message.ToolUseBlock;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+import reactor.core.publisher.Flux;
+
+/** Converts AgentScope streaming events to OpenAI Responses semantic stream events. */
+public class ResponsesStreamingAdapter {
+
+    private final ResponsesResponseBuilder responseBuilder;
+
+    public ResponsesStreamingAdapter(ResponsesResponseBuilder responseBuilder) {
+        this.responseBuilder = responseBuilder;
+    }
+
+    public Flux<ResponsesStreamEvent> stream(
+            ReActAgent agent, List<Msg> messages, ResponsesRequest request, String responseId) {
+        StreamOptions options =
+                StreamOptions.builder()
+                        .eventTypes(EventType.REASONING, EventType.TOOL_RESULT)
+                        .incremental(true)
+                        .build();
+
+        ResponsesStreamEvent created = new ResponsesStreamEvent("response.created");
+        created.setResponse(responseBuilder.baseResponse(request, responseId, "in_progress"));
+
+        AtomicBoolean hasSeenIncrementalReasoning = new AtomicBoolean(false);
+        Flux<ResponsesStreamEvent> body =
+                agent.stream(messages, options)
+                        .filter(event -> event.getMessage() != null)
+                        .doOnNext(
+                                event -> {
+                                    if (event.getType() == EventType.REASONING && !event.isLast()) {
+                                        hasSeenIncrementalReasoning.set(true);
+                                    }
+                                })
+                        .flatMap(
+                                event ->
+                                        convertEvent(
+                                                event,
+                                                request,
+                                                responseId,
+                                                !(event.getType() == EventType.REASONING
+                                                        && event.isLast()
+                                                        && hasSeenIncrementalReasoning.get())));
+
+        return Flux.concat(Flux.just(created), body);
+    }
+
+    public ResponsesStreamEvent errorEvent(Throwable error, String responseId) {
+        ResponsesStreamEvent event = new ResponsesStreamEvent("response.failed");
+        event.setResponseId(responseId);
+        event.setError(
+                java.util.Map.of(
+                        "type",
+                        "server_error",
+                        "message",
+                        error != null ? error.getMessage() : "Unknown error occurred"));
+        return event;
+    }
+
+    private Flux<ResponsesStreamEvent> convertEvent(
+            Event event, ResponsesRequest request, String responseId, boolean includeText) {
+        List<ResponsesStreamEvent> events = new ArrayList<>();
+        Msg msg = event.getMessage();
+        if (msg == null || msg.getContent() == null) {
+            return Flux.empty();
+        }
+
+        if (includeText) {
+            for (ContentBlock block : msg.getContent()) {
+                if (block instanceof TextBlock textBlock
+                        && textBlock.getText() != null
+                        && !textBlock.getText().isEmpty()) {
+                    ResponsesStreamEvent delta =
+                            new ResponsesStreamEvent("response.output_text.delta");
+                    delta.setResponseId(responseId);
+                    delta.setOutputIndex(0);
+                    delta.setContentIndex(0);
+                    delta.setDelta(textBlock.getText());
+                    events.add(delta);
+                }
+            }
+        }
+
+        for (ContentBlock block : msg.getContent()) {
+            if (block instanceof ToolUseBlock toolUseBlock) {
+                ResponsesStreamEvent itemAdded =
+                        new ResponsesStreamEvent("response.output_item.added");
+                itemAdded.setResponseId(responseId);
+                itemAdded.setOutputIndex(events.size());
+                itemAdded.setItem(responseBuilder.toolUseItem(toolUseBlock));
+                events.add(itemAdded);
+
+                ResponsesStreamEvent argsDelta =
+                        new ResponsesStreamEvent("response.function_call_arguments.delta");
+                argsDelta.setResponseId(responseId);
+                argsDelta.setItemId(toolUseBlock.getId());
+                argsDelta.setDelta(
+                        toolUseBlock.getContent() != null
+                                ? toolUseBlock.getContent()
+                                : ProtocolJsonUtils.toJson(toolUseBlock.getInput()));
+                events.add(argsDelta);
+            }
+        }
+
+        if (event.isLast()) {
+            ResponsesStreamEvent completed =
+                    new ResponsesStreamEvent(
+                            msg.getGenerateReason() == GenerateReason.MAX_ITERATIONS
+                                    ? "response.incomplete"
+                                    : "response.completed");
+            completed.setResponse(responseBuilder.buildResponse(request, msg, responseId));
+            events.add(completed);
+        }
+        return Flux.fromIterable(events);
+    }
+}

--- a/agentscope-extensions/agentscope-extensions-llm-interfaces-web/src/main/java/io/agentscope/core/llm/interfacesweb/responses/ResponsesStreamingAdapter.java
+++ b/agentscope-extensions/agentscope-extensions-llm-interfaces-web/src/main/java/io/agentscope/core/llm/interfacesweb/responses/ResponsesStreamingAdapter.java
@@ -89,7 +89,7 @@ public class ResponsesStreamingAdapter {
             Event event, ResponsesRequest request, String responseId, boolean includeText) {
         List<ResponsesStreamEvent> events = new ArrayList<>();
         Msg msg = event.getMessage();
-        if (msg == null || msg.getContent() == null) {
+        if (msg.getContent() == null) {
             return Flux.empty();
         }
 

--- a/agentscope-extensions/agentscope-extensions-llm-interfaces-web/src/main/java/io/agentscope/core/llm/interfacesweb/responses/ResponsesTool.java
+++ b/agentscope-extensions/agentscope-extensions-llm-interfaces-web/src/main/java/io/agentscope/core/llm/interfacesweb/responses/ResponsesTool.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.core.llm.interfacesweb.responses;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Map;
+
+/** Function tool definition in the OpenAI Responses shape. */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class ResponsesTool {
+
+    private String type = "function";
+    private String name;
+    private String description;
+    private Map<String, Object> parameters;
+    private Boolean strict;
+
+    @JsonProperty("function")
+    private Map<String, Object> function;
+
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public Map<String, Object> getParameters() {
+        return parameters;
+    }
+
+    public void setParameters(Map<String, Object> parameters) {
+        this.parameters = parameters;
+    }
+
+    public Boolean getStrict() {
+        return strict;
+    }
+
+    public void setStrict(Boolean strict) {
+        this.strict = strict;
+    }
+
+    public Map<String, Object> getFunction() {
+        return function;
+    }
+
+    public void setFunction(Map<String, Object> function) {
+        this.function = function;
+    }
+}

--- a/agentscope-extensions/agentscope-extensions-llm-interfaces-web/src/main/java/io/agentscope/core/llm/interfacesweb/responses/ResponsesToolConverter.java
+++ b/agentscope-extensions/agentscope-extensions-llm-interfaces-web/src/main/java/io/agentscope/core/llm/interfacesweb/responses/ResponsesToolConverter.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.core.llm.interfacesweb.responses;
+
+import io.agentscope.core.model.ToolSchema;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/** Converts OpenAI Responses function tools to AgentScope tool schemas. */
+public class ResponsesToolConverter {
+
+    public List<ToolSchema> convert(List<ResponsesTool> tools) {
+        if (tools == null || tools.isEmpty()) {
+            return List.of();
+        }
+        List<ToolSchema> schemas = new ArrayList<>();
+        for (ResponsesTool tool : tools) {
+            ToolSchema schema = convert(tool);
+            if (schema != null) {
+                schemas.add(schema);
+            }
+        }
+        return schemas;
+    }
+
+    private ToolSchema convert(ResponsesTool tool) {
+        if (tool == null) {
+            return null;
+        }
+        if (tool.getType() != null && !"function".equals(tool.getType())) {
+            return null;
+        }
+
+        String name = tool.getName();
+        String description = tool.getDescription();
+        Map<String, Object> parameters = tool.getParameters();
+        Boolean strict = tool.getStrict();
+
+        if (tool.getFunction() != null) {
+            Map<String, Object> function = tool.getFunction();
+            name = value(function, "name", name);
+            description = value(function, "description", description);
+            Object params = function.get("parameters");
+            if (params instanceof Map<?, ?> map) {
+                parameters = castMap(map);
+            }
+            Object strictValue = function.get("strict");
+            if (strictValue instanceof Boolean bool) {
+                strict = bool;
+            }
+        }
+
+        if (name == null || name.isBlank()) {
+            return null;
+        }
+        if (description == null) {
+            description = "";
+        }
+        return ToolSchema.builder()
+                .name(name)
+                .description(description)
+                .parameters(parameters != null ? parameters : Map.of("type", "object"))
+                .strict(strict)
+                .build();
+    }
+
+    private String value(Map<String, Object> map, String key, String defaultValue) {
+        Object value = map.get(key);
+        return value != null ? String.valueOf(value) : defaultValue;
+    }
+
+    private Map<String, Object> castMap(Map<?, ?> map) {
+        java.util.LinkedHashMap<String, Object> result = new java.util.LinkedHashMap<>();
+        map.forEach((key, value) -> result.put(String.valueOf(key), value));
+        return result;
+    }
+}

--- a/agentscope-extensions/agentscope-extensions-llm-interfaces-web/src/main/java/io/agentscope/core/llm/interfacesweb/responses/ResponsesUsage.java
+++ b/agentscope-extensions/agentscope-extensions-llm-interfaces-web/src/main/java/io/agentscope/core/llm/interfacesweb/responses/ResponsesUsage.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.core.llm.interfacesweb.responses;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/** Token usage in OpenAI Responses format. */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class ResponsesUsage {
+
+    @JsonProperty("input_tokens")
+    private Integer inputTokens;
+
+    @JsonProperty("output_tokens")
+    private Integer outputTokens;
+
+    @JsonProperty("total_tokens")
+    private Integer totalTokens;
+
+    public ResponsesUsage() {}
+
+    public ResponsesUsage(Integer inputTokens, Integer outputTokens) {
+        this.inputTokens = inputTokens;
+        this.outputTokens = outputTokens;
+        if (inputTokens != null || outputTokens != null) {
+            this.totalTokens =
+                    (inputTokens != null ? inputTokens : 0)
+                            + (outputTokens != null ? outputTokens : 0);
+        }
+    }
+
+    public Integer getInputTokens() {
+        return inputTokens;
+    }
+
+    public void setInputTokens(Integer inputTokens) {
+        this.inputTokens = inputTokens;
+    }
+
+    public Integer getOutputTokens() {
+        return outputTokens;
+    }
+
+    public void setOutputTokens(Integer outputTokens) {
+        this.outputTokens = outputTokens;
+    }
+
+    public Integer getTotalTokens() {
+        return totalTokens;
+    }
+
+    public void setTotalTokens(Integer totalTokens) {
+        this.totalTokens = totalTokens;
+    }
+}

--- a/agentscope-extensions/agentscope-extensions-llm-interfaces-web/src/test/java/io/agentscope/core/llm/interfacesweb/anthropic/AnthropicDtoTest.java
+++ b/agentscope-extensions/agentscope-extensions-llm-interfaces-web/src/test/java/io/agentscope/core/llm/interfacesweb/anthropic/AnthropicDtoTest.java
@@ -113,12 +113,14 @@ class AnthropicDtoTest {
     @Test
     @DisplayName("Should expose Anthropic stream event accessors")
     void shouldExposeAnthropicStreamEventAccessors() {
+        AnthropicStreamEvent defaults = new AnthropicStreamEvent();
         AnthropicStreamEvent event = new AnthropicStreamEvent("content_block_delta");
         AnthropicMessagesResponse message = new AnthropicMessagesResponse();
         AnthropicUsage usage = new AnthropicUsage(1, 2);
         Map<String, Object> contentBlock = Map.of("type", "text");
         Map<String, Object> delta = Map.of("text", "hel");
 
+        assertEquals(null, defaults.getType());
         event.setMessage(message);
         event.setIndex(0);
         event.setContentBlock(contentBlock);

--- a/agentscope-extensions/agentscope-extensions-llm-interfaces-web/src/test/java/io/agentscope/core/llm/interfacesweb/anthropic/AnthropicDtoTest.java
+++ b/agentscope-extensions/agentscope-extensions-llm-interfaces-web/src/test/java/io/agentscope/core/llm/interfacesweb/anthropic/AnthropicDtoTest.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.core.llm.interfacesweb.anthropic;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("Anthropic DTO Tests")
+class AnthropicDtoTest {
+
+    @Test
+    @DisplayName("Should expose Anthropic request accessors")
+    void shouldExposeAnthropicRequestAccessors() {
+        AnthropicMessage message = new AnthropicMessage();
+        AnthropicTool tool = new AnthropicTool();
+        AnthropicMessagesRequest request = new AnthropicMessagesRequest();
+        Map<String, Object> toolChoice = Map.of("type", "auto");
+
+        request.setModel("claude-test");
+        request.setSystem("system prompt");
+        request.setMessages(List.of(message));
+        request.setTools(List.of(tool));
+        request.setStream(true);
+        request.setMaxTokens(128);
+        request.setToolChoice(toolChoice);
+
+        assertEquals("claude-test", request.getModel());
+        assertEquals("system prompt", request.getSystem());
+        assertEquals(List.of(message), request.getMessages());
+        assertEquals(List.of(tool), request.getTools());
+        assertEquals(true, request.getStream());
+        assertEquals(128, request.getMaxTokens());
+        assertEquals(toolChoice, request.getToolChoice());
+    }
+
+    @Test
+    @DisplayName("Should expose Anthropic message and tool accessors")
+    void shouldExposeAnthropicMessageAndToolAccessors() {
+        AnthropicMessage message = new AnthropicMessage();
+        AnthropicTool tool = new AnthropicTool();
+        Map<String, Object> schema = Map.of("type", "object");
+
+        message.setRole("user");
+        message.setContent("hello");
+        tool.setName("search");
+        tool.setDescription("Search docs");
+        tool.setInputSchema(schema);
+
+        assertEquals("user", message.getRole());
+        assertEquals("hello", message.getContent());
+        assertEquals("search", tool.getName());
+        assertEquals("Search docs", tool.getDescription());
+        assertEquals(schema, tool.getInputSchema());
+    }
+
+    @Test
+    @DisplayName("Should expose Anthropic response accessors")
+    void shouldExposeAnthropicResponseAccessors() {
+        AnthropicUsage usage = new AnthropicUsage(4, 6);
+        List<Map<String, Object>> content = List.of(Map.of("type", "text", "text", "hello"));
+        AnthropicMessagesResponse response = new AnthropicMessagesResponse();
+
+        response.setId("msg_1");
+        response.setType("message");
+        response.setRole("assistant");
+        response.setModel("claude-test");
+        response.setContent(content);
+        response.setStopReason("end_turn");
+        response.setStopSequence(null);
+        response.setUsage(usage);
+
+        assertEquals("msg_1", response.getId());
+        assertEquals("message", response.getType());
+        assertEquals("assistant", response.getRole());
+        assertEquals("claude-test", response.getModel());
+        assertEquals(content, response.getContent());
+        assertEquals("end_turn", response.getStopReason());
+        assertEquals(null, response.getStopSequence());
+        assertSame(usage, response.getUsage());
+    }
+
+    @Test
+    @DisplayName("Should expose Anthropic usage accessors")
+    void shouldExposeAnthropicUsageAccessors() {
+        AnthropicUsage usage = new AnthropicUsage();
+
+        usage.setInputTokens(7);
+        usage.setOutputTokens(9);
+
+        assertEquals(7, usage.getInputTokens());
+        assertEquals(9, usage.getOutputTokens());
+        assertEquals(2, new AnthropicUsage(1, 2).getOutputTokens());
+    }
+
+    @Test
+    @DisplayName("Should expose Anthropic stream event accessors")
+    void shouldExposeAnthropicStreamEventAccessors() {
+        AnthropicStreamEvent event = new AnthropicStreamEvent("content_block_delta");
+        AnthropicMessagesResponse message = new AnthropicMessagesResponse();
+        AnthropicUsage usage = new AnthropicUsage(1, 2);
+        Map<String, Object> contentBlock = Map.of("type", "text");
+        Map<String, Object> delta = Map.of("text", "hel");
+
+        event.setMessage(message);
+        event.setIndex(0);
+        event.setContentBlock(contentBlock);
+        event.setDelta(delta);
+        event.setUsage(usage);
+        event.setStopReason("end_turn");
+
+        assertEquals("content_block_delta", event.getType());
+        assertSame(message, event.getMessage());
+        assertEquals(0, event.getIndex());
+        assertEquals(contentBlock, event.getContentBlock());
+        assertEquals(delta, event.getDelta());
+        assertSame(usage, event.getUsage());
+        assertEquals("end_turn", event.getStopReason());
+
+        event.setType("message_stop");
+        assertEquals("message_stop", event.getType());
+    }
+}

--- a/agentscope-extensions/agentscope-extensions-llm-interfaces-web/src/test/java/io/agentscope/core/llm/interfacesweb/anthropic/AnthropicMessageConverterTest.java
+++ b/agentscope-extensions/agentscope-extensions-llm-interfaces-web/src/test/java/io/agentscope/core/llm/interfacesweb/anthropic/AnthropicMessageConverterTest.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.core.llm.interfacesweb.anthropic;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.agentscope.core.llm.interfacesweb.common.ProtocolException;
+import io.agentscope.core.message.ImageBlock;
+import io.agentscope.core.message.Msg;
+import io.agentscope.core.message.MsgRole;
+import io.agentscope.core.message.TextBlock;
+import io.agentscope.core.message.ToolResultBlock;
+import io.agentscope.core.message.ToolUseBlock;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("AnthropicMessageConverter Tests")
+class AnthropicMessageConverterTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final AnthropicMessageConverter converter = new AnthropicMessageConverter();
+
+    @Test
+    @DisplayName("Should parse system prompt and message history")
+    void shouldParseSystemPromptAndMessages() throws Exception {
+        AnthropicMessagesRequest request =
+                objectMapper.readValue(
+                        """
+                        {
+                          "model": "claude-test",
+                          "system": "Be helpful",
+                          "messages": [
+                            {"role": "user", "content": "Hello"},
+                            {"role": "assistant", "content": "Hi"}
+                          ]
+                        }
+                        """,
+                        AnthropicMessagesRequest.class);
+
+        List<Msg> messages = converter.convert(request);
+
+        assertEquals(3, messages.size());
+        assertEquals(MsgRole.SYSTEM, messages.get(0).getRole());
+        assertEquals("Be helpful", messages.get(0).getTextContent());
+        assertEquals(MsgRole.USER, messages.get(1).getRole());
+        assertEquals("Hello", messages.get(1).getTextContent());
+        assertEquals(MsgRole.ASSISTANT, messages.get(2).getRole());
+        assertEquals("Hi", messages.get(2).getTextContent());
+    }
+
+    @Test
+    @DisplayName("Should parse image, tool_use, and tool_result content blocks")
+    void shouldParseToolAndImageBlocks() throws Exception {
+        AnthropicMessagesRequest request =
+                objectMapper.readValue(
+                        """
+                        {
+                          "model": "claude-test",
+                          "messages": [
+                            {
+                              "role": "assistant",
+                              "content": [
+                                {"type": "text", "text": "Checking"},
+                                {
+                                  "type": "tool_use",
+                                  "id": "toolu_1",
+                                  "name": "get_weather",
+                                  "input": {"city": "Paris"}
+                                }
+                              ]
+                            },
+                            {
+                              "role": "user",
+                              "content": [
+                                {
+                                  "type": "tool_result",
+                                  "tool_use_id": "toolu_1",
+                                  "content": "Sunny"
+                                },
+                                {
+                                  "type": "image",
+                                  "source": {
+                                    "type": "url",
+                                    "url": "https://example.com/a.png"
+                                  }
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                        """,
+                        AnthropicMessagesRequest.class);
+
+        List<Msg> messages = converter.convert(request);
+
+        assertEquals(MsgRole.ASSISTANT, messages.get(0).getRole());
+        assertEquals("Checking", ((TextBlock) messages.get(0).getContent().get(0)).getText());
+        ToolUseBlock toolUse =
+                assertInstanceOf(ToolUseBlock.class, messages.get(0).getContent().get(1));
+        assertEquals("toolu_1", toolUse.getId());
+        assertEquals("get_weather", toolUse.getName());
+        assertEquals(Map.of("city", "Paris"), toolUse.getInput());
+
+        assertEquals(MsgRole.USER, messages.get(1).getRole());
+        ToolResultBlock result =
+                assertInstanceOf(ToolResultBlock.class, messages.get(1).getContent().get(0));
+        assertEquals("toolu_1", result.getId());
+        assertEquals("Sunny", ((TextBlock) result.getOutput().get(0)).getText());
+        assertInstanceOf(ImageBlock.class, messages.get(1).getContent().get(1));
+    }
+
+    @Test
+    @DisplayName("Should reject empty Anthropic messages")
+    void shouldRejectEmptyMessages() {
+        AnthropicMessagesRequest request = new AnthropicMessagesRequest();
+
+        ProtocolException error =
+                assertThrows(ProtocolException.class, () -> converter.convert(request));
+
+        assertEquals("invalid_request_error", error.getCode());
+    }
+}

--- a/agentscope-extensions/agentscope-extensions-llm-interfaces-web/src/test/java/io/agentscope/core/llm/interfacesweb/anthropic/AnthropicMessageConverterTest.java
+++ b/agentscope-extensions/agentscope-extensions-llm-interfaces-web/src/test/java/io/agentscope/core/llm/interfacesweb/anthropic/AnthropicMessageConverterTest.java
@@ -20,6 +20,8 @@ import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.NullNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.agentscope.core.llm.interfacesweb.common.ProtocolException;
 import io.agentscope.core.message.ImageBlock;
 import io.agentscope.core.message.Msg;
@@ -177,6 +179,7 @@ class AnthropicMessageConverterTest {
                 objectMapper.readValue(
                         """
                         {
+                          "system": null,
                           "messages": [
                             {"role": "user"},
                             {"role": "tool", "content": ["plain", null]},
@@ -198,6 +201,13 @@ class AnthropicMessageConverterTest {
                             {
                               "role": "tool",
                               "content": [{"type": "tool_result", "tool_use_id": "toolu_3"}]
+                            },
+                            {
+                              "content": {"type": "custom", "payload": true}
+                            },
+                            {
+                              "role": "assistant",
+                              "content": [{"type": "image", "source": null}]
                             }
                           ]
                         }
@@ -219,6 +229,63 @@ class AnthropicMessageConverterTest {
         ToolResultBlock toolResult =
                 assertInstanceOf(ToolResultBlock.class, messages.get(5).getContent().get(0));
         assertEquals("", ((TextBlock) toolResult.getOutput().get(0)).getText());
+        assertEquals(MsgRole.USER, messages.get(6).getRole());
+        assertEquals("{\"type\":\"custom\",\"payload\":true}", messages.get(6).getTextContent());
+        assertEquals("[Unsupported image]", messages.get(7).getTextContent());
+    }
+
+    @Test
+    @DisplayName("Should ignore blank system prompt")
+    void shouldIgnoreBlankSystemPrompt() throws Exception {
+        AnthropicMessagesRequest request =
+                objectMapper.readValue(
+                        """
+                        {
+                          "system": " ",
+                          "messages": [
+                            {"role": "user", "content": "Hello"}
+                          ]
+                        }
+                        """,
+                        AnthropicMessagesRequest.class);
+
+        List<Msg> messages = converter.convert(request);
+
+        assertEquals(1, messages.size());
+        assertEquals("Hello", messages.get(0).getTextContent());
+    }
+
+    @Test
+    @DisplayName("Should parse explicit JSON null nodes")
+    void shouldParseExplicitJsonNullNodes() {
+        AnthropicMessagesRequest request = new AnthropicMessagesRequest();
+        request.setSystem(NullNode.getInstance());
+
+        AnthropicMessage emptyContent = new AnthropicMessage();
+        emptyContent.setRole("user");
+        emptyContent.setContent(List.of(NullNode.getInstance()));
+        AnthropicMessage nullNodeContent = new AnthropicMessage();
+        nullNodeContent.setRole("user");
+        nullNodeContent.setContent(NullNode.getInstance());
+
+        ObjectNode resultPart = objectMapper.createObjectNode();
+        resultPart.put("type", "tool_result");
+        resultPart.put("tool_use_id", "toolu_null");
+        resultPart.set("content", NullNode.getInstance());
+        AnthropicMessage nullResult = new AnthropicMessage();
+        nullResult.setRole("tool");
+        nullResult.setContent(List.of(resultPart));
+
+        request.setMessages(List.of(emptyContent, nullNodeContent, nullResult));
+
+        List<Msg> messages = converter.convert(request);
+
+        assertEquals(3, messages.size());
+        assertEquals("", messages.get(0).getTextContent());
+        assertEquals("", messages.get(1).getTextContent());
+        ToolResultBlock result =
+                assertInstanceOf(ToolResultBlock.class, messages.get(2).getContent().get(0));
+        assertEquals("", ((TextBlock) result.getOutput().get(0)).getText());
     }
 
     @Test

--- a/agentscope-extensions/agentscope-extensions-llm-interfaces-web/src/test/java/io/agentscope/core/llm/interfacesweb/anthropic/AnthropicMessageConverterTest.java
+++ b/agentscope-extensions/agentscope-extensions-llm-interfaces-web/src/test/java/io/agentscope/core/llm/interfacesweb/anthropic/AnthropicMessageConverterTest.java
@@ -188,8 +188,16 @@ class AnthropicMessageConverterTest {
                               }
                             },
                             {
+                              "role": "",
+                              "content": {"type": "image"}
+                            },
+                            {
                               "role": "assistant",
                               "content": [{"type": "tool_use", "id": "toolu_2", "name": "noop"}]
+                            },
+                            {
+                              "role": "tool",
+                              "content": [{"type": "tool_result", "tool_use_id": "toolu_3"}]
                             }
                           ]
                         }
@@ -202,10 +210,15 @@ class AnthropicMessageConverterTest {
         assertEquals(MsgRole.TOOL, messages.get(1).getRole());
         assertEquals("plain", ((TextBlock) messages.get(1).getContent().get(0)).getText());
         assertEquals("[Unsupported image]", messages.get(2).getTextContent());
+        assertEquals(MsgRole.USER, messages.get(3).getRole());
+        assertEquals("[Unsupported image]", messages.get(3).getTextContent());
         ToolUseBlock toolUse =
-                assertInstanceOf(ToolUseBlock.class, messages.get(3).getContent().get(0));
+                assertInstanceOf(ToolUseBlock.class, messages.get(4).getContent().get(0));
         assertEquals(Map.of(), toolUse.getInput());
         assertEquals("{}", toolUse.getContent());
+        ToolResultBlock toolResult =
+                assertInstanceOf(ToolResultBlock.class, messages.get(5).getContent().get(0));
+        assertEquals("", ((TextBlock) toolResult.getOutput().get(0)).getText());
     }
 
     @Test

--- a/agentscope-extensions/agentscope-extensions-llm-interfaces-web/src/test/java/io/agentscope/core/llm/interfacesweb/anthropic/AnthropicMessageConverterTest.java
+++ b/agentscope-extensions/agentscope-extensions-llm-interfaces-web/src/test/java/io/agentscope/core/llm/interfacesweb/anthropic/AnthropicMessageConverterTest.java
@@ -171,6 +171,44 @@ class AnthropicMessageConverterTest {
     }
 
     @Test
+    @DisplayName("Should parse null, scalar, and unsupported content shapes")
+    void shouldParseNullScalarAndUnsupportedContentShapes() throws Exception {
+        AnthropicMessagesRequest request =
+                objectMapper.readValue(
+                        """
+                        {
+                          "messages": [
+                            {"role": "user"},
+                            {"role": "tool", "content": ["plain", null]},
+                            {
+                              "role": "assistant",
+                              "content": {
+                                "type": "image",
+                                "source": {"type": "file", "file_id": "img_1"}
+                              }
+                            },
+                            {
+                              "role": "assistant",
+                              "content": [{"type": "tool_use", "id": "toolu_2", "name": "noop"}]
+                            }
+                          ]
+                        }
+                        """,
+                        AnthropicMessagesRequest.class);
+
+        List<Msg> messages = converter.convert(request);
+
+        assertEquals("", messages.get(0).getTextContent());
+        assertEquals(MsgRole.TOOL, messages.get(1).getRole());
+        assertEquals("plain", ((TextBlock) messages.get(1).getContent().get(0)).getText());
+        assertEquals("[Unsupported image]", messages.get(2).getTextContent());
+        ToolUseBlock toolUse =
+                assertInstanceOf(ToolUseBlock.class, messages.get(3).getContent().get(0));
+        assertEquals(Map.of(), toolUse.getInput());
+        assertEquals("{}", toolUse.getContent());
+    }
+
+    @Test
     @DisplayName("Should reject empty Anthropic messages")
     void shouldRejectEmptyMessages() {
         AnthropicMessagesRequest request = new AnthropicMessagesRequest();

--- a/agentscope-extensions/agentscope-extensions-llm-interfaces-web/src/test/java/io/agentscope/core/llm/interfacesweb/anthropic/AnthropicMessageConverterTest.java
+++ b/agentscope-extensions/agentscope-extensions-llm-interfaces-web/src/test/java/io/agentscope/core/llm/interfacesweb/anthropic/AnthropicMessageConverterTest.java
@@ -128,6 +128,49 @@ class AnthropicMessageConverterTest {
     }
 
     @Test
+    @DisplayName("Should parse structured system, base64 images, and unknown blocks")
+    void shouldParseStructuredSystemAndBase64Images() throws Exception {
+        AnthropicMessagesRequest request =
+                objectMapper.readValue(
+                        """
+                        {
+                          "model": "claude-test",
+                          "system": [
+                            {"type": "text", "text": "Use tools carefully"}
+                          ],
+                          "messages": [
+                            {
+                              "role": "user",
+                              "content": [
+                                {
+                                  "type": "image",
+                                  "source": {
+                                    "type": "base64",
+                                    "media_type": "image/png",
+                                    "data": "abc"
+                                  }
+                                },
+                                {
+                                  "type": "custom",
+                                  "text": "fallback"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                        """,
+                        AnthropicMessagesRequest.class);
+
+        List<Msg> messages = converter.convert(request);
+
+        assertEquals(2, messages.size());
+        assertEquals(MsgRole.SYSTEM, messages.get(0).getRole());
+        assertEquals("Use tools carefully", messages.get(0).getTextContent());
+        assertInstanceOf(ImageBlock.class, messages.get(1).getContent().get(0));
+        assertEquals("fallback", ((TextBlock) messages.get(1).getContent().get(1)).getText());
+    }
+
+    @Test
     @DisplayName("Should reject empty Anthropic messages")
     void shouldRejectEmptyMessages() {
         AnthropicMessagesRequest request = new AnthropicMessagesRequest();

--- a/agentscope-extensions/agentscope-extensions-llm-interfaces-web/src/test/java/io/agentscope/core/llm/interfacesweb/anthropic/AnthropicResponseBuilderTest.java
+++ b/agentscope-extensions/agentscope-extensions-llm-interfaces-web/src/test/java/io/agentscope/core/llm/interfacesweb/anthropic/AnthropicResponseBuilderTest.java
@@ -17,6 +17,8 @@ package io.agentscope.core.llm.interfacesweb.anthropic;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.agentscope.core.message.GenerateReason;
 import io.agentscope.core.message.MessageMetadataKeys;
@@ -79,8 +81,15 @@ class AnthropicResponseBuilderTest {
                         .textContent("partial")
                         .generateReason(GenerateReason.MAX_ITERATIONS)
                         .build();
+        Msg suspended =
+                Msg.builder()
+                        .role(MsgRole.ASSISTANT)
+                        .textContent("suspended")
+                        .generateReason(GenerateReason.TOOL_SUSPENDED)
+                        .build();
 
         assertEquals("tool_use", builder.stopReason(toolReply));
+        assertEquals("tool_use", builder.stopReason(suspended));
         assertEquals("max_tokens", builder.stopReason(maxIters));
         assertEquals("end_turn", builder.stopReason(null));
     }
@@ -89,9 +98,38 @@ class AnthropicResponseBuilderTest {
     @DisplayName("Should build Anthropic error shape")
     void shouldBuildErrorShape() {
         Map<String, Object> error = builder.buildError(new IllegalStateException("boom"));
+        Map<String, Object> fallback = builder.buildError(null);
 
         assertEquals("error", error.get("type"));
         assertNotNull(error.get("error"));
+        assertEquals("error", fallback.get("type"));
+        assertNotNull(fallback.get("error"));
+    }
+
+    @Test
+    @DisplayName("Should build empty Anthropic base response with null request")
+    void shouldBuildBaseResponseWithNullRequest() {
+        AnthropicMessagesResponse response = builder.baseResponse(null, "msg_1");
+
+        assertEquals("msg_1", response.getId());
+        assertEquals(null, response.getModel());
+        assertEquals(0, response.getUsage().getInputTokens());
+    }
+
+    @Test
+    @DisplayName("Should build Anthropic responses for null and no-usage replies")
+    void shouldBuildResponsesForNullAndNoUsageReplies() {
+        AnthropicMessagesResponse nullReply =
+                builder.buildResponse(request("claude-test"), null, "msg_null");
+        Msg noUsage = Msg.builder().role(MsgRole.ASSISTANT).textContent("Hello").build();
+        AnthropicMessagesResponse noUsageReply =
+                builder.buildResponse(request("claude-test"), noUsage, "msg_no_usage");
+
+        assertEquals("end_turn", nullReply.getStopReason());
+        assertTrue(nullReply.getContent().isEmpty());
+        assertNull(nullReply.getUsage());
+        assertEquals("end_turn", noUsageReply.getStopReason());
+        assertNull(noUsageReply.getUsage());
     }
 
     private AnthropicMessagesRequest request(String model) {

--- a/agentscope-extensions/agentscope-extensions-llm-interfaces-web/src/test/java/io/agentscope/core/llm/interfacesweb/anthropic/AnthropicResponseBuilderTest.java
+++ b/agentscope-extensions/agentscope-extensions-llm-interfaces-web/src/test/java/io/agentscope/core/llm/interfacesweb/anthropic/AnthropicResponseBuilderTest.java
@@ -82,6 +82,7 @@ class AnthropicResponseBuilderTest {
 
         assertEquals("tool_use", builder.stopReason(toolReply));
         assertEquals("max_tokens", builder.stopReason(maxIters));
+        assertEquals("end_turn", builder.stopReason(null));
     }
 
     @Test

--- a/agentscope-extensions/agentscope-extensions-llm-interfaces-web/src/test/java/io/agentscope/core/llm/interfacesweb/anthropic/AnthropicResponseBuilderTest.java
+++ b/agentscope-extensions/agentscope-extensions-llm-interfaces-web/src/test/java/io/agentscope/core/llm/interfacesweb/anthropic/AnthropicResponseBuilderTest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.core.llm.interfacesweb.anthropic;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import io.agentscope.core.message.GenerateReason;
+import io.agentscope.core.message.MessageMetadataKeys;
+import io.agentscope.core.message.Msg;
+import io.agentscope.core.message.MsgRole;
+import io.agentscope.core.message.ToolUseBlock;
+import io.agentscope.core.model.ChatUsage;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("AnthropicResponseBuilder Tests")
+class AnthropicResponseBuilderTest {
+
+    private final AnthropicResponseBuilder builder = new AnthropicResponseBuilder();
+
+    @Test
+    @DisplayName("Should build Anthropic text response with usage")
+    void shouldBuildTextResponseWithUsage() {
+        Msg reply =
+                Msg.builder()
+                        .role(MsgRole.ASSISTANT)
+                        .textContent("Hello")
+                        .metadata(
+                                Map.of(
+                                        MessageMetadataKeys.CHAT_USAGE,
+                                        ChatUsage.builder().inputTokens(2).outputTokens(4).build()))
+                        .build();
+
+        AnthropicMessagesResponse response =
+                builder.buildResponse(request("claude-test"), reply, "msg_1");
+
+        assertEquals("msg_1", response.getId());
+        assertEquals("message", response.getType());
+        assertEquals("assistant", response.getRole());
+        assertEquals("claude-test", response.getModel());
+        assertEquals("text", response.getContent().get(0).get("type"));
+        assertEquals("Hello", response.getContent().get(0).get("text"));
+        assertEquals("end_turn", response.getStopReason());
+        assertEquals(2, response.getUsage().getInputTokens());
+        assertEquals(4, response.getUsage().getOutputTokens());
+    }
+
+    @Test
+    @DisplayName("Should map stop reasons for tool use and max tokens")
+    void shouldMapStopReasons() {
+        Msg toolReply =
+                Msg.builder()
+                        .role(MsgRole.ASSISTANT)
+                        .content(
+                                ToolUseBlock.builder()
+                                        .id("toolu_1")
+                                        .name("lookup")
+                                        .input(Map.of())
+                                        .build())
+                        .build();
+        Msg maxIters =
+                Msg.builder()
+                        .role(MsgRole.ASSISTANT)
+                        .textContent("partial")
+                        .generateReason(GenerateReason.MAX_ITERATIONS)
+                        .build();
+
+        assertEquals("tool_use", builder.stopReason(toolReply));
+        assertEquals("max_tokens", builder.stopReason(maxIters));
+    }
+
+    @Test
+    @DisplayName("Should build Anthropic error shape")
+    void shouldBuildErrorShape() {
+        Map<String, Object> error = builder.buildError(new IllegalStateException("boom"));
+
+        assertEquals("error", error.get("type"));
+        assertNotNull(error.get("error"));
+    }
+
+    private AnthropicMessagesRequest request(String model) {
+        AnthropicMessagesRequest request = new AnthropicMessagesRequest();
+        request.setModel(model);
+        return request;
+    }
+}

--- a/agentscope-extensions/agentscope-extensions-llm-interfaces-web/src/test/java/io/agentscope/core/llm/interfacesweb/anthropic/AnthropicStreamingAdapterTest.java
+++ b/agentscope-extensions/agentscope-extensions-llm-interfaces-web/src/test/java/io/agentscope/core/llm/interfacesweb/anthropic/AnthropicStreamingAdapterTest.java
@@ -51,6 +51,18 @@ class AnthropicStreamingAdapterTest {
                         .role(MsgRole.ASSISTANT)
                         .content(TextBlock.builder().text("Hel").build())
                         .build();
+        Msg delta2 =
+                Msg.builder()
+                        .role(MsgRole.ASSISTANT)
+                        .content(TextBlock.builder().text("lo").build())
+                        .build();
+        TextBlock nullText = mock(TextBlock.class);
+        when(nullText.getText()).thenReturn(null);
+        Msg skippedText =
+                Msg.builder()
+                        .role(MsgRole.ASSISTANT)
+                        .content(nullText, TextBlock.builder().text("").build())
+                        .build();
         Msg finalReply =
                 Msg.builder()
                         .role(MsgRole.ASSISTANT)
@@ -60,7 +72,9 @@ class AnthropicStreamingAdapterTest {
         when(agent.stream(anyList(), any(StreamOptions.class)))
                 .thenReturn(
                         Flux.just(
+                                new Event(EventType.TOOL_RESULT, skippedText, false),
                                 new Event(EventType.REASONING, delta, false),
+                                new Event(EventType.REASONING, delta2, false),
                                 new Event(EventType.REASONING, finalReply, true)));
 
         AnthropicMessagesRequest request = new AnthropicMessagesRequest();
@@ -76,6 +90,10 @@ class AnthropicStreamingAdapterTest {
                         event ->
                                 "content_block_delta".equals(event.getType())
                                         && "Hel".equals(event.getDelta().get("text")))
+                .expectNextMatches(
+                        event ->
+                                "content_block_delta".equals(event.getType())
+                                        && "lo".equals(event.getDelta().get("text")))
                 .expectNextMatches(
                         event ->
                                 "content_block_stop".equals(event.getType())

--- a/agentscope-extensions/agentscope-extensions-llm-interfaces-web/src/test/java/io/agentscope/core/llm/interfacesweb/anthropic/AnthropicStreamingAdapterTest.java
+++ b/agentscope-extensions/agentscope-extensions-llm-interfaces-web/src/test/java/io/agentscope/core/llm/interfacesweb/anthropic/AnthropicStreamingAdapterTest.java
@@ -15,6 +15,7 @@
  */
 package io.agentscope.core.llm.interfacesweb.anthropic;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.Mockito.mock;
@@ -128,5 +129,73 @@ class AnthropicStreamingAdapterTest {
                 .expectNextMatches(event -> "message_delta".equals(event.getType()))
                 .expectNextMatches(event -> "message_stop".equals(event.getType()))
                 .verifyComplete();
+    }
+
+    @Test
+    @DisplayName("Should emit explicit tool-use JSON content")
+    void shouldEmitExplicitToolUseJsonContent() {
+        ReActAgent agent = mock(ReActAgent.class);
+        Msg toolUse =
+                Msg.builder()
+                        .role(MsgRole.ASSISTANT)
+                        .content(
+                                ToolUseBlock.builder()
+                                        .id("toolu_1")
+                                        .name("lookup")
+                                        .input(Map.of("ignored", true))
+                                        .content("{\"city\":\"Paris\"}")
+                                        .build())
+                        .build();
+
+        when(agent.stream(anyList(), any(StreamOptions.class)))
+                .thenReturn(Flux.just(new Event(EventType.REASONING, toolUse, true)));
+
+        AnthropicMessagesRequest request = new AnthropicMessagesRequest();
+        request.setModel("claude-test");
+
+        StepVerifier.create(adapter.stream(agent, List.of(toolUse), request, "msg_1"))
+                .expectNextMatches(event -> "message_start".equals(event.getType()))
+                .expectNextMatches(event -> "content_block_start".equals(event.getType()))
+                .expectNextMatches(
+                        event ->
+                                "content_block_delta".equals(event.getType())
+                                        && "{\"city\":\"Paris\"}"
+                                                .equals(event.getDelta().get("partial_json")))
+                .expectNextMatches(event -> "content_block_stop".equals(event.getType()))
+                .expectNextMatches(event -> "message_delta".equals(event.getType()))
+                .expectNextMatches(event -> "message_stop".equals(event.getType()))
+                .verifyComplete();
+    }
+
+    @Test
+    @DisplayName("Should ignore stream events without messages")
+    void shouldIgnoreStreamEventsWithoutMessages() {
+        ReActAgent agent = mock(ReActAgent.class);
+        Msg emptyMessage = mock(Msg.class);
+        when(emptyMessage.getContent()).thenReturn(null);
+        when(agent.stream(anyList(), any(StreamOptions.class)))
+                .thenReturn(
+                        Flux.just(
+                                new Event(EventType.REASONING, null, false),
+                                new Event(EventType.REASONING, emptyMessage, false)));
+
+        AnthropicMessagesRequest request = new AnthropicMessagesRequest();
+
+        StepVerifier.create(adapter.stream(agent, List.of(), request, "msg_1"))
+                .expectNextMatches(event -> "message_start".equals(event.getType()))
+                .verifyComplete();
+    }
+
+    @Test
+    @DisplayName("Should build Anthropic stream error events")
+    void shouldBuildErrorEvents() {
+        AnthropicStreamEvent known = adapter.errorEvent(new RuntimeException("boom"));
+        AnthropicStreamEvent unknown = adapter.errorEvent(null);
+
+        assertEquals("error", known.getType());
+        assertEquals("boom", ((Map<?, ?>) known.getDelta().get("error")).get("message"));
+        assertEquals(
+                "Unknown error occurred",
+                ((Map<?, ?>) unknown.getDelta().get("error")).get("message"));
     }
 }

--- a/agentscope-extensions/agentscope-extensions-llm-interfaces-web/src/test/java/io/agentscope/core/llm/interfacesweb/anthropic/AnthropicStreamingAdapterTest.java
+++ b/agentscope-extensions/agentscope-extensions-llm-interfaces-web/src/test/java/io/agentscope/core/llm/interfacesweb/anthropic/AnthropicStreamingAdapterTest.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.core.llm.interfacesweb.anthropic;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.agentscope.core.ReActAgent;
+import io.agentscope.core.agent.Event;
+import io.agentscope.core.agent.EventType;
+import io.agentscope.core.agent.StreamOptions;
+import io.agentscope.core.message.Msg;
+import io.agentscope.core.message.MsgRole;
+import io.agentscope.core.message.TextBlock;
+import io.agentscope.core.message.ToolUseBlock;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Flux;
+import reactor.test.StepVerifier;
+
+@DisplayName("AnthropicStreamingAdapter Tests")
+class AnthropicStreamingAdapterTest {
+
+    private final AnthropicStreamingAdapter adapter =
+            new AnthropicStreamingAdapter(new AnthropicResponseBuilder());
+
+    @Test
+    @DisplayName("Should emit Anthropic text stream event order")
+    void shouldEmitTextStreamEventOrder() {
+        ReActAgent agent = mock(ReActAgent.class);
+        Msg delta =
+                Msg.builder()
+                        .role(MsgRole.ASSISTANT)
+                        .content(TextBlock.builder().text("Hel").build())
+                        .build();
+        Msg finalReply =
+                Msg.builder()
+                        .role(MsgRole.ASSISTANT)
+                        .content(TextBlock.builder().text("Hello").build())
+                        .build();
+
+        when(agent.stream(anyList(), any(StreamOptions.class)))
+                .thenReturn(
+                        Flux.just(
+                                new Event(EventType.REASONING, delta, false),
+                                new Event(EventType.REASONING, finalReply, true)));
+
+        AnthropicMessagesRequest request = new AnthropicMessagesRequest();
+        request.setModel("claude-test");
+
+        StepVerifier.create(adapter.stream(agent, List.of(delta), request, "msg_1"))
+                .expectNextMatches(event -> "message_start".equals(event.getType()))
+                .expectNextMatches(
+                        event ->
+                                "content_block_start".equals(event.getType())
+                                        && event.getIndex() == 0)
+                .expectNextMatches(
+                        event ->
+                                "content_block_delta".equals(event.getType())
+                                        && "Hel".equals(event.getDelta().get("text")))
+                .expectNextMatches(
+                        event ->
+                                "content_block_stop".equals(event.getType())
+                                        && event.getIndex() == 0)
+                .expectNextMatches(
+                        event ->
+                                "message_delta".equals(event.getType())
+                                        && "end_turn".equals(event.getDelta().get("stop_reason")))
+                .expectNextMatches(event -> "message_stop".equals(event.getType()))
+                .verifyComplete();
+    }
+
+    @Test
+    @DisplayName("Should start first tool-use block at index zero when there is no text")
+    void shouldStartToolBlockAtZeroWhenNoText() {
+        ReActAgent agent = mock(ReActAgent.class);
+        Msg toolUse =
+                Msg.builder()
+                        .role(MsgRole.ASSISTANT)
+                        .content(
+                                ToolUseBlock.builder()
+                                        .id("toolu_1")
+                                        .name("lookup")
+                                        .input(Map.of("city", "Paris"))
+                                        .build())
+                        .build();
+
+        when(agent.stream(anyList(), any(StreamOptions.class)))
+                .thenReturn(Flux.just(new Event(EventType.REASONING, toolUse, true)));
+
+        AnthropicMessagesRequest request = new AnthropicMessagesRequest();
+        request.setModel("claude-test");
+
+        StepVerifier.create(adapter.stream(agent, List.of(toolUse), request, "msg_1"))
+                .expectNextMatches(event -> "message_start".equals(event.getType()))
+                .expectNextMatches(
+                        event ->
+                                "content_block_start".equals(event.getType())
+                                        && event.getIndex() == 0
+                                        && "tool_use".equals(event.getContentBlock().get("type")))
+                .expectNextMatches(
+                        event ->
+                                "content_block_delta".equals(event.getType())
+                                        && event.getIndex() == 0
+                                        && "{\"city\":\"Paris\"}"
+                                                .equals(event.getDelta().get("partial_json")))
+                .expectNextMatches(
+                        event ->
+                                "content_block_stop".equals(event.getType())
+                                        && event.getIndex() == 0)
+                .expectNextMatches(event -> "message_delta".equals(event.getType()))
+                .expectNextMatches(event -> "message_stop".equals(event.getType()))
+                .verifyComplete();
+    }
+}

--- a/agentscope-extensions/agentscope-extensions-llm-interfaces-web/src/test/java/io/agentscope/core/llm/interfacesweb/anthropic/AnthropicToolConverterTest.java
+++ b/agentscope-extensions/agentscope-extensions-llm-interfaces-web/src/test/java/io/agentscope/core/llm/interfacesweb/anthropic/AnthropicToolConverterTest.java
@@ -16,8 +16,10 @@
 package io.agentscope.core.llm.interfacesweb.anthropic;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.agentscope.core.model.ToolSchema;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.DisplayName;
@@ -39,6 +41,24 @@ class AnthropicToolConverterTest {
         assertEquals(1, schemas.size());
         assertEquals("get_weather", schemas.get(0).getName());
         assertEquals("Get weather", schemas.get(0).getDescription());
+        assertEquals(Map.of("type", "object"), schemas.get(0).getParameters());
+    }
+
+    @Test
+    @DisplayName("Should skip invalid tools and apply defaults")
+    void shouldSkipInvalidToolsAndApplyDefaults() {
+        AnthropicTool minimal = new AnthropicTool();
+        minimal.setName("lookup");
+        AnthropicTool blank = new AnthropicTool();
+        blank.setName(" ");
+
+        List<ToolSchema> schemas =
+                new AnthropicToolConverter().convert(Arrays.asList(null, blank, minimal));
+
+        assertTrue(new AnthropicToolConverter().convert(null).isEmpty());
+        assertTrue(new AnthropicToolConverter().convert(List.of()).isEmpty());
+        assertEquals(1, schemas.size());
+        assertEquals("", schemas.get(0).getDescription());
         assertEquals(Map.of("type", "object"), schemas.get(0).getParameters());
     }
 }

--- a/agentscope-extensions/agentscope-extensions-llm-interfaces-web/src/test/java/io/agentscope/core/llm/interfacesweb/anthropic/AnthropicToolConverterTest.java
+++ b/agentscope-extensions/agentscope-extensions-llm-interfaces-web/src/test/java/io/agentscope/core/llm/interfacesweb/anthropic/AnthropicToolConverterTest.java
@@ -51,9 +51,10 @@ class AnthropicToolConverterTest {
         minimal.setName("lookup");
         AnthropicTool blank = new AnthropicTool();
         blank.setName(" ");
+        AnthropicTool missing = new AnthropicTool();
 
         List<ToolSchema> schemas =
-                new AnthropicToolConverter().convert(Arrays.asList(null, blank, minimal));
+                new AnthropicToolConverter().convert(Arrays.asList(null, blank, missing, minimal));
 
         assertTrue(new AnthropicToolConverter().convert(null).isEmpty());
         assertTrue(new AnthropicToolConverter().convert(List.of()).isEmpty());

--- a/agentscope-extensions/agentscope-extensions-llm-interfaces-web/src/test/java/io/agentscope/core/llm/interfacesweb/anthropic/AnthropicToolConverterTest.java
+++ b/agentscope-extensions/agentscope-extensions-llm-interfaces-web/src/test/java/io/agentscope/core/llm/interfacesweb/anthropic/AnthropicToolConverterTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.core.llm.interfacesweb.anthropic;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import io.agentscope.core.model.ToolSchema;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("AnthropicToolConverter Tests")
+class AnthropicToolConverterTest {
+
+    @Test
+    @DisplayName("Should convert Anthropic tools to AgentScope tool schemas")
+    void shouldConvertAnthropicTools() {
+        AnthropicTool tool = new AnthropicTool();
+        tool.setName("get_weather");
+        tool.setDescription("Get weather");
+        tool.setInputSchema(Map.of("type", "object"));
+
+        List<ToolSchema> schemas = new AnthropicToolConverter().convert(List.of(tool));
+
+        assertEquals(1, schemas.size());
+        assertEquals("get_weather", schemas.get(0).getName());
+        assertEquals("Get weather", schemas.get(0).getDescription());
+        assertEquals(Map.of("type", "object"), schemas.get(0).getParameters());
+    }
+}

--- a/agentscope-extensions/agentscope-extensions-llm-interfaces-web/src/test/java/io/agentscope/core/llm/interfacesweb/common/ProtocolJsonUtilsTest.java
+++ b/agentscope-extensions/agentscope-extensions-llm-interfaces-web/src/test/java/io/agentscope/core/llm/interfacesweb/common/ProtocolJsonUtilsTest.java
@@ -23,6 +23,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.NullNode;
 import java.util.Map;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -38,7 +39,9 @@ class ProtocolJsonUtilsTest {
         assertTrue(ProtocolJsonUtils.parseObject("{bad").isEmpty());
         assertEquals("Paris", ProtocolJsonUtils.parseObject("{\"city\":\"Paris\"}").get("city"));
 
+        assertTrue(ProtocolJsonUtils.parseRequiredObject(null, "arguments").isEmpty());
         assertTrue(ProtocolJsonUtils.parseRequiredObject("", "arguments").isEmpty());
+        assertTrue(ProtocolJsonUtils.parseRequiredObject(" ", "arguments").isEmpty());
         assertEquals(3, ProtocolJsonUtils.parseRequiredObject("{\"n\":3}", "arguments").get("n"));
 
         ProtocolException error =
@@ -56,16 +59,21 @@ class ProtocolJsonUtilsTest {
         assertTrue(ProtocolJsonUtils.toMap(null).isEmpty());
 
         JsonNode node = ProtocolJsonUtils.OBJECT_MAPPER.readTree("{\"enabled\":true}");
+        JsonNode falseNode = ProtocolJsonUtils.OBJECT_MAPPER.readTree("{\"enabled\":false}");
+        JsonNode nullNode = ProtocolJsonUtils.OBJECT_MAPPER.readTree("{\"name\":null}");
         assertSame(node, ProtocolJsonUtils.toJsonNode(node));
         assertNull(ProtocolJsonUtils.toJsonNode(null));
         assertTrue(ProtocolJsonUtils.truthy(node, "enabled"));
+        assertFalse(ProtocolJsonUtils.truthy(falseNode, "enabled"));
         assertFalse(ProtocolJsonUtils.truthy(null, "enabled"));
         assertFalse(ProtocolJsonUtils.truthy(node, "missing"));
 
         JsonNode objectNode = ProtocolJsonUtils.toJsonNode(Map.of("name", "lookup"));
         assertEquals("lookup", ProtocolJsonUtils.textValue(objectNode, "name"));
         assertNull(ProtocolJsonUtils.textValue(null, "name"));
+        assertNull(ProtocolJsonUtils.textValue(nullNode, "name"));
         assertNull(ProtocolJsonUtils.textValue(objectNode, "missing"));
+        assertSame(NullNode.getInstance(), ProtocolJsonUtils.toJsonNode(NullNode.getInstance()));
     }
 
     @Test

--- a/agentscope-extensions/agentscope-extensions-llm-interfaces-web/src/test/java/io/agentscope/core/llm/interfacesweb/common/ProtocolJsonUtilsTest.java
+++ b/agentscope-extensions/agentscope-extensions-llm-interfaces-web/src/test/java/io/agentscope/core/llm/interfacesweb/common/ProtocolJsonUtilsTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.core.llm.interfacesweb.common;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("ProtocolJsonUtils Tests")
+class ProtocolJsonUtilsTest {
+
+    @Test
+    @DisplayName("Should parse optional and required JSON objects")
+    void shouldParseOptionalAndRequiredObjects() {
+        assertTrue(ProtocolJsonUtils.parseObject(null).isEmpty());
+        assertTrue(ProtocolJsonUtils.parseObject(" ").isEmpty());
+        assertTrue(ProtocolJsonUtils.parseObject("{bad").isEmpty());
+        assertEquals("Paris", ProtocolJsonUtils.parseObject("{\"city\":\"Paris\"}").get("city"));
+
+        assertTrue(ProtocolJsonUtils.parseRequiredObject("", "arguments").isEmpty());
+        assertEquals(3, ProtocolJsonUtils.parseRequiredObject("{\"n\":3}", "arguments").get("n"));
+
+        ProtocolException error =
+                assertThrows(
+                        ProtocolException.class,
+                        () -> ProtocolJsonUtils.parseRequiredObject("{bad", "arguments"));
+        assertEquals("invalid_request_error", error.getCode());
+    }
+
+    @Test
+    @DisplayName("Should normalize dynamic JSON values")
+    void shouldNormalizeDynamicJsonValues() throws Exception {
+        Map<String, Object> map = ProtocolJsonUtils.toMap(Map.of(7, "seven"));
+        assertEquals("seven", map.get("7"));
+        assertTrue(ProtocolJsonUtils.toMap(null).isEmpty());
+
+        JsonNode node = ProtocolJsonUtils.OBJECT_MAPPER.readTree("{\"enabled\":true}");
+        assertSame(node, ProtocolJsonUtils.toJsonNode(node));
+        assertNull(ProtocolJsonUtils.toJsonNode(null));
+        assertTrue(ProtocolJsonUtils.truthy(node, "enabled"));
+        assertFalse(ProtocolJsonUtils.truthy(node, "missing"));
+
+        JsonNode objectNode = ProtocolJsonUtils.toJsonNode(Map.of("name", "lookup"));
+        assertEquals("lookup", ProtocolJsonUtils.textValue(objectNode, "name"));
+        assertNull(ProtocolJsonUtils.textValue(objectNode, "missing"));
+    }
+
+    @Test
+    @DisplayName("Should serialize dynamic JSON values")
+    void shouldSerializeDynamicJsonValues() {
+        assertEquals("{}", ProtocolJsonUtils.toJson(null));
+        assertEquals("{\"raw\":true}", ProtocolJsonUtils.toJson("{\"raw\":true}"));
+        assertEquals("{\"a\":1}", ProtocolJsonUtils.toJson(Map.of("a", 1)));
+    }
+}

--- a/agentscope-extensions/agentscope-extensions-llm-interfaces-web/src/test/java/io/agentscope/core/llm/interfacesweb/common/ProtocolJsonUtilsTest.java
+++ b/agentscope-extensions/agentscope-extensions-llm-interfaces-web/src/test/java/io/agentscope/core/llm/interfacesweb/common/ProtocolJsonUtilsTest.java
@@ -59,10 +59,12 @@ class ProtocolJsonUtilsTest {
         assertSame(node, ProtocolJsonUtils.toJsonNode(node));
         assertNull(ProtocolJsonUtils.toJsonNode(null));
         assertTrue(ProtocolJsonUtils.truthy(node, "enabled"));
+        assertFalse(ProtocolJsonUtils.truthy(null, "enabled"));
         assertFalse(ProtocolJsonUtils.truthy(node, "missing"));
 
         JsonNode objectNode = ProtocolJsonUtils.toJsonNode(Map.of("name", "lookup"));
         assertEquals("lookup", ProtocolJsonUtils.textValue(objectNode, "name"));
+        assertNull(ProtocolJsonUtils.textValue(null, "name"));
         assertNull(ProtocolJsonUtils.textValue(objectNode, "missing"));
     }
 
@@ -72,5 +74,6 @@ class ProtocolJsonUtilsTest {
         assertEquals("{}", ProtocolJsonUtils.toJson(null));
         assertEquals("{\"raw\":true}", ProtocolJsonUtils.toJson("{\"raw\":true}"));
         assertEquals("{\"a\":1}", ProtocolJsonUtils.toJson(Map.of("a", 1)));
+        assertEquals("{}", ProtocolJsonUtils.toJson(new Object()));
     }
 }

--- a/agentscope-extensions/agentscope-extensions-llm-interfaces-web/src/test/java/io/agentscope/core/llm/interfacesweb/common/ProtocolMessageUtilsTest.java
+++ b/agentscope-extensions/agentscope-extensions-llm-interfaces-web/src/test/java/io/agentscope/core/llm/interfacesweb/common/ProtocolMessageUtilsTest.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.core.llm.interfacesweb.common;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.agentscope.core.message.Base64Source;
+import io.agentscope.core.message.ImageBlock;
+import io.agentscope.core.message.Msg;
+import io.agentscope.core.message.MsgRole;
+import io.agentscope.core.message.TextBlock;
+import io.agentscope.core.message.ThinkingBlock;
+import io.agentscope.core.message.ToolResultBlock;
+import io.agentscope.core.message.ToolUseBlock;
+import io.agentscope.core.message.URLSource;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("ProtocolMessageUtils Tests")
+class ProtocolMessageUtilsTest {
+
+    @Test
+    @DisplayName("Should create and read text messages safely")
+    void shouldCreateAndReadTextMessagesSafely() {
+        Msg text = ProtocolMessageUtils.textMessage(MsgRole.USER, null);
+
+        assertEquals(MsgRole.USER, text.getRole());
+        assertEquals("", ProtocolMessageUtils.textContent(text));
+        assertEquals("", ProtocolMessageUtils.textContent(null));
+        assertTrue(ProtocolMessageUtils.contentParts(null, false).isEmpty());
+    }
+
+    @Test
+    @DisplayName("Should convert content blocks to Responses-style parts")
+    void shouldConvertContentBlocksToResponsesParts() {
+        Msg message =
+                ProtocolMessageUtils.message(
+                        MsgRole.ASSISTANT,
+                        List.of(
+                                TextBlock.builder().text("hello").build(),
+                                ThinkingBlock.builder().thinking("reasoning").build(),
+                                ImageBlock.builder()
+                                        .source(
+                                                URLSource.builder()
+                                                        .url("https://example.com/a.png")
+                                                        .build())
+                                        .build(),
+                                ToolUseBlock.builder()
+                                        .id("call_1")
+                                        .name("lookup")
+                                        .input(Map.of("q", "Paris"))
+                                        .build(),
+                                ToolResultBlock.builder()
+                                        .id("call_1")
+                                        .name("lookup")
+                                        .output(TextBlock.builder().text("Sunny").build())
+                                        .build()));
+
+        List<Map<String, Object>> parts = ProtocolMessageUtils.contentParts(message, false);
+
+        assertEquals("hello", parts.get(0).get("text"));
+        assertEquals("reasoning", parts.get(1).get("thinking"));
+        assertEquals("input_image", parts.get(2).get("type"));
+        assertEquals("https://example.com/a.png", parts.get(2).get("image_url"));
+        assertEquals(Map.of("q", "Paris"), parts.get(3).get("input"));
+        assertEquals("Sunny", parts.get(4).get("content"));
+    }
+
+    @Test
+    @DisplayName("Should convert image blocks to Anthropic-style parts")
+    void shouldConvertImageBlocksToAnthropicParts() {
+        Msg message =
+                ProtocolMessageUtils.message(
+                        MsgRole.USER,
+                        List.of(
+                                ImageBlock.builder()
+                                        .source(
+                                                Base64Source.builder()
+                                                        .mediaType("image/png")
+                                                        .data("abc")
+                                                        .build())
+                                        .build(),
+                                ImageBlock.builder()
+                                        .source(
+                                                URLSource.builder()
+                                                        .url("https://example.com/a.png")
+                                                        .build())
+                                        .build()));
+
+        List<Map<String, Object>> parts = ProtocolMessageUtils.contentParts(message, true);
+
+        Map<?, ?> base64Source = (Map<?, ?>) parts.get(0).get("source");
+        assertEquals("base64", base64Source.get("type"));
+        assertEquals("image/png", base64Source.get("media_type"));
+        assertEquals("abc", base64Source.get("data"));
+
+        Map<?, ?> urlSource = (Map<?, ?>) parts.get(1).get("source");
+        assertEquals("url", urlSource.get("type"));
+        assertEquals("https://example.com/a.png", urlSource.get("url"));
+    }
+
+    @Test
+    @DisplayName("Should handle tool result text fallbacks")
+    void shouldHandleToolResultTextFallbacks() {
+        assertEquals("", ProtocolMessageUtils.toolResultText(null));
+        assertEquals(
+                "",
+                ProtocolMessageUtils.toolResultText(
+                        ToolResultBlock.builder()
+                                .output(ThinkingBlock.builder().thinking("internal").build())
+                                .build()));
+    }
+}

--- a/agentscope-extensions/agentscope-extensions-llm-interfaces-web/src/test/java/io/agentscope/core/llm/interfacesweb/common/ProtocolMessageUtilsTest.java
+++ b/agentscope-extensions/agentscope-extensions-llm-interfaces-web/src/test/java/io/agentscope/core/llm/interfacesweb/common/ProtocolMessageUtilsTest.java
@@ -22,6 +22,7 @@ import io.agentscope.core.message.Base64Source;
 import io.agentscope.core.message.ImageBlock;
 import io.agentscope.core.message.Msg;
 import io.agentscope.core.message.MsgRole;
+import io.agentscope.core.message.Source;
 import io.agentscope.core.message.TextBlock;
 import io.agentscope.core.message.ThinkingBlock;
 import io.agentscope.core.message.ToolResultBlock;
@@ -44,6 +45,9 @@ class ProtocolMessageUtilsTest {
         assertEquals("", ProtocolMessageUtils.textContent(text));
         assertEquals("", ProtocolMessageUtils.textContent(null));
         assertTrue(ProtocolMessageUtils.contentParts(null, false).isEmpty());
+        assertTrue(
+                ProtocolMessageUtils.contentParts(Msg.builder().role(MsgRole.USER).build(), false)
+                        .isEmpty());
     }
 
     @Test
@@ -80,6 +84,30 @@ class ProtocolMessageUtilsTest {
         assertEquals("https://example.com/a.png", parts.get(2).get("image_url"));
         assertEquals(Map.of("q", "Paris"), parts.get(3).get("input"));
         assertEquals("Sunny", parts.get(4).get("content"));
+    }
+
+    @Test
+    @DisplayName("Should convert fallback content parts")
+    void shouldConvertFallbackContentParts() {
+        Msg message =
+                ProtocolMessageUtils.message(
+                        MsgRole.USER,
+                        List.of(
+                                ToolUseBlock.builder().id("call_1").name("lookup").build(),
+                                ImageBlock.builder()
+                                        .source(
+                                                Base64Source.builder()
+                                                        .mediaType("image/png")
+                                                        .data("abc")
+                                                        .build())
+                                        .build(),
+                                ImageBlock.builder().source(new Source()).build()));
+
+        List<Map<String, Object>> parts = ProtocolMessageUtils.contentParts(message, false);
+
+        assertEquals(Map.of(), parts.get(0).get("input"));
+        assertEquals("data:image/png;base64,abc", parts.get(1).get("image_url"));
+        assertEquals("[Unsupported image source]", parts.get(2).get("text"));
     }
 
     @Test

--- a/agentscope-extensions/agentscope-extensions-llm-interfaces-web/src/test/java/io/agentscope/core/llm/interfacesweb/common/ProtocolMessageUtilsTest.java
+++ b/agentscope-extensions/agentscope-extensions-llm-interfaces-web/src/test/java/io/agentscope/core/llm/interfacesweb/common/ProtocolMessageUtilsTest.java
@@ -17,6 +17,8 @@ package io.agentscope.core.llm.interfacesweb.common;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import io.agentscope.core.message.Base64Source;
 import io.agentscope.core.message.ImageBlock;
@@ -44,7 +46,11 @@ class ProtocolMessageUtilsTest {
         assertEquals(MsgRole.USER, text.getRole());
         assertEquals("", ProtocolMessageUtils.textContent(text));
         assertEquals("", ProtocolMessageUtils.textContent(null));
+        Msg nullContent = mock(Msg.class);
+        when(nullContent.getContent()).thenReturn(null);
+        assertEquals("", ProtocolMessageUtils.textContent(nullContent));
         assertTrue(ProtocolMessageUtils.contentParts(null, false).isEmpty());
+        assertTrue(ProtocolMessageUtils.contentParts(nullContent, false).isEmpty());
         assertTrue(
                 ProtocolMessageUtils.contentParts(Msg.builder().role(MsgRole.USER).build(), false)
                         .isEmpty());
@@ -146,7 +152,11 @@ class ProtocolMessageUtilsTest {
     @Test
     @DisplayName("Should handle tool result text fallbacks")
     void shouldHandleToolResultTextFallbacks() {
+        ToolResultBlock nullOutput = mock(ToolResultBlock.class);
+        when(nullOutput.getOutput()).thenReturn(null);
+
         assertEquals("", ProtocolMessageUtils.toolResultText(null));
+        assertEquals("", ProtocolMessageUtils.toolResultText(nullOutput));
         assertEquals(
                 "",
                 ProtocolMessageUtils.toolResultText(

--- a/agentscope-extensions/agentscope-extensions-llm-interfaces-web/src/test/java/io/agentscope/core/llm/interfacesweb/responses/ResponsesDtoTest.java
+++ b/agentscope-extensions/agentscope-extensions-llm-interfaces-web/src/test/java/io/agentscope/core/llm/interfacesweb/responses/ResponsesDtoTest.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.core.llm.interfacesweb.responses;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("Responses DTO Tests")
+class ResponsesDtoTest {
+
+    @Test
+    @DisplayName("Should expose Responses output content accessors")
+    void shouldExposeResponsesOutputContentAccessors() {
+        ResponsesOutputContent content = new ResponsesOutputContent("output_text", "hello");
+
+        assertEquals("output_text", content.getType());
+        assertEquals("hello", content.getText());
+
+        content.setType("summary_text");
+        content.setText("summary");
+
+        assertEquals("summary_text", content.getType());
+        assertEquals("summary", content.getText());
+    }
+
+    @Test
+    @DisplayName("Should expose Responses output item accessors")
+    void shouldExposeResponsesOutputItemAccessors() {
+        ResponsesOutputContent content = new ResponsesOutputContent("output_text", "hello");
+        ResponsesOutputItem item = new ResponsesOutputItem();
+
+        item.setId("item_1");
+        item.setType("message");
+        item.setStatus("completed");
+        item.setRole("assistant");
+        item.setContent(List.of(content));
+        item.setName("lookup");
+        item.setArguments("{\"q\":\"weather\"}");
+        item.setCallId("call_1");
+
+        assertEquals("item_1", item.getId());
+        assertEquals("message", item.getType());
+        assertEquals("completed", item.getStatus());
+        assertEquals("assistant", item.getRole());
+        assertEquals(List.of(content), item.getContent());
+        assertEquals("lookup", item.getName());
+        assertEquals("{\"q\":\"weather\"}", item.getArguments());
+        assertEquals("call_1", item.getCallId());
+    }
+
+    @Test
+    @DisplayName("Should expose Responses response accessors")
+    void shouldExposeResponsesResponseAccessors() {
+        ResponsesOutputItem item = new ResponsesOutputItem();
+        ResponsesUsage usage = new ResponsesUsage(3, 5);
+        ResponsesResponse response = new ResponsesResponse();
+
+        response.setId("resp_1");
+        response.setObject("response");
+        response.setStatus("completed");
+        response.setModel("test-model");
+        response.setOutput(List.of(item));
+        response.setUsage(usage);
+        response.setError(Map.of("type", "none"));
+        response.setCreatedAt(42L);
+        response.setOutputText("hello");
+
+        assertEquals("resp_1", response.getId());
+        assertEquals("response", response.getObject());
+        assertEquals("completed", response.getStatus());
+        assertEquals("test-model", response.getModel());
+        assertEquals(List.of(item), response.getOutput());
+        assertSame(usage, response.getUsage());
+        assertEquals(Map.of("type", "none"), response.getError());
+        assertEquals(42L, response.getCreatedAt());
+        assertEquals("hello", response.getOutputText());
+    }
+
+    @Test
+    @DisplayName("Should calculate Responses usage totals")
+    void shouldCalculateResponsesUsageTotals() {
+        ResponsesUsage both = new ResponsesUsage(3, 5);
+        ResponsesUsage inputOnly = new ResponsesUsage(3, null);
+        ResponsesUsage outputOnly = new ResponsesUsage(null, 5);
+        ResponsesUsage empty = new ResponsesUsage(null, null);
+
+        assertEquals(8, both.getTotalTokens());
+        assertEquals(3, inputOnly.getTotalTokens());
+        assertEquals(5, outputOnly.getTotalTokens());
+        assertNull(empty.getTotalTokens());
+
+        empty.setInputTokens(7);
+        empty.setOutputTokens(11);
+        empty.setTotalTokens(18);
+
+        assertEquals(7, empty.getInputTokens());
+        assertEquals(11, empty.getOutputTokens());
+        assertEquals(18, empty.getTotalTokens());
+    }
+
+    @Test
+    @DisplayName("Should expose Responses stream event accessors")
+    void shouldExposeResponsesStreamEventAccessors() {
+        ResponsesStreamEvent event = new ResponsesStreamEvent("response.output_text.delta");
+        ResponsesResponse response = new ResponsesResponse();
+        ResponsesOutputItem item = new ResponsesOutputItem();
+        Map<String, Object> error = Map.of("message", "boom");
+
+        event.setResponse(response);
+        event.setItem(item);
+        event.setDelta("hel");
+        event.setError(error);
+        event.setResponseId("resp_1");
+        event.setOutputIndex(1);
+        event.setContentIndex(2);
+        event.setItemId("item_1");
+
+        assertEquals("response.output_text.delta", event.getType());
+        assertSame(response, event.getResponse());
+        assertSame(item, event.getItem());
+        assertEquals("hel", event.getDelta());
+        assertEquals(error, event.getError());
+        assertEquals("resp_1", event.getResponseId());
+        assertEquals(1, event.getOutputIndex());
+        assertEquals(2, event.getContentIndex());
+        assertEquals("item_1", event.getItemId());
+
+        event.setType("response.completed");
+        assertEquals("response.completed", event.getType());
+    }
+}

--- a/agentscope-extensions/agentscope-extensions-llm-interfaces-web/src/test/java/io/agentscope/core/llm/interfacesweb/responses/ResponsesDtoTest.java
+++ b/agentscope-extensions/agentscope-extensions-llm-interfaces-web/src/test/java/io/agentscope/core/llm/interfacesweb/responses/ResponsesDtoTest.java
@@ -30,8 +30,10 @@ class ResponsesDtoTest {
     @Test
     @DisplayName("Should expose Responses output content accessors")
     void shouldExposeResponsesOutputContentAccessors() {
+        ResponsesOutputContent defaults = new ResponsesOutputContent();
         ResponsesOutputContent content = new ResponsesOutputContent("output_text", "hello");
 
+        assertNull(defaults.getType());
         assertEquals("output_text", content.getType());
         assertEquals("hello", content.getText());
 
@@ -98,11 +100,13 @@ class ResponsesDtoTest {
     @Test
     @DisplayName("Should calculate Responses usage totals")
     void shouldCalculateResponsesUsageTotals() {
+        ResponsesUsage defaults = new ResponsesUsage();
         ResponsesUsage both = new ResponsesUsage(3, 5);
         ResponsesUsage inputOnly = new ResponsesUsage(3, null);
         ResponsesUsage outputOnly = new ResponsesUsage(null, 5);
         ResponsesUsage empty = new ResponsesUsage(null, null);
 
+        assertNull(defaults.getInputTokens());
         assertEquals(8, both.getTotalTokens());
         assertEquals(3, inputOnly.getTotalTokens());
         assertEquals(5, outputOnly.getTotalTokens());
@@ -120,11 +124,13 @@ class ResponsesDtoTest {
     @Test
     @DisplayName("Should expose Responses stream event accessors")
     void shouldExposeResponsesStreamEventAccessors() {
+        ResponsesStreamEvent defaults = new ResponsesStreamEvent();
         ResponsesStreamEvent event = new ResponsesStreamEvent("response.output_text.delta");
         ResponsesResponse response = new ResponsesResponse();
         ResponsesOutputItem item = new ResponsesOutputItem();
         Map<String, Object> error = Map.of("message", "boom");
 
+        assertNull(defaults.getType());
         event.setResponse(response);
         event.setItem(item);
         event.setDelta("hel");

--- a/agentscope-extensions/agentscope-extensions-llm-interfaces-web/src/test/java/io/agentscope/core/llm/interfacesweb/responses/ResponsesMessageConverterTest.java
+++ b/agentscope-extensions/agentscope-extensions-llm-interfaces-web/src/test/java/io/agentscope/core/llm/interfacesweb/responses/ResponsesMessageConverterTest.java
@@ -20,6 +20,9 @@ import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.NullNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.agentscope.core.llm.interfacesweb.common.ProtocolException;
 import io.agentscope.core.message.ImageBlock;
 import io.agentscope.core.message.Msg;
@@ -27,6 +30,7 @@ import io.agentscope.core.message.MsgRole;
 import io.agentscope.core.message.TextBlock;
 import io.agentscope.core.message.ToolResultBlock;
 import io.agentscope.core.message.ToolUseBlock;
+import java.lang.reflect.Method;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.DisplayName;
@@ -151,6 +155,63 @@ class ResponsesMessageConverterTest {
         assertEquals(
                 "{\"type\":\"unsupported\",\"payload\":{\"text\":\"fallback text\"}}",
                 ((TextBlock) messages.get(0).getContent().get(1)).getText());
+    }
+
+    @Test
+    @DisplayName("Should parse blank instructions and branchy fallback content")
+    void shouldParseBlankInstructionsAndBranchyFallbackContent() throws Exception {
+        ResponsesRequest request =
+                objectMapper.readValue(
+                        """
+                        {
+                          "instructions": " ",
+                          "previous_response_id": " ",
+                          "input": [
+                            {
+                              "role": "system",
+                              "content": {"type": "text", "text": "system text"}
+                            },
+                            {
+                              "role": "user",
+                              "content": {"type": "output_text", "text": "out"}
+                            },
+                            {
+                              "role": "user",
+                              "content": {"type": "input_text"}
+                            },
+                            {
+                              "role": "user",
+                              "content": {"payload": true}
+                            },
+                            {
+                              "type": "function_call",
+                              "call_id": "call_blank",
+                              "name": "noop",
+                              "arguments": ""
+                            },
+                            {
+                              "type": "function_call_output",
+                              "call_id": "call_empty"
+                            }
+                          ]
+                        }
+                        """,
+                        ResponsesRequest.class);
+
+        List<Msg> messages = converter.convert(request);
+
+        assertEquals(6, messages.size());
+        assertEquals(MsgRole.SYSTEM, messages.get(0).getRole());
+        assertEquals("system text", messages.get(0).getTextContent());
+        assertEquals("out", messages.get(1).getTextContent());
+        assertEquals("", messages.get(2).getTextContent());
+        assertEquals("{\"payload\":true}", messages.get(3).getTextContent());
+        ToolUseBlock toolUse =
+                assertInstanceOf(ToolUseBlock.class, messages.get(4).getContent().get(0));
+        assertEquals(Map.of(), toolUse.getInput());
+        ToolResultBlock toolResult =
+                assertInstanceOf(ToolResultBlock.class, messages.get(5).getContent().get(0));
+        assertEquals("", ((TextBlock) toolResult.getOutput().get(0)).getText());
     }
 
     @Test
@@ -280,6 +341,47 @@ class ResponsesMessageConverterTest {
                 assertInstanceOf(ToolResultBlock.class, messages.get(4).getContent().get(0));
         assertEquals("", ((TextBlock) nullResult.getOutput().get(0)).getText());
         assertEquals("", messages.get(5).getTextContent());
+    }
+
+    @Test
+    @DisplayName("Should parse explicit JSON null nodes and empty object fallbacks")
+    void shouldParseExplicitJsonNullNodesAndEmptyObjectFallbacks() throws Exception {
+        ResponsesRequest nullInput = new ResponsesRequest();
+        nullInput.setInput(NullNode.getInstance());
+        assertEquals(
+                "invalid_request_error",
+                assertThrows(ProtocolException.class, () -> converter.convert(nullInput))
+                        .getCode());
+
+        ArrayNode input = objectMapper.createArrayNode();
+        ObjectNode emptyAssistant = input.addObject();
+        emptyAssistant.put("role", "assistant");
+        ObjectNode nullContent = input.addObject();
+        nullContent.put("role", "user");
+        nullContent.set("content", NullNode.getInstance());
+        ObjectNode nullToolResult = input.addObject();
+        nullToolResult.put("type", "function_call_output");
+        nullToolResult.put("call_id", "call_null");
+        nullToolResult.set("content", NullNode.getInstance());
+
+        ResponsesRequest request = new ResponsesRequest();
+        request.setInput(input);
+
+        List<Msg> messages = converter.convert(request);
+
+        assertEquals(3, messages.size());
+        assertEquals(MsgRole.ASSISTANT, messages.get(0).getRole());
+        assertEquals("", messages.get(0).getTextContent());
+        assertEquals("", messages.get(1).getTextContent());
+        ToolResultBlock result =
+                assertInstanceOf(ToolResultBlock.class, messages.get(2).getContent().get(0));
+        assertEquals("", ((TextBlock) result.getOutput().get(0)).getText());
+
+        Method extractText =
+                ResponsesMessageConverter.class.getDeclaredMethod(
+                        "extractText", com.fasterxml.jackson.databind.JsonNode.class);
+        extractText.setAccessible(true);
+        assertEquals("", extractText.invoke(converter, new Object[] {null}));
     }
 
     @Test

--- a/agentscope-extensions/agentscope-extensions-llm-interfaces-web/src/test/java/io/agentscope/core/llm/interfacesweb/responses/ResponsesMessageConverterTest.java
+++ b/agentscope-extensions/agentscope-extensions-llm-interfaces-web/src/test/java/io/agentscope/core/llm/interfacesweb/responses/ResponsesMessageConverterTest.java
@@ -154,6 +154,89 @@ class ResponsesMessageConverterTest {
     }
 
     @Test
+    @DisplayName("Should parse scalar items, object content, roles, and fallback outputs")
+    void shouldParseScalarItemsObjectContentRolesAndFallbackOutputs() throws Exception {
+        ResponsesRequest request =
+                objectMapper.readValue(
+                        """
+                        {
+                          "model": "test-model",
+                          "input": [
+                            "plain",
+                            {"role": "assistant", "text": "assistant text"},
+                            {"role": "tool", "output_text": "tool text"},
+                            {"role": "unknown", "content": "content text"},
+                            {
+                              "role": "user",
+                              "content": {
+                                "type": "image",
+                                "url": "https://example.com/b.png"
+                              }
+                            },
+                            {
+                              "role": "user",
+                              "content": {"type": "input_image"}
+                            },
+                            {
+                              "role": "assistant",
+                              "content": {"type": "tool_use", "id": "call_2", "name": "noop"}
+                            },
+                            {
+                              "type": "function_call",
+                              "id": "call_3",
+                              "name": "noop",
+                              "arguments": "{}"
+                            },
+                            {
+                              "type": "function_call_output",
+                              "call_id": "call_3",
+                              "content": [{"type": "output_text", "text": "done"}]
+                            }
+                          ]
+                        }
+                        """,
+                        ResponsesRequest.class);
+
+        List<Msg> messages = converter.convert(request);
+
+        assertEquals("plain", messages.get(0).getTextContent());
+        assertEquals(MsgRole.ASSISTANT, messages.get(1).getRole());
+        assertEquals("assistant text", messages.get(1).getTextContent());
+        assertEquals(MsgRole.TOOL, messages.get(2).getRole());
+        assertEquals("tool text", messages.get(2).getTextContent());
+        assertEquals(MsgRole.USER, messages.get(3).getRole());
+        assertEquals("content text", messages.get(3).getTextContent());
+        assertInstanceOf(ImageBlock.class, messages.get(4).getContent().get(0));
+        assertEquals("[Unsupported image]", messages.get(5).getTextContent());
+        ToolUseBlock inlineTool =
+                assertInstanceOf(ToolUseBlock.class, messages.get(6).getContent().get(0));
+        assertEquals(Map.of(), inlineTool.getInput());
+        assertEquals("{}", inlineTool.getContent());
+        ToolUseBlock functionCall =
+                assertInstanceOf(ToolUseBlock.class, messages.get(7).getContent().get(0));
+        assertEquals("call_3", functionCall.getId());
+        ToolResultBlock result =
+                assertInstanceOf(ToolResultBlock.class, messages.get(8).getContent().get(0));
+        assertEquals("done", ((TextBlock) result.getOutput().get(0)).getText());
+    }
+
+    @Test
+    @DisplayName("Should reject unsupported scalar input")
+    void shouldRejectUnsupportedScalarInput() throws Exception {
+        ResponsesRequest request =
+                objectMapper.readValue(
+                        """
+                        {"model": "test", "input": 42}
+                        """,
+                        ResponsesRequest.class);
+
+        ProtocolException error =
+                assertThrows(ProtocolException.class, () -> converter.convert(request));
+
+        assertEquals("invalid_request_error", error.getCode());
+    }
+
+    @Test
     @DisplayName("Should reject unsupported stateful Responses fields")
     void shouldRejectUnsupportedStatefulFields() throws Exception {
         ResponsesRequest previous =

--- a/agentscope-extensions/agentscope-extensions-llm-interfaces-web/src/test/java/io/agentscope/core/llm/interfacesweb/responses/ResponsesMessageConverterTest.java
+++ b/agentscope-extensions/agentscope-extensions-llm-interfaces-web/src/test/java/io/agentscope/core/llm/interfacesweb/responses/ResponsesMessageConverterTest.java
@@ -221,6 +221,84 @@ class ResponsesMessageConverterTest {
     }
 
     @Test
+    @DisplayName("Should parse loose content parts and role fallbacks")
+    void shouldParseLooseContentPartsAndRoleFallbacks() throws Exception {
+        ResponsesRequest request =
+                objectMapper.readValue(
+                        """
+                        {
+                          "input": [
+                            {"content": [null, "loose text"]},
+                            {
+                              "role": "",
+                              "content": {
+                                "type": "input_image",
+                                "image_url": "data:image/png;base64abc"
+                              }
+                            },
+                            {
+                              "role": "assistant",
+                              "content": {
+                                "type": "tool_use",
+                                "id": "call_4",
+                                "name": "lookup",
+                                "input": {"city": "Paris"}
+                              }
+                            },
+                            {
+                              "type": "function_call_output",
+                              "call_id": "call_4",
+                              "content": "finished"
+                            },
+                            {
+                              "type": "function_call_output",
+                              "call_id": "call_5",
+                              "content": null
+                            },
+                            {
+                              "role": "user",
+                              "content": {"type": "output_text", "text": ""}
+                            }
+                          ]
+                        }
+                        """,
+                        ResponsesRequest.class);
+
+        List<Msg> messages = converter.convert(request);
+
+        assertEquals(MsgRole.USER, messages.get(0).getRole());
+        assertEquals("loose text", messages.get(0).getTextContent());
+        assertEquals(MsgRole.USER, messages.get(1).getRole());
+        assertInstanceOf(ImageBlock.class, messages.get(1).getContent().get(0));
+        ToolUseBlock toolUse =
+                assertInstanceOf(ToolUseBlock.class, messages.get(2).getContent().get(0));
+        assertEquals(Map.of("city", "Paris"), toolUse.getInput());
+        ToolResultBlock textResult =
+                assertInstanceOf(ToolResultBlock.class, messages.get(3).getContent().get(0));
+        assertEquals("finished", ((TextBlock) textResult.getOutput().get(0)).getText());
+        ToolResultBlock nullResult =
+                assertInstanceOf(ToolResultBlock.class, messages.get(4).getContent().get(0));
+        assertEquals("", ((TextBlock) nullResult.getOutput().get(0)).getText());
+        assertEquals("", messages.get(5).getTextContent());
+    }
+
+    @Test
+    @DisplayName("Should reject arrays without input messages")
+    void shouldRejectArraysWithoutInputMessages() throws Exception {
+        ResponsesRequest request =
+                objectMapper.readValue(
+                        """
+                        {"input": [null]}
+                        """,
+                        ResponsesRequest.class);
+
+        ProtocolException error =
+                assertThrows(ProtocolException.class, () -> converter.convert(request));
+
+        assertEquals("invalid_request_error", error.getCode());
+    }
+
+    @Test
     @DisplayName("Should reject unsupported scalar input")
     void shouldRejectUnsupportedScalarInput() throws Exception {
         ResponsesRequest request =

--- a/agentscope-extensions/agentscope-extensions-llm-interfaces-web/src/test/java/io/agentscope/core/llm/interfacesweb/responses/ResponsesMessageConverterTest.java
+++ b/agentscope-extensions/agentscope-extensions-llm-interfaces-web/src/test/java/io/agentscope/core/llm/interfacesweb/responses/ResponsesMessageConverterTest.java
@@ -1,0 +1,192 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.core.llm.interfacesweb.responses;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.agentscope.core.llm.interfacesweb.common.ProtocolException;
+import io.agentscope.core.message.ImageBlock;
+import io.agentscope.core.message.Msg;
+import io.agentscope.core.message.MsgRole;
+import io.agentscope.core.message.TextBlock;
+import io.agentscope.core.message.ToolResultBlock;
+import io.agentscope.core.message.ToolUseBlock;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("ResponsesMessageConverter Tests")
+class ResponsesMessageConverterTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final ResponsesMessageConverter converter = new ResponsesMessageConverter();
+
+    @Test
+    @DisplayName("Should parse instructions and string input")
+    void shouldParseInstructionsAndStringInput() throws Exception {
+        ResponsesRequest request =
+                objectMapper.readValue(
+                        """
+                        {
+                          "model": "test-model",
+                          "instructions": "Be concise",
+                          "input": "Hello",
+                          "parallel_tool_calls": true
+                        }
+                        """,
+                        ResponsesRequest.class);
+
+        List<Msg> messages = converter.convert(request);
+
+        assertEquals(2, messages.size());
+        assertEquals(MsgRole.SYSTEM, messages.get(0).getRole());
+        assertEquals("Be concise", messages.get(0).getTextContent());
+        assertEquals(MsgRole.USER, messages.get(1).getRole());
+        assertEquals("Hello", messages.get(1).getTextContent());
+    }
+
+    @Test
+    @DisplayName("Should parse message-array input, tools, images, and function outputs")
+    void shouldParseMessageArrayInput() throws Exception {
+        ResponsesRequest request =
+                objectMapper.readValue(
+                        """
+                        {
+                          "model": "test-model",
+                          "stream": true,
+                          "input": [
+                            {
+                              "role": "user",
+                              "content": [
+                                {"type": "input_text", "text": "What is the weather?"},
+                                {"type": "input_image", "image_url": "https://example.com/a.png"}
+                              ]
+                            },
+                            {
+                              "type": "function_call",
+                              "call_id": "call_1",
+                              "name": "get_weather",
+                              "arguments": "{\\"city\\":\\"Paris\\"}"
+                            },
+                            {
+                              "type": "function_call_output",
+                              "call_id": "call_1",
+                              "name": "get_weather",
+                              "output": "Sunny"
+                            }
+                          ]
+                        }
+                        """,
+                        ResponsesRequest.class);
+
+        List<Msg> messages = converter.convert(request);
+
+        assertEquals(3, messages.size());
+        assertEquals(MsgRole.USER, messages.get(0).getRole());
+        assertEquals("What is the weather?", messages.get(0).getTextContent());
+        assertInstanceOf(ImageBlock.class, messages.get(0).getContent().get(1));
+
+        assertEquals(MsgRole.ASSISTANT, messages.get(1).getRole());
+        ToolUseBlock toolUse =
+                assertInstanceOf(ToolUseBlock.class, messages.get(1).getContent().get(0));
+        assertEquals("call_1", toolUse.getId());
+        assertEquals("get_weather", toolUse.getName());
+        assertEquals(Map.of("city", "Paris"), toolUse.getInput());
+
+        assertEquals(MsgRole.TOOL, messages.get(2).getRole());
+        ToolResultBlock toolResult =
+                assertInstanceOf(ToolResultBlock.class, messages.get(2).getContent().get(0));
+        assertEquals("call_1", toolResult.getId());
+        assertEquals("get_weather", toolResult.getName());
+        assertEquals("Sunny", ((TextBlock) toolResult.getOutput().get(0)).getText());
+    }
+
+    @Test
+    @DisplayName("Should reject unsupported stateful Responses fields")
+    void shouldRejectUnsupportedStatefulFields() throws Exception {
+        ResponsesRequest previous =
+                objectMapper.readValue(
+                        """
+                        {"model": "test", "input": "hello", "previous_response_id": "resp_1"}
+                        """,
+                        ResponsesRequest.class);
+        ResponsesRequest conversation =
+                objectMapper.readValue(
+                        """
+                        {"model": "test", "input": "hello", "conversation": {"id": "conv_1"}}
+                        """,
+                        ResponsesRequest.class);
+        ResponsesRequest background =
+                objectMapper.readValue(
+                        """
+                        {"model": "test", "input": "hello", "background": true}
+                        """,
+                        ResponsesRequest.class);
+
+        assertEquals(
+                "unsupported_feature",
+                assertThrows(ProtocolException.class, () -> converter.convert(previous)).getCode());
+        assertEquals(
+                "unsupported_feature",
+                assertThrows(ProtocolException.class, () -> converter.convert(conversation))
+                        .getCode());
+        assertEquals(
+                "unsupported_feature",
+                assertThrows(ProtocolException.class, () -> converter.convert(background))
+                        .getCode());
+    }
+
+    @Test
+    @DisplayName("Should reject malformed function-call arguments")
+    void shouldRejectMalformedFunctionArguments() throws Exception {
+        ResponsesRequest request =
+                objectMapper.readValue(
+                        """
+                        {
+                          "model": "test",
+                          "input": [
+                            {
+                              "type": "function_call",
+                              "call_id": "call_1",
+                              "name": "bad_tool",
+                              "arguments": "{bad-json"
+                            }
+                          ]
+                        }
+                        """,
+                        ResponsesRequest.class);
+
+        ProtocolException error =
+                assertThrows(ProtocolException.class, () -> converter.convert(request));
+
+        assertEquals("invalid_request_error", error.getCode());
+    }
+
+    @Test
+    @DisplayName("Should require input")
+    void shouldRequireInput() {
+        ResponsesRequest request = new ResponsesRequest();
+
+        ProtocolException error =
+                assertThrows(ProtocolException.class, () -> converter.convert(request));
+
+        assertEquals("invalid_request_error", error.getCode());
+    }
+}

--- a/agentscope-extensions/agentscope-extensions-llm-interfaces-web/src/test/java/io/agentscope/core/llm/interfacesweb/responses/ResponsesMessageConverterTest.java
+++ b/agentscope-extensions/agentscope-extensions-llm-interfaces-web/src/test/java/io/agentscope/core/llm/interfacesweb/responses/ResponsesMessageConverterTest.java
@@ -119,6 +119,41 @@ class ResponsesMessageConverterTest {
     }
 
     @Test
+    @DisplayName("Should parse object input, data images, and fallback text content")
+    void shouldParseObjectInputAndFallbackContent() throws Exception {
+        ResponsesRequest request =
+                objectMapper.readValue(
+                        """
+                        {
+                          "model": "test-model",
+                          "input": {
+                            "role": "developer",
+                            "content": [
+                              {
+                                "type": "input_image",
+                                "image_url": "data:image/png;base64,abc"
+                              },
+                              {
+                                "type": "unsupported",
+                                "payload": {"text": "fallback text"}
+                              }
+                            ]
+                          }
+                        }
+                        """,
+                        ResponsesRequest.class);
+
+        List<Msg> messages = converter.convert(request);
+
+        assertEquals(1, messages.size());
+        assertEquals(MsgRole.SYSTEM, messages.get(0).getRole());
+        assertInstanceOf(ImageBlock.class, messages.get(0).getContent().get(0));
+        assertEquals(
+                "{\"type\":\"unsupported\",\"payload\":{\"text\":\"fallback text\"}}",
+                ((TextBlock) messages.get(0).getContent().get(1)).getText());
+    }
+
+    @Test
     @DisplayName("Should reject unsupported stateful Responses fields")
     void shouldRejectUnsupportedStatefulFields() throws Exception {
         ResponsesRequest previous =

--- a/agentscope-extensions/agentscope-extensions-llm-interfaces-web/src/test/java/io/agentscope/core/llm/interfacesweb/responses/ResponsesRequestTest.java
+++ b/agentscope-extensions/agentscope-extensions-llm-interfaces-web/src/test/java/io/agentscope/core/llm/interfacesweb/responses/ResponsesRequestTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.core.llm.interfacesweb.responses;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("ResponsesRequest Tests")
+class ResponsesRequestTest {
+
+    @Test
+    @DisplayName("Should expose all request fields")
+    void shouldExposeAllRequestFields() {
+        ResponsesRequest request = new ResponsesRequest();
+        ResponsesTool tool = new ResponsesTool();
+        Object input = Map.of("role", "user");
+        Object metadata = Map.of("trace", "1");
+        Object conversation = Map.of("id", "conv_1");
+        Object toolChoice = Map.of("type", "auto");
+        Map<String, Object> text = Map.of("format", Map.of("type", "text"));
+
+        request.setModel("model");
+        request.setInput(input);
+        request.setInstructions("Be brief");
+        request.setStream(true);
+        request.setTools(List.of(tool));
+        request.setMetadata(metadata);
+        request.setPreviousResponseId("resp_1");
+        request.setConversation(conversation);
+        request.setBackground(false);
+        request.setStore(true);
+        request.setToolChoice(toolChoice);
+        request.setText(text);
+
+        assertEquals("model", request.getModel());
+        assertSame(input, request.getInput());
+        assertEquals("Be brief", request.getInstructions());
+        assertTrue(request.getStream());
+        assertEquals(List.of(tool), request.getTools());
+        assertSame(metadata, request.getMetadata());
+        assertEquals("resp_1", request.getPreviousResponseId());
+        assertSame(conversation, request.getConversation());
+        assertFalse(request.getBackground());
+        assertTrue(request.getStore());
+        assertSame(toolChoice, request.getToolChoice());
+        assertEquals(text, request.getText());
+    }
+}

--- a/agentscope-extensions/agentscope-extensions-llm-interfaces-web/src/test/java/io/agentscope/core/llm/interfacesweb/responses/ResponsesResponseBuilderTest.java
+++ b/agentscope-extensions/agentscope-extensions-llm-interfaces-web/src/test/java/io/agentscope/core/llm/interfacesweb/responses/ResponsesResponseBuilderTest.java
@@ -17,12 +17,17 @@ package io.agentscope.core.llm.interfacesweb.responses;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
+import io.agentscope.core.message.AudioBlock;
 import io.agentscope.core.message.GenerateReason;
 import io.agentscope.core.message.MessageMetadataKeys;
 import io.agentscope.core.message.Msg;
 import io.agentscope.core.message.MsgRole;
+import io.agentscope.core.message.Source;
 import io.agentscope.core.message.TextBlock;
 import io.agentscope.core.message.ThinkingBlock;
 import io.agentscope.core.message.ToolUseBlock;
@@ -118,6 +123,12 @@ class ResponsesResponseBuilderTest {
     @DisplayName("Should return no output items for null replies")
     void shouldReturnNoOutputItemsForNullReplies() {
         assertTrue(builder.outputItems(null, "resp_1").isEmpty());
+        ResponsesResponse response = builder.buildResponse(request("test-model"), null, "resp_1");
+        assertEquals("completed", response.getStatus());
+        assertNull(response.getUsage());
+        Msg nullContent = mock(Msg.class);
+        when(nullContent.getContent()).thenReturn(null);
+        assertTrue(builder.outputItems(nullContent, "resp_1").isEmpty());
     }
 
     @Test
@@ -134,6 +145,22 @@ class ResponsesResponseBuilderTest {
         assertEquals(1, items.size());
         assertEquals("message", items.get(0).getType());
         assertTrue(items.get(0).getContent().get(0).getText().contains("hidden reasoning"));
+
+        Msg ignored =
+                Msg.builder()
+                        .role(MsgRole.ASSISTANT)
+                        .content(AudioBlock.builder().source(new Source()).build())
+                        .build();
+        assertTrue(builder.outputItems(ignored, "resp_2").isEmpty());
+
+        Msg textAndThinking =
+                Msg.builder()
+                        .role(MsgRole.ASSISTANT)
+                        .content(
+                                TextBlock.builder().text("visible").build(),
+                                ThinkingBlock.builder().thinking("hidden").build())
+                        .build();
+        assertEquals(1, builder.outputItems(textAndThinking, "resp_3").size());
     }
 
     @Test
@@ -150,6 +177,15 @@ class ResponsesResponseBuilderTest {
         ResponsesOutputItem item = builder.toolUseItem(block);
 
         assertEquals("{\"city\":\"Paris\"}", item.getArguments());
+
+        ToolUseBlock blankContent =
+                ToolUseBlock.builder()
+                        .id("call_2")
+                        .name("lookup")
+                        .content(" ")
+                        .input(Map.of("city", "Rome"))
+                        .build();
+        assertEquals("{\"city\":\"Rome\"}", builder.toolUseItem(blankContent).getArguments());
     }
 
     private ResponsesRequest request(String model) {

--- a/agentscope-extensions/agentscope-extensions-llm-interfaces-web/src/test/java/io/agentscope/core/llm/interfacesweb/responses/ResponsesResponseBuilderTest.java
+++ b/agentscope-extensions/agentscope-extensions-llm-interfaces-web/src/test/java/io/agentscope/core/llm/interfacesweb/responses/ResponsesResponseBuilderTest.java
@@ -24,8 +24,10 @@ import io.agentscope.core.message.MessageMetadataKeys;
 import io.agentscope.core.message.Msg;
 import io.agentscope.core.message.MsgRole;
 import io.agentscope.core.message.TextBlock;
+import io.agentscope.core.message.ThinkingBlock;
 import io.agentscope.core.message.ToolUseBlock;
 import io.agentscope.core.model.ChatUsage;
+import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -99,6 +101,55 @@ class ResponsesResponseBuilderTest {
         assertEquals("", response.getOutputText());
         assertTrue(response.getOutput().isEmpty());
         assertNotNull(response.getError());
+    }
+
+    @Test
+    @DisplayName("Should build failed Responses payload with fallback message")
+    void shouldBuildFailedResponseWithFallbackMessage() {
+        ResponsesResponse response = builder.buildErrorResponse(null, null, "resp_1");
+
+        assertEquals("failed", response.getStatus());
+        assertEquals("", response.getOutputText());
+        assertTrue(response.getOutput().isEmpty());
+        assertEquals(null, response.getModel());
+    }
+
+    @Test
+    @DisplayName("Should return no output items for null replies")
+    void shouldReturnNoOutputItemsForNullReplies() {
+        assertTrue(builder.outputItems(null, "resp_1").isEmpty());
+    }
+
+    @Test
+    @DisplayName("Should serialize non-text blocks as fallback message output")
+    void shouldSerializeNonTextBlocksAsFallbackMessageOutput() {
+        Msg reply =
+                Msg.builder()
+                        .role(MsgRole.ASSISTANT)
+                        .content(ThinkingBlock.builder().thinking("hidden reasoning").build())
+                        .build();
+
+        List<ResponsesOutputItem> items = builder.outputItems(reply, "resp_1");
+
+        assertEquals(1, items.size());
+        assertEquals("message", items.get(0).getType());
+        assertTrue(items.get(0).getContent().get(0).getText().contains("hidden reasoning"));
+    }
+
+    @Test
+    @DisplayName("Should prefer explicit tool-call argument content")
+    void shouldPreferExplicitToolCallArgumentContent() {
+        ToolUseBlock block =
+                ToolUseBlock.builder()
+                        .id("call_1")
+                        .name("lookup")
+                        .content("{\"city\":\"Paris\"}")
+                        .input(Map.of("city", "London"))
+                        .build();
+
+        ResponsesOutputItem item = builder.toolUseItem(block);
+
+        assertEquals("{\"city\":\"Paris\"}", item.getArguments());
     }
 
     private ResponsesRequest request(String model) {

--- a/agentscope-extensions/agentscope-extensions-llm-interfaces-web/src/test/java/io/agentscope/core/llm/interfacesweb/responses/ResponsesResponseBuilderTest.java
+++ b/agentscope-extensions/agentscope-extensions-llm-interfaces-web/src/test/java/io/agentscope/core/llm/interfacesweb/responses/ResponsesResponseBuilderTest.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.core.llm.interfacesweb.responses;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.agentscope.core.message.GenerateReason;
+import io.agentscope.core.message.MessageMetadataKeys;
+import io.agentscope.core.message.Msg;
+import io.agentscope.core.message.MsgRole;
+import io.agentscope.core.message.TextBlock;
+import io.agentscope.core.message.ToolUseBlock;
+import io.agentscope.core.model.ChatUsage;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("ResponsesResponseBuilder Tests")
+class ResponsesResponseBuilderTest {
+
+    private final ResponsesResponseBuilder builder = new ResponsesResponseBuilder();
+
+    @Test
+    @DisplayName("Should build text, tool-call, usage, and completion status")
+    void shouldBuildTextToolUsageAndStatus() {
+        ResponsesRequest request = request("test-model");
+        Msg reply =
+                Msg.builder()
+                        .role(MsgRole.ASSISTANT)
+                        .content(
+                                TextBlock.builder().text("Hello").build(),
+                                ToolUseBlock.builder()
+                                        .id("call_1")
+                                        .name("lookup")
+                                        .input(Map.of("q", "Paris"))
+                                        .build())
+                        .metadata(
+                                Map.of(
+                                        MessageMetadataKeys.CHAT_USAGE,
+                                        ChatUsage.builder().inputTokens(3).outputTokens(5).build()))
+                        .build();
+
+        ResponsesResponse response = builder.buildResponse(request, reply, "resp_1");
+
+        assertEquals("resp_1", response.getId());
+        assertEquals("response", response.getObject());
+        assertEquals("completed", response.getStatus());
+        assertEquals("test-model", response.getModel());
+        assertEquals("Hello", response.getOutputText());
+        assertEquals(2, response.getOutput().size());
+        assertEquals("message", response.getOutput().get(0).getType());
+        assertEquals("output_text", response.getOutput().get(0).getContent().get(0).getType());
+        assertEquals("function_call", response.getOutput().get(1).getType());
+        assertEquals("call_1", response.getOutput().get(1).getCallId());
+        assertEquals("{\"q\":\"Paris\"}", response.getOutput().get(1).getArguments());
+        assertEquals(3, response.getUsage().getInputTokens());
+        assertEquals(5, response.getUsage().getOutputTokens());
+        assertEquals(8, response.getUsage().getTotalTokens());
+    }
+
+    @Test
+    @DisplayName("Should map max iterations to incomplete status")
+    void shouldMapMaxIterationsToIncompleteStatus() {
+        Msg reply =
+                Msg.builder()
+                        .role(MsgRole.ASSISTANT)
+                        .textContent("partial")
+                        .generateReason(GenerateReason.MAX_ITERATIONS)
+                        .build();
+
+        ResponsesResponse response = builder.buildResponse(request("test-model"), reply, "resp_1");
+
+        assertEquals("incomplete", response.getStatus());
+    }
+
+    @Test
+    @DisplayName("Should build failed Responses payload")
+    void shouldBuildFailedResponse() {
+        ResponsesResponse response =
+                builder.buildErrorResponse(
+                        request("test-model"), new IllegalStateException("boom"), "resp_1");
+
+        assertEquals("failed", response.getStatus());
+        assertEquals("", response.getOutputText());
+        assertTrue(response.getOutput().isEmpty());
+        assertNotNull(response.getError());
+    }
+
+    private ResponsesRequest request(String model) {
+        ResponsesRequest request = new ResponsesRequest();
+        request.setModel(model);
+        return request;
+    }
+}

--- a/agentscope-extensions/agentscope-extensions-llm-interfaces-web/src/test/java/io/agentscope/core/llm/interfacesweb/responses/ResponsesStreamingAdapterTest.java
+++ b/agentscope-extensions/agentscope-extensions-llm-interfaces-web/src/test/java/io/agentscope/core/llm/interfacesweb/responses/ResponsesStreamingAdapterTest.java
@@ -24,6 +24,7 @@ import io.agentscope.core.ReActAgent;
 import io.agentscope.core.agent.Event;
 import io.agentscope.core.agent.EventType;
 import io.agentscope.core.agent.StreamOptions;
+import io.agentscope.core.message.GenerateReason;
 import io.agentscope.core.message.Msg;
 import io.agentscope.core.message.MsgRole;
 import io.agentscope.core.message.TextBlock;
@@ -110,6 +111,99 @@ class ResponsesStreamingAdapterTest {
                                 "response.function_call_arguments.delta".equals(event.getType())
                                         && "{\"city\":\"Paris\"}".equals(event.getDelta()))
                 .expectNextMatches(event -> "response.completed".equals(event.getType()))
+                .verifyComplete();
+    }
+
+    @Test
+    @DisplayName("Should emit function-call explicit argument deltas")
+    void shouldEmitFunctionCallExplicitArgumentDeltas() {
+        ReActAgent agent = mock(ReActAgent.class);
+        Msg toolUse =
+                Msg.builder()
+                        .role(MsgRole.ASSISTANT)
+                        .content(
+                                ToolUseBlock.builder()
+                                        .id("call_1")
+                                        .name("lookup")
+                                        .content("{\"city\":\"Paris\"}")
+                                        .input(Map.of("city", "London"))
+                                        .build())
+                        .build();
+
+        when(agent.stream(anyList(), any(StreamOptions.class)))
+                .thenReturn(Flux.just(new Event(EventType.TOOL_RESULT, toolUse, false)));
+
+        ResponsesRequest request = new ResponsesRequest();
+        request.setModel("test-model");
+
+        StepVerifier.create(adapter.stream(agent, List.of(toolUse), request, "resp_1"))
+                .expectNextMatches(event -> "response.created".equals(event.getType()))
+                .expectNextMatches(event -> "response.output_item.added".equals(event.getType()))
+                .expectNextMatches(
+                        event ->
+                                "response.function_call_arguments.delta".equals(event.getType())
+                                        && "{\"city\":\"Paris\"}".equals(event.getDelta()))
+                .verifyComplete();
+    }
+
+    @Test
+    @DisplayName("Should emit incomplete final stream event")
+    void shouldEmitIncompleteFinalStreamEvent() {
+        ReActAgent agent = mock(ReActAgent.class);
+        Msg finalReply =
+                Msg.builder()
+                        .role(MsgRole.ASSISTANT)
+                        .textContent("partial")
+                        .generateReason(GenerateReason.MAX_ITERATIONS)
+                        .build();
+
+        when(agent.stream(anyList(), any(StreamOptions.class)))
+                .thenReturn(Flux.just(new Event(EventType.REASONING, finalReply, true)));
+
+        StepVerifier.create(
+                        adapter.stream(
+                                agent, List.of(finalReply), new ResponsesRequest(), "resp_1"))
+                .expectNextMatches(event -> "response.created".equals(event.getType()))
+                .expectNextMatches(event -> "response.output_text.delta".equals(event.getType()))
+                .expectNextMatches(
+                        event ->
+                                "response.incomplete".equals(event.getType())
+                                        && "incomplete".equals(event.getResponse().getStatus()))
+                .verifyComplete();
+    }
+
+    @Test
+    @DisplayName("Should ignore events without messages")
+    void shouldIgnoreEventsWithoutMessages() {
+        ReActAgent agent = mock(ReActAgent.class);
+
+        when(agent.stream(anyList(), any(StreamOptions.class)))
+                .thenReturn(Flux.just(new Event(EventType.REASONING, null, true)));
+
+        StepVerifier.create(adapter.stream(agent, List.of(), new ResponsesRequest(), "resp_1"))
+                .expectNextMatches(event -> "response.created".equals(event.getType()))
+                .verifyComplete();
+    }
+
+    @Test
+    @DisplayName("Should build Responses stream error events")
+    void shouldBuildResponsesStreamErrorEvents() {
+        ResponsesStreamEvent explicit = adapter.errorEvent(new RuntimeException("boom"), "resp_1");
+        ResponsesStreamEvent fallback = adapter.errorEvent(null, "resp_2");
+
+        StepVerifier.create(Flux.just(explicit, fallback))
+                .expectNextMatches(
+                        event ->
+                                "response.failed".equals(event.getType())
+                                        && "resp_1".equals(event.getResponseId())
+                                        && event.getError().toString().contains("boom"))
+                .expectNextMatches(
+                        event ->
+                                "response.failed".equals(event.getType())
+                                        && "resp_2".equals(event.getResponseId())
+                                        && event.getError()
+                                                .toString()
+                                                .contains("Unknown error occurred"))
                 .verifyComplete();
     }
 }

--- a/agentscope-extensions/agentscope-extensions-llm-interfaces-web/src/test/java/io/agentscope/core/llm/interfacesweb/responses/ResponsesStreamingAdapterTest.java
+++ b/agentscope-extensions/agentscope-extensions-llm-interfaces-web/src/test/java/io/agentscope/core/llm/interfacesweb/responses/ResponsesStreamingAdapterTest.java
@@ -176,9 +176,14 @@ class ResponsesStreamingAdapterTest {
     @DisplayName("Should ignore events without messages")
     void shouldIgnoreEventsWithoutMessages() {
         ReActAgent agent = mock(ReActAgent.class);
+        Msg emptyMessage = mock(Msg.class);
+        when(emptyMessage.getContent()).thenReturn(null);
 
         when(agent.stream(anyList(), any(StreamOptions.class)))
-                .thenReturn(Flux.just(new Event(EventType.REASONING, null, true)));
+                .thenReturn(
+                        Flux.just(
+                                new Event(EventType.REASONING, null, false),
+                                new Event(EventType.REASONING, emptyMessage, true)));
 
         StepVerifier.create(adapter.stream(agent, List.of(), new ResponsesRequest(), "resp_1"))
                 .expectNextMatches(event -> "response.created".equals(event.getType()))

--- a/agentscope-extensions/agentscope-extensions-llm-interfaces-web/src/test/java/io/agentscope/core/llm/interfacesweb/responses/ResponsesStreamingAdapterTest.java
+++ b/agentscope-extensions/agentscope-extensions-llm-interfaces-web/src/test/java/io/agentscope/core/llm/interfacesweb/responses/ResponsesStreamingAdapterTest.java
@@ -51,6 +51,13 @@ class ResponsesStreamingAdapterTest {
                         .role(MsgRole.ASSISTANT)
                         .content(TextBlock.builder().text("Hel").build())
                         .build();
+        TextBlock nullText = mock(TextBlock.class);
+        when(nullText.getText()).thenReturn(null);
+        Msg skippedText =
+                Msg.builder()
+                        .role(MsgRole.ASSISTANT)
+                        .content(nullText, TextBlock.builder().text("").build())
+                        .build();
         Msg finalReply =
                 Msg.builder()
                         .role(MsgRole.ASSISTANT)
@@ -60,6 +67,7 @@ class ResponsesStreamingAdapterTest {
         when(agent.stream(anyList(), any(StreamOptions.class)))
                 .thenReturn(
                         Flux.just(
+                                new Event(EventType.TOOL_RESULT, skippedText, false),
                                 new Event(EventType.REASONING, delta, false),
                                 new Event(EventType.REASONING, finalReply, true)));
 

--- a/agentscope-extensions/agentscope-extensions-llm-interfaces-web/src/test/java/io/agentscope/core/llm/interfacesweb/responses/ResponsesStreamingAdapterTest.java
+++ b/agentscope-extensions/agentscope-extensions-llm-interfaces-web/src/test/java/io/agentscope/core/llm/interfacesweb/responses/ResponsesStreamingAdapterTest.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.core.llm.interfacesweb.responses;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.agentscope.core.ReActAgent;
+import io.agentscope.core.agent.Event;
+import io.agentscope.core.agent.EventType;
+import io.agentscope.core.agent.StreamOptions;
+import io.agentscope.core.message.Msg;
+import io.agentscope.core.message.MsgRole;
+import io.agentscope.core.message.TextBlock;
+import io.agentscope.core.message.ToolUseBlock;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Flux;
+import reactor.test.StepVerifier;
+
+@DisplayName("ResponsesStreamingAdapter Tests")
+class ResponsesStreamingAdapterTest {
+
+    private final ResponsesStreamingAdapter adapter =
+            new ResponsesStreamingAdapter(new ResponsesResponseBuilder());
+
+    @Test
+    @DisplayName("Should emit semantic Responses stream event order")
+    void shouldEmitSemanticResponsesEvents() {
+        ReActAgent agent = mock(ReActAgent.class);
+        Msg delta =
+                Msg.builder()
+                        .role(MsgRole.ASSISTANT)
+                        .content(TextBlock.builder().text("Hel").build())
+                        .build();
+        Msg finalReply =
+                Msg.builder()
+                        .role(MsgRole.ASSISTANT)
+                        .content(TextBlock.builder().text("Hello").build())
+                        .build();
+
+        when(agent.stream(anyList(), any(StreamOptions.class)))
+                .thenReturn(
+                        Flux.just(
+                                new Event(EventType.REASONING, delta, false),
+                                new Event(EventType.REASONING, finalReply, true)));
+
+        ResponsesRequest request = new ResponsesRequest();
+        request.setModel("test-model");
+
+        StepVerifier.create(adapter.stream(agent, List.of(delta), request, "resp_1"))
+                .expectNextMatches(event -> "response.created".equals(event.getType()))
+                .expectNextMatches(
+                        event ->
+                                "response.output_text.delta".equals(event.getType())
+                                        && "Hel".equals(event.getDelta()))
+                .expectNextMatches(
+                        event ->
+                                "response.completed".equals(event.getType())
+                                        && "Hello".equals(event.getResponse().getOutputText()))
+                .verifyComplete();
+    }
+
+    @Test
+    @DisplayName("Should emit function-call stream events")
+    void shouldEmitFunctionCallStreamEvents() {
+        ReActAgent agent = mock(ReActAgent.class);
+        Msg toolUse =
+                Msg.builder()
+                        .role(MsgRole.ASSISTANT)
+                        .content(
+                                ToolUseBlock.builder()
+                                        .id("call_1")
+                                        .name("lookup")
+                                        .input(Map.of("city", "Paris"))
+                                        .build())
+                        .build();
+
+        when(agent.stream(anyList(), any(StreamOptions.class)))
+                .thenReturn(Flux.just(new Event(EventType.REASONING, toolUse, true)));
+
+        ResponsesRequest request = new ResponsesRequest();
+        request.setModel("test-model");
+
+        StepVerifier.create(adapter.stream(agent, List.of(toolUse), request, "resp_1"))
+                .expectNextMatches(event -> "response.created".equals(event.getType()))
+                .expectNextMatches(
+                        event ->
+                                "response.output_item.added".equals(event.getType())
+                                        && "function_call".equals(event.getItem().getType()))
+                .expectNextMatches(
+                        event ->
+                                "response.function_call_arguments.delta".equals(event.getType())
+                                        && "{\"city\":\"Paris\"}".equals(event.getDelta()))
+                .expectNextMatches(event -> "response.completed".equals(event.getType()))
+                .verifyComplete();
+    }
+}

--- a/agentscope-extensions/agentscope-extensions-llm-interfaces-web/src/test/java/io/agentscope/core/llm/interfacesweb/responses/ResponsesToolConverterTest.java
+++ b/agentscope-extensions/agentscope-extensions-llm-interfaces-web/src/test/java/io/agentscope/core/llm/interfacesweb/responses/ResponsesToolConverterTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.core.llm.interfacesweb.responses;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import io.agentscope.core.model.ToolSchema;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("ResponsesToolConverter Tests")
+class ResponsesToolConverterTest {
+
+    @Test
+    @DisplayName("Should convert both flat and nested OpenAI function tool shapes")
+    void shouldConvertFlatAndNestedFunctionTools() {
+        ResponsesTool flat = new ResponsesTool();
+        flat.setType("function");
+        flat.setName("lookup");
+        flat.setDescription("Lookup data");
+        flat.setParameters(Map.of("type", "object"));
+        flat.setStrict(true);
+
+        ResponsesTool nested = new ResponsesTool();
+        nested.setType("function");
+        nested.setFunction(
+                Map.of(
+                        "name",
+                        "search",
+                        "description",
+                        "Search data",
+                        "parameters",
+                        Map.of("type", "object"),
+                        "strict",
+                        false));
+
+        List<ToolSchema> schemas = new ResponsesToolConverter().convert(List.of(flat, nested));
+
+        assertEquals(2, schemas.size());
+        assertEquals("lookup", schemas.get(0).getName());
+        assertEquals(Boolean.TRUE, schemas.get(0).getStrict());
+        assertEquals("search", schemas.get(1).getName());
+        assertEquals(Boolean.FALSE, schemas.get(1).getStrict());
+    }
+}

--- a/agentscope-extensions/agentscope-extensions-llm-interfaces-web/src/test/java/io/agentscope/core/llm/interfacesweb/responses/ResponsesToolConverterTest.java
+++ b/agentscope-extensions/agentscope-extensions-llm-interfaces-web/src/test/java/io/agentscope/core/llm/interfacesweb/responses/ResponsesToolConverterTest.java
@@ -16,8 +16,10 @@
 package io.agentscope.core.llm.interfacesweb.responses;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.agentscope.core.model.ToolSchema;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.DisplayName;
@@ -56,5 +58,43 @@ class ResponsesToolConverterTest {
         assertEquals(Boolean.TRUE, schemas.get(0).getStrict());
         assertEquals("search", schemas.get(1).getName());
         assertEquals(Boolean.FALSE, schemas.get(1).getStrict());
+    }
+
+    @Test
+    @DisplayName("Should skip unsupported and invalid Responses tools")
+    void shouldSkipUnsupportedAndInvalidResponsesTools() {
+        ResponsesTool unsupported = new ResponsesTool();
+        unsupported.setType("web_search_preview");
+
+        ResponsesTool blankName = new ResponsesTool();
+        blankName.setType("function");
+        blankName.setName(" ");
+
+        List<ToolSchema> schemas =
+                new ResponsesToolConverter().convert(Arrays.asList(null, unsupported, blankName));
+
+        assertTrue(schemas.isEmpty());
+        assertTrue(new ResponsesToolConverter().convert(null).isEmpty());
+        assertTrue(new ResponsesToolConverter().convert(List.of()).isEmpty());
+    }
+
+    @Test
+    @DisplayName("Should apply defaults for minimal Responses tools")
+    void shouldApplyDefaultsForMinimalResponsesTools() {
+        ResponsesTool minimal = new ResponsesTool();
+        minimal.setType("function");
+        minimal.setName("lookup");
+
+        ResponsesTool nested = new ResponsesTool();
+        nested.setType("function");
+        nested.setFunction(Map.of("name", "search", "parameters", "ignored", "strict", "yes"));
+
+        List<ToolSchema> schemas = new ResponsesToolConverter().convert(List.of(minimal, nested));
+
+        assertEquals(2, schemas.size());
+        assertEquals("", schemas.get(0).getDescription());
+        assertEquals(Map.of("type", "object"), schemas.get(0).getParameters());
+        assertEquals("search", schemas.get(1).getName());
+        assertEquals(Map.of("type", "object"), schemas.get(1).getParameters());
     }
 }

--- a/agentscope-extensions/agentscope-extensions-llm-interfaces-web/src/test/java/io/agentscope/core/llm/interfacesweb/responses/ResponsesToolConverterTest.java
+++ b/agentscope-extensions/agentscope-extensions-llm-interfaces-web/src/test/java/io/agentscope/core/llm/interfacesweb/responses/ResponsesToolConverterTest.java
@@ -69,9 +69,12 @@ class ResponsesToolConverterTest {
         ResponsesTool blankName = new ResponsesTool();
         blankName.setType("function");
         blankName.setName(" ");
+        ResponsesTool missingName = new ResponsesTool();
+        missingName.setType("function");
 
         List<ToolSchema> schemas =
-                new ResponsesToolConverter().convert(Arrays.asList(null, unsupported, blankName));
+                new ResponsesToolConverter()
+                        .convert(Arrays.asList(null, unsupported, blankName, missingName));
 
         assertTrue(schemas.isEmpty());
         assertTrue(new ResponsesToolConverter().convert(null).isEmpty());
@@ -84,17 +87,22 @@ class ResponsesToolConverterTest {
         ResponsesTool minimal = new ResponsesTool();
         minimal.setType("function");
         minimal.setName("lookup");
+        ResponsesTool noType = new ResponsesTool();
+        noType.setType(null);
+        noType.setName("no_type");
 
         ResponsesTool nested = new ResponsesTool();
         nested.setType("function");
         nested.setFunction(Map.of("name", "search", "parameters", "ignored", "strict", "yes"));
 
-        List<ToolSchema> schemas = new ResponsesToolConverter().convert(List.of(minimal, nested));
+        List<ToolSchema> schemas =
+                new ResponsesToolConverter().convert(List.of(minimal, noType, nested));
 
-        assertEquals(2, schemas.size());
+        assertEquals(3, schemas.size());
         assertEquals("", schemas.get(0).getDescription());
         assertEquals(Map.of("type", "object"), schemas.get(0).getParameters());
-        assertEquals("search", schemas.get(1).getName());
-        assertEquals(Map.of("type", "object"), schemas.get(1).getParameters());
+        assertEquals("no_type", schemas.get(1).getName());
+        assertEquals("search", schemas.get(2).getName());
+        assertEquals(Map.of("type", "object"), schemas.get(2).getParameters());
     }
 }

--- a/agentscope-extensions/agentscope-extensions-rag-simple/src/main/java/io/agentscope/core/rag/reader/ImageReader.java
+++ b/agentscope-extensions/agentscope-extensions-rag-simple/src/main/java/io/agentscope/core/rag/reader/ImageReader.java
@@ -72,8 +72,11 @@ public class ImageReader implements Reader {
 
         return Mono.fromCallable(
                         () -> {
+                            String imagePath = input.asString();
+                            if (imagePath == null || imagePath.isBlank()) {
+                                throw new ReaderException("Image path cannot be blank");
+                            }
                             try {
-                                String imagePath = input.asString();
                                 return loadImageDocument(imagePath);
                             } catch (Exception e) {
                                 throw new ReaderException("Failed to read image from: " + input, e);

--- a/agentscope-extensions/agentscope-extensions-rag-simple/src/main/java/io/agentscope/core/rag/reader/ImageReader.java
+++ b/agentscope-extensions/agentscope-extensions-rag-simple/src/main/java/io/agentscope/core/rag/reader/ImageReader.java
@@ -15,11 +15,18 @@
  */
 package io.agentscope.core.rag.reader;
 
+import io.agentscope.core.formatter.MediaUtils;
+import io.agentscope.core.message.Base64Source;
 import io.agentscope.core.message.ImageBlock;
+import io.agentscope.core.message.Source;
 import io.agentscope.core.message.URLSource;
 import io.agentscope.core.rag.exception.ReaderException;
 import io.agentscope.core.rag.model.Document;
 import io.agentscope.core.rag.model.DocumentMetadata;
+import java.io.IOException;
+import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.List;
 import reactor.core.publisher.Mono;
 
@@ -86,20 +93,12 @@ public class ImageReader implements Reader {
      * @param imagePath the path to the image file (can be local file path or URL)
      * @return a list containing a single Document with image content
      */
-    private List<Document> loadImageDocument(String imagePath) {
+    private List<Document> loadImageDocument(String imagePath) throws IOException {
         // Generate deterministic doc_id using MD5 of image path (matching Python implementation)
         String docId = ReaderUtils.generateDocIdMD5(imagePath);
 
-        // Create ImageBlock with URLSource
-        String url;
-        if (isUrl(imagePath)) {
-            url = imagePath;
-        } else {
-            // For local files, use file:// protocol
-            url = imagePath.startsWith("file://") ? imagePath : "file://" + imagePath;
-        }
-
-        URLSource source = URLSource.builder().url(url).build();
+        // Create ImageBlock with a source suitable for local or remote use
+        Source source = toImageSource(imagePath);
         ImageBlock content = ImageBlock.builder().source(source).build();
 
         // If OCR is enabled, extract text from image
@@ -122,9 +121,50 @@ public class ImageReader implements Reader {
             return false;
         }
         String lowerPath = path.toLowerCase();
-        return lowerPath.startsWith("http://")
-                || lowerPath.startsWith("https://")
-                || lowerPath.startsWith("file://");
+        return lowerPath.startsWith("http://") || lowerPath.startsWith("https://");
+    }
+
+    private Source toImageSource(String imagePath) throws IOException {
+        if (isUrl(imagePath)) {
+            return URLSource.builder().url(imagePath).build();
+        }
+
+        Path localPath = toLocalPath(imagePath);
+        if (localPath != null && Files.exists(localPath)) {
+            String mediaType = MediaUtils.determineMediaType(localPath.toString());
+            String data = MediaUtils.fileToBase64(localPath.toString());
+            return Base64Source.builder().mediaType(mediaType).data(data).build();
+        }
+
+        return URLSource.builder().url(toImageUrl(imagePath)).build();
+    }
+
+    private Path toLocalPath(String imagePath) {
+        if (imagePath == null || imagePath.isBlank()) {
+            return null;
+        }
+        if (imagePath.toLowerCase().startsWith("file:")) {
+            try {
+                return Path.of(URI.create(imagePath.replace('\\', '/')));
+            } catch (IllegalArgumentException ignored) {
+                imagePath = imagePath.replaceFirst("(?i)^file:/+", "");
+            }
+        }
+        return Path.of(imagePath).toAbsolutePath().normalize();
+    }
+
+    private String toImageUrl(String imagePath) {
+        if (isUrl(imagePath)) {
+            return imagePath;
+        }
+        if (imagePath != null && imagePath.toLowerCase().startsWith("file:")) {
+            try {
+                return URI.create(imagePath.replace('\\', '/')).toString();
+            } catch (IllegalArgumentException ignored) {
+                imagePath = imagePath.replaceFirst("(?i)^file:/+", "");
+            }
+        }
+        return Path.of(imagePath).toAbsolutePath().normalize().toUri().toString();
     }
 
     /**

--- a/agentscope-extensions/agentscope-extensions-rag-simple/src/main/java/io/agentscope/core/rag/reader/ImageReader.java
+++ b/agentscope-extensions/agentscope-extensions-rag-simple/src/main/java/io/agentscope/core/rag/reader/ImageReader.java
@@ -133,7 +133,7 @@ public class ImageReader implements Reader {
         }
 
         Path localPath = toLocalPath(imagePath);
-        if (localPath != null && Files.exists(localPath)) {
+        if (Files.exists(localPath)) {
             String mediaType = MediaUtils.determineMediaType(localPath.toString());
             String data = MediaUtils.fileToBase64(localPath.toString());
             return Base64Source.builder().mediaType(mediaType).data(data).build();
@@ -160,7 +160,7 @@ public class ImageReader implements Reader {
         if (isUrl(imagePath)) {
             return imagePath;
         }
-        if (imagePath != null && imagePath.toLowerCase().startsWith("file:")) {
+        if (imagePath.toLowerCase().startsWith("file:")) {
             try {
                 return URI.create(imagePath.replace('\\', '/')).toString();
             } catch (IllegalArgumentException ignored) {

--- a/agentscope-extensions/agentscope-extensions-rag-simple/src/test/java/io/agentscope/core/rag/hook/GenericRAGHookTest.java
+++ b/agentscope-extensions/agentscope-extensions-rag-simple/src/test/java/io/agentscope/core/rag/hook/GenericRAGHookTest.java
@@ -27,9 +27,11 @@ import io.agentscope.core.hook.PreCallEvent;
 import io.agentscope.core.hook.PreReasoningEvent;
 import io.agentscope.core.interruption.InterruptContext;
 import io.agentscope.core.message.ContentBlock;
+import io.agentscope.core.message.ImageBlock;
 import io.agentscope.core.message.Msg;
 import io.agentscope.core.message.MsgRole;
 import io.agentscope.core.message.TextBlock;
+import io.agentscope.core.message.URLSource;
 import io.agentscope.core.rag.GenericRAGHook;
 import io.agentscope.core.rag.Knowledge;
 import io.agentscope.core.rag.knowledge.SimpleKnowledge;
@@ -317,6 +319,50 @@ class GenericRAGHookTest {
                             assertTrue(content.contains("knowledge base"));
                             assertTrue(
                                     content.contains("Content 1") || content.contains("Content 2"));
+                        })
+                .verifyComplete();
+    }
+
+    @Test
+    @DisplayName("Should preserve non-text content blocks in retrieved knowledge")
+    void testPreserveNonTextKnowledgeBlocks() {
+        Knowledge imageKnowledge =
+                new Knowledge() {
+                    @Override
+                    public Mono<Void> addDocuments(List<Document> documents) {
+                        return Mono.empty();
+                    }
+
+                    @Override
+                    public Mono<List<Document>> retrieve(String query, RetrieveConfig config) {
+                        ImageBlock image =
+                                ImageBlock.builder()
+                                        .source(
+                                                URLSource.builder()
+                                                        .url("https://example.com/chart.png")
+                                                        .build())
+                                        .build();
+                        Document doc = new Document(new DocumentMetadata(image, "image-doc", "0"));
+                        doc.setScore(0.75);
+                        return Mono.just(List.of(doc));
+                    }
+                };
+        GenericRAGHook imageHook = new GenericRAGHook(imageKnowledge);
+        Msg userMsg =
+                Msg.builder()
+                        .role(MsgRole.USER)
+                        .content(TextBlock.builder().text("show chart").build())
+                        .build();
+        PreCallEvent event = new PreCallEvent(mockAgent, new ArrayList<>(List.of(userMsg)));
+
+        StepVerifier.create(imageHook.onEvent(event))
+                .assertNext(
+                        result -> {
+                            List<Msg> messages = result.getInputMessages();
+                            Msg knowledgeMsg = messages.get(1);
+                            assertTrue(
+                                    knowledgeMsg.getTextContent().contains("[ImageBlock follows]"));
+                            assertInstanceOf(ImageBlock.class, knowledgeMsg.getContent().get(1));
                         })
                 .verifyComplete();
     }

--- a/agentscope-extensions/agentscope-extensions-rag-simple/src/test/java/io/agentscope/core/rag/reader/ImageReaderTest.java
+++ b/agentscope-extensions/agentscope-extensions-rag-simple/src/test/java/io/agentscope/core/rag/reader/ImageReaderTest.java
@@ -26,6 +26,7 @@ import io.agentscope.core.message.URLSource;
 import io.agentscope.core.rag.exception.ReaderException;
 import io.agentscope.core.rag.model.Document;
 import io.agentscope.core.rag.model.DocumentMetadata;
+import java.lang.reflect.Method;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
@@ -194,6 +195,21 @@ class ImageReaderTest {
                                             .startsWith("file:"));
                         })
                 .verifyComplete();
+    }
+
+    @Test
+    @DisplayName("Should expose defensive private image path fallbacks")
+    void testDefensiveImagePathFallbacks() throws Exception {
+        ImageReader reader = new ImageReader();
+        Method toLocalPath = ImageReader.class.getDeclaredMethod("toLocalPath", String.class);
+        Method toImageUrl = ImageReader.class.getDeclaredMethod("toImageUrl", String.class);
+        toLocalPath.setAccessible(true);
+        toImageUrl.setAccessible(true);
+
+        assertEquals(null, toLocalPath.invoke(reader, new Object[] {null}));
+        assertEquals(
+                "https://example.com/image.png",
+                toImageUrl.invoke(reader, "https://example.com/image.png"));
     }
 
     @Test

--- a/agentscope-extensions/agentscope-extensions-rag-simple/src/test/java/io/agentscope/core/rag/reader/ImageReaderTest.java
+++ b/agentscope-extensions/agentscope-extensions-rag-simple/src/test/java/io/agentscope/core/rag/reader/ImageReaderTest.java
@@ -20,15 +20,19 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import io.agentscope.core.message.Base64Source;
 import io.agentscope.core.message.ImageBlock;
 import io.agentscope.core.message.URLSource;
 import io.agentscope.core.rag.exception.ReaderException;
 import io.agentscope.core.rag.model.Document;
 import io.agentscope.core.rag.model.DocumentMetadata;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import reactor.test.StepVerifier;
 
 /**
@@ -37,6 +41,8 @@ import reactor.test.StepVerifier;
 @Tag("unit")
 @DisplayName("ImageReader Unit Tests")
 class ImageReaderTest {
+
+    @TempDir Path tempDir;
 
     @Test
     @DisplayName("Should create ImageReader with default settings")
@@ -111,6 +117,27 @@ class ImageReaderTest {
                             assertTrue(imageBlock.getSource() instanceof URLSource);
                             URLSource urlSource = (URLSource) imageBlock.getSource();
                             assertEquals("https://example.com/image.png", urlSource.getUrl());
+                        })
+                .verifyComplete();
+    }
+
+    @Test
+    @DisplayName("Should read existing local images as base64 source")
+    void testReadExistingLocalImageAsBase64() throws Exception {
+        Path image = tempDir.resolve("pixel.png");
+        Files.write(image, new byte[] {(byte) 0x89, 'P', 'N', 'G', 0x0D, 0x0A, 0x1A, 0x0A});
+
+        ImageReader reader = new ImageReader();
+
+        StepVerifier.create(reader.read(ReaderInput.fromString(image.toString())))
+                .assertNext(
+                        documents -> {
+                            ImageBlock imageBlock =
+                                    (ImageBlock) documents.get(0).getMetadata().getContent();
+                            Base64Source source = (Base64Source) imageBlock.getSource();
+                            assertEquals("image/png", source.getMediaType());
+                            assertNotNull(source.getData());
+                            assertFalse(source.getData().isBlank());
                         })
                 .verifyComplete();
     }

--- a/agentscope-extensions/agentscope-extensions-rag-simple/src/test/java/io/agentscope/core/rag/reader/ImageReaderTest.java
+++ b/agentscope-extensions/agentscope-extensions-rag-simple/src/test/java/io/agentscope/core/rag/reader/ImageReaderTest.java
@@ -143,6 +143,70 @@ class ImageReaderTest {
     }
 
     @Test
+    @DisplayName("Should read existing file URI images as base64 source")
+    void testReadExistingFileUriImageAsBase64() throws Exception {
+        Path image = tempDir.resolve("pixel.png");
+        Files.write(image, new byte[] {(byte) 0x89, 'P', 'N', 'G', 0x0D, 0x0A, 0x1A, 0x0A});
+
+        ImageReader reader = new ImageReader();
+
+        StepVerifier.create(reader.read(ReaderInput.fromString(image.toUri().toString())))
+                .assertNext(
+                        documents -> {
+                            ImageBlock imageBlock =
+                                    (ImageBlock) documents.get(0).getMetadata().getContent();
+                            assertTrue(imageBlock.getSource() instanceof Base64Source);
+                        })
+                .verifyComplete();
+    }
+
+    @Test
+    @DisplayName("Should preserve missing file URIs as URL source")
+    void testReadMissingFileUriAsUrlSource() throws Exception {
+        Path missing = tempDir.resolve("missing.png");
+        ImageReader reader = new ImageReader();
+
+        StepVerifier.create(reader.read(ReaderInput.fromString(missing.toUri().toString())))
+                .assertNext(
+                        documents -> {
+                            ImageBlock imageBlock =
+                                    (ImageBlock) documents.get(0).getMetadata().getContent();
+                            URLSource source = (URLSource) imageBlock.getSource();
+                            assertEquals(missing.toUri().toString(), source.getUrl());
+                        })
+                .verifyComplete();
+    }
+
+    @Test
+    @DisplayName("Should tolerate invalid file URIs as local URL source")
+    void testReadInvalidFileUriAsLocalUrlSource() throws Exception {
+        ImageReader reader = new ImageReader();
+
+        StepVerifier.create(reader.read(ReaderInput.fromString("file://%")))
+                .assertNext(
+                        documents -> {
+                            ImageBlock imageBlock =
+                                    (ImageBlock) documents.get(0).getMetadata().getContent();
+                            assertTrue(imageBlock.getSource() instanceof URLSource);
+                            assertTrue(
+                                    ((URLSource) imageBlock.getSource())
+                                            .getUrl()
+                                            .startsWith("file:"));
+                        })
+                .verifyComplete();
+    }
+
+    @Test
+    @DisplayName("Should wrap blank image path failures")
+    void testReadBlankImagePathFailure() throws Exception {
+        ImageReader reader = new ImageReader();
+
+        StepVerifier.create(reader.read(ReaderInput.fromString(" ")))
+                .expectError(ReaderException.class)
+                .verify();
+    }
+
+    @Test
     @DisplayName("Should handle null input")
     void testNullInput() throws ReaderException {
         ImageReader reader = new ImageReader();

--- a/agentscope-extensions/agentscope-extensions-rag-simple/src/test/java/io/agentscope/core/rag/reader/ImageReaderTest.java
+++ b/agentscope-extensions/agentscope-extensions-rag-simple/src/test/java/io/agentscope/core/rag/reader/ImageReaderTest.java
@@ -19,6 +19,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import io.agentscope.core.message.Base64Source;
 import io.agentscope.core.message.ImageBlock;
@@ -123,6 +125,23 @@ class ImageReaderTest {
     }
 
     @Test
+    @DisplayName("Should read image from HTTP URL")
+    void testReadFromHttpURL() throws ReaderException {
+        ImageReader reader = new ImageReader();
+        ReaderInput input = ReaderInput.fromString("http://example.com/image.png");
+
+        StepVerifier.create(reader.read(input))
+                .assertNext(
+                        documents -> {
+                            ImageBlock imageBlock =
+                                    (ImageBlock) documents.get(0).getMetadata().getContent();
+                            URLSource source = (URLSource) imageBlock.getSource();
+                            assertEquals("http://example.com/image.png", source.getUrl());
+                        })
+                .verifyComplete();
+    }
+
+    @Test
     @DisplayName("Should read existing local images as base64 source")
     void testReadExistingLocalImageAsBase64() throws Exception {
         Path image = tempDir.resolve("pixel.png");
@@ -207,6 +226,8 @@ class ImageReaderTest {
         toImageUrl.setAccessible(true);
 
         assertEquals(null, toLocalPath.invoke(reader, new Object[] {null}));
+        assertEquals(null, toLocalPath.invoke(reader, " "));
+        assertTrue(((String) toImageUrl.invoke(reader, "missing.png")).endsWith("missing.png"));
         assertEquals(
                 "https://example.com/image.png",
                 toImageUrl.invoke(reader, "https://example.com/image.png"));
@@ -220,6 +241,10 @@ class ImageReaderTest {
         StepVerifier.create(reader.read(ReaderInput.fromString(" ")))
                 .expectError(ReaderException.class)
                 .verify();
+
+        ReaderInput nullPath = mock(ReaderInput.class);
+        when(nullPath.asString()).thenReturn(null);
+        StepVerifier.create(reader.read(nullPath)).expectError(ReaderException.class).verify();
     }
 
     @Test

--- a/agentscope-extensions/agentscope-spring-boot-starters/agentscope-llm-interfaces-web-starter/pom.xml
+++ b/agentscope-extensions/agentscope-spring-boot-starters/agentscope-llm-interfaces-web-starter/pom.xml
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2024-2026 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.agentscope</groupId>
+        <artifactId>agentscope-spring-boot-starters</artifactId>
+        <version>${revision}</version>
+    </parent>
+
+    <artifactId>agentscope-llm-interfaces-web-starter</artifactId>
+    <name>AgentScope Java - LLM Interfaces Web Starter</name>
+    <description>Spring Boot starter exposing OpenAI Chat, OpenAI Responses, and Anthropic Messages style HTTP APIs for AgentScope agents</description>
+
+    <properties>
+        <maven.deploy.skip>false</maven.deploy.skip>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.agentscope</groupId>
+            <artifactId>agentscope-core</artifactId>
+            <optional>true</optional>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.agentscope</groupId>
+            <artifactId>agentscope-extensions-chat-completions-web</artifactId>
+            <version>${revision}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.agentscope</groupId>
+            <artifactId>agentscope-extensions-llm-interfaces-web</artifactId>
+            <version>${revision}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.agentscope</groupId>
+            <artifactId>agentscope-spring-boot-starter</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-configuration-processor</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/agentscope-extensions/agentscope-spring-boot-starters/agentscope-llm-interfaces-web-starter/src/main/java/io/agentscope/spring/boot/llm/interfacesweb/LlmInterfacesController.java
+++ b/agentscope-extensions/agentscope-spring-boot-starters/agentscope-llm-interfaces-web-starter/src/main/java/io/agentscope/spring/boot/llm/interfacesweb/LlmInterfacesController.java
@@ -1,0 +1,310 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.spring.boot.llm.interfacesweb;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import io.agentscope.core.ReActAgent;
+import io.agentscope.core.chat.completions.builder.ChatCompletionsResponseBuilder;
+import io.agentscope.core.chat.completions.converter.ChatMessageConverter;
+import io.agentscope.core.chat.completions.converter.OpenAIToolConverter;
+import io.agentscope.core.chat.completions.model.ChatCompletionsChunk;
+import io.agentscope.core.chat.completions.model.ChatCompletionsRequest;
+import io.agentscope.core.chat.completions.streaming.ChatCompletionsStreamingAdapter;
+import io.agentscope.core.llm.interfacesweb.anthropic.AnthropicMessageConverter;
+import io.agentscope.core.llm.interfacesweb.anthropic.AnthropicMessagesRequest;
+import io.agentscope.core.llm.interfacesweb.anthropic.AnthropicResponseBuilder;
+import io.agentscope.core.llm.interfacesweb.anthropic.AnthropicStreamEvent;
+import io.agentscope.core.llm.interfacesweb.anthropic.AnthropicStreamingAdapter;
+import io.agentscope.core.llm.interfacesweb.anthropic.AnthropicToolConverter;
+import io.agentscope.core.llm.interfacesweb.common.ProtocolJsonUtils;
+import io.agentscope.core.llm.interfacesweb.responses.ResponsesMessageConverter;
+import io.agentscope.core.llm.interfacesweb.responses.ResponsesRequest;
+import io.agentscope.core.llm.interfacesweb.responses.ResponsesResponseBuilder;
+import io.agentscope.core.llm.interfacesweb.responses.ResponsesStreamEvent;
+import io.agentscope.core.llm.interfacesweb.responses.ResponsesStreamingAdapter;
+import io.agentscope.core.llm.interfacesweb.responses.ResponsesToolConverter;
+import io.agentscope.core.message.Msg;
+import io.agentscope.core.model.Model;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.codec.ServerSentEvent;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+/** Aggregated OpenAI Chat, OpenAI Responses, and Anthropic Messages endpoints. */
+@RestController
+@RequestMapping
+public class LlmInterfacesController {
+
+    private final ObjectProvider<ReActAgent> agentProvider;
+    private final ObjectProvider<Model> modelProvider;
+    private final LlmInterfacesProperties properties;
+    private final ChatMessageConverter chatMessageConverter;
+    private final OpenAIToolConverter openAIToolConverter;
+    private final ChatCompletionsResponseBuilder chatResponseBuilder;
+    private final ChatCompletionsStreamingAdapter chatStreamingAdapter;
+    private final ResponsesMessageConverter responsesMessageConverter;
+    private final ResponsesToolConverter responsesToolConverter;
+    private final ResponsesResponseBuilder responsesResponseBuilder;
+    private final ResponsesStreamingAdapter responsesStreamingAdapter;
+    private final AnthropicMessageConverter anthropicMessageConverter;
+    private final AnthropicToolConverter anthropicToolConverter;
+    private final AnthropicResponseBuilder anthropicResponseBuilder;
+    private final AnthropicStreamingAdapter anthropicStreamingAdapter;
+
+    public LlmInterfacesController(
+            ObjectProvider<ReActAgent> agentProvider,
+            ObjectProvider<Model> modelProvider,
+            LlmInterfacesProperties properties,
+            ChatMessageConverter chatMessageConverter,
+            OpenAIToolConverter openAIToolConverter,
+            ChatCompletionsResponseBuilder chatResponseBuilder,
+            ChatCompletionsStreamingAdapter chatStreamingAdapter,
+            ResponsesMessageConverter responsesMessageConverter,
+            ResponsesToolConverter responsesToolConverter,
+            ResponsesResponseBuilder responsesResponseBuilder,
+            ResponsesStreamingAdapter responsesStreamingAdapter,
+            AnthropicMessageConverter anthropicMessageConverter,
+            AnthropicToolConverter anthropicToolConverter,
+            AnthropicResponseBuilder anthropicResponseBuilder,
+            AnthropicStreamingAdapter anthropicStreamingAdapter) {
+        this.agentProvider = agentProvider;
+        this.modelProvider = modelProvider;
+        this.properties = properties;
+        this.chatMessageConverter = chatMessageConverter;
+        this.openAIToolConverter = openAIToolConverter;
+        this.chatResponseBuilder = chatResponseBuilder;
+        this.chatStreamingAdapter = chatStreamingAdapter;
+        this.responsesMessageConverter = responsesMessageConverter;
+        this.responsesToolConverter = responsesToolConverter;
+        this.responsesResponseBuilder = responsesResponseBuilder;
+        this.responsesStreamingAdapter = responsesStreamingAdapter;
+        this.anthropicMessageConverter = anthropicMessageConverter;
+        this.anthropicToolConverter = anthropicToolConverter;
+        this.anthropicResponseBuilder = anthropicResponseBuilder;
+        this.anthropicStreamingAdapter = anthropicStreamingAdapter;
+    }
+
+    @PostMapping(
+            value = "${agentscope.llm-interfaces.base-path:/v1}/chat/completions",
+            consumes = MediaType.APPLICATION_JSON_VALUE)
+    public Object chatCompletions(@RequestBody ChatCompletionsRequest request) {
+        if (!properties.getChat().isEnabled()) {
+            return disabled("chat");
+        }
+        String requestId = "chatcmpl-" + UUID.randomUUID();
+        if (request.getModel() == null || request.getModel().isBlank()) {
+            request.setModel(activeModelName());
+        }
+
+        try {
+            ReActAgent agent = newAgent();
+            if (request.getTools() != null && !request.getTools().isEmpty()) {
+                agent.getToolkit()
+                        .registerSchemas(
+                                openAIToolConverter.convertToToolSchemas(request.getTools()));
+            }
+            List<Msg> messages = chatMessageConverter.convertMessages(request.getMessages());
+            if (messages.isEmpty()) {
+                return Mono.error(new IllegalArgumentException("At least one message is required"));
+            }
+            if (Boolean.TRUE.equals(request.getStream())) {
+                Flux<ServerSentEvent<String>> stream =
+                        chatStreamingAdapter.stream(agent, messages, requestId, request.getModel())
+                                .map(this::chatChunkToSse)
+                                .concatWith(
+                                        Flux.just(
+                                                ServerSentEvent.<String>builder()
+                                                        .data("[DONE]")
+                                                        .build()));
+                return sse(stream);
+            }
+            return agent.call(messages)
+                    .map(reply -> chatResponseBuilder.buildResponse(request, reply, requestId))
+                    .onErrorResume(
+                            error ->
+                                    Mono.just(
+                                            chatResponseBuilder.buildErrorResponse(
+                                                    request, error, requestId)));
+        } catch (Exception e) {
+            return Mono.error(e);
+        }
+    }
+
+    @PostMapping(
+            value = "${agentscope.llm-interfaces.base-path:/v1}/responses",
+            consumes = MediaType.APPLICATION_JSON_VALUE)
+    public Object responses(@RequestBody ResponsesRequest request) {
+        if (!properties.getResponses().isEnabled()) {
+            return disabled("responses");
+        }
+        String responseId = "resp_" + UUID.randomUUID();
+        if (request.getModel() == null || request.getModel().isBlank()) {
+            request.setModel(activeModelName());
+        }
+
+        try {
+            ReActAgent agent = newAgent();
+            if (request.getTools() != null && !request.getTools().isEmpty()) {
+                agent.getToolkit()
+                        .registerSchemas(responsesToolConverter.convert(request.getTools()));
+            }
+            List<Msg> messages = responsesMessageConverter.convert(request);
+            if (Boolean.TRUE.equals(request.getStream())) {
+                Flux<ServerSentEvent<String>> stream =
+                        responsesStreamingAdapter.stream(agent, messages, request, responseId)
+                                .map(this::responsesEventToSse)
+                                .onErrorResume(
+                                        error ->
+                                                Flux.just(
+                                                        responsesEventToSse(
+                                                                responsesStreamingAdapter
+                                                                        .errorEvent(
+                                                                                error,
+                                                                                responseId))));
+                return sse(stream);
+            }
+            return agent.call(messages)
+                    .map(
+                            reply ->
+                                    responsesResponseBuilder.buildResponse(
+                                            request, reply, responseId))
+                    .onErrorResume(
+                            error ->
+                                    Mono.just(
+                                            responsesResponseBuilder.buildErrorResponse(
+                                                    request, error, responseId)));
+        } catch (Exception e) {
+            return Mono.just(responsesResponseBuilder.buildErrorResponse(request, e, responseId));
+        }
+    }
+
+    @PostMapping(
+            value = "${agentscope.llm-interfaces.base-path:/v1}/messages",
+            consumes = MediaType.APPLICATION_JSON_VALUE)
+    public Object anthropicMessages(@RequestBody AnthropicMessagesRequest request) {
+        if (!properties.getAnthropic().isEnabled()) {
+            return disabled("anthropic");
+        }
+        String messageId = "msg_" + UUID.randomUUID();
+        if (request.getModel() == null || request.getModel().isBlank()) {
+            request.setModel(activeModelName());
+        }
+
+        try {
+            ReActAgent agent = newAgent();
+            if (request.getTools() != null && !request.getTools().isEmpty()) {
+                agent.getToolkit()
+                        .registerSchemas(anthropicToolConverter.convert(request.getTools()));
+            }
+            List<Msg> messages = anthropicMessageConverter.convert(request);
+            if (Boolean.TRUE.equals(request.getStream())) {
+                Flux<ServerSentEvent<String>> stream =
+                        anthropicStreamingAdapter.stream(agent, messages, request, messageId)
+                                .map(this::anthropicEventToSse)
+                                .onErrorResume(
+                                        error ->
+                                                Flux.just(
+                                                        anthropicEventToSse(
+                                                                anthropicStreamingAdapter
+                                                                        .errorEvent(error))));
+                return sse(stream);
+            }
+            return agent.call(messages)
+                    .<Object>map(
+                            reply ->
+                                    anthropicResponseBuilder.buildResponse(
+                                            request, reply, messageId))
+                    .onErrorResume(error -> Mono.just(anthropicResponseBuilder.buildError(error)));
+        } catch (Exception e) {
+            return Mono.just(anthropicResponseBuilder.buildError(e));
+        }
+    }
+
+    @GetMapping(
+            value = "${agentscope.llm-interfaces.base-path:/v1}/models",
+            produces = MediaType.APPLICATION_JSON_VALUE)
+    public Map<String, Object> models() {
+        String modelName = activeModelName();
+        return Map.of(
+                "object",
+                "list",
+                "data",
+                List.of(Map.of("id", modelName, "object", "model", "owned_by", "agentscope")));
+    }
+
+    private ReActAgent newAgent() {
+        ReActAgent agent = agentProvider.getObject();
+        if (agent == null) {
+            throw new IllegalStateException("Failed to create ReActAgent");
+        }
+        return agent;
+    }
+
+    private String activeModelName() {
+        Model model = modelProvider.getIfAvailable();
+        return model != null ? model.getModelName() : "agentscope-agent";
+    }
+
+    private ResponseEntity<Map<String, Object>> disabled(String endpoint) {
+        return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                .body(
+                        Map.of(
+                                "error",
+                                Map.of(
+                                        "type",
+                                        "not_found_error",
+                                        "message",
+                                        endpoint + " endpoint is disabled")));
+    }
+
+    private ResponseEntity<Flux<ServerSentEvent<String>>> sse(
+            Flux<ServerSentEvent<String>> stream) {
+        return ResponseEntity.ok()
+                .header("Content-Type", MediaType.TEXT_EVENT_STREAM_VALUE)
+                .body(stream);
+    }
+
+    private ServerSentEvent<String> chatChunkToSse(ChatCompletionsChunk chunk) {
+        return ServerSentEvent.<String>builder().data(json(chunk)).build();
+    }
+
+    private ServerSentEvent<String> responsesEventToSse(ResponsesStreamEvent event) {
+        return ServerSentEvent.<String>builder().event(event.getType()).data(json(event)).build();
+    }
+
+    private ServerSentEvent<String> anthropicEventToSse(AnthropicStreamEvent event) {
+        return ServerSentEvent.<String>builder().event(event.getType()).data(json(event)).build();
+    }
+
+    private String json(Object value) {
+        try {
+            return ProtocolJsonUtils.OBJECT_MAPPER.writeValueAsString(value);
+        } catch (JsonProcessingException e) {
+            return "{\"error\":\"Serialization error\"}";
+        }
+    }
+}

--- a/agentscope-extensions/agentscope-spring-boot-starters/agentscope-llm-interfaces-web-starter/src/main/java/io/agentscope/spring/boot/llm/interfacesweb/LlmInterfacesProperties.java
+++ b/agentscope-extensions/agentscope-spring-boot-starters/agentscope-llm-interfaces-web-starter/src/main/java/io/agentscope/spring/boot/llm/interfacesweb/LlmInterfacesProperties.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.spring.boot.llm.interfacesweb;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/** Configuration properties for the aggregated LLM interface endpoints. */
+@ConfigurationProperties(prefix = "agentscope.llm-interfaces")
+public class LlmInterfacesProperties {
+
+    private boolean enabled = true;
+    private String basePath = "/v1";
+    private boolean ignoreUnknownFields = true;
+    private boolean ignoreInvalidThinking = true;
+    private Endpoint chat = new Endpoint(true);
+    private Endpoint responses = new Endpoint(true);
+    private Endpoint anthropic = new Endpoint(true);
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    public String getBasePath() {
+        return basePath;
+    }
+
+    public void setBasePath(String basePath) {
+        this.basePath = basePath;
+    }
+
+    public boolean isIgnoreUnknownFields() {
+        return ignoreUnknownFields;
+    }
+
+    public void setIgnoreUnknownFields(boolean ignoreUnknownFields) {
+        this.ignoreUnknownFields = ignoreUnknownFields;
+    }
+
+    public boolean isIgnoreInvalidThinking() {
+        return ignoreInvalidThinking;
+    }
+
+    public void setIgnoreInvalidThinking(boolean ignoreInvalidThinking) {
+        this.ignoreInvalidThinking = ignoreInvalidThinking;
+    }
+
+    public Endpoint getChat() {
+        return chat;
+    }
+
+    public void setChat(Endpoint chat) {
+        this.chat = chat;
+    }
+
+    public Endpoint getResponses() {
+        return responses;
+    }
+
+    public void setResponses(Endpoint responses) {
+        this.responses = responses;
+    }
+
+    public Endpoint getAnthropic() {
+        return anthropic;
+    }
+
+    public void setAnthropic(Endpoint anthropic) {
+        this.anthropic = anthropic;
+    }
+
+    public static class Endpoint {
+        private boolean enabled;
+
+        public Endpoint() {}
+
+        public Endpoint(boolean enabled) {
+            this.enabled = enabled;
+        }
+
+        public boolean isEnabled() {
+            return enabled;
+        }
+
+        public void setEnabled(boolean enabled) {
+            this.enabled = enabled;
+        }
+    }
+}

--- a/agentscope-extensions/agentscope-spring-boot-starters/agentscope-llm-interfaces-web-starter/src/main/java/io/agentscope/spring/boot/llm/interfacesweb/LlmInterfacesWebAutoConfiguration.java
+++ b/agentscope-extensions/agentscope-spring-boot-starters/agentscope-llm-interfaces-web-starter/src/main/java/io/agentscope/spring/boot/llm/interfacesweb/LlmInterfacesWebAutoConfiguration.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.spring.boot.llm.interfacesweb;
+
+import io.agentscope.core.ReActAgent;
+import io.agentscope.core.chat.completions.builder.ChatCompletionsResponseBuilder;
+import io.agentscope.core.chat.completions.converter.ChatMessageConverter;
+import io.agentscope.core.chat.completions.converter.OpenAIToolConverter;
+import io.agentscope.core.chat.completions.streaming.ChatCompletionsStreamingAdapter;
+import io.agentscope.core.llm.interfacesweb.anthropic.AnthropicMessageConverter;
+import io.agentscope.core.llm.interfacesweb.anthropic.AnthropicResponseBuilder;
+import io.agentscope.core.llm.interfacesweb.anthropic.AnthropicStreamingAdapter;
+import io.agentscope.core.llm.interfacesweb.anthropic.AnthropicToolConverter;
+import io.agentscope.core.llm.interfacesweb.responses.ResponsesMessageConverter;
+import io.agentscope.core.llm.interfacesweb.responses.ResponsesResponseBuilder;
+import io.agentscope.core.llm.interfacesweb.responses.ResponsesStreamingAdapter;
+import io.agentscope.core.llm.interfacesweb.responses.ResponsesToolConverter;
+import io.agentscope.core.model.Model;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+
+/** Auto-configuration for aggregated OpenAI/Anthropic-compatible LLM HTTP endpoints. */
+@AutoConfiguration
+@EnableConfigurationProperties(LlmInterfacesProperties.class)
+@ConditionalOnProperty(
+        prefix = "agentscope.llm-interfaces",
+        name = "enabled",
+        havingValue = "true",
+        matchIfMissing = true)
+@ConditionalOnClass(ReActAgent.class)
+public class LlmInterfacesWebAutoConfiguration {
+
+    @Bean
+    @ConditionalOnMissingBean
+    public ChatMessageConverter llmInterfacesChatMessageConverter() {
+        return new ChatMessageConverter();
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    public OpenAIToolConverter llmInterfacesOpenAIToolConverter() {
+        return new OpenAIToolConverter();
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    public ChatCompletionsResponseBuilder llmInterfacesChatResponseBuilder() {
+        return new ChatCompletionsResponseBuilder();
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    public ChatCompletionsStreamingAdapter llmInterfacesChatStreamingAdapter() {
+        return new ChatCompletionsStreamingAdapter();
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    public ResponsesMessageConverter responsesMessageConverter() {
+        return new ResponsesMessageConverter();
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    public ResponsesToolConverter responsesToolConverter() {
+        return new ResponsesToolConverter();
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    public ResponsesResponseBuilder responsesResponseBuilder() {
+        return new ResponsesResponseBuilder();
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    public ResponsesStreamingAdapter responsesStreamingAdapter(
+            ResponsesResponseBuilder responseBuilder) {
+        return new ResponsesStreamingAdapter(responseBuilder);
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    public AnthropicMessageConverter anthropicMessageConverter() {
+        return new AnthropicMessageConverter();
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    public AnthropicToolConverter anthropicToolConverter() {
+        return new AnthropicToolConverter();
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    public AnthropicResponseBuilder anthropicResponseBuilder() {
+        return new AnthropicResponseBuilder();
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    public AnthropicStreamingAdapter anthropicStreamingAdapter(
+            AnthropicResponseBuilder responseBuilder) {
+        return new AnthropicStreamingAdapter(responseBuilder);
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    public LlmInterfacesController llmInterfacesController(
+            ObjectProvider<ReActAgent> agentProvider,
+            ObjectProvider<Model> modelProvider,
+            LlmInterfacesProperties properties,
+            ChatMessageConverter chatMessageConverter,
+            OpenAIToolConverter openAIToolConverter,
+            ChatCompletionsResponseBuilder chatResponseBuilder,
+            ChatCompletionsStreamingAdapter chatStreamingAdapter,
+            ResponsesMessageConverter responsesMessageConverter,
+            ResponsesToolConverter responsesToolConverter,
+            ResponsesResponseBuilder responsesResponseBuilder,
+            ResponsesStreamingAdapter responsesStreamingAdapter,
+            AnthropicMessageConverter anthropicMessageConverter,
+            AnthropicToolConverter anthropicToolConverter,
+            AnthropicResponseBuilder anthropicResponseBuilder,
+            AnthropicStreamingAdapter anthropicStreamingAdapter) {
+        return new LlmInterfacesController(
+                agentProvider,
+                modelProvider,
+                properties,
+                chatMessageConverter,
+                openAIToolConverter,
+                chatResponseBuilder,
+                chatStreamingAdapter,
+                responsesMessageConverter,
+                responsesToolConverter,
+                responsesResponseBuilder,
+                responsesStreamingAdapter,
+                anthropicMessageConverter,
+                anthropicToolConverter,
+                anthropicResponseBuilder,
+                anthropicStreamingAdapter);
+    }
+}

--- a/agentscope-extensions/agentscope-spring-boot-starters/agentscope-llm-interfaces-web-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/agentscope-extensions/agentscope-spring-boot-starters/agentscope-llm-interfaces-web-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+io.agentscope.spring.boot.llm.interfacesweb.LlmInterfacesWebAutoConfiguration

--- a/agentscope-extensions/agentscope-spring-boot-starters/agentscope-llm-interfaces-web-starter/src/test/java/io/agentscope/spring/boot/llm/interfacesweb/LlmInterfacesControllerTest.java
+++ b/agentscope-extensions/agentscope-spring-boot-starters/agentscope-llm-interfaces-web-starter/src/test/java/io/agentscope/spring/boot/llm/interfacesweb/LlmInterfacesControllerTest.java
@@ -37,6 +37,7 @@ import io.agentscope.core.chat.completions.model.ChatMessage;
 import io.agentscope.core.chat.completions.model.OpenAITool;
 import io.agentscope.core.chat.completions.model.OpenAIToolFunction;
 import io.agentscope.core.chat.completions.streaming.ChatCompletionsStreamingAdapter;
+import io.agentscope.core.llm.interfacesweb.anthropic.AnthropicMessage;
 import io.agentscope.core.llm.interfacesweb.anthropic.AnthropicMessageConverter;
 import io.agentscope.core.llm.interfacesweb.anthropic.AnthropicMessagesRequest;
 import io.agentscope.core.llm.interfacesweb.anthropic.AnthropicMessagesResponse;
@@ -184,6 +185,94 @@ class LlmInterfacesControllerTest {
 
         StepVerifier.create(responseMono).expectNextCount(1).verifyComplete();
         assertNotNull(toolkit.getTool("lookup"));
+    }
+
+    @Test
+    @DisplayName("Should preserve explicit models and tolerate empty tool lists")
+    void shouldPreserveExplicitModelsAndTolerateEmptyToolLists() {
+        Msg reply = Msg.builder().role(MsgRole.ASSISTANT).textContent("Hi").build();
+        when(agent.call(anyList()))
+                .thenReturn(Mono.just(reply), Mono.just(reply), Mono.just(reply));
+
+        ChatCompletionsRequest chat = new ChatCompletionsRequest();
+        chat.setModel("explicit-chat");
+        chat.setMessages(List.of(new ChatMessage("user", "Hello")));
+        chat.setTools(List.of());
+
+        @SuppressWarnings("unchecked")
+        Mono<ChatCompletionsResponse> chatMono =
+                (Mono<ChatCompletionsResponse>) controller.chatCompletions(chat);
+        StepVerifier.create(chatMono)
+                .assertNext(response -> assertEquals("explicit-chat", response.getModel()))
+                .verifyComplete();
+
+        ResponsesRequest responses = new ResponsesRequest();
+        responses.setModel("explicit-responses");
+        responses.setInput("Hello");
+        responses.setTools(List.of());
+
+        @SuppressWarnings("unchecked")
+        Mono<ResponsesResponse> responsesMono =
+                (Mono<ResponsesResponse>) controller.responses(responses);
+        StepVerifier.create(responsesMono)
+                .assertNext(response -> assertEquals("explicit-responses", response.getModel()))
+                .verifyComplete();
+
+        AnthropicMessage anthropicMessage = new AnthropicMessage();
+        anthropicMessage.setRole("user");
+        anthropicMessage.setContent("Hello");
+        AnthropicMessagesRequest anthropic = new AnthropicMessagesRequest();
+        anthropic.setModel("explicit-anthropic");
+        anthropic.setMessages(List.of(anthropicMessage));
+        anthropic.setTools(List.of());
+
+        @SuppressWarnings("unchecked")
+        Mono<AnthropicMessagesResponse> anthropicMono =
+                (Mono<AnthropicMessagesResponse>) controller.anthropicMessages(anthropic);
+        StepVerifier.create(anthropicMono)
+                .assertNext(response -> assertEquals("explicit-anthropic", response.getModel()))
+                .verifyComplete();
+    }
+
+    @Test
+    @DisplayName("Should default blank protocol model names")
+    void shouldDefaultBlankProtocolModelNames() {
+        Msg reply = Msg.builder().role(MsgRole.ASSISTANT).textContent("Hi").build();
+        when(agent.call(anyList()))
+                .thenReturn(Mono.just(reply), Mono.just(reply), Mono.just(reply));
+
+        ChatCompletionsRequest chat = new ChatCompletionsRequest();
+        chat.setModel(" ");
+        chat.setMessages(List.of(new ChatMessage("user", "Hello")));
+        @SuppressWarnings("unchecked")
+        Mono<ChatCompletionsResponse> chatMono =
+                (Mono<ChatCompletionsResponse>) controller.chatCompletions(chat);
+        StepVerifier.create(chatMono)
+                .assertNext(response -> assertEquals("active-model", response.getModel()))
+                .verifyComplete();
+
+        ResponsesRequest responses = new ResponsesRequest();
+        responses.setModel(" ");
+        responses.setInput("Hello");
+        @SuppressWarnings("unchecked")
+        Mono<ResponsesResponse> responsesMono =
+                (Mono<ResponsesResponse>) controller.responses(responses);
+        StepVerifier.create(responsesMono)
+                .assertNext(response -> assertEquals("active-model", response.getModel()))
+                .verifyComplete();
+
+        AnthropicMessage anthropicMessage = new AnthropicMessage();
+        anthropicMessage.setRole("user");
+        anthropicMessage.setContent("Hello");
+        AnthropicMessagesRequest anthropic = new AnthropicMessagesRequest();
+        anthropic.setModel(" ");
+        anthropic.setMessages(List.of(anthropicMessage));
+        @SuppressWarnings("unchecked")
+        Mono<AnthropicMessagesResponse> anthropicMono =
+                (Mono<AnthropicMessagesResponse>) controller.anthropicMessages(anthropic);
+        StepVerifier.create(anthropicMono)
+                .assertNext(response -> assertEquals("active-model", response.getModel()))
+                .verifyComplete();
     }
 
     @Test

--- a/agentscope-extensions/agentscope-spring-boot-starters/agentscope-llm-interfaces-web-starter/src/test/java/io/agentscope/spring/boot/llm/interfacesweb/LlmInterfacesControllerTest.java
+++ b/agentscope-extensions/agentscope-spring-boot-starters/agentscope-llm-interfaces-web-starter/src/test/java/io/agentscope/spring/boot/llm/interfacesweb/LlmInterfacesControllerTest.java
@@ -17,6 +17,7 @@ package io.agentscope.spring.boot.llm.interfacesweb;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.Mockito.mock;
@@ -33,23 +34,28 @@ import io.agentscope.core.chat.completions.converter.OpenAIToolConverter;
 import io.agentscope.core.chat.completions.model.ChatCompletionsRequest;
 import io.agentscope.core.chat.completions.model.ChatCompletionsResponse;
 import io.agentscope.core.chat.completions.model.ChatMessage;
+import io.agentscope.core.chat.completions.model.OpenAITool;
+import io.agentscope.core.chat.completions.model.OpenAIToolFunction;
 import io.agentscope.core.chat.completions.streaming.ChatCompletionsStreamingAdapter;
 import io.agentscope.core.llm.interfacesweb.anthropic.AnthropicMessageConverter;
 import io.agentscope.core.llm.interfacesweb.anthropic.AnthropicMessagesRequest;
 import io.agentscope.core.llm.interfacesweb.anthropic.AnthropicMessagesResponse;
 import io.agentscope.core.llm.interfacesweb.anthropic.AnthropicResponseBuilder;
+import io.agentscope.core.llm.interfacesweb.anthropic.AnthropicStreamEvent;
 import io.agentscope.core.llm.interfacesweb.anthropic.AnthropicStreamingAdapter;
 import io.agentscope.core.llm.interfacesweb.anthropic.AnthropicToolConverter;
 import io.agentscope.core.llm.interfacesweb.responses.ResponsesMessageConverter;
 import io.agentscope.core.llm.interfacesweb.responses.ResponsesRequest;
 import io.agentscope.core.llm.interfacesweb.responses.ResponsesResponse;
 import io.agentscope.core.llm.interfacesweb.responses.ResponsesResponseBuilder;
+import io.agentscope.core.llm.interfacesweb.responses.ResponsesStreamEvent;
 import io.agentscope.core.llm.interfacesweb.responses.ResponsesStreamingAdapter;
 import io.agentscope.core.llm.interfacesweb.responses.ResponsesToolConverter;
 import io.agentscope.core.message.Msg;
 import io.agentscope.core.message.MsgRole;
 import io.agentscope.core.message.TextBlock;
 import io.agentscope.core.model.Model;
+import io.agentscope.core.tool.Toolkit;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
@@ -157,6 +163,65 @@ class LlmInterfacesControllerTest {
     }
 
     @Test
+    @DisplayName("Should register Chat Completions tools")
+    void shouldRegisterChatCompletionsTools() {
+        Toolkit toolkit = new Toolkit();
+        when(agent.getToolkit()).thenReturn(toolkit);
+        ChatCompletionsRequest request = new ChatCompletionsRequest();
+        request.setMessages(List.of(new ChatMessage("user", "Hello")));
+        request.setStream(false);
+        OpenAIToolFunction function = new OpenAIToolFunction();
+        function.setName("lookup");
+        function.setDescription("Lookup data");
+        function.setParameters(Map.of("type", "object"));
+        request.setTools(List.of(new OpenAITool(function)));
+        Msg reply = Msg.builder().role(MsgRole.ASSISTANT).textContent("Hi").build();
+        when(agent.call(anyList())).thenReturn(Mono.just(reply));
+
+        @SuppressWarnings("unchecked")
+        Mono<ChatCompletionsResponse> responseMono =
+                (Mono<ChatCompletionsResponse>) controller.chatCompletions(request);
+
+        StepVerifier.create(responseMono).expectNextCount(1).verifyComplete();
+        assertNotNull(toolkit.getTool("lookup"));
+    }
+
+    @Test
+    @DisplayName("Should reject empty Chat Completions messages")
+    void shouldRejectEmptyChatMessages() {
+        ChatCompletionsRequest request = new ChatCompletionsRequest();
+        request.setMessages(List.of());
+
+        @SuppressWarnings("unchecked")
+        Mono<Object> responseMono = (Mono<Object>) controller.chatCompletions(request);
+
+        StepVerifier.create(responseMono)
+                .expectErrorMatches(
+                        error ->
+                                error instanceof IllegalArgumentException
+                                        && error.getMessage()
+                                                .contains("At least one message is required"))
+                .verify();
+    }
+
+    @Test
+    @DisplayName("Should surface Chat Completions conversion errors")
+    void shouldSurfaceChatConversionErrors() {
+        ChatCompletionsRequest request = new ChatCompletionsRequest();
+        request.setMessages(List.of(new ChatMessage("alien", "Hello")));
+
+        @SuppressWarnings("unchecked")
+        Mono<Object> responseMono = (Mono<Object>) controller.chatCompletions(request);
+
+        StepVerifier.create(responseMono)
+                .expectErrorMatches(
+                        error ->
+                                error instanceof IllegalArgumentException
+                                        && error.getMessage().contains("Unknown message role"))
+                .verify();
+    }
+
+    @Test
     @DisplayName("Should emit Chat Completions SSE done sentinel")
     void shouldEmitChatCompletionsDoneSentinel() {
         ChatCompletionsRequest request = new ChatCompletionsRequest();
@@ -200,6 +265,103 @@ class LlmInterfacesControllerTest {
                             assertEquals("completed", response.getStatus());
                             assertEquals("Hi", response.getOutputText());
                         })
+                .verifyComplete();
+    }
+
+    @Test
+    @DisplayName("Should register Responses tools")
+    void shouldRegisterResponsesTools() throws Exception {
+        Toolkit toolkit = new Toolkit();
+        when(agent.getToolkit()).thenReturn(toolkit);
+        ResponsesRequest request =
+                objectMapper.readValue(
+                        """
+                        {
+                          "input": "Hello",
+                          "tools": [
+                            {
+                              "type": "function",
+                              "name": "lookup",
+                              "description": "Lookup data",
+                              "parameters": {"type": "object"}
+                            }
+                          ]
+                        }
+                        """,
+                        ResponsesRequest.class);
+        Msg reply = Msg.builder().role(MsgRole.ASSISTANT).textContent("Hi").build();
+        when(agent.call(anyList())).thenReturn(Mono.just(reply));
+
+        @SuppressWarnings("unchecked")
+        Mono<ResponsesResponse> responseMono =
+                (Mono<ResponsesResponse>) controller.responses(request);
+
+        StepVerifier.create(responseMono).expectNextCount(1).verifyComplete();
+        assertNotNull(toolkit.getTool("lookup"));
+    }
+
+    @Test
+    @DisplayName("Should build Responses errors for agent failures")
+    void shouldBuildResponsesErrorsForAgentFailures() throws Exception {
+        ResponsesRequest request = new ResponsesRequest();
+        request.setInput(objectMapper.readTree("\"Hello\""));
+        when(agent.call(anyList())).thenReturn(Mono.error(new RuntimeException("boom")));
+
+        @SuppressWarnings("unchecked")
+        Mono<ResponsesResponse> responseMono =
+                (Mono<ResponsesResponse>) controller.responses(request);
+
+        StepVerifier.create(responseMono)
+                .assertNext(
+                        response -> {
+                            assertEquals("failed", response.getStatus());
+                            @SuppressWarnings("unchecked")
+                            Map<String, Object> error = (Map<String, Object>) response.getError();
+                            assertEquals("server_error", error.get("type"));
+                        })
+                .verifyComplete();
+    }
+
+    @Test
+    @DisplayName("Should serialize Responses SSE failures defensively")
+    void shouldSerializeResponsesSseFailuresDefensively() throws Exception {
+        @SuppressWarnings("unchecked")
+        ObjectProvider<ReActAgent> agentProvider = mock(ObjectProvider.class);
+        @SuppressWarnings("unchecked")
+        ObjectProvider<Model> modelProvider = mock(ObjectProvider.class);
+        ReActAgent localAgent = mock(ReActAgent.class);
+        when(agentProvider.getObject()).thenReturn(localAgent);
+        when(modelProvider.getIfAvailable()).thenReturn(null);
+        ResponsesStreamingAdapter streamingAdapter = mock(ResponsesStreamingAdapter.class);
+        ResponsesStreamEvent event = new ResponsesStreamEvent("response.created");
+        event.setError(new Object());
+        when(streamingAdapter.stream(any(), anyList(), any(), any())).thenReturn(Flux.just(event));
+        LlmInterfacesController localController =
+                new LlmInterfacesController(
+                        agentProvider,
+                        modelProvider,
+                        new LlmInterfacesProperties(),
+                        new ChatMessageConverter(),
+                        new OpenAIToolConverter(),
+                        new ChatCompletionsResponseBuilder(),
+                        new ChatCompletionsStreamingAdapter(),
+                        new ResponsesMessageConverter(),
+                        new ResponsesToolConverter(),
+                        new ResponsesResponseBuilder(),
+                        streamingAdapter,
+                        new AnthropicMessageConverter(),
+                        new AnthropicToolConverter(),
+                        new AnthropicResponseBuilder(),
+                        new AnthropicStreamingAdapter(new AnthropicResponseBuilder()));
+        ResponsesRequest request = new ResponsesRequest();
+        request.setInput(objectMapper.readTree("\"Hello\""));
+        request.setStream(true);
+
+        ResponseEntity<Flux<ServerSentEvent<String>>> response =
+                assertInstanceOf(ResponseEntity.class, localController.responses(request));
+
+        StepVerifier.create(response.getBody())
+                .expectNextMatches(sse -> "{\"error\":\"Serialization error\"}".equals(sse.data()))
                 .verifyComplete();
     }
 
@@ -289,6 +451,107 @@ class LlmInterfacesControllerTest {
                             assertEquals("active-model", message.getModel());
                             assertEquals("Hi", message.getContent().get(0).get("text"));
                         })
+                .verifyComplete();
+    }
+
+    @Test
+    @DisplayName("Should register Anthropic tools")
+    void shouldRegisterAnthropicTools() throws Exception {
+        Toolkit toolkit = new Toolkit();
+        when(agent.getToolkit()).thenReturn(toolkit);
+        AnthropicMessagesRequest request =
+                objectMapper.readValue(
+                        """
+                        {
+                          "messages": [{"role": "user", "content": "Hello"}],
+                          "tools": [
+                            {
+                              "name": "lookup",
+                              "description": "Lookup data",
+                              "input_schema": {"type": "object"}
+                            }
+                          ]
+                        }
+                        """,
+                        AnthropicMessagesRequest.class);
+        Msg reply = Msg.builder().role(MsgRole.ASSISTANT).textContent("Hi").build();
+        when(agent.call(anyList())).thenReturn(Mono.just(reply));
+
+        @SuppressWarnings("unchecked")
+        Mono<Object> responseMono = (Mono<Object>) controller.anthropicMessages(request);
+
+        StepVerifier.create(responseMono).expectNextCount(1).verifyComplete();
+        assertNotNull(toolkit.getTool("lookup"));
+    }
+
+    @Test
+    @DisplayName("Should build Anthropic errors for agent failures")
+    void shouldBuildAnthropicErrorsForAgentFailures() throws Exception {
+        AnthropicMessagesRequest request =
+                objectMapper.readValue(
+                        """
+                        {"messages": [{"role": "user", "content": "Hello"}]}
+                        """,
+                        AnthropicMessagesRequest.class);
+        when(agent.call(anyList())).thenReturn(Mono.error(new RuntimeException("boom")));
+
+        @SuppressWarnings("unchecked")
+        Mono<Object> responseMono = (Mono<Object>) controller.anthropicMessages(request);
+
+        StepVerifier.create(responseMono)
+                .assertNext(
+                        response -> {
+                            @SuppressWarnings("unchecked")
+                            Map<String, Object> body = (Map<String, Object>) response;
+                            assertEquals("error", body.get("type"));
+                        })
+                .verifyComplete();
+    }
+
+    @Test
+    @DisplayName("Should serialize Anthropic SSE failures defensively")
+    void shouldSerializeAnthropicSseFailuresDefensively() throws Exception {
+        @SuppressWarnings("unchecked")
+        ObjectProvider<ReActAgent> agentProvider = mock(ObjectProvider.class);
+        @SuppressWarnings("unchecked")
+        ObjectProvider<Model> modelProvider = mock(ObjectProvider.class);
+        ReActAgent localAgent = mock(ReActAgent.class);
+        when(agentProvider.getObject()).thenReturn(localAgent);
+        when(modelProvider.getIfAvailable()).thenReturn(null);
+        AnthropicStreamingAdapter streamingAdapter = mock(AnthropicStreamingAdapter.class);
+        AnthropicStreamEvent event = new AnthropicStreamEvent("message_start");
+        event.setDelta(Map.of("bad", new Object()));
+        when(streamingAdapter.stream(any(), anyList(), any(), any())).thenReturn(Flux.just(event));
+        AnthropicResponseBuilder responseBuilder = new AnthropicResponseBuilder();
+        LlmInterfacesController localController =
+                new LlmInterfacesController(
+                        agentProvider,
+                        modelProvider,
+                        new LlmInterfacesProperties(),
+                        new ChatMessageConverter(),
+                        new OpenAIToolConverter(),
+                        new ChatCompletionsResponseBuilder(),
+                        new ChatCompletionsStreamingAdapter(),
+                        new ResponsesMessageConverter(),
+                        new ResponsesToolConverter(),
+                        new ResponsesResponseBuilder(),
+                        new ResponsesStreamingAdapter(new ResponsesResponseBuilder()),
+                        new AnthropicMessageConverter(),
+                        new AnthropicToolConverter(),
+                        responseBuilder,
+                        streamingAdapter);
+        AnthropicMessagesRequest request =
+                objectMapper.readValue(
+                        """
+                        {"stream": true, "messages": [{"role": "user", "content": "Hello"}]}
+                        """,
+                        AnthropicMessagesRequest.class);
+
+        ResponseEntity<Flux<ServerSentEvent<String>>> response =
+                assertInstanceOf(ResponseEntity.class, localController.anthropicMessages(request));
+
+        StepVerifier.create(response.getBody())
+                .expectNextMatches(sse -> "{\"error\":\"Serialization error\"}".equals(sse.data()))
                 .verifyComplete();
     }
 
@@ -417,5 +680,40 @@ class LlmInterfacesControllerTest {
         assertEquals(HttpStatus.NOT_FOUND, chat.getStatusCode());
         assertEquals(HttpStatus.NOT_FOUND, responses.getStatusCode());
         assertEquals(HttpStatus.NOT_FOUND, anthropic.getStatusCode());
+    }
+
+    @Test
+    @DisplayName("Should convert missing agent into protocol errors")
+    void shouldConvertMissingAgentIntoProtocolErrors() throws Exception {
+        @SuppressWarnings("unchecked")
+        ObjectProvider<ReActAgent> agentProvider = mock(ObjectProvider.class);
+        @SuppressWarnings("unchecked")
+        ObjectProvider<Model> modelProvider = mock(ObjectProvider.class);
+        when(agentProvider.getObject()).thenReturn(null);
+        when(modelProvider.getIfAvailable()).thenReturn(null);
+        LlmInterfacesController noAgentController =
+                newController(agentProvider, modelProvider, new LlmInterfacesProperties());
+        ResponsesRequest responsesRequest = new ResponsesRequest();
+        responsesRequest.setInput(objectMapper.readTree("\"Hello\""));
+        AnthropicMessagesRequest anthropicRequest =
+                objectMapper.readValue(
+                        """
+                        {"messages": [{"role": "user", "content": "Hello"}]}
+                        """,
+                        AnthropicMessagesRequest.class);
+
+        @SuppressWarnings("unchecked")
+        Mono<ResponsesResponse> responsesMono =
+                (Mono<ResponsesResponse>) noAgentController.responses(responsesRequest);
+        @SuppressWarnings("unchecked")
+        Mono<Object> anthropicMono =
+                (Mono<Object>) noAgentController.anthropicMessages(anthropicRequest);
+
+        StepVerifier.create(responsesMono)
+                .expectNextMatches(response -> "failed".equals(response.getStatus()))
+                .verifyComplete();
+        StepVerifier.create(anthropicMono)
+                .expectNextMatches(response -> ((Map<?, ?>) response).get("type").equals("error"))
+                .verifyComplete();
     }
 }

--- a/agentscope-extensions/agentscope-spring-boot-starters/agentscope-llm-interfaces-web-starter/src/test/java/io/agentscope/spring/boot/llm/interfacesweb/LlmInterfacesControllerTest.java
+++ b/agentscope-extensions/agentscope-spring-boot-starters/agentscope-llm-interfaces-web-starter/src/test/java/io/agentscope/spring/boot/llm/interfacesweb/LlmInterfacesControllerTest.java
@@ -56,6 +56,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.codec.ServerSentEvent;
 import reactor.core.publisher.Flux;
@@ -69,6 +70,7 @@ class LlmInterfacesControllerTest {
 
     private LlmInterfacesController controller;
     private ReActAgent agent;
+    private LlmInterfacesProperties properties;
 
     @SuppressWarnings("unchecked")
     @BeforeEach
@@ -82,25 +84,32 @@ class LlmInterfacesControllerTest {
         when(modelProvider.getIfAvailable()).thenReturn(model);
         when(model.getModelName()).thenReturn("active-model");
 
+        properties = new LlmInterfacesProperties();
+        controller = newController(agentProvider, modelProvider, properties);
+    }
+
+    private LlmInterfacesController newController(
+            ObjectProvider<ReActAgent> agentProvider,
+            ObjectProvider<Model> modelProvider,
+            LlmInterfacesProperties properties) {
         ResponsesResponseBuilder responsesResponseBuilder = new ResponsesResponseBuilder();
         AnthropicResponseBuilder anthropicResponseBuilder = new AnthropicResponseBuilder();
-        controller =
-                new LlmInterfacesController(
-                        agentProvider,
-                        modelProvider,
-                        new LlmInterfacesProperties(),
-                        new ChatMessageConverter(),
-                        new OpenAIToolConverter(),
-                        new ChatCompletionsResponseBuilder(),
-                        new ChatCompletionsStreamingAdapter(),
-                        new ResponsesMessageConverter(),
-                        new ResponsesToolConverter(),
-                        responsesResponseBuilder,
-                        new ResponsesStreamingAdapter(responsesResponseBuilder),
-                        new AnthropicMessageConverter(),
-                        new AnthropicToolConverter(),
-                        anthropicResponseBuilder,
-                        new AnthropicStreamingAdapter(anthropicResponseBuilder));
+        return new LlmInterfacesController(
+                agentProvider,
+                modelProvider,
+                properties,
+                new ChatMessageConverter(),
+                new OpenAIToolConverter(),
+                new ChatCompletionsResponseBuilder(),
+                new ChatCompletionsStreamingAdapter(),
+                new ResponsesMessageConverter(),
+                new ResponsesToolConverter(),
+                responsesResponseBuilder,
+                new ResponsesStreamingAdapter(responsesResponseBuilder),
+                new AnthropicMessageConverter(),
+                new AnthropicToolConverter(),
+                anthropicResponseBuilder,
+                new AnthropicStreamingAdapter(anthropicResponseBuilder));
     }
 
     @Test
@@ -122,6 +131,27 @@ class LlmInterfacesControllerTest {
                             assertEquals("active-model", response.getModel());
                             assertEquals(
                                     "Hi", response.getChoices().get(0).getMessage().getContent());
+                        })
+                .verifyComplete();
+    }
+
+    @Test
+    @DisplayName("Should build Chat Completions error responses")
+    void shouldBuildChatCompletionsErrorResponses() {
+        ChatCompletionsRequest request = new ChatCompletionsRequest();
+        request.setMessages(List.of(new ChatMessage("user", "Hello")));
+        request.setStream(false);
+        when(agent.call(anyList())).thenReturn(Mono.error(new RuntimeException("boom")));
+
+        Object result = controller.chatCompletions(request);
+
+        @SuppressWarnings("unchecked")
+        Mono<ChatCompletionsResponse> responseMono = (Mono<ChatCompletionsResponse>) result;
+        StepVerifier.create(responseMono)
+                .assertNext(
+                        response -> {
+                            assertEquals("active-model", response.getModel());
+                            assertEquals("error", response.getChoices().get(0).getFinishReason());
                         })
                 .verifyComplete();
     }
@@ -195,6 +225,45 @@ class LlmInterfacesControllerTest {
     }
 
     @Test
+    @DisplayName("Should emit Responses SSE errors")
+    void shouldEmitResponsesSseErrors() throws Exception {
+        ResponsesRequest request = new ResponsesRequest();
+        request.setInput(objectMapper.readTree("\"Hello\""));
+        request.setStream(true);
+        when(agent.stream(anyList(), any(StreamOptions.class)))
+                .thenReturn(Flux.error(new RuntimeException("boom")));
+
+        Object result = controller.responses(request);
+
+        ResponseEntity<Flux<ServerSentEvent<String>>> response =
+                assertInstanceOf(ResponseEntity.class, result);
+        StepVerifier.create(response.getBody())
+                .expectNextMatches(event -> "response.created".equals(event.event()))
+                .expectNextMatches(event -> "response.failed".equals(event.event()))
+                .verifyComplete();
+    }
+
+    @Test
+    @DisplayName("Should build Responses error shapes for invalid requests")
+    void shouldBuildResponsesErrorShapesForInvalidRequests() {
+        ResponsesRequest request = new ResponsesRequest();
+
+        Object result = controller.responses(request);
+
+        @SuppressWarnings("unchecked")
+        Mono<ResponsesResponse> responseMono = (Mono<ResponsesResponse>) result;
+        StepVerifier.create(responseMono)
+                .assertNext(
+                        response -> {
+                            assertEquals("failed", response.getStatus());
+                            @SuppressWarnings("unchecked")
+                            Map<String, Object> error = (Map<String, Object>) response.getError();
+                            assertEquals("server_error", error.get("type"));
+                        })
+                .verifyComplete();
+    }
+
+    @Test
     @DisplayName("Should handle Anthropic Messages requests")
     void shouldHandleAnthropicRequests() throws Exception {
         AnthropicMessagesRequest request =
@@ -254,6 +323,50 @@ class LlmInterfacesControllerTest {
     }
 
     @Test
+    @DisplayName("Should emit Anthropic SSE errors")
+    void shouldEmitAnthropicSseErrors() throws Exception {
+        AnthropicMessagesRequest request =
+                objectMapper.readValue(
+                        """
+                        {
+                          "stream": true,
+                          "messages": [{"role": "user", "content": "Hello"}]
+                        }
+                        """,
+                        AnthropicMessagesRequest.class);
+        when(agent.stream(anyList(), any(StreamOptions.class)))
+                .thenReturn(Flux.error(new RuntimeException("boom")));
+
+        Object result = controller.anthropicMessages(request);
+
+        ResponseEntity<Flux<ServerSentEvent<String>>> response =
+                assertInstanceOf(ResponseEntity.class, result);
+        StepVerifier.create(response.getBody())
+                .expectNextMatches(event -> "message_start".equals(event.event()))
+                .expectNextMatches(event -> "error".equals(event.event()))
+                .verifyComplete();
+    }
+
+    @Test
+    @DisplayName("Should build Anthropic error shapes for invalid requests")
+    void shouldBuildAnthropicErrorShapesForInvalidRequests() {
+        AnthropicMessagesRequest request = new AnthropicMessagesRequest();
+
+        Object result = controller.anthropicMessages(request);
+
+        @SuppressWarnings("unchecked")
+        Mono<Object> responseMono = (Mono<Object>) result;
+        StepVerifier.create(responseMono)
+                .assertNext(
+                        response -> {
+                            @SuppressWarnings("unchecked")
+                            Map<String, Object> body = (Map<String, Object>) response;
+                            assertEquals("error", body.get("type"));
+                        })
+                .verifyComplete();
+    }
+
+    @Test
     @DisplayName("Should expose active model through models endpoint")
     void shouldExposeModelsEndpoint() {
         Map<String, Object> response = controller.models();
@@ -262,5 +375,47 @@ class LlmInterfacesControllerTest {
         List<Map<String, Object>> models = (List<Map<String, Object>>) response.get("data");
         assertEquals("list", response.get("object"));
         assertEquals("active-model", models.get(0).get("id"));
+    }
+
+    @Test
+    @DisplayName("Should fall back to default model name when model bean is absent")
+    void shouldFallBackToDefaultModelNameWhenModelBeanIsAbsent() {
+        @SuppressWarnings("unchecked")
+        ObjectProvider<ReActAgent> agentProvider = mock(ObjectProvider.class);
+        @SuppressWarnings("unchecked")
+        ObjectProvider<Model> modelProvider = mock(ObjectProvider.class);
+        when(modelProvider.getIfAvailable()).thenReturn(null);
+        LlmInterfacesController noModelController =
+                newController(agentProvider, modelProvider, new LlmInterfacesProperties());
+
+        Map<String, Object> response = noModelController.models();
+
+        @SuppressWarnings("unchecked")
+        List<Map<String, Object>> models = (List<Map<String, Object>>) response.get("data");
+        assertEquals("agentscope-agent", models.get(0).get("id"));
+    }
+
+    @Test
+    @DisplayName("Should return disabled endpoint errors")
+    void shouldReturnDisabledEndpointErrors() {
+        properties.getChat().setEnabled(false);
+        properties.getResponses().setEnabled(false);
+        properties.getAnthropic().setEnabled(false);
+
+        ResponseEntity<?> chat =
+                assertInstanceOf(
+                        ResponseEntity.class,
+                        controller.chatCompletions(new ChatCompletionsRequest()));
+        ResponseEntity<?> responses =
+                assertInstanceOf(
+                        ResponseEntity.class, controller.responses(new ResponsesRequest()));
+        ResponseEntity<?> anthropic =
+                assertInstanceOf(
+                        ResponseEntity.class,
+                        controller.anthropicMessages(new AnthropicMessagesRequest()));
+
+        assertEquals(HttpStatus.NOT_FOUND, chat.getStatusCode());
+        assertEquals(HttpStatus.NOT_FOUND, responses.getStatusCode());
+        assertEquals(HttpStatus.NOT_FOUND, anthropic.getStatusCode());
     }
 }

--- a/agentscope-extensions/agentscope-spring-boot-starters/agentscope-llm-interfaces-web-starter/src/test/java/io/agentscope/spring/boot/llm/interfacesweb/LlmInterfacesControllerTest.java
+++ b/agentscope-extensions/agentscope-spring-boot-starters/agentscope-llm-interfaces-web-starter/src/test/java/io/agentscope/spring/boot/llm/interfacesweb/LlmInterfacesControllerTest.java
@@ -1,0 +1,266 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.spring.boot.llm.interfacesweb;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.agentscope.core.ReActAgent;
+import io.agentscope.core.agent.Event;
+import io.agentscope.core.agent.EventType;
+import io.agentscope.core.agent.StreamOptions;
+import io.agentscope.core.chat.completions.builder.ChatCompletionsResponseBuilder;
+import io.agentscope.core.chat.completions.converter.ChatMessageConverter;
+import io.agentscope.core.chat.completions.converter.OpenAIToolConverter;
+import io.agentscope.core.chat.completions.model.ChatCompletionsRequest;
+import io.agentscope.core.chat.completions.model.ChatCompletionsResponse;
+import io.agentscope.core.chat.completions.model.ChatMessage;
+import io.agentscope.core.chat.completions.streaming.ChatCompletionsStreamingAdapter;
+import io.agentscope.core.llm.interfacesweb.anthropic.AnthropicMessageConverter;
+import io.agentscope.core.llm.interfacesweb.anthropic.AnthropicMessagesRequest;
+import io.agentscope.core.llm.interfacesweb.anthropic.AnthropicMessagesResponse;
+import io.agentscope.core.llm.interfacesweb.anthropic.AnthropicResponseBuilder;
+import io.agentscope.core.llm.interfacesweb.anthropic.AnthropicStreamingAdapter;
+import io.agentscope.core.llm.interfacesweb.anthropic.AnthropicToolConverter;
+import io.agentscope.core.llm.interfacesweb.responses.ResponsesMessageConverter;
+import io.agentscope.core.llm.interfacesweb.responses.ResponsesRequest;
+import io.agentscope.core.llm.interfacesweb.responses.ResponsesResponse;
+import io.agentscope.core.llm.interfacesweb.responses.ResponsesResponseBuilder;
+import io.agentscope.core.llm.interfacesweb.responses.ResponsesStreamingAdapter;
+import io.agentscope.core.llm.interfacesweb.responses.ResponsesToolConverter;
+import io.agentscope.core.message.Msg;
+import io.agentscope.core.message.MsgRole;
+import io.agentscope.core.message.TextBlock;
+import io.agentscope.core.model.Model;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.codec.ServerSentEvent;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+@DisplayName("LlmInterfacesController Tests")
+class LlmInterfacesControllerTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    private LlmInterfacesController controller;
+    private ReActAgent agent;
+
+    @SuppressWarnings("unchecked")
+    @BeforeEach
+    void setUp() {
+        ObjectProvider<ReActAgent> agentProvider = mock(ObjectProvider.class);
+        ObjectProvider<Model> modelProvider = mock(ObjectProvider.class);
+        Model model = mock(Model.class);
+        agent = mock(ReActAgent.class);
+
+        when(agentProvider.getObject()).thenReturn(agent);
+        when(modelProvider.getIfAvailable()).thenReturn(model);
+        when(model.getModelName()).thenReturn("active-model");
+
+        ResponsesResponseBuilder responsesResponseBuilder = new ResponsesResponseBuilder();
+        AnthropicResponseBuilder anthropicResponseBuilder = new AnthropicResponseBuilder();
+        controller =
+                new LlmInterfacesController(
+                        agentProvider,
+                        modelProvider,
+                        new LlmInterfacesProperties(),
+                        new ChatMessageConverter(),
+                        new OpenAIToolConverter(),
+                        new ChatCompletionsResponseBuilder(),
+                        new ChatCompletionsStreamingAdapter(),
+                        new ResponsesMessageConverter(),
+                        new ResponsesToolConverter(),
+                        responsesResponseBuilder,
+                        new ResponsesStreamingAdapter(responsesResponseBuilder),
+                        new AnthropicMessageConverter(),
+                        new AnthropicToolConverter(),
+                        anthropicResponseBuilder,
+                        new AnthropicStreamingAdapter(anthropicResponseBuilder));
+    }
+
+    @Test
+    @DisplayName("Should handle Chat Completions requests")
+    void shouldHandleChatCompletionsRequests() {
+        ChatCompletionsRequest request = new ChatCompletionsRequest();
+        request.setMessages(List.of(new ChatMessage("user", "Hello")));
+        request.setStream(false);
+        Msg reply = Msg.builder().role(MsgRole.ASSISTANT).textContent("Hi").build();
+        when(agent.call(anyList())).thenReturn(Mono.just(reply));
+
+        Object result = controller.chatCompletions(request);
+
+        @SuppressWarnings("unchecked")
+        Mono<ChatCompletionsResponse> responseMono = (Mono<ChatCompletionsResponse>) result;
+        StepVerifier.create(responseMono)
+                .assertNext(
+                        response -> {
+                            assertEquals("active-model", response.getModel());
+                            assertEquals(
+                                    "Hi", response.getChoices().get(0).getMessage().getContent());
+                        })
+                .verifyComplete();
+    }
+
+    @Test
+    @DisplayName("Should emit Chat Completions SSE done sentinel")
+    void shouldEmitChatCompletionsDoneSentinel() {
+        ChatCompletionsRequest request = new ChatCompletionsRequest();
+        request.setMessages(List.of(new ChatMessage("user", "Hello")));
+        request.setStream(true);
+        Msg reply =
+                Msg.builder()
+                        .role(MsgRole.ASSISTANT)
+                        .content(TextBlock.builder().text("Hi").build())
+                        .build();
+        when(agent.stream(anyList(), any(StreamOptions.class)))
+                .thenReturn(Flux.just(new Event(EventType.REASONING, reply, true)));
+
+        Object result = controller.chatCompletions(request);
+
+        ResponseEntity<Flux<ServerSentEvent<String>>> response =
+                assertInstanceOf(ResponseEntity.class, result);
+        StepVerifier.create(response.getBody())
+                .expectNextMatches(event -> event.data().contains("chat.completion.chunk"))
+                .expectNextMatches(event -> event.data().contains("\"finish_reason\":\"stop\""))
+                .expectNextMatches(event -> "[DONE]".equals(event.data()))
+                .verifyComplete();
+    }
+
+    @Test
+    @DisplayName("Should handle Responses create requests")
+    void shouldHandleResponsesRequests() throws Exception {
+        ResponsesRequest request = new ResponsesRequest();
+        request.setInput(objectMapper.readTree("\"Hello\""));
+        Msg reply = Msg.builder().role(MsgRole.ASSISTANT).textContent("Hi").build();
+        when(agent.call(anyList())).thenReturn(Mono.just(reply));
+
+        Object result = controller.responses(request);
+
+        @SuppressWarnings("unchecked")
+        Mono<ResponsesResponse> responseMono = (Mono<ResponsesResponse>) result;
+        StepVerifier.create(responseMono)
+                .assertNext(
+                        response -> {
+                            assertEquals("active-model", response.getModel());
+                            assertEquals("completed", response.getStatus());
+                            assertEquals("Hi", response.getOutputText());
+                        })
+                .verifyComplete();
+    }
+
+    @Test
+    @DisplayName("Should emit Responses SSE semantic events")
+    void shouldEmitResponsesSseEvents() throws Exception {
+        ResponsesRequest request = new ResponsesRequest();
+        request.setInput(objectMapper.readTree("\"Hello\""));
+        request.setStream(true);
+        Msg reply = Msg.builder().role(MsgRole.ASSISTANT).textContent("Hi").build();
+        when(agent.stream(anyList(), any(StreamOptions.class)))
+                .thenReturn(Flux.just(new Event(EventType.REASONING, reply, true)));
+
+        Object result = controller.responses(request);
+
+        ResponseEntity<Flux<ServerSentEvent<String>>> response =
+                assertInstanceOf(ResponseEntity.class, result);
+        StepVerifier.create(response.getBody())
+                .expectNextMatches(event -> "response.created".equals(event.event()))
+                .expectNextMatches(event -> "response.output_text.delta".equals(event.event()))
+                .expectNextMatches(event -> "response.completed".equals(event.event()))
+                .verifyComplete();
+    }
+
+    @Test
+    @DisplayName("Should handle Anthropic Messages requests")
+    void shouldHandleAnthropicRequests() throws Exception {
+        AnthropicMessagesRequest request =
+                objectMapper.readValue(
+                        """
+                        {
+                          "messages": [{"role": "user", "content": "Hello"}]
+                        }
+                        """,
+                        AnthropicMessagesRequest.class);
+        Msg reply = Msg.builder().role(MsgRole.ASSISTANT).textContent("Hi").build();
+        when(agent.call(anyList())).thenReturn(Mono.just(reply));
+
+        Object result = controller.anthropicMessages(request);
+
+        @SuppressWarnings("unchecked")
+        Mono<Object> responseMono = (Mono<Object>) result;
+        StepVerifier.create(responseMono)
+                .assertNext(
+                        response -> {
+                            AnthropicMessagesResponse message =
+                                    assertInstanceOf(AnthropicMessagesResponse.class, response);
+                            assertEquals("active-model", message.getModel());
+                            assertEquals("Hi", message.getContent().get(0).get("text"));
+                        })
+                .verifyComplete();
+    }
+
+    @Test
+    @DisplayName("Should emit Anthropic SSE semantic events")
+    void shouldEmitAnthropicSseEvents() throws Exception {
+        AnthropicMessagesRequest request =
+                objectMapper.readValue(
+                        """
+                        {
+                          "stream": true,
+                          "messages": [{"role": "user", "content": "Hello"}]
+                        }
+                        """,
+                        AnthropicMessagesRequest.class);
+        Msg reply = Msg.builder().role(MsgRole.ASSISTANT).textContent("Hi").build();
+        when(agent.stream(anyList(), any(StreamOptions.class)))
+                .thenReturn(Flux.just(new Event(EventType.REASONING, reply, true)));
+
+        Object result = controller.anthropicMessages(request);
+
+        ResponseEntity<Flux<ServerSentEvent<String>>> response =
+                assertInstanceOf(ResponseEntity.class, result);
+        StepVerifier.create(response.getBody())
+                .expectNextMatches(event -> "message_start".equals(event.event()))
+                .expectNextMatches(event -> "content_block_start".equals(event.event()))
+                .expectNextMatches(event -> "content_block_delta".equals(event.event()))
+                .expectNextMatches(event -> "content_block_stop".equals(event.event()))
+                .expectNextMatches(event -> "message_delta".equals(event.event()))
+                .expectNextMatches(event -> "message_stop".equals(event.event()))
+                .verifyComplete();
+    }
+
+    @Test
+    @DisplayName("Should expose active model through models endpoint")
+    void shouldExposeModelsEndpoint() {
+        Map<String, Object> response = controller.models();
+
+        @SuppressWarnings("unchecked")
+        List<Map<String, Object>> models = (List<Map<String, Object>>) response.get("data");
+        assertEquals("list", response.get("object"));
+        assertEquals("active-model", models.get(0).get("id"));
+    }
+}

--- a/agentscope-extensions/agentscope-spring-boot-starters/agentscope-llm-interfaces-web-starter/src/test/java/io/agentscope/spring/boot/llm/interfacesweb/LlmInterfacesPropertiesTest.java
+++ b/agentscope-extensions/agentscope-spring-boot-starters/agentscope-llm-interfaces-web-starter/src/test/java/io/agentscope/spring/boot/llm/interfacesweb/LlmInterfacesPropertiesTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.spring.boot.llm.interfacesweb;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("LlmInterfacesProperties Tests")
+class LlmInterfacesPropertiesTest {
+
+    @Test
+    @DisplayName("Should expose expected defaults")
+    void shouldExposeDefaults() {
+        LlmInterfacesProperties properties = new LlmInterfacesProperties();
+
+        assertTrue(properties.isEnabled());
+        assertEquals("/v1", properties.getBasePath());
+        assertTrue(properties.isIgnoreUnknownFields());
+        assertTrue(properties.isIgnoreInvalidThinking());
+        assertTrue(properties.getChat().isEnabled());
+        assertTrue(properties.getResponses().isEnabled());
+        assertTrue(properties.getAnthropic().isEnabled());
+    }
+}

--- a/agentscope-extensions/agentscope-spring-boot-starters/agentscope-llm-interfaces-web-starter/src/test/java/io/agentscope/spring/boot/llm/interfacesweb/LlmInterfacesPropertiesTest.java
+++ b/agentscope-extensions/agentscope-spring-boot-starters/agentscope-llm-interfaces-web-starter/src/test/java/io/agentscope/spring/boot/llm/interfacesweb/LlmInterfacesPropertiesTest.java
@@ -16,6 +16,7 @@
 package io.agentscope.spring.boot.llm.interfacesweb;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.DisplayName;
@@ -36,5 +37,32 @@ class LlmInterfacesPropertiesTest {
         assertTrue(properties.getChat().isEnabled());
         assertTrue(properties.getResponses().isEnabled());
         assertTrue(properties.getAnthropic().isEnabled());
+    }
+
+    @Test
+    @DisplayName("Should expose mutable endpoint configuration")
+    void shouldExposeMutableEndpointConfiguration() {
+        LlmInterfacesProperties properties = new LlmInterfacesProperties();
+        LlmInterfacesProperties.Endpoint chat = new LlmInterfacesProperties.Endpoint();
+        LlmInterfacesProperties.Endpoint responses = new LlmInterfacesProperties.Endpoint(false);
+        LlmInterfacesProperties.Endpoint anthropic = new LlmInterfacesProperties.Endpoint(true);
+
+        properties.setEnabled(false);
+        properties.setBasePath("/api");
+        properties.setIgnoreUnknownFields(false);
+        properties.setIgnoreInvalidThinking(false);
+        chat.setEnabled(false);
+        anthropic.setEnabled(false);
+        properties.setChat(chat);
+        properties.setResponses(responses);
+        properties.setAnthropic(anthropic);
+
+        assertFalse(properties.isEnabled());
+        assertEquals("/api", properties.getBasePath());
+        assertFalse(properties.isIgnoreUnknownFields());
+        assertFalse(properties.isIgnoreInvalidThinking());
+        assertFalse(properties.getChat().isEnabled());
+        assertFalse(properties.getResponses().isEnabled());
+        assertFalse(properties.getAnthropic().isEnabled());
     }
 }

--- a/agentscope-extensions/agentscope-spring-boot-starters/agentscope-llm-interfaces-web-starter/src/test/java/io/agentscope/spring/boot/llm/interfacesweb/LlmInterfacesWebAutoConfigurationTest.java
+++ b/agentscope-extensions/agentscope-spring-boot-starters/agentscope-llm-interfaces-web-starter/src/test/java/io/agentscope/spring/boot/llm/interfacesweb/LlmInterfacesWebAutoConfigurationTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.spring.boot.llm.interfacesweb;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.agentscope.core.ReActAgent;
+import io.agentscope.core.chat.completions.builder.ChatCompletionsResponseBuilder;
+import io.agentscope.core.chat.completions.converter.ChatMessageConverter;
+import io.agentscope.core.chat.completions.converter.OpenAIToolConverter;
+import io.agentscope.core.chat.completions.streaming.ChatCompletionsStreamingAdapter;
+import io.agentscope.core.llm.interfacesweb.anthropic.AnthropicMessageConverter;
+import io.agentscope.core.llm.interfacesweb.anthropic.AnthropicResponseBuilder;
+import io.agentscope.core.llm.interfacesweb.anthropic.AnthropicStreamingAdapter;
+import io.agentscope.core.llm.interfacesweb.anthropic.AnthropicToolConverter;
+import io.agentscope.core.llm.interfacesweb.responses.ResponsesMessageConverter;
+import io.agentscope.core.llm.interfacesweb.responses.ResponsesResponseBuilder;
+import io.agentscope.core.llm.interfacesweb.responses.ResponsesStreamingAdapter;
+import io.agentscope.core.llm.interfacesweb.responses.ResponsesToolConverter;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.WebApplicationContextRunner;
+
+@DisplayName("LLM Interfaces Web Auto Configuration Tests")
+class LlmInterfacesWebAutoConfigurationTest {
+
+    private final WebApplicationContextRunner contextRunner =
+            new WebApplicationContextRunner()
+                    .withConfiguration(
+                            AutoConfigurations.of(LlmInterfacesWebAutoConfiguration.class))
+                    .withBean(
+                            ReActAgent.class, () -> ReActAgent.builder().name("testAgent").build())
+                    .withPropertyValues("agentscope.llm-interfaces.enabled=true");
+
+    @Test
+    @DisplayName("Should create default beans when enabled")
+    void shouldCreateDefaultBeansWhenEnabled() {
+        contextRunner.run(
+                context -> {
+                    assertThat(context).hasSingleBean(ChatMessageConverter.class);
+                    assertThat(context).hasSingleBean(OpenAIToolConverter.class);
+                    assertThat(context).hasSingleBean(ChatCompletionsResponseBuilder.class);
+                    assertThat(context).hasSingleBean(ChatCompletionsStreamingAdapter.class);
+                    assertThat(context).hasSingleBean(ResponsesMessageConverter.class);
+                    assertThat(context).hasSingleBean(ResponsesToolConverter.class);
+                    assertThat(context).hasSingleBean(ResponsesResponseBuilder.class);
+                    assertThat(context).hasSingleBean(ResponsesStreamingAdapter.class);
+                    assertThat(context).hasSingleBean(AnthropicMessageConverter.class);
+                    assertThat(context).hasSingleBean(AnthropicToolConverter.class);
+                    assertThat(context).hasSingleBean(AnthropicResponseBuilder.class);
+                    assertThat(context).hasSingleBean(AnthropicStreamingAdapter.class);
+                    assertThat(context).hasSingleBean(LlmInterfacesController.class);
+                    assertThat(context.getBean(LlmInterfacesProperties.class).getBasePath())
+                            .isEqualTo("/v1");
+                });
+    }
+
+    @Test
+    @DisplayName("Should not create beans when disabled")
+    void shouldNotCreateBeansWhenDisabled() {
+        contextRunner
+                .withPropertyValues("agentscope.llm-interfaces.enabled=false")
+                .run(
+                        context -> {
+                            assertThat(context).doesNotHaveBean(ChatMessageConverter.class);
+                            assertThat(context).doesNotHaveBean(ResponsesMessageConverter.class);
+                            assertThat(context).doesNotHaveBean(AnthropicMessageConverter.class);
+                            assertThat(context).doesNotHaveBean(LlmInterfacesController.class);
+                        });
+    }
+}

--- a/agentscope-extensions/agentscope-spring-boot-starters/pom.xml
+++ b/agentscope-extensions/agentscope-spring-boot-starters/pom.xml
@@ -41,6 +41,7 @@
         <module>agentscope-a2a-spring-boot-starter</module>
         <module>agentscope-agui-spring-boot-starter</module>
         <module>agentscope-chat-completions-web-starter</module>
+        <module>agentscope-llm-interfaces-web-starter</module>
         <module>agentscope-nacos-spring-boot-starter</module>
     </modules>
 

--- a/agentscope-extensions/pom.xml
+++ b/agentscope-extensions/pom.xml
@@ -52,6 +52,7 @@
         <module>agentscope-spring-boot-starters</module>
         <module>agentscope-extensions-agui</module>
         <module>agentscope-extensions-chat-completions-web</module>
+        <module>agentscope-extensions-llm-interfaces-web</module>
         <module>agentscope-extensions-agent-protocol</module>
         <module>agentscope-extensions-higress</module>
         <module>agentscope-extensions-kotlin</module>

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/example/support/InMemorySandbox.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/example/support/InMemorySandbox.java
@@ -21,15 +21,24 @@ import io.agentscope.harness.agent.sandbox.Sandbox;
 import io.agentscope.harness.agent.sandbox.SandboxState;
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.PathMatcher;
+import java.util.Comparator;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * Test-only {@link Sandbox} that uses a local temp directory as the workspace.
  */
 public class InMemorySandbox implements Sandbox {
+
+    private static final Pattern FIND_FILES_PATTERN =
+            Pattern.compile("^find\\s+'([^']*)'\\s+-type\\s+f\\s+-name\\s+'([^']*)'.*");
 
     private final InMemorySandboxState state;
     private final Path workspaceDir;
@@ -85,8 +94,13 @@ public class InMemorySandbox implements Sandbox {
     @Override
     public ExecResult exec(RuntimeContext runtimeContext, String command, Integer timeoutSeconds)
             throws Exception {
+        ExecResult handled = executeBuiltIn(command);
+        if (handled != null) {
+            return handled;
+        }
+
         int timeout = timeoutSeconds != null ? timeoutSeconds : defaultTimeoutSeconds;
-        ProcessBuilder pb = new ProcessBuilder("sh", "-c", command);
+        ProcessBuilder pb = shell(command);
         pb.directory(workspaceDir.toFile());
         pb.redirectErrorStream(false);
         Process process = pb.start();
@@ -97,9 +111,47 @@ public class InMemorySandbox implements Sandbox {
             return new ExecResult(124, "", "Command timed out after " + timeout + "s", false);
         }
 
-        String stdout = new String(process.getInputStream().readAllBytes());
-        String stderr = new String(process.getErrorStream().readAllBytes());
+        String stdout = new String(process.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
+        String stderr = new String(process.getErrorStream().readAllBytes(), StandardCharsets.UTF_8);
         return new ExecResult(process.exitValue(), stdout, stderr, false);
+    }
+
+    private ExecResult executeBuiltIn(String command) throws Exception {
+        Matcher matcher = FIND_FILES_PATTERN.matcher(command != null ? command.trim() : "");
+        if (!matcher.matches()) {
+            return null;
+        }
+
+        String relativePath = matcher.group(1);
+        String glob = matcher.group(2);
+        Path root =
+                workspaceDir
+                        .resolve(
+                                relativePath == null || relativePath.isBlank() ? "." : relativePath)
+                        .normalize();
+        if (!root.startsWith(workspaceDir) || !Files.exists(root)) {
+            return new ExecResult(0, "", "", false);
+        }
+
+        PathMatcher pathMatcher = root.getFileSystem().getPathMatcher("glob:" + glob);
+        List<String> files;
+        try (var walk = Files.walk(root)) {
+            files =
+                    walk.filter(Files::isRegularFile)
+                            .filter(path -> pathMatcher.matches(path.getFileName()))
+                            .map(workspaceDir::relativize)
+                            .map(path -> path.toString().replace('\\', '/'))
+                            .sorted(Comparator.naturalOrder())
+                            .toList();
+        }
+        return new ExecResult(0, String.join("\n", files), "", false);
+    }
+
+    private ProcessBuilder shell(String command) {
+        if (System.getProperty("os.name", "").toLowerCase().contains("win")) {
+            return new ProcessBuilder("cmd.exe", "/c", command);
+        }
+        return new ProcessBuilder("sh", "-c", command);
     }
 
     @Override

--- a/docs/en/quickstart/installation.md
+++ b/docs/en/quickstart/installation.md
@@ -194,6 +194,13 @@ implementation 'io.agentscope:agentscope-core:1.0.12'
 | [agentscope-extensions-studio](https://central.sonatype.com/artifact/io.agentscope/agentscope-extensions-studio) | Studio Integration | `io.agentscope:agentscope-extensions-studio` |
 | [agentscope-extensions-agui](https://central.sonatype.com/artifact/io.agentscope/agentscope-extensions-agui) | AG-UI Protocol | `io.agentscope:agentscope-extensions-agui` |
 
+#### Web API Compatibility
+
+| Module | Feature | Maven Coordinates |
+|--------|---------|-------------------|
+| [agentscope-extensions-chat-completions-web](https://central.sonatype.com/artifact/io.agentscope/agentscope-extensions-chat-completions-web) | OpenAI Chat Completions adapter | `io.agentscope:agentscope-extensions-chat-completions-web` |
+| [agentscope-extensions-llm-interfaces-web](https://central.sonatype.com/artifact/io.agentscope/agentscope-extensions-llm-interfaces-web) | OpenAI Chat Completions, OpenAI Responses, and Anthropic Messages adapters | `io.agentscope:agentscope-extensions-llm-interfaces-web` |
+
 Extension modules automatically include their required third-party dependencies.
 
 #### Example: Core + Mem0 Extension
@@ -215,6 +222,16 @@ Extension modules automatically include their required third-party dependencies.
 <dependency>
     <groupId>io.agentscope</groupId>
     <artifactId>agentscope-spring-boot-starter</artifactId>
+    <version>1.0.12</version>
+</dependency>
+```
+
+To expose one `ReActAgent` through OpenAI Chat Completions, OpenAI Responses, and Anthropic Messages style HTTP APIs, add the aggregated web starter:
+
+```xml
+<dependency>
+    <groupId>io.agentscope</groupId>
+    <artifactId>agentscope-llm-interfaces-web-starter</artifactId>
     <version>1.0.12</version>
 </dependency>
 ```

--- a/docs/zh/quickstart/installation.md
+++ b/docs/zh/quickstart/installation.md
@@ -198,6 +198,13 @@ implementation 'io.agentscope:agentscope-core:1.0.12'
 | [agentscope-extensions-studio](https://central.sonatype.com/artifact/io.agentscope/agentscope-extensions-studio) | Studio 集成 | `io.agentscope:agentscope-extensions-studio` |
 | [agentscope-extensions-agui](https://central.sonatype.com/artifact/io.agentscope/agentscope-extensions-agui) | AG-UI 协议 | `io.agentscope:agentscope-extensions-agui` |
 
+#### Web API 兼容
+
+| 模块 | 功能 | Maven 坐标 |
+|-----|------|-----------|
+| [agentscope-extensions-chat-completions-web](https://central.sonatype.com/artifact/io.agentscope/agentscope-extensions-chat-completions-web) | OpenAI Chat Completions 适配 | `io.agentscope:agentscope-extensions-chat-completions-web` |
+| [agentscope-extensions-llm-interfaces-web](https://central.sonatype.com/artifact/io.agentscope/agentscope-extensions-llm-interfaces-web) | OpenAI Chat Completions、OpenAI Responses 和 Anthropic Messages 适配 | `io.agentscope:agentscope-extensions-llm-interfaces-web` |
+
 扩展模块会自动带上所需的第三方依赖，不用手动加。
 
 #### 示例：Core + Mem0 扩展
@@ -219,6 +226,16 @@ implementation 'io.agentscope:agentscope-core:1.0.12'
 <dependency>
     <groupId>io.agentscope</groupId>
     <artifactId>agentscope-spring-boot-starter</artifactId>
+    <version>1.0.12</version>
+</dependency>
+```
+
+如果要把同一个 `ReActAgent` 暴露成 OpenAI Chat Completions、OpenAI Responses 和 Anthropic Messages 风格的 HTTP API，可以加入聚合 Web starter：
+
+```xml
+<dependency>
+    <groupId>io.agentscope</groupId>
+    <artifactId>agentscope-llm-interfaces-web-starter</artifactId>
     <version>1.0.12</version>
 </dependency>
 ```


### PR DESCRIPTION
## Summary

Add a new `agentscope-extensions-llm-interfaces-web` module and Spring Boot starter that let one AgentScope `ReActAgent` expose stateless OpenAI Chat Completions, OpenAI Responses, and Anthropic Messages compatible endpoints under `/v1`.

The existing Chat Completions web extension remains intact. The new module reuses its Chat path and adds protocol adapters for Responses and Anthropic requests, responses, tools, usage, finish reasons, and SSE event streams. It also adds `/v1/models`, tolerant request parsing for common SDK extra fields, and clear unsupported-feature errors for stateful Responses fields.

## Additional fixes

- Handle Spring Boot 4 request binding by accepting dynamic protocol JSON as `Object` and normalizing inside the adapter layer.
- Fix Windows/local full-test compatibility for sandbox `find`, file URL extension detection, multimodal RAG injection, and local image inputs.
- Register the new artifacts in extension/starter parents, BOM, all-in-one distribution, installation docs, and a runnable documentation example.

## Validation

- `mvn -pl agentscope-extensions/agentscope-extensions-llm-interfaces-web,agentscope-extensions/agentscope-spring-boot-starters/agentscope-llm-interfaces-web-starter -am test`
- `mvn spotless:check`
- `mvn test`
- Packaged and ran `agentscope-examples/documentation/llm-interfaces-web`, then verified curl fixtures for `/v1/models`, `/v1/chat/completions`, `/v1/responses`, `/v1/messages`, Chat `[DONE]`, Responses `response.created` / `response.output_text.delta` / `response.completed`, and Anthropic `message_start` / `content_block_delta` / `message_delta` / `message_stop`.

## References

- OpenAI Responses API and streaming docs
- Anthropic Messages and streaming docs
- nanollm protocol aggregation ideas used only as reference, not as proxy/routing/admin implementation