### PR TITLE
Fix Gemini media URL extension parsing

### DIFF
--- a/agentscope-core/src/main/java/io/agentscope/core/formatter/gemini/GeminiMediaConverter.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/formatter/gemini/GeminiMediaConverter.java
@@ -17,6 +17,7 @@ package io.agentscope.core.formatter.gemini;
 
 import com.google.genai.types.Blob;
 import com.google.genai.types.Part;
+import io.agentscope.core.formatter.MediaUtils;
 import io.agentscope.core.message.AudioBlock;
 import io.agentscope.core.message.Base64Source;
 import io.agentscope.core.message.ImageBlock;
@@ -190,10 +191,10 @@ public class GeminiMediaConverter {
      * @return File extension in lowercase (without dot)
      */
     private String extractExtension(String url) {
-        int lastDotIndex = url.lastIndexOf('.');
-        if (lastDotIndex == -1 || lastDotIndex == url.length() - 1) {
+        String extension = MediaUtils.getExtension(url);
+        if (extension.isBlank()) {
             throw new IllegalArgumentException("Cannot extract file extension from: " + url);
         }
-        return url.substring(lastDotIndex + 1).toLowerCase();
+        return extension.toLowerCase();
     }
 }

--- a/agentscope-core/src/test/java/io/agentscope/core/formatter/gemini/GeminiMediaConverterTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/formatter/gemini/GeminiMediaConverterTest.java
@@ -32,6 +32,8 @@ import io.agentscope.core.message.VideoBlock;
 import java.io.OutputStream;
 import java.net.InetSocketAddress;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Base64;
 import org.junit.jupiter.api.Test;
 
@@ -176,6 +178,21 @@ class GeminiMediaConverterTest extends GeminiFormatterTestBase {
         ImageBlock block = ImageBlock.builder().source(source).build();
 
         assertThrows(RuntimeException.class, () -> converter.convertToInlineDataPart(block));
+    }
+
+    @Test
+    void testMissingExtension() throws Exception {
+        Path fileWithoutExtension = Files.createTempFile("gemini_media_no_extension", "");
+        Files.writeString(fileWithoutExtension, "fake image content");
+        try {
+            URLSource source = URLSource.builder().url(fileWithoutExtension.toString()).build();
+            ImageBlock block = ImageBlock.builder().source(source).build();
+
+            assertThrows(
+                    IllegalArgumentException.class, () -> converter.convertToInlineDataPart(block));
+        } finally {
+            Files.deleteIfExists(fileWithoutExtension);
+        }
     }
 
     @Test

--- a/agentscope-core/src/test/java/io/agentscope/core/formatter/gemini/GeminiMediaConverterTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/formatter/gemini/GeminiMediaConverterTest.java
@@ -23,11 +23,15 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.google.genai.types.Blob;
 import com.google.genai.types.Part;
+import com.sun.net.httpserver.HttpServer;
 import io.agentscope.core.message.AudioBlock;
 import io.agentscope.core.message.Base64Source;
 import io.agentscope.core.message.ImageBlock;
 import io.agentscope.core.message.URLSource;
 import io.agentscope.core.message.VideoBlock;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import org.junit.jupiter.api.Test;
 
@@ -76,6 +80,38 @@ class GeminiMediaConverterTest extends GeminiFormatterTestBase {
         byte[] expectedData = "fake image content".getBytes();
         assertArrayEquals(expectedData, blob.data().get());
         assertEquals("image/png", blob.mimeType().get());
+    }
+
+    @Test
+    void testConvertImageBlockWithUrlQueryString() throws Exception {
+        HttpServer server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+        server.createContext(
+                "/test.png",
+                exchange -> {
+                    byte[] body = "fake image content".getBytes(StandardCharsets.UTF_8);
+                    exchange.getResponseHeaders().add("Content-Type", "image/png");
+                    exchange.sendResponseHeaders(200, body.length);
+                    try (OutputStream out = exchange.getResponseBody()) {
+                        out.write(body);
+                    }
+                });
+        server.start();
+        try {
+            String url =
+                    "http://127.0.0.1:" + server.getAddress().getPort() + "/test.png?token=abc123";
+            URLSource source = URLSource.builder().url(url).build();
+            ImageBlock block = ImageBlock.builder().source(source).build();
+
+            Part result = converter.convertToInlineDataPart(block);
+
+            assertNotNull(result);
+            Blob blob = result.inlineData().orElseThrow();
+            assertArrayEquals(
+                    "fake image content".getBytes(StandardCharsets.UTF_8), blob.data().get());
+            assertEquals("image/png", blob.mimeType().get());
+        } finally {
+            server.stop(0);
+        }
     }
 
     @Test


### PR DESCRIPTION
## AgentScope-Java Version

Local main branch 

## Description

Fixes #1645
This PR fixes Gemini media URL extension parsing for remote media URLs that contain query strings or fragments.

Previously, `GeminiMediaConverter` extracted the file extension by taking the substring after the last `.` in the full URL string. For URLs like:

```text
https://cdn.example.com/image.png?token=abc123
```

the parsed extension became:

```text
png?token=abc123
```

which caused the converter to reject an otherwise valid PNG URL.

This PR updates `GeminiMediaConverter` to reuse `MediaUtils.getExtension()`, which already handles URL paths separately from query strings and fragments. A regression test was added to verify that an image URL like `/test.png?token=abc123` is accepted and converted with MIME type `image/png`.

Tested with:

```bash
mvn -pl agentscope-core "-Dtest=GeminiMediaConverterTest" test -q
mvn -pl agentscope-core spotless:check -q
git diff --check
```

## Checklist

Please check the following items before code is ready to be reviewed.

- [x] Code has been formatted with `mvn spotless:apply`
- [x] All tests are passing (`mvn test`)
- [x] Javadoc comments are complete and follow project conventions
- [x] Related documentation has been updated (e.g. links, examples, etc.)
- [x] Code is ready for review