### PR TITLE
fix(agent): fallback to synthetic tool when native structured output fails

### DIFF
--- a/agentscope-core/src/main/java/io/agentscope/core/ReActAgent.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/ReActAgent.java
@@ -1027,11 +1027,25 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
                                             .strict(true)
                                             .build());
 
+                    int contextSizeBefore = scope.state.contextMutable().size();
+
                     return scope.doCallInner(msgs)
                             .flatMap(
                                     result -> {
                                         Msg out = wrapNativeStructuredResult(result);
                                         return saveStateToSession(scope).thenReturn(out);
+                                    })
+                            .onErrorResume(
+                                    e -> {
+                                        scope.rollbackContext(contextSizeBefore);
+                                        scope.nativeResponseFormat = null;
+                                        log.warn(
+                                                "Native structured output failed ({}) — falling"
+                                                        + " back to synthetic tool path",
+                                                e.getMessage() != null
+                                                        ? e.getMessage()
+                                                        : e.getClass().getSimpleName());
+                                        return doFallbackStructuredCall(msgs, jsonSchema);
                                     });
                 });
     }
@@ -1808,6 +1822,14 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
         private void addToContext(List<Msg> msgs) {
             if (msgs != null) {
                 state.contextMutable().addAll(msgs);
+            }
+        }
+
+        /** Roll back context to a given size on fallback, e.g. after native structured output failure. */
+        void rollbackContext(int targetSize) {
+            List<Msg> ctx = state.contextMutable();
+            while (ctx.size() > targetSize) {
+                ctx.remove(ctx.size() - 1);
             }
         }
 

--- a/agentscope-core/src/main/java/io/agentscope/core/ReActAgent.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/ReActAgent.java
@@ -989,7 +989,7 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
                                         e.getMessage() != null
                                                 ? e.getMessage()
                                                 : e.getClass().getSimpleName());
-                                return doFallbackStructuredCall(List.of(), jsonSchema);
+                                return doFallbackStructuredCall(msgs, jsonSchema);
                             });
         }
         return doFallbackStructuredCall(msgs, jsonSchema);
@@ -1035,17 +1035,10 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
                                         Msg out = wrapNativeStructuredResult(result);
                                         return saveStateToSession(scope).thenReturn(out);
                                     })
-                            .onErrorResume(
+                            .doOnError(
                                     e -> {
                                         scope.rollbackContext(contextSizeBefore);
                                         scope.nativeResponseFormat = null;
-                                        log.warn(
-                                                "Native structured output failed ({}) — falling"
-                                                        + " back to synthetic tool path",
-                                                e.getMessage() != null
-                                                        ? e.getMessage()
-                                                        : e.getClass().getSimpleName());
-                                        return doFallbackStructuredCall(msgs, jsonSchema);
                                     });
                 });
     }

--- a/agentscope-core/src/main/java/io/agentscope/core/ReActAgent.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/ReActAgent.java
@@ -980,7 +980,17 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
                         ? JsonSchemaUtils.generateSchemaFromClass(targetClass)
                         : JsonSchemaUtils.generateSchemaFromJsonNode(schemaDesc);
         if (model.supportsNativeStructuredOutput()) {
-            return doNativeStructuredCall(msgs, jsonSchema);
+            return doNativeStructuredCall(msgs, jsonSchema)
+                    .onErrorResume(
+                            e -> {
+                                log.warn(
+                                        "Native structured output failed ({}) — falling back to"
+                                                + " synthetic tool path",
+                                        e.getMessage() != null
+                                                ? e.getMessage()
+                                                : e.getClass().getSimpleName());
+                                return doFallbackStructuredCall(msgs, jsonSchema);
+                            });
         }
         return doFallbackStructuredCall(msgs, jsonSchema);
     }
@@ -1850,7 +1860,7 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
                                         event.getEffectiveGenerateOptions() != null
                                                 ? event.getEffectiveGenerateOptions()
                                                 : buildGenerateOptions();
-                                if (nativeResponseFormat != null) {
+                                if (nativeResponseFormat != null && soTool == null) {
                                     options =
                                             GenerateOptions.mergeOptions(
                                                     GenerateOptions.builder()

--- a/agentscope-core/src/main/java/io/agentscope/core/ReActAgent.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/ReActAgent.java
@@ -989,7 +989,7 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
                                         e.getMessage() != null
                                                 ? e.getMessage()
                                                 : e.getClass().getSimpleName());
-                                return doFallbackStructuredCall(msgs, jsonSchema);
+                                return doFallbackStructuredCall(List.of(), jsonSchema);
                             });
         }
         return doFallbackStructuredCall(msgs, jsonSchema);

--- a/agentscope-core/src/test/java/io/agentscope/core/agent/ReActAgentStructuredOutputTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/agent/ReActAgentStructuredOutputTest.java
@@ -31,11 +31,13 @@ import io.agentscope.core.message.ThinkingBlock;
 import io.agentscope.core.message.ToolUseBlock;
 import io.agentscope.core.model.ChatResponse;
 import io.agentscope.core.model.ChatUsage;
+import io.agentscope.core.model.Model;
 import io.agentscope.core.tool.Toolkit;
 import io.agentscope.core.util.JsonUtils;
 import java.time.Duration;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.RepeatedTest;
@@ -639,5 +641,84 @@ class ReActAgentStructuredOutputTest {
         // no IllegalStateException throw
         WeatherResponse result2 = response2.getStructuredData(WeatherResponse.class);
         assertNotNull(result2);
+    }
+
+    @Test
+    @DisplayName("Native structured output failure should fallback to synthetic tool path")
+    void testNativeStructuredOutputFallback() {
+        Map<String, Object> toolInput =
+                Map.of(
+                        "response",
+                        Map.of(
+                                "location", "TestCity",
+                                "temperature", "25°C",
+                                "condition", "Cloudy"));
+
+        final AtomicInteger callCount = new AtomicInteger(0);
+        Model nativeThrowModel =
+                new MockModel(
+                        msgs -> {
+                            int count = callCount.getAndIncrement();
+                            if (count == 0) {
+                                throw new RuntimeException("Mock native structured output failure");
+                            }
+                            // After fallback: return tool call then text, same as normal flow
+                            boolean hasToolResults =
+                                    msgs.stream().anyMatch(m -> m.getRole() == MsgRole.TOOL);
+                            if (!hasToolResults) {
+                                return List.of(
+                                        ChatResponse.builder()
+                                                .id("msg_1")
+                                                .content(
+                                                        List.of(
+                                                                ToolUseBlock.builder()
+                                                                        .id("call_fb")
+                                                                        .name("generate_response")
+                                                                        .input(toolInput)
+                                                                        .content(
+                                                                                JsonUtils
+                                                                                        .getJsonCodec()
+                                                                                        .toJson(
+                                                                                                toolInput))
+                                                                        .build()))
+                                                .build());
+                            }
+                            return List.of(
+                                    ChatResponse.builder()
+                                            .id("msg_2")
+                                            .content(
+                                                    List.of(
+                                                            TextBlock.builder()
+                                                                    .text("Done")
+                                                                    .build()))
+                                            .build());
+                        }) {
+                    @Override
+                    public boolean supportsNativeStructuredOutput() {
+                        return true;
+                    }
+                };
+
+        ReActAgent agent =
+                ReActAgent.builder()
+                        .name("fallback-agent")
+                        .sysPrompt("You are an assistant")
+                        .model(nativeThrowModel)
+                        .build();
+
+        Msg inputMsg =
+                Msg.builder()
+                        .name("user")
+                        .role(MsgRole.USER)
+                        .content(TextBlock.builder().text("Whats the weather?").build())
+                        .build();
+
+        Msg response = agent.call(inputMsg, WeatherResponse.class).block(Duration.ofSeconds(10));
+        assertNotNull(response);
+        WeatherResponse result = response.getStructuredData(WeatherResponse.class);
+        assertNotNull(result);
+        assertEquals("TestCity", result.location);
+        assertEquals("25°C", result.temperature);
+        assertEquals("Cloudy", result.condition);
     }
 }


### PR DESCRIPTION
## Problem

`OpenAIChatModel.supportsNativeStructuredOutput()` returns `true` for all OpenAI-compatible backends, but DeepSeek, vLLM, and other providers do not support `response_format`. This causes `agent.call(msg, OutputClass.class)` to fail with HTTP 400.

Fixes #1742, fixes #1720

## Changes

Three changes in `ReActAgent.java`:

**1. `doStructuredCall()` — catch native failures, route to fallback**

```java
return doNativeStructuredCall(msgs, jsonSchema)
        .onErrorResume(e -> {
            log.warn("Native structured output failed — falling back to synthetic tool path");
            return doFallbackStructuredCall(msgs, jsonSchema);
        });
```

**2. `doNativeStructuredCall()` — roll back context on failure**

Before starting `doCallInner`, snapshot the context size. On error via `doOnError`: roll back messages added by the failed native attempt, and clear `scope.nativeResponseFormat`. This prevents the native call's `addToContext(msgs)` from being duplicated when the fallback re-runs.

**3. `reasoning()` — guard native format in fallback mode**

```java
if (nativeResponseFormat != null \u0026\u0026 soTool == null) {
```

`nativeResponseFormat` and `soTool` are mutually exclusive — the guard prevents stale `nativeResponseFormat` from being injected during fallback, even if future code paths fail to clear it.

## Design

- **Auto-fallback, zero configuration.** No Builder flags, no user knowledge required. True OpenAI backends succeed on the native path; backends that crash now succeed via fallback.
- **Cleanup on failure, not retry.** `doNativeStructuredCall` is responsible for managing its own side effects — it uses `doOnError` to roll back context and clear scope state, then lets the error propagate to `doStructuredCall` which handles the fallback routing.