### PR TITLE
fix(workspace): inject subagents and skills summary into workspace co…

### DIFF
--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/middleware/WorkspaceContextMiddleware.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/middleware/WorkspaceContextMiddleware.java
@@ -140,12 +140,16 @@ public class WorkspaceContextMiddleware implements MiddlewareBase {
         String sessionContext = buildSessionContextSection(workspace, rc);
 
         String knowledgeBlock = buildKnowledgeBlock(rc, knowledgeContent, workspace);
+        String subagentsBlock = buildSubagentsBlock(rc, workspace);
+        String skillsBlock = buildSkillsBlock(rc, workspace);
         String additionalBlock = buildAdditionalContextBlock(rc);
 
         int fixedTokens =
                 estimateTokens(sessionContext)
                         + estimateTokens(agentsContent)
                         + estimateTokens(knowledgeBlock)
+                        + estimateTokens(subagentsBlock)
+                        + estimateTokens(skillsBlock)
                         + estimateTokens(additionalBlock);
         int memoryTokens = estimateTokens(memoryContent);
         int available = maxContextTokens - fixedTokens;
@@ -157,7 +161,13 @@ public class WorkspaceContextMiddleware implements MiddlewareBase {
                 buildWorkspaceParagraph(workspace, workspaceManager.getFilesystem());
         String loadedContext =
                 buildLoadedContextSection(
-                        agentsContent, memoryContent, knowledgeBlock, additionalBlock, rc);
+                        agentsContent,
+                        memoryContent,
+                        knowledgeBlock,
+                        subagentsBlock,
+                        skillsBlock,
+                        additionalBlock,
+                        rc);
         return assembleSection(
                 sessionContext, GUIDANCE_TEMPLATE, workspaceParagraph, loadedContext);
     }
@@ -338,6 +348,8 @@ public class WorkspaceContextMiddleware implements MiddlewareBase {
             String agentsContent,
             String memoryContent,
             String knowledgeBlock,
+            String subagentsBlock,
+            String skillsBlock,
             String additionalBlock,
             RuntimeContext rc) {
         StringBuilder sb = new StringBuilder();
@@ -345,6 +357,12 @@ public class WorkspaceContextMiddleware implements MiddlewareBase {
         sb.append(buildXmlContext("agents_context", agentsContent));
         sb.append(buildXmlContext("memory_context", memoryContent));
         sb.append(buildXmlContext("domain_knowledge_context", knowledgeBlock));
+        if (!subagentsBlock.isBlank()) {
+            sb.append("  ").append(subagentsBlock).append("\n");
+        }
+        if (!skillsBlock.isBlank()) {
+            sb.append("  ").append(skillsBlock).append("\n");
+        }
         if (!additionalBlock.isBlank()) {
             sb.append(additionalBlock);
         }
@@ -413,5 +431,97 @@ public class WorkspaceContextMiddleware implements MiddlewareBase {
         }
 
         return sb.toString();
+    }
+
+    /**
+     * Builds a summary of subagent declarations found in the workspace {@code subagents/} directory.
+     * Lists available subagent names and their description from YAML frontmatter.
+     */
+    private String buildSubagentsBlock(RuntimeContext rc, Path workspace) {
+        List<Path> subagentFiles = workspaceManager.listSubagentFiles(rc);
+        if (subagentFiles.isEmpty()) {
+            return "";
+        }
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("<subagents_context>\n");
+        sb.append("Available subagents (declare via agent_spawn tool):\n");
+        for (Path subagentFile : subagentFiles) {
+            String fileName = subagentFile.getFileName().toString();
+            String agentId =
+                    fileName.endsWith(".md")
+                            ? fileName.substring(0, fileName.length() - 3)
+                            : fileName;
+            String content =
+                    workspaceManager.readManagedWorkspaceFileUtf8(
+                            rc, workspace.relativize(subagentFile).toString().replace('\\', '/'));
+            String description = extractDescriptionFromFrontmatter(content);
+            sb.append("- ").append(agentId);
+            if (description != null && !description.isBlank()) {
+                sb.append(": ").append(description.strip());
+            }
+            sb.append("\n");
+        }
+        sb.append("</subagents_context>");
+        return sb.toString();
+    }
+
+    /**
+     * Builds a summary of skill directories found in the workspace {@code skills/} directory.
+     * Lists available skill names and their description from SKILL.md frontmatter.
+     */
+    private String buildSkillsBlock(RuntimeContext rc, Path workspace) {
+        List<Path> skillDirs = workspaceManager.listSkillDirs(rc);
+        if (skillDirs.isEmpty()) {
+            return "";
+        }
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("<skills_context>\n");
+        sb.append("Available skills (load via load_skill_through_path tool):\n");
+        for (Path skillDir : skillDirs) {
+            String skillName = skillDir.getFileName().toString();
+            String skillMdRel =
+                    workspace.relativize(skillDir).toString().replace('\\', '/') + "/SKILL.md";
+            String content = workspaceManager.readManagedWorkspaceFileUtf8(rc, skillMdRel);
+            String description = extractDescriptionFromFrontmatter(content);
+            sb.append("- ").append(skillName);
+            if (description != null && !description.isBlank()) {
+                sb.append(": ").append(description.strip());
+            }
+            sb.append("\n");
+        }
+        sb.append("</skills_context>");
+        return sb.toString();
+    }
+
+    /**
+     * Best-effort extraction of the {@code description} field from YAML frontmatter.
+     * Returns {@code null} if no frontmatter or no description field is found.
+     */
+    static String extractDescriptionFromFrontmatter(String content) {
+        if (content == null || content.isBlank()) {
+            return null;
+        }
+        String stripped = content.strip();
+        if (!stripped.startsWith("---")) {
+            return null;
+        }
+        int end = stripped.indexOf("---", 3);
+        if (end < 0) {
+            return null;
+        }
+        String frontmatter = stripped.substring(3, end);
+        // Simple line-by-line parse for "description:" key
+        for (String line : frontmatter.split("\n")) {
+            String trimmed = line.strip();
+            if (trimmed.startsWith("description:")) {
+                return trimmed.substring("description:".length()).strip();
+            }
+            if (trimmed.startsWith("description :")) {
+                return trimmed.substring("description :".length()).strip();
+            }
+        }
+        return null;
     }
 }

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/workspace/WorkspaceConstants.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/workspace/WorkspaceConstants.java
@@ -28,6 +28,7 @@ public final class WorkspaceConstants {
 
     public static final String MEMORY_DIR = "memory";
     public static final String SKILLS_DIR = "skills";
+    public static final String SUBAGENTS_DIR = "subagents";
     public static final String KNOWLEDGE_DIR = "knowledge";
     public static final String KNOWLEDGE_MD = "KNOWLEDGE.md";
     public static final String RULES_DIR = "rules";

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/workspace/WorkspaceManager.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/workspace/WorkspaceManager.java
@@ -24,6 +24,7 @@ import static io.agentscope.harness.agent.workspace.WorkspaceConstants.MEMORY_MD
 import static io.agentscope.harness.agent.workspace.WorkspaceConstants.SESSIONS_DIR;
 import static io.agentscope.harness.agent.workspace.WorkspaceConstants.SESSIONS_STORE;
 import static io.agentscope.harness.agent.workspace.WorkspaceConstants.SKILLS_DIR;
+import static io.agentscope.harness.agent.workspace.WorkspaceConstants.SUBAGENTS_DIR;
 import static io.agentscope.harness.agent.workspace.WorkspaceConstants.TASKS_DIR;
 
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -285,6 +286,10 @@ public class WorkspaceManager implements AutoCloseable {
         return workspace.resolve(SKILLS_DIR);
     }
 
+    public Path getSubagentsDir() {
+        return workspace.resolve(SUBAGENTS_DIR);
+    }
+
     public Path getKnowledgeDir() {
         return workspace.resolve(KNOWLEDGE_DIR);
     }
@@ -319,6 +324,98 @@ public class WorkspaceManager implements AutoCloseable {
                                 });
             } catch (IOException e) {
                 log.warn("Failed to list knowledge files: {}", e.getMessage());
+            }
+        }
+
+        List<Path> result = new ArrayList<>();
+        for (String rel : relativePaths) {
+            result.add(workspace.resolve(rel));
+        }
+        return result;
+    }
+
+    /**
+     * Lists all subagent declaration files ({@code *.md}) under the {@code subagents/} directory.
+     * Union of filesystem + local disk, deduplicated by relative path.
+     */
+    public List<Path> listSubagentFiles(RuntimeContext rc) {
+        Set<String> relativePaths = new LinkedHashSet<>();
+
+        if (filesystem != null) {
+            GlobResult glob = filesystem.glob(rc, "*.md", SUBAGENTS_DIR);
+            if (glob.isSuccess() && glob.matches() != null) {
+                for (FileInfo fi : glob.matches()) {
+                    if (fi.path() != null && !fi.path().isBlank()) {
+                        relativePaths.add(normalizeRelativePath(fi.path().trim()));
+                    }
+                }
+            }
+        }
+
+        Path dir = getSubagentsDir();
+        if (Files.isDirectory(dir)) {
+            try (Stream<Path> list = Files.list(dir)) {
+                list.filter(Files::isRegularFile)
+                        .filter(p -> p.toString().endsWith(".md"))
+                        .forEach(
+                                p -> {
+                                    String rel =
+                                            workspace
+                                                    .relativize(p.normalize())
+                                                    .toString()
+                                                    .replace('\\', '/');
+                                    relativePaths.add(rel);
+                                });
+            } catch (IOException e) {
+                log.warn("Failed to list subagent files: {}", e.getMessage());
+            }
+        }
+
+        List<Path> result = new ArrayList<>();
+        for (String rel : relativePaths) {
+            result.add(workspace.resolve(rel));
+        }
+        return result;
+    }
+
+    /**
+     * Lists all skill directories under the {@code skills/} directory.
+     * Union of filesystem + local disk, deduplicated by relative path.
+     */
+    public List<Path> listSkillDirs(RuntimeContext rc) {
+        Set<String> relativePaths = new LinkedHashSet<>();
+
+        if (filesystem != null) {
+            GlobResult glob = filesystem.glob(rc, "SKILL.md", SKILLS_DIR);
+            if (glob.isSuccess() && glob.matches() != null) {
+                for (FileInfo fi : glob.matches()) {
+                    if (fi.path() != null && !fi.path().isBlank()) {
+                        String normalized = normalizeRelativePath(fi.path().trim());
+                        // Extract the skill directory name (parent of SKILL.md)
+                        int idx = normalized.lastIndexOf('/');
+                        if (idx > 0) {
+                            relativePaths.add(normalized.substring(0, idx));
+                        }
+                    }
+                }
+            }
+        }
+
+        Path dir = getSkillsDir();
+        if (Files.isDirectory(dir)) {
+            try (Stream<Path> list = Files.list(dir)) {
+                list.filter(Files::isDirectory)
+                        .forEach(
+                                p -> {
+                                    String rel =
+                                            workspace
+                                                    .relativize(p.normalize())
+                                                    .toString()
+                                                    .replace('\\', '/');
+                                    relativePaths.add(rel);
+                                });
+            } catch (IOException e) {
+                log.warn("Failed to list skill directories: {}", e.getMessage());
             }
         }
 

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/middleware/WorkspaceContextMiddlewareTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/middleware/WorkspaceContextMiddlewareTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.harness.agent.middleware;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import org.junit.jupiter.api.Test;
+
+class WorkspaceContextMiddlewareTest {
+
+    @Test
+    void extractDescriptionFromFrontmatter_simpleDescription() {
+        String content =
+                "---\n"
+                        + "description: Code review specialist\n"
+                        + "workspace:\n"
+                        + "  mode: isolated\n"
+                        + "---\n"
+                        + "\n"
+                        + "You are a code review subagent.";
+        String desc = WorkspaceContextMiddleware.extractDescriptionFromFrontmatter(content);
+        assertNotNull(desc);
+        assertEquals("Code review specialist", desc);
+    }
+
+    @Test
+    void extractDescriptionFromFrontmatter_quotedDescription() {
+        String content =
+                "---\n"
+                        + "description: \"A long description with special chars: @#$\"\n"
+                        + "---\n"
+                        + "\n"
+                        + "Body text.";
+        String desc = WorkspaceContextMiddleware.extractDescriptionFromFrontmatter(content);
+        assertNotNull(desc);
+        assertEquals("\"A long description with special chars: @#$\"", desc);
+    }
+
+    @Test
+    void extractDescriptionFromFrontmatter_noDescription() {
+        String content = "---\n" + "workspace:\n" + "  mode: shared\n" + "---\n" + "\n" + "Body.";
+        String desc = WorkspaceContextMiddleware.extractDescriptionFromFrontmatter(content);
+        assertNull(desc);
+    }
+
+    @Test
+    void extractDescriptionFromFrontmatter_noFrontmatter() {
+        String content = "Just a plain markdown file without frontmatter.";
+        String desc = WorkspaceContextMiddleware.extractDescriptionFromFrontmatter(content);
+        assertNull(desc);
+    }
+
+    @Test
+    void extractDescriptionFromFrontmatter_nullContent() {
+        assertNull(WorkspaceContextMiddleware.extractDescriptionFromFrontmatter(null));
+    }
+
+    @Test
+    void extractDescriptionFromFrontmatter_blankContent() {
+        assertNull(WorkspaceContextMiddleware.extractDescriptionFromFrontmatter("   "));
+    }
+
+    @Test
+    void extractDescriptionFromFrontmatter_unclosedFrontmatter() {
+        String content = "---\n" + "description: Test\n" + "no closing frontmatter";
+        assertNull(WorkspaceContextMiddleware.extractDescriptionFromFrontmatter(content));
+    }
+
+    @Test
+    void extractDescriptionFromFrontmatter_emptyDescription() {
+        String content = "---\n" + "description:\n" + "---\n" + "Body.";
+        String desc = WorkspaceContextMiddleware.extractDescriptionFromFrontmatter(content);
+        // Empty description value — should return empty string
+        assertNotNull(desc);
+        assertEquals("", desc);
+    }
+}


### PR DESCRIPTION
…ntext

The WorkspaceContextMiddleware previously only injected AGENTS.md, MEMORY.md, and knowledge/ content into the system prompt. Subagent declarations and skill directories were not included in the injected workspace context, causing the LLM to be unaware of available subagents and skills defined in the workspace.

This change adds:
- SUBAGENTS_DIR constant to WorkspaceConstants
- getSubagentsDir(), listSubagentFiles(), listSkillDirs() methods to WorkspaceManager
- buildSubagentsBlock() and buildSkillsBlock() in WorkspaceContextMiddleware to inject subagent and skill summaries (name + description from YAML frontmatter) into <loaded_context>
- extractDescriptionFromFrontmatter() utility for parsing YAML frontmatter description fields
- Unit tests for extractDescriptionFromFrontmatter()

Closes #1650

## AgentScope-Java Version

[The version of AgentScope-Java you are working on, e.g. 1.0.12, check your pom.xml dependency version or run `mvn dependency:tree | grep agentscope-parent:pom`(only mac/linux)]

## Description

[Please describe the background, purpose, changes made, and how to test this PR]

## Checklist

Please check the following items before code is ready to be reviewed.

- [ ]  Code has been formatted with `mvn spotless:apply`
- [ ]  All tests are passing (`mvn test`)
- [ ]  Javadoc comments are complete and follow project conventions
- [ ]  Related documentation has been updated (e.g. links, examples, etc.)
- [ ]  Code is ready for review
