### PR TITLE
修复 DataAgent Session REST 读取 workspace transcript

### DIFF
--- a/agentscope-examples/agents/agentscope-dataagent/src/main/java/io/agentscope/dataagent/web/api/SessionController.java
+++ b/agentscope-examples/agents/agentscope-dataagent/src/main/java/io/agentscope/dataagent/web/api/SessionController.java
@@ -16,17 +16,15 @@
 package io.agentscope.dataagent.web.api;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import io.agentscope.core.agent.RuntimeContext;
 import io.agentscope.dataagent.runtime.DataAgentBootstrap;
-import io.agentscope.dataagent.runtime.session.HistoryResult;
 import io.agentscope.dataagent.runtime.session.SessionAgentManager;
 import io.agentscope.dataagent.runtime.session.SessionEntry;
 import io.agentscope.dataagent.runtime.session.SessionKind;
 import io.agentscope.dataagent.web.catalog.AgentCatalogService;
 import io.agentscope.dataagent.web.session.SessionReadStateStore;
+import io.agentscope.dataagent.web.session.SessionTranscriptReader;
 import io.agentscope.dataagent.web.session.SessionTurnParser;
-import io.agentscope.harness.agent.HarnessAgent;
-import io.agentscope.harness.agent.workspace.WorkspaceManager;
+import io.agentscope.dataagent.web.workspace.WorkspaceManagerFactory;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
@@ -64,19 +62,22 @@ import reactor.core.publisher.Mono;
 @RequestMapping("/api/agents/{agentId}/sessions")
 public class SessionController {
 
-    private final DataAgentBootstrap bootstrap;
     private final SessionAgentManager sessionAgentManager;
     private final SessionReadStateStore readStateStore;
     private final AgentCatalogService catalogService;
+    private final SessionTranscriptReader transcriptReader;
 
     public SessionController(
             DataAgentBootstrap builderBootstrap,
             SessionReadStateStore readStateStore,
-            AgentCatalogService catalogService) {
-        this.bootstrap = builderBootstrap;
+            AgentCatalogService catalogService,
+            WorkspaceManagerFactory workspaceManagerFactory) {
         this.sessionAgentManager = builderBootstrap.gateway().sessionAgentManager();
         this.readStateStore = readStateStore;
         this.catalogService = catalogService;
+        this.transcriptReader =
+                new SessionTranscriptReader(
+                        sessionAgentManager, catalogService, workspaceManagerFactory::forAgent);
     }
 
     @GetMapping("/inbox")
@@ -286,44 +287,13 @@ public class SessionController {
 
     /**
      * Reads the chat content for a session. The actual transcript lives at the per-agent workspace
-     * under {@code agents/<innerAgentId>/sessions/<sessionId>.log.jsonl}, written by the harness
-     * memory hooks. The {@link SessionAgentManager} registry stores a stale legacy path
-     * ({@code .json}) keyed by the harness UUID rooted at the main-agent workspace, so its
-     * {@code history(...)} cannot be used here.
-     *
-     * <p>Reads go through the per-agent {@link WorkspaceManager}'s composite filesystem (which is
-     * what the harness writes through), so multi-tenant deployments backed by the shared
-     * {@link io.agentscope.harness.agent.store.BaseStore} stay correct. Falls back to
-     * {@link SessionAgentManager#history} only if the WorkspaceManager cannot be resolved
-     * (e.g. the agent has been unloaded).
+     * under {@code agents/<runtimeAgentId>/sessions/<sessionId>.log.jsonl}. Reads borrow a live
+     * workspace view through {@link WorkspaceManagerFactory} so they work out of band from agent
+     * call contexts. Falls back to {@link SessionAgentManager#history} only if the live workspace
+     * cannot be resolved or does not yet contain the JSONL transcript.
      */
     private String readSessionLogContent(String urlAgentId, SessionEntry entry) {
-        String gatewayAgentId = catalogService.peekGatewayAgentId(entry.userId(), urlAgentId);
-        HarnessAgent ha =
-                gatewayAgentId != null ? bootstrap.gateway().findAgent(gatewayAgentId) : null;
-        if (ha != null) {
-            WorkspaceManager wm = ha.getWorkspaceManager();
-            String innerAgentId = ha.getName();
-            if (wm != null && innerAgentId != null && !innerAgentId.isBlank()) {
-                String relLog =
-                        "agents/" + innerAgentId + "/sessions/" + entry.sessionId() + ".log.jsonl";
-                String fromLog = wm.readManagedWorkspaceFileUtf8(RuntimeContext.empty(), relLog);
-                if (fromLog != null && !fromLog.isEmpty()) {
-                    return fromLog;
-                }
-                String relCtx =
-                        "agents/" + innerAgentId + "/sessions/" + entry.sessionId() + ".jsonl";
-                String fromCtx = wm.readManagedWorkspaceFileUtf8(RuntimeContext.empty(), relCtx);
-                if (fromCtx != null && !fromCtx.isEmpty()) {
-                    return fromCtx;
-                }
-            }
-        }
-        HistoryResult raw = sessionAgentManager.history(entry.sessionKey(), 0);
-        if (raw == null || raw.error() != null) {
-            return "";
-        }
-        return raw.content() != null ? raw.content() : "";
+        return transcriptReader.readSessionLogContent(urlAgentId, entry);
     }
 
     // -----------------------------------------------------------------

--- a/agentscope-examples/agents/agentscope-dataagent/src/main/java/io/agentscope/dataagent/web/session/SessionTranscriptReader.java
+++ b/agentscope-examples/agents/agentscope-dataagent/src/main/java/io/agentscope/dataagent/web/session/SessionTranscriptReader.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.dataagent.web.session;
+
+import io.agentscope.core.agent.RuntimeContext;
+import io.agentscope.dataagent.runtime.session.HistoryResult;
+import io.agentscope.dataagent.runtime.session.SessionAgentManager;
+import io.agentscope.dataagent.runtime.session.SessionEntry;
+import io.agentscope.dataagent.web.catalog.AgentCatalogService;
+import io.agentscope.dataagent.web.catalog.AgentDefinition;
+import io.agentscope.harness.agent.workspace.WorkspaceManager;
+import java.util.Objects;
+
+/**
+ * Reads session transcripts through a borrowed workspace view so REST reads do not depend on an
+ * active agent call context.
+ */
+public final class SessionTranscriptReader {
+
+    private final SessionAgentManager sessionAgentManager;
+    private final AgentCatalogService catalogService;
+    private final SessionWorkspaceProvider workspaceProvider;
+
+    public SessionTranscriptReader(
+            SessionAgentManager sessionAgentManager,
+            AgentCatalogService catalogService,
+            SessionWorkspaceProvider workspaceProvider) {
+        this.sessionAgentManager =
+                Objects.requireNonNull(sessionAgentManager, "sessionAgentManager");
+        this.catalogService = Objects.requireNonNull(catalogService, "catalogService");
+        this.workspaceProvider = Objects.requireNonNull(workspaceProvider, "workspaceProvider");
+    }
+
+    public String readSessionLogContent(String urlAgentId, SessionEntry entry) {
+        WorkspaceManager workspaceManager = resolveWorkspaceManager(urlAgentId, entry);
+        if (workspaceManager != null) {
+            String runtimeAgentId = entry.agentId();
+            if (runtimeAgentId != null && !runtimeAgentId.isBlank()) {
+                String relLog =
+                        "agents/"
+                                + runtimeAgentId
+                                + "/sessions/"
+                                + entry.sessionId()
+                                + ".log.jsonl";
+                String fromLog =
+                        workspaceManager.readManagedWorkspaceFileUtf8(
+                                RuntimeContext.empty(), relLog);
+                if (fromLog != null && !fromLog.isEmpty()) {
+                    return fromLog;
+                }
+                String relCtx =
+                        "agents/"
+                                + runtimeAgentId
+                                + "/sessions/"
+                                + entry.sessionId()
+                                + ".jsonl";
+                String fromCtx =
+                        workspaceManager.readManagedWorkspaceFileUtf8(
+                                RuntimeContext.empty(), relCtx);
+                if (fromCtx != null && !fromCtx.isEmpty()) {
+                    return fromCtx;
+                }
+            }
+        }
+        HistoryResult raw = sessionAgentManager.history(entry.sessionKey(), 0);
+        if (raw == null || raw.error() != null) {
+            return "";
+        }
+        return raw.content() != null ? raw.content() : "";
+    }
+
+    private WorkspaceManager resolveWorkspaceManager(String urlAgentId, SessionEntry entry) {
+        if (entry == null || entry.userId() == null || entry.userId().isBlank()) {
+            return null;
+        }
+        if (urlAgentId == null || urlAgentId.isBlank()) {
+            return null;
+        }
+        AgentDefinition def = catalogService.findVisible(entry.userId(), urlAgentId).orElse(null);
+        if (def == null) {
+            return null;
+        }
+        String runtimeAgentId = entry.agentId();
+        if (runtimeAgentId == null || runtimeAgentId.isBlank()) {
+            runtimeAgentId = catalogService.peekGatewayAgentId(entry.userId(), urlAgentId);
+        }
+        if (runtimeAgentId == null || runtimeAgentId.isBlank()) {
+            return null;
+        }
+        return workspaceProvider.forAgent(
+                entry.userId(), runtimeAgentId, def.workspacePath());
+    }
+
+    @FunctionalInterface
+    public interface SessionWorkspaceProvider {
+        WorkspaceManager forAgent(String ownerId, String agentId, String workspacePath);
+    }
+}

--- a/agentscope-examples/agents/agentscope-dataagent/src/test/java/io/agentscope/dataagent/web/session/SessionTranscriptReaderTest.java
+++ b/agentscope-examples/agents/agentscope-dataagent/src/test/java/io/agentscope/dataagent/web/session/SessionTranscriptReaderTest.java
@@ -1,0 +1,181 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.dataagent.web.session;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.agentscope.dataagent.runtime.session.HistoryResult;
+import io.agentscope.dataagent.runtime.session.SessionAgentManager;
+import io.agentscope.dataagent.runtime.session.SessionEntry;
+import io.agentscope.dataagent.runtime.session.SessionKind;
+import io.agentscope.dataagent.web.catalog.AgentCatalogService;
+import io.agentscope.dataagent.web.catalog.AgentDefinition;
+import io.agentscope.harness.agent.workspace.WorkspaceManager;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class SessionTranscriptReaderTest {
+
+    @TempDir Path workspaceRoot;
+
+    @Mock SessionAgentManager sessionAgentManager;
+
+    @Mock AgentCatalogService catalogService;
+
+    @Test
+    void readsBorrowedWorkspaceBeforeHistoryFallback() throws Exception {
+        String userId = "alice";
+        String logicalAgentId = "data-agent";
+        String runtimeAgentId = "uca-alice-data-agent";
+        String sessionId = "session-1";
+        SessionEntry entry =
+                new SessionEntry(
+                        "agent:" + runtimeAgentId + ":main:" + sessionId,
+                        runtimeAgentId,
+                        sessionId,
+                        null,
+                        SessionKind.MAIN,
+                        null,
+                        0,
+                        1L,
+                        1L,
+                        workspaceRoot.resolve("legacy.json").toString(),
+                        null,
+                        "|x:agentId=" + runtimeAgentId + "|",
+                        userId);
+
+        AgentDefinition definition = agentDefinition(logicalAgentId, "custom-root", userId);
+        when(catalogService.findVisible(userId, logicalAgentId)).thenReturn(Optional.of(definition));
+
+        AtomicReference<String> ownerRef = new AtomicReference<>();
+        AtomicReference<String> agentRef = new AtomicReference<>();
+        AtomicReference<String> workspacePathRef = new AtomicReference<>();
+        SessionTranscriptReader reader =
+                new SessionTranscriptReader(
+                        sessionAgentManager,
+                        catalogService,
+                        (ownerId, agentId, workspacePath) -> {
+                            ownerRef.set(ownerId);
+                            agentRef.set(agentId);
+                            workspacePathRef.set(workspacePath);
+                            return new WorkspaceManager(workspaceRoot);
+                        });
+
+        Path logDir = workspaceRoot.resolve("agents").resolve(runtimeAgentId).resolve("sessions");
+        Files.createDirectories(logDir);
+        String jsonl =
+                """
+                {"type":"message","id":"1","role":"ASSISTANT","content":"Hello from sandbox","timestamp":1}
+                """;
+        Files.writeString(logDir.resolve(sessionId + ".log.jsonl"), jsonl);
+
+        String content = reader.readSessionLogContent(logicalAgentId, entry);
+
+        assertThat(content).contains("Hello from sandbox");
+        assertThat(ownerRef).hasValue(userId);
+        assertThat(agentRef).hasValue(runtimeAgentId);
+        assertThat(workspacePathRef).hasValue("custom-root");
+        verify(sessionAgentManager, never()).history(anyString(), anyInt());
+    }
+
+    @Test
+    void fallsBackToHistoryWhenBorrowedWorkspaceIsEmpty() {
+        String userId = "alice";
+        String logicalAgentId = "data-agent";
+        String runtimeAgentId = "uca-alice-data-agent";
+        String sessionId = "session-2";
+        SessionEntry entry =
+                new SessionEntry(
+                        "agent:" + runtimeAgentId + ":main:" + sessionId,
+                        runtimeAgentId,
+                        sessionId,
+                        null,
+                        SessionKind.MAIN,
+                        null,
+                        0,
+                        1L,
+                        1L,
+                        workspaceRoot.resolve("legacy.json").toString(),
+                        null,
+                        "|x:agentId=" + runtimeAgentId + "|",
+                        userId);
+
+        AgentDefinition definition = agentDefinition(logicalAgentId, null, userId);
+        when(catalogService.findVisible(userId, logicalAgentId)).thenReturn(Optional.of(definition));
+        when(sessionAgentManager.history(entry.sessionKey(), 0))
+                .thenReturn(
+                        new HistoryResult(
+                                entry.sessionKey(),
+                                entry.sessionFilePath(),
+                                "legacy payload",
+                                null));
+
+        SessionTranscriptReader reader =
+                new SessionTranscriptReader(
+                        sessionAgentManager,
+                        catalogService,
+                        (ownerId, agentId, workspacePath) -> new WorkspaceManager(workspaceRoot));
+
+        String content = reader.readSessionLogContent(logicalAgentId, entry);
+
+        assertThat(content).isEqualTo("legacy payload");
+        verify(sessionAgentManager).history(entry.sessionKey(), 0);
+    }
+
+    private static AgentDefinition agentDefinition(
+            String id, String workspacePath, String ownerId) {
+        return new AgentDefinition(
+                id,
+                id,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                AgentDefinition.SCOPE_USER,
+                ownerId,
+                1L,
+                1L,
+                null,
+                AgentDefinition.RUN_AS_INVOKER,
+                null,
+                workspacePath,
+                null,
+                null,
+                null);
+    }
+}


### PR DESCRIPTION
## 背景
Session REST 读取依赖活跃调用上下文，导致离线/REST 场景下无法正确读取 session transcript。

## 变更
- 抽取 `SessionTranscriptReader`，通过 `WorkspaceManagerFactory` 借用 live sandbox 读取日志。
- 优先读取运行时 agent 对应的 `*.log.jsonl`，再回退到 `SessionAgentManager.history(...)`。
- 补充单测覆盖 workspace 命中与历史回退路径。

## 验证
- `mvn -Dspotless.check.skip=true -pl agentscope-examples/agents/agentscope-dataagent -am -Dtest=SessionTranscriptReaderTest test`

## 关联 Issue
- Fixes #1626
- 相关 Issue: [#1626](https://github.com/agentscope-ai/agentscope-java/issues/1626)