### PR TITLE
fix(mysql): 修复 JdbcStore 在 utf8mb4 下初始化表失败

### DIFF
--- a/agentscope-extensions/agentscope-extensions-mysql/src/main/java/io/agentscope/extensions/mysql/store/MysqlJdbcStoreDialect.java
+++ b/agentscope-extensions/agentscope-extensions-mysql/src/main/java/io/agentscope/extensions/mysql/store/MysqlJdbcStoreDialect.java
@@ -20,9 +20,10 @@ public class MysqlJdbcStoreDialect implements JdbcStoreDialect {
 
     @Override
     public String getCreateTableSql() {
+        // Keep the composite primary key under InnoDB's utf8mb4 3072-byte limit.
         return "CREATE TABLE IF NOT EXISTS %s ("
-                + "  namespace_path VARCHAR(768)  NOT NULL,"
-                + "  item_key       VARCHAR(190)  NOT NULL,"
+                + "  namespace_path VARCHAR(512)  NOT NULL,"
+                + "  item_key       VARCHAR(255)  NOT NULL,"
                 + "  value_json     LONGTEXT      NOT NULL,"
                 + "  version        BIGINT        NOT NULL,"
                 + "  updated_at     BIGINT        NOT NULL,"

--- a/agentscope-extensions/agentscope-extensions-mysql/src/test/java/io/agentscope/extensions/mysql/store/MysqlJdbcStoreDialectTest.java
+++ b/agentscope-extensions/agentscope-extensions-mysql/src/test/java/io/agentscope/extensions/mysql/store/MysqlJdbcStoreDialectTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.extensions.mysql.store;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.junit.jupiter.api.Test;
+
+class MysqlJdbcStoreDialectTest {
+
+    private static final int INNODB_UTF8MB4_INDEX_LIMIT_BYTES = 3072;
+    private static final int UTF8MB4_MAX_BYTES_PER_CHAR = 4;
+
+    @Test
+    void createTablePrimaryKeyFitsInnoDbUtf8mb4Limit() {
+        String ddl = new MysqlJdbcStoreDialect().getCreateTableSql();
+
+        int namespacePathLength = varcharLength(ddl, "namespace_path");
+        int itemKeyLength = varcharLength(ddl, "item_key");
+        long compositePkBytes =
+                (long) (namespacePathLength + itemKeyLength) * UTF8MB4_MAX_BYTES_PER_CHAR;
+
+        assertTrue(
+                compositePkBytes <= INNODB_UTF8MB4_INDEX_LIMIT_BYTES,
+                () ->
+                        String.format(
+                                "Composite PK is %d bytes, over the InnoDB utf8mb4 limit of %d"
+                                        + " bytes",
+                                compositePkBytes, INNODB_UTF8MB4_INDEX_LIMIT_BYTES));
+    }
+
+    private static int varcharLength(String ddl, String columnName) {
+        Matcher matcher =
+                Pattern.compile("(?i)\\b" + Pattern.quote(columnName) + "\\s+VARCHAR\\((\\d+)\\)")
+                        .matcher(ddl);
+        if (!matcher.find()) {
+            throw new IllegalStateException("Missing VARCHAR definition for " + columnName);
+        }
+        return Integer.parseInt(matcher.group(1));
+    }
+}


### PR DESCRIPTION
## 关联 Issue
- Fixes #1765

## 背景
MySQL/MariaDB 下 `agentscope_store` 的联合主键在 `utf8mb4` 编码下超过 InnoDB 3072 字节限制，导致 schema 初始化失败。

## 修改
- 将 MySQL 方言中的 `namespace_path` 调整为 `VARCHAR(512)`
- 将 `item_key` 调整为 `VARCHAR(255)`
- 新增回归测试，校验联合主键长度不超过 InnoDB 的 `utf8mb4` 限制

## 验证
- `mvn -pl agentscope-extensions/agentscope-extensions-mysql -am -Dtest=MysqlJdbcStoreDialectTest test`