### PR TITLE
fix(sandbox): use deterministic snapshot IDs and fix BuilderConfig local-mode startup crash

### DIFF
--- a/.fastRequest/config/fastRequestCurrentProjectConfig.json
+++ b/.fastRequest/config/fastRequestCurrentProjectConfig.json
@@ -1,0 +1,34 @@
+{
+	"apiDocTemplate":"#if (${namingPolicy}=='byDoc')\n$H1 ${methodDescription}\n#else\n$H1 $!{methodName}\n\n$H3 Method description\n\n```\n$!{methodDescription}\n```\n#end\n\n> URL: $!{url}\n>\n> Origin Url: $!{originUrl}\n>\n> Type: $!{methodType}\n\n\n$H3 Request headers\n\n|Header Name| Header Value|\n|---------|------|\n#foreach( $h in ${headerList})\n|$h.type|$h.value|\n#end\n\n$H3 Parameters\n\n$H5 Path parameters\n\n| Parameter | Type | Value | Description |\n|---------|------|------|------------|\n#foreach( $node in ${pathKeyValueList})\n|$node.key|$!{node.type}|$!{node.value}|$!{node.comment}|\n#end\n\n\n$H5 URL parameters\n\n|Required| Parameter | Type | Value | Description |\n|---------|---------|------|------|------------|\n#foreach( $node in ${urlParamsKeyValueList})\n|$!{node.enabled}|$!{node.key}|$!{node.type}|$!{node.value}|$!{node.comment}|\n#end\n\n\n$H5 Body parameters\n\n$H6 JSON\n\n```\n${jsonParam}\n```\n\n$H6 JSON document\n\n```\n${jsonParamDocument}\n```\n\n\n$H5 Form URL-Encoded\n|Required| Parameter | Type | Value | Description |\n|---------|---------|------|------|------------|\n#foreach( $node in ${urlEncodedKeyValueList})\n|$!{node.enabled}|$!{node.key}|$!{node.type}|$!{node.value}|$!{node.comment}|\n#end\n\n\n$H5 Multipart\n|Required | Parameter | Type | Value | Description |\n|---------|---------|------|------|------------|\n#foreach( $node in ${multipartKeyValueList})\n|$!{node.enabled}|$!{node.key}|$!{node.type}|$!{node.value}|$!{node.comment}|\n#end\n\n\n$H3 Response\n\n$H5 Response example\n\n```\n$!{responseExample}\n```\n\n$H5 Response document\n```\n$!{returnDocument}\n```\n\n\n",
+	"apifoxSetting":{
+		"domain":"https://api.apifox.com",
+		"syncAfterSave":false
+	},
+	"dataList":[],
+	"envList":[],
+	"headerList":[],
+	"ignoreParseFieldList":[],
+	"maxDescriptionLength":-1,
+	"pmCollectionId":"",
+	"postScript":"",
+	"preScript":"",
+	"projectList":[],
+	"searchTruncatedCode":"",
+	"syncModel":{
+		"branch":"master",
+		"domain":"https://github.com",
+		"enabled":false,
+		"gitToken":"",
+		"namingPolicy":"byDoc",
+		"owner":"",
+		"repo":"",
+		"repoUrl":"",
+		"syncAfterRun":false,
+		"type":"github"
+	},
+	"syncPmAfterSave":false,
+	"urlEncodedKeyValueList":[],
+	"urlParamsKeyValueList":[],
+	"urlSuffix":"",
+	"workspaceId":""
+}

--- a/agentscope-examples/agents/agentscope-builder/src/main/java/io/agentscope/builder/web/config/BuilderConfig.java
+++ b/agentscope-examples/agents/agentscope-builder/src/main/java/io/agentscope/builder/web/config/BuilderConfig.java
@@ -214,13 +214,15 @@ public class BuilderConfig {
                 b -> {
                     b.middleware(new ToolNotificationMiddleware(toolEventBus));
                     b.stateStore(stateStore);
-                    // `activity/` is routed to the shared BaseStore so the per-agent audit log
-                    // (written by AgentActivityStore) is visible across pods, not pinned to the
-                    // local disk of whichever pod served the write.
-                    b.filesystem(
-                            new RemoteFilesystemSpec(baseStore)
-                                    .isolationScope(IsolationScope.USER)
-                                    .addSharedPrefix("activity/"));
+                    if (sessionOpt.isPresent()) {
+                        // `activity/` is routed to the shared BaseStore so the per-agent audit
+                        // log (written by AgentActivityStore) is visible across pods, not pinned
+                        // to the local disk of whichever pod served the write.
+                        b.filesystem(
+                                new RemoteFilesystemSpec(baseStore)
+                                        .isolationScope(IsolationScope.USER)
+                                        .addSharedPrefix("activity/"));
+                    }
                 });
 
         BuilderBootstrap bootstrap = builder.build();

--- a/agentscope-extensions/agentscope-extensions-sandbox/agentscope-extensions-sandbox-agentrun/src/main/java/io/agentscope/extensions/sandbox/agentrun/AgentRunSandboxClient.java
+++ b/agentscope-extensions/agentscope-extensions-sandbox/agentscope-extensions-sandbox-agentrun/src/main/java/io/agentscope/extensions/sandbox/agentrun/AgentRunSandboxClient.java
@@ -65,6 +65,15 @@ public class AgentRunSandboxClient implements SandboxClient<AgentRunSandboxClien
             WorkspaceSpec workspaceSpec,
             SandboxSnapshotSpec snapshotSpec,
             AgentRunSandboxClientOptions options) {
+        return create(workspaceSpec, snapshotSpec, options, null);
+    }
+
+    @Override
+    public Sandbox create(
+            WorkspaceSpec workspaceSpec,
+            SandboxSnapshotSpec snapshotSpec,
+            AgentRunSandboxClientOptions options,
+            String snapshotId) {
         AgentRunSandboxClientOptions merged = merge(options);
         merged.validate();
 
@@ -85,7 +94,9 @@ public class AgentRunSandboxClient implements SandboxClient<AgentRunSandboxClien
         state.setWorkspaceOnNas(isWorkspaceUnderMounts(merged));
 
         if (snapshotSpec != null) {
-            state.setSnapshot(snapshotSpec.build(sessionId));
+            String effectiveSnapshotId =
+                    snapshotId != null && !snapshotId.isBlank() ? snapshotId : sessionId;
+            state.setSnapshot(snapshotSpec.build(effectiveSnapshotId));
         }
 
         log.debug(

--- a/agentscope-extensions/agentscope-extensions-sandbox/agentscope-extensions-sandbox-agentrun/src/test/java/io/agentscope/extensions/sandbox/agentrun/AgentRunSandboxClientSnapshotIdTest.java
+++ b/agentscope-extensions/agentscope-extensions-sandbox/agentscope-extensions-sandbox-agentrun/src/test/java/io/agentscope/extensions/sandbox/agentrun/AgentRunSandboxClientSnapshotIdTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.agentscope.extensions.sandbox.agentrun;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -28,6 +43,21 @@ class AgentRunSandboxClientSnapshotIdTest {
     }
 
     @TempDir Path tempDir;
+
+    @Test
+    @DisplayName("constructor tolerates null defaultOptions")
+    void constructorWithNullDefaultOptions() {
+        AgentRunSandboxClient c = new AgentRunSandboxClient(null, null);
+        AgentRunSandboxClientOptions opts = new AgentRunSandboxClientOptions();
+        opts.setApiKey("test-key");
+        opts.setTemplateName("test-template");
+        opts.setMcpServerUrl("http://localhost:8080");
+        opts.setRegion("cn-hangzhou");
+        opts.setAccountId("123456789");
+        Sandbox sandbox = c.create(new WorkspaceSpec(), null, opts);
+        assertNotNull(sandbox);
+        assertNotNull(sandbox.getState().getSessionId());
+    }
 
     @Test
     @DisplayName("3-arg create delegates to 4-arg")

--- a/agentscope-extensions/agentscope-extensions-sandbox/agentscope-extensions-sandbox-agentrun/src/test/java/io/agentscope/extensions/sandbox/agentrun/AgentRunSandboxClientSnapshotIdTest.java
+++ b/agentscope-extensions/agentscope-extensions-sandbox/agentscope-extensions-sandbox-agentrun/src/test/java/io/agentscope/extensions/sandbox/agentrun/AgentRunSandboxClientSnapshotIdTest.java
@@ -1,0 +1,69 @@
+package io.agentscope.extensions.sandbox.agentrun;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import io.agentscope.harness.agent.sandbox.Sandbox;
+import io.agentscope.harness.agent.sandbox.SandboxState;
+import io.agentscope.harness.agent.sandbox.WorkspaceSpec;
+import io.agentscope.harness.agent.sandbox.snapshot.LocalSnapshotSpec;
+import io.agentscope.harness.agent.sandbox.snapshot.SandboxSnapshot;
+import java.nio.file.Path;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class AgentRunSandboxClientSnapshotIdTest {
+
+    private final AgentRunSandboxClient client;
+
+    AgentRunSandboxClientSnapshotIdTest() {
+        AgentRunSandboxClientOptions opts = new AgentRunSandboxClientOptions();
+        opts.setApiKey("test-key");
+        opts.setTemplateName("test-template");
+        opts.setMcpServerUrl("http://localhost:8080");
+        opts.setRegion("cn-hangzhou");
+        opts.setAccountId("123456789");
+        this.client = new AgentRunSandboxClient(opts, null);
+    }
+
+    @TempDir Path tempDir;
+
+    @Test
+    @DisplayName("3-arg create delegates to 4-arg")
+    void threeArgDelegatesToFourArg() {
+        Sandbox sandbox = client.create(new WorkspaceSpec(), null, null);
+        assertNotNull(sandbox);
+        assertNotNull(sandbox.getState().getSessionId());
+    }
+
+    @Test
+    @DisplayName("4-arg create uses provided snapshotId")
+    void usesProvidedSnapshotId() {
+        LocalSnapshotSpec spec = new LocalSnapshotSpec(tempDir.toString());
+        Sandbox sandbox = client.create(new WorkspaceSpec(), spec, null, "dave");
+        SandboxState state = sandbox.getState();
+        assertNotNull(state.getSnapshot());
+        assertEquals("dave", snapshotIdOf(state.getSnapshot()));
+    }
+
+    @Test
+    @DisplayName("4-arg create falls back to sessionId when null")
+    void fallsBackWhenNull() {
+        LocalSnapshotSpec spec = new LocalSnapshotSpec(tempDir.toString());
+        Sandbox sandbox = client.create(new WorkspaceSpec(), spec, null, null);
+        SandboxState state = sandbox.getState();
+        assertNotNull(state.getSnapshot());
+        assertEquals(state.getSessionId(), snapshotIdOf(state.getSnapshot()));
+    }
+
+    private static String snapshotIdOf(SandboxSnapshot snapshot) {
+        try {
+            java.lang.reflect.Field f = snapshot.getClass().getDeclaredField("id");
+            f.setAccessible(true);
+            return (String) f.get(snapshot);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/agentscope-extensions/agentscope-extensions-sandbox/agentscope-extensions-sandbox-daytona/src/main/java/io/agentscope/extensions/sandbox/daytona/DaytonaSandboxClient.java
+++ b/agentscope-extensions/agentscope-extensions-sandbox/agentscope-extensions-sandbox-daytona/src/main/java/io/agentscope/extensions/sandbox/daytona/DaytonaSandboxClient.java
@@ -57,6 +57,15 @@ public class DaytonaSandboxClient implements SandboxClient<DaytonaSandboxClientO
             WorkspaceSpec workspaceSpec,
             SandboxSnapshotSpec snapshotSpec,
             DaytonaSandboxClientOptions options) {
+        return create(workspaceSpec, snapshotSpec, options, null);
+    }
+
+    @Override
+    public Sandbox create(
+            WorkspaceSpec workspaceSpec,
+            SandboxSnapshotSpec snapshotSpec,
+            DaytonaSandboxClientOptions options,
+            String snapshotId) {
         String sessionId = UUID.randomUUID().toString();
         DaytonaSandboxClientOptions merged = merge(options);
 
@@ -70,7 +79,9 @@ public class DaytonaSandboxClient implements SandboxClient<DaytonaSandboxClientO
         state.setWorkspaceRootReady(false);
 
         if (snapshotSpec != null) {
-            state.setSnapshot(snapshotSpec.build(sessionId));
+            String effectiveSnapshotId =
+                    snapshotId != null && !snapshotId.isBlank() ? snapshotId : sessionId;
+            state.setSnapshot(snapshotSpec.build(effectiveSnapshotId));
         }
 
         log.debug("[sandbox-daytona] Creating sandbox sessionId={}", sessionId);

--- a/agentscope-extensions/agentscope-extensions-sandbox/agentscope-extensions-sandbox-daytona/src/test/java/io/agentscope/extensions/sandbox/daytona/DaytonaSandboxClientSnapshotIdTest.java
+++ b/agentscope-extensions/agentscope-extensions-sandbox/agentscope-extensions-sandbox-daytona/src/test/java/io/agentscope/extensions/sandbox/daytona/DaytonaSandboxClientSnapshotIdTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.agentscope.extensions.sandbox.daytona;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -18,6 +33,15 @@ class DaytonaSandboxClientSnapshotIdTest {
     private final DaytonaSandboxClient client = new DaytonaSandboxClient();
 
     @TempDir Path tempDir;
+
+    @Test
+    @DisplayName("constructor tolerates null defaultOptions")
+    void constructorWithNullDefaultOptions() {
+        DaytonaSandboxClient c = new DaytonaSandboxClient(null, null);
+        Sandbox sandbox = c.create(new WorkspaceSpec(), null, null);
+        assertNotNull(sandbox);
+        assertNotNull(sandbox.getState().getSessionId());
+    }
 
     @Test
     @DisplayName("3-arg create delegates to 4-arg")

--- a/agentscope-extensions/agentscope-extensions-sandbox/agentscope-extensions-sandbox-daytona/src/test/java/io/agentscope/extensions/sandbox/daytona/DaytonaSandboxClientSnapshotIdTest.java
+++ b/agentscope-extensions/agentscope-extensions-sandbox/agentscope-extensions-sandbox-daytona/src/test/java/io/agentscope/extensions/sandbox/daytona/DaytonaSandboxClientSnapshotIdTest.java
@@ -1,0 +1,59 @@
+package io.agentscope.extensions.sandbox.daytona;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import io.agentscope.harness.agent.sandbox.Sandbox;
+import io.agentscope.harness.agent.sandbox.SandboxState;
+import io.agentscope.harness.agent.sandbox.WorkspaceSpec;
+import io.agentscope.harness.agent.sandbox.snapshot.LocalSnapshotSpec;
+import io.agentscope.harness.agent.sandbox.snapshot.SandboxSnapshot;
+import java.nio.file.Path;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class DaytonaSandboxClientSnapshotIdTest {
+
+    private final DaytonaSandboxClient client = new DaytonaSandboxClient();
+
+    @TempDir Path tempDir;
+
+    @Test
+    @DisplayName("3-arg create delegates to 4-arg")
+    void threeArgDelegatesToFourArg() {
+        Sandbox sandbox = client.create(new WorkspaceSpec(), null, null);
+        assertNotNull(sandbox);
+        assertNotNull(sandbox.getState().getSessionId());
+    }
+
+    @Test
+    @DisplayName("4-arg create uses provided snapshotId")
+    void usesProvidedSnapshotId() {
+        LocalSnapshotSpec spec = new LocalSnapshotSpec(tempDir.toString());
+        Sandbox sandbox = client.create(new WorkspaceSpec(), spec, null, "eve");
+        SandboxState state = sandbox.getState();
+        assertNotNull(state.getSnapshot());
+        assertEquals("eve", snapshotIdOf(state.getSnapshot()));
+    }
+
+    @Test
+    @DisplayName("4-arg create falls back to sessionId when null")
+    void fallsBackWhenNull() {
+        LocalSnapshotSpec spec = new LocalSnapshotSpec(tempDir.toString());
+        Sandbox sandbox = client.create(new WorkspaceSpec(), spec, null, null);
+        SandboxState state = sandbox.getState();
+        assertNotNull(state.getSnapshot());
+        assertEquals(state.getSessionId(), snapshotIdOf(state.getSnapshot()));
+    }
+
+    private static String snapshotIdOf(SandboxSnapshot snapshot) {
+        try {
+            java.lang.reflect.Field f = snapshot.getClass().getDeclaredField("id");
+            f.setAccessible(true);
+            return (String) f.get(snapshot);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/agentscope-extensions/agentscope-extensions-sandbox/agentscope-extensions-sandbox-e2b/src/main/java/io/agentscope/extensions/sandbox/e2b/E2bSandboxClient.java
+++ b/agentscope-extensions/agentscope-extensions-sandbox/agentscope-extensions-sandbox-e2b/src/main/java/io/agentscope/extensions/sandbox/e2b/E2bSandboxClient.java
@@ -56,6 +56,15 @@ public class E2bSandboxClient implements SandboxClient<E2bSandboxClientOptions> 
             WorkspaceSpec workspaceSpec,
             SandboxSnapshotSpec snapshotSpec,
             E2bSandboxClientOptions options) {
+        return create(workspaceSpec, snapshotSpec, options, null);
+    }
+
+    @Override
+    public Sandbox create(
+            WorkspaceSpec workspaceSpec,
+            SandboxSnapshotSpec snapshotSpec,
+            E2bSandboxClientOptions options,
+            String snapshotId) {
         String sessionId = UUID.randomUUID().toString();
         E2bSandboxClientOptions merged = merge(options);
 
@@ -70,7 +79,9 @@ public class E2bSandboxClient implements SandboxClient<E2bSandboxClientOptions> 
         state.setSandboxDomain(merged.getDomain());
 
         if (snapshotSpec != null) {
-            state.setSnapshot(snapshotSpec.build(sessionId));
+            String effectiveSnapshotId =
+                    snapshotId != null && !snapshotId.isBlank() ? snapshotId : sessionId;
+            state.setSnapshot(snapshotSpec.build(effectiveSnapshotId));
         }
 
         log.debug("[sandbox-e2b] Creating sandbox sessionId={}", sessionId);

--- a/agentscope-extensions/agentscope-extensions-sandbox/agentscope-extensions-sandbox-e2b/src/test/java/io/agentscope/extensions/sandbox/e2b/E2bSandboxClientSnapshotIdTest.java
+++ b/agentscope-extensions/agentscope-extensions-sandbox/agentscope-extensions-sandbox-e2b/src/test/java/io/agentscope/extensions/sandbox/e2b/E2bSandboxClientSnapshotIdTest.java
@@ -1,0 +1,59 @@
+package io.agentscope.extensions.sandbox.e2b;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import io.agentscope.harness.agent.sandbox.Sandbox;
+import io.agentscope.harness.agent.sandbox.SandboxState;
+import io.agentscope.harness.agent.sandbox.WorkspaceSpec;
+import io.agentscope.harness.agent.sandbox.snapshot.LocalSnapshotSpec;
+import io.agentscope.harness.agent.sandbox.snapshot.SandboxSnapshot;
+import java.nio.file.Path;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class E2bSandboxClientSnapshotIdTest {
+
+    private final E2bSandboxClient client = new E2bSandboxClient();
+
+    @TempDir Path tempDir;
+
+    @Test
+    @DisplayName("3-arg create delegates to 4-arg")
+    void threeArgDelegatesToFourArg() {
+        Sandbox sandbox = client.create(new WorkspaceSpec(), null, null);
+        assertNotNull(sandbox);
+        assertNotNull(sandbox.getState().getSessionId());
+    }
+
+    @Test
+    @DisplayName("4-arg create uses provided snapshotId")
+    void usesProvidedSnapshotId() {
+        LocalSnapshotSpec spec = new LocalSnapshotSpec(tempDir.toString());
+        Sandbox sandbox = client.create(new WorkspaceSpec(), spec, null, "charlie");
+        SandboxState state = sandbox.getState();
+        assertNotNull(state.getSnapshot());
+        assertEquals("charlie", snapshotIdOf(state.getSnapshot()));
+    }
+
+    @Test
+    @DisplayName("4-arg create falls back to sessionId when null")
+    void fallsBackWhenNull() {
+        LocalSnapshotSpec spec = new LocalSnapshotSpec(tempDir.toString());
+        Sandbox sandbox = client.create(new WorkspaceSpec(), spec, null, null);
+        SandboxState state = sandbox.getState();
+        assertNotNull(state.getSnapshot());
+        assertEquals(state.getSessionId(), snapshotIdOf(state.getSnapshot()));
+    }
+
+    private static String snapshotIdOf(SandboxSnapshot snapshot) {
+        try {
+            java.lang.reflect.Field f = snapshot.getClass().getDeclaredField("id");
+            f.setAccessible(true);
+            return (String) f.get(snapshot);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/agentscope-extensions/agentscope-extensions-sandbox/agentscope-extensions-sandbox-e2b/src/test/java/io/agentscope/extensions/sandbox/e2b/E2bSandboxClientSnapshotIdTest.java
+++ b/agentscope-extensions/agentscope-extensions-sandbox/agentscope-extensions-sandbox-e2b/src/test/java/io/agentscope/extensions/sandbox/e2b/E2bSandboxClientSnapshotIdTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.agentscope.extensions.sandbox.e2b;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -18,6 +33,15 @@ class E2bSandboxClientSnapshotIdTest {
     private final E2bSandboxClient client = new E2bSandboxClient();
 
     @TempDir Path tempDir;
+
+    @Test
+    @DisplayName("constructor tolerates null defaultOptions")
+    void constructorWithNullDefaultOptions() {
+        E2bSandboxClient c = new E2bSandboxClient(null, null);
+        Sandbox sandbox = c.create(new WorkspaceSpec(), null, null);
+        assertNotNull(sandbox);
+        assertNotNull(sandbox.getState().getSessionId());
+    }
 
     @Test
     @DisplayName("3-arg create delegates to 4-arg")

--- a/agentscope-extensions/agentscope-extensions-sandbox/agentscope-extensions-sandbox-kubernetes/src/main/java/io/agentscope/extensions/sandbox/kubernetes/KubernetesSandboxClient.java
+++ b/agentscope-extensions/agentscope-extensions-sandbox/agentscope-extensions-sandbox-kubernetes/src/main/java/io/agentscope/extensions/sandbox/kubernetes/KubernetesSandboxClient.java
@@ -143,12 +143,10 @@ public class KubernetesSandboxClient implements SandboxClient<KubernetesSandboxC
     }
 
     private KubernetesSandboxClientOptions merge(KubernetesSandboxClientOptions callOptions) {
-        KubernetesSandboxClientOptions base =
-                defaultOptions != null ? defaultOptions : new KubernetesSandboxClientOptions();
+        KubernetesSandboxClientOptions o = copy(defaultOptions);
         if (callOptions == null) {
-            return copy(base);
+            return o;
         }
-        KubernetesSandboxClientOptions o = copy(base);
         if (callOptions.getKubernetesClient() != null) {
             o.setKubernetesClient(callOptions.getKubernetesClient());
         }

--- a/agentscope-extensions/agentscope-extensions-sandbox/agentscope-extensions-sandbox-kubernetes/src/main/java/io/agentscope/extensions/sandbox/kubernetes/KubernetesSandboxClient.java
+++ b/agentscope-extensions/agentscope-extensions-sandbox/agentscope-extensions-sandbox-kubernetes/src/main/java/io/agentscope/extensions/sandbox/kubernetes/KubernetesSandboxClient.java
@@ -68,6 +68,15 @@ public class KubernetesSandboxClient implements SandboxClient<KubernetesSandboxC
             WorkspaceSpec workspaceSpec,
             SandboxSnapshotSpec snapshotSpec,
             KubernetesSandboxClientOptions options) {
+        return create(workspaceSpec, snapshotSpec, options, null);
+    }
+
+    @Override
+    public Sandbox create(
+            WorkspaceSpec workspaceSpec,
+            SandboxSnapshotSpec snapshotSpec,
+            KubernetesSandboxClientOptions options,
+            String snapshotId) {
         String sessionId = UUID.randomUUID().toString();
         KubernetesSandboxClientOptions merged = merge(options);
 
@@ -82,7 +91,9 @@ public class KubernetesSandboxClient implements SandboxClient<KubernetesSandboxC
         state.setWorkspaceRootReady(false);
 
         if (snapshotSpec != null) {
-            state.setSnapshot(snapshotSpec.build(sessionId));
+            String effectiveSnapshotId =
+                    snapshotId != null && !snapshotId.isBlank() ? snapshotId : sessionId;
+            state.setSnapshot(snapshotSpec.build(effectiveSnapshotId));
         }
 
         KubernetesClient kc = resolveClient(merged);

--- a/agentscope-extensions/agentscope-extensions-sandbox/agentscope-extensions-sandbox-kubernetes/src/test/java/io/agentscope/extensions/sandbox/kubernetes/KubernetesSandboxClientSnapshotIdTest.java
+++ b/agentscope-extensions/agentscope-extensions-sandbox/agentscope-extensions-sandbox-kubernetes/src/test/java/io/agentscope/extensions/sandbox/kubernetes/KubernetesSandboxClientSnapshotIdTest.java
@@ -1,0 +1,59 @@
+package io.agentscope.extensions.sandbox.kubernetes;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import io.agentscope.harness.agent.sandbox.Sandbox;
+import io.agentscope.harness.agent.sandbox.SandboxState;
+import io.agentscope.harness.agent.sandbox.WorkspaceSpec;
+import io.agentscope.harness.agent.sandbox.snapshot.LocalSnapshotSpec;
+import io.agentscope.harness.agent.sandbox.snapshot.SandboxSnapshot;
+import java.nio.file.Path;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class KubernetesSandboxClientSnapshotIdTest {
+
+    private final KubernetesSandboxClient client = new KubernetesSandboxClient();
+
+    @TempDir Path tempDir;
+
+    @Test
+    @DisplayName("3-arg create delegates to 4-arg")
+    void threeArgDelegatesToFourArg() {
+        Sandbox sandbox = client.create(new WorkspaceSpec(), null, null);
+        assertNotNull(sandbox);
+        assertNotNull(sandbox.getState().getSessionId());
+    }
+
+    @Test
+    @DisplayName("4-arg create uses provided snapshotId")
+    void usesProvidedSnapshotId() {
+        LocalSnapshotSpec spec = new LocalSnapshotSpec(tempDir.toString());
+        Sandbox sandbox = client.create(new WorkspaceSpec(), spec, null, "bob");
+        SandboxState state = sandbox.getState();
+        assertNotNull(state.getSnapshot());
+        assertEquals("bob", snapshotIdOf(state.getSnapshot()));
+    }
+
+    @Test
+    @DisplayName("4-arg create falls back to sessionId when null")
+    void fallsBackWhenNull() {
+        LocalSnapshotSpec spec = new LocalSnapshotSpec(tempDir.toString());
+        Sandbox sandbox = client.create(new WorkspaceSpec(), spec, null, null);
+        SandboxState state = sandbox.getState();
+        assertNotNull(state.getSnapshot());
+        assertEquals(state.getSessionId(), snapshotIdOf(state.getSnapshot()));
+    }
+
+    private static String snapshotIdOf(SandboxSnapshot snapshot) {
+        try {
+            java.lang.reflect.Field f = snapshot.getClass().getDeclaredField("id");
+            f.setAccessible(true);
+            return (String) f.get(snapshot);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/agentscope-extensions/agentscope-extensions-sandbox/agentscope-extensions-sandbox-kubernetes/src/test/java/io/agentscope/extensions/sandbox/kubernetes/KubernetesSandboxClientSnapshotIdTest.java
+++ b/agentscope-extensions/agentscope-extensions-sandbox/agentscope-extensions-sandbox-kubernetes/src/test/java/io/agentscope/extensions/sandbox/kubernetes/KubernetesSandboxClientSnapshotIdTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.agentscope.extensions.sandbox.kubernetes;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -18,6 +33,15 @@ class KubernetesSandboxClientSnapshotIdTest {
     private final KubernetesSandboxClient client = new KubernetesSandboxClient();
 
     @TempDir Path tempDir;
+
+    @Test
+    @DisplayName("constructor tolerates null defaultOptions")
+    void constructorWithNullDefaultOptions() {
+        KubernetesSandboxClient c = new KubernetesSandboxClient(null, null);
+        Sandbox sandbox = c.create(new WorkspaceSpec(), null, null);
+        assertNotNull(sandbox);
+        assertNotNull(sandbox.getState().getSessionId());
+    }
 
     @Test
     @DisplayName("3-arg create delegates to 4-arg")

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/sandbox/SandboxClient.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/sandbox/SandboxClient.java
@@ -32,6 +32,26 @@ public interface SandboxClient<O extends SandboxClientOptions> {
     Sandbox create(WorkspaceSpec workspaceSpec, SandboxSnapshotSpec snapshotSpec, O options);
 
     /**
+     * Creates a new sandbox with a caller-supplied stable snapshot identifier.
+     *
+     * <p>The {@code snapshotId} is passed to {@link SandboxSnapshotSpec#build(String)} so that
+     * the snapshot file name is deterministic across sandbox re-creations. This allows a
+     * previously-persisted snapshot to be found when the sandbox container/pod is lost but the
+     * snapshot archive survives on disk or in remote storage.
+     *
+     * <p>The default implementation ignores {@code snapshotId} and delegates to
+     * {@link #create(WorkspaceSpec, SandboxSnapshotSpec, SandboxClientOptions)}, preserving
+     * backward compatibility for existing implementations.
+     */
+    default Sandbox create(
+            WorkspaceSpec workspaceSpec,
+            SandboxSnapshotSpec snapshotSpec,
+            O options,
+            String snapshotId) {
+        return create(workspaceSpec, snapshotSpec, options);
+    }
+
+    /**
      * Resumes a sandbox from previously serialized {@link SandboxState}.
      */
     Sandbox resume(SandboxState state);

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/sandbox/SandboxManager.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/sandbox/SandboxManager.java
@@ -122,6 +122,8 @@ public class SandboxManager {
                             ? sandboxContext.getWorkspaceSpec().copy()
                             : new WorkspaceSpec();
 
+            String snapshotId = scopeKey.map(SandboxIsolationKey::getValue).orElse(null);
+
             @SuppressWarnings("unchecked")
             SandboxClient<SandboxClientOptions> typedClient =
                     (SandboxClient<SandboxClientOptions>) client;
@@ -129,7 +131,8 @@ public class SandboxManager {
                     typedClient.create(
                             spec,
                             sandboxContext.getSnapshotSpec(),
-                            sandboxContext.getClientOptions());
+                            sandboxContext.getClientOptions(),
+                            snapshotId);
             return SandboxAcquireResult.selfManaged(sandbox, lease);
 
         } catch (Exception e) {

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/sandbox/impl/docker/DockerSandboxClient.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/sandbox/impl/docker/DockerSandboxClient.java
@@ -60,6 +60,15 @@ public class DockerSandboxClient implements SandboxClient<DockerSandboxClientOpt
             WorkspaceSpec workspaceSpec,
             SandboxSnapshotSpec snapshotSpec,
             DockerSandboxClientOptions options) {
+        return create(workspaceSpec, snapshotSpec, options, null);
+    }
+
+    @Override
+    public Sandbox create(
+            WorkspaceSpec workspaceSpec,
+            SandboxSnapshotSpec snapshotSpec,
+            DockerSandboxClientOptions options,
+            String snapshotId) {
         String sessionId = UUID.randomUUID().toString();
 
         String image =
@@ -86,7 +95,9 @@ public class DockerSandboxClient implements SandboxClient<DockerSandboxClientOpt
         }
 
         if (snapshotSpec != null) {
-            state.setSnapshot(snapshotSpec.build(sessionId));
+            String effectiveSnapshotId =
+                    snapshotId != null && !snapshotId.isBlank() ? snapshotId : sessionId;
+            state.setSnapshot(snapshotSpec.build(effectiveSnapshotId));
         }
 
         log.debug("[sandbox-docker] Creating new sandbox: id={}, image={}", sessionId, image);

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/example/support/InMemorySandboxClient.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/example/support/InMemorySandboxClient.java
@@ -53,6 +53,15 @@ public class InMemorySandboxClient implements SandboxClient<SandboxClientOptions
             WorkspaceSpec workspaceSpec,
             SandboxSnapshotSpec snapshotSpec,
             SandboxClientOptions options) {
+        return create(workspaceSpec, snapshotSpec, options, null);
+    }
+
+    @Override
+    public Sandbox create(
+            WorkspaceSpec workspaceSpec,
+            SandboxSnapshotSpec snapshotSpec,
+            SandboxClientOptions options,
+            String snapshotId) {
         createCount.incrementAndGet();
         String sessionId = UUID.randomUUID().toString();
         Path workspaceDir = baseDir.resolve(sessionId);

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/sandbox/SandboxClientDefaultMethodTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/sandbox/SandboxClientDefaultMethodTest.java
@@ -1,0 +1,53 @@
+package io.agentscope.harness.agent.sandbox;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+import io.agentscope.harness.agent.sandbox.snapshot.SandboxSnapshotSpec;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/** Tests for the default 4-arg create() method on {@link SandboxClient}. */
+@ExtendWith(MockitoExtension.class)
+class SandboxClientDefaultMethodTest {
+
+    @Mock Sandbox sandbox3arg;
+
+    @Test
+    @DisplayName("default 4-arg create delegates to 3-arg create")
+    void defaultMethodDelegates() {
+        SandboxClient<SandboxClientOptions> client =
+                new SandboxClient<>() {
+                    @Override
+                    public Sandbox create(
+                            WorkspaceSpec ws, SandboxSnapshotSpec ss, SandboxClientOptions opts) {
+                        return sandbox3arg;
+                    }
+
+                    @Override
+                    public Sandbox resume(SandboxState state) {
+                        return null;
+                    }
+
+                    @Override
+                    public void delete(Sandbox sandbox) {}
+
+                    @Override
+                    public String serializeState(SandboxState state) {
+                        return null;
+                    }
+
+                    @Override
+                    public SandboxState deserializeState(String json) {
+                        return null;
+                    }
+                };
+
+        Sandbox result = client.create(new WorkspaceSpec(), null, null, "some-snapshot-id");
+        assertSame(sandbox3arg, result);
+        assertNotNull(result);
+    }
+}

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/sandbox/SandboxClientDefaultMethodTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/sandbox/SandboxClientDefaultMethodTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.agentscope.harness.agent.sandbox;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/sandbox/SandboxManagerIsolationTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/sandbox/SandboxManagerIsolationTest.java
@@ -102,7 +102,7 @@ class SandboxManagerIsolationTest {
 
         assertSame(resumedSandbox, result.getSandbox());
         assertEquals(true, result.isSelfManaged());
-        verify(client, never()).create(any(), any(), any());
+        verify(client, never()).create(any(), any(), any(), any());
     }
 
     // ---- Priority 3: state store miss → Priority 4 fresh create ----
@@ -110,7 +110,7 @@ class SandboxManagerIsolationTest {
     @Test
     void priority3_stateStoreMiss_createsFreshSession() throws Exception {
         when(stateStore.load(any())).thenReturn(Optional.empty());
-        when(client.create(any(), any(), any())).thenReturn(freshSandbox);
+        when(client.create(any(), any(), any(), any())).thenReturn(freshSandbox);
 
         RuntimeContext rtx = RuntimeContext.builder().sessionId("sess-2").build();
         SandboxContext sCtx =
@@ -122,14 +122,14 @@ class SandboxManagerIsolationTest {
         SandboxAcquireResult result = manager.acquire(sCtx, rtx);
 
         assertSame(freshSandbox, result.getSandbox());
-        verify(client).create(any(), any(), any());
+        verify(client).create(any(), any(), any(), any());
     }
 
     // ---- Priority 4 (no session key → scope key empty → fresh create) ----
 
     @Test
     void noScopeKey_createsFreshSession() throws Exception {
-        when(client.create(any(), any(), any())).thenReturn(freshSandbox);
+        when(client.create(any(), any(), any(), any())).thenReturn(freshSandbox);
 
         RuntimeContext rtx = RuntimeContext.builder().build(); // no userId or sessionId
         SandboxContext sCtx = SandboxContext.builder().build(); // scope = null → USER default
@@ -166,7 +166,7 @@ class SandboxManagerIsolationTest {
                 };
         manager = new SandboxManager(client, stateStore, AGENT_ID, guard);
         when(stateStore.load(any())).thenReturn(Optional.empty());
-        when(client.create(any(), any(), any())).thenReturn(freshSandbox);
+        when(client.create(any(), any(), any(), any())).thenReturn(freshSandbox);
 
         RuntimeContext rtx = RuntimeContext.builder().userId("user-42").build();
         SandboxContext sCtx = SandboxContext.builder().isolationScope(IsolationScope.USER).build();
@@ -180,7 +180,7 @@ class SandboxManagerIsolationTest {
 
     @Test
     void userScope_missingUserId_createsFreshSession() throws Exception {
-        when(client.create(any(), any(), any())).thenReturn(freshSandbox);
+        when(client.create(any(), any(), any(), any())).thenReturn(freshSandbox);
 
         RuntimeContext rtx = RuntimeContext.builder().build(); // no userId
         SandboxContext sCtx = SandboxContext.builder().isolationScope(IsolationScope.USER).build();
@@ -196,7 +196,7 @@ class SandboxManagerIsolationTest {
     @Test
     void agentScope_alwaysHasScopeKey() throws Exception {
         when(stateStore.load(any())).thenReturn(Optional.empty());
-        when(client.create(any(), any(), any())).thenReturn(freshSandbox);
+        when(client.create(any(), any(), any(), any())).thenReturn(freshSandbox);
 
         SandboxContext sCtx = SandboxContext.builder().isolationScope(IsolationScope.AGENT).build();
 
@@ -211,7 +211,7 @@ class SandboxManagerIsolationTest {
     @Test
     void globalScope_alwaysHasScopeKey() throws Exception {
         when(stateStore.load(any())).thenReturn(Optional.empty());
-        when(client.create(any(), any(), any())).thenReturn(freshSandbox);
+        when(client.create(any(), any(), any(), any())).thenReturn(freshSandbox);
 
         SandboxContext sCtx =
                 SandboxContext.builder().isolationScope(IsolationScope.GLOBAL).build();

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/sandbox/impl/docker/DockerSandboxClientSnapshotIdTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/sandbox/impl/docker/DockerSandboxClientSnapshotIdTest.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.harness.agent.sandbox.impl.docker;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import io.agentscope.harness.agent.sandbox.Sandbox;
+import io.agentscope.harness.agent.sandbox.SandboxState;
+import io.agentscope.harness.agent.sandbox.WorkspaceSpec;
+import io.agentscope.harness.agent.sandbox.snapshot.LocalSnapshotSpec;
+import io.agentscope.harness.agent.sandbox.snapshot.SandboxSnapshot;
+import java.nio.file.Path;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/** Tests for {@link DockerSandboxClient} snapshotId handling. */
+class DockerSandboxClientSnapshotIdTest {
+
+    private final DockerSandboxClient client = new DockerSandboxClient();
+
+    @TempDir Path tempDir;
+
+    @Nested
+    @DisplayName("3-arg create()")
+    class ThreeArgCreate {
+
+        @Test
+        @DisplayName("delegates to 4-arg with null snapshotId")
+        void delegatesToFourArg() {
+            Sandbox sandbox = client.create(new WorkspaceSpec(), null, null);
+            assertNotNull(sandbox);
+            assertNotNull(sandbox.getState());
+            assertNotNull(sandbox.getState().getSessionId());
+        }
+    }
+
+    @Nested
+    @DisplayName("4-arg create() with snapshotId")
+    class FourArgCreate {
+
+        @Test
+        @DisplayName("uses provided snapshotId when non-blank")
+        void usesProvidedSnapshotId() {
+            LocalSnapshotSpec spec = new LocalSnapshotSpec(tempDir.toString());
+            Sandbox sandbox = client.create(new WorkspaceSpec(), spec, null, "alice");
+            SandboxState state = sandbox.getState();
+
+            assertNotNull(state.getSnapshot());
+            assertEquals("alice", snapshotIdOf(state.getSnapshot()));
+        }
+
+        @Test
+        @DisplayName("falls back to sessionId when snapshotId is null")
+        void fallsBackWhenNull() {
+            LocalSnapshotSpec spec = new LocalSnapshotSpec(tempDir.toString());
+            Sandbox sandbox = client.create(new WorkspaceSpec(), spec, null, null);
+            SandboxState state = sandbox.getState();
+
+            assertNotNull(state.getSnapshot());
+            assertEquals(state.getSessionId(), snapshotIdOf(state.getSnapshot()));
+        }
+
+        @Test
+        @DisplayName("falls back to sessionId when snapshotId is blank")
+        void fallsBackWhenBlank() {
+            LocalSnapshotSpec spec = new LocalSnapshotSpec(tempDir.toString());
+            Sandbox sandbox = client.create(new WorkspaceSpec(), spec, null, "  ");
+            SandboxState state = sandbox.getState();
+
+            assertNotNull(state.getSnapshot());
+            assertEquals(state.getSessionId(), snapshotIdOf(state.getSnapshot()));
+        }
+
+        @Test
+        @DisplayName("sets null snapshot when snapshotSpec is null")
+        void nullSnapshotSpec() {
+            Sandbox sandbox = client.create(new WorkspaceSpec(), null, null, "alice");
+            SandboxState state = sandbox.getState();
+            assertNull(state.getSnapshot());
+        }
+
+        @Test
+        @DisplayName("sets default image when options is null")
+        void nullOptions() {
+            Sandbox sandbox = client.create(new WorkspaceSpec(), null, null, "test-id");
+            DockerSandboxState state = (DockerSandboxState) sandbox.getState();
+            assertEquals("ubuntu:22.04", state.getImage());
+            assertEquals("/workspace", state.getWorkspaceRoot());
+        }
+
+        @Test
+        @DisplayName("uses option values when provided")
+        void withOptions() {
+            DockerSandboxClientOptions opts =
+                    new DockerSandboxClientOptions().image("python:3.11").workspaceRoot("/app");
+            Sandbox sandbox = client.create(new WorkspaceSpec(), null, opts, "test-id");
+            DockerSandboxState state = (DockerSandboxState) sandbox.getState();
+            assertEquals("python:3.11", state.getImage());
+            assertEquals("/app", state.getWorkspaceRoot());
+        }
+
+        @Test
+        @DisplayName("generates unique sessionId per call")
+        void uniqueSessionIds() {
+            Sandbox s1 = client.create(new WorkspaceSpec(), null, null, "same-id");
+            Sandbox s2 = client.create(new WorkspaceSpec(), null, null, "same-id");
+            assertNotNull(s1.getState().getSessionId());
+            assertNotNull(s2.getState().getSessionId());
+        }
+    }
+
+    private static String snapshotIdOf(SandboxSnapshot snapshot) {
+        try {
+            java.lang.reflect.Field f = snapshot.getClass().getDeclaredField("id");
+            f.setAccessible(true);
+            return (String) f.get(snapshot);
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to read snapshot id via reflection", e);
+        }
+    }
+}


### PR DESCRIPTION
## AgentScope-Java Version

2.0.0-SNAPSHOT

## Description

### Background

Two bugs were discovered:

1. **BuilderConfig local-mode startup crash**: `BuilderConfig.builderBootstrap()` unconditionally configures `RemoteFilesystemSpec` for all agents, but when no distributed `AgentStateStore` bean is present, it falls back to `InMemoryAgentStateStore`. `HarnessAgent.build()` rejects this combination (`RemoteFilesystemSpec` + local state store), causing a startup `IllegalStateException`.

2. **Sandbox snapshot cannot be restored**: `DockerSandboxClient.create()` generates a random UUID as the snapshot identifier each time. When a sandbox container is lost but the snapshot `.tar` file survives, a re-creation generates a new UUID, making `LocalSandboxSnapshot.isRestorable()` always return `false` — the old snapshot is orphaned and workspace state (e.g. created files) is lost between agent calls.

### Changes

**BuilderConfig fix** (`BuilderConfig.java`):
- Wrap `RemoteFilesystemSpec` configuration in `if (sessionOpt.isPresent())` so it is only applied when a distributed `AgentStateStore` bean is available. Local mode uses the default local filesystem.

**Deterministic snapshot IDs** (9 files):
- Add a new default method `SandboxClient.create(WorkspaceSpec, SandboxSnapshotSpec, O, String snapshotId)` that accepts a caller-supplied stable snapshot identifier.
- `SandboxManager.acquire()` at Priority 4 now derives `snapshotId` from the `SandboxIsolationKey` (e.g. userId "alice") and passes it to the client. This ensures the same user/agent always maps to the same snapshot file (e.g. `.ws/alice.tar`).
- All 6 `SandboxClient` implementations (`Docker`, `Kubernetes`, `E2B`, `Daytona`, `AgentRun`, `InMemory`) override the 4-arg method and use the provided `snapshotId` for `snapshotSpec.build()`, falling back to the random UUID when `snapshotId` is null.
- Updated `SandboxManagerIsolationTest` mocks to match the new 4-arg call signature.

### How to test

1. **BuilderConfig fix**: Start `BuilderApp` without configuring a distributed `AgentStateStore` (no Redis). The app should boot successfully in local mode instead of throwing `IllegalStateException`.

2. **Snapshot restore**: Run the `DockerSandboxDemo1` example:
   - Ask the agent to create `hello.txt` → succeeds, snapshot persisted
   - Ask the agent to check if `hello.txt` exists → should find the file (previously failed)
   - Verify that `.ws/{userId}.tar` is created with a deterministic name derived from the isolation key

## Checklist

Please check the following items before code is ready to be reviewed.

- [ ] Code has been formatted with `mvn spotless:apply`
- [x] All tests are passing (`mvn test`)
- [ ] Javadoc comments are complete and follow project conventions
- [ ] Related documentation has been updated (e.g. links, examples, etc.)
- [ ] Code is ready for review