### PR TITLE
docs: fix non-existent .sandboxContext() in docs examples

### DIFF
--- a/docs/v1/en/docs/harness/sandbox/index.md
+++ b/docs/v1/en/docs/harness/sandbox/index.md
@@ -119,7 +119,7 @@ SandboxContext callCtx = SandboxContext.builder()
 
 RuntimeContext ctx = RuntimeContext.builder()
     .sessionId("my-session")
-    .sandboxContext(callCtx)      // overrides the defaultSandboxContext from build time
+    .put(SandboxContext.class, callCtx)      // overrides the defaultSandboxContext from build time
     .build();
 
 agent.call(msgs, ctx).block();
@@ -151,7 +151,7 @@ SandboxContext callCtx = SandboxContext.builder()
     .build();
 
 RuntimeContext ctx = RuntimeContext.builder()
-    .sandboxContext(callCtx)
+    .put(SandboxContext.class, callCtx)
     .build();
 
 agent.call(msgs, ctx).block();
@@ -164,11 +164,11 @@ agent.call(msgs, ctx).block();
 Sandbox sharedSandbox = ...;  // already start()ed
 
 agent1.call(msgs1, RuntimeContext.builder()
-    .sandboxContext(SandboxContext.builder().externalSandbox(sharedSandbox).client(client).build())
+    .put(SandboxContext.class, SandboxContext.builder().externalSandbox(sharedSandbox).client(client).build())
     .build()).block();
 
 agent2.call(msgs2, RuntimeContext.builder()
-    .sandboxContext(SandboxContext.builder().externalSandbox(sharedSandbox).client(client).build())
+    .put(SandboxContext.class, SandboxContext.builder().externalSandbox(sharedSandbox).client(client).build())
     .build()).block();
 
 // Manually shutdown after all agents are done

--- a/docs/v1/zh/docs/harness/sandbox/index.md
+++ b/docs/v1/zh/docs/harness/sandbox/index.md
@@ -119,7 +119,7 @@ SandboxContext callCtx = SandboxContext.builder()
 
 RuntimeContext ctx = RuntimeContext.builder()
     .sessionId("my-session")
-    .sandboxContext(callCtx)      // 覆盖构建时的 defaultSandboxContext
+    .put(SandboxContext.class, callCtx)      // 覆盖构建时的 defaultSandboxContext
     .build();
 
 agent.call(msgs, ctx).block();
@@ -151,7 +151,7 @@ SandboxContext callCtx = SandboxContext.builder()
     .build();
 
 RuntimeContext ctx = RuntimeContext.builder()
-    .sandboxContext(callCtx)
+    .put(SandboxContext.class, callCtx)
     .build();
 
 agent.call(msgs, ctx).block();
@@ -164,11 +164,11 @@ agent.call(msgs, ctx).block();
 Sandbox sharedSandbox = ...;  // 已 start()
 
 agent1.call(msgs1, RuntimeContext.builder()
-    .sandboxContext(SandboxContext.builder().externalSandbox(sharedSandbox).client(client).build())
+    .put(SandboxContext.class, SandboxContext.builder().externalSandbox(sharedSandbox).client(client).build())
     .build()).block();
 
 agent2.call(msgs2, RuntimeContext.builder()
-    .sandboxContext(SandboxContext.builder().externalSandbox(sharedSandbox).client(client).build())
+    .put(SandboxContext.class, SandboxContext.builder().externalSandbox(sharedSandbox).client(client).build())
     .build()).block();
 
 // 所有 agent 用完后手动 shutdown

--- a/docs/v2/en/docs/harness/sandbox.md
+++ b/docs/v2/en/docs/harness/sandbox.md
@@ -155,7 +155,7 @@ SandboxContext callCtx = SandboxContext.builder()
 
 agent.call(msgs, RuntimeContext.builder()
     .sessionId("my-session")
-    .sandboxContext(callCtx)
+    .put(SandboxContext.class, callCtx)
     .build()).block();
 
 // shut it down yourself when done

--- a/docs/v2/zh/docs/harness/sandbox.md
+++ b/docs/v2/zh/docs/harness/sandbox.md
@@ -155,7 +155,7 @@ SandboxContext callCtx = SandboxContext.builder()
 
 agent.call(msgs, RuntimeContext.builder()
     .sessionId("my-session")
-    .sandboxContext(callCtx)
+    .put(SandboxContext.class, callCtx)
     .build()).block();
 
 mySandbox.shutdown();


### PR DESCRIPTION
RuntimeContext.Builder has no .sandboxContext() method. Replace with .put(SandboxContext.class, ...) to match the actual API and how HarnessAgent retrieves it.

Closes #1791

## Summary

Fix issue #1791 - the documentation examples call `.sandboxContext(callCtx)` on `RuntimeContext.Builder`, which does not exist. Replace with the correct `.put(SandboxContext.class, callCtx)` API.

## Changes

- `docs/v2/zh/docs/harness/sandbox.md` (line 158)
- `docs/v2/en/docs/harness/sandbox.md` (line 158)
- `docs/v1/zh/docs/harness/sandbox/index.md` (4 occurrences)
- `docs/v1/en/docs/harness/sandbox/index.md` (4 occurrences)

## AgentScope-Java Version

latest (docs only change, no code change)

## Checklist

- [ ] Code has been formatted with `mvn spotless:apply`
- [x] All tests are passing (`mvn test`) — docs only, no code change
- [ ] Javadoc comments are complete and follow project conventions
- [x] Related documentation has been updated (e.g. links, examples, etc.)
- [ ] Code is ready for review
