### PR TITLE
fix: propagate runtime context through streamEvents middleware

### DIFF
--- a/agentscope-core/src/main/java/io/agentscope/core/ReActAgent.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/ReActAgent.java
@@ -506,6 +506,22 @@ public class ReActAgent extends StructuredOutputCapableAgent implements AutoClos
      * @return event stream covering the full agent invocation lifecycle
      */
     public Flux<AgentEvent> streamEvents(List<Msg> msgs) {
+        return streamEvents(msgs, RuntimeContext.empty());
+    }
+
+    /**
+     * Stream fine-grained {@link AgentEvent}s with a caller-supplied {@link RuntimeContext}.
+     *
+     * <p>Mirrors the {@code call(msgs, context)} overload: the supplied context is carried
+     * through the {@link AgentInput} so middleware and the underlying {@code call()} invocation
+     * observe the same per-call context.
+     *
+     * @param msgs input messages
+     * @param context runtime context to propagate into the call
+     * @return event stream covering the full agent invocation lifecycle
+     */
+    public Flux<AgentEvent> streamEvents(List<Msg> msgs, RuntimeContext context) {
+        RuntimeContext runtimeContext = context != null ? context : RuntimeContext.empty();
         String replyId = UUID.randomUUID().toString().replace("-", "");
         Function<AgentInput, Flux<AgentEvent>> core =
                 input ->
@@ -517,7 +533,7 @@ public class ReActAgent extends StructuredOutputCapableAgent implements AutoClos
                                             reactor.util.context.Context subscriberCtx =
                                                     reactor.util.context.Context.of(
                                                             sink.contextView());
-                                            call(input.msgs())
+                                            call(input.msgs(), input.runtimeContext())
                                                     .doFinally(
                                                             signal -> {
                                                                 sink.next(
@@ -531,7 +547,7 @@ public class ReActAgent extends StructuredOutputCapableAgent implements AutoClos
                                         FluxSink.OverflowStrategy.BUFFER)
                                 .doOnError(e -> activeEventSink.set(null));
         return MiddlewareChain.build(middlewares, this, MiddlewareBase::onAgent, core)
-                .apply(new AgentInput(msgs == null ? List.of() : msgs));
+                .apply(new AgentInput(msgs == null ? List.of() : msgs, runtimeContext));
     }
 
     /**
@@ -542,22 +558,6 @@ public class ReActAgent extends StructuredOutputCapableAgent implements AutoClos
      */
     public Flux<AgentEvent> streamEvents(Msg msg) {
         return streamEvents(List.of(msg));
-    }
-
-    /**
-     * Stream fine-grained {@link AgentEvent}s with a caller-supplied {@link RuntimeContext}.
-     *
-     * <p>Mirrors the {@code call(msgs, context)} overload: the supplied context is installed
-     * as the pending runtime context for the underlying {@code call()} invocation that drives
-     * the event stream.
-     *
-     * @param msgs input messages
-     * @param context runtime context to propagate into the call
-     * @return event stream covering the full agent invocation lifecycle
-     */
-    public Flux<AgentEvent> streamEvents(List<Msg> msgs, RuntimeContext context) {
-        this.pendingRuntimeContext = context;
-        return streamEvents(msgs);
     }
 
     /**

--- a/agentscope-core/src/main/java/io/agentscope/core/middleware/AgentInput.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/middleware/AgentInput.java
@@ -15,6 +15,7 @@
  */
 package io.agentscope.core.middleware;
 
+import io.agentscope.core.agent.RuntimeContext;
 import io.agentscope.core.message.Msg;
 import java.util.List;
 
@@ -22,5 +23,16 @@ import java.util.List;
  * Input context for {@link MiddlewareBase#onAgent}.
  *
  * @param msgs the input messages to the agent
+ * @param runtimeContext per-call runtime context for this agent invocation
  */
-public record AgentInput(List<Msg> msgs) {}
+public record AgentInput(List<Msg> msgs, RuntimeContext runtimeContext) {
+
+    public AgentInput(List<Msg> msgs) {
+        this(msgs, RuntimeContext.empty());
+    }
+
+    public AgentInput {
+        msgs = msgs != null ? msgs : List.of();
+        runtimeContext = runtimeContext != null ? runtimeContext : RuntimeContext.empty();
+    }
+}

--- a/agentscope-core/src/main/java/io/agentscope/core/middleware/AgentInput.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/middleware/AgentInput.java
@@ -32,7 +32,7 @@ public record AgentInput(List<Msg> msgs, RuntimeContext runtimeContext) {
     }
 
     public AgentInput {
-        msgs = msgs != null ? msgs : List.of();
+        msgs = msgs != null ? List.copyOf(msgs) : List.of();
         runtimeContext = runtimeContext != null ? runtimeContext : RuntimeContext.empty();
     }
 }

--- a/agentscope-core/src/main/java/io/agentscope/core/tool/ToolCallParam.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/tool/ToolCallParam.java
@@ -49,6 +49,7 @@ public class ToolCallParam {
     private final Map<String, Object> input;
     private final Agent agent;
     private final RuntimeContext runtimeContext;
+    private final ToolExecutionContext context;
     private final ToolEmitter emitter;
 
     private ToolCallParam(Builder builder) {
@@ -56,6 +57,7 @@ public class ToolCallParam {
         this.input = builder.input != null ? new HashMap<>(builder.input) : Collections.emptyMap();
         this.agent = builder.agent;
         this.runtimeContext = builder.runtimeContext;
+        this.context = builder.context;
         this.emitter = builder.emitter;
     }
 
@@ -103,6 +105,9 @@ public class ToolCallParam {
      */
     @Deprecated
     public ToolExecutionContext getContext() {
+        if (context != null) {
+            return context;
+        }
         return runtimeContext != null ? runtimeContext.asToolExecutionContext() : null;
     }
 
@@ -163,6 +168,7 @@ public class ToolCallParam {
         private Map<String, Object> input;
         private Agent agent;
         private RuntimeContext runtimeContext;
+        private ToolExecutionContext context;
         private ToolEmitter emitter;
 
         private Builder() {}
@@ -171,6 +177,7 @@ public class ToolCallParam {
             this.toolUseBlock = source.toolUseBlock;
             this.input = source.input.isEmpty() ? null : source.input;
             this.agent = source.agent;
+            this.runtimeContext = source.runtimeContext;
             this.context = source.context;
             this.emitter = source.emitter;
         }
@@ -216,6 +223,7 @@ public class ToolCallParam {
          */
         public Builder runtimeContext(RuntimeContext runtimeContext) {
             this.runtimeContext = runtimeContext;
+            this.context = null;
             return this;
         }
 
@@ -228,10 +236,13 @@ public class ToolCallParam {
          */
         @Deprecated
         public Builder context(ToolExecutionContext context) {
+            this.context = context;
             if (context != null) {
                 RuntimeContext.Builder rcb = RuntimeContext.builder();
                 rcb.toolExecutionContext(context);
                 this.runtimeContext = rcb.build();
+            } else {
+                this.runtimeContext = null;
             }
             return this;
         }

--- a/agentscope-core/src/main/java/io/agentscope/core/tool/ToolCallParam.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/tool/ToolCallParam.java
@@ -241,8 +241,6 @@ public class ToolCallParam {
                 RuntimeContext.Builder rcb = RuntimeContext.builder();
                 rcb.toolExecutionContext(context);
                 this.runtimeContext = rcb.build();
-            } else {
-                this.runtimeContext = null;
             }
             return this;
         }

--- a/agentscope-core/src/test/java/io/agentscope/core/middleware/AgentInputTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/middleware/AgentInputTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.core.middleware;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import io.agentscope.core.message.Msg;
+import io.agentscope.core.message.MsgRole;
+import io.agentscope.core.message.TextBlock;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class AgentInputTest {
+
+    @Test
+    void copiesMessagesDefensively() {
+        List<Msg> messages = new ArrayList<>();
+        messages.add(userText("first"));
+
+        AgentInput input = new AgentInput(messages);
+
+        messages.add(userText("second"));
+
+        assertEquals(1, input.msgs().size());
+        assertThrows(
+                UnsupportedOperationException.class, () -> input.msgs().add(userText("third")));
+    }
+
+    private static Msg userText(String text) {
+        return Msg.builder()
+                .role(MsgRole.USER)
+                .content(TextBlock.builder().text(text).build())
+                .build();
+    }
+}

--- a/agentscope-core/src/test/java/io/agentscope/core/tool/ToolCallParamTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/tool/ToolCallParamTest.java
@@ -25,6 +25,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import io.agentscope.core.agent.Agent;
+import io.agentscope.core.agent.RuntimeContext;
 import io.agentscope.core.message.ToolResultBlock;
 import io.agentscope.core.message.ToolUseBlock;
 import java.util.ArrayList;
@@ -115,6 +116,24 @@ class ToolCallParamTest {
                             .build();
 
             assertNotNull(param);
+        }
+
+        @Test
+        @DisplayName("context(null) should preserve existing runtime context")
+        void testContextNullPreservesRuntimeContext() {
+            ToolUseBlock toolUseBlock =
+                    ToolUseBlock.builder().id("id").name("tool").input(Map.of()).build();
+            RuntimeContext runtimeContext =
+                    RuntimeContext.builder().userId("alice").sessionId("session-1").build();
+
+            ToolCallParam param =
+                    ToolCallParam.builder()
+                            .toolUseBlock(toolUseBlock)
+                            .runtimeContext(runtimeContext)
+                            .context(null)
+                            .build();
+
+            assertSame(runtimeContext, param.getRuntimeContext());
         }
     }
 

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/middleware/AtPathExpansionMiddleware.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/middleware/AtPathExpansionMiddleware.java
@@ -16,7 +16,6 @@
 package io.agentscope.harness.agent.middleware;
 
 import io.agentscope.core.agent.Agent;
-import io.agentscope.core.agent.AgentBase;
 import io.agentscope.core.agent.RuntimeContext;
 import io.agentscope.core.event.AgentEvent;
 import io.agentscope.core.message.Msg;
@@ -101,10 +100,7 @@ public class AtPathExpansionMiddleware implements MiddlewareBase {
             return next.apply(input);
         }
 
-        RuntimeContext rc =
-                agent instanceof AgentBase ab && ab.getRuntimeContext() != null
-                        ? ab.getRuntimeContext()
-                        : RuntimeContext.empty();
+        RuntimeContext rc = input.runtimeContext();
 
         List<Msg> rewritten = new ArrayList<>(input.msgs().size());
         boolean changed = false;
@@ -119,7 +115,7 @@ public class AtPathExpansionMiddleware implements MiddlewareBase {
             }
             rewritten.add(expanded);
         }
-        return next.apply(changed ? new AgentInput(rewritten) : input);
+        return next.apply(changed ? new AgentInput(rewritten, input.runtimeContext()) : input);
     }
 
     private boolean supportsExpansion(AbstractFilesystem fs) {

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/middleware/MemoryFlushMiddleware.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/middleware/MemoryFlushMiddleware.java
@@ -17,7 +17,6 @@ package io.agentscope.harness.agent.middleware;
 
 import io.agentscope.core.ReActAgent;
 import io.agentscope.core.agent.Agent;
-import io.agentscope.core.agent.AgentBase;
 import io.agentscope.core.agent.RuntimeContext;
 import io.agentscope.core.event.AgentEvent;
 import io.agentscope.core.message.Msg;
@@ -58,10 +57,7 @@ public class MemoryFlushMiddleware implements MiddlewareBase {
     @Override
     public Flux<AgentEvent> onAgent(
             Agent agent, AgentInput input, Function<AgentInput, Flux<AgentEvent>> next) {
-        final RuntimeContext rc =
-                agent instanceof AgentBase ab && ab.getRuntimeContext() != null
-                        ? ab.getRuntimeContext()
-                        : RuntimeContext.empty();
+        final RuntimeContext rc = input.runtimeContext();
         return next.apply(input).doOnComplete(() -> doFlush(agent, rc).subscribe());
     }
 

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/middleware/MemoryMaintenanceMiddleware.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/middleware/MemoryMaintenanceMiddleware.java
@@ -16,7 +16,6 @@
 package io.agentscope.harness.agent.middleware;
 
 import io.agentscope.core.agent.Agent;
-import io.agentscope.core.agent.AgentBase;
 import io.agentscope.core.agent.RuntimeContext;
 import io.agentscope.core.event.AgentEvent;
 import io.agentscope.core.middleware.AgentInput;
@@ -88,10 +87,7 @@ public class MemoryMaintenanceMiddleware implements MiddlewareBase {
     @Override
     public Flux<AgentEvent> onAgent(
             Agent agent, AgentInput input, Function<AgentInput, Flux<AgentEvent>> next) {
-        final RuntimeContext rc =
-                agent instanceof AgentBase ab && ab.getRuntimeContext() != null
-                        ? ab.getRuntimeContext()
-                        : RuntimeContext.empty();
+        final RuntimeContext rc = input.runtimeContext();
         return next.apply(input).doOnComplete(() -> maybeRunMaintenance(rc));
     }
 

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/middleware/MemoryMiddlewareRuntimeContextTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/middleware/MemoryMiddlewareRuntimeContextTest.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.harness.agent.middleware;
+
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.agentscope.core.ReActAgent;
+import io.agentscope.core.agent.RuntimeContext;
+import io.agentscope.core.event.AgentEvent;
+import io.agentscope.core.message.Msg;
+import io.agentscope.core.message.MsgRole;
+import io.agentscope.core.message.TextBlock;
+import io.agentscope.core.model.ChatResponse;
+import io.agentscope.core.model.Model;
+import io.agentscope.core.tool.Toolkit;
+import io.agentscope.harness.agent.filesystem.AbstractFilesystem;
+import io.agentscope.harness.agent.filesystem.spec.RemoteFilesystemSpec;
+import io.agentscope.harness.agent.store.InMemoryStore;
+import io.agentscope.harness.agent.workspace.WorkspaceManager;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.function.BooleanSupplier;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import reactor.core.publisher.Flux;
+
+class MemoryMiddlewareRuntimeContextTest {
+
+    @Test
+    void memoryFlushUsesStreamEventsRuntimeContextForRemoteFilesystemNamespace(
+            @TempDir Path workspace) throws Exception {
+        InMemoryStore store = new InMemoryStore();
+        AbstractFilesystem fs =
+                new RemoteFilesystemSpec(store).toFilesystem(workspace, "agent-a", rc -> List.of());
+
+        try (WorkspaceManager workspaceManager = new WorkspaceManager(workspace, fs)) {
+            Model model = stubModel("- remember alice");
+            ReActAgent agent =
+                    ReActAgent.builder()
+                            .name("agent-a")
+                            .model(model)
+                            .toolkit(new Toolkit())
+                            .middleware(new MemoryFlushMiddleware(workspaceManager, model))
+                            .build();
+
+            RuntimeContext runtimeContext =
+                    RuntimeContext.builder().userId("alice").sessionId("session-1").build();
+
+            List<AgentEvent> events =
+                    agent.streamEvents(List.of(userText("remember alice")), runtimeContext)
+                            .collectList()
+                            .block(Duration.ofSeconds(5));
+            assertTrue(events != null && !events.isEmpty(), "agent event stream should complete");
+
+            String todayPath = "/" + LocalDate.now() + ".md";
+            List<String> aliceNamespace = List.of("agents", "agent-a", "users", "alice", "memory");
+            List<String> defaultNamespace =
+                    List.of("agents", "agent-a", "users", "_default", "memory");
+
+            assertTrue(
+                    waitUntil(() -> store.get(aliceNamespace, todayPath) != null),
+                    "memory flush should write the daily ledger under the caller user namespace");
+            assertNull(
+                    store.get(defaultNamespace, todayPath),
+                    "memory flush must not fall back to the anonymous _default namespace");
+        }
+    }
+
+    private static Msg userText(String text) {
+        return Msg.builder()
+                .role(MsgRole.USER)
+                .content(TextBlock.builder().text(text).build())
+                .build();
+    }
+
+    private static Model stubModel(String assistantText) {
+        Model model = mock(Model.class);
+        when(model.getModelName()).thenReturn("stub-model");
+        ChatResponse chunk =
+                new ChatResponse(
+                        "stub-id",
+                        List.of(TextBlock.builder().text(assistantText).build()),
+                        null,
+                        Map.of(),
+                        "stop");
+        when(model.stream(anyList(), any(), any())).thenReturn(Flux.just(chunk));
+        return model;
+    }
+
+    private static boolean waitUntil(BooleanSupplier condition) throws InterruptedException {
+        long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(3);
+        while (System.nanoTime() < deadline) {
+            if (condition.getAsBoolean()) {
+                return true;
+            }
+            Thread.sleep(25);
+        }
+        return condition.getAsBoolean();
+    }
+}

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/middleware/MemoryMiddlewareRuntimeContextTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/middleware/MemoryMiddlewareRuntimeContextTest.java
@@ -15,7 +15,6 @@
  */
 package io.agentscope.harness.agent.middleware;
 
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
@@ -34,14 +33,13 @@ import io.agentscope.core.tool.Toolkit;
 import io.agentscope.harness.agent.filesystem.AbstractFilesystem;
 import io.agentscope.harness.agent.filesystem.spec.RemoteFilesystemSpec;
 import io.agentscope.harness.agent.store.InMemoryStore;
+import io.agentscope.harness.agent.store.StoreItem;
 import io.agentscope.harness.agent.workspace.WorkspaceManager;
 import java.nio.file.Path;
 import java.time.Duration;
-import java.time.LocalDate;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
-import java.util.function.BooleanSupplier;
+import java.util.function.Supplier;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import reactor.core.publisher.Flux;
@@ -74,16 +72,18 @@ class MemoryMiddlewareRuntimeContextTest {
                             .block(Duration.ofSeconds(5));
             assertTrue(events != null && !events.isEmpty(), "agent event stream should complete");
 
-            String todayPath = "/" + LocalDate.now() + ".md";
             List<String> aliceNamespace = List.of("agents", "agent-a", "users", "alice", "memory");
             List<String> defaultNamespace =
                     List.of("agents", "agent-a", "users", "_default", "memory");
+            List<StoreItem> aliceItems =
+                    waitForItems(() -> store.search(aliceNamespace, 10, 0), Duration.ofSeconds(10));
 
             assertTrue(
-                    waitUntil(() -> store.get(aliceNamespace, todayPath) != null),
+                    aliceItems.stream()
+                            .anyMatch(item -> item.key().matches("/\\d{4}-\\d{2}-\\d{2}\\.md")),
                     "memory flush should write the daily ledger under the caller user namespace");
-            assertNull(
-                    store.get(defaultNamespace, todayPath),
+            assertTrue(
+                    store.search(defaultNamespace, 10, 0).isEmpty(),
                     "memory flush must not fall back to the anonymous _default namespace");
         }
     }
@@ -109,14 +109,17 @@ class MemoryMiddlewareRuntimeContextTest {
         return model;
     }
 
-    private static boolean waitUntil(BooleanSupplier condition) throws InterruptedException {
-        long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(3);
+    private static List<StoreItem> waitForItems(
+            Supplier<List<StoreItem>> supplier, Duration timeout) throws InterruptedException {
+        long deadline = System.nanoTime() + timeout.toNanos();
+        List<StoreItem> items = supplier.get();
         while (System.nanoTime() < deadline) {
-            if (condition.getAsBoolean()) {
-                return true;
+            if (!items.isEmpty()) {
+                return items;
             }
             Thread.sleep(25);
+            items = supplier.get();
         }
-        return condition.getAsBoolean();
+        return items;
     }
 }


### PR DESCRIPTION

## AgentScope-Java Version

2.0.0-SNAPSHOT

## Description

Fixes #1623.

This PR fixes a runtime context propagation bug in `ReActAgent.streamEvents(..., RuntimeContext)` that caused memory middleware to resolve remote filesystem namespaces with an empty/default runtime context. In `IsolationScope.USER`, memory flushes could write under the anonymous `_default` user namespace instead of the caller's actual `userId`.

### Background

`MemoryFlushMiddleware` and related middleware previously read `RuntimeContext` from the agent instance during `onAgent`. However, for `streamEvents(..., RuntimeContext)`, the supplied context was only bound later during the underlying agent call lifecycle. This ordering meant middleware could observe an empty context and persist memory to the wrong namespace.

### Changes Made

- Added `RuntimeContext` to `AgentInput` so each middleware invocation receives the per-call context explicitly.
- Updated `ReActAgent.streamEvents(List<Msg>, RuntimeContext)` to pass the runtime context through `AgentInput` and into the underlying `call(...)`.
- Updated memory/path middlewares to read or preserve `input.runtimeContext()`:
  - `MemoryFlushMiddleware`
  - `MemoryMaintenanceMiddleware`
  - `AtPathExpansionMiddleware`
- Added a regression test covering remote filesystem memory namespace resolution.
- Preserved deprecated `ToolExecutionContext` compatibility in `ToolCallParam` copy/builder behavior while keeping the newer `RuntimeContext` path intact.

### How to Test

The following commands were run successfully:

- `mvn -pl agentscope-harness -am -Dtest=MemoryMiddlewareRuntimeContextTest,AtPathExpansionMiddlewareTest test`
- `mvn -pl agentscope-core -Dtest=ReActAgentMiddlewareIntegrationTest,ReActAgentRuntimeContextTest,ToolCallParamTest test`
- `mvn -pl agentscope-harness -am test`
- `git diff --cached --check`

## Checklist

Please check the following items before code is ready to be reviewed.

- [x] Code formatting has been checked with Maven Spotless during test runs
- [x] Related tests are passing (`mvn -pl agentscope-harness -am test`)
- [x] Javadoc comments are complete and follow project conventions
- [x] Related documentation update is not required for this bugfix
- [x] Code is ready for review