### PR TITLE
fix(harness): make session JSONL offload idempotent

### DIFF
--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/memory/MemoryFlushManager.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/memory/MemoryFlushManager.java
@@ -32,7 +32,9 @@ import java.nio.file.Path;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -244,7 +246,18 @@ public class MemoryFlushManager {
             // (cross-machine handoff) are included in the merged file pushed to remote.
             tree.syncFromRemote();
 
-            String lastId = null;
+            List<SessionEntry> existingEntries = new ArrayList<>(tree.getAllEntries());
+            Set<String> existingIds =
+                    existingEntries.stream()
+                            .map(SessionEntry::getId)
+                            .collect(Collectors.toCollection(HashSet::new));
+            String lastId =
+                    existingEntries.isEmpty()
+                            ? null
+                            : existingEntries.get(existingEntries.size() - 1).getId();
+
+            // The caller passes the full conversation on every turn. Use the stable Msg IDs
+            // to keep the session JSONL append-only and idempotent across repeated offloads.
             for (Msg msg : messages) {
                 if (msg.getRole() == null || isSessionContextMessage(msg)) {
                     continue;
@@ -253,11 +266,16 @@ public class MemoryFlushManager {
                 if (rendered == null || rendered.isBlank()) {
                     continue;
                 }
+                String entryId = normalizeEntryId(msg.getId());
+                if (entryId != null && existingIds.contains(entryId)) {
+                    continue;
+                }
                 String toolCallId = extractToolCallId(msg);
                 SessionEntry.MessageEntry entry =
                         new SessionEntry.MessageEntry(
-                                null, lastId, null, msg.getRole().name(), rendered, toolCallId);
+                                entryId, lastId, null, msg.getRole().name(), rendered, toolCallId);
                 tree.append(entry);
+                existingIds.add(entry.getId());
                 lastId = entry.getId();
             }
 
@@ -282,6 +300,10 @@ public class MemoryFlushManager {
             }
         }
         return null;
+    }
+
+    private static String normalizeEntryId(String id) {
+        return id != null && !id.isBlank() ? id : null;
     }
 
     /**

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/memory/MemoryFlushManager.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/memory/MemoryFlushManager.java
@@ -267,6 +267,11 @@ public class MemoryFlushManager {
                     continue;
                 }
                 String entryId = normalizeEntryId(msg.getId());
+                if (entryId == null) {
+                    log.warn(
+                            "Msg without stable ID encountered (role={}); dedup skipped",
+                            msg.getRole());
+                }
                 if (entryId != null && existingIds.contains(entryId)) {
                     continue;
                 }

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/memory/MemoryFlushManagerOffloadTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/memory/MemoryFlushManagerOffloadTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.harness.agent.memory;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import io.agentscope.core.agent.RuntimeContext;
+import io.agentscope.core.message.Msg;
+import io.agentscope.core.message.MsgRole;
+import io.agentscope.core.message.TextBlock;
+import io.agentscope.harness.agent.memory.session.SessionEntry;
+import io.agentscope.harness.agent.memory.session.SessionTree;
+import io.agentscope.harness.agent.workspace.WorkspaceManager;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class MemoryFlushManagerOffloadTest {
+
+    @TempDir Path workspace;
+
+    @Test
+    void offloadMessages_skipsAlreadyPersistedPrefix_andKeepsChain() throws Exception {
+        RuntimeContext rc = RuntimeContext.builder().sessionId("session-1").build();
+
+        try (WorkspaceManager workspaceManager = new WorkspaceManager(workspace)) {
+            MemoryFlushManager flushManager = new MemoryFlushManager(workspaceManager, null);
+
+            flushManager.offloadMessages(
+                    rc,
+                    List.of(
+                            message("m1", MsgRole.USER, "hello"),
+                            message("m2", MsgRole.ASSISTANT, "world")),
+                    "agent-a",
+                    "session-1");
+
+            flushManager.offloadMessages(
+                    rc,
+                    List.of(
+                            message("m1", MsgRole.USER, "hello"),
+                            message("m2", MsgRole.ASSISTANT, "world"),
+                            message("m3", MsgRole.USER, "follow-up"),
+                            message("m4", MsgRole.ASSISTANT, "reply")),
+                    "agent-a",
+                    "session-1");
+        }
+
+        Path context = workspace.resolve("agents/agent-a/sessions/session-1.jsonl");
+        assertEquals(4, Files.readAllLines(context).size(), "offload should stay idempotent");
+
+        SessionTree tree = new SessionTree(context, workspace, null);
+        tree.load();
+        assertEquals(4, tree.size());
+
+        List<SessionEntry.MessageEntry> entries = tree.getMessageEntries();
+        assertEquals(
+                List.of("m1", "m2", "m3", "m4"),
+                entries.stream().map(SessionEntry.MessageEntry::getId).toList());
+        assertEquals(
+                Arrays.asList(null, "m1", "m2", "m3"),
+                entries.stream().map(SessionEntry.MessageEntry::getParentId).toList());
+    }
+
+    private static Msg message(String id, MsgRole role, String text) {
+        return Msg.builder()
+                .id(id)
+                .role(role)
+                .content(TextBlock.builder().text(text).build())
+                .build();
+    }
+}

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/memory/MemoryFlushManagerOffloadTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/memory/MemoryFlushManagerOffloadTest.java
@@ -77,6 +77,52 @@ class MemoryFlushManagerOffloadTest {
                 entries.stream().map(SessionEntry.MessageEntry::getParentId).toList());
     }
 
+    @Test
+    void offloadMessages_nullAndBlankIds_stillAppendButDoNotBreakStableIds() throws Exception {
+        RuntimeContext rc = RuntimeContext.builder().sessionId("session-1").build();
+
+        try (WorkspaceManager workspaceManager = new WorkspaceManager(workspace)) {
+            MemoryFlushManager flushManager = new MemoryFlushManager(workspaceManager, null);
+
+            List<Msg> batch =
+                    List.of(
+                            message("m1", MsgRole.USER, "stable-hello"),
+                            message(null, MsgRole.ASSISTANT, "anonymous-null"),
+                            message("", MsgRole.USER, "anonymous-blank"),
+                            message("m2", MsgRole.ASSISTANT, "stable-world"));
+
+            flushManager.offloadMessages(rc, batch, "agent-a", "session-1");
+            flushManager.offloadMessages(rc, batch, "agent-a", "session-1");
+        }
+
+        Path context = workspace.resolve("agents/agent-a/sessions/session-1.jsonl");
+        SessionTree tree = new SessionTree(context, workspace, null);
+        tree.load();
+
+        List<SessionEntry.MessageEntry> entries = tree.getMessageEntries();
+        assertEquals(6, entries.size());
+        assertEquals(
+                1,
+                entries.stream()
+                        .filter(entry -> "stable-hello".equals(entry.getContent()))
+                        .count());
+        assertEquals(
+                1,
+                entries.stream()
+                        .filter(entry -> "stable-world".equals(entry.getContent()))
+                        .count());
+        assertEquals(
+                2,
+                entries.stream()
+                        .filter(entry -> "anonymous-null".equals(entry.getContent()))
+                        .count());
+        assertEquals(
+                2,
+                entries.stream()
+                        .filter(entry -> "anonymous-blank".equals(entry.getContent()))
+                        .count());
+    }
+
     private static Msg message(String id, MsgRole role, String text) {
         return Msg.builder()
                 .id(id)


### PR DESCRIPTION
## 现象
在 `HarnessAgent` 使用 `DistributedStore + RemoteFilesystemSpec` 时，同一个 session 多轮请求后，`agents/<agentId>/sessions/<sessionId>.jsonl` 会持续变大，历史消息会被重复写入。

## 复现步骤
1. 创建启用了分布式存储的 `HarnessAgent`
2. 同一 session 连续发送 2 次及以上消息
3. 检查 `contextFile` / `logFile` / DB 镜像内容

## 预期行为
- 已经 offload 过的历史消息不应再次被追加
- `flush()` 后的 session JSONL 应保持幂等，不应随请求次数重复膨胀

## 实际行为
- 第 2 次及后续请求会把历史消息再次写入文件末尾
- 文件和 DB 镜像都会随请求次数增长

## 影响
- session 文件持续膨胀
- 后续 `load()` / `syncFromRemote()` 成本越来越高
- 长时间运行的 agent 容易出现存储和性能问题

## 验收标准
- 连续多轮请求后，session JSONL 不应重复追加已有历史消息
- 回归测试应覆盖重复 flush、sync 去重和 DB 镜像一致性