### PR TITLE
fix(core): dispose event stream upstream subscription on cancel

### DIFF
--- a/agentscope-core/src/main/java/io/agentscope/core/agent/AgentBase.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/agent/AgentBase.java
@@ -41,6 +41,8 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 import java.util.function.Supplier;
+import reactor.core.Disposable;
+import reactor.core.Disposables;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.FluxSink;
 import reactor.core.publisher.Mono;
@@ -910,37 +912,44 @@ public abstract class AgentBase implements StateModule, Agent {
                                             // into this parent sink without an extra Flux layer.
                                             SubagentEventBus bus = sink::next;
 
+                                            Disposable.Swap upstreamSubscription =
+                                                    Disposables.swap();
+                                            sink.onDispose(upstreamSubscription);
+
                                             // Use Mono.defer to ensure trace context propagation
                                             // while maintaining streaming hook functionality
-                                            Mono.defer(() -> callSupplier.get())
-                                                    .contextWrite(
-                                                            context ->
-                                                                    context.put(
-                                                                                    SubagentEventBus
-                                                                                            .CONTEXT_KEY,
-                                                                                    bus)
-                                                                            .putAll(ctxView))
-                                                    .doFinally(
-                                                            signalType -> {
-                                                                // Remove temporary hook
-                                                                hooks.remove(streamingHook);
-                                                            })
-                                                    .subscribe(
-                                                            finalMsg -> {
-                                                                if (options.shouldStream(
-                                                                        EventType.AGENT_RESULT)) {
-                                                                    sink.next(
-                                                                            new Event(
-                                                                                    EventType
-                                                                                            .AGENT_RESULT,
-                                                                                    finalMsg,
-                                                                                    true));
-                                                                }
+                                            upstreamSubscription.update(
+                                                    Mono.defer(() -> callSupplier.get())
+                                                            .contextWrite(
+                                                                    context ->
+                                                                            context.put(
+                                                                                            SubagentEventBus
+                                                                                                    .CONTEXT_KEY,
+                                                                                            bus)
+                                                                                    .putAll(
+                                                                                            ctxView))
+                                                            .doFinally(
+                                                                    signalType -> {
+                                                                        // Remove temporary hook
+                                                                        hooks.remove(streamingHook);
+                                                                    })
+                                                            .subscribe(
+                                                                    finalMsg -> {
+                                                                        if (options.shouldStream(
+                                                                                EventType
+                                                                                        .AGENT_RESULT)) {
+                                                                            sink.next(
+                                                                                    new Event(
+                                                                                            EventType
+                                                                                                    .AGENT_RESULT,
+                                                                                            finalMsg,
+                                                                                            true));
+                                                                        }
 
-                                                                // Complete the stream
-                                                                sink.complete();
-                                                            },
-                                                            sink::error);
+                                                                        // Complete the stream
+                                                                        sink.complete();
+                                                                    },
+                                                                    sink::error));
                                         },
                                         FluxSink.OverflowStrategy.BUFFER)
                                 .publishOn(Schedulers.boundedElastic()));

--- a/agentscope-core/src/test/java/io/agentscope/core/agent/AgentBaseTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/agent/AgentBaseTest.java
@@ -32,12 +32,14 @@ import java.time.Duration;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Schedulers;
+import reactor.test.StepVerifier;
 
 /**
  * Unit tests for AgentBase class.
@@ -109,6 +111,67 @@ class AgentBaseTest {
                             .content(TextBlock.builder().text("Interrupted").build())
                             .build();
             return Mono.just(interruptMsg);
+        }
+    }
+
+    static class CancellableStreamAgent extends AgentBase {
+        private final AtomicInteger callCount = new AtomicInteger();
+        private final CountDownLatch firstCallStarted = new CountDownLatch(1);
+        private final CountDownLatch firstCallCancelled = new CountDownLatch(1);
+        private final CountDownLatch executionReleased = new CountDownLatch(1);
+
+        CancellableStreamAgent(String name) {
+            super(name);
+        }
+
+        boolean awaitFirstCallStarted(Duration timeout) {
+            return awaitLatch(firstCallStarted, timeout);
+        }
+
+        boolean awaitFirstCallCancelled(Duration timeout) {
+            return awaitLatch(firstCallCancelled, timeout);
+        }
+
+        boolean awaitExecutionReleased(Duration timeout) {
+            return awaitLatch(executionReleased, timeout);
+        }
+
+        private boolean awaitLatch(CountDownLatch latch, Duration timeout) {
+            try {
+                return latch.await(timeout.toMillis(), TimeUnit.MILLISECONDS);
+            } catch (InterruptedException ex) {
+                Thread.currentThread().interrupt();
+                return false;
+            }
+        }
+
+        @Override
+        protected Mono<Msg> doCall(List<Msg> msgs) {
+            if (callCount.incrementAndGet() == 1) {
+                return Mono.<Msg>create(sink -> firstCallStarted.countDown())
+                        .doOnCancel(firstCallCancelled::countDown);
+            }
+            return Mono.just(
+                    Msg.builder()
+                            .name(getName())
+                            .role(MsgRole.ASSISTANT)
+                            .content(TextBlock.builder().text("Recovered").build())
+                            .build());
+        }
+
+        @Override
+        protected Mono<Msg> handleInterrupt(InterruptContext context, Msg... originalArgs) {
+            return Mono.just(
+                    Msg.builder()
+                            .name(getName())
+                            .role(MsgRole.ASSISTANT)
+                            .content(TextBlock.builder().text("Interrupted").build())
+                            .build());
+        }
+
+        @Override
+        protected void afterAgentExecution() {
+            executionReleased.countDown();
         }
     }
 
@@ -351,5 +414,33 @@ class AgentBaseTest {
         assertNotNull(firstResponse.get(), "First call should complete successfully");
         assertNotNull(secondResponse.get(), "Second call should complete successfully");
         assertTrue(error.get() == null, "No error should occur during concurrent calls");
+    }
+
+    @Test
+    @DisplayName("Should release stream execution when downstream cancels")
+    void testStreamCancellationReleasesExecution() throws InterruptedException {
+        CancellableStreamAgent cancellableAgent = new CancellableStreamAgent("CancellableAgent");
+        Msg inputMsg = TestUtils.createUserMessage("User", "Cancel me");
+
+        StepVerifier.create(cancellableAgent.stream(inputMsg))
+                .then(
+                        () ->
+                                assertTrue(
+                                        cancellableAgent.awaitFirstCallStarted(
+                                                Duration.ofSeconds(1)),
+                                        "First stream call should start"))
+                .thenCancel()
+                .verify(Duration.ofSeconds(5));
+
+        assertTrue(
+                cancellableAgent.awaitFirstCallCancelled(Duration.ofSeconds(1)),
+                "Cancelling the stream should dispose the upstream call");
+        assertTrue(
+                cancellableAgent.awaitExecutionReleased(Duration.ofSeconds(1)),
+                "Cancelling the stream should release the execution lock");
+
+        Msg response = cancellableAgent.call(inputMsg).block(Duration.ofSeconds(1));
+        assertNotNull(response, "Agent should accept a new call after stream cancellation");
+        assertEquals("Recovered", TestUtils.extractTextContent(response));
     }
 }


### PR DESCRIPTION
### 背景
`AgentBase#createEventStream` 当前通过 `Mono.defer(...).subscribe(...)` 驱动流式调用，但下游取消订阅时，上游执行中的订阅没有被及时释放。

这会带来两个问题：
- 已取消的流在后台继续执行，形成“幽灵任务”
- `running` 状态可能没有及时释放，导致后续请求报 `Agent is still running`

### 修改内容
- 在 `AgentBase#createEventStream` 中，把上游订阅绑定到 `FluxSink` 的 dispose 生命周期
- 使用 `Disposable.Swap` 配合 `sink.onDispose(...)`，确保下游取消时可以及时 `dispose` 正在执行的上游订阅
- 保留现有的流式 hook、subagent event bus 和结果事件发射逻辑不变

### 测试
新增回归测试，覆盖以下场景：
- 第一次 `stream()` 被取消后，上游订阅会收到 cancel
- 取消后执行锁能够及时释放
- 第二次 `call()` 可以立即成功，不会再因为残留 `running=true` 失败

已验证：
- `mvn -pl agentscope-core -am -DskipTests spotless:apply`
- `mvn -pl agentscope-core -am "-Dtest=AgentBaseTest,AgentStreamingTest" test`

Fixes #1466