### PR TITLE
fix: 修复 v2 流式事件中 THINKING_BLOCK_END / MODEL_CALL_END / AGENT_END 的收尾顺序

### DIFF
--- a/agentscope-core/src/main/java/io/agentscope/core/ReActAgent.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/ReActAgent.java
@@ -1993,6 +1993,7 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
             String replyId = UUID.randomUUID().toString().replace("-", "");
             AtomicBoolean textStarted = new AtomicBoolean(false);
             AtomicBoolean thinkingStarted = new AtomicBoolean(false);
+            AtomicBoolean thinkingEnded = new AtomicBoolean(false);
             Set<String> startedToolCalls = ConcurrentHashMap.newKeySet();
 
             Flux<AgentEvent> modelEvents =
@@ -2018,6 +2019,7 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
                                                     context,
                                                     textStarted,
                                                     thinkingStarted,
+                                                    thinkingEnded,
                                                     withToolEvents
                                                             ? startedToolCalls
                                                             : ConcurrentHashMap.newKeySet(),
@@ -2033,9 +2035,8 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
                                 if (textStarted.get()) {
                                     events.add(new TextBlockEndEvent(replyId, "text"));
                                 }
-                                if (thinkingStarted.get()) {
-                                    events.add(new ThinkingBlockEndEvent(replyId, "thinking"));
-                                }
+                                emitThinkingBlockEndIfNeeded(
+                                        replyId, thinkingStarted, thinkingEnded, events);
                                 for (String toolId : startedToolCalls) {
                                     events.add(new ToolCallEndEvent(replyId, toolId));
                                 }
@@ -2052,8 +2053,13 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
                 ReasoningContext context,
                 AtomicBoolean textStarted,
                 AtomicBoolean thinkingStarted,
+                AtomicBoolean thinkingEnded,
                 Set<String> startedToolCalls,
                 List<AgentEvent> events) {
+
+            if (!(block instanceof ThinkingBlock)) {
+                emitThinkingBlockEndIfNeeded(replyId, thinkingStarted, thinkingEnded, events);
+            }
 
             if (block instanceof TextBlock tb) {
                 if (textStarted.compareAndSet(false, true)) {
@@ -2082,6 +2088,16 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
                             new ToolCallDeltaEvent(
                                     replyId, toolId != null ? toolId : "", tub.getContent()));
                 }
+            }
+        }
+
+        private void emitThinkingBlockEndIfNeeded(
+                String replyId,
+                AtomicBoolean thinkingStarted,
+                AtomicBoolean thinkingEnded,
+                List<AgentEvent> events) {
+            if (thinkingStarted.get() && thinkingEnded.compareAndSet(false, true)) {
+                events.add(new ThinkingBlockEndEvent(replyId, "thinking"));
             }
         }
 
@@ -2301,6 +2317,7 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
 
             List<Map.Entry<ToolUseBlock, ToolResultBlock>> deniedEntries = new ArrayList<>();
             List<ToolUseBlock> approved = new ArrayList<>();
+            Set<String> emittedToolResultIds = ConcurrentHashMap.newKeySet();
             for (ToolUseBlock tc : toolCalls) {
                 if (deniedIds.contains(tc.getId())) {
                     ToolResultBlock denied =
@@ -2347,6 +2364,11 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
                             parentCtx ->
                                     Flux.<AgentEvent>create(
                                             sink -> {
+                                                sink.onDispose(
+                                                        () ->
+                                                                toolkit.setInternalChunkCallback(
+                                                                        null));
+
                                                 for (ToolUseBlock tool : approved) {
                                                     sink.next(
                                                             new ToolResultStartEvent(
@@ -2357,27 +2379,18 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
 
                                                 toolkit.setInternalChunkCallback(
                                                         (toolUse, chunk) -> {
-                                                            if (chunk.getOutput() != null) {
+                                                            if (chunk.getOutput() != null
+                                                                    && !chunk.getOutput()
+                                                                            .isEmpty()) {
+                                                                emittedToolResultIds.add(
+                                                                        toolUse.getId());
                                                                 for (ContentBlock block :
                                                                         chunk.getOutput()) {
-                                                                    if (block
-                                                                            instanceof
-                                                                            TextBlock tb) {
-                                                                        sink.next(
-                                                                                new ToolResultTextDeltaEvent(
-                                                                                        replyId,
-                                                                                        toolUse
-                                                                                                .getId(),
-                                                                                        tb
-                                                                                                .getText()));
-                                                                    } else {
-                                                                        sink.next(
-                                                                                new ToolResultDataDeltaEvent(
-                                                                                        replyId,
-                                                                                        toolUse
-                                                                                                .getId(),
-                                                                                        block));
-                                                                    }
+                                                                    emitToolResultBlock(
+                                                                            sink,
+                                                                            replyId,
+                                                                            toolUse.getId(),
+                                                                            block);
                                                                 }
                                                             }
                                                             hookDispatcher
@@ -2403,6 +2416,17 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
                                                                                     ToolUseBlock,
                                                                                     ToolResultBlock>
                                                                             entry : results) {
+                                                                        if (emittedToolResultIds
+                                                                                .add(
+                                                                                        entry.getKey()
+                                                                                                .getId())) {
+                                                                            emitToolResultOutput(
+                                                                                    sink,
+                                                                                    replyId,
+                                                                                    entry.getKey(),
+                                                                                    entry.getValue()
+                                                                                            .getOutput());
+                                                                        }
                                                                         ToolResultState state =
                                                                                 determineToolResultState(
                                                                                         entry
@@ -2420,6 +2444,28 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
                                             }));
 
             return deniedEvents.concatWith(approvedEvents);
+        }
+
+        private void emitToolResultOutput(
+                FluxSink<AgentEvent> sink,
+                String replyId,
+                ToolUseBlock toolUse,
+                List<ContentBlock> output) {
+            if (toolUse == null || output == null || output.isEmpty()) {
+                return;
+            }
+            for (ContentBlock block : output) {
+                emitToolResultBlock(sink, replyId, toolUse.getId(), block);
+            }
+        }
+
+        private void emitToolResultBlock(
+                FluxSink<AgentEvent> sink, String replyId, String toolCallId, ContentBlock block) {
+            if (block instanceof TextBlock tb) {
+                sink.next(new ToolResultTextDeltaEvent(replyId, toolCallId, tb.getText()));
+            } else {
+                sink.next(new ToolResultDataDeltaEvent(replyId, toolCallId, block));
+            }
         }
 
         /**
@@ -2838,6 +2884,7 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
             String replyId = UUID.randomUUID().toString().replace("-", "");
             AtomicBoolean textStarted = new AtomicBoolean(false);
             AtomicBoolean thinkingStarted = new AtomicBoolean(false);
+            AtomicBoolean thinkingEnded = new AtomicBoolean(false);
 
             Flux<AgentEvent> modelEvents =
                     mci.model().stream(mci.messages(), mci.tools(), mci.options())
@@ -2857,6 +2904,13 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
 
                                         List<AgentEvent> events = new ArrayList<>();
                                         for (ContentBlock block : chunk.getContent()) {
+                                            if (!(block instanceof ThinkingBlock)) {
+                                                emitThinkingBlockEndIfNeeded(
+                                                        replyId,
+                                                        thinkingStarted,
+                                                        thinkingEnded,
+                                                        events);
+                                            }
                                             if (block instanceof TextBlock tb) {
                                                 if (textStarted.compareAndSet(false, true)) {
                                                     events.add(
@@ -2895,9 +2949,8 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
                                 if (textStarted.get()) {
                                     events.add(new TextBlockEndEvent(replyId, "text"));
                                 }
-                                if (thinkingStarted.get()) {
-                                    events.add(new ThinkingBlockEndEvent(replyId, "thinking"));
-                                }
+                                emitThinkingBlockEndIfNeeded(
+                                        replyId, thinkingStarted, thinkingEnded, events);
                                 events.add(new ModelCallEndEvent(replyId, context.getChatUsage()));
                                 return Flux.fromIterable(events);
                             });

--- a/agentscope-core/src/main/java/io/agentscope/core/ReActAgent.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/ReActAgent.java
@@ -1192,6 +1192,7 @@ public class ReActAgent extends StructuredOutputCapableAgent implements AutoClos
         String replyId = UUID.randomUUID().toString().replace("-", "");
         AtomicBoolean textStarted = new AtomicBoolean(false);
         AtomicBoolean thinkingStarted = new AtomicBoolean(false);
+        AtomicBoolean thinkingEnded = new AtomicBoolean(false);
         Set<String> startedToolCalls = ConcurrentHashMap.newKeySet();
 
         Flux<AgentEvent> modelEvents =
@@ -1215,6 +1216,7 @@ public class ReActAgent extends StructuredOutputCapableAgent implements AutoClos
                                                 context,
                                                 textStarted,
                                                 thinkingStarted,
+                                                thinkingEnded,
                                                 withToolEvents
                                                         ? startedToolCalls
                                                         : ConcurrentHashMap.newKeySet(),
@@ -1230,9 +1232,8 @@ public class ReActAgent extends StructuredOutputCapableAgent implements AutoClos
                             if (textStarted.get()) {
                                 events.add(new TextBlockEndEvent(replyId, "text"));
                             }
-                            if (thinkingStarted.get()) {
-                                events.add(new ThinkingBlockEndEvent(replyId, "thinking"));
-                            }
+                            emitThinkingBlockEndIfNeeded(
+                                    replyId, thinkingStarted, thinkingEnded, events);
                             for (String toolId : startedToolCalls) {
                                 events.add(new ToolCallEndEvent(replyId, toolId));
                             }
@@ -1249,8 +1250,13 @@ public class ReActAgent extends StructuredOutputCapableAgent implements AutoClos
             ReasoningContext context,
             AtomicBoolean textStarted,
             AtomicBoolean thinkingStarted,
+            AtomicBoolean thinkingEnded,
             Set<String> startedToolCalls,
             List<AgentEvent> events) {
+
+        if (!(block instanceof ThinkingBlock)) {
+            emitThinkingBlockEndIfNeeded(replyId, thinkingStarted, thinkingEnded, events);
+        }
 
         if (block instanceof TextBlock tb) {
             if (textStarted.compareAndSet(false, true)) {
@@ -1279,6 +1285,16 @@ public class ReActAgent extends StructuredOutputCapableAgent implements AutoClos
                         new ToolCallDeltaEvent(
                                 replyId, toolId != null ? toolId : "", tub.getContent()));
             }
+        }
+    }
+
+    private void emitThinkingBlockEndIfNeeded(
+            String replyId,
+            AtomicBoolean thinkingStarted,
+            AtomicBoolean thinkingEnded,
+            List<AgentEvent> events) {
+        if (thinkingStarted.get() && thinkingEnded.compareAndSet(false, true)) {
+            events.add(new ThinkingBlockEndEvent(replyId, "thinking"));
         }
     }
 
@@ -1488,6 +1504,7 @@ public class ReActAgent extends StructuredOutputCapableAgent implements AutoClos
 
         List<Map.Entry<ToolUseBlock, ToolResultBlock>> deniedEntries = new ArrayList<>();
         List<ToolUseBlock> approved = new ArrayList<>();
+        Set<String> emittedToolResultIds = ConcurrentHashMap.newKeySet();
         for (ToolUseBlock tc : toolCalls) {
             if (deniedIds.contains(tc.getId())) {
                 ToolResultBlock denied =
@@ -1530,6 +1547,9 @@ public class ReActAgent extends StructuredOutputCapableAgent implements AutoClos
                         parentCtx ->
                                 Flux.<AgentEvent>create(
                                         sink -> {
+                                            sink.onDispose(
+                                                    () -> toolkit.setInternalChunkCallback(null));
+
                                             for (ToolUseBlock tool : approved) {
                                                 sink.next(
                                                         new ToolResultStartEvent(
@@ -1540,22 +1560,17 @@ public class ReActAgent extends StructuredOutputCapableAgent implements AutoClos
 
                                             toolkit.setInternalChunkCallback(
                                                     (toolUse, chunk) -> {
-                                                        if (chunk.getOutput() != null) {
+                                                        if (chunk.getOutput() != null
+                                                                && !chunk.getOutput().isEmpty()) {
+                                                            emittedToolResultIds.add(
+                                                                    toolUse.getId());
                                                             for (ContentBlock block :
                                                                     chunk.getOutput()) {
-                                                                if (block instanceof TextBlock tb) {
-                                                                    sink.next(
-                                                                            new ToolResultTextDeltaEvent(
-                                                                                    replyId,
-                                                                                    toolUse.getId(),
-                                                                                    tb.getText()));
-                                                                } else {
-                                                                    sink.next(
-                                                                            new ToolResultDataDeltaEvent(
-                                                                                    replyId,
-                                                                                    toolUse.getId(),
-                                                                                    block));
-                                                                }
+                                                                emitToolResultBlock(
+                                                                        sink,
+                                                                        replyId,
+                                                                        toolUse.getId(),
+                                                                        block);
                                                             }
                                                         }
                                                         hookDispatcher
@@ -1581,6 +1596,16 @@ public class ReActAgent extends StructuredOutputCapableAgent implements AutoClos
                                                                                 ToolUseBlock,
                                                                                 ToolResultBlock>
                                                                         entry : results) {
+                                                                    if (emittedToolResultIds.add(
+                                                                            entry.getKey()
+                                                                                    .getId())) {
+                                                                        emitToolResultOutput(
+                                                                                sink,
+                                                                                replyId,
+                                                                                entry.getKey(),
+                                                                                entry.getValue()
+                                                                                        .getOutput());
+                                                                    }
                                                                     ToolResultState state =
                                                                             determineToolResultState(
                                                                                     entry
@@ -1598,6 +1623,28 @@ public class ReActAgent extends StructuredOutputCapableAgent implements AutoClos
                                         }));
 
         return deniedEvents.concatWith(approvedEvents);
+    }
+
+    private void emitToolResultOutput(
+            FluxSink<AgentEvent> sink,
+            String replyId,
+            ToolUseBlock toolUse,
+            List<ContentBlock> output) {
+        if (toolUse == null || output == null || output.isEmpty()) {
+            return;
+        }
+        for (ContentBlock block : output) {
+            emitToolResultBlock(sink, replyId, toolUse.getId(), block);
+        }
+    }
+
+    private void emitToolResultBlock(
+            FluxSink<AgentEvent> sink, String replyId, String toolCallId, ContentBlock block) {
+        if (block instanceof TextBlock tb) {
+            sink.next(new ToolResultTextDeltaEvent(replyId, toolCallId, tb.getText()));
+        } else {
+            sink.next(new ToolResultDataDeltaEvent(replyId, toolCallId, block));
+        }
     }
 
     /**
@@ -1924,6 +1971,7 @@ public class ReActAgent extends StructuredOutputCapableAgent implements AutoClos
         String replyId = UUID.randomUUID().toString().replace("-", "");
         AtomicBoolean textStarted = new AtomicBoolean(false);
         AtomicBoolean thinkingStarted = new AtomicBoolean(false);
+        AtomicBoolean thinkingEnded = new AtomicBoolean(false);
 
         Flux<AgentEvent> modelEvents =
                 mci.model().stream(mci.messages(), mci.tools(), mci.options())
@@ -1943,6 +1991,13 @@ public class ReActAgent extends StructuredOutputCapableAgent implements AutoClos
 
                                     List<AgentEvent> events = new ArrayList<>();
                                     for (ContentBlock block : chunk.getContent()) {
+                                        if (!(block instanceof ThinkingBlock)) {
+                                            emitThinkingBlockEndIfNeeded(
+                                                    replyId,
+                                                    thinkingStarted,
+                                                    thinkingEnded,
+                                                    events);
+                                        }
                                         if (block instanceof TextBlock tb) {
                                             if (textStarted.compareAndSet(false, true)) {
                                                 events.add(
@@ -1979,9 +2034,8 @@ public class ReActAgent extends StructuredOutputCapableAgent implements AutoClos
                             if (textStarted.get()) {
                                 events.add(new TextBlockEndEvent(replyId, "text"));
                             }
-                            if (thinkingStarted.get()) {
-                                events.add(new ThinkingBlockEndEvent(replyId, "thinking"));
-                            }
+                            emitThinkingBlockEndIfNeeded(
+                                    replyId, thinkingStarted, thinkingEnded, events);
                             events.add(new ModelCallEndEvent(replyId, context.getChatUsage()));
                             return Flux.fromIterable(events);
                         });

--- a/agentscope-core/src/test/java/io/agentscope/core/agent/ReActAgentNewLoopReplyTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/agent/ReActAgentNewLoopReplyTest.java
@@ -22,6 +22,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import io.agentscope.core.ReActAgent;
 import io.agentscope.core.event.AgentEndEvent;
 import io.agentscope.core.event.AgentEvent;
+import io.agentscope.core.event.AgentEventType;
 import io.agentscope.core.event.AgentStartEvent;
 import io.agentscope.core.event.ExceedMaxItersEvent;
 import io.agentscope.core.event.ModelCallEndEvent;
@@ -41,6 +42,7 @@ import io.agentscope.core.model.ChatResponse;
 import io.agentscope.core.model.GenerateOptions;
 import io.agentscope.core.model.ToolSchema;
 import io.agentscope.core.state.AgentState;
+import io.agentscope.core.agent.test.MockModel;
 import io.agentscope.core.tool.AgentTool;
 import io.agentscope.core.tool.ToolCallParam;
 import io.agentscope.core.tool.Toolkit;
@@ -161,6 +163,33 @@ class ReActAgentNewLoopReplyTest {
         long modelEnds = events.stream().filter(e -> e instanceof ModelCallEndEvent).count();
         assertEquals(1L, modelStarts);
         assertEquals(1L, modelEnds);
+    }
+
+    @Test
+    void thinkingBlockEndsBeforeTextBlockStarts() {
+        ReActAgent agent =
+                ReActAgent.builder()
+                        .name("asst")
+                        .model(MockModel.withThinking("I am thinking.", "Final answer"))
+                        .toolkit(new Toolkit())
+                        .build();
+
+        List<AgentEvent> events = agent.streamEvents(List.of()).collectList().block();
+        assertNotNull(events);
+
+        assertEquals(
+                List.of(
+                        AgentEventType.AGENT_START,
+                        AgentEventType.MODEL_CALL_START,
+                        AgentEventType.THINKING_BLOCK_START,
+                        AgentEventType.THINKING_BLOCK_DELTA,
+                        AgentEventType.THINKING_BLOCK_END,
+                        AgentEventType.TEXT_BLOCK_START,
+                        AgentEventType.TEXT_BLOCK_DELTA,
+                        AgentEventType.TEXT_BLOCK_END,
+                        AgentEventType.MODEL_CALL_END,
+                        AgentEventType.AGENT_END),
+                events.stream().map(AgentEvent::getType).toList());
     }
 
     @Test

--- a/agentscope-core/src/test/java/io/agentscope/core/agent/ReActAgentNewLoopReplyTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/agent/ReActAgentNewLoopReplyTest.java
@@ -20,8 +20,10 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.agentscope.core.ReActAgent;
+import io.agentscope.core.agent.test.MockModel;
 import io.agentscope.core.event.AgentEndEvent;
 import io.agentscope.core.event.AgentEvent;
+import io.agentscope.core.event.AgentEventType;
 import io.agentscope.core.event.AgentStartEvent;
 import io.agentscope.core.event.ExceedMaxItersEvent;
 import io.agentscope.core.event.ModelCallEndEvent;
@@ -161,6 +163,33 @@ class ReActAgentNewLoopReplyTest {
         long modelEnds = events.stream().filter(e -> e instanceof ModelCallEndEvent).count();
         assertEquals(1L, modelStarts);
         assertEquals(1L, modelEnds);
+    }
+
+    @Test
+    void thinkingBlockEndsBeforeTextBlockStarts() {
+        ReActAgent agent =
+                ReActAgent.builder()
+                        .name("asst")
+                        .model(MockModel.withThinking("I am thinking.", "Final answer"))
+                        .toolkit(new Toolkit())
+                        .build();
+
+        List<AgentEvent> events = agent.streamEvents(List.of()).collectList().block();
+        assertNotNull(events);
+
+        assertEquals(
+                List.of(
+                        AgentEventType.AGENT_START,
+                        AgentEventType.MODEL_CALL_START,
+                        AgentEventType.THINKING_BLOCK_START,
+                        AgentEventType.THINKING_BLOCK_DELTA,
+                        AgentEventType.THINKING_BLOCK_END,
+                        AgentEventType.TEXT_BLOCK_START,
+                        AgentEventType.TEXT_BLOCK_DELTA,
+                        AgentEventType.TEXT_BLOCK_END,
+                        AgentEventType.MODEL_CALL_END,
+                        AgentEventType.AGENT_END),
+                events.stream().map(AgentEvent::getType).toList());
     }
 
     @Test


### PR DESCRIPTION
## 关联 Issue
- Closes #1634

## 变更内容
- 修复 v2 流式事件中 `THINKING_BLOCK_END`、`MODEL_CALL_END`、`AGENT_END` 顺序延后的问题。
- 在模型流中遇到非 `ThinkingBlock` 时立即结束 thinking block，确保 `THINKING_BLOCK_END` 早于正文流开始。
- 同步修正 summary 流的收尾顺序。
- 补充事件顺序测试，防止回归。

## 验证
- 已完成针对性编译验证。
- 新增测试覆盖 `THINKING_BLOCK_END -> TEXT_BLOCK_START` 的顺序约束。