### PR TITLE
fix(tool): fix compilation error in ToolCallParam Builder copy constructor

### DIFF
--- a/agentscope-core/src/main/java/io/agentscope/core/tool/ToolCallParam.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/tool/ToolCallParam.java
@@ -171,7 +171,7 @@ public class ToolCallParam {
             this.toolUseBlock = source.toolUseBlock;
             this.input = source.input.isEmpty() ? null : source.input;
             this.agent = source.agent;
-            this.context = source.context;
+            this.runtimeContext = source.runtimeContext;
             this.emitter = source.emitter;
         }
 

--- a/agentscope-core/src/test/java/io/agentscope/core/tool/ToolCallParamTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/tool/ToolCallParamTest.java
@@ -160,7 +160,7 @@ class ToolCallParamTest {
             assertEquals(original.getToolUseBlock(), copy.getToolUseBlock());
             assertEquals(original.getInput(), copy.getInput());
             assertEquals(original.getAgent(), copy.getAgent());
-            assertEquals(original.getContext(), copy.getContext());
+            assertSame(original.getRuntimeContext(), copy.getRuntimeContext());
             assertSame(original.getEmitter(), copy.getEmitter());
         }
 
@@ -287,7 +287,7 @@ class ToolCallParamTest {
             // Immutable fields should be the same references
             assertSame(original.getToolUseBlock(), copy.getToolUseBlock());
             assertSame(original.getAgent(), copy.getAgent());
-            assertSame(original.getContext(), copy.getContext());
+            assertSame(original.getRuntimeContext(), copy.getRuntimeContext());
         }
 
         @Test


### PR DESCRIPTION
## Summary
- Fix compilation failure in `ToolCallParam.Builder` copy constructor where `context` was not renamed to `runtimeContext` along with the field rename.

## Test plan
- [x] `mvn compile -pl agentscope-core` passes locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)