### PR TITLE
fix(core): copy runtime context in ToolCallParam builder

### DIFF
--- a/agentscope-core/src/main/java/io/agentscope/core/tool/ToolCallParam.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/tool/ToolCallParam.java
@@ -144,7 +144,7 @@ public class ToolCallParam {
      *
      * <p>Note: The input map structure is copied so that entries can be modified
      * independently, but nested values (typed as Object) remain shared.
-     * Immutable fields (toolUseBlock, agent, context, emitter) are shared by reference.
+     * Immutable fields (toolUseBlock, agent, runtimeContext, emitter) are shared by reference.
      *
      * @param source The existing ToolCallParam to copy values from
      * @return A new builder pre-populated with the source's values
@@ -171,7 +171,7 @@ public class ToolCallParam {
             this.toolUseBlock = source.toolUseBlock;
             this.input = source.input.isEmpty() ? null : source.input;
             this.agent = source.agent;
-            this.context = source.context;
+            this.runtimeContext = source.runtimeContext;
             this.emitter = source.emitter;
         }
 

--- a/agentscope-core/src/test/java/io/agentscope/core/tool/ToolCallParamTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/tool/ToolCallParamTest.java
@@ -160,7 +160,7 @@ class ToolCallParamTest {
             assertEquals(original.getToolUseBlock(), copy.getToolUseBlock());
             assertEquals(original.getInput(), copy.getInput());
             assertEquals(original.getAgent(), copy.getAgent());
-            assertEquals(original.getContext(), copy.getContext());
+            assertSame(original.getRuntimeContext(), copy.getRuntimeContext());
             assertSame(original.getEmitter(), copy.getEmitter());
         }
 
@@ -287,7 +287,7 @@ class ToolCallParamTest {
             // Immutable fields should be the same references
             assertSame(original.getToolUseBlock(), copy.getToolUseBlock());
             assertSame(original.getAgent(), copy.getAgent());
-            assertSame(original.getContext(), copy.getContext());
+            assertSame(original.getRuntimeContext(), copy.getRuntimeContext());
         }
 
         @Test


### PR DESCRIPTION
## AgentScope-Java Version

2.0.0-SNAPSHOT

## Description

Fixes (https://github.com/agentscope-ai/agentscope-java/issues/1608)

`ToolCallParam` was migrated to store `RuntimeContext`, while the newly added copy builder still referenced the old `context` field. This caused compilation failures.

This PR updates the copy builder to copy `runtimeContext` from the source `ToolCallParam`. It also updates the related tests to assert that the copied parameter preserves the same `RuntimeContext` reference, instead of asserting identity on the deprecated `getContext()` projection.


## Checklist

Please check the following items before code is ready to be reviewed.

- [ ]  Code has been formatted with `mvn spotless:apply`
- [ ]  All tests are passing (`mvn test`)
- [x]  Javadoc comments are complete and follow project conventions
- [x]  Related documentation has been updated (e.g. links, examples, etc.)
- [x]  Code is ready for review
