### PR TITLE
fix: 修复中文 Skill 名在 ASCII 路径编码环境下保存失败的问题

### DIFF
--- a/agentscope-core/src/main/java/io/agentscope/core/skill/util/SkillFileSystemHelper.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/skill/util/SkillFileSystemHelper.java
@@ -31,6 +31,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.regex.Pattern;
 import java.util.stream.Stream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -50,6 +51,8 @@ public final class SkillFileSystemHelper {
 
     private static final Logger logger = LoggerFactory.getLogger(SkillFileSystemHelper.class);
     private static final String SKILL_FILE_NAME = "SKILL.md";
+    private static final String ENCODED_SKILL_DIR_PREFIX = "__utf8__";
+    private static final Pattern ASCII_SAFE_SKILL_DIR_NAME = Pattern.compile("[A-Za-z0-9._ -]+");
 
     private SkillFileSystemHelper() {}
 
@@ -213,9 +216,13 @@ public final class SkillFileSystemHelper {
         try {
             for (AgentSkill skill : skills) {
                 String skillName = skill.getName();
-                Path skillDir = validateAndResolvePath(baseDir, skillName);
+                validateSkillName(skillName);
+                Optional<Path> existingSkillDir = findSkillDirectoryByName(baseDir, skillName);
+                Path skillDir =
+                        existingSkillDir.orElseGet(
+                                () -> validateAndResolvePath(baseDir, skillName));
 
-                if (Files.exists(skillDir)) {
+                if (existingSkillDir.isPresent() || Files.exists(skillDir)) {
                     if (!force) {
                         logger.info(
                                 "Skill directory already exists and force=false: {}", skillName);
@@ -310,12 +317,10 @@ public final class SkillFileSystemHelper {
      * @throws IllegalArgumentException if the path escapes the base directory
      */
     public static Path validateAndResolvePath(Path baseDir, String skillName) {
-        if (skillName == null || skillName.isEmpty()) {
-            throw new IllegalArgumentException("Skill name cannot be null or empty");
-        }
+        validateSkillName(skillName);
 
         Path absoluteBaseDir = baseDir.toAbsolutePath().normalize();
-        Path resolvedPath = absoluteBaseDir.resolve(skillName).normalize();
+        Path resolvedPath = absoluteBaseDir.resolve(toSkillDirectoryName(skillName)).normalize();
 
         if (!resolvedPath.startsWith(absoluteBaseDir)) {
             throw new IllegalArgumentException(
@@ -325,6 +330,39 @@ public final class SkillFileSystemHelper {
         }
 
         return resolvedPath;
+    }
+
+    private static void validateSkillName(String skillName) {
+        if (skillName == null || skillName.isBlank()) {
+            throw new IllegalArgumentException("Skill name cannot be null or empty");
+        }
+        if (".".equals(skillName) || "..".equals(skillName)) {
+            throw new IllegalArgumentException("Skill name cannot be '.' or '..'");
+        }
+        if (skillName.indexOf('/') >= 0 || skillName.indexOf('\\') >= 0) {
+            throw new IllegalArgumentException("Skill name cannot contain path separators");
+        }
+        for (int i = 0; i < skillName.length(); i++) {
+            if (Character.isISOControl(skillName.charAt(i))) {
+                throw new IllegalArgumentException("Skill name cannot contain control characters");
+            }
+        }
+    }
+
+    private static String toSkillDirectoryName(String skillName) {
+        if (isAsciiSafeSkillDirectoryName(skillName)) {
+            return skillName;
+        }
+        String encoded =
+                Base64.getUrlEncoder()
+                        .withoutPadding()
+                        .encodeToString(skillName.getBytes(StandardCharsets.UTF_8));
+        return ENCODED_SKILL_DIR_PREFIX + encoded;
+    }
+
+    private static boolean isAsciiSafeSkillDirectoryName(String skillName) {
+        return !skillName.startsWith(ENCODED_SKILL_DIR_PREFIX)
+                && ASCII_SAFE_SKILL_DIR_NAME.matcher(skillName).matches();
     }
 
     /**

--- a/agentscope-core/src/test/java/io/agentscope/core/skill/util/SkillFileSystemHelperTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/skill/util/SkillFileSystemHelperTest.java
@@ -32,6 +32,7 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
@@ -318,6 +319,44 @@ class SkillFileSystemHelperTest {
     }
 
     @Test
+    @DisplayName("Should reject path separators in skill names")
+    void testValidateAndResolvePath_PathSeparatorRejected() {
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> SkillFileSystemHelper.validateAndResolvePath(skillsBaseDir, "bad/name"));
+    }
+
+    @Test
+    @DisplayName("Should save non-ASCII skill names using an ASCII-safe directory")
+    void testSaveSkills_NonAsciiSkillName_UsesAsciiSafeDirectory() throws IOException {
+        Set<String> before = listDirectoryNames(skillsBaseDir);
+        String skillName = "中文 Skill 名";
+        AgentSkill skill = new AgentSkill(skillName, "中文描述", "内容", Map.of());
+
+        boolean result = SkillFileSystemHelper.saveSkills(skillsBaseDir, List.of(skill), false);
+        assertTrue(result);
+
+        Set<String> after = listDirectoryNames(skillsBaseDir);
+        after.removeAll(before);
+        assertEquals(1, after.size());
+
+        String dirName = after.iterator().next();
+        assertNotNull(dirName);
+        assertTrue(dirName.startsWith("__utf8__"));
+        assertTrue(dirName.chars().allMatch(ch -> ch >= 0x20 && ch <= 0x7E));
+
+        Path savedSkillFile = skillsBaseDir.resolve(dirName).resolve("SKILL.md");
+        assertTrue(Files.exists(savedSkillFile));
+
+        AgentSkill loaded = SkillFileSystemHelper.loadSkill(skillsBaseDir, skillName, "source");
+        assertEquals(skillName, loaded.getName());
+        assertTrue(SkillFileSystemHelper.getAllSkillNames(skillsBaseDir).contains(skillName));
+        assertTrue(SkillFileSystemHelper.skillExists(skillsBaseDir, skillName));
+        assertTrue(SkillFileSystemHelper.deleteSkill(skillsBaseDir, skillName));
+        assertFalse(SkillFileSystemHelper.skillExists(skillsBaseDir, skillName));
+    }
+
+    @Test
     @DisplayName("Should delete directory recursively")
     void testDeleteDirectory() throws IOException {
         Path dir = tempDir.resolve("to-delete");
@@ -511,5 +550,13 @@ class SkillFileSystemHelperTest {
                         + content;
 
         Files.writeString(skillDir.resolve("SKILL.md"), skillMd, StandardCharsets.UTF_8);
+    }
+
+    private static Set<String> listDirectoryNames(Path dir) throws IOException {
+        try (var paths = Files.list(dir)) {
+            return paths.filter(Files::isDirectory)
+                    .map(path -> path.getFileName().toString())
+                    .collect(java.util.stream.Collectors.toSet());
+        }
     }
 }


### PR DESCRIPTION
## AgentScope-Java Version

2.0.0-SNAPSHOT

## Description

close #1705

### 背景

在部分 Docker / Linux 环境中，系统 locale 可能为 `POSIX`，JVM 的 `sun.jnu.encoding` 会退化为 `ANSI_X3.4-1968`。在这种情况下，如果 Skill 名称包含中文，当前保存逻辑会直接将 `skillName` 作为目录名参与 `Path.resolve(skillName)`，从而导致路径编码异常，最终保存失败。

这个问题的本质不是文件内容编码，而是“路径名编码”在 ASCII 环境下无法安全处理中文目录名。

### 本次修改

本次修复将 Skill 的“逻辑名称”和“物理目录名称”解耦，避免继续直接使用中文 Skill 名作为磁盘目录名：

1. 保存 Skill 时，先基于 `SKILL.md` 中的 metadata name 查找已有目录。
2. 对新的 Skill 目录名增加安全转换逻辑：
   - 如果 Skill 名是 ASCII-safe，则继续使用原名称作为目录名；
   - 如果 Skill 名包含中文或其他非 ASCII 字符，则转换为 ASCII-safe 目录名（`__utf8__` 前缀 + Base64 URL-safe 编码）。
3. 增加 Skill 名合法性校验，拒绝以下非法输入：
   - 空名称
   - `.` / `..`
   - 路径分隔符
   - 控制字符
4. 保持 `load / exists / list / delete` 等行为仍然基于 `SKILL.md` 中的 metadata name 工作，确保外部使用方式不变。

### 测试说明

本次补充了针对该问题的回归测试，主要覆盖：

- 路径分隔符应被拒绝；
- 中文 Skill 名可以成功保存；
- 保存后的物理目录名为 ASCII-safe；
- `loadSkill`、`getAllSkillNames`、`skillExists`、`deleteSkill` 在中文 Skill 名场景下仍可正常工作。

本地已验证：

- `mvn -pl agentscope-core -am spotless:check`
- `mvn -pl agentscope-core -am "-Dtest=SkillFileSystemHelperTest" "-Dsurefire.failIfNoSpecifiedTests=false" test`

## Checklist

- [x] Code has been formatted and passes Spotless check
- [ ] All tests are passing (`mvn test`)
- [ ] Javadoc comments are complete and follow project conventions
- [ ] Related documentation has been updated (e.g. links, examples, etc.)
- [x] Code is ready for review