### PR TITLE
feat(sandbox): add environment variable injection for KubernetesFiles…

### DIFF
--- a/agentscope-extensions/agentscope-extensions-sandbox/agentscope-extensions-sandbox-kubernetes/pom.xml
+++ b/agentscope-extensions/agentscope-extensions-sandbox/agentscope-extensions-sandbox-kubernetes/pom.xml
@@ -41,5 +41,21 @@
             <groupId>io.fabric8</groupId>
             <artifactId>kubernetes-client</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/agentscope-extensions/agentscope-extensions-sandbox/agentscope-extensions-sandbox-kubernetes/src/main/java/io/agentscope/extensions/sandbox/kubernetes/Fabric8KubernetesPodRuntime.java
+++ b/agentscope-extensions/agentscope-extensions-sandbox/agentscope-extensions-sandbox-kubernetes/src/main/java/io/agentscope/extensions/sandbox/kubernetes/Fabric8KubernetesPodRuntime.java
@@ -22,6 +22,7 @@ import io.agentscope.harness.agent.sandbox.WorkspaceMountSupport;
 import io.agentscope.harness.agent.sandbox.WorkspaceSpec;
 import io.agentscope.harness.agent.sandbox.layout.BindMountEntry;
 import io.fabric8.kubernetes.api.model.ContainerBuilder;
+import io.fabric8.kubernetes.api.model.EnvVar;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.PodBuilder;
 import io.fabric8.kubernetes.api.model.PodSpecBuilder;
@@ -219,6 +220,18 @@ public class Fabric8KubernetesPodRuntime {
                 requests.put("memory", new Quantity(templateOptions.getMemoryRequest()));
             }
             cb.withResources(rb.withRequests(requests).build());
+        }
+
+        // Inject environment variables from WorkspaceSpec (parity with DockerSandbox)
+        WorkspaceSpec wsEnv = state.getWorkspaceSpec();
+        if (wsEnv != null && wsEnv.getEnvironment() != null) {
+            List<EnvVar> envVars = new ArrayList<>();
+            for (Map.Entry<String, String> e : wsEnv.getEnvironment().entrySet()) {
+                envVars.add(new EnvVar(e.getKey(), e.getValue(), null));
+            }
+            if (!envVars.isEmpty()) {
+                cb.withEnv(envVars);
+            }
         }
 
         List<Volume> bindVolumes = new ArrayList<>();

--- a/agentscope-extensions/agentscope-extensions-sandbox/agentscope-extensions-sandbox-kubernetes/src/test/java/io/agentscope/extensions/sandbox/kubernetes/Fabric8KubernetesPodRuntimeTest.java
+++ b/agentscope-extensions/agentscope-extensions-sandbox/agentscope-extensions-sandbox-kubernetes/src/test/java/io/agentscope/extensions/sandbox/kubernetes/Fabric8KubernetesPodRuntimeTest.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.extensions.sandbox.kubernetes;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+
+import io.agentscope.harness.agent.sandbox.WorkspaceSpec;
+import io.fabric8.kubernetes.api.model.EnvVar;
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.PodList;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.dsl.MixedOperation;
+import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
+import io.fabric8.kubernetes.client.dsl.PodResource;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+@MockitoSettings(strictness = Strictness.LENIENT)
+@ExtendWith(MockitoExtension.class)
+class Fabric8KubernetesPodRuntimeTest {
+
+    @Mock KubernetesClient kc;
+
+    @SuppressWarnings("unchecked")
+    MixedOperation<Pod, PodList, PodResource> pods =
+            (MixedOperation<Pod, PodList, PodResource>) mock(MixedOperation.class);
+
+    @SuppressWarnings("unchecked")
+    NonNamespaceOperation<Pod, PodList, PodResource> inNamespace =
+            (NonNamespaceOperation<Pod, PodList, PodResource>) mock(NonNamespaceOperation.class);
+
+    @Mock PodResource podResource;
+
+    KubernetesSandboxClientOptions opts;
+    Fabric8KubernetesPodRuntime runtime;
+
+    @BeforeEach
+    void setUp() {
+        opts = new KubernetesSandboxClientOptions();
+        runtime = new Fabric8KubernetesPodRuntime(kc, opts);
+
+        doReturn(pods).when(kc).pods();
+        doReturn(inNamespace).when(pods).inNamespace(anyString());
+        doReturn(podResource).when(inNamespace).resource(any(Pod.class));
+        doReturn(mock(Pod.class)).when(podResource).create();
+        // waitUntilReady stub
+        doReturn(podResource).when(inNamespace).withName(anyString());
+        doReturn(mock(Pod.class)).when(podResource).waitUntilReady(any(long.class), any());
+    }
+
+    @Test
+    void ensurePodReady_injectsEnvironmentVariablesFromWorkspaceSpec() throws Exception {
+        WorkspaceSpec ws = new WorkspaceSpec();
+        ws.setEnvironment(Map.of("MY_KEY", "my_val", "ANOTHER", "123"));
+
+        KubernetesSandboxState state = new KubernetesSandboxState();
+        state.setSessionId("test-session-id");
+        state.setNamespace("default");
+        state.setContainerName("workspace");
+        state.setImage("ubuntu:22.04");
+        state.setWorkspaceRoot("/workspace");
+        state.setWorkspaceSpec(ws);
+
+        ArgumentCaptor<Pod> podCaptor = ArgumentCaptor.forClass(Pod.class);
+        doReturn(podResource).when(inNamespace).resource(podCaptor.capture());
+
+        runtime.ensurePodReady(state);
+
+        Pod created = podCaptor.getValue();
+        List<EnvVar> envVars = created.getSpec().getContainers().get(0).getEnv();
+        Map<String, String> actual =
+                envVars.stream()
+                        .collect(
+                                java.util.stream.Collectors.toMap(
+                                        EnvVar::getName, EnvVar::getValue));
+
+        assertEquals("my_val", actual.get("MY_KEY"));
+        assertEquals("123", actual.get("ANOTHER"));
+    }
+
+    @Test
+    void ensurePodReady_noEnvVars_podCreatedWithoutEnv() throws Exception {
+        KubernetesSandboxState state = new KubernetesSandboxState();
+        state.setSessionId("test-session-id-2");
+        state.setNamespace("default");
+        state.setContainerName("workspace");
+        state.setImage("ubuntu:22.04");
+        state.setWorkspaceRoot("/workspace");
+
+        ArgumentCaptor<Pod> podCaptor = ArgumentCaptor.forClass(Pod.class);
+        doReturn(podResource).when(inNamespace).resource(podCaptor.capture());
+
+        runtime.ensurePodReady(state);
+
+        Pod created = podCaptor.getValue();
+        List<EnvVar> envVars = created.getSpec().getContainers().get(0).getEnv();
+        assertTrue(envVars == null || envVars.isEmpty());
+    }
+
+    @Test
+    void buildPodName_truncatesLongSessionId() {
+        String longId = "12345678-1234-1234-1234-123456789012";
+        String name = Fabric8KubernetesPodRuntime.buildPodName(longId);
+        assertTrue(name.length() <= 63);
+        assertTrue(name.startsWith("as-sbx-"));
+    }
+}


### PR DESCRIPTION
AgentScope-Java Version

2.0.0-SNAPSHOT

Description

Background

KubernetesFilesystemSpec 无法向 Pod 注入运行时环境变量（如 KST_API_KEY），唯一替代方案是通过 workspace 文件投影传递，但这会将密钥持久化到快照存储，存在安全风险。关联 issue：#1712。

Root cause analysis

Fabric8KubernetesPodRuntime.createPod() 的 ContainerBuilder 从未调用 .withEnv()。

调查 DockerSandbox 实现后发现，环境变量的正确数据源是 WorkspaceSpec.getEnvironment()，而非 SandboxClientOptions.environment（后者在 Docker 实现中是未被使用的死字段）。因此本 PR 不修改 KubernetesSandboxClientOptions，直接对齐 Docker 的活路径。

Changes

- Fabric8KubernetesPodRuntime.createPod(): 读取 state.getWorkspaceSpec().getEnvironment()，通过 ContainerBuilder.withEnv() 注入 Pod 容器，与 DockerSandbox.buildDockerRunCommand() 行为完全对称
- pom.xml: 新增 junit-jupiter、mockito-core、mockito-junit-jupiter 测试依赖
- Fabric8KubernetesPodRuntimeTest: 3 个测试用例，验证 env 注入、无 env 时空列表、buildPodName 长度裁剪

How to test

构造 WorkspaceSpec，设置 environment(Map.of("MY_KEY", "val"))，传入 KubernetesFilesystemSpec.workspaceSpec(ws)，启动 sandbox 后在容器内执行 echo $MY_KEY，应输出 val。

Checklist

- [x] Code has been formatted with mvn spotless:apply
- [x] All tests are passing (mvn test)
- [ ] Javadoc comments are complete and follow project conventions
- [ ] Related documentation has been updated (e.g. links, examples, etc.)
- [x] Code is ready for review
