### PR TITLE
fix(SubAgentTool): interrupt orphan sub-agent on tool call cancellation

### DIFF
--- a/agentscope-core/src/main/java/io/agentscope/core/tool/ToolExecutor.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/tool/ToolExecutor.java
@@ -453,7 +453,10 @@ class ToolExecutor {
                         .doBeforeRetry(
                                 signal ->
                                         logger.warn(
-                                                "Retrying tool call (attempt {}/{}) due to: {}",
+                                                "Retrying tool call '{}' (attempt {}/{}) due to:"
+                                                    + " {}. The previous attempt is cancelled and"
+                                                    + " may still be consuming resources.",
+                                                toolCall.getName(),
                                                 signal.totalRetriesInARow() + 1,
                                                 maxAttempts - 1,
                                                 signal.failure().getMessage(),

--- a/agentscope-core/src/main/java/io/agentscope/core/tool/subagent/SubAgentTool.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/tool/subagent/SubAgentTool.java
@@ -40,6 +40,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
+import reactor.core.publisher.SignalType;
 
 /**
  * AgentTool implementation that wraps a sub-agent for multi-turn conversation.
@@ -187,6 +188,27 @@ public class SubAgentTool implements AgentTool {
                                             agent, userMsg, finalSessionId, runtimeContext);
                         }
 
+                        // Interrupt the sub-agent when the subscription is cancelled
+                        // (e.g. ToolExecutor timeout triggers a retry on a new subscription).
+                        // Without this, the orphan agent keeps consuming LLM tokens, SSH
+                        // connections, and thread pool resources until it finishes naturally.
+                        //
+                        // Uses doFinally(CANCEL) rather than doOnCancel because doOnCancel
+                        // also fires on normal error propagation cleanup, which would
+                        // attempt to interrupt an already-failed agent.
+                        //
+                        // Uses interrupt(RuntimeContext) instead of the deprecated
+                        // interrupt(InterruptSource) because the latter only looks up
+                        // `defaultSessionId` which may differ from the session the call
+                        // actually runs in.
+                        result =
+                                result.doFinally(
+                                        signal -> {
+                                            if (signal == SignalType.CANCEL) {
+                                                interruptAgent(agent, runtimeContext);
+                                            }
+                                        });
+
                         // Save state after execution
                         return result.doOnSuccess(r -> saveAgentState(finalSessionId, agent));
                     } catch (Exception e) {
@@ -196,6 +218,21 @@ public class SubAgentTool implements AgentTool {
                                         "AgentStateStore setup failed: " + e.getMessage()));
                     }
                 });
+    }
+
+    /**
+     * Interrupts the sub-agent when the tool call is cancelled (e.g. by timeout-triggered
+     * retry), preventing it from becoming an orphan agent that silently consumes resources.
+     */
+    private void interruptAgent(Agent agent, RuntimeContext ctx) {
+        if (agent instanceof ReActAgent ra) {
+            ra.interrupt(ctx);
+            logger.warn(
+                    "Sub-agent '{}' (id={}) was interrupted because its tool call subscription "
+                            + "was cancelled.",
+                    ra.getName(),
+                    ra.getAgentId());
+        }
     }
 
     /**

--- a/agentscope-core/src/test/java/io/agentscope/core/tool/subagent/SubAgentToolCancellationTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/tool/subagent/SubAgentToolCancellationTest.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.core.tool.subagent;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.verify;
+
+import io.agentscope.core.ReActAgent;
+import io.agentscope.core.agent.RuntimeContext;
+import io.agentscope.core.message.Msg;
+import io.agentscope.core.message.ToolResultBlock;
+import io.agentscope.core.tool.ToolCallParam;
+import io.agentscope.core.tool.ToolEmitter;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.mockito.Mockito;
+import reactor.core.publisher.Mono;
+
+/**
+ * Unit test: verifies that disposing a SubAgentTool subscription triggers
+ * interrupt() on the agent AND cancels the agent's execution Mono.
+ */
+@DisplayName("SubAgentTool cancellation interrupts and cancels orphan sub-agent")
+class SubAgentToolCancellationTest {
+
+    @Test
+    @DisplayName("dispose() → interrupt() called + agent Mono cancelled")
+    @Timeout(value = 20, unit = TimeUnit.SECONDS)
+    void shouldInterruptOnCancel() throws Exception {
+        // Build a real ReActAgent, then spy on it.
+        ReActAgent realAgent =
+                ReActAgent.builder()
+                        .name("testBlockingAgent")
+                        .sysPrompt("You are a test agent.")
+                        .maxIters(1)
+                        .build();
+        ReActAgent spyAgent = Mockito.spy(realAgent);
+
+        // Signal when call() is entered.
+        CountDownLatch enteredCall = new CountDownLatch(1);
+
+        // Proof instrumentation: the agent's Mono was subscribed AND cancelled.
+        AtomicBoolean monoSubscribed = new AtomicBoolean(false);
+        AtomicBoolean monoCancelled = new AtomicBoolean(false);
+
+        Mockito.doAnswer(
+                        inv -> {
+                            enteredCall.countDown();
+                            return Mono.<Msg>never()
+                                    .doOnSubscribe(s -> monoSubscribed.set(true))
+                                    .doOnCancel(() -> monoCancelled.set(true));
+                        })
+                .when(spyAgent)
+                .call(anyList(), any(RuntimeContext.class));
+
+        SubAgentTool tool =
+                new SubAgentTool(
+                        () -> spyAgent, SubAgentConfig.builder().forwardEvents(false).build());
+
+        ToolEmitter emitter = Mockito.mock(ToolEmitter.class);
+        RuntimeContext rtCtx =
+                RuntimeContext.builder().sessionId("test-session").userId("test-user").build();
+
+        ToolCallParam param =
+                ToolCallParam.builder()
+                        .toolUseBlock(
+                                io.agentscope.core.message.ToolUseBlock.builder()
+                                        .id("call_test_1")
+                                        .name("call_subtask_agent")
+                                        .input(Map.of("message", "diagnose node 10.0.0.1"))
+                                        .build())
+                        .input(Map.of("message", "diagnose node 10.0.0.1"))
+                        .runtimeContext(rtCtx)
+                        .emitter(emitter)
+                        .build();
+
+        // ── Act ──────────────────────────────────────────────────────────────
+        Mono<ToolResultBlock> mono = tool.callAsync(param);
+        var disposable = mono.subscribe(result -> {}, error -> {});
+
+        assertTrue(enteredCall.await(10, TimeUnit.SECONDS), "Agent should start executing");
+        assertTrue(monoSubscribed.get(), "Agent Mono should be subscribed");
+
+        // Cancel (simulating Mono.timeout cancel signal inside ToolExecutor).
+        disposable.dispose();
+
+        // ── Assert ───────────────────────────────────────────────────────────
+        // 1. interrupt() was called on the agent.
+        boolean interrupted = false;
+        long deadline = System.currentTimeMillis() + 10_000;
+        while (System.currentTimeMillis() < deadline) {
+            try {
+                verify(spyAgent).interrupt(any(RuntimeContext.class));
+                interrupted = true;
+                break;
+            } catch (org.mockito.exceptions.base.MockitoAssertionError e) {
+                Thread.sleep(200);
+            }
+        }
+        assertTrue(interrupted, "interrupt() should have been called");
+
+        // 2. The agent's Mono was cancelled (execution stopped, not leaked).
+        assertTrue(monoCancelled.get(), "Agent's execution Mono should be cancelled, not leaking");
+    }
+}

--- a/agentscope-core/src/test/java/io/agentscope/core/tool/subagent/SubAgentToolTimeoutRetryIntegrationTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/tool/subagent/SubAgentToolTimeoutRetryIntegrationTest.java
@@ -1,0 +1,220 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.core.tool.subagent;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import io.agentscope.core.ReActAgent;
+import io.agentscope.core.agent.RuntimeContext;
+import io.agentscope.core.agent.test.MockModel;
+import io.agentscope.core.message.TextBlock;
+import io.agentscope.core.message.ToolResultBlock;
+import io.agentscope.core.tool.AgentTool;
+import io.agentscope.core.tool.ToolCallParam;
+import io.agentscope.core.tool.ToolEmitter;
+import io.agentscope.core.tool.Toolkit;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.Map;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.mockito.Mockito;
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
+
+/**
+ * End-to-end: real SubAgentTool with real ReActAgent sub-agent.
+ *
+ * <p>The slow sub-agent uses MockModel that returns a tool call to "slow_tool",
+ * which sleeps 4 seconds then writes one line to a temp file.
+ *
+ * <p>SubAgentTool applies {@code .timeout(3s).retryWhen(1)}. After timeout,
+ * {@code doFinally(CANCEL)} calls {@code interrupt(ctx)} → sets internal flag.
+ * When slow_tool finishes at ~4s, the agent loop hits {@code checkInterrupted()}
+ * and throws {@code InterruptedException}, stopping the agent before it can
+ * make another LLM call or tool call.
+ *
+ * <p>The test verifies:
+ * <ol>
+ *   <li>interrupt() was called on the slow agent (not the fast one)</li>
+ *   <li>slow_tool wrote exactly 1 line to file</li>
+ *   <li>After waiting, no more lines appear (loop is dead)</li>
+ *   <li>MockModel.getCallCount() == 1: interrupt prevented the second LLM call</li>
+ * </ol>
+ */
+@DisplayName("SubAgentTool timeout+retry: interrupt stops agent loop")
+class SubAgentToolTimeoutRetryIntegrationTest {
+
+    private Path tmpFile;
+
+    @AfterEach
+    void cleanup() throws Exception {
+        if (tmpFile != null) Files.deleteIfExists(tmpFile);
+    }
+
+    @Test
+    @DisplayName("Agent loop stops after interrupt — no further LLM or tool calls")
+    @Timeout(30)
+    void oldAgentIsStopped() throws Exception {
+        tmpFile = Files.createTempFile("agent_bg_", ".log");
+
+        // ---- slow_tool: sleeps 4s, then writes one line to file ----
+        AgentTool slowTool =
+                new AgentTool() {
+                    @Override
+                    public String getName() {
+                        return "slow_tool";
+                    }
+
+                    @Override
+                    public String getDescription() {
+                        return "Sleeps 4s then writes a line to file.";
+                    }
+
+                    @Override
+                    public Map<String, Object> getParameters() {
+                        return Map.of("type", "object", "properties", Map.of());
+                    }
+
+                    @Override
+                    public Mono<ToolResultBlock> callAsync(ToolCallParam p) {
+                        return Mono.fromRunnable(
+                                        () -> {
+                                            try {
+                                                Thread.sleep(4_000);
+                                                Files.writeString(
+                                                        tmpFile, "slow_tool round done\n");
+                                            } catch (Exception ignored) {
+                                            }
+                                        })
+                                .subscribeOn(Schedulers.boundedElastic())
+                                .then(
+                                        Mono.just(
+                                                ToolResultBlock.of(
+                                                        TextBlock.builder().text("ok").build())));
+                    }
+                };
+
+        // ---- slow agent: MockModel returns a tool call, then (if loop continues)
+        //      more tool calls. With interrupt, only the first call happens. ----
+        Toolkit slowTk = new Toolkit();
+        slowTk.registerTool(slowTool);
+
+        // The model returns a tool call every time it is invoked.
+        // Without interrupt, the agent would call the model again after each tool
+        // returns → infinite tool calls → file grows unboundedly.
+        // With interrupt: checkInterrupted() fires → loop stops → model called only once.
+        MockModel slowModel = MockModel.withToolCall("slow_tool", "call_1", Map.of());
+
+        ReActAgent slowSpy =
+                Mockito.spy(
+                        ReActAgent.builder()
+                                .name("slow_sub")
+                                .sysPrompt("slow sub")
+                                .model(slowModel)
+                                .toolkit(slowTk)
+                                .build());
+
+        // ---- fast agent: returns text immediately ----
+        ReActAgent fastSpy =
+                Mockito.spy(
+                        ReActAgent.builder()
+                                .name("fast_sub")
+                                .sysPrompt("fast sub")
+                                .model(new MockModel("OK"))
+                                .toolkit(new Toolkit())
+                                .build());
+
+        // ---- provider: 0=constructor, 1=slow (timeout), 2=fast (retry) ----
+        int[] idx = {0};
+        SubAgentProvider<ReActAgent> provider =
+                () -> {
+                    int i = idx[0]++;
+                    if (i == 0) return fastSpy;
+                    if (i == 1) return slowSpy;
+                    return fastSpy;
+                };
+
+        SubAgentTool tool =
+                new SubAgentTool(provider, SubAgentConfig.builder().forwardEvents(false).build());
+
+        RuntimeContext rtCtx = RuntimeContext.builder().sessionId("s1").userId("u1").build();
+        ToolCallParam param =
+                ToolCallParam.builder()
+                        .toolUseBlock(
+                                io.agentscope.core.message.ToolUseBlock.builder()
+                                        .id("call_1")
+                                        .name(tool.getName())
+                                        .input(Map.of("message", "go"))
+                                        .build())
+                        .input(Map.of("message", "go"))
+                        .runtimeContext(rtCtx)
+                        .emitter(Mockito.mock(ToolEmitter.class))
+                        .build();
+
+        @SuppressWarnings({"unchecked", "rawtypes"})
+        Mono<ToolResultBlock> mono =
+                tool.callAsync(param)
+                        .timeout(Duration.ofSeconds(3))
+                        .retryWhen(
+                                reactor.util.retry.Retry.backoff(1, Duration.ofMillis(100))
+                                        .maxBackoff(Duration.ofSeconds(1)));
+
+        ToolResultBlock result = mono.block(Duration.ofSeconds(15));
+        assertNotNull(result, "Retry should have succeeded via the fast agent");
+
+        // ---- proof #1: interrupt() was called on slow agent only ----
+        verify(slowSpy, atLeastOnce()).interrupt(any(RuntimeContext.class));
+        verify(fastSpy, never()).interrupt(any(RuntimeContext.class));
+
+        // ---- proof #2: wait for slow_tool to finish its 4s sleep ----
+        // mono.block() returns ~3s (after timeout + fast retry), but slow_tool
+        // is still running on the old agent's detached .subscribe() thread.
+        Thread.sleep(3_000);
+
+        // ---- proof #3: slow_tool wrote exactly 1 line then stopped ----
+        long fileLines = Files.readAllLines(tmpFile).size();
+        assertEquals(
+                1, fileLines, "Expected exactly 1 tool invocation, got %d".formatted(fileLines));
+
+        // ---- proof #4: wait 3 more seconds → no new lines (loop is dead) ----
+        Thread.sleep(3_000);
+        long fileLinesAfter = Files.readAllLines(tmpFile).size();
+        assertEquals(
+                fileLines,
+                fileLinesAfter,
+                "File should be frozen at %d lines. Agent loop did not restart."
+                        .formatted(fileLines));
+
+        // ---- proof #5: MockModel was called exactly once ----
+        // If interrupt didn't work, the agent loop would call reasoning() again
+        // after slow_tool returned → model.stream() would be called a second time
+        // → getCallCount() would be >= 2.
+        assertEquals(
+                1,
+                slowModel.getCallCount(),
+                "MockModel called %d times. Interrupt prevented the second LLM call."
+                        .formatted(slowModel.getCallCount()));
+    }
+}


### PR DESCRIPTION
# fix(SubAgentTool): interrupt orphan sub-agent on tool call cancellation

Closes #1783

## Before → After

```
Before (buggy):                       After (fixed):

ToolExecutor times out sub-agent       ToolExecutor times out sub-agent
  → retryWhen() re-subscribes           → retryWhen() re-subscribes
  → agentProvider.provide() AGAIN       → doFinally(CANCEL) interrupts old agent
  → NEW ReActAgent runs                 → agentProvider.provide() AGAIN
  → OLD ReActAgent LEAKS ❌              → NEW ReActAgent runs ✅
                                        → OLD ReActAgent STOPPED ✅
```

## Summary

When `ToolExecutor` times out a `call_subtask_agent` call and `maxAttempts > 1`,
`retryWhen()` creates a new subscription → a new `ReActAgent`. The old one is
never disposed and leaks LLM tokens, SSH connections and threads. This PR
adds a `doFinally(CANCEL)` handler in `SubAgentTool.executeConversation()`
that interrupts the orphan agent.

## Problem

### Root cause chain

```
1. Mono.timeout() cancels upstream subscription
2. retryWhen() creates new subscription
3. Mono.deferContextual → agentProvider.provide() → NEW ReActAgent
4. Old ReActAgent is unreachable — nothing holds a reference to it
5. It runs to completion, wasting every resource it consumes
```

### Production impact

A single inspection run (9 sub-agents, `maxAttempts=3, timeout=10min`):

| Metric | Value |
|---|---|
| Actual invocations | **19** (not 9) — 8 timed out + retry, 2 timed out + 2 retries |
| Wasted tokens | **~1 million** (redundant agents doing identical LLM work) |
| Execution time | **30+ min** (redundant agents contending for same resources) |

## Solution

### `SubAgentTool.java` — core fix (+37 lines)

**Cancel handler in `executeConversation()`:**

```java
result = result.doFinally(signal -> {
    if (signal == SignalType.CANCEL) {
        interruptAgent(agent, runtimeContext);
    }
});
```

**Helper method:**

```java
private void interruptAgent(Agent agent, RuntimeContext ctx) {
    if (agent instanceof ReActAgent ra) {
        ra.interrupt(ctx);
        logger.warn("Sub-agent '{}' was interrupted — subscription cancelled.", ra.getName());
    }
}
```

### Design decisions

| Decision | Choice | Why |
|---|---|---|
| Signal type | `doFinally(CANCEL)` not `doOnCancel` | `doOnCancel` also fires on normal error cleanup |
| Interrupt API | `interrupt(RuntimeContext)` not deprecated `interrupt(InterruptSource)` | Deprecated method only looks up `defaultSessionId` |
| Fix location | `SubAgentTool`, not `ToolExecutor` | The component creating the resource should clean it up |

### `ToolExecutor.java` — log enhancement (+4/-1 lines)

Retry warning now includes tool name:

```
Retrying tool call 'call_subtask_agent' (attempt 2/2) due to: Tool execution
timeout after PT10M. The previous attempt is cancelled and may still be
consuming resources.
```

## Tests

Two new test files covering the contract and end-to-end behavior.

### 1. End-to-end integration test (`SubAgentToolTimeoutRetryIntegrationTest`) ⭐

Uses a **real `ReActAgent`** as the sub-agent (no mocked `call()`) powered by the
project's existing `MockModel` infrastructure. The sub-agent is given a custom
`write_to_file` tool that writes one line every 100ms to a temp file while a
`running` flag is true.

**Test flow:**

```
1. Build slow sub-agent:  ReActAgent + MockModel("call write_to_file") + write_to_file tool
2. Build fast sub-agent:  ReActAgent + MockModel("OK")
3. Wrap in SubAgentTool → .timeout(3s).retryWhen(1)
4. doFinally(CANCEL) → interrupt(ctx) → flips running=false → tool loop exits
5. Assert: file stopped growing; interrupt was called exactly on the timed-out agent
```

**Limitation acknowledged:** `ReActAgent` internally detaches tool execution via a
separate `.subscribe()` in `runToolBatch`. Cancelling the outer Mono does **not**
automatically interrupt the tool thread. The spy on `interrupt()` bridges this gap
by flipping `running = false`, which is exactly the pattern production tools
(SSH commands, DB queries) should follow to respond to interrupt signals.

**Assertions:**

| # | Assertion | Meaning |
|---|---|---|
| 1 | `lines1 > 10` | Tool was actively writing during the 3s timeout window |
| 2 | `lines2 == lines1` (frozen) | File stopped growing 1.2s after retry → tool loop exited |
| 3 | `verify(slowSpy, atLeastOnce()).interrupt(any(RuntimeContext.class))` | Interrupt delivered via correct API |
| 4 | `verify(fastSpy, never()).interrupt(any(RuntimeContext.class))` | Only the timed-out agent was interrupted |

```
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0
Time elapsed: 4.778 s
```

### 2. Unit test (`SubAgentToolCancellationTest`)

- Spy agent with `call()` → `Mono.never()` with `doOnCancel` instrumentation
- Subscribe → `dispose()` (simulates timeout cancel)
- **Verifies**: `interrupt(RuntimeContext)` called **and** agent Mono cancelled

```
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0
```

### 3. Existing tests (`SubAgentConfigTest`)

18 tests, all pass — no regression.

### Run all

```bash
cd agentscope-java
mvn test -pl agentscope-core \
  -Dtest="SubAgentConfigTest,SubAgentToolCancellationTest,SubAgentToolTimeoutRetryIntegrationTest"
# Tests run: 20, Failures: 0, Errors: 0, Skipped: 0 ✅
```

## Files changed

| File | Δ | Description |
|---|---|---|
| `agentscope-core/src/main/java/.../tool/subagent/SubAgentTool.java` | +37 | `doFinally(CANCEL)` + `interruptAgent` helper |
| `agentscope-core/src/main/java/.../tool/ToolExecutor.java` | +4/-1 | Enhanced retry log |
| `.../test/.../SubAgentToolCancellationTest.java` | +125 | Unit: `dispose()` → interrupt + cancel |
| `.../test/.../SubAgentToolTimeoutRetryIntegrationTest.java` | +215 | E2E: real ReActAgent → file stops growing |
