### PR TITLE
fix sandbox glob_files recursive patterns

### DIFF
--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/filesystem/sandbox/BaseSandboxFilesystem.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/filesystem/sandbox/BaseSandboxFilesystem.java
@@ -279,7 +279,7 @@ public abstract class BaseSandboxFilesystem implements AbstractSandboxFilesystem
         String grepOpts = "-rHnF";
         String globPattern = "";
         if (glob != null && !glob.isBlank()) {
-            globPattern = "--include=" + FilesystemUtils.shellQuote(glob);
+            globPattern = "--include=" + FilesystemUtils.shellQuote(stripRecursivePrefix(glob));
         }
         String patternEscaped = FilesystemUtils.shellQuote(pattern);
 
@@ -319,9 +319,7 @@ public abstract class BaseSandboxFilesystem implements AbstractSandboxFilesystem
     @Override
     public GlobResult glob(RuntimeContext runtimeContext, String pattern, String path) {
         String escapedPath = FilesystemUtils.shellQuote(path != null ? path : "/");
-        String findNamePattern =
-                pattern != null && pattern.startsWith("**/") ? pattern.substring(3) : pattern;
-        String escapedPattern = FilesystemUtils.shellQuote(findNamePattern);
+        String escapedPattern = FilesystemUtils.shellQuote(stripRecursivePrefix(pattern));
 
         String cmd =
                 "find " + escapedPath + " -type f -name " + escapedPattern + " 2>/dev/null | sort";
@@ -379,6 +377,21 @@ public abstract class BaseSandboxFilesystem implements AbstractSandboxFilesystem
         ExecuteResponse result =
                 execute(runtimeContext, "test -e " + escapedPath + " && echo yes || echo no", null);
         return result.output() != null && result.output().strip().startsWith("yes");
+    }
+
+    /**
+     * Strips the recursive glob prefix {@code **&#47;} from a pattern so it can be passed to
+     * tools like {@code find -name} or {@code grep --include=} that match only the filename
+     * portion. For example, {@code **&#47;*.java} becomes {@code *.java}.
+     *
+     * @param pattern the glob pattern, may be {@code null}
+     * @return the pattern with any leading {@code **&#47;} removed, or the original value if absent
+     */
+    private static String stripRecursivePrefix(String pattern) {
+        if (pattern != null && pattern.startsWith("**/")) {
+            return pattern.substring(3);
+        }
+        return pattern;
     }
 
     private static String jsonEscape(String s) {

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/filesystem/sandbox/BaseSandboxFilesystem.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/filesystem/sandbox/BaseSandboxFilesystem.java
@@ -319,7 +319,9 @@ public abstract class BaseSandboxFilesystem implements AbstractSandboxFilesystem
     @Override
     public GlobResult glob(RuntimeContext runtimeContext, String pattern, String path) {
         String escapedPath = FilesystemUtils.shellQuote(path != null ? path : "/");
-        String escapedPattern = FilesystemUtils.shellQuote(pattern);
+        String findNamePattern =
+                pattern != null && pattern.startsWith("**/") ? pattern.substring(3) : pattern;
+        String escapedPattern = FilesystemUtils.shellQuote(findNamePattern);
 
         String cmd =
                 "find " + escapedPath + " -type f -name " + escapedPattern + " 2>/dev/null | sort";

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/filesystem/sandbox/BaseSandboxFilesystemTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/filesystem/sandbox/BaseSandboxFilesystemTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.harness.agent.filesystem.sandbox;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.agentscope.core.agent.RuntimeContext;
+import io.agentscope.harness.agent.filesystem.model.ExecuteResponse;
+import io.agentscope.harness.agent.filesystem.model.FileDownloadResponse;
+import io.agentscope.harness.agent.filesystem.model.FileUploadResponse;
+import io.agentscope.harness.agent.filesystem.model.GlobResult;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.Test;
+
+class BaseSandboxFilesystemTest {
+
+    private static final RuntimeContext RT = RuntimeContext.empty();
+
+    @Test
+    void glob_recursivePattern_stripsDoubleStarPrefixBeforeFindName() {
+        FakeSandboxFilesystem filesystem = new FakeSandboxFilesystem();
+
+        GlobResult result = filesystem.glob(RT, "**/*.md", "/workspace");
+
+        assertTrue(result.isSuccess());
+        assertEquals(
+                "find '/workspace' -type f -name '*.md' 2>/dev/null | sort",
+                filesystem.lastCommand);
+        assertEquals(
+                List.of("/workspace/README.md", "/workspace/docs/guide.md"),
+                result.matches().stream().map(match -> match.path()).collect(Collectors.toList()));
+    }
+
+    private static final class FakeSandboxFilesystem extends BaseSandboxFilesystem {
+
+        private String lastCommand;
+
+        @Override
+        public String id() {
+            return "fake";
+        }
+
+        @Override
+        public ExecuteResponse execute(
+                RuntimeContext runtimeContext, String command, Integer timeoutSeconds) {
+            lastCommand = command;
+            if ("find '/workspace' -type f -name '*.md' 2>/dev/null | sort".equals(command)) {
+                return new ExecuteResponse(
+                        "/workspace/README.md\n/workspace/docs/guide.md\n", 0, false);
+            }
+            return new ExecuteResponse("", 0, false);
+        }
+
+        @Override
+        public List<FileUploadResponse> uploadFiles(
+                RuntimeContext runtimeContext, List<Map.Entry<String, byte[]>> files) {
+            return List.of();
+        }
+
+        @Override
+        public List<FileDownloadResponse> downloadFiles(
+                RuntimeContext runtimeContext, List<String> paths) {
+            return List.of();
+        }
+    }
+}

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/filesystem/sandbox/BaseSandboxFilesystemTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/filesystem/sandbox/BaseSandboxFilesystemTest.java
@@ -47,6 +47,21 @@ class BaseSandboxFilesystemTest {
                 result.matches().stream().map(match -> match.path()).collect(Collectors.toList()));
     }
 
+    @Test
+    void glob_plainPattern_keepsFindNamePatternUnchanged() {
+        FakeSandboxFilesystem filesystem = new FakeSandboxFilesystem();
+
+        GlobResult result = filesystem.glob(RT, "*.md", "/workspace");
+
+        assertTrue(result.isSuccess());
+        assertEquals(
+                "find '/workspace' -type f -name '*.md' 2>/dev/null | sort",
+                filesystem.lastCommand);
+        assertEquals(
+                List.of("/workspace/README.md", "/workspace/docs/guide.md"),
+                result.matches().stream().map(match -> match.path()).collect(Collectors.toList()));
+    }
+
     private static final class FakeSandboxFilesystem extends BaseSandboxFilesystem {
 
         private String lastCommand;


### PR DESCRIPTION
## Summary
- normalize leading `**/` in sandbox `glob()` before passing the pattern to `find -name`
- add a regression test covering `glob_files` calls like `**/*.md`

## Root Cause
The `glob_files` tool description advertises recursive patterns such as `**/*.java`, but `BaseSandboxFilesystem.glob()` forwarded that pattern directly to `find -name`. `find -name` matches the filename portion only, so the leading `**/` caused sandbox-backed recursive glob calls to return no matches.

## Validation
- `mvn -pl agentscope-harness -am -Dtest=BaseSandboxFilesystemTest,FilesystemGlobTest test`