### PR TITLE
fix(Harness Sandbox mode)沙箱模式多线程安全问题，以及doflush时，沙箱已经关闭的bug修复

### DIFF
--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/HarnessAgent.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/HarnessAgent.java
@@ -1880,7 +1880,7 @@ public class HarnessAgent implements Agent, AutoCloseable {
                                 resolvedAgentId,
                                 executionGuard);
                 sandboxLifecycleMw =
-                        new SandboxLifecycleMiddleware(sandboxManager, capturedSandboxFs);
+                        new SandboxLifecycleMiddleware(sandboxManager);
             }
             WorkspaceManager wsManager =
                     new WorkspaceManager(resolvedWorkspace, filesystem, workspaceIndex, nsFactory);

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/HarnessAgent.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/HarnessAgent.java
@@ -2051,8 +2051,7 @@ public class HarnessAgent implements Agent, AutoCloseable {
                                 stateStore,
                                 resolvedAgentId,
                                 executionGuard);
-                sandboxLifecycleMw =
-                        new SandboxLifecycleMiddleware(sandboxManager);
+                sandboxLifecycleMw = new SandboxLifecycleMiddleware(sandboxManager);
             }
             WorkspaceManager wsManager =
                     new WorkspaceManager(resolvedWorkspace, filesystem, workspaceIndex, nsFactory);

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/HarnessAgent.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/HarnessAgent.java
@@ -43,6 +43,7 @@ import io.agentscope.core.tool.ToolExecutionContext;
 import io.agentscope.core.tool.Toolkit;
 import io.agentscope.harness.agent.filesystem.AbstractFilesystem;
 import io.agentscope.harness.agent.filesystem.OverlayFilesystem;
+import io.agentscope.harness.agent.filesystem.local.LocalFilesystem;
 import io.agentscope.harness.agent.filesystem.local.LocalFilesystemWithShell;
 import io.agentscope.harness.agent.filesystem.remote.store.NamespaceFactory;
 import io.agentscope.harness.agent.filesystem.sandbox.AbstractSandboxFilesystem;
@@ -2074,16 +2075,24 @@ public class HarnessAgent implements Agent, AutoCloseable {
 
             // ---- MessageBus / AsyncToolRegistry: workspace defaults ----
             // If not set explicitly or via DistributedStore, fall back to workspace-backed
-            // implementations that use the same AbstractFilesystem as the rest of the agent.
-            if (messageBus == null && filesystem != null) {
+            // implementations. When the agent's filesystem is sandbox-backed, bus and
+            // async-tool-registry I/O is routed through a host-side LocalFilesystem rooted at
+            // the workspace: bus state must outlive sandbox sessions (which are torn down per
+            // IsolationScope), and async-tool/subagent completion callbacks fire outside any
+            // per-call RuntimeContext so they have no active sandbox to reach.
+            AbstractFilesystem busFilesystem =
+                    filesystem instanceof SandboxBackedFilesystem
+                            ? new LocalFilesystem(resolvedWorkspace)
+                            : filesystem;
+            if (messageBus == null && busFilesystem != null) {
                 messageBus =
                         new io.agentscope.harness.agent.bus.WorkspaceMessageBus(
-                                filesystem, ".agentscope/bus");
+                                busFilesystem, ".agentscope/bus");
             }
-            if (asyncToolRegistry == null && filesystem != null) {
+            if (asyncToolRegistry == null && busFilesystem != null) {
                 asyncToolRegistry =
                         new io.agentscope.harness.agent.bus.WorkspaceAsyncToolRegistry(
-                                filesystem, ".agentscope/bus/async-tools");
+                                busFilesystem, ".agentscope/bus/async-tools");
             }
 
             // ---- Middlewares ----

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/filesystem/sandbox/SandboxBackedFilesystem.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/filesystem/sandbox/SandboxBackedFilesystem.java
@@ -21,7 +21,6 @@ import io.agentscope.harness.agent.filesystem.model.FileDownloadResponse;
 import io.agentscope.harness.agent.filesystem.model.FileUploadResponse;
 import io.agentscope.harness.agent.sandbox.ExecResult;
 import io.agentscope.harness.agent.sandbox.Sandbox;
-import io.agentscope.harness.agent.sandbox.SandboxAware;
 import io.agentscope.harness.agent.sandbox.SandboxException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
@@ -39,25 +38,14 @@ import org.slf4j.LoggerFactory;
  * via the volatile {@code sandbox} field by {@link
  * io.agentscope.harness.agent.middleware.SandboxLifecycleMiddleware}.
  */
-public class SandboxBackedFilesystem extends BaseSandboxFilesystem implements SandboxAware {
+public class SandboxBackedFilesystem extends BaseSandboxFilesystem {
 
     private static final Logger log = LoggerFactory.getLogger(SandboxBackedFilesystem.class);
 
     private final String fsId;
-    private volatile Sandbox sandbox;
 
     public SandboxBackedFilesystem() {
         this.fsId = "sandbox-" + UUID.randomUUID().toString().substring(0, 8);
-    }
-
-    @Override
-    public void setSandbox(Sandbox sandbox) {
-        this.sandbox = sandbox;
-    }
-
-    @Override
-    public Sandbox getSandbox() {
-        return sandbox;
     }
 
     @Override
@@ -68,7 +56,7 @@ public class SandboxBackedFilesystem extends BaseSandboxFilesystem implements Sa
     @Override
     public ExecuteResponse execute(
             RuntimeContext runtimeContext, String command, Integer timeoutSeconds) {
-        Sandbox active = requireSandbox();
+        Sandbox active = requireSandbox(runtimeContext);
         try {
             ExecResult result = active.exec(runtimeContext, command, timeoutSeconds);
             return new ExecuteResponse(
@@ -91,7 +79,7 @@ public class SandboxBackedFilesystem extends BaseSandboxFilesystem implements Sa
     @Override
     public List<FileUploadResponse> uploadFiles(
             RuntimeContext runtimeContext, List<Map.Entry<String, byte[]>> files) {
-        Sandbox active = requireSandbox();
+        Sandbox active = requireSandbox(runtimeContext);
         List<FileUploadResponse> results = new ArrayList<>(files.size());
 
         for (Map.Entry<String, byte[]> file : files) {
@@ -135,7 +123,7 @@ public class SandboxBackedFilesystem extends BaseSandboxFilesystem implements Sa
     @Override
     public List<FileDownloadResponse> downloadFiles(
             RuntimeContext runtimeContext, List<String> paths) {
-        Sandbox active = requireSandbox();
+        Sandbox active = requireSandbox(runtimeContext);
         List<FileDownloadResponse> results = new ArrayList<>(paths.size());
 
         for (String path : paths) {
@@ -171,8 +159,8 @@ public class SandboxBackedFilesystem extends BaseSandboxFilesystem implements Sa
         return results;
     }
 
-    private Sandbox requireSandbox() {
-        Sandbox s = sandbox;
+    private Sandbox requireSandbox(RuntimeContext runtimeContext) {
+        Sandbox s = runtimeContext != null ? runtimeContext.get(Sandbox.class) : null;
         if (s == null) {
             throw new SandboxException.SandboxConfigurationException(
                     "No active sandbox — sandbox filesystem used outside of a call context");

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/middleware/MemoryFlushMiddleware.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/middleware/MemoryFlushMiddleware.java
@@ -27,6 +27,7 @@ import io.agentscope.core.state.AgentState;
 import io.agentscope.harness.agent.IsolationScope;
 import io.agentscope.harness.agent.memory.MemoryConfig;
 import io.agentscope.harness.agent.memory.MemoryFlushManager;
+import io.agentscope.harness.agent.sandbox.Sandbox;
 import io.agentscope.harness.agent.workspace.WorkspaceManager;
 import java.time.Duration;
 import java.time.Instant;
@@ -125,6 +126,13 @@ public class MemoryFlushMiddleware implements MiddlewareBase {
             AgentInput input,
             Function<AgentInput, Flux<AgentEvent>> next) {
         final RuntimeContext rc = ctx != null ? ctx : RuntimeContext.empty();
+        boolean isSandBox = rc.get(Sandbox.class) != null;
+        if (isSandBox) {
+            return next.apply(input)
+                    .concatWith(
+                            reactor.core.publisher.Mono.defer(() -> doFlush(agent, rc))
+                                    .cast(AgentEvent.class));
+        }
         return next.apply(input).doOnComplete(() -> doFlush(agent, rc).subscribe());
     }
 

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/middleware/SandboxLifecycleMiddleware.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/middleware/SandboxLifecycleMiddleware.java
@@ -17,6 +17,7 @@ package io.agentscope.harness.agent.middleware;
 
 import io.agentscope.core.agent.RuntimeContext;
 import io.agentscope.core.middleware.MiddlewareBase;
+import io.agentscope.harness.agent.filesystem.sandbox.SandboxBackedFilesystem;
 import io.agentscope.harness.agent.sandbox.Sandbox;
 import io.agentscope.harness.agent.sandbox.SandboxAcquireResult;
 import io.agentscope.harness.agent.sandbox.SandboxContext;

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/middleware/SandboxLifecycleMiddleware.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/middleware/SandboxLifecycleMiddleware.java
@@ -17,7 +17,6 @@ package io.agentscope.harness.agent.middleware;
 
 import io.agentscope.core.agent.RuntimeContext;
 import io.agentscope.core.middleware.MiddlewareBase;
-import io.agentscope.harness.agent.filesystem.sandbox.SandboxBackedFilesystem;
 import io.agentscope.harness.agent.sandbox.Sandbox;
 import io.agentscope.harness.agent.sandbox.SandboxAcquireResult;
 import io.agentscope.harness.agent.sandbox.SandboxContext;

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/middleware/SandboxLifecycleMiddleware.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/middleware/SandboxLifecycleMiddleware.java
@@ -22,7 +22,6 @@ import io.agentscope.harness.agent.sandbox.Sandbox;
 import io.agentscope.harness.agent.sandbox.SandboxAcquireResult;
 import io.agentscope.harness.agent.sandbox.SandboxContext;
 import io.agentscope.harness.agent.sandbox.SandboxManager;
-import java.util.concurrent.atomic.AtomicReference;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -34,33 +33,35 @@ import org.slf4j.LoggerFactory;
  *   <li>Read {@link SandboxContext} from the current {@link RuntimeContext}</li>
  *   <li>Acquire a session via {@link SandboxManager}</li>
  *   <li>Start the session (4-branch workspace init)</li>
- *   <li>Inject the live session into the {@link SandboxBackedFilesystem} proxy</li>
+ *   <li>Stash the live {@link Sandbox} and {@link SandboxAcquireResult} on the per-call
+ *       {@link RuntimeContext} so {@link SandboxBackedFilesystem} can resolve it without sharing
+ *       instance state across concurrent calls</li>
  * </ol>
  *
  * <h2>doFinally</h2>
  * <ol>
+ *   <li>Read the {@link SandboxAcquireResult} back from the {@link RuntimeContext}</li>
  *   <li>Persist sandbox session state via {@link SandboxManager} and
  *       {@link io.agentscope.harness.agent.sandbox.SessionSandboxStateStore}</li>
  *   <li>Release the session via {@link SandboxManager} (stop + optional shutdown)</li>
- *   <li>Clear the session reference from the filesystem proxy</li>
+ *   <li>Clear the stashed entries from the {@link RuntimeContext}</li>
  * </ol>
  *
- * <p>Post-call failures (persist, release) are logged but do not propagate — this ensures
- * the agent call result is always returned to the caller even if sandbox cleanup fails.
+ * <p>Per-call state lives on the {@link RuntimeContext} (per-call object) rather than on this
+ * middleware instance, which means a single {@code HarnessAgent} can safely serve concurrent calls
+ * with different {@link SandboxContext}s without cross-call sandbox bleed-through.
+ *
+ * <p>Post-call failures (persist, release) are logged but do not propagate — this ensures the
+ * agent call result is always returned to the caller even if sandbox cleanup fails.
  */
 public class SandboxLifecycleMiddleware implements MiddlewareBase {
 
     private static final Logger log = LoggerFactory.getLogger(SandboxLifecycleMiddleware.class);
 
     private final SandboxManager sandboxManager;
-    private final SandboxBackedFilesystem filesystemProxy;
-    private final AtomicReference<SandboxAcquireResult> currentAcquireResult =
-            new AtomicReference<>();
 
-    public SandboxLifecycleMiddleware(
-            SandboxManager sandboxManager, SandboxBackedFilesystem filesystemProxy) {
+    public SandboxLifecycleMiddleware(SandboxManager sandboxManager) {
         this.sandboxManager = sandboxManager;
-        this.filesystemProxy = filesystemProxy;
     }
 
     /**
@@ -83,13 +84,12 @@ public class SandboxLifecycleMiddleware implements MiddlewareBase {
             Sandbox sandbox = result.getSandbox();
             try {
                 sandbox.start();
-                filesystemProxy.setSandbox(sandbox);
-                currentAcquireResult.set(result);
+                ctx.put(Sandbox.class, sandbox);
+                ctx.put(SandboxAcquireResult.class, result);
                 log.debug(
                         "[sandbox-mw] Acquired sandbox {}",
                         sandbox.getState() != null ? sandbox.getState().getSessionId() : "?");
             } catch (Exception e) {
-                filesystemProxy.setSandbox(null);
                 try {
                     sandboxManager.release(result);
                 } catch (Exception releaseErr) {
@@ -111,14 +111,19 @@ public class SandboxLifecycleMiddleware implements MiddlewareBase {
      * Releases the sandbox after the current call. Called from
      * {@code ReActAgent.afterAgentExecution()} to ensure cleanup for both paths.
      *
-     * @param ctx the per-call RuntimeContext (captured at acquire time)
+     * @param ctx the per-call RuntimeContext (same instance used at acquire time)
      */
     public void releaseForCall(RuntimeContext ctx) {
-        SandboxAcquireResult result = currentAcquireResult.getAndSet(null);
+        if (ctx == null) {
+            return;
+        }
+        SandboxAcquireResult result = ctx.get(SandboxAcquireResult.class);
         if (result == null) {
             return;
         }
-        SandboxContext sandboxContext = ctx != null ? ctx.get(SandboxContext.class) : null;
+        ctx.put(SandboxAcquireResult.class, null);
+        ctx.put(Sandbox.class, null);
+        SandboxContext sandboxContext = ctx.get(SandboxContext.class);
         try {
             sandboxManager.persistState(result, sandboxContext, ctx);
         } catch (Exception e) {
@@ -130,6 +135,5 @@ public class SandboxLifecycleMiddleware implements MiddlewareBase {
             log.warn("[sandbox-mw] Failed to release sandbox session: {}", e.getMessage(), e);
         }
         result.getLease().close();
-        filesystemProxy.setSandbox(null);
     }
 }


### PR DESCRIPTION
…reading issues.The sandbox will be released before MemoryFlushMiddleWare executed.

## AgentScope-Java Version

2.0.0-RC3

## Description

Sandbox模式bug很多，HarnessAgent设计是可复用，在sandbox模式同时访问agent的时候，SandboxLifecycleMiddleware内部的sanbox对象没有线程安全保护，sandbox需要放入context中获取。
另外MemoryFlushMiddleware在执行doFlush的时候，因为是异步的,HarnessAgent在releaseForCall的时候可能已经停掉了sandbox, 异步的doflush已经进不去沙箱获取和上传文件了。sandbox模式比较特殊，其他模式应该没问题，主流程在HarnessAgent里编排的，要改动挺大（担心影响后面的统一设计），先临时把sandbox模式的doflush做成了同步执行，其他的继续走异步。坐等官方统一解决吧。另外还有state返序列化失败，数据库存不进去数等等问题（本pr没修）

## Checklist

Please check the following items before code is ready to be reviewed.

- [ ]  Code has been formatted with `mvn spotless:apply`
- [ ]  All tests are passing (`mvn test`)
- [ ]  Javadoc comments are complete and follow project conventions
- [ ]  Related documentation has been updated (e.g. links, examples, etc.)
- [ ]  Code is ready for review
