### PR TITLE
fix: 同步动态 skill tool 激活状态

### DIFF
--- a/agentscope-core/src/main/java/io/agentscope/core/ReActAgent.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/ReActAgent.java
@@ -593,7 +593,11 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
 
     @Override
     protected void consumeSystemMsgAfterPreCall(Msg systemMsg, Object callScope) {
-        ((CallExecution) callScope).systemMsg = systemMsg;
+        CallExecution scope = (CallExecution) callScope;
+        scope.systemMsg = systemMsg;
+        // onSystemPrompt middleware can mutate the live toolkit before the first reasoning
+        // round, so mirror those active-group changes into the call-scoped AgentState now.
+        syncToolkitToState(scope.state);
     }
 
     @Override
@@ -2200,6 +2204,11 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
                             })
                     .flatMap(
                             results -> {
+                                // Tool execution can activate or deactivate toolkit groups
+                                // (for example, a skill loader exposing newly bound tools).
+                                // Persist that live toolkit state before any branch resumes
+                                // reasoning or returns early.
+                                syncToolkitToState(state);
                                 // Middleware requested stop during acting — return immediately with
                                 // the requested GenerateReason, preserving any results already
                                 // collected.

--- a/agentscope-core/src/main/java/io/agentscope/core/skill/AgentSkill.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/skill/AgentSkill.java
@@ -68,6 +68,8 @@ import java.util.Set;
  */
 @Deprecated(since = "2.0.0")
 public class AgentSkill {
+    public static final String TOOL_GROUP_SUFFIX = "_skill_tools";
+
     private final Map<String, Object> metadata;
     private final String skillContent;
     private final Map<String, String> resources;
@@ -268,6 +270,19 @@ public class AgentSkill {
      */
     public String getSkillId() {
         return getName() + "_" + source;
+    }
+
+    /**
+     * Gets the toolkit tool-group name used for tools registered under a skill.
+     *
+     * @param skillId the skill identifier
+     * @return the tool-group name for that skill
+     */
+    public static String toolGroupName(String skillId) {
+        if (skillId == null || skillId.isEmpty()) {
+            throw new IllegalArgumentException("skillId must not be null or empty");
+        }
+        return skillId + TOOL_GROUP_SUFFIX;
     }
 
     /**

--- a/agentscope-core/src/main/java/io/agentscope/core/skill/RegisteredSkill.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/skill/RegisteredSkill.java
@@ -72,6 +72,6 @@ class RegisteredSkill {
      * @return The tool group name
      */
     public String getToolsGroupName() {
-        return skillId + "_skill_tools";
+        return AgentSkill.toolGroupName(skillId);
     }
 }

--- a/agentscope-core/src/main/java/io/agentscope/core/skill/SkillBox.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/skill/SkillBox.java
@@ -577,7 +577,7 @@ public class SkillBox {
                     throw new IllegalStateException(
                             "Must bind toolkit or call toolkit() before apply()");
                 }
-                String skillToolGroup = skill.getSkillId() + "_skill_tools";
+                String skillToolGroup = AgentSkill.toolGroupName(skill.getSkillId());
                 if (toolkit.getToolGroup(skillToolGroup) == null) {
                     toolkit.createToolGroup(skillToolGroup, skillToolGroup, false);
                 }

--- a/agentscope-core/src/test/java/io/agentscope/core/agent/ReActAgentToolGroupSyncTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/agent/ReActAgentToolGroupSyncTest.java
@@ -1,0 +1,278 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.core.agent;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.agentscope.core.ReActAgent;
+import io.agentscope.core.message.Msg;
+import io.agentscope.core.message.TextBlock;
+import io.agentscope.core.message.ToolResultBlock;
+import io.agentscope.core.message.ToolUseBlock;
+import io.agentscope.core.middleware.MiddlewareBase;
+import io.agentscope.core.model.ChatModelBase;
+import io.agentscope.core.model.ChatResponse;
+import io.agentscope.core.model.ChatUsage;
+import io.agentscope.core.model.GenerateOptions;
+import io.agentscope.core.model.ToolSchema;
+import io.agentscope.core.tool.AgentTool;
+import io.agentscope.core.tool.ToolCallParam;
+import io.agentscope.core.tool.Toolkit;
+import io.agentscope.core.util.JsonUtils;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+@DisplayName("ReActAgent Tool Group Sync")
+class ReActAgentToolGroupSyncTest {
+
+    private static final Duration TIMEOUT = Duration.ofSeconds(3);
+
+    @Test
+    @DisplayName("onSystemPrompt-activated groups are visible in the first reasoning round")
+    void onSystemPromptActivatedGroupsVisibleImmediately() {
+        Toolkit toolkit = new Toolkit();
+        CopyOnWriteArrayList<List<String>> seenToolRounds = new CopyOnWriteArrayList<>();
+
+        AgentTool dynamicProbe = simpleTool("dynamic_probe", "dynamic-ready");
+        MiddlewareBase middleware =
+                new MiddlewareBase() {
+                    @Override
+                    public Mono<String> onSystemPrompt(
+                            Agent agent, RuntimeContext ctx, String currentPrompt) {
+                        Toolkit liveToolkit = agent.getToolkit();
+                        if (liveToolkit.getToolGroup("dynamic_skill_tools") == null) {
+                            liveToolkit.createToolGroup(
+                                    "dynamic_skill_tools", "dynamic skill tools", false);
+                        }
+                        if (liveToolkit.getTool("dynamic_probe") == null) {
+                            liveToolkit
+                                    .registration()
+                                    .agentTool(dynamicProbe)
+                                    .group("dynamic_skill_tools")
+                                    .apply();
+                        }
+                        liveToolkit.updateToolGroups(List.of("dynamic_skill_tools"), true);
+                        return Mono.just(currentPrompt);
+                    }
+                };
+
+        ChatModelBase model =
+                new ChatModelBase() {
+                    @Override
+                    public String getModelName() {
+                        return "capture-first-round-tools";
+                    }
+
+                    @Override
+                    protected Flux<ChatResponse> doStream(
+                            List<Msg> messages, List<ToolSchema> tools, GenerateOptions options) {
+                        seenToolRounds.add(toolNames(tools));
+                        return Flux.just(textResponse("done"));
+                    }
+                };
+
+        ReActAgent agent =
+                ReActAgent.builder()
+                        .name("tool-sync-agent")
+                        .sysPrompt("system")
+                        .model(model)
+                        .toolkit(toolkit)
+                        .middlewares(List.of(middleware))
+                        .build();
+
+        Msg out = agent.call(List.of()).block(TIMEOUT);
+
+        assertNotNull(out);
+        assertEquals(1, seenToolRounds.size());
+        assertTrue(
+                seenToolRounds.get(0).contains("dynamic_probe"),
+                "expected first reasoning round to see the middleware-activated tool, got "
+                        + seenToolRounds);
+        assertTrue(
+                agent.getAgentState()
+                        .getToolContext()
+                        .getActivatedGroups()
+                        .contains("dynamic_skill_tools"));
+    }
+
+    @Test
+    @DisplayName("tool-activated groups become visible on the next reasoning round")
+    void actingActivatedGroupsVisibleOnNextReasoningRound() {
+        Toolkit toolkit = new Toolkit();
+        String skillGroup = "weather_workspace_skill_tools";
+        toolkit.createToolGroup(skillGroup, skillGroup, false);
+        toolkit.registration()
+                .agentTool(
+                        new AgentTool() {
+                            @Override
+                            public String getName() {
+                                return "load_skill_through_path";
+                            }
+
+                            @Override
+                            public String getDescription() {
+                                return "Activate a skill tool group";
+                            }
+
+                            @Override
+                            public Map<String, Object> getParameters() {
+                                return Map.of(
+                                        "type",
+                                        "object",
+                                        "properties",
+                                        Map.of(
+                                                "skillId", Map.of("type", "string"),
+                                                "path", Map.of("type", "string")),
+                                        "required",
+                                        List.of("skillId", "path"));
+                            }
+
+                            @Override
+                            public Mono<ToolResultBlock> callAsync(ToolCallParam param) {
+                                param.getAgent()
+                                        .getToolkit()
+                                        .updateToolGroups(List.of(skillGroup), true);
+                                return Mono.just(ToolResultBlock.text("loaded"));
+                            }
+                        })
+                .apply();
+        toolkit.registration()
+                .agentTool(simpleTool("weather_lookup", "sunny"))
+                .group(skillGroup)
+                .apply();
+
+        AtomicInteger round = new AtomicInteger();
+        CopyOnWriteArrayList<List<String>> seenToolRounds = new CopyOnWriteArrayList<>();
+        ChatModelBase model =
+                new ChatModelBase() {
+                    @Override
+                    public String getModelName() {
+                        return "capture-post-acting-tools";
+                    }
+
+                    @Override
+                    protected Flux<ChatResponse> doStream(
+                            List<Msg> messages, List<ToolSchema> tools, GenerateOptions options) {
+                        List<String> toolNames = toolNames(tools);
+                        seenToolRounds.add(toolNames);
+                        return switch (round.getAndIncrement()) {
+                            case 0 -> {
+                                assertTrue(
+                                        toolNames.contains("load_skill_through_path"),
+                                        "expected skill loader in first round tools: " + toolNames);
+                                assertFalse(
+                                        toolNames.contains("weather_lookup"),
+                                        "skill-bound tool should stay hidden before activation: "
+                                                + toolNames);
+                                yield Flux.just(
+                                        toolCallResponse(
+                                                "load_skill_through_path",
+                                                "load-1",
+                                                Map.of(
+                                                        "skillId",
+                                                        "weather_workspace",
+                                                        "path",
+                                                        "SKILL.md")));
+                            }
+                            case 1 -> {
+                                assertTrue(
+                                        toolNames.contains("weather_lookup"),
+                                        "expected activated skill tool in next reasoning round: "
+                                                + toolNames);
+                                yield Flux.just(
+                                        toolCallResponse("weather_lookup", "weather-1", Map.of()));
+                            }
+                            default -> Flux.just(textResponse("done"));
+                        };
+                    }
+                };
+
+        ReActAgent agent =
+                ReActAgent.builder()
+                        .name("tool-sync-agent")
+                        .sysPrompt("system")
+                        .model(model)
+                        .toolkit(toolkit)
+                        .build();
+
+        Msg out = agent.call(List.of()).block(TIMEOUT);
+
+        assertNotNull(out);
+        assertEquals(3, seenToolRounds.size());
+        assertTrue(
+                agent.getAgentState().getToolContext().getActivatedGroups().contains(skillGroup));
+    }
+
+    private static AgentTool simpleTool(String name, String resultText) {
+        return new AgentTool() {
+            @Override
+            public String getName() {
+                return name;
+            }
+
+            @Override
+            public String getDescription() {
+                return "Test tool " + name;
+            }
+
+            @Override
+            public Map<String, Object> getParameters() {
+                return Map.of("type", "object", "properties", Map.of());
+            }
+
+            @Override
+            public Mono<ToolResultBlock> callAsync(ToolCallParam param) {
+                return Mono.just(ToolResultBlock.text(resultText));
+            }
+        };
+    }
+
+    private static List<String> toolNames(List<ToolSchema> tools) {
+        return tools == null ? List.of() : tools.stream().map(ToolSchema::getName).toList();
+    }
+
+    private static ChatResponse textResponse(String text) {
+        return ChatResponse.builder()
+                .content(List.of(TextBlock.builder().text(text).build()))
+                .usage(new ChatUsage(1, 1, 0))
+                .build();
+    }
+
+    private static ChatResponse toolCallResponse(
+            String toolName, String toolCallId, Map<String, Object> input) {
+        return ChatResponse.builder()
+                .content(
+                        List.of(
+                                ToolUseBlock.builder()
+                                        .name(toolName)
+                                        .id(toolCallId)
+                                        .input(input)
+                                        .content(JsonUtils.getJsonCodec().toJson(input))
+                                        .build()))
+                .usage(new ChatUsage(1, 1, 0))
+                .build();
+    }
+}

--- a/agentscope-core/src/test/java/io/agentscope/core/skill/AgentSkillTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/skill/AgentSkillTest.java
@@ -179,6 +179,14 @@ class AgentSkillTest {
     }
 
     @Test
+    @DisplayName("Should build shared tool group name from skill id")
+    void testToolGroupNameHelper() {
+        AgentSkill skill = new AgentSkill("weather", "desc", "content", null, "workspace");
+
+        assertEquals("weather_workspace_skill_tools", AgentSkill.toolGroupName(skill.getSkillId()));
+    }
+
+    @Test
     @DisplayName("Should resources immutability")
     void testResourcesImmutability() {
         Map<String, String> originalResources = new HashMap<>();

--- a/agentscope-core/src/test/java/io/agentscope/core/skill/RegisteredSkillTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/skill/RegisteredSkillTest.java
@@ -85,7 +85,7 @@ class RegisteredSkillTest {
 
         String toolsGroupName = skill.getToolsGroupName();
 
-        assertEquals("my_skill_skill_tools", toolsGroupName);
+        assertEquals(AgentSkill.toolGroupName("my_skill"), toolsGroupName);
     }
 
     @Test
@@ -95,7 +95,7 @@ class RegisteredSkillTest {
 
         String toolsGroupName = skill.getToolsGroupName();
 
-        assertEquals("skill-123_custom_skill_tools", toolsGroupName);
+        assertEquals(AgentSkill.toolGroupName("skill-123_custom"), toolsGroupName);
     }
 
     @Test

--- a/agentscope-core/src/test/java/io/agentscope/core/skill/SkillBoxTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/skill/SkillBoxTest.java
@@ -122,7 +122,7 @@ class SkillBoxTest {
             AgentSkill skill = new AgentSkill("my_skill", "My Skill", "# Content", null);
 
             // Before registration, the tool group should not exist
-            String toolsGroupName = skill.getSkillId() + "_skill_tools";
+            String toolsGroupName = AgentSkill.toolGroupName(skill.getSkillId());
             assertNull(
                     toolkit.getToolGroup(toolsGroupName),
                     "Tool group should not exist before skill registration");
@@ -266,7 +266,7 @@ class SkillBoxTest {
 
             skillBox.registration().skill(skill).agentTool(testTool).apply();
 
-            String toolsGroupName = skill.getSkillId() + "_skill_tools";
+            String toolsGroupName = AgentSkill.toolGroupName(skill.getSkillId());
 
             assertFalse(
                     skillBox.isSkillActive(skill.getSkillId()),
@@ -306,7 +306,7 @@ class SkillBoxTest {
                             null);
             skillBox.registerSkill(purePromptSkill);
 
-            String toolsGroupName = purePromptSkill.getSkillId() + "_skill_tools";
+            String toolsGroupName = AgentSkill.toolGroupName(purePromptSkill.getSkillId());
             assertNull(
                     toolkit.getToolGroup(toolsGroupName),
                     "ToolGroup should not exist for pure prompt skill");

--- a/agentscope-core/src/test/java/io/agentscope/core/skill/SkillBoxToolsTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/skill/SkillBoxToolsTest.java
@@ -176,7 +176,7 @@ class SkillBoxToolsTest {
         AgentTool tool = toolkit.getTool("load_skill_through_path");
 
         String skillId = "test_skill_custom";
-        String toolGroupName = skillId + "_skill_tools";
+        String toolGroupName = AgentSkill.toolGroupName(skillId);
 
         assertFalse(skillBox.isSkillActive(skillId));
 
@@ -296,7 +296,7 @@ class SkillBoxToolsTest {
         AgentTool tool = toolkit.getTool("load_skill_through_path");
 
         String skillId = "test_skill_custom";
-        String toolGroupName = skillId + "_skill_tools";
+        String toolGroupName = AgentSkill.toolGroupName(skillId);
 
         assertFalse(skillBox.isSkillActive(skillId));
 
@@ -489,7 +489,8 @@ class SkillBoxToolsTest {
         assertFalse(isErrorResult(result), "Should not fail when skill has no tools");
         assertTrue(skillBox.isSkillActive(skillId), "Skill should still be activated");
         assertNull(
-                toolkit.getToolGroup(skillId + "_skill_tools"), "Tool group should not be created");
+                toolkit.getToolGroup(AgentSkill.toolGroupName(skillId)),
+                "Tool group should not be created");
     }
 
     @Test

--- a/agentscope-core/src/test/java/io/agentscope/core/skill/SkillRuntimeIntegrationTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/skill/SkillRuntimeIntegrationTest.java
@@ -92,7 +92,7 @@ class SkillRuntimeIntegrationTest {
         skillBox.registration().skill(calculatorSkill).agentTool(calculatorMultiply).apply();
 
         String skillId = calculatorSkill.getSkillId();
-        String toolGroupName = skillId + "_skill_tools";
+        String toolGroupName = AgentSkill.toolGroupName(skillId);
 
         // Step 2: Verify initial state - skill and tool group inactive
         assertFalse(skillBox.isSkillActive(skillId), "Skill should be inactive initially");
@@ -177,8 +177,8 @@ class SkillRuntimeIntegrationTest {
 
         String mathSkillId = mathSkill.getSkillId();
         String weatherSkillId = weatherSkill.getSkillId();
-        String mathToolGroupName = mathSkillId + "_skill_tools";
-        String weatherToolGroupName = weatherSkillId + "_skill_tools";
+        String mathToolGroupName = AgentSkill.toolGroupName(mathSkillId);
+        String weatherToolGroupName = AgentSkill.toolGroupName(weatherSkillId);
 
         // Load first skill
         loadSkill(mathSkillId);

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/skill/runtime/SkillLoadTool.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/skill/runtime/SkillLoadTool.java
@@ -187,9 +187,12 @@ public final class SkillLoadTool implements AgentTool {
             toolkit = toolkitRef.get();
         }
         if (toolkit == null) {
+            log.debug(
+                    "activateSkillTools: no toolkit available for skill '{}'",
+                    entry.skill().getSkillId());
             return;
         }
-        String toolGroupName = entry.skill().getSkillId() + "_skill_tools";
+        String toolGroupName = AgentSkill.toolGroupName(entry.skill().getSkillId());
         if (toolkit.getToolGroup(toolGroupName) == null) {
             return;
         }

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/skill/runtime/SkillLoadTool.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/skill/runtime/SkillLoadTool.java
@@ -20,6 +20,7 @@ import io.agentscope.core.skill.AgentSkill;
 import io.agentscope.core.skill.util.MarkdownSkillParser;
 import io.agentscope.core.tool.AgentTool;
 import io.agentscope.core.tool.ToolCallParam;
+import io.agentscope.core.tool.Toolkit;
 import io.agentscope.harness.agent.skill.SkillResources;
 import java.util.ArrayList;
 import java.util.LinkedHashSet;
@@ -59,12 +60,19 @@ public final class SkillLoadTool implements AgentTool {
     private static final Logger log = LoggerFactory.getLogger(SkillLoadTool.class);
 
     private final AtomicReference<SkillCatalog> catalogRef;
+    private final AtomicReference<Toolkit> toolkitRef;
 
     public SkillLoadTool(AtomicReference<SkillCatalog> catalogRef) {
+        this(catalogRef, null);
+    }
+
+    public SkillLoadTool(
+            AtomicReference<SkillCatalog> catalogRef, AtomicReference<Toolkit> toolkitRef) {
         if (catalogRef == null) {
             throw new IllegalArgumentException("catalogRef must not be null");
         }
         this.catalogRef = catalogRef;
+        this.toolkitRef = toolkitRef;
     }
 
     @Override
@@ -134,24 +142,26 @@ public final class SkillLoadTool implements AgentTool {
                                         + "'. Check the available skills list."));
             }
 
-            return Mono.just(loadOne(entry, path));
+            return Mono.just(loadOne(entry, path, param));
         } catch (Exception e) {
             log.error("load_skill_through_path failed", e);
             return Mono.just(ToolResultBlock.error(e.getMessage()));
         }
     }
 
-    private ToolResultBlock loadOne(HarnessSkillEntry entry, String path) {
+    private ToolResultBlock loadOne(HarnessSkillEntry entry, String path, ToolCallParam param) {
         AgentSkill skill = entry.skill();
 
         // 1. Special case: SKILL.md returns the parsed body text.
         if (SKILL_FILE.equals(path)) {
+            activateSkillTools(entry, param);
             return ToolResultBlock.text(formatSkillMarkdown(entry));
         }
 
         // 2. In-memory map (Layer 1/3 host repos + marketplace fully-loaded resources).
         Map<String, String> mem = skill.getResources();
         if (mem != null && mem.containsKey(path)) {
+            activateSkillTools(entry, param);
             return ToolResultBlock.text(formatResource(entry, path, mem.get(path)));
         }
 
@@ -159,12 +169,31 @@ public final class SkillLoadTool implements AgentTool {
         if (entry.lazyResources() != null) {
             Optional<String> lazy = entry.lazyResources().read(path);
             if (lazy.isPresent()) {
+                activateSkillTools(entry, param);
                 return ToolResultBlock.text(formatResource(entry, path, lazy.get()));
             }
         }
 
         // 4. Not found: enumerate both sources so the model sees real options.
         return ToolResultBlock.error(formatNotFound(entry, path));
+    }
+
+    private void activateSkillTools(HarnessSkillEntry entry, ToolCallParam param) {
+        Toolkit toolkit = null;
+        if (param != null && param.getAgent() != null) {
+            toolkit = param.getAgent().getToolkit();
+        }
+        if (toolkit == null && toolkitRef != null) {
+            toolkit = toolkitRef.get();
+        }
+        if (toolkit == null) {
+            return;
+        }
+        String toolGroupName = entry.skill().getSkillId() + "_skill_tools";
+        if (toolkit.getToolGroup(toolGroupName) == null) {
+            return;
+        }
+        toolkit.updateToolGroups(List.of(toolGroupName), true);
     }
 
     // ---------------------------------------------------------------------

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/skill/runtime/SkillRuntime.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/skill/runtime/SkillRuntime.java
@@ -38,6 +38,7 @@ public final class SkillRuntime {
 
     private final AtomicReference<SkillCatalog> catalogRef =
             new AtomicReference<>(SkillCatalog.empty());
+    private final AtomicReference<Toolkit> toolkitRef = new AtomicReference<>();
     private final AtomicBoolean toolInstalled = new AtomicBoolean(false);
     private final SkillLoadTool loadTool;
     private final SkillPromptBuilder promptBuilder;
@@ -48,7 +49,7 @@ public final class SkillRuntime {
 
     public SkillRuntime(SkillPromptBuilder promptBuilder) {
         this.promptBuilder = promptBuilder != null ? promptBuilder : new SkillPromptBuilder();
-        this.loadTool = new SkillLoadTool(catalogRef);
+        this.loadTool = new SkillLoadTool(catalogRef, toolkitRef);
     }
 
     /** Snapshot accessor mainly for tests; not for runtime mutation. */
@@ -69,6 +70,7 @@ public final class SkillRuntime {
      */
     public void install(SkillCatalog catalog, Toolkit toolkit) {
         catalogRef.set(catalog != null ? catalog : SkillCatalog.empty());
+        toolkitRef.set(toolkit);
         if (toolkit == null) {
             return;
         }

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/skill/runtime/SkillRuntimeTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/skill/runtime/SkillRuntimeTest.java
@@ -215,6 +215,22 @@ class SkillRuntimeTest {
             assertTrue(err1.contains("skillId"));
         }
 
+        @Test
+        void loadingSkillActivatesSkillToolGroupViaRuntimeToolkitFallback() {
+            Toolkit tk = new Toolkit();
+            tk.createToolGroup("alpha_workspace_skill_tools", "alpha skill tools", false);
+
+            SkillRuntime r = new SkillRuntime();
+            HarnessSkillEntry e = HarnessSkillEntry.of(skill("alpha", "workspace"), null);
+            r.install(SkillCatalog.of(List.of(e)), tk);
+
+            invoke(r, "alpha_workspace", "SKILL.md");
+
+            assertTrue(
+                    tk.getToolGroup("alpha_workspace_skill_tools").isActive(),
+                    "loading a skill should activate its bound tool group");
+        }
+
         private ToolResultBlock invoke(SkillRuntime r, String skillId, String path) {
             ToolCallParam p =
                     ToolCallParam.builder().input(Map.of("skillId", skillId, "path", path)).build();
@@ -254,6 +270,31 @@ class SkillRuntimeTest {
             assertEquals(List.of("second_src"), r.currentCatalog().ids());
             // Same instance still registered.
             assertSame(r.loadTool(), tk.getTool(SkillLoadTool.TOOL_NAME));
+        }
+
+        @Test
+        void laterInstallRefreshesToolkitFallbackReference() {
+            Toolkit firstToolkit = new Toolkit();
+            firstToolkit.createToolGroup("alpha_workspace_skill_tools", "alpha skill tools", false);
+            Toolkit secondToolkit = new Toolkit();
+            secondToolkit.createToolGroup(
+                    "alpha_workspace_skill_tools", "alpha skill tools", false);
+
+            SkillRuntime r = new SkillRuntime();
+            HarnessSkillEntry entry = HarnessSkillEntry.of(skill("alpha", "workspace"), null);
+            SkillCatalog catalog = SkillCatalog.of(List.of(entry));
+
+            r.install(catalog, firstToolkit);
+            r.install(catalog, secondToolkit);
+
+            ToolCallParam p =
+                    ToolCallParam.builder()
+                            .input(Map.of("skillId", "alpha_workspace", "path", "SKILL.md"))
+                            .build();
+            r.loadTool().callAsync(p).block();
+
+            assertFalse(firstToolkit.getToolGroup("alpha_workspace_skill_tools").isActive());
+            assertTrue(secondToolkit.getToolGroup("alpha_workspace_skill_tools").isActive());
         }
     }
 

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/skill/runtime/SkillRuntimeTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/skill/runtime/SkillRuntimeTest.java
@@ -218,7 +218,8 @@ class SkillRuntimeTest {
         @Test
         void loadingSkillActivatesSkillToolGroupViaRuntimeToolkitFallback() {
             Toolkit tk = new Toolkit();
-            tk.createToolGroup("alpha_workspace_skill_tools", "alpha skill tools", false);
+            String toolGroupName = AgentSkill.toolGroupName("alpha_workspace");
+            tk.createToolGroup(toolGroupName, "alpha skill tools", false);
 
             SkillRuntime r = new SkillRuntime();
             HarnessSkillEntry e = HarnessSkillEntry.of(skill("alpha", "workspace"), null);
@@ -227,7 +228,7 @@ class SkillRuntimeTest {
             invoke(r, "alpha_workspace", "SKILL.md");
 
             assertTrue(
-                    tk.getToolGroup("alpha_workspace_skill_tools").isActive(),
+                    tk.getToolGroup(toolGroupName).isActive(),
                     "loading a skill should activate its bound tool group");
         }
 
@@ -275,10 +276,10 @@ class SkillRuntimeTest {
         @Test
         void laterInstallRefreshesToolkitFallbackReference() {
             Toolkit firstToolkit = new Toolkit();
-            firstToolkit.createToolGroup("alpha_workspace_skill_tools", "alpha skill tools", false);
+            String toolGroupName = AgentSkill.toolGroupName("alpha_workspace");
+            firstToolkit.createToolGroup(toolGroupName, "alpha skill tools", false);
             Toolkit secondToolkit = new Toolkit();
-            secondToolkit.createToolGroup(
-                    "alpha_workspace_skill_tools", "alpha skill tools", false);
+            secondToolkit.createToolGroup(toolGroupName, "alpha skill tools", false);
 
             SkillRuntime r = new SkillRuntime();
             HarnessSkillEntry entry = HarnessSkillEntry.of(skill("alpha", "workspace"), null);
@@ -293,8 +294,8 @@ class SkillRuntimeTest {
                             .build();
             r.loadTool().callAsync(p).block();
 
-            assertFalse(firstToolkit.getToolGroup("alpha_workspace_skill_tools").isActive());
-            assertTrue(secondToolkit.getToolGroup("alpha_workspace_skill_tools").isActive());
+            assertFalse(firstToolkit.getToolGroup(toolGroupName).isActive());
+            assertTrue(secondToolkit.getToolGroup(toolGroupName).isActive());
         }
     }
 


### PR DESCRIPTION
## 问题背景

Issue #1715 中，动态 skill 在两处会出现工具不可见的问题：

1. `onSystemPrompt` 阶段新注册或激活的 tool group 没有同步到当前 call state，导致首轮 reasoning 看不到动态工具。
2. `load_skill_through_path` 执行后，toolkit 中对应的 skill tool group 已经激活，但 `ReActAgent` 下一轮 reasoning 仍然读取旧的 state active groups，导致 skill-bound tools 仍不可见。

## 变更内容

1. 在 `ReActAgent` 中补充 toolkit active groups 到当前 call state 的同步时机：
   - `consumeSystemMsgAfterPreCall(...)` 后同步一次，保证首轮 reasoning 可见；
   - acting 阶段工具执行完成后再次同步，保证下一轮 reasoning 可见。
2. 在 harness 侧补齐 skill load 后的 tool group 激活逻辑：
   - `SkillLoadTool` 成功加载 skill 后，优先使用 `param.getAgent().getToolkit()`，否则 fallback 到 runtime 持有的 toolkit；
   - 如果存在 `<skillId>_skill_tools`，则立即激活对应 group。
3. 在 `SkillRuntime.install(...)` 中，每次安装时刷新 runtime 持有的 toolkit 引用。
4. 补充回归测试，覆盖：
   - `onSystemPrompt` 激活的 group 在首轮 reasoning 可见；
   - tool 执行后激活的 group 在下一轮 reasoning 可见；
   - harness 中 load skill 后会激活对应 skill tool group，且 toolkit fallback 引用会刷新。

## 验证

已执行并通过以下测试：

- `mvn -pl agentscope-core '-Dtest=ReActAgentToolGroupSyncTest' '-Dsurefire.failIfNoSpecifiedTests=false' test`
- `mvn -pl agentscope-core '-Dtest=SkillRuntimeIntegrationTest,ReActAgentMiddlewareIntegrationTest' '-Dsurefire.failIfNoSpecifiedTests=false' test`
- `mvn -pl agentscope-harness -am '-Dtest=SkillRuntimeTest' '-Dsurefire.failIfNoSpecifiedTests=false' test`
- `mvn -pl agentscope-harness -am '-Dtest=SkillLoadToolFrontmatterViewTest' '-Dsurefire.failIfNoSpecifiedTests=false' test`
