### PR TITLE
Fix OpenTelemetry context storage in TelemetryTracer

### DIFF
--- a/agentscope-extensions/agentscope-extensions-studio/src/main/java/io/agentscope/core/tracing/telemetry/TelemetryTracer.java
+++ b/agentscope-extensions/agentscope-extensions-studio/src/main/java/io/agentscope/core/tracing/telemetry/TelemetryTracer.java
@@ -97,7 +97,7 @@ public class TelemetryTracer implements Tracer {
                             AGENTSCOPE_FUNCTION_NAME, getFunctionName(instance, "callAgent"));
 
                     Span span = spanBuilder.startSpan();
-                    Context otelContext = span.storeInContext(Context.current());
+                    Context otelContext = span.storeInContext(parentContext);
 
                     return otelContext
                             .wrapSupplier(agentCall)
@@ -135,7 +135,7 @@ public class TelemetryTracer implements Tracer {
                             AGENTSCOPE_FUNCTION_NAME, getFunctionName(instance, "callModel"));
 
                     Span span = spanBuilder.startSpan();
-                    Context otelContext = span.storeInContext(Context.current());
+                    Context otelContext = span.storeInContext(parentContext);
 
                     StreamChatResponseAggregator aggregator = StreamChatResponseAggregator.create();
 
@@ -179,7 +179,7 @@ public class TelemetryTracer implements Tracer {
                             AGENTSCOPE_FUNCTION_NAME, getFunctionName(instance, "callTool"));
 
                     Span span = spanBuilder.startSpan();
-                    Context otelContext = span.storeInContext(Context.current());
+                    Context otelContext = span.storeInContext(parentContext);
 
                     return otelContext
                             .wrapSupplier(toolKitCall)


### PR DESCRIPTION
## AgentScope-Java Version

[1.0.12]

## Description

Update the TelemetryTracer to use the parent context for storing the OpenTelemetry context instead of the current context. This change improves the context management during telemetry operations.

## Checklist

- [ ]  Code has been formatted with `mvn spotless:apply`
- [ ]  All tests are passing (`mvn test`)
- [ ]  Javadoc comments are complete and follow project conventions
- [ ]  Related documentation has been updated (e.g. links, examples, etc.)
- [ ]  Code is ready for review

