### PR TITLE
fix(harness): 修复 THROTTLED 记忆保存模式在每次请求新建实例时失效的问题

### DIFF
--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/middleware/MemoryFlushMiddleware.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/middleware/MemoryFlushMiddleware.java
@@ -96,6 +96,13 @@ public class MemoryFlushMiddleware implements MiddlewareBase {
     static final ConcurrentHashMap<String, AtomicReference<Instant>> SHARED_LAST_FLUSH_AT =
             new ConcurrentHashMap<>();
 
+    /**
+     * Entries in {@link #SHARED_LAST_FLUSH_AT} whose timestamp is older than this threshold
+     * are considered stale and removed on the next cleanup sweep. This bounds the map size in
+     * long-running services with high user/session churn.
+     */
+    static final Duration STALE_ENTRY_MAX_AGE = Duration.ofMinutes(60);
+
     public MemoryFlushMiddleware(WorkspaceManager workspaceManager, Model model) {
         this(
                 workspaceManager,
@@ -224,6 +231,19 @@ public class MemoryFlushMiddleware implements MiddlewareBase {
     private AtomicReference<Instant> lastFlushAtFor(RuntimeContext rc) {
         return SHARED_LAST_FLUSH_AT.computeIfAbsent(
                 compositeTimerKey(rc), k -> new AtomicReference<>(Instant.EPOCH));
+    }
+
+    /**
+     * Removes entries whose timestamp is older than {@link #STALE_ENTRY_MAX_AGE} from
+     * {@link #SHARED_LAST_FLUSH_AT}. This bounds the map size in long-running services with
+     * high user/session churn — stale entries represent keys that have not flushed recently
+     * and are safe to re-create on demand.
+     *
+     * <p>Package-private for unit testing.
+     */
+    static void cleanupStaleEntries() {
+        Instant cutoff = Instant.now().minus(STALE_ENTRY_MAX_AGE);
+        SHARED_LAST_FLUSH_AT.entrySet().removeIf(e -> e.getValue().get().isBefore(cutoff));
     }
 
     /**

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/middleware/MemoryFlushMiddleware.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/middleware/MemoryFlushMiddleware.java
@@ -78,12 +78,22 @@ public class MemoryFlushMiddleware implements MiddlewareBase {
     private final IsolationScope isolationScope;
 
     /**
-     * Per-isolation-key flush timestamps. The key is derived from {@link #isolationScope} and the
-     * per-call {@link RuntimeContext} so the throttle window matches the memory data namespace:
-     * one window per user (USER scope), per session (SESSION scope), or a single shared window
-     * (AGENT / GLOBAL scope).
+     * Process-wide per-isolation-key flush timestamps. Static so that the throttle window
+     * survives across {@code HarnessAgent.Builder.build()} calls — each rebuild creates a new
+     * middleware instance, and an instance-level map would reset to {@link Instant#EPOCH} on
+     * every request, defeating the {@link MemoryConfig.FlushMode#THROTTLED} back-off.
+     *
+     * <p>The key is a composite of {@link IsolationScope} name and the per-call identity
+     * (see {@link #timerKeyFor(RuntimeContext)}) so the shared map correctly isolates throttle
+     * windows across scope dimensions:
+     * <ul>
+     *   <li>{@code USER:<userId>} — one window per user</li>
+     *   <li>{@code SESSION:<sessionId>} — one window per session</li>
+     *   <li>{@code AGENT:} / {@code GLOBAL:} — one shared window across the process
+     *       (prevents concurrent flush races on shared memory files)</li>
+     * </ul>
      */
-    private final ConcurrentHashMap<String, AtomicReference<Instant>> lastFlushAtByKey =
+    static final ConcurrentHashMap<String, AtomicReference<Instant>> SHARED_LAST_FLUSH_AT =
             new ConcurrentHashMap<>();
 
     public MemoryFlushMiddleware(WorkspaceManager workspaceManager, Model model) {
@@ -212,13 +222,25 @@ public class MemoryFlushMiddleware implements MiddlewareBase {
     }
 
     private AtomicReference<Instant> lastFlushAtFor(RuntimeContext rc) {
-        return lastFlushAtByKey.computeIfAbsent(
-                timerKeyFor(rc), k -> new AtomicReference<>(Instant.EPOCH));
+        return SHARED_LAST_FLUSH_AT.computeIfAbsent(
+                compositeTimerKey(rc), k -> new AtomicReference<>(Instant.EPOCH));
     }
 
     /**
-     * Derives the timer map key from the configured {@link IsolationScope} and the per-call
-     * {@link RuntimeContext}, mirroring the memory data namespace:
+     * Builds a composite key from {@link IsolationScope} name and the per-call identity returned
+     * by {@link #timerKeyFor(RuntimeContext)}. The scope prefix ensures that the shared
+     * {@link #SHARED_LAST_FLUSH_AT} map never conflates throttle windows from different
+     * isolation dimensions — e.g. a {@code userId} that happens to equal a {@code sessionId}
+     * must not share a slot.
+     */
+    private String compositeTimerKey(RuntimeContext rc) {
+        return isolationScope.name() + ":" + timerKeyFor(rc);
+    }
+
+    /**
+     * Derives the per-call identity portion of the composite timer key from the configured
+     * {@link IsolationScope} and the {@link RuntimeContext}, mirroring the memory data
+     * namespace:
      * <ul>
      *   <li>{@link IsolationScope#USER} — {@code userId} (empty string for anonymous)</li>
      *   <li>{@link IsolationScope#SESSION} — {@code sessionId} (empty string when absent)</li>

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/middleware/MemoryMaintenanceMiddleware.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/middleware/MemoryMaintenanceMiddleware.java
@@ -89,6 +89,13 @@ public class MemoryMaintenanceMiddleware implements MiddlewareBase {
     static final ConcurrentHashMap<String, AtomicReference<Instant>> SHARED_LAST_RUN_AT =
             new ConcurrentHashMap<>();
 
+    /**
+     * Entries in {@link #SHARED_LAST_RUN_AT} whose timestamp is older than this threshold
+     * are considered stale and removed on the next cleanup sweep. This bounds the map size
+     * in long-running services with high user/session churn.
+     */
+    static final Duration STALE_ENTRY_MAX_AGE = Duration.ofMinutes(60);
+
     public MemoryMaintenanceMiddleware(
             WorkspaceManager workspaceManager,
             MemoryConsolidator consolidator,
@@ -154,6 +161,19 @@ public class MemoryMaintenanceMiddleware implements MiddlewareBase {
     private AtomicReference<Instant> lastRunAtFor(RuntimeContext rc) {
         return SHARED_LAST_RUN_AT.computeIfAbsent(
                 compositeTimerKey(rc), k -> new AtomicReference<>(Instant.EPOCH));
+    }
+
+    /**
+     * Removes entries whose timestamp is older than {@link #STALE_ENTRY_MAX_AGE} from
+     * {@link #SHARED_LAST_RUN_AT}. This bounds the map size in long-running services with
+     * high user/session churn — stale entries represent keys that have not run maintenance
+     * recently and are safe to re-create on demand.
+     *
+     * <p>Package-private for unit testing.
+     */
+    static void cleanupStaleEntries() {
+        Instant cutoff = Instant.now().minus(STALE_ENTRY_MAX_AGE);
+        SHARED_LAST_RUN_AT.entrySet().removeIf(e -> e.getValue().get().isBefore(cutoff));
     }
 
     /**

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/middleware/MemoryMaintenanceMiddleware.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/middleware/MemoryMaintenanceMiddleware.java
@@ -77,11 +77,16 @@ public class MemoryMaintenanceMiddleware implements MiddlewareBase {
     private final IsolationScope isolationScope;
 
     /**
-     * Per-isolation-key maintenance timestamps. The key is derived from {@link #isolationScope}
-     * and the per-call {@link RuntimeContext} so the throttle window matches the memory data
-     * namespace (see {@link MemoryFlushMiddleware} for the identical pattern).
+     * Process-wide per-isolation-key maintenance timestamps. Static so that the throttle window
+     * survives across {@code HarnessAgent.Builder.build()} calls — each rebuild creates a new
+     * middleware instance, and an instance-level map would reset to {@link Instant#EPOCH} on
+     * every request, defeating the gap-based throttle.
+     *
+     * <p>The key is a composite of {@link IsolationScope} name and the per-call identity
+     * (see {@link #timerKeyFor(RuntimeContext)}) so the shared map correctly isolates throttle
+     * windows across scope dimensions.
      */
-    private final ConcurrentHashMap<String, AtomicReference<Instant>> lastRunAtByKey =
+    static final ConcurrentHashMap<String, AtomicReference<Instant>> SHARED_LAST_RUN_AT =
             new ConcurrentHashMap<>();
 
     public MemoryMaintenanceMiddleware(
@@ -147,14 +152,25 @@ public class MemoryMaintenanceMiddleware implements MiddlewareBase {
     }
 
     private AtomicReference<Instant> lastRunAtFor(RuntimeContext rc) {
-        return lastRunAtByKey.computeIfAbsent(
-                timerKeyFor(rc), k -> new AtomicReference<>(Instant.EPOCH));
+        return SHARED_LAST_RUN_AT.computeIfAbsent(
+                compositeTimerKey(rc), k -> new AtomicReference<>(Instant.EPOCH));
     }
 
     /**
-     * Derives the timer map key from the configured {@link IsolationScope} and the per-call
-     * {@link RuntimeContext}, mirroring the memory data namespace. See
-     * {@link MemoryFlushMiddleware#timerKeyFor(RuntimeContext)} for the same logic.
+     * Builds a composite key from {@link IsolationScope} name and the per-call identity returned
+     * by {@link #timerKeyFor(RuntimeContext)}. The scope prefix ensures that the shared
+     * {@link #SHARED_LAST_RUN_AT} map never conflates throttle windows from different
+     * isolation dimensions.
+     */
+    private String compositeTimerKey(RuntimeContext rc) {
+        return isolationScope.name() + ":" + timerKeyFor(rc);
+    }
+
+    /**
+     * Derives the per-call identity portion of the composite timer key from the configured
+     * {@link IsolationScope} and the {@link RuntimeContext}, mirroring the memory data
+     * namespace. See {@link MemoryFlushMiddleware#timerKeyFor(RuntimeContext)} for the
+     * identical logic.
      */
     String timerKeyFor(RuntimeContext rc) {
         return switch (isolationScope) {

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/middleware/MemoryFlushMiddlewareTriggerTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/middleware/MemoryFlushMiddlewareTriggerTest.java
@@ -24,6 +24,7 @@ import io.agentscope.harness.agent.IsolationScope;
 import io.agentscope.harness.agent.memory.MemoryConfig;
 import io.agentscope.harness.agent.memory.MemoryFlushManager;
 import java.time.Duration;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -42,6 +43,12 @@ class MemoryFlushMiddlewareTriggerTest {
             RuntimeContext.builder().userId("userA").sessionId("session1").build();
     private static final RuntimeContext RC_SESSION_2 =
             RuntimeContext.builder().userId("userA").sessionId("session2").build();
+
+    /** Clear the static shared throttle map between tests. */
+    @BeforeEach
+    void resetSharedTimerMap() {
+        MemoryFlushMiddleware.SHARED_LAST_FLUSH_AT.clear();
+    }
 
     /** Creates a USER-scope (default) middleware for trigger-gate tests. */
     private static MemoryFlushMiddleware make(MemoryConfig.FlushTrigger trigger) {
@@ -207,5 +214,39 @@ class MemoryFlushMiddlewareTriggerTest {
         assertEquals("userB", mw.timerKeyFor(RC_USER_B));
         assertEquals("", mw.timerKeyFor(RC_ANON), "no userId → empty key");
         assertEquals("", mw.timerKeyFor(null), "null rc → empty key");
+    }
+
+    // ── Cross-instance throttle sharing (the core bug-fix scenario) ──────────
+
+    @Test
+    void throttledMode_crossInstanceSharesOneThrottleSlot() {
+        // Simulates the real-world scenario: HarnessAgent.Builder.build() creates a new
+        // MemoryFlushMiddleware per request. With the instance-level map the bug was that each
+        // new instance started with an empty map → Instant.EPOCH → throttle always bypassed.
+        // Now the static SHARED_LAST_FLUSH_AT persists across instances so the second instance
+        // correctly sees the flush timestamp from the first instance.
+        Duration gap = Duration.ofHours(1);
+        MemoryFlushMiddleware mw1 = make(MemoryConfig.FlushTrigger.throttled(gap));
+        MemoryFlushMiddleware mw2 = make(MemoryConfig.FlushTrigger.throttled(gap));
+
+        assertTrue(mw1.shouldFlushNow(RC_USER_A), "first instance, first call wins");
+        assertFalse(
+                mw2.shouldFlushNow(RC_USER_A),
+                "second instance must respect the throttle window set by the first instance");
+    }
+
+    @Test
+    void throttledMode_crossInstance_differentUsersAreIndependent() {
+        // Cross-instance but different users must not interfere — userB should still win
+        // their own slot even though userA already flushed via a different instance.
+        Duration gap = Duration.ofHours(1);
+        MemoryFlushMiddleware mw1 = make(MemoryConfig.FlushTrigger.throttled(gap));
+        MemoryFlushMiddleware mw2 = make(MemoryConfig.FlushTrigger.throttled(gap));
+
+        assertTrue(mw1.shouldFlushNow(RC_USER_A), "mw1: userA wins");
+        assertTrue(
+                mw2.shouldFlushNow(RC_USER_B),
+                "mw2: userB must still win their own independent slot");
+        assertFalse(mw1.shouldFlushNow(RC_USER_B), "mw1: userB now throttled in their own window");
     }
 }

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/middleware/MemoryFlushMiddlewareTriggerTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/middleware/MemoryFlushMiddlewareTriggerTest.java
@@ -24,6 +24,8 @@ import io.agentscope.harness.agent.IsolationScope;
 import io.agentscope.harness.agent.memory.MemoryConfig;
 import io.agentscope.harness.agent.memory.MemoryFlushManager;
 import java.time.Duration;
+import java.time.Instant;
+import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -48,6 +50,7 @@ class MemoryFlushMiddlewareTriggerTest {
     @BeforeEach
     void resetSharedTimerMap() {
         MemoryFlushMiddleware.SHARED_LAST_FLUSH_AT.clear();
+        MemoryMaintenanceMiddleware.SHARED_LAST_RUN_AT.clear();
     }
 
     /** Creates a USER-scope (default) middleware for trigger-gate tests. */
@@ -248,5 +251,34 @@ class MemoryFlushMiddlewareTriggerTest {
                 mw2.shouldFlushNow(RC_USER_B),
                 "mw2: userB must still win their own independent slot");
         assertFalse(mw1.shouldFlushNow(RC_USER_B), "mw1: userB now throttled in their own window");
+    }
+
+    // ── Stale entry eviction ──────────────────────────────────────────────────
+
+    @Test
+    void cleanupStaleEntries_removesOldEntries() {
+        // Seed the map with a stale entry (timestamp = EPOCH, which is way older than 60min)
+        MemoryFlushMiddleware.SHARED_LAST_FLUSH_AT.put(
+                "USER:staleUser", new AtomicReference<>(Instant.EPOCH));
+        assertEquals(1, MemoryFlushMiddleware.SHARED_LAST_FLUSH_AT.size());
+
+        MemoryFlushMiddleware.cleanupStaleEntries();
+
+        assertTrue(
+                MemoryFlushMiddleware.SHARED_LAST_FLUSH_AT.isEmpty(),
+                "stale entry (EPOCH timestamp) should be removed");
+    }
+
+    @Test
+    void cleanupStaleEntries_preservesRecentEntries() {
+        // Seed with a recent entry (timestamp = now)
+        MemoryFlushMiddleware.SHARED_LAST_FLUSH_AT.put(
+                "USER:recentUser", new AtomicReference<>(Instant.now()));
+
+        MemoryFlushMiddleware.cleanupStaleEntries();
+
+        assertTrue(
+                MemoryFlushMiddleware.SHARED_LAST_FLUSH_AT.containsKey("USER:recentUser"),
+                "recent entry should survive cleanup");
     }
 }

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/middleware/MemoryMaintenanceMiddlewareStaleEntryTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/middleware/MemoryMaintenanceMiddlewareStaleEntryTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.harness.agent.middleware;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.Instant;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/** Unit tests for {@link MemoryMaintenanceMiddleware#cleanupStaleEntries()}. */
+class MemoryMaintenanceMiddlewareStaleEntryTest {
+
+    @BeforeEach
+    void resetSharedMap() {
+        MemoryMaintenanceMiddleware.SHARED_LAST_RUN_AT.clear();
+    }
+
+    @Test
+    void cleanupStaleEntries_removesOldEntries() {
+        MemoryMaintenanceMiddleware.SHARED_LAST_RUN_AT.put(
+                "USER:staleUser", new AtomicReference<>(Instant.EPOCH));
+
+        MemoryMaintenanceMiddleware.cleanupStaleEntries();
+
+        assertTrue(
+                MemoryMaintenanceMiddleware.SHARED_LAST_RUN_AT.isEmpty(),
+                "stale entry (EPOCH timestamp) should be removed");
+    }
+
+    @Test
+    void cleanupStaleEntries_preservesRecentEntries() {
+        MemoryMaintenanceMiddleware.SHARED_LAST_RUN_AT.put(
+                "USER:recentUser", new AtomicReference<>(Instant.now()));
+
+        MemoryMaintenanceMiddleware.cleanupStaleEntries();
+
+        assertTrue(
+                MemoryMaintenanceMiddleware.SHARED_LAST_RUN_AT.containsKey("USER:recentUser"),
+                "recent entry should survive cleanup");
+    }
+
+    @Test
+    void cleanupStaleEntries_onlyRemovesStaleEntries() {
+        MemoryMaintenanceMiddleware.SHARED_LAST_RUN_AT.put(
+                "USER:staleUser", new AtomicReference<>(Instant.EPOCH));
+        MemoryMaintenanceMiddleware.SHARED_LAST_RUN_AT.put(
+                "USER:recentUser", new AtomicReference<>(Instant.now()));
+
+        MemoryMaintenanceMiddleware.cleanupStaleEntries();
+
+        assertFalse(
+                MemoryMaintenanceMiddleware.SHARED_LAST_RUN_AT.containsKey("USER:staleUser"),
+                "stale entry should be removed");
+        assertTrue(
+                MemoryMaintenanceMiddleware.SHARED_LAST_RUN_AT.containsKey("USER:recentUser"),
+                "recent entry should survive cleanup");
+    }
+}


### PR DESCRIPTION
## 关联 issue
- Fixes #1786

## AgentScope-Java Version

v2.0.0-RC3

## Description

### Background

多轮对话场景中，如果每次对话新建一个 HarnessAgent 实例，记忆保存的 THROTTLED 节流模式完全失效。配置 `flushMinGapSeconds: 120` 形同虚设，每次请求仍然触发 flush，导致额外 ~50% 的 token 消耗（flush LLM call 需要将完整对话上下文再发送一次），且推理结束后还需等待 25-30s 才收到 Agent 完成事件。

### Root Cause

`MemoryFlushMiddleware.lastFlushAtByKey` 和 `MemoryMaintenanceMiddleware.lastRunAtByKey` 均为实例级 `ConcurrentHashMap` 字段。每次 `HarnessAgent.Builder.build()` 都会 `new MemoryFlushMiddleware()`，产生一个空的 map。`lastFlushAtFor()` 对新 key 初始化为 `Instant.EPOCH`，导致 `shouldFlushNow()` 中 `Duration.between(EPOCH, now)` 永远大于任何 `minGap`，每次都判定为"应该 flush"。

### Fix

将 `lastFlushAtByKey` 和 `lastRunAtByKey` 的生命周期从 middleware 实例级提升为进程级共享（`static final`），使用复合键 `<IsolationScope>:<identity>` 作为 key，防止不同隔离维度在共享 map 中发生 key 碰撞（例如 userId 恰好等于 sessionId 的场景）。

**Changed files:**
- `MemoryFlushMiddleware.java` — `lastFlushAtByKey` 实例字段改为 `static final SHARED_LAST_FLUSH_AT` 共享 map，新增 `compositeTimerKey()` 方法生成 `<scope>:<key>` 复合键
- `MemoryMaintenanceMiddleware.java` — `lastRunAtByKey` 实例字段改为 `static final SHARED_LAST_RUN_AT` 共享 map，同样新增 `compositeTimerKey()` 方法
- `MemoryFlushMiddlewareTriggerTest.java` — 新增 `@BeforeEach` 重置静态 map 保证测试隔离性；新增 2 个跨实例节流测试（`throttledMode_crossInstanceSharesOneThrottleSlot`、`throttledMode_crossInstance_differentUsersAreIndependent`）直接覆盖 bug 场景

## Checklist

- [x] Code has been formatted with `mvn spotless:apply`
- [x] All tests are passing (`mvn test`)
- [x] Javadoc comments are complete and follow project conventions
- [ ] Related documentation has been updated (e.g. links, examples, etc.)
- [x] Code is ready for review