### PR TITLE
Feat/kubernetes sandbox env injection

### DIFF
--- a/agentscope-extensions/agentscope-extensions-sandbox/agentscope-extensions-sandbox-kubernetes/src/main/java/io/agentscope/extensions/sandbox/kubernetes/Fabric8KubernetesPodRuntime.java
+++ b/agentscope-extensions/agentscope-extensions-sandbox/agentscope-extensions-sandbox-kubernetes/src/main/java/io/agentscope/extensions/sandbox/kubernetes/Fabric8KubernetesPodRuntime.java
@@ -212,7 +212,7 @@ public class Fabric8KubernetesPodRuntime {
                         .withArgs("while true; do sleep 3600; done");
 
         Map<String, String> env = templateOptions.getEnvironment();
-        if (env != null && !env.isEmpty()) {
+        if (!env.isEmpty()) {
             List<EnvVar> envVars =
                     env.entrySet().stream()
                             .map(
@@ -222,7 +222,7 @@ public class Fabric8KubernetesPodRuntime {
                                                     .withValue(e.getValue())
                                                     .build())
                             .toList();
-            cb.withEnv(envVars);
+            cb.addAllToEnv(envVars);
         }
 
         if (templateOptions.getCpuRequest() != null || templateOptions.getMemoryRequest() != null) {

--- a/agentscope-extensions/agentscope-extensions-sandbox/agentscope-extensions-sandbox-kubernetes/src/main/java/io/agentscope/extensions/sandbox/kubernetes/Fabric8KubernetesPodRuntime.java
+++ b/agentscope-extensions/agentscope-extensions-sandbox/agentscope-extensions-sandbox-kubernetes/src/main/java/io/agentscope/extensions/sandbox/kubernetes/Fabric8KubernetesPodRuntime.java
@@ -22,6 +22,8 @@ import io.agentscope.harness.agent.sandbox.WorkspaceMountSupport;
 import io.agentscope.harness.agent.sandbox.WorkspaceSpec;
 import io.agentscope.harness.agent.sandbox.layout.BindMountEntry;
 import io.fabric8.kubernetes.api.model.ContainerBuilder;
+import io.fabric8.kubernetes.api.model.EnvVar;
+import io.fabric8.kubernetes.api.model.EnvVarBuilder;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.PodBuilder;
 import io.fabric8.kubernetes.api.model.PodSpecBuilder;
@@ -208,6 +210,20 @@ public class Fabric8KubernetesPodRuntime {
                         .withImage(state.getImage())
                         .withCommand("sh", "-c")
                         .withArgs("while true; do sleep 3600; done");
+
+        Map<String, String> env = templateOptions.getEnvironment();
+        if (env != null && !env.isEmpty()) {
+            List<EnvVar> envVars =
+                    env.entrySet().stream()
+                            .map(
+                                    e ->
+                                            new EnvVarBuilder()
+                                                    .withName(e.getKey())
+                                                    .withValue(e.getValue())
+                                                    .build())
+                            .toList();
+            cb.withEnv(envVars);
+        }
 
         if (templateOptions.getCpuRequest() != null || templateOptions.getMemoryRequest() != null) {
             ResourceRequirementsBuilder rb = new ResourceRequirementsBuilder();

--- a/agentscope-extensions/agentscope-extensions-sandbox/agentscope-extensions-sandbox-kubernetes/src/main/java/io/agentscope/extensions/sandbox/kubernetes/KubernetesFilesystemSpec.java
+++ b/agentscope-extensions/agentscope-extensions-sandbox/agentscope-extensions-sandbox-kubernetes/src/main/java/io/agentscope/extensions/sandbox/kubernetes/KubernetesFilesystemSpec.java
@@ -87,6 +87,11 @@ public class KubernetesFilesystemSpec extends SandboxFilesystemSpec {
         return this;
     }
 
+    public KubernetesFilesystemSpec environment(Map<String, String> environment) {
+        options.setEnvironment(environment);
+        return this;
+    }
+
     public KubernetesFilesystemSpec snapshotSpec(SandboxSnapshotSpec snapshotSpec) {
         this.snapshotSpec = snapshotSpec;
         return this;

--- a/agentscope-extensions/agentscope-extensions-sandbox/agentscope-extensions-sandbox-kubernetes/src/main/java/io/agentscope/extensions/sandbox/kubernetes/KubernetesSandboxClient.java
+++ b/agentscope-extensions/agentscope-extensions-sandbox/agentscope-extensions-sandbox-kubernetes/src/main/java/io/agentscope/extensions/sandbox/kubernetes/KubernetesSandboxClient.java
@@ -174,7 +174,7 @@ public class KubernetesSandboxClient implements SandboxClient<KubernetesSandboxC
             o.setMemoryRequest(callOptions.getMemoryRequest());
         }
         if (callOptions.getEnvironment() != null && !callOptions.getEnvironment().isEmpty()) {
-            Map<String, String> merged = new HashMap<>(base.getEnvironment());
+            Map<String, String> merged = new HashMap<>(o.getEnvironment());
             merged.putAll(callOptions.getEnvironment());
             o.setEnvironment(merged);
         }

--- a/agentscope-extensions/agentscope-extensions-sandbox/agentscope-extensions-sandbox-kubernetes/src/main/java/io/agentscope/extensions/sandbox/kubernetes/KubernetesSandboxClient.java
+++ b/agentscope-extensions/agentscope-extensions-sandbox/agentscope-extensions-sandbox-kubernetes/src/main/java/io/agentscope/extensions/sandbox/kubernetes/KubernetesSandboxClient.java
@@ -25,6 +25,8 @@ import io.agentscope.harness.agent.sandbox.json.HarnessSandboxJacksonModule;
 import io.agentscope.harness.agent.sandbox.snapshot.SandboxSnapshotSpec;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClientBuilder;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.UUID;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -171,6 +173,11 @@ public class KubernetesSandboxClient implements SandboxClient<KubernetesSandboxC
         if (callOptions.getMemoryRequest() != null) {
             o.setMemoryRequest(callOptions.getMemoryRequest());
         }
+        if (callOptions.getEnvironment() != null && !callOptions.getEnvironment().isEmpty()) {
+            Map<String, String> merged = new HashMap<>(base.getEnvironment());
+            merged.putAll(callOptions.getEnvironment());
+            o.setEnvironment(merged);
+        }
         return o;
     }
 
@@ -187,6 +194,7 @@ public class KubernetesSandboxClient implements SandboxClient<KubernetesSandboxC
         o.setPodLabels(src.getPodLabels());
         o.setCpuRequest(src.getCpuRequest());
         o.setMemoryRequest(src.getMemoryRequest());
+        o.setEnvironment(src.getEnvironment());
         return o;
     }
 

--- a/agentscope-extensions/agentscope-extensions-sandbox/agentscope-extensions-sandbox-kubernetes/src/main/java/io/agentscope/extensions/sandbox/kubernetes/KubernetesSandboxClient.java
+++ b/agentscope-extensions/agentscope-extensions-sandbox/agentscope-extensions-sandbox-kubernetes/src/main/java/io/agentscope/extensions/sandbox/kubernetes/KubernetesSandboxClient.java
@@ -133,7 +133,7 @@ public class KubernetesSandboxClient implements SandboxClient<KubernetesSandboxC
         }
     }
 
-    private KubernetesSandboxClientOptions merge(KubernetesSandboxClientOptions callOptions) {
+    KubernetesSandboxClientOptions merge(KubernetesSandboxClientOptions callOptions) {
         KubernetesSandboxClientOptions base =
                 defaultOptions != null ? defaultOptions : new KubernetesSandboxClientOptions();
         if (callOptions == null) {

--- a/agentscope-extensions/agentscope-extensions-sandbox/agentscope-extensions-sandbox-kubernetes/src/main/java/io/agentscope/extensions/sandbox/kubernetes/KubernetesSandboxClientOptions.java
+++ b/agentscope-extensions/agentscope-extensions-sandbox/agentscope-extensions-sandbox-kubernetes/src/main/java/io/agentscope/extensions/sandbox/kubernetes/KubernetesSandboxClientOptions.java
@@ -19,6 +19,7 @@ import io.agentscope.harness.agent.sandbox.SandboxClient;
 import io.agentscope.harness.agent.sandbox.SandboxClientOptions;
 import io.fabric8.kubernetes.client.Config;
 import io.fabric8.kubernetes.client.KubernetesClient;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -36,6 +37,7 @@ public class KubernetesSandboxClientOptions extends SandboxClientOptions {
     private Map<String, String> podLabels = new HashMap<>();
     private String cpuRequest;
     private String memoryRequest;
+    private Map<String, String> environment = new HashMap<>();
 
     @Override
     public String getType() {
@@ -137,5 +139,13 @@ public class KubernetesSandboxClientOptions extends SandboxClientOptions {
 
     public void setMemoryRequest(String memoryRequest) {
         this.memoryRequest = memoryRequest;
+    }
+
+    public Map<String, String> getEnvironment() {
+        return Collections.unmodifiableMap(environment);
+    }
+
+    public void setEnvironment(Map<String, String> environment) {
+        this.environment = environment != null ? new HashMap<>(environment) : new HashMap<>();
     }
 }

--- a/agentscope-extensions/agentscope-extensions-sandbox/agentscope-extensions-sandbox-kubernetes/src/test/java/io/agentscope/extensions/sandbox/kubernetes/KubernetesSandboxClientOptionsTest.java
+++ b/agentscope-extensions/agentscope-extensions-sandbox/agentscope-extensions-sandbox-kubernetes/src/test/java/io/agentscope/extensions/sandbox/kubernetes/KubernetesSandboxClientOptionsTest.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.extensions.sandbox.kubernetes;
+
+import java.util.Map;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class KubernetesSandboxClientOptionsTest {
+
+    // -- KubernetesSandboxClientOptions --
+
+    @Test
+    void environmentDefaultsToEmpty() {
+        KubernetesSandboxClientOptions opts = new KubernetesSandboxClientOptions();
+        Assertions.assertNotNull(opts.getEnvironment());
+        Assertions.assertTrue(opts.getEnvironment().isEmpty());
+    }
+
+    @Test
+    void setEnvironmentDefensivelyCopies() {
+        KubernetesSandboxClientOptions opts = new KubernetesSandboxClientOptions();
+        Map<String, String> original = new java.util.HashMap<>();
+        original.put("K", "V");
+        opts.setEnvironment(original);
+        original.put("K2", "V2");
+        Assertions.assertFalse(
+                opts.getEnvironment().containsKey("K2"),
+                "setEnvironment should copy, not retain original reference");
+    }
+
+    @Test
+    void setEnvironmentNullClearsMap() {
+        KubernetesSandboxClientOptions opts = new KubernetesSandboxClientOptions();
+        opts.setEnvironment(Map.of("K", "V"));
+        opts.setEnvironment(null);
+        Assertions.assertTrue(opts.getEnvironment().isEmpty());
+    }
+
+    @Test
+    void getEnvironmentIsUnmodifiable() {
+        KubernetesSandboxClientOptions opts = new KubernetesSandboxClientOptions();
+        opts.setEnvironment(Map.of("K", "V"));
+        Assertions.assertThrows(
+                UnsupportedOperationException.class, () -> opts.getEnvironment().put("X", "Y"));
+    }
+
+    // -- KubernetesSandboxClient merge / copy --
+
+    @Test
+    void mergeNoCallOptionsPreservesSpecEnv() {
+        KubernetesSandboxClient client = clientWithSpecEnv(Map.of("SPEC_KEY", "spec_val"));
+        KubernetesSandboxClientOptions merged = client.merge(null);
+        Assertions.assertEquals("spec_val", merged.getEnvironment().get("SPEC_KEY"));
+    }
+
+    @Test
+    void mergeEmptyCallEnvPreservesSpecEnv() {
+        KubernetesSandboxClient client = clientWithSpecEnv(Map.of("SPEC_KEY", "spec_val"));
+        KubernetesSandboxClientOptions call = new KubernetesSandboxClientOptions();
+        KubernetesSandboxClientOptions merged = client.merge(call);
+        Assertions.assertEquals("spec_val", merged.getEnvironment().get("SPEC_KEY"));
+    }
+
+    @Test
+    void mergeCallEnvOverridesSpecEnv() {
+        KubernetesSandboxClient client = clientWithSpecEnv(Map.of("KEY", "spec_val"));
+        KubernetesSandboxClientOptions call = new KubernetesSandboxClientOptions();
+        call.setEnvironment(Map.of("KEY", "call_val"));
+        KubernetesSandboxClientOptions merged = client.merge(call);
+        Assertions.assertEquals(
+                "call_val",
+                merged.getEnvironment().get("KEY"),
+                "call-level env should override spec-level env for same key");
+    }
+
+    @Test
+    void mergeCallEnvAddsToSpecEnv() {
+        KubernetesSandboxClient client = clientWithSpecEnv(Map.of("SPEC_KEY", "spec_val"));
+        KubernetesSandboxClientOptions call = new KubernetesSandboxClientOptions();
+        call.setEnvironment(Map.of("CALL_KEY", "call_val"));
+        KubernetesSandboxClientOptions merged = client.merge(call);
+        Assertions.assertEquals(
+                "spec_val",
+                merged.getEnvironment().get("SPEC_KEY"),
+                "spec-level keys absent from call-level should be preserved");
+        Assertions.assertEquals(
+                "call_val",
+                merged.getEnvironment().get("CALL_KEY"),
+                "call-level keys should be added");
+    }
+
+    // -- helpers --
+
+    private static KubernetesSandboxClient clientWithSpecEnv(Map<String, String> env) {
+        KubernetesSandboxClientOptions spec = new KubernetesSandboxClientOptions();
+        spec.setEnvironment(env);
+        return new KubernetesSandboxClient(spec);
+    }
+}


### PR DESCRIPTION
Summary

Adds environment(Map<String, String>) support to KubernetesFilesystemSpec, bringing it to parity with DockerFilesystemSpec. Env vars are injected into the K8s Pod container spec at creation time via Fabric8 ContainerBuilder.addAllToEnv().

Fixes / Relates to: #

---
Description

Background & Purpose

DockerFilesystemSpec supports per-call environment variable injection via .environment(Map), but KubernetesFilesystemSpec has no equivalent. This blocks use cases where per-user secrets (e.g. an API key for a CLI tool pre-installed in the container image) need to be passed into the sandbox Pod without being written to the workspace filesystem — writing to workspace would cause the secret to land in JdbcSnapshotSpec / agent_sandbox_snapshots.

Changes Made

- KubernetesSandboxClientOptions: add environment field (defaults to empty map) with defensive-copy setter and unmodifiable-view getter
- KubernetesFilesystemSpec: add fluent environment(Map<String, String>) builder method
- KubernetesSandboxClient: include environment in merge() (call-level keys override spec-level; non-overridden spec-level keys are preserved) and copy()
- Fabric8KubernetesPodRuntime.createPod(): apply env map via ContainerBuilder.addAllToEnv() (additive, safe for future env var additions)
- KubernetesSandboxClientOptionsTest: 8 unit tests covering options defensive copy, null-safety, unmodifiable getter, and all merge() semantics

How to Test

1. Configure a KubernetesFilesystemSpec with .environment(Map.of("MY_VAR", "hello")) and run HarnessAgent against a real or mock K8s cluster
2. Inside the sandbox, run execute_shell_command("echo $MY_VAR") and verify the output is hello
3. Run the unit tests: mvn test -pl agentscope-extensions/agentscope-extensions-sandbox/agentscope-extensions-sandbox-kubernetes

---
Checklist

- [x] Code has been formatted according to project guidelines (Spotless applied)
- [x] All automated tests are passing (KubernetesSandboxClientOptionsTest, KubernetesSandboxStateSerdeTest)
- [x] Documentation / inline comments have been updated accordingly
- [x] Code is ready for review