### PR TITLE
feat(session-redis): add TTL support for Redis session keys

### DIFF
--- a/agentscope-extensions/agentscope-extensions-session-redis/src/main/java/io/agentscope/core/session/redis/RedisClientAdapter.java
+++ b/agentscope-extensions/agentscope-extensions-session-redis/src/main/java/io/agentscope/core/session/redis/RedisClientAdapter.java
@@ -125,6 +125,14 @@ public interface RedisClientAdapter {
     Set<String> findKeysByPattern(String pattern);
 
     /**
+     * Set a timeout on a key. After the timeout has expired, the key will automatically be deleted.
+     *
+     * @param key the Redis key
+     * @param seconds the timeout in seconds, 0 to remove the existing timeout
+     */
+    void expire(String key, long seconds);
+
+    /**
      * Close the adapter and release resources.
      */
     void close();

--- a/agentscope-extensions/agentscope-extensions-session-redis/src/main/java/io/agentscope/core/session/redis/RedisSession.java
+++ b/agentscope-extensions/agentscope-extensions-session-redis/src/main/java/io/agentscope/core/session/redis/RedisSession.java
@@ -175,6 +175,20 @@ import redis.clients.jedis.UnifiedJedis;
  *     .keyPrefix("myapp:session:")
  *     .build();
  * }</pre>
+ *
+ * <p><strong>Session TTL (Auto-Expiry) Example:</strong></p>
+ *
+ * <pre>{@code
+ * // Create Redis client
+ * RedisClient redisClient = RedisClient.create("redis://localhost:6379");
+ *
+ * // Build RedisSession with 30-minute TTL — keys auto-expire after inactivity
+ * Session session = RedisSession.builder()
+ *     .jedisClient(redisClient)
+ *     .keyPrefix("myapp:session:")
+ *     .ttlSeconds(1800)
+ *     .build();
+ * }</pre>
  */
 public class RedisSession implements Session {
 
@@ -190,6 +204,8 @@ public class RedisSession implements Session {
 
     private final String keyPrefix;
 
+    private final long ttlSeconds;
+
     private RedisSession(Builder builder) {
         if (builder.client == null) {
             throw new IllegalArgumentException("Redis client cannot be null");
@@ -199,6 +215,7 @@ public class RedisSession implements Session {
         }
         this.client = builder.client;
         this.keyPrefix = builder.keyPrefix;
+        this.ttlSeconds = builder.ttlSeconds;
     }
 
     /**
@@ -220,6 +237,8 @@ public class RedisSession implements Session {
             client.set(redisKey, json);
             // Track this key in the session's key set
             client.addToSet(keysKey, key);
+            // Refresh TTL on affected keys
+            expireIfEnabled(redisKey, keysKey);
         } catch (Exception e) {
             throw new RuntimeException("Failed to save state: " + key, e);
         }
@@ -261,6 +280,8 @@ public class RedisSession implements Session {
             client.set(hashKey, currentHash);
             // Track this key in the session's key set
             client.addToSet(keysKey, key + LIST_SUFFIX);
+            // Refresh TTL on affected keys
+            expireIfEnabled(listKey, hashKey, keysKey);
         } catch (Exception e) {
             throw new RuntimeException("Failed to save list: " + key, e);
         }
@@ -427,6 +448,23 @@ public class RedisSession implements Session {
     }
 
     /**
+     * Refresh TTL on the given Redis keys if TTL is configured.
+     *
+     * <p>When TTL is set (greater than 0), each call refreshes the expiry on the affected keys,
+     * so that the session data lives as long as it is being actively used.
+     *
+     * @param keys the Redis keys to set expiry on
+     */
+    private void expireIfEnabled(String... keys) {
+        if (ttlSeconds <= 0) {
+            return;
+        }
+        for (String key : keys) {
+            client.expire(key, ttlSeconds);
+        }
+    }
+
+    /**
      * Builder for {@link RedisSession}.
      *
      * <p>The builder supports multiple Redis client types. Only one client type should be set.
@@ -446,8 +484,27 @@ public class RedisSession implements Session {
 
         private RedisClientAdapter client;
 
+        private long ttlSeconds = 0;
+
         public Builder keyPrefix(String keyPrefix) {
             this.keyPrefix = keyPrefix;
+            return this;
+        }
+
+        /**
+         * Sets the TTL (time-to-live) in seconds for all keys written by this session.
+         *
+         * <p>When set to a value greater than 0, each {@code save()} call will refresh the
+         * expiry on the affected Redis keys. This means session data will automatically be
+         * deleted after the configured duration of inactivity.
+         *
+         * <p>When set to 0 (default), keys are persisted indefinitely.
+         *
+         * @param ttlSeconds the TTL in seconds, 0 to disable expiry
+         * @return This builder instance for method chaining
+         */
+        public Builder ttlSeconds(long ttlSeconds) {
+            this.ttlSeconds = ttlSeconds;
             return this;
         }
 

--- a/agentscope-extensions/agentscope-extensions-session-redis/src/main/java/io/agentscope/core/session/redis/jedis/JedisClientAdapter.java
+++ b/agentscope-extensions/agentscope-extensions-session-redis/src/main/java/io/agentscope/core/session/redis/jedis/JedisClientAdapter.java
@@ -169,6 +169,11 @@ public class JedisClientAdapter implements RedisClientAdapter {
     }
 
     @Override
+    public void expire(String key, long seconds) {
+        unifiedJedis.expire(key, seconds);
+    }
+
+    @Override
     public void close() {
         unifiedJedis.close();
     }

--- a/agentscope-extensions/agentscope-extensions-session-redis/src/main/java/io/agentscope/core/session/redis/lettuce/LettuceClientAdapter.java
+++ b/agentscope-extensions/agentscope-extensions-session-redis/src/main/java/io/agentscope/core/session/redis/lettuce/LettuceClientAdapter.java
@@ -281,6 +281,15 @@ public class LettuceClientAdapter implements RedisClientAdapter {
     }
 
     @Override
+    public void expire(String key, long seconds) {
+        if (commands != null) {
+            commands.expire(key, seconds);
+        } else {
+            clusterCommands.expire(key, seconds);
+        }
+    }
+
+    @Override
     public void close() {
         try {
             closeable.close();

--- a/agentscope-extensions/agentscope-extensions-session-redis/src/main/java/io/agentscope/core/session/redis/redisson/RedissonClientAdapter.java
+++ b/agentscope-extensions/agentscope-extensions-session-redis/src/main/java/io/agentscope/core/session/redis/redisson/RedissonClientAdapter.java
@@ -16,6 +16,7 @@
 package io.agentscope.core.session.redis.redisson;
 
 import io.agentscope.core.session.redis.RedisClientAdapter;
+import java.time.Duration;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -212,6 +213,11 @@ public class RedissonClientAdapter implements RedisClientAdapter {
             result.add(key);
         }
         return result;
+    }
+
+    @Override
+    public void expire(String key, long seconds) {
+        redissonClient.getBucket(key, StringCodec.INSTANCE).expire(Duration.ofSeconds(seconds));
     }
 
     @Override

--- a/agentscope-extensions/agentscope-extensions-session-redis/src/test/java/io/agentscope/core/session/redis/JedisSessionTest.java
+++ b/agentscope-extensions/agentscope-extensions-session-redis/src/test/java/io/agentscope/core/session/redis/JedisSessionTest.java
@@ -21,9 +21,11 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -276,6 +278,44 @@ class JedisSessionTest {
                         .build();
         session.close();
         verify(unifiedJedis).close();
+    }
+
+    @Test
+    @DisplayName("Should set TTL on keys when ttlSeconds is configured")
+    void testSaveWithTtl() {
+        RedisSession session =
+                RedisSession.builder()
+                        .jedisClient(unifiedJedis)
+                        .keyPrefix("agentscope:session:")
+                        .ttlSeconds(1800)
+                        .build();
+
+        SessionKey sessionKey = SimpleSessionKey.of("session1");
+        TestState state = new TestState("test_value", 42);
+
+        session.save(sessionKey, "testModule", state);
+
+        // Verify expire was called with correct TTL on both the state key and the _keys set
+        verify(unifiedJedis).expire("agentscope:session:session1:testModule", 1800);
+        verify(unifiedJedis).expire("agentscope:session:session1:_keys", 1800);
+    }
+
+    @Test
+    @DisplayName("Should not set TTL when ttlSeconds is not configured")
+    void testSaveWithoutTtl() {
+        RedisSession session =
+                RedisSession.builder()
+                        .jedisClient(unifiedJedis)
+                        .keyPrefix("agentscope:session:")
+                        .build();
+
+        SessionKey sessionKey = SimpleSessionKey.of("session1");
+        TestState state = new TestState("test_value", 42);
+
+        session.save(sessionKey, "testModule", state);
+
+        // Verify expire was never called
+        verify(unifiedJedis, never()).expire(anyString(), anyLong());
     }
 
     /** Simple test state record for testing. */


### PR DESCRIPTION
## Summary

为 RedisSession 添加 TTL（过期时间）支持，解决 Session 数据在 Redis 中永久存储的问题。

## Motivation

当前 RedisSession 保存数据时使用普通 `SET` 命令，Key 无过期时间，数据永久驻留 Redis。在生产环境中，会话数据应该有自动过期能力，避免 Redis 内存持续增长。

## Changes

- `RedisClientAdapter` 接口新增 `expire(String key, long seconds)` 方法
- `JedisClientAdapter` / `LettuceClientAdapter` / `RedissonClientAdapter` 各自实现 `expire`
- `RedisSession.Builder` 新增 `ttlSeconds(long)` 配置项，默认 `0`（不过期）
- `save()` 方法在写入数据后自动刷新受影响 Key 的 TTL

## Usage

```java
Session session = RedisSession.builder()
    .jedisClient(jedis)
    .keyPrefix("myapp:session:")
    .ttlSeconds(1800)  // 30 分钟无操作自动过期
    .build();
```

每次 `save()` 调用都会刷新 TTL，持续活跃则不会过期。

## Backward Compatibility

完全向后兼容。`ttlSeconds` 默认 `0`，行为与之前完全一致。

## Test Plan

- [x] `testSaveWithTtl` — 验证 TTL 配置后 `expire` 被正确调用
- [x] `testSaveWithoutTtl` — 验证不配置 TTL 时不调用 `expire`
- [x] spotless 格式化检查通过
- [x] 全部已有测试无回归

🤖 Generated with [Claude Code](https://claude.com/claude-code)