### PR TITLE
fix(agui,harness): propagate runtime context and harden shell working_directory

### DIFF
--- a/agentscope-core/src/main/java/io/agentscope/core/agent/Agent.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/agent/Agent.java
@@ -17,6 +17,8 @@ package io.agentscope.core.agent;
 
 import io.agentscope.core.message.Msg;
 import io.agentscope.core.tool.Toolkit;
+import java.util.List;
+import reactor.core.publisher.Flux;
 
 /**
  * Complete agent interface combining all capabilities.
@@ -96,6 +98,22 @@ public interface Agent extends CallableAgent, StreamableAgent, ObservableAgent {
      */
     default io.agentscope.core.state.AgentState getAgentState() {
         return null;
+    }
+
+    /**
+     * Stream execution events with a per-call {@link RuntimeContext}.
+     *
+     * <p>The default implementation preserves backward compatibility by delegating to
+     * {@link #stream(List, StreamOptions)} when an implementation does not override this overload.
+     *
+     * @param msgs Input messages
+     * @param options Stream configuration options
+     * @param runtimeContext Per-call runtime context, or {@code null}
+     * @return Flux of events emitted during execution
+     */
+    default Flux<Event> stream(
+            List<Msg> msgs, StreamOptions options, RuntimeContext runtimeContext) {
+        return stream(msgs, options);
     }
 
     /**

--- a/agentscope-core/src/test/java/io/agentscope/core/agent/AgentStreamingTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/agent/AgentStreamingTest.java
@@ -47,6 +47,7 @@ class AgentStreamingTest {
     static class TestStreamingAgent extends AgentBase {
         private String responseText = "Test response";
         private boolean shouldFail = false;
+        private final AtomicInteger legacyStreamCallCount = new AtomicInteger();
 
         TestStreamingAgent(String name) {
             super(name);
@@ -58,6 +59,10 @@ class AgentStreamingTest {
 
         void setShouldFail(boolean shouldFail) {
             this.shouldFail = shouldFail;
+        }
+
+        int getLegacyStreamCallCount() {
+            return legacyStreamCallCount.get();
         }
 
         @Override
@@ -73,6 +78,12 @@ class AgentStreamingTest {
                             .content(TextBlock.builder().text(responseText).build())
                             .build();
             return Mono.just(response);
+        }
+
+        @Override
+        public reactor.core.publisher.Flux<Event> stream(List<Msg> msgs, StreamOptions options) {
+            legacyStreamCallCount.incrementAndGet();
+            return super.stream(msgs, options);
         }
 
         @Override
@@ -229,6 +240,29 @@ class AgentStreamingTest {
         assertFalse(events.isEmpty());
         Event lastEvent = events.get(events.size() - 1);
         assertEquals(EventType.AGENT_RESULT, lastEvent.getType());
+    }
+
+    @Test
+    void testThreeArgStreamFallsBackToLegacyImplementation() {
+        TestStreamingAgent agent = new TestStreamingAgent("test-agent");
+        agent.setResponseText("Response");
+
+        List<Msg> inputMsgs =
+                List.of(
+                        Msg.builder()
+                                .name("user")
+                                .role(MsgRole.USER)
+                                .content(List.of(TextBlock.builder().text("Hello").build()))
+                                .build());
+
+        StreamOptions options = StreamOptions.builder().build();
+        RuntimeContext runtimeContext = RuntimeContext.builder().sessionId("sess-1").build();
+
+        List<Event> events = new ArrayList<>();
+        agent.stream(inputMsgs, options, runtimeContext).doOnNext(events::add).blockLast();
+
+        assertFalse(events.isEmpty());
+        assertEquals(1, agent.getLegacyStreamCallCount());
     }
 
     @Test

--- a/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/main/java/io/agentscope/core/agui/adapter/AguiAgentAdapter.java
+++ b/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/main/java/io/agentscope/core/agui/adapter/AguiAgentAdapter.java
@@ -18,6 +18,7 @@ package io.agentscope.core.agui.adapter;
 import io.agentscope.core.agent.Agent;
 import io.agentscope.core.agent.Event;
 import io.agentscope.core.agent.EventType;
+import io.agentscope.core.agent.RuntimeContext;
 import io.agentscope.core.agent.StreamOptions;
 import io.agentscope.core.agui.converter.AguiMessageConverter;
 import io.agentscope.core.agui.event.AguiEvent;
@@ -89,6 +90,17 @@ public class AguiAgentAdapter {
      * @return A Flux of AG-UI events
      */
     public Flux<AguiEvent> run(RunAgentInput input) {
+        return run(input, null);
+    }
+
+    /**
+     * Run the agent with AG-UI protocol input and a per-call runtime context.
+     *
+     * @param input The AG-UI run input
+     * @param runtimeContext Per-call runtime context, or {@code null}
+     * @return A Flux of AG-UI events
+     */
+    public Flux<AguiEvent> run(RunAgentInput input, RuntimeContext runtimeContext) {
         return Flux.defer(
                 () -> {
                     String threadId = input.getThreadId();
@@ -107,13 +119,18 @@ public class AguiAgentAdapter {
                     // Track state for event conversion
                     EventConversionState state = new EventConversionState(threadId, runId);
 
+                    Flux<Event> agentStream =
+                            runtimeContext != null
+                                    ? agent.stream(msgs, options, runtimeContext)
+                                    : agent.stream(msgs, options);
+
                     return Flux.concat(
                                     // Emit RUN_STARTED
                                     Flux.just(new AguiEvent.RunStarted(threadId, runId)),
                                     // Stream agent events and convert to AG-UI events
                                     // Use concatMapIterable to preserve strict event ordering
-                                    agent.stream(msgs, options)
-                                            .concatMapIterable(event -> convertEvent(event, state)),
+                                    agentStream.concatMapIterable(
+                                            event -> convertEvent(event, state)),
                                     // Emit any pending end events and RUN_FINISHED
                                     Flux.defer(() -> finishRun(state)))
                             .onErrorResume(

--- a/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/main/java/io/agentscope/core/agui/processor/AguiRequestProcessor.java
+++ b/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/main/java/io/agentscope/core/agui/processor/AguiRequestProcessor.java
@@ -16,6 +16,7 @@
 package io.agentscope.core.agui.processor;
 
 import io.agentscope.core.agent.Agent;
+import io.agentscope.core.agent.RuntimeContext;
 import io.agentscope.core.agui.adapter.AguiAdapterConfig;
 import io.agentscope.core.agui.adapter.AguiAgentAdapter;
 import io.agentscope.core.agui.event.AguiEvent;
@@ -85,6 +86,23 @@ public class AguiRequestProcessor {
      * @return A ProcessResult containing the agent and event stream
      */
     public ProcessResult process(RunAgentInput input, String headerAgentId, String pathAgentId) {
+        return process(input, headerAgentId, pathAgentId, null);
+    }
+
+    /**
+     * Process an AG-UI request with an explicit runtime context.
+     *
+     * @param input The run agent input
+     * @param headerAgentId The agent ID from HTTP header (may be null)
+     * @param pathAgentId The agent ID from URL path variable (may be null)
+     * @param runtimeContext Per-call runtime context, or {@code null}
+     * @return A ProcessResult containing the agent and event stream
+     */
+    public ProcessResult process(
+            RunAgentInput input,
+            String headerAgentId,
+            String pathAgentId,
+            RuntimeContext runtimeContext) {
         String threadId = input.getThreadId();
 
         // Resolve agent ID
@@ -104,7 +122,11 @@ public class AguiRequestProcessor {
 
         // Create adapter and run
         AguiAgentAdapter adapter = new AguiAgentAdapter(agent, config);
-        Flux<AguiEvent> events = adapter.run(effectiveInput);
+        RuntimeContext effectiveRuntimeContext =
+                runtimeContext != null
+                        ? runtimeContext
+                        : RuntimeContext.builder().sessionId(threadId).build();
+        Flux<AguiEvent> events = adapter.run(effectiveInput, effectiveRuntimeContext);
 
         return new ProcessResult(agent, events);
     }

--- a/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/test/java/io/agentscope/core/agui/adapter/AguiAgentAdapterTest.java
+++ b/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/test/java/io/agentscope/core/agui/adapter/AguiAgentAdapterTest.java
@@ -22,11 +22,13 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.agentscope.core.agent.Agent;
 import io.agentscope.core.agent.Event;
 import io.agentscope.core.agent.EventType;
+import io.agentscope.core.agent.RuntimeContext;
 import io.agentscope.core.agent.StreamOptions;
 import io.agentscope.core.agui.event.AguiEvent;
 import io.agentscope.core.agui.model.AguiMessage;
@@ -41,6 +43,7 @@ import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import reactor.core.publisher.Flux;
 import reactor.test.StepVerifier;
 
@@ -81,6 +84,32 @@ class AguiAgentAdapterTest {
         AguiEvent.RunStarted started = (AguiEvent.RunStarted) events.get(0);
         assertEquals("thread-1", started.getThreadId());
         assertEquals("run-1", started.getRunId());
+    }
+
+    @Test
+    void testRunWithRuntimeContextUsesContextAwareStream() {
+        RuntimeContext runtimeContext =
+                RuntimeContext.builder().sessionId("session-1").userId("alice").build();
+
+        when(mockAgent.stream(anyList(), any(StreamOptions.class), any(RuntimeContext.class)))
+                .thenReturn(Flux.empty());
+
+        RunAgentInput input =
+                RunAgentInput.builder()
+                        .threadId("thread-1")
+                        .runId("run-1")
+                        .messages(List.of(AguiMessage.userMessage("msg-1", "Hello")))
+                        .build();
+
+        List<AguiEvent> events = adapter.run(input, runtimeContext).collectList().block();
+
+        assertNotNull(events);
+        assertEquals(2, events.size());
+
+        ArgumentCaptor<RuntimeContext> captor = ArgumentCaptor.forClass(RuntimeContext.class);
+        verify(mockAgent).stream(anyList(), any(StreamOptions.class), captor.capture());
+        assertEquals("session-1", captor.getValue().getSessionId());
+        assertEquals("alice", captor.getValue().getUserId());
     }
 
     @Test

--- a/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/test/java/io/agentscope/core/agui/processor/AguiRequestProcessorTest.java
+++ b/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/test/java/io/agentscope/core/agui/processor/AguiRequestProcessorTest.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.core.agui.processor;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.same;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.agentscope.core.agent.Agent;
+import io.agentscope.core.agent.Event;
+import io.agentscope.core.agent.EventType;
+import io.agentscope.core.agent.RuntimeContext;
+import io.agentscope.core.agent.StreamOptions;
+import io.agentscope.core.agui.adapter.AguiAdapterConfig;
+import io.agentscope.core.agui.event.AguiEvent;
+import io.agentscope.core.agui.model.AguiMessage;
+import io.agentscope.core.agui.model.RunAgentInput;
+import io.agentscope.core.message.Msg;
+import io.agentscope.core.message.MsgRole;
+import io.agentscope.core.message.TextBlock;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import reactor.core.publisher.Flux;
+
+class AguiRequestProcessorTest {
+
+    @Test
+    void processSeedsRuntimeContextFromThreadIdWhenAbsent() {
+        AgentResolver resolver = mock(AgentResolver.class);
+        Agent agent = mock(Agent.class);
+        AguiRequestProcessor processor =
+                AguiRequestProcessor.builder()
+                        .agentResolver(resolver)
+                        .config(AguiAdapterConfig.defaultConfig())
+                        .build();
+
+        RunAgentInput input =
+                RunAgentInput.builder()
+                        .threadId("thread-1")
+                        .runId("run-1")
+                        .messages(List.of(AguiMessage.userMessage("msg-1", "Hello")))
+                        .build();
+
+        when(resolver.resolveAgent("default", "thread-1")).thenReturn(agent);
+        when(resolver.hasMemory("thread-1")).thenReturn(false);
+
+        Msg assistantMsg =
+                Msg.builder()
+                        .id("assistant-1")
+                        .role(MsgRole.ASSISTANT)
+                        .content(TextBlock.builder().text("ok").build())
+                        .build();
+        Event event = new Event(EventType.REASONING, assistantMsg, true);
+        when(agent.stream(anyList(), any(StreamOptions.class), any(RuntimeContext.class)))
+                .thenReturn(Flux.just(event));
+
+        AguiRequestProcessor.ProcessResult result = processor.process(input, null, null);
+        List<AguiEvent> events = result.events().collectList().block();
+
+        assertNotNull(events);
+        assertEquals(4, events.size());
+
+        ArgumentCaptor<RuntimeContext> captor = ArgumentCaptor.forClass(RuntimeContext.class);
+        verify(agent).stream(anyList(), any(StreamOptions.class), captor.capture());
+        assertEquals("thread-1", captor.getValue().getSessionId());
+        assertNull(captor.getValue().getUserId());
+    }
+
+    @Test
+    void processUsesProvidedRuntimeContext() {
+        AgentResolver resolver = mock(AgentResolver.class);
+        Agent agent = mock(Agent.class);
+        AguiRequestProcessor processor =
+                AguiRequestProcessor.builder()
+                        .agentResolver(resolver)
+                        .config(AguiAdapterConfig.defaultConfig())
+                        .build();
+
+        RuntimeContext runtimeContext =
+                RuntimeContext.builder().sessionId("session-override").userId("alice").build();
+
+        RunAgentInput input =
+                RunAgentInput.builder()
+                        .threadId("thread-1")
+                        .runId("run-1")
+                        .messages(List.of(AguiMessage.userMessage("msg-1", "Hello")))
+                        .build();
+
+        when(resolver.resolveAgent("default", "thread-1")).thenReturn(agent);
+        when(resolver.hasMemory("thread-1")).thenReturn(false);
+        when(agent.stream(anyList(), any(StreamOptions.class), same(runtimeContext)))
+                .thenReturn(Flux.empty());
+
+        AguiRequestProcessor.ProcessResult result =
+                processor.process(input, null, null, runtimeContext);
+        List<AguiEvent> events = result.events().collectList().block();
+
+        assertNotNull(events);
+        assertEquals(2, events.size());
+        verify(agent).stream(anyList(), any(StreamOptions.class), same(runtimeContext));
+    }
+}

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/tool/ShellExecuteTool.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/tool/ShellExecuteTool.java
@@ -20,6 +20,9 @@ import io.agentscope.core.tool.Tool;
 import io.agentscope.core.tool.ToolParam;
 import io.agentscope.harness.agent.filesystem.model.ExecuteResponse;
 import io.agentscope.harness.agent.filesystem.sandbox.AbstractSandboxFilesystem;
+import io.agentscope.harness.agent.filesystem.util.FilesystemUtils;
+import java.nio.file.InvalidPathException;
+import java.nio.file.Path;
 
 /**
  * Shell execution tool backed by a {@link AbstractSandboxFilesystem}.
@@ -55,7 +58,11 @@ public class ShellExecuteTool {
                     int timeout) {
         String effectiveCommand = command;
         if (workingDirectory != null && !workingDirectory.isBlank()) {
-            effectiveCommand = "cd " + workingDirectory + " && " + command;
+            effectiveCommand =
+                    "cd "
+                            + FilesystemUtils.shellQuote(validateWorkingDirectory(workingDirectory))
+                            + " && "
+                            + command;
         }
 
         ExecuteResponse result =
@@ -70,5 +77,38 @@ public class ShellExecuteTool {
             sb.append("\n(output was truncated)");
         }
         return sb.toString();
+    }
+
+    private static String validateWorkingDirectory(String workingDirectory) {
+        if (workingDirectory == null || workingDirectory.isBlank()) {
+            throw new IllegalArgumentException("working_directory must not be null or blank");
+        }
+        if (isAbsoluteWorkingDirectory(workingDirectory)) {
+            throw new IllegalArgumentException(
+                    "working_directory must be relative: " + workingDirectory);
+        }
+        try {
+            for (Path segment : Path.of(workingDirectory)) {
+                if ("..".equals(segment.toString())) {
+                    throw new IllegalArgumentException(
+                            "working_directory may not contain '..': " + workingDirectory);
+                }
+            }
+        } catch (InvalidPathException e) {
+            throw new IllegalArgumentException("Invalid working_directory: " + workingDirectory, e);
+        }
+        return workingDirectory;
+    }
+
+    private static boolean isAbsoluteWorkingDirectory(String workingDirectory) {
+        return workingDirectory.startsWith("/")
+                || workingDirectory.startsWith("\\")
+                || isWindowsDriveAbsolute(workingDirectory);
+    }
+
+    private static boolean isWindowsDriveAbsolute(String workingDirectory) {
+        return workingDirectory.length() >= 2
+                && Character.isLetter(workingDirectory.charAt(0))
+                && workingDirectory.charAt(1) == ':';
     }
 }

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/tool/ShellExecuteTool.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/tool/ShellExecuteTool.java
@@ -83,6 +83,10 @@ public class ShellExecuteTool {
         if (workingDirectory == null || workingDirectory.isBlank()) {
             throw new IllegalArgumentException("working_directory must not be null or blank");
         }
+        if (workingDirectory.indexOf('\0') >= 0) {
+            throw new IllegalArgumentException(
+                    "working_directory must not contain null bytes: " + workingDirectory);
+        }
         if (isAbsoluteWorkingDirectory(workingDirectory)) {
             throw new IllegalArgumentException(
                     "working_directory must be relative: " + workingDirectory);

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/tool/ShellExecuteToolTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/tool/ShellExecuteToolTest.java
@@ -62,6 +62,15 @@ class ShellExecuteToolTest {
                 () -> tool.execute(runtimeContext, "pwd", "/tmp", 15));
         assertThrows(
                 IllegalArgumentException.class,
+                () -> tool.execute(runtimeContext, "pwd", "C:\\tmp", 15));
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> tool.execute(runtimeContext, "pwd", "\\\\server\\share", 15));
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> tool.execute(runtimeContext, "pwd", "safe\0dir", 15));
+        assertThrows(
+                IllegalArgumentException.class,
                 () -> tool.execute(runtimeContext, "pwd", "../outside", 15));
         assertThrows(
                 IllegalArgumentException.class,

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/tool/ShellExecuteToolTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/tool/ShellExecuteToolTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.harness.agent.tool;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.same;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.agentscope.core.agent.RuntimeContext;
+import io.agentscope.harness.agent.filesystem.model.ExecuteResponse;
+import io.agentscope.harness.agent.filesystem.sandbox.AbstractSandboxFilesystem;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+class ShellExecuteToolTest {
+
+    @Test
+    void executeQuotesWorkingDirectoryBeforeShellCommand() {
+        AbstractSandboxFilesystem sandbox = mock(AbstractSandboxFilesystem.class);
+        ShellExecuteTool tool = new ShellExecuteTool(sandbox);
+        RuntimeContext runtimeContext = RuntimeContext.builder().sessionId("sess-1").build();
+
+        when(sandbox.execute(any(), anyString(), anyInt()))
+                .thenReturn(new ExecuteResponse("hello", 0, false));
+
+        String result = tool.execute(runtimeContext, "pwd", "nested dir/o'clock", 15);
+
+        assertEquals("Exit code: 0\n\nhello", result);
+
+        ArgumentCaptor<String> commandCaptor = ArgumentCaptor.forClass(String.class);
+        verify(sandbox).execute(same(runtimeContext), commandCaptor.capture(), eq(15));
+        assertEquals("cd 'nested dir/o'\\''clock' && pwd", commandCaptor.getValue());
+    }
+
+    @Test
+    void executeRejectsUnsafeWorkingDirectoryValues() {
+        ShellExecuteTool tool = new ShellExecuteTool(mock(AbstractSandboxFilesystem.class));
+        RuntimeContext runtimeContext = RuntimeContext.empty();
+
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> tool.execute(runtimeContext, "pwd", "/tmp", 15));
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> tool.execute(runtimeContext, "pwd", "../outside", 15));
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> tool.execute(runtimeContext, "pwd", "safe/../../outside", 15));
+    }
+}


### PR DESCRIPTION
## What
- 为 AGUI 请求链路补上 `RuntimeContext` 透传，避免通过 AGUI 进入时丢失会话上下文。
- 收紧 `ShellExecuteTool` 的 `working_directory`，拒绝绝对路径和 `..` 逃逸，并对 `cd` 参数做 shell quoting。

## Why
- 解决 issue #1777 中的两个问题：
  - AGUI 路径缺少 per-call runtime context
  - shell 工具的工作目录可能逃出命名空间

## Tests
- `mvn -pl agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui,agentscope-harness -am -DskipITs test "-Dtest=AguiAgentAdapterTest,AguiRequestProcessorTest,ShellExecuteToolTest"`