### PR TITLE
fix(harness): avoid shell-based sandbox edit

### DIFF
--- a/agentscope-core/src/main/java/io/agentscope/core/tool/ToolCallParam.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/tool/ToolCallParam.java
@@ -144,7 +144,7 @@ public class ToolCallParam {
      *
      * <p>Note: The input map structure is copied so that entries can be modified
      * independently, but nested values (typed as Object) remain shared.
-     * Immutable fields (toolUseBlock, agent, context, emitter) are shared by reference.
+     * Immutable fields (toolUseBlock, agent, runtimeContext, emitter) are shared by reference.
      *
      * @param source The existing ToolCallParam to copy values from
      * @return A new builder pre-populated with the source's values
@@ -171,7 +171,7 @@ public class ToolCallParam {
             this.toolUseBlock = source.toolUseBlock;
             this.input = source.input.isEmpty() ? null : source.input;
             this.agent = source.agent;
-            this.context = source.context;
+            this.runtimeContext = source.runtimeContext;
             this.emitter = source.emitter;
         }
 

--- a/agentscope-core/src/test/java/io/agentscope/core/tool/ToolCallParamTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/tool/ToolCallParamTest.java
@@ -160,7 +160,9 @@ class ToolCallParamTest {
             assertEquals(original.getToolUseBlock(), copy.getToolUseBlock());
             assertEquals(original.getInput(), copy.getInput());
             assertEquals(original.getAgent(), copy.getAgent());
-            assertEquals(original.getContext(), copy.getContext());
+            assertSame(original.getRuntimeContext(), copy.getRuntimeContext());
+            assertNotNull(copy.getContext());
+            assertEquals(original.getContext().get(String.class), copy.getContext().get(String.class));
             assertSame(original.getEmitter(), copy.getEmitter());
         }
 
@@ -249,6 +251,7 @@ class ToolCallParamTest {
             assertEquals(original.getToolUseBlock(), copy.getToolUseBlock());
             assertTrue(copy.getInput().isEmpty());
             assertNull(copy.getAgent());
+            assertNull(copy.getRuntimeContext());
             assertNull(copy.getContext());
         }
 
@@ -287,7 +290,9 @@ class ToolCallParamTest {
             // Immutable fields should be the same references
             assertSame(original.getToolUseBlock(), copy.getToolUseBlock());
             assertSame(original.getAgent(), copy.getAgent());
-            assertSame(original.getContext(), copy.getContext());
+            assertSame(original.getRuntimeContext(), copy.getRuntimeContext());
+            assertNotNull(copy.getContext());
+            assertEquals(original.getContext().get(String.class), copy.getContext().get(String.class));
         }
 
         @Test

--- a/agentscope-core/src/test/java/io/agentscope/core/tool/ToolCallParamTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/tool/ToolCallParamTest.java
@@ -162,7 +162,8 @@ class ToolCallParamTest {
             assertEquals(original.getAgent(), copy.getAgent());
             assertSame(original.getRuntimeContext(), copy.getRuntimeContext());
             assertNotNull(copy.getContext());
-            assertEquals(original.getContext().get(String.class), copy.getContext().get(String.class));
+            assertEquals(
+                    original.getContext().get(String.class), copy.getContext().get(String.class));
             assertSame(original.getEmitter(), copy.getEmitter());
         }
 
@@ -292,7 +293,8 @@ class ToolCallParamTest {
             assertSame(original.getAgent(), copy.getAgent());
             assertSame(original.getRuntimeContext(), copy.getRuntimeContext());
             assertNotNull(copy.getContext());
-            assertEquals(original.getContext().get(String.class), copy.getContext().get(String.class));
+            assertEquals(
+                    original.getContext().get(String.class), copy.getContext().get(String.class));
         }
 
         @Test

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/filesystem/sandbox/BaseSandboxFilesystem.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/filesystem/sandbox/BaseSandboxFilesystem.java
@@ -30,19 +30,24 @@ import io.agentscope.harness.agent.filesystem.model.LsResult;
 import io.agentscope.harness.agent.filesystem.model.ReadResult;
 import io.agentscope.harness.agent.filesystem.model.WriteResult;
 import io.agentscope.harness.agent.filesystem.util.FilesystemUtils;
+import java.nio.ByteBuffer;
+import java.nio.charset.CharacterCodingException;
+import java.nio.charset.CodingErrorAction;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
-import java.util.Base64;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.locks.ReentrantLock;
 
 /**
  * Abstract base sandbox implementation with {@link #execute} as the core abstract method.
  *
  * <p>This class provides default implementations for all {@link AbstractFilesystem} methods by
- * delegating
- * to shell commands via {@link #execute}. File listing, grep, and glob use standard Unix
- * commands. Read uses server-side commands for paginated access. Write delegates content
- * transfer to {@link #uploadFiles}. Edit uses server-side commands for string replacement.
+ * delegating to shell commands via {@link #execute}. File listing, grep, and glob use standard
+ * Unix commands. Read uses server-side commands for paginated access. Write delegates content
+ * transfer to {@link #uploadFiles}. Edit downloads the file, applies replacement in Java, and
+ * uploads the updated content back.
  *
  * <p>Subclasses must implement:
  * <ul>
@@ -53,6 +58,8 @@ import java.util.Map;
  * </ul>
  */
 public abstract class BaseSandboxFilesystem implements AbstractSandboxFilesystem {
+
+    private final ConcurrentHashMap<String, ReentrantLock> editLocks = new ConcurrentHashMap<>();
 
     @Override
     public abstract String id();
@@ -192,84 +199,66 @@ public abstract class BaseSandboxFilesystem implements AbstractSandboxFilesystem
             String oldString,
             String newString,
             boolean replaceAll) {
-        String payload =
-                "{\"path\":\""
-                        + jsonEscape(filePath)
-                        + "\","
-                        + "\"old\":\""
-                        + jsonEscape(oldString)
-                        + "\","
-                        + "\"new\":\""
-                        + jsonEscape(newString)
-                        + "\","
-                        + "\"replace_all\":"
-                        + replaceAll
-                        + "}";
-        String payloadB64 =
-                Base64.getEncoder()
-                        .encodeToString(payload.getBytes(java.nio.charset.StandardCharsets.UTF_8));
-
-        String cmd =
-                "python3 -c \"import sys, os, base64, json\\n"
-                    + "payload ="
-                    + " json.loads(base64.b64decode(sys.stdin.read().strip()).decode('utf-8'))\\n"
-                    + "path, old, new = payload['path'], payload['old'], payload['new']\\n"
-                    + "replace_all = payload.get('replace_all', False)\\n"
-                    + "if not os.path.isfile(path):\\n"
-                    + "    print(json.dumps({'error': 'file_not_found'}))\\n"
-                    + "    sys.exit(0)\\n"
-                    + "with open(path, 'rb') as f: text = f.read().decode('utf-8')\\n"
-                    + "count = text.count(old)\\n"
-                    + "if count == 0:\\n"
-                    + "    print(json.dumps({'error': 'string_not_found'}))\\n"
-                    + "    sys.exit(0)\\n"
-                    + "if count > 1 and not replace_all:\\n"
-                    + "    print(json.dumps({'error': 'multiple_occurrences', 'count': count}))\\n"
-                    + "    sys.exit(0)\\n"
-                    + "result = text.replace(old, new) if replace_all else text.replace(old, new,"
-                    + " 1)\\n"
-                    + "with open(path, 'wb') as f: f.write(result.encode('utf-8'))\\n"
-                    + "print(json.dumps({'count': count}))\\n"
-                    + "\" 2>&1 <<'__EDIT_EOF__'\n"
-                        + payloadB64
-                        + "\n__EDIT_EOF__\n";
-
-        ExecuteResponse result = execute(runtimeContext, cmd, null);
-        String output = result.output() != null ? result.output().strip() : "";
-
-        if (output.contains("\"error\"")) {
-            if (output.contains("file_not_found")) {
-                return EditResult.fail("Error: File '" + filePath + "' not found");
-            }
-            if (output.contains("string_not_found")) {
-                return EditResult.fail("Error: String not found in file: '" + oldString + "'");
-            }
-            if (output.contains("multiple_occurrences")) {
+        ReentrantLock lock = editLocks.computeIfAbsent(filePath, key -> new ReentrantLock());
+        lock.lock();
+        try {
+            List<FileDownloadResponse> downloads = downloadFiles(runtimeContext, List.of(filePath));
+            if (downloads.isEmpty()) {
                 return EditResult.fail(
-                        "Error: String '"
-                                + oldString
-                                + "' appears multiple times. Use replaceAll=true to replace all"
-                                + " occurrences.");
+                        "Error editing file '" + filePath + "': download returned no response");
             }
-            return EditResult.fail("Error editing file '" + filePath + "': " + output);
-        }
 
-        if (output.contains("\"count\"")) {
+            FileDownloadResponse download = downloads.get(0);
+            if (!download.isSuccess() || download.content() == null) {
+                String error =
+                        download.error() != null ? download.error() : "unknown download error";
+                if (isMissingFileError(error)) {
+                    return EditResult.fail("Error: File '" + filePath + "' not found");
+                }
+                return EditResult.fail("Error editing file '" + filePath + "': " + error);
+            }
+
+            String content;
             try {
-                int countIdx = output.indexOf("\"count\":") + 8;
-                int endIdx = output.indexOf('}', countIdx);
-                int count = Integer.parseInt(output.substring(countIdx, endIdx).trim());
-                return EditResult.ok(filePath, count);
-            } catch (NumberFormatException e) {
-                return EditResult.ok(filePath, 1);
+                content = decodeUtf8Strict(download.content());
+            } catch (CharacterCodingException e) {
+                return EditResult.fail(
+                        "Error editing file '" + filePath + "': file content is not valid UTF-8");
             }
-        }
 
-        return EditResult.fail(
-                "Error editing file '"
-                        + filePath
-                        + "': unexpected server response: "
-                        + output.substring(0, Math.min(200, output.length())));
+            Object[] result =
+                    FilesystemUtils.performStringReplacement(
+                            content, oldString, newString, replaceAll);
+
+            if (result.length == 1) {
+                return EditResult.fail((String) result[0]);
+            }
+
+            String newContent = (String) result[0];
+            int occurrences = (int) result[1];
+
+            List<FileUploadResponse> uploads =
+                    uploadFiles(
+                            runtimeContext,
+                            List.of(
+                                    Map.entry(
+                                            filePath,
+                                            newContent.getBytes(StandardCharsets.UTF_8))));
+            if (uploads.isEmpty()) {
+                return EditResult.fail(
+                        "Error editing file '" + filePath + "': upload returned no response");
+            }
+
+            FileUploadResponse upload = uploads.get(0);
+            if (!upload.isSuccess()) {
+                String error = upload.error() != null ? upload.error() : "unknown upload error";
+                return EditResult.fail("Error editing file '" + filePath + "': " + error);
+            }
+
+            return EditResult.ok(filePath, occurrences);
+        } finally {
+            lock.unlock();
+        }
     }
 
     @Override
@@ -379,14 +368,21 @@ public abstract class BaseSandboxFilesystem implements AbstractSandboxFilesystem
         return result.output() != null && result.output().strip().startsWith("yes");
     }
 
-    private static String jsonEscape(String s) {
-        if (s == null) {
-            return "";
+    private String decodeUtf8Strict(byte[] content) throws CharacterCodingException {
+        return StandardCharsets.UTF_8.newDecoder()
+                .onMalformedInput(CodingErrorAction.REPORT)
+                .onUnmappableCharacter(CodingErrorAction.REPORT)
+                .decode(ByteBuffer.wrap(content))
+                .toString();
+    }
+
+    private boolean isMissingFileError(String error) {
+        if (error == null) {
+            return false;
         }
-        return s.replace("\\", "\\\\")
-                .replace("\"", "\\\"")
-                .replace("\n", "\\n")
-                .replace("\r", "\\r")
-                .replace("\t", "\\t");
+        String normalized = error.toLowerCase();
+        return normalized.contains("no such file")
+                || normalized.contains("not found")
+                || normalized.contains("file_not_found");
     }
 }

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/filesystem/sandbox/BaseSandboxFilesystem.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/filesystem/sandbox/BaseSandboxFilesystem.java
@@ -369,7 +369,8 @@ public abstract class BaseSandboxFilesystem implements AbstractSandboxFilesystem
     }
 
     private String decodeUtf8Strict(byte[] content) throws CharacterCodingException {
-        return StandardCharsets.UTF_8.newDecoder()
+        return StandardCharsets.UTF_8
+                .newDecoder()
                 .onMalformedInput(CodingErrorAction.REPORT)
                 .onUnmappableCharacter(CodingErrorAction.REPORT)
                 .decode(ByteBuffer.wrap(content))

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/filesystem/sandbox/BaseSandboxFilesystemTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/filesystem/sandbox/BaseSandboxFilesystemTest.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.harness.agent.filesystem.sandbox;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.agentscope.core.agent.RuntimeContext;
+import io.agentscope.harness.agent.filesystem.model.EditResult;
+import io.agentscope.harness.agent.filesystem.model.ExecuteResponse;
+import io.agentscope.harness.agent.filesystem.model.FileDownloadResponse;
+import io.agentscope.harness.agent.filesystem.model.FileUploadResponse;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Test;
+
+class BaseSandboxFilesystemTest {
+
+    private static final RuntimeContext RT = RuntimeContext.empty();
+
+    @Test
+    void edit_usesDownloadReplaceUploadWithoutShellExecution() {
+        InMemorySandboxFilesystem fs = new InMemorySandboxFilesystem();
+        fs.put("/workspace/note.txt", "hello\nworld\nhello");
+
+        EditResult result = fs.edit(RT, "/workspace/note.txt", "world", "there", false);
+
+        assertTrue(result.isSuccess());
+        assertEquals("/workspace/note.txt", result.path());
+        assertEquals(1, result.occurrences());
+        assertEquals("hello\nthere\nhello", fs.contentOf("/workspace/note.txt"));
+        assertEquals(1, fs.downloadCalls.get());
+        assertEquals(1, fs.uploadCalls.get());
+        assertEquals(0, fs.executeCalls.get());
+    }
+
+    @Test
+    void edit_returnsNotFoundWhenDownloadFails() {
+        InMemorySandboxFilesystem fs = new InMemorySandboxFilesystem();
+
+        EditResult result = fs.edit(RT, "/workspace/missing.txt", "old", "new", false);
+
+        assertFalse(result.isSuccess());
+        assertEquals("Error: File '/workspace/missing.txt' not found", result.error());
+        assertEquals(1, fs.downloadCalls.get());
+        assertEquals(0, fs.uploadCalls.get());
+        assertEquals(0, fs.executeCalls.get());
+    }
+
+    private static final class InMemorySandboxFilesystem extends BaseSandboxFilesystem {
+        private final Map<String, byte[]> files = new ConcurrentHashMap<>();
+        private final AtomicInteger executeCalls = new AtomicInteger();
+        private final AtomicInteger downloadCalls = new AtomicInteger();
+        private final AtomicInteger uploadCalls = new AtomicInteger();
+
+        @Override
+        public String id() {
+            return "in-memory";
+        }
+
+        @Override
+        public ExecuteResponse execute(
+                RuntimeContext runtimeContext, String command, Integer timeoutSeconds) {
+            executeCalls.incrementAndGet();
+            throw new AssertionError("edit must not call execute()");
+        }
+
+        @Override
+        public List<FileUploadResponse> uploadFiles(
+                RuntimeContext runtimeContext, List<Map.Entry<String, byte[]>> files) {
+            uploadCalls.incrementAndGet();
+            List<FileUploadResponse> responses = new ArrayList<>(files.size());
+            for (Map.Entry<String, byte[]> file : files) {
+                this.files.put(file.getKey(), file.getValue());
+                responses.add(FileUploadResponse.success(file.getKey()));
+            }
+            return responses;
+        }
+
+        @Override
+        public List<FileDownloadResponse> downloadFiles(
+                RuntimeContext runtimeContext, List<String> paths) {
+            downloadCalls.incrementAndGet();
+            List<FileDownloadResponse> responses = new ArrayList<>(paths.size());
+            for (String path : paths) {
+                byte[] content = files.get(path);
+                if (content == null) {
+                    responses.add(FileDownloadResponse.fail(path, "No such file or directory"));
+                } else {
+                    responses.add(FileDownloadResponse.success(path, content));
+                }
+            }
+            return responses;
+        }
+
+        void put(String path, String content) {
+            files.put(path, content.getBytes(StandardCharsets.UTF_8));
+        }
+
+        String contentOf(String path) {
+            byte[] content = files.get(path);
+            return content == null ? null : new String(content, StandardCharsets.UTF_8);
+        }
+    }
+}


### PR DESCRIPTION
## 变更说明

本 PR 修复了 #1609，移除了 `BaseSandboxFilesystem.edit()` 中基于 shell/Python 的编辑实现。

旧实现会拼接 `python3 -c` 命令，并用字面量 `\n` 连接 Python 代码。在 Aone、E2B 等远程沙箱中，这种命令可能被 Python 当成单行代码处理，进而触发 `SyntaxError`。

现在 `edit()` 改为更稳定的流程：

1. 通过沙箱文件接口下载目标文件
2. 在 Java 侧完成字符串替换
3. 将修改后的内容重新上传回沙箱

## 具体改动

- 将 `BaseSandboxFilesystem.edit()` 从 shell/Python 执行改为 download -> replace -> upload
- 保持现有编辑语义不变，包括：
  - 文件不存在
  - 目标字符串不存在
  - `replaceAll=false` 时出现多处匹配
  - 上传/下载失败
  - 文件内容不是合法 UTF-8
- 新增回归测试，确保 `edit()` 不再依赖 `execute()`

## 附带修复

本 PR 同时修复了 `ToolCallParam.builder(source)` 的拷贝构造问题。

当前 `upstream/main` 中，这里错误地使用了 `source.context`，但 Builder 实际字段是 `runtimeContext`，会导致 `agentscope-core` 编译失败。本 PR 一并修正了这处赋值，并补充了相关测试覆盖。

## 验证

执行命令：

```bash
mvn --% -pl agentscope-harness -am -Dtest=ToolCallParamTest,BaseSandboxFilesystemTest,CompositeFilesystemTest,FilesystemDeleteMoveExistsTest,FilesystemGlobTest,LocalFilesystemModeTest,RemoteFilesystemCASTest,RemoteFilesystemGrepTest,RemoteFilesystemSpecTest -Dspotless.check.skip=true test