### PR TITLE
fix(skill-runtime): use skill name instead of composite ID for SkillFilter matching …issues/1768

### DIFF
--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/skill/runtime/SkillPromptBuilder.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/skill/runtime/SkillPromptBuilder.java
@@ -128,8 +128,8 @@ public final class SkillPromptBuilder {
         boolean anyWithFilesRoot = false;
 
         for (HarnessSkillEntry entry : catalog.all()) {
-            String id = entry.skill().getSkillId();
-            if (!effective.isAllowed(id)) {
+            String skillName = entry.skill().getName();
+            if (!effective.isAllowed(skillName)) {
                 continue;
             }
             if (!any) {

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/skill/runtime/SkillRuntimeTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/skill/runtime/SkillRuntimeTest.java
@@ -114,7 +114,7 @@ class SkillRuntimeTest {
             HarnessSkillEntry visible = HarnessSkillEntry.of(skill("visible", "src"), null);
             HarnessSkillEntry hidden = HarnessSkillEntry.of(skill("hidden", "src"), null);
             SkillCatalog cat = SkillCatalog.of(List.of(visible, hidden));
-            SkillFilter only = SkillFilter.only("visible_src");
+            SkillFilter only = SkillFilter.only("visible");
 
             String out = new SkillPromptBuilder().render(cat, only);
             assertTrue(out.contains("<skill-id>visible_src</skill-id>"));
@@ -128,6 +128,26 @@ class SkillRuntimeTest {
                     "",
                     new SkillPromptBuilder()
                             .render(SkillCatalog.of(List.of(e)), SkillFilter.none()));
+        }
+
+        @Test
+        void filterWithBareNameMatchesCompositeId() {
+            HarnessSkillEntry visible =
+                    HarnessSkillEntry.of(
+                            skill("host-forensics-client", "filesystem-agentscope_skills"), null);
+            HarnessSkillEntry hidden =
+                    HarnessSkillEntry.of(
+                            skill("other-skill", "filesystem-agentscope_skills"), null);
+            SkillCatalog cat = SkillCatalog.of(List.of(visible, hidden));
+            // User passes bare skill name (the natural API usage)
+            SkillFilter only = SkillFilter.only("host-forensics-client");
+
+            String out = new SkillPromptBuilder().render(cat, only);
+            assertTrue(
+                    out.contains(
+                            "<skill-id>host-forensics-client_filesystem-agentscope_skills</skill-id>"));
+            assertFalse(
+                    out.contains("<skill-id>other-skill_filesystem-agentscope_skills</skill-id>"));
         }
     }
 


### PR DESCRIPTION
…issues/1768

## AgentScope-Java Version

2.0.0-SNAPSHOT

## Description

### Background

`SkillFilter.only("host-forensics-client")` does not work as expected when used with `HarnessAgent`. The whitelisted skill is silently filtered out, and the rendered skill prompt is empty.

### Root Cause

In `SkillPromptBuilder#render(SkillCatalog, SkillFilter)`, the code passes `entry.skill().getSkillId()` to `SkillFilter#isAllowed()`. However, `getSkillId()` returns a composite ID in the format `name_source` (e.g. `host-forensics-client_filesystem-agentscope_skills`), while users naturally pass bare skill names (e.g. `host-forensics-client`) to `SkillFilter.only(...)`. Since `isAllowed()` performs an exact `contains()` check, the match always fails, making WHITELIST / BLACKLIST / OVERLAY_ENABLE / OVERLAY_DISABLE modes effectively unusable.

### Fix

Replace `entry.skill().getSkillId()` with `entry.skill().getName()` in `SkillPromptBuilder#render()` so the filter key matches the bare skill name that users configure.

**Changed files:**
- `SkillPromptBuilder.java` — 1-line fix: `getSkillId()` → `getName()`
- `SkillRuntimeTest.java` — updated existing test to use bare name; added new test `filterWithBareNameMatchesCompositeId` that reproduces the reported scenario
