### PR TITLE
fix(model): apply thinkingBudget to OpenAI-compatible API request

### DIFF
--- a/agentscope-core/src/main/java/io/agentscope/core/formatter/openai/OpenAIChatFormatter.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/formatter/openai/OpenAIChatFormatter.java
@@ -81,6 +81,13 @@ public class OpenAIChatFormatter extends OpenAIBaseFormatter {
             request.setReasoningEffort(reasoningEffort);
         }
 
+        // Apply thinking budget
+        Integer thinkingBudget =
+                getOptionOrDefault(options, defaultOptions, GenerateOptions::getThinkingBudget);
+        if (thinkingBudget != null) {
+            request.setThinkingBudget(thinkingBudget);
+        }
+
         // Apply top_p
         Double topP = getOptionOrDefault(options, defaultOptions, GenerateOptions::getTopP);
         if (topP != null) {

--- a/agentscope-core/src/main/java/io/agentscope/core/formatter/openai/dto/OpenAIRequest.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/formatter/openai/dto/OpenAIRequest.java
@@ -129,6 +129,17 @@ public class OpenAIRequest {
     private String reasoningEffort;
 
     /**
+     * Maximum tokens allocated for the model's internal thinking/reasoning process.
+     * Supported by OpenAI-compatible providers that expose a thinking budget parameter
+     * (e.g., Alibaba Cloud Bailian/DashScope Qwen3 series via {@code thinking_budget}).
+     * When set, the model is prevented from spending more than this many tokens on
+     * reasoning, leaving the remainder of {@code max_completion_tokens} for the
+     * visible response.
+     */
+    @JsonProperty("thinking_budget")
+    private Integer thinkingBudget;
+
+    /**
      * Controls whether to allow parallel tool calls.
      * Set to false to disable parallel tool calling.
      */
@@ -345,6 +356,14 @@ public class OpenAIRequest {
         this.reasoningEffort = reasoningEffort;
     }
 
+    public Integer getThinkingBudget() {
+        return thinkingBudget;
+    }
+
+    public void setThinkingBudget(Integer thinkingBudget) {
+        this.thinkingBudget = thinkingBudget;
+    }
+
     public Boolean getParallelToolCalls() {
         return parallelToolCalls;
     }
@@ -551,6 +570,11 @@ public class OpenAIRequest {
 
         public Builder reasoningEffort(String reasoningEffort) {
             request.setReasoningEffort(reasoningEffort);
+            return this;
+        }
+
+        public Builder thinkingBudget(Integer thinkingBudget) {
+            request.setThinkingBudget(thinkingBudget);
             return this;
         }
 

--- a/agentscope-core/src/test/java/io/agentscope/core/formatter/openai/OpenAIChatFormatterTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/formatter/openai/OpenAIChatFormatterTest.java
@@ -380,6 +380,64 @@ class OpenAIChatFormatterTest {
     }
 
     @Nested
+    @DisplayName("thinkingBudget Tests")
+    class ThinkingBudgetTests {
+
+        @Test
+        @DisplayName("Should apply thinkingBudget from GenerateOptions")
+        void testApplyThinkingBudget() {
+            OpenAIRequest request =
+                    OpenAIRequest.builder().model("qwen3.7-max").messages(List.of()).build();
+
+            GenerateOptions options = GenerateOptions.builder().thinkingBudget(4096).build();
+
+            formatter.applyOptions(request, options, null);
+
+            assertEquals(4096, request.getThinkingBudget());
+        }
+
+        @Test
+        @DisplayName("Should apply thinkingBudget from defaultOptions when options is null")
+        void testApplyThinkingBudgetFromDefault() {
+            OpenAIRequest request =
+                    OpenAIRequest.builder().model("qwen3.7-max").messages(List.of()).build();
+
+            GenerateOptions defaultOptions = GenerateOptions.builder().thinkingBudget(2048).build();
+
+            formatter.applyOptions(request, null, defaultOptions);
+
+            assertEquals(2048, request.getThinkingBudget());
+        }
+
+        @Test
+        @DisplayName("Options thinkingBudget should override defaultOptions")
+        void testThinkingBudgetOptionsOverridesDefault() {
+            OpenAIRequest request =
+                    OpenAIRequest.builder().model("qwen3.7-max").messages(List.of()).build();
+
+            GenerateOptions defaultOptions = GenerateOptions.builder().thinkingBudget(1000).build();
+            GenerateOptions options = GenerateOptions.builder().thinkingBudget(8000).build();
+
+            formatter.applyOptions(request, options, defaultOptions);
+
+            assertEquals(8000, request.getThinkingBudget());
+        }
+
+        @Test
+        @DisplayName("Should not set thinkingBudget when not specified")
+        void testThinkingBudgetNotSetWhenAbsent() {
+            OpenAIRequest request =
+                    OpenAIRequest.builder().model("gpt-4o").messages(List.of()).build();
+
+            GenerateOptions options = GenerateOptions.builder().temperature(0.7).build();
+
+            formatter.applyOptions(request, options, null);
+
+            assertNull(request.getThinkingBudget());
+        }
+    }
+
+    @Nested
     @DisplayName("applyAdditionalBodyParams Tests")
     class ApplyAdditionalBodyParamsTests {
 


### PR DESCRIPTION
## Summary

`GenerateOptions.thinkingBudget` was stored in the options object but **never mapped to `OpenAIRequest`**, causing the `thinking_budget` parameter to be silently dropped from all OpenAI-compatible API calls.

## Root Cause

In `OpenAIChatFormatter.applyOptions()`, all other `GenerateOptions` fields were correctly mapped to `OpenAIRequest` setters — but `thinkingBudget` was missing. Additionally, `OpenAIRequest` had no `thinking_budget` field at all.

| Field | Status (before fix) |
|-------|---------------------|
| `temperature` → `request.setTemperature()` | ✅ handled |
| `reasoningEffort` → `request.setReasoningEffort()` | ✅ handled |
| `maxCompletionTokens` → `request.setMaxCompletionTokens()` | ✅ handled |
| **`thinkingBudget`** → **NOT HANDLED — silently dropped** | ❌ missing |

This breaks reasoning/thinking models (e.g. Qwen3, DeepSeek-R1): without the cap, the model exhausts all `max_completion_tokens` on `reasoning_content` and returns an **empty `content` field**.

## Changes

- **`OpenAIRequest.java`**: Add `@JsonProperty("thinking_budget")` field with getter/setter and Builder method
- **`OpenAIChatFormatter.java`**: Map `GenerateOptions.thinkingBudget` in `applyOptions()`
- **`OpenAIChatFormatterTest.java`**: Add `ThinkingBudgetTests` with 4 unit tests covering: direct options, default fallback, override, and absent cases

## Testing

All 948 existing unit tests pass. `spotless:check` passes.

## Before / After

**Before** — `thinkingBudget` silently ignored:
```java
GenerateOptions.builder()
    .maxCompletionTokens(8192)
    .thinkingBudget(4096) // silently dropped — not in HTTP request
    .build()
// HTTP body: {"max_completion_tokens": 8192}
```

**After** — `thinking_budget` correctly sent:
```java
GenerateOptions.builder()
    .maxCompletionTokens(8192)
    .thinkingBudget(4096) // now included
    .build()
// HTTP body: {"max_completion_tokens": 8192, "thinking_budget": 4096}
```

Fixes #1697