### PR TITLE
fix(core): copy runtime context in ToolCallParam builder

### DIFF
--- a/agentscope-core/src/main/java/io/agentscope/core/tool/ToolCallParam.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/tool/ToolCallParam.java
@@ -171,7 +171,7 @@ public class ToolCallParam {
             this.toolUseBlock = source.toolUseBlock;
             this.input = source.input.isEmpty() ? null : source.input;
             this.agent = source.agent;
-            this.context = source.context;
+            this.runtimeContext = source.runtimeContext;
             this.emitter = source.emitter;
         }
 


### PR DESCRIPTION
## AgentScope-Java Version

2.0.0-SNAPSHOT

## Description

This PR fixes a compilation failure in `ToolCallParam.Builder`.

After updating to the latest `upstream/main`, the project fails to compile because the copy constructor in `ToolCallParam.Builder` references a non-existing field:

```java
this.context = source.context;
```

However, the current builder field is named `runtimeContext`, and `ToolCallParam` also exposes `runtimeContext`, not `context`.

This PR updates the copy constructor to correctly copy the runtime context:

```java
this.runtimeContext = source.runtimeContext;
```

### Changes

- Fix `ToolCallParam.Builder(ToolCallParam source)` to copy `source.runtimeContext` into `this.runtimeContext`.
- No behavior change beyond restoring the intended copy-builder behavior and fixing compilation.

### How to test

Run:

```bash
mvn -pl agentscope-core -am compile -DskipTests
```

The command should complete successfully.

## Checklist

Please check the following items before code is ready to be reviewed.

- [ ] Code has been formatted with `mvn spotless:apply`
- [ ] All tests are passing (`mvn test`)
- [x] Javadoc comments are complete and follow project conventions
- [ ] Related documentation has been updated (e.g. links, examples, etc.)
- [x] Code is ready for review
