### PR TITLE
fix(nacos-starter): auto-configurations should be opt-in (matchIfMissing=false) and fix A2A server-addr override

### DIFF
--- a/agentscope-extensions/agentscope-spring-boot-starters/agentscope-nacos-spring-boot-starter/src/main/java/io/agentscope/spring/boot/nacos/AgentscopeA2aNacosAutoConfiguration.java
+++ b/agentscope-extensions/agentscope-spring-boot-starters/agentscope-nacos-spring-boot-starter/src/main/java/io/agentscope/spring/boot/nacos/AgentscopeA2aNacosAutoConfiguration.java
@@ -112,7 +112,7 @@ public class AgentscopeA2aNacosAutoConfiguration implements Closeable {
             prefix = NacosConstants.A2A_NACOS_DISCOVERY_PREFIX,
             name = "enabled",
             havingValue = "true",
-            matchIfMissing = false)
+            matchIfMissing = true)
     public AgentCardResolver nacosAgentCardResolver() {
         return new NacosAgentCardResolver(a2aService);
     }
@@ -128,7 +128,7 @@ public class AgentscopeA2aNacosAutoConfiguration implements Closeable {
             prefix = NacosConstants.A2A_NACOS_REGISTRY_PREFIX,
             name = "enabled",
             havingValue = "true",
-            matchIfMissing = false)
+            matchIfMissing = true)
     public AgentRegistry nacosAgentRegistry(AgentScopeA2aNacosProperties a2aNacosProperties) {
         return NacosAgentRegistry.builder(a2aService)
                 .nacosA2aProperties(buildNacosA2aProperties(a2aNacosProperties))

--- a/agentscope-extensions/agentscope-spring-boot-starters/agentscope-nacos-spring-boot-starter/src/main/java/io/agentscope/spring/boot/nacos/AgentscopeA2aNacosAutoConfiguration.java
+++ b/agentscope-extensions/agentscope-spring-boot-starters/agentscope-nacos-spring-boot-starter/src/main/java/io/agentscope/spring/boot/nacos/AgentscopeA2aNacosAutoConfiguration.java
@@ -54,7 +54,7 @@ import org.springframework.context.annotation.Bean;
         prefix = NacosConstants.A2A_NACOS_PREFIX,
         name = "enabled",
         havingValue = "true",
-        matchIfMissing = true)
+        matchIfMissing = false)
 public class AgentscopeA2aNacosAutoConfiguration implements Closeable {
 
     private static final Logger log =
@@ -81,7 +81,7 @@ public class AgentscopeA2aNacosAutoConfiguration implements Closeable {
             AgentScopeA2aNacosProperties a2aNacosProperties)
             throws NacosException {
         Properties nacosClientProperties = nacosProperties.getNacosProperties();
-        nacosClientProperties.putAll(a2aNacosProperties.getNacosProperties());
+        nacosClientProperties.putAll(a2aNacosProperties.getExplicitNacosProperties());
         return AiFactory.createAiService(nacosClientProperties);
     }
 
@@ -112,7 +112,7 @@ public class AgentscopeA2aNacosAutoConfiguration implements Closeable {
             prefix = NacosConstants.A2A_NACOS_DISCOVERY_PREFIX,
             name = "enabled",
             havingValue = "true",
-            matchIfMissing = true)
+            matchIfMissing = false)
     public AgentCardResolver nacosAgentCardResolver() {
         return new NacosAgentCardResolver(a2aService);
     }
@@ -128,7 +128,7 @@ public class AgentscopeA2aNacosAutoConfiguration implements Closeable {
             prefix = NacosConstants.A2A_NACOS_REGISTRY_PREFIX,
             name = "enabled",
             havingValue = "true",
-            matchIfMissing = true)
+            matchIfMissing = false)
     public AgentRegistry nacosAgentRegistry(AgentScopeA2aNacosProperties a2aNacosProperties) {
         return NacosAgentRegistry.builder(a2aService)
                 .nacosA2aProperties(buildNacosA2aProperties(a2aNacosProperties))

--- a/agentscope-extensions/agentscope-spring-boot-starters/agentscope-nacos-spring-boot-starter/src/main/java/io/agentscope/spring/boot/nacos/AgentscopeNacosPromptAutoConfiguration.java
+++ b/agentscope-extensions/agentscope-spring-boot-starters/agentscope-nacos-spring-boot-starter/src/main/java/io/agentscope/spring/boot/nacos/AgentscopeNacosPromptAutoConfiguration.java
@@ -54,7 +54,7 @@ import org.springframework.context.annotation.Bean;
         prefix = NacosConstants.NACOS_PROMPT_PREFIX,
         name = "enabled",
         havingValue = "true",
-        matchIfMissing = true)
+        matchIfMissing = false)
 public class AgentscopeNacosPromptAutoConfiguration {
 
     @Bean(name = "agentscopePromptAiService")

--- a/agentscope-extensions/agentscope-spring-boot-starters/agentscope-nacos-spring-boot-starter/src/test/java/io/agentscope/spring/boot/nacos/AgentscopeA2aNacosAutoConfigurationTest.java
+++ b/agentscope-extensions/agentscope-spring-boot-starters/agentscope-nacos-spring-boot-starter/src/test/java/io/agentscope/spring/boot/nacos/AgentscopeA2aNacosAutoConfigurationTest.java
@@ -63,6 +63,7 @@ class AgentscopeA2aNacosAutoConfigurationTest {
                     .withConfiguration(
                             AutoConfigurations.of(AgentscopeA2aNacosAutoConfiguration.class))
                     .withPropertyValues(
+                            "agentscope.a2a.nacos.enabled=true",
                             "agentscope.a2a.nacos.server-addr=127.0.0.1:8848",
                             "agentscope.a2a.nacos.namespace=public")
                     .run(
@@ -119,6 +120,7 @@ class AgentscopeA2aNacosAutoConfigurationTest {
                     .withConfiguration(
                             AutoConfigurations.of(AgentscopeA2aNacosAutoConfiguration.class))
                     .withPropertyValues(
+                            "agentscope.a2a.nacos.enabled=true",
                             "agentscope.a2a.nacos.server-addr=127.0.0.1:8848",
                             "agentscope.a2a.nacos.namespace=public")
                     .run(
@@ -139,6 +141,7 @@ class AgentscopeA2aNacosAutoConfigurationTest {
                     .withConfiguration(
                             AutoConfigurations.of(AgentscopeA2aNacosAutoConfiguration.class))
                     .withPropertyValues(
+                            "agentscope.a2a.nacos.enabled=true",
                             "agentscope.a2a.nacos.server-addr=127.0.0.1:8848",
                             "agentscope.a2a.nacos.namespace=public")
                     .run(
@@ -158,7 +161,9 @@ class AgentscopeA2aNacosAutoConfigurationTest {
             new ApplicationContextRunner()
                     .withConfiguration(
                             AutoConfigurations.of(AgentscopeA2aNacosAutoConfiguration.class))
-                    .withPropertyValues("agentscope.a2a.nacos.discovery.enabled=false")
+                    .withPropertyValues(
+                            "agentscope.a2a.nacos.enabled=true",
+                            "agentscope.a2a.nacos.discovery.enabled=false")
                     .run(
                             context -> {
                                 assertThat(context).doesNotHaveBean(AgentCardResolver.class);
@@ -175,7 +180,9 @@ class AgentscopeA2aNacosAutoConfigurationTest {
             new ApplicationContextRunner()
                     .withConfiguration(
                             AutoConfigurations.of(AgentscopeA2aNacosAutoConfiguration.class))
-                    .withPropertyValues("agentscope.a2a.nacos.registry.enabled=false")
+                    .withPropertyValues(
+                            "agentscope.a2a.nacos.enabled=true",
+                            "agentscope.a2a.nacos.registry.enabled=false")
                     .run(
                             context -> {
                                 assertThat(context).hasSingleBean(AgentCardResolver.class);
@@ -193,6 +200,7 @@ class AgentscopeA2aNacosAutoConfigurationTest {
                     .withConfiguration(
                             AutoConfigurations.of(AgentscopeA2aNacosAutoConfiguration.class))
                     .withPropertyValues(
+                            "agentscope.a2a.nacos.enabled=true",
                             "agentscope.a2a.nacos.server-addr=127.0.0.1:8848",
                             "agentscope.a2a.nacos.namespace=test-namespace",
                             "agentscope.a2a.nacos.username=test-user",
@@ -237,6 +245,7 @@ class AgentscopeA2aNacosAutoConfigurationTest {
                             AutoConfigurations.of(AgentscopeA2aNacosAutoConfiguration.class))
                     .withBean(AgentCardResolver.class, () -> mockResolver)
                     .withPropertyValues(
+                            "agentscope.a2a.nacos.enabled=true",
                             "agentscope.a2a.nacos.server-addr=127.0.0.1:8848",
                             "agentscope.a2a.nacos.namespace=public")
                     .run(
@@ -259,6 +268,7 @@ class AgentscopeA2aNacosAutoConfigurationTest {
                             AutoConfigurations.of(AgentscopeA2aNacosAutoConfiguration.class))
                     .withBean(AgentRegistry.class, () -> mockRegistry)
                     .withPropertyValues(
+                            "agentscope.a2a.nacos.enabled=true",
                             "agentscope.a2a.nacos.server-addr=127.0.0.1:8848",
                             "agentscope.a2a.nacos.namespace=public")
                     .run(
@@ -278,6 +288,7 @@ class AgentscopeA2aNacosAutoConfigurationTest {
             new ApplicationContextRunner()
                     .withConfiguration(
                             AutoConfigurations.of(AgentscopeA2aNacosAutoConfiguration.class))
+                    .withPropertyValues("agentscope.a2a.nacos.enabled=true")
                     .run(context -> assertThat(context).hasNotFailed());
         }
     }
@@ -291,6 +302,7 @@ class AgentscopeA2aNacosAutoConfigurationTest {
                     .withConfiguration(
                             AutoConfigurations.of(AgentscopeA2aNacosAutoConfiguration.class))
                     .withPropertyValues(
+                            "agentscope.a2a.nacos.enabled=true",
                             "agentscope.a2a.nacos.registry.enabled=true",
                             "agentscope.a2a.nacos.registry.register-as-latest=true",
                             "agentscope.a2a.nacos.registry.enabled-register-endpoint=true",
@@ -321,7 +333,9 @@ class AgentscopeA2aNacosAutoConfigurationTest {
             new ApplicationContextRunner()
                     .withConfiguration(
                             AutoConfigurations.of(AgentscopeA2aNacosAutoConfiguration.class))
-                    .withPropertyValues("agentscope.a2a.nacos.discovery.enabled=true")
+                    .withPropertyValues(
+                            "agentscope.a2a.nacos.enabled=true",
+                            "agentscope.a2a.nacos.discovery.enabled=true")
                     .run(
                             context -> {
                                 assertThat(context).hasSingleBean(AgentCardResolver.class);
@@ -346,6 +360,7 @@ class AgentscopeA2aNacosAutoConfigurationTest {
                     .withConfiguration(
                             AutoConfigurations.of(AgentscopeA2aNacosAutoConfiguration.class))
                     .withPropertyValues(
+                            "agentscope.a2a.nacos.enabled=true",
                             "agentscope.a2a.nacos.server-addr=127.0.0.1:8848",
                             "agentscope.a2a.nacos.namespace=public")
                     .run(


### PR DESCRIPTION
AgentScope-Java Version
2.0.0-RC2

Description

Two bugs in agentscope-nacos-spring-boot-starter cause startup crashes and silent server-addr override.

1. matchIfMissing=true on @ConditionalOnProperty in AgentscopeNacosPromptAutoConfiguration and AgentscopeA2aNacosAutoConfiguration (and its nested discovery/registry beans) causes both auto-configurations to activate even when the user has not configured the feature. The Javadoc states these are opt-in features requiring enabled=true, but the implementation behaves as opt-out. Changed matchIfMissing to false.

2. AgentscopeA2aNacosAutoConfiguration.a2aService() calls a2aNacosProperties.getNacosProperties() when merging A2A-specific config on top of the base config. getNacosProperties() fills in 127.0.0.1:8848 as a default, which then overwrites the user-configured agentscope.nacos.server-addr via putAll. Fixed by using getExplicitNacosProperties() instead — BaseNacosProperties documents this method as the correct choice for overlay/merge scenarios.

To test: existing tests shouldNotCreateBeansWhenDisabled and shouldNotCreateNacosBeansWhenDisabled cover the matchIfMissing fix. The server-addr fix can be verified by running shouldNotOverwriteGlobalServerAddrWhenPromptNotSet in AgentscopeNacosPromptAutoConfigurationTest.

Fixes #1707