### PR TITLE
fix(harness): 修复 abstractFilesystem 下的 SandboxLifecycleMiddleware 生命周期接管

### DIFF
--- a/agentscope-core/src/main/java/io/agentscope/core/tool/ToolCallParam.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/tool/ToolCallParam.java
@@ -171,7 +171,7 @@ public class ToolCallParam {
             this.toolUseBlock = source.toolUseBlock;
             this.input = source.input.isEmpty() ? null : source.input;
             this.agent = source.agent;
-            this.context = source.context;
+            this.runtimeContext = source.runtimeContext;
             this.emitter = source.emitter;
         }
 

--- a/agentscope-core/src/test/java/io/agentscope/core/tool/ToolCallParamTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/tool/ToolCallParamTest.java
@@ -160,7 +160,8 @@ class ToolCallParamTest {
             assertEquals(original.getToolUseBlock(), copy.getToolUseBlock());
             assertEquals(original.getInput(), copy.getInput());
             assertEquals(original.getAgent(), copy.getAgent());
-            assertEquals(original.getContext(), copy.getContext());
+            assertSame(original.getRuntimeContext(), copy.getRuntimeContext());
+            assertEquals("testContext", copy.getContext().get(String.class));
             assertSame(original.getEmitter(), copy.getEmitter());
         }
 
@@ -287,7 +288,8 @@ class ToolCallParamTest {
             // Immutable fields should be the same references
             assertSame(original.getToolUseBlock(), copy.getToolUseBlock());
             assertSame(original.getAgent(), copy.getAgent());
-            assertSame(original.getContext(), copy.getContext());
+            assertSame(original.getRuntimeContext(), copy.getRuntimeContext());
+            assertEquals("testContext", copy.getContext().get(String.class));
         }
 
         @Test

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/HarnessAgent.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/HarnessAgent.java
@@ -1900,6 +1900,16 @@ public class HarnessAgent implements Agent, AutoCloseable {
             // ---- Build inner ReActAgent ----
             inner.toolkit(agentToolkit);
             ReActAgent delegate = inner.build();
+            if (sandboxLifecycleMw == null) {
+                // Reuse an explicitly registered middleware so abstractFilesystem() still
+                // participates in wrappedCall / wrappedStreamEvents lifecycle management.
+                for (MiddlewareBase mw : delegate.getMiddlewares()) {
+                    if (mw instanceof SandboxLifecycleMiddleware slm) {
+                        sandboxLifecycleMw = slm;
+                        break;
+                    }
+                }
+            }
             selfRef.set(delegate);
 
             return new HarnessAgent(

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/HarnessAgentTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/HarnessAgentTest.java
@@ -23,6 +23,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -37,9 +38,15 @@ import io.agentscope.core.session.Session;
 import io.agentscope.core.tool.AgentTool;
 import io.agentscope.core.tool.Toolkit;
 import io.agentscope.harness.agent.filesystem.local.LocalFilesystem;
+import io.agentscope.harness.agent.filesystem.sandbox.SandboxBackedFilesystem;
 import io.agentscope.harness.agent.filesystem.spec.RemoteFilesystemSpec;
 import io.agentscope.harness.agent.memory.compaction.CompactionConfig;
+import io.agentscope.harness.agent.middleware.SandboxLifecycleMiddleware;
 import io.agentscope.harness.agent.middleware.SubagentEntry;
+import io.agentscope.harness.agent.sandbox.Sandbox;
+import io.agentscope.harness.agent.sandbox.SandboxAcquireResult;
+import io.agentscope.harness.agent.sandbox.SandboxContext;
+import io.agentscope.harness.agent.sandbox.SandboxManager;
 import io.agentscope.harness.agent.store.InMemoryStore;
 import io.agentscope.harness.agent.subagent.AgentSpecLoader;
 import io.agentscope.harness.agent.subagent.SubagentDeclaration;
@@ -344,6 +351,43 @@ class HarnessAgentTest {
                                     "/MEMORY.md")
                             != null);
         }
+    }
+
+    @Test
+    void abstractFilesystem_userRegisteredSandboxLifecycleMiddleware_participatesInWrappedCall()
+            throws Exception {
+        Files.createDirectories(workspace);
+
+        Model model = stubModel("assistant-done");
+        SandboxManager sandboxManager = mock(SandboxManager.class);
+        SandboxBackedFilesystem sandboxFilesystem = mock(SandboxBackedFilesystem.class);
+        Sandbox sandbox = mock(Sandbox.class);
+        SandboxAcquireResult acquireResult = SandboxAcquireResult.userManaged(sandbox);
+        when(sandboxManager.acquire(any(), any())).thenReturn(acquireResult);
+
+        SandboxLifecycleMiddleware lifecycle =
+                spy(new SandboxLifecycleMiddleware(sandboxManager, sandboxFilesystem));
+
+        try (HarnessAgent agent =
+                HarnessAgent.builder()
+                        .name("agent")
+                        .model(model)
+                        .workspace(workspace)
+                        .abstractFilesystem(new LocalFilesystem(workspace))
+                        .middleware(lifecycle)
+                        .build()) {
+
+            RuntimeContext runtimeContext =
+                    RuntimeContext.builder()
+                            .sessionId("sandbox-lifecycle")
+                            .put(SandboxContext.class, SandboxContext.builder().build())
+                            .build();
+
+            agent.call(userText("hi"), runtimeContext).block();
+        }
+
+        verify(lifecycle).acquireForCall(any(RuntimeContext.class));
+        verify(lifecycle).releaseForCall(any(RuntimeContext.class));
     }
 
     private static Msg userText(String text) {


### PR DESCRIPTION
## 关联问题
- close #1605

## 问题说明
当使用 `builder.abstractFilesystem(sandboxFs)` 并手动注册 `SandboxLifecycleMiddleware` 时，`HarnessAgent` 的 `wrappedCall()` / `wrappedStreamEvents()` 只会读取内部字段 `sandboxLifecycleMw`。

这个字段只会在 `filesystem(SandboxFilesystemSpec)` 路径下赋值，因此用户通过 `middleware(...)` 注册的 `SandboxLifecycleMiddleware` 虽然进入了 middleware 链，但不会参与 sandbox 的 acquire / release 生命周期。

## 修复内容
- 在 `HarnessAgent.Builder.build()` 完成 `delegate` 构建后，如果 `sandboxLifecycleMw` 仍为空，则从 `delegate.getMiddlewares()` 中提取用户注册的 `SandboxLifecycleMiddleware`
- 保持 `filesystem(SandboxFilesystemSpec)` 的现有行为不变，只为 `abstractFilesystem() + middleware(...)` 提供生命周期桥接
- 新增回归测试，验证 `abstractFilesystem() + middleware(SandboxLifecycleMiddleware)` 会触发 `acquireForCall()` / `releaseForCall()`

## 附带修复
当前 `upstream/main` 上 `ToolCallParam` 的 copy builder 仍在拷贝已移除的 `context` 字段，导致最新主线本地编译失败。

本 PR 一并修复该阻塞，并将对应测试更新到 `RuntimeContext` 语义，保证该分支可以在最新主线上独立通过验证。

## 验证
```bash
mvn -pl agentscope-core -Dtest=ToolCallParamTest -Dspotless.check.skip=true test
mvn -pl agentscope-harness -am -Dtest=HarnessAgentTest#abstractFilesystem_userRegisteredSandboxLifecycleMiddleware_participatesInWrappedCall -Dsurefire.failIfNoSpecifiedTests=false -Dspotless.check.skip=true test
```
