### PR TITLE
Fix Ollama streaming null generate options

### DIFF
--- a/agentscope-core/src/main/java/io/agentscope/core/model/OllamaChatModel.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/model/OllamaChatModel.java
@@ -138,11 +138,13 @@ public class OllamaChatModel extends ChatModelBase {
     @Override
     protected Flux<ChatResponse> doStream(
             List<Msg> messages, List<ToolSchema> tools, GenerateOptions options) {
+        GenerateOptions effectiveOptions =
+                options != null ? options : GenerateOptions.builder().build();
         return streamWithHttpClient(
                 messages,
                 tools,
-                options.getToolChoice(),
-                OllamaOptions.fromGenerateOptions(options),
+                effectiveOptions.getToolChoice(),
+                OllamaOptions.fromGenerateOptions(effectiveOptions),
                 true);
     }
 

--- a/agentscope-core/src/test/java/io/agentscope/core/model/OllamaChatModelTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/model/OllamaChatModelTest.java
@@ -270,6 +270,39 @@ class OllamaChatModelTest {
     }
 
     @Test
+    @DisplayName("Should handle streaming chat request with null options")
+    void testStreamChatRequestWithNullOptions() {
+        String part1 =
+                "{\"model\":\""
+                        + TEST_MODEL_NAME
+                        + "\",\"message\":{\"role\":\"assistant\",\"content\":\"Hello\"},\"done\":false}";
+        String part2 =
+                "{\"model\":\""
+                        + TEST_MODEL_NAME
+                        + "\",\"done\":true,\"total_duration\":100,\"eval_count\":1}";
+
+        when(httpTransport.stream(any(HttpRequest.class))).thenReturn(Flux.just(part1, part2));
+
+        Flux<ChatResponse> flux =
+                model.stream(
+                        List.of(Msg.builder().role(MsgRole.USER).textContent("Hi").build()),
+                        null,
+                        null);
+
+        List<ChatResponse> responses = flux.collectList().block();
+
+        assertNotNull(responses);
+        assertEquals(2, responses.size());
+        ContentBlock content = responses.get(0).getContent().get(0);
+        assertTrue(content instanceof TextBlock);
+        assertEquals("Hello", ((TextBlock) content).getText());
+
+        ArgumentCaptor<HttpRequest> captor = ArgumentCaptor.forClass(HttpRequest.class);
+        verify(httpTransport).stream(captor.capture());
+        assertEquals("POST", captor.getValue().getMethod());
+    }
+
+    @Test
     @DisplayName("Integration Test: Real connection to local Ollama")
     void testRealConnection() {
         System.out.println("Running testRealConnection (Mocked for speed)...");


### PR DESCRIPTION
## AgentScope-Java Version

Version: agentscope-harness:2.0.0-RC1
Java: 21

## Description
fixs#1644
This PR fixes a NullPointerException in the Ollama streaming path when `GenerateOptions` is not explicitly configured.

Background:
`HarnessAgent.streamEvents()` can ultimately call the Ollama model streaming API with `GenerateOptions == null`. `OllamaChatModel.doStream(...)` previously accessed `options.getToolChoice()` directly, which caused an NPE. Non-streaming calls were unaffected because the options conversion path already handled null values.

Changes made:
- Added a null-safe default `GenerateOptions.builder().build()` in `OllamaChatModel.doStream(...)`.
- Added a regression test covering `OllamaChatModel.stream(..., null)` to ensure streaming works without explicit generate options.

How to test:
- `mvn -pl agentscope-core -Dtest=OllamaChatModelTest test`
- `mvn -pl agentscope-core -Dtest=OllamaChatModelTest#testStreamChatRequestWithNullOptions test`
- `git diff --check`

## Checklist

Please check the following items before code is ready to be reviewed.

- [x ] Code has been formatted with `mvn spotless:apply`
- [x] All tests are passing (`mvn test`)
- [x] Javadoc comments are complete and follow project conventions
- [x] Related documentation has been updated (e.g. links, examples, etc.)
- [x] Code is ready for review