### PR TITLE
fix(harness): treat '.' as root in CompositeFilesystem route merging

### DIFF
--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/filesystem/CompositeFilesystem.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/filesystem/CompositeFilesystem.java
@@ -188,7 +188,7 @@ public class CompositeFilesystem implements AbstractFilesystem {
             return LsResult.success(remapped);
         }
 
-        if ("/".equals(path)) {
+        if ("/".equals(path) || ".".equals(path)) {
             List<FileInfo> results = new ArrayList<>();
             LsResult defaultResult = defaultBackend.ls(runtimeContext, path);
             if (defaultResult.isSuccess() && defaultResult.entries() != null) {
@@ -269,7 +269,7 @@ public class CompositeFilesystem implements AbstractFilesystem {
             }
         }
 
-        if (path == null || "/".equals(path)) {
+        if (path == null || "/".equals(path) || ".".equals(path)) {
             List<GrepMatch> allMatches = new ArrayList<>();
             GrepResult defaultResult = defaultBackend.grep(runtimeContext, pattern, path, glob);
             if (!defaultResult.isSuccess()) {
@@ -332,7 +332,7 @@ public class CompositeFilesystem implements AbstractFilesystem {
 
         // Non-root path that didn't match any route: delegate to default backend only.
         // Route scanning only makes sense for root-level recursive globs.
-        if (path != null && !"/".equals(path)) {
+        if (path != null && !"/".equals(path) && !".".equals(path)) {
             return defaultBackend.glob(runtimeContext, pattern, path);
         }
 

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/filesystem/CompositeFilesystemTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/filesystem/CompositeFilesystemTest.java
@@ -20,6 +20,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -28,6 +29,7 @@ import io.agentscope.harness.agent.filesystem.local.LocalFilesystem;
 import io.agentscope.harness.agent.filesystem.model.FileInfo;
 import io.agentscope.harness.agent.filesystem.model.FileUploadResponse;
 import io.agentscope.harness.agent.filesystem.model.GlobResult;
+import io.agentscope.harness.agent.filesystem.model.LsResult;
 import io.agentscope.harness.agent.filesystem.model.ReadResult;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -213,5 +215,30 @@ class CompositeFilesystemTest {
         assertTrue(jsonPaths.contains("tools.json"));
         assertFalse(
                 jsonPaths.contains("AGENTS.md"), "AGENTS.md must not match *.json: " + jsonPaths);
+    }
+
+    /**
+     * Regression for #1737: when path is "." (which WorkspacePathNormalizer returns for
+     * workspace root), route directories should still be merged into the listing.
+     */
+    @Test
+    void lsRoot_mergesRouteEntriesWhenPathIsDot() {
+        AbstractFilesystem routeBackend = mock(AbstractFilesystem.class);
+        when(routeBackend.ls(any(), anyString()))
+                .thenReturn(LsResult.success(List.of(FileInfo.ofFile("/SKILL.md", 10, ""))));
+
+        AbstractFilesystem defaultBackend = mock(AbstractFilesystem.class);
+        when(defaultBackend.ls(any(), anyString())).thenReturn(LsResult.success(List.of()));
+
+        CompositeFilesystem composite =
+                new CompositeFilesystem(defaultBackend, Map.of("/skills/", routeBackend));
+
+        LsResult result = composite.ls(CTX, ".");
+
+        assertTrue(result.isSuccess());
+        List<String> paths = result.entries().stream().map(FileInfo::path).toList();
+        assertTrue(
+                paths.stream().anyMatch(p -> p.startsWith("/skills")),
+                "route entries should appear when listing root with '.', got: " + paths);
     }
 }


### PR DESCRIPTION
## Problem

`WorkspacePathNormalizer` returns `"."` when the path equals the workspace prefix. In sandbox/remote mode where the workspace is `/workspace`, an LLM calling `list_files("/workspace")` results in `CompositeFilesystem.ls(".")`. However, `ls()`, `grep()`, and `glob()` only recognized `"/"` as root — `"."` was treated as a regular path and route directories (skills/, memory/, knowledge/, etc.) were silently excluded from listings.

Fixes #1737

## Changes

`CompositeFilesystem.java`:

- `ls()`: add `\|\| ".".equals(path)` to the root check
- `grep()`: add `\|\| ".".equals(path)` to the root check  
- `glob()`: add `&& !".".equals(path)` to the non-root early-return guard

`CompositeFilesystemTest.java`:

- Add `lsRoot_mergesRouteEntriesWhenPathIsDot` — verifies route entries appear when listing root with `"."`