### PR TITLE
fix(tool): allow custom default vision model in OpenAIMultiModalTool

### DIFF
--- a/agentscope-core/src/main/java/io/agentscope/core/tool/multimodal/OpenAIMultiModalTool.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/tool/multimodal/OpenAIMultiModalTool.java
@@ -116,9 +116,22 @@ public class OpenAIMultiModalTool {
      * @param client the OpenAI client
      */
     protected OpenAIMultiModalTool(OpenAIClient client) {
+        this(client, "gpt-4o");
+    }
+
+    /**
+     * Create a new OpenAIMultiModalTool with custom client and default model (for testing).
+     *
+     * @param client the OpenAI client
+     * @param defaultModelName the default vision model name
+     */
+    protected OpenAIMultiModalTool(OpenAIClient client, String defaultModelName) {
+        if (defaultModelName == null || defaultModelName.trim().isEmpty()) {
+            throw new IllegalArgumentException("defaultModelName cannot be empty.");
+        }
         this.apiKey = "test-key";
         this.baseUrl = null;
-        this.defaultModelName = "gpt-4o";
+        this.defaultModelName = defaultModelName;
         this.client = client;
     }
 

--- a/agentscope-core/src/main/java/io/agentscope/core/tool/multimodal/OpenAIMultiModalTool.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/tool/multimodal/OpenAIMultiModalTool.java
@@ -67,13 +67,16 @@ public class OpenAIMultiModalTool {
     /** Base URL for OpenAI API (defaults to https://api.openai.com). */
     private final String baseUrl;
 
+    /** Default vision model used when the caller does not specify one. */
+    private final String defaultModelName;
+
     /**
      * Create a new OpenAIMultiModalTool with default base URL.
      *
      * @param apiKey the OpenAI API key
      */
     public OpenAIMultiModalTool(String apiKey) {
-        this(apiKey, null);
+        this(apiKey, null, "gpt-4o");
     }
 
     /**
@@ -83,11 +86,27 @@ public class OpenAIMultiModalTool {
      * @param baseUrl the base URL (null for default https://api.openai.com)
      */
     public OpenAIMultiModalTool(String apiKey, String baseUrl) {
+        this(apiKey, baseUrl, "gpt-4o");
+    }
+
+    /**
+     * Create a new OpenAIMultiModalTool with custom base URL and default vision model.
+     *
+     * @param apiKey the OpenAI API key
+     * @param baseUrl the base URL (null for default https://api.openai.com)
+     * @param defaultModelName the default vision model name used when the caller omits the model
+     *     parameter (e.g., "gpt-4o" for OpenAI, or your backend's vision model name)
+     */
+    public OpenAIMultiModalTool(String apiKey, String baseUrl, String defaultModelName) {
         if (apiKey == null || apiKey.trim().isEmpty()) {
             throw new IllegalArgumentException("OpenAI API key cannot be empty.");
         }
+        if (defaultModelName == null || defaultModelName.trim().isEmpty()) {
+            throw new IllegalArgumentException("defaultModelName cannot be empty.");
+        }
         this.apiKey = apiKey;
         this.baseUrl = baseUrl;
+        this.defaultModelName = defaultModelName;
         this.client = new OpenAIClient();
     }
 
@@ -99,6 +118,7 @@ public class OpenAIMultiModalTool {
     protected OpenAIMultiModalTool(OpenAIClient client) {
         this.apiKey = "test-key";
         this.baseUrl = null;
+        this.defaultModelName = "gpt-4o";
         this.client = client;
     }
 
@@ -249,7 +269,7 @@ public class OpenAIMultiModalTool {
      *
      * @param imageUrls the URLs of the images to analyze
      * @param prompt the text prompt describing what to extract from the images
-     * @param model the vision model to use (e.g., "gpt-4o", "gpt-4-vision-preview")
+     * @param model the vision model to use (leave empty to use the configured default)
      * @param maxTokens the maximum number of tokens in the response
      * @return a ToolResultBlock containing the text description of the images
      */
@@ -272,8 +292,8 @@ public class OpenAIMultiModalTool {
             @ToolParam(
                             name = "model",
                             description =
-                                    "The vision model to use, e.g., 'gpt-4o',"
-                                            + " 'gpt-4-vision-preview'",
+                                    "The vision model to use (leave empty to use the configured"
+                                            + " default)",
                             required = false)
                     String model,
             @ToolParam(
@@ -283,7 +303,9 @@ public class OpenAIMultiModalTool {
                     Integer maxTokens) {
 
         String finalModel =
-                Optional.ofNullable(model).filter(s -> !s.trim().isEmpty()).orElse("gpt-4o");
+                Optional.ofNullable(model)
+                        .filter(s -> !s.trim().isEmpty())
+                        .orElse(this.defaultModelName);
         String finalPrompt =
                 Optional.ofNullable(prompt)
                         .filter(s -> !s.trim().isEmpty())

--- a/agentscope-core/src/test/java/io/agentscope/core/tool/multimodal/OpenAIMultiModalToolTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/tool/multimodal/OpenAIMultiModalToolTest.java
@@ -17,8 +17,10 @@ package io.agentscope.core.tool.multimodal;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -64,5 +66,42 @@ class OpenAIMultiModalToolTest {
         ImageBlock image = (ImageBlock) content.get(0);
         assertTrue(image.getSource() instanceof URLSource);
         assertEquals("https://example.com/cat.png", ((URLSource) image.getSource()).getUrl());
+    }
+
+    @Test
+    void testImageToText_usesCustomDefaultModel() {
+        String imageUrl = "https://example.com/image.png";
+        String jsonResponse =
+                "{\"choices\": [{\"message\": {\"content\": \"A cat sitting on a mat.\"}}]}";
+
+        when(client.callApi(
+                        any(),
+                        any(),
+                        eq("/v1/chat/completions"),
+                        argThat(
+                                req -> {
+                                    @SuppressWarnings("unchecked")
+                                    java.util.Map<String, Object> map =
+                                            (java.util.Map<String, Object>) req;
+                                    return "my-custom-vision-model".equals(map.get("model"));
+                                })))
+                .thenReturn(jsonResponse);
+
+        OpenAIMultiModalTool toolWithCustomModel =
+                new OpenAIMultiModalTool(client, "my-custom-vision-model");
+
+        Mono<ToolResultBlock> resultMono =
+                toolWithCustomModel.openaiImageToText(imageUrl, null, null, null);
+        ToolResultBlock result = resultMono.block();
+
+        assertNotNull(result);
+    }
+
+    @Test
+    void testConstructor_rejectsBlankDefaultModelName() {
+        assertThrows(
+                IllegalArgumentException.class, () -> new OpenAIMultiModalTool("key", null, ""));
+        assertThrows(
+                IllegalArgumentException.class, () -> new OpenAIMultiModalTool("key", null, null));
     }
 }


### PR DESCRIPTION
## AgentScope-Java Version

2.0.0-RC2

## Description

When `openaiImageToText` is called without a `model` parameter, the fallback
was hardcoded to `"gpt-4o"`. Non-OpenAI-compatible backends (e.g. MiniMax
proxies) don't recognize that model name and return HTTP 503, which looks like
a transient outage and is hard to diagnose.

The `@ToolParam` description also mentioned `gpt-4o` and `gpt-4-vision-preview`
explicitly, steering the LLM toward OpenAI-specific names even when a different
backend was configured.

Fixes #1694

**Changes:**
- Add `defaultModelName` field and a new 3-argument constructor
  `OpenAIMultiModalTool(String apiKey, String baseUrl, String defaultModelName)`
- Existing 1-arg and 2-arg constructors delegate to the new one with `"gpt-4o"`
  as the default (fully backward compatible)
- Replace the hardcoded `"gpt-4o"` fallback in `openaiImageToText` with
  `this.defaultModelName`
- Remove OpenAI-specific model name hints from the `@ToolParam` description
  and Javadoc

## Checklist

- [x]  Code has been formatted with `mvn spotless:apply`
- [x]  All tests are passing (`mvn test`)
- [x]  Javadoc comments are complete and follow project conventions
- [ ]  Related documentation has been updated (e.g. links, examples, etc.)
- [x]  Code is ready for review