### PR TITLE
docs(v2): fix incorrect getToolName() → getToolCallName() in documentation

### DIFF
--- a/docs/v2/en/docs/building-blocks/agent.md
+++ b/docs/v2/en/docs/building-blocks/agent.md
@@ -255,7 +255,7 @@ agent.streamEvents(new UserMessage("Summarize the README."))
                 System.out.print(((TextBlockDeltaEvent) event).getDelta());
             } else if (event.getType() == AgentEventType.TOOL_CALL_START) {
                 // The agent is about to call a tool — surface the call info
-                System.out.println("\n[tool] " + ((ToolCallStartEvent) event).getToolName());
+                System.out.println("\n[tool] " + ((ToolCallStartEvent) event).getToolCallName());
             }
             // Other events: thinking blocks, tool results, reply end, etc.
         })

--- a/docs/v2/en/docs/harness/plan-mode.md
+++ b/docs/v2/en/docs/harness/plan-mode.md
@@ -193,7 +193,7 @@ To observe task changes in real time through the event stream, listen for `todo_
 ```java
 agent.streamEvents(message)
     .filter(e -> e.getType() == AgentEventType.TOOL_RESULT_END)
-    .filter(e -> "todo_write".equals(((ToolResultEndEvent) e).getToolName()))
+    .filter(e -> "todo_write".equals(((ToolResultEndEvent) e).getToolCallName()))
     .doOnNext(e -> {
         // Re-read the latest task list from state
         var tasks = agent.getAgentState(userId, sessionId)

--- a/docs/v2/en/docs/harness/subagent.md
+++ b/docs/v2/en/docs/harness/subagent.md
@@ -361,7 +361,7 @@ parent.streamEvents(new UserMessage(message), ctx)
         if (event.getType() == AgentEventType.TEXT_BLOCK_DELTA) {
             System.out.print(prefix + ((TextBlockDeltaEvent) event).getDelta());
         } else if (event.getType() == AgentEventType.TOOL_CALL_START) {
-            System.out.println(prefix + "[tool] " + ((ToolCallStartEvent) event).getToolName());
+            System.out.println(prefix + "[tool] " + ((ToolCallStartEvent) event).getToolCallName());
         } else if (event.getType() == AgentEventType.AGENT_START) {
             if (src != null) System.out.println("── child started: " + src);
         } else if (event.getType() == AgentEventType.AGENT_END) {
@@ -402,7 +402,7 @@ public Flux<ServerSentEvent<String>> chat(@RequestParam String message,
                 if (event instanceof TextBlockDeltaEvent delta) {
                     payload.put("delta", delta.getDelta());
                 } else if (event instanceof ToolCallStartEvent start) {
-                    payload.put("toolName", start.getToolName());
+                    payload.put("toolName", start.getToolCallName());
                 }
                 return ServerSentEvent.<String>builder()
                         .data(objectMapper.writeValueAsString(payload))

--- a/docs/v2/en/docs/quickstart.md
+++ b/docs/v2/en/docs/quickstart.md
@@ -105,7 +105,7 @@ agent.streamEvents(new UserMessage("Summarize today in three bullets."))
                 System.out.print(((TextBlockDeltaEvent) event).getDelta());
             } else if (event.getType() == AgentEventType.TOOL_CALL_START) {
                 // The agent is about to call a tool — surface the call info
-                System.out.println("\n[tool] " + ((ToolCallStartEvent) event).getToolName());
+                System.out.println("\n[tool] " + ((ToolCallStartEvent) event).getToolCallName());
             }
             // Other events: thinking blocks, tool results, reply end, etc.
         })

--- a/docs/v2/zh/docs/building-blocks/agent.md
+++ b/docs/v2/zh/docs/building-blocks/agent.md
@@ -255,7 +255,7 @@ agent.streamEvents(new UserMessage("总结一下 README 的内容。"))
                 System.out.print(((TextBlockDeltaEvent) event).getDelta());
             } else if (event.getType() == AgentEventType.TOOL_CALL_START) {
                 // 智能体即将调用工具 —— 展示调用信息
-                System.out.println("\n[tool] " + ((ToolCallStartEvent) event).getToolName());
+                System.out.println("\n[tool] " + ((ToolCallStartEvent) event).getToolCallName());
             }
             // 其他事件：思考块、工具结果、回复结束等
         })

--- a/docs/v2/zh/docs/harness/plan-mode.md
+++ b/docs/v2/zh/docs/harness/plan-mode.md
@@ -193,7 +193,7 @@ GET /v1/admin/sessions/{sessionId}/tasks
 ```java
 agent.streamEvents(message)
     .filter(e -> e.getType() == AgentEventType.TOOL_RESULT_END)
-    .filter(e -> "todo_write".equals(((ToolResultEndEvent) e).getToolName()))
+    .filter(e -> "todo_write".equals(((ToolResultEndEvent) e).getToolCallName()))
     .doOnNext(e -> {
         // 从 state 中读取最新任务列表
         var tasks = agent.getAgentState(userId, sessionId)

--- a/docs/v2/zh/docs/harness/subagent.md
+++ b/docs/v2/zh/docs/harness/subagent.md
@@ -361,7 +361,7 @@ parent.streamEvents(new UserMessage(message), ctx)
         if (event.getType() == AgentEventType.TEXT_BLOCK_DELTA) {
             System.out.print(prefix + ((TextBlockDeltaEvent) event).getDelta());
         } else if (event.getType() == AgentEventType.TOOL_CALL_START) {
-            System.out.println(prefix + "[tool] " + ((ToolCallStartEvent) event).getToolName());
+            System.out.println(prefix + "[tool] " + ((ToolCallStartEvent) event).getToolCallName());
         } else if (event.getType() == AgentEventType.AGENT_START) {
             if (src != null) System.out.println("── 子 agent 启动: " + src);
         } else if (event.getType() == AgentEventType.AGENT_END) {
@@ -402,7 +402,7 @@ public Flux<ServerSentEvent<String>> chat(@RequestParam String message,
                 if (event instanceof TextBlockDeltaEvent delta) {
                     payload.put("delta", delta.getDelta());
                 } else if (event instanceof ToolCallStartEvent start) {
-                    payload.put("toolName", start.getToolName());
+                    payload.put("toolName", start.getToolCallName());
                 }
                 return ServerSentEvent.<String>builder()
                         .data(objectMapper.writeValueAsString(payload))

--- a/docs/v2/zh/docs/quickstart.md
+++ b/docs/v2/zh/docs/quickstart.md
@@ -105,7 +105,7 @@ agent.streamEvents(new UserMessage("帮我把今天的关键点列三条。"))
                 System.out.print(((TextBlockDeltaEvent) event).getDelta());
             } else if (event.getType() == AgentEventType.TOOL_CALL_START) {
                 // 智能体即将调用工具 —— 展示调用信息
-                System.out.println("\n[tool] " + ((ToolCallStartEvent) event).getToolName());
+                System.out.println("\n[tool] " + ((ToolCallStartEvent) event).getToolCallName());
             }
             // 其他事件：思考块、工具结果、回复结束等
         })


### PR DESCRIPTION
fix incorrect getToolName() → getToolCallName() in documentation

## AgentScope-Java Version

[2.0.0-RC1 → 2.0.0-RC3]

## Description

版本v2中的类[ToolCallStartEvent](https://github.com/agentscope-ai/agentscope-java/blame/release/2.0.0-RC3/agentscope-core/src/main/java/io/agentscope/core/event/ToolCallStartEvent.java)与[ToolResultEndEvent](https://github.com/agentscope-ai/agentscope-java/blob/release/2.0.0-RC3/agentscope-core/src/main/java/io/agentscope/core/event/ToolResultEndEvent.java)中，方法`getToolName()`已统一为`getToolCallName()`，而v2的文档漏做修改，现提交修正

In version v2, for the classes [ToolCallStartEvent](https://github.com/agentscope-ai/agentscope-java/blame/release/2.0.0-RC3/agentscope-core/src/main/java/io/agentscope/core/event/ToolCallStartEvent.java) and [ToolResultEndEvent](https://github.com/agentscope-ai/agentscope-java/blob/release/2.0.0-RC3/agentscope-core/src/main/java/io/agentscope/core/event/ToolResultEndEvent.java), the method `getToolName()` has been uniformly changed to `getToolCallName()`. However, the documentation for version v2 failed to make this correction. Now, the correction is being submitted.

## Checklist

Please check the following items before code is ready to be reviewed.

- [x]  Code has been formatted with `mvn spotless:apply`
- [x]  All tests are passing (`mvn test`)
- [x]  Javadoc comments are complete and follow project conventions
- [x]  Related documentation has been updated (e.g. links, examples, etc.)
- [x]  Code is ready for review
