### PR TITLE
fix: preserve typed runtime context across copies

### DIFF
--- a/agentscope-core/src/main/java/io/agentscope/core/ReActAgent.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/ReActAgent.java
@@ -612,10 +612,7 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
             return RuntimeContext.empty();
         }
         if (toolExecutionContext != null) {
-            return RuntimeContext.builder()
-                    .userId(run.getUserId())
-                    .sessionId(run.getSessionId())
-                    .agentState(run.getAgentState())
+            return RuntimeContext.builder(run)
                     .toolExecutionContext(
                             ToolExecutionContext.merge(
                                     run.asToolExecutionContext(), toolExecutionContext))

--- a/agentscope-core/src/main/java/io/agentscope/core/agent/RuntimeContext.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/agent/RuntimeContext.java
@@ -66,13 +66,20 @@ public class RuntimeContext {
         if (builder.stringExtras != null) {
             this.stringAttributes.putAll(builder.stringExtras);
         }
-        for (Map.Entry<Class<?>, Object> e : builder.typedSingletons.entrySet()) {
-            if (e.getValue() == null) {
+        for (Map.Entry<Class<?>, Map<String, Object>> e : builder.typedValues.entrySet()) {
+            Class<?> type = e.getKey();
+            Map<String, Object> values = e.getValue();
+            if (type == null || values == null || values.isEmpty()) {
                 continue;
             }
-            @SuppressWarnings("unchecked")
-            Class<Object> type = (Class<Object>) e.getKey();
-            putValue(TYPED_DEFAULT_KEY, type, e.getValue());
+            for (Map.Entry<String, Object> typedEntry : values.entrySet()) {
+                if (typedEntry.getKey() == null || typedEntry.getValue() == null) {
+                    continue;
+                }
+                @SuppressWarnings("unchecked")
+                Class<Object> typedClass = (Class<Object>) type;
+                putValue(typedEntry.getKey(), typedClass, typedEntry.getValue());
+            }
         }
     }
 
@@ -167,7 +174,7 @@ public class RuntimeContext {
         if (type == RuntimeContext.class) {
             return (T) this;
         }
-        return null;
+        return getAssignableValue(TYPED_DEFAULT_KEY, type);
     }
 
     public <T> void put(Class<T> type, T value) {
@@ -193,6 +200,10 @@ public class RuntimeContext {
         if (TYPED_DEFAULT_KEY.equals(key) && type == RuntimeContext.class) {
             return (T) this;
         }
+        T assignable = getAssignableValue(key, type);
+        if (assignable != null) {
+            return assignable;
+        }
         Object fromString = stringAttributes.get(key);
         if (type.isInstance(fromString)) {
             return (T) fromString;
@@ -209,6 +220,10 @@ public class RuntimeContext {
         } else {
             putValue(key, type, value);
         }
+    }
+
+    public static Builder builder(RuntimeContext source) {
+        return new Builder().from(source);
     }
 
     /**
@@ -234,6 +249,42 @@ public class RuntimeContext {
             return null;
         }
         return type.isInstance(o) ? type.cast(o) : null;
+    }
+
+    private <T> T getAssignableValue(String key, Class<T> type) {
+        if (type == null) {
+            return null;
+        }
+        T candidate = null;
+        Class<?> candidateType = null;
+        for (Map.Entry<Class<?>, ConcurrentMap<String, Object>> entry :
+                typedAttributes.entrySet()) {
+            Class<?> storedType = entry.getKey();
+            if (storedType == null || !type.isAssignableFrom(storedType)) {
+                continue;
+            }
+            Map<String, Object> values = entry.getValue();
+            if (values == null) {
+                continue;
+            }
+            Object o = values.get(key);
+            if (o == null || !type.isInstance(o)) {
+                continue;
+            }
+            if (candidate == null) {
+                candidate = type.cast(o);
+                candidateType = storedType;
+                continue;
+            }
+            if (candidateType.equals(storedType)) {
+                continue;
+            }
+            if (candidateType.isAssignableFrom(storedType)) {
+                candidate = type.cast(o);
+                candidateType = storedType;
+            }
+        }
+        return candidate;
     }
 
     private <T> void removeTyped(Class<T> type, String key) {
@@ -275,7 +326,7 @@ public class RuntimeContext {
         private String sessionId;
         private String userId;
         private Map<String, Object> stringExtras;
-        private final Map<Class<?>, Object> typedSingletons = new HashMap<>();
+        private final Map<Class<?>, Map<String, Object>> typedValues = new HashMap<>();
         private ToolExecutionContext toolExecutionContext;
         private AgentState agentState;
 
@@ -314,8 +365,34 @@ public class RuntimeContext {
         }
 
         public <T> Builder put(Class<T> type, T value) {
-            if (type != null) {
-                this.typedSingletons.put(type, value);
+            return put(TYPED_DEFAULT_KEY, type, value);
+        }
+
+        public <T> Builder put(String key, Class<T> type, T value) {
+            if (key == null || type == null || value == null) {
+                return this;
+            }
+            this.typedValues.computeIfAbsent(type, k -> new HashMap<>()).put(key, value);
+            return this;
+        }
+
+        public Builder from(RuntimeContext source) {
+            if (source == null) {
+                return this;
+            }
+            this.sessionId = source.sessionId;
+            this.userId = source.userId;
+            this.agentState = source.agentState;
+            this.toolExecutionContext = source.toolExecutionContext;
+            if (!source.stringAttributes.isEmpty()) {
+                this.stringExtras = new ConcurrentHashMap<>(source.stringAttributes);
+            }
+            for (Map.Entry<Class<?>, ConcurrentMap<String, Object>> entry :
+                    source.typedAttributes.entrySet()) {
+                if (entry.getValue() == null || entry.getValue().isEmpty()) {
+                    continue;
+                }
+                this.typedValues.put(entry.getKey(), new HashMap<>(entry.getValue()));
             }
             return this;
         }
@@ -349,31 +426,13 @@ public class RuntimeContext {
         @Override
         @SuppressWarnings("unchecked")
         public <T> T get(String key, Class<T> type) {
-            T t = runtimeContext.getValue(key, type);
-            if (t != null) {
-                return t;
-            }
-            if (TYPED_DEFAULT_KEY.equals(key) && type == RuntimeContext.class) {
-                return (T) runtimeContext;
-            }
-            Object fromString = runtimeContext.stringAttributes.get(key);
-            if (type.isInstance(fromString)) {
-                return (T) fromString;
-            }
-            return null;
+            return runtimeContext.get(key, type);
         }
 
         @Override
         @SuppressWarnings("unchecked")
         public <T> T get(Class<T> type) {
-            T t = get(TYPED_DEFAULT_KEY, type);
-            if (t != null) {
-                return t;
-            }
-            if (type == RuntimeContext.class) {
-                return (T) runtimeContext;
-            }
-            return null;
+            return runtimeContext.get(type);
         }
 
         @Override

--- a/agentscope-core/src/test/java/io/agentscope/core/agent/ReActAgentRuntimeContextTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/agent/ReActAgentRuntimeContextTest.java
@@ -18,6 +18,7 @@ package io.agentscope.core.agent;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.agentscope.core.ReActAgent;
@@ -37,9 +38,11 @@ import io.agentscope.core.message.ToolUseBlock;
 import io.agentscope.core.model.ChatResponse;
 import io.agentscope.core.model.ChatUsage;
 import io.agentscope.core.tool.Tool;
+import io.agentscope.core.tool.ToolExecutionContext;
 import io.agentscope.core.tool.ToolParam;
 import io.agentscope.core.tool.Toolkit;
 import io.agentscope.core.util.JsonUtils;
+import java.lang.reflect.Method;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -143,6 +146,42 @@ class ReActAgentRuntimeContextTest {
                         .getContext()
                         .stream()
                         .anyMatch(m -> m.hasContentBlocks(ToolResultBlock.class)));
+    }
+
+    @Test
+    void buildMergedRuntimeContextCopiesTypedData() throws Exception {
+        ReActAgent agent =
+                ReActAgent.builder()
+                        .name(TestConstants.TEST_REACT_AGENT_NAME)
+                        .sysPrompt(TestConstants.DEFAULT_SYS_PROMPT)
+                        .model(new MockModel("ok"))
+                        .toolkit(new Toolkit())
+                        .toolExecutionContext(
+                                ToolExecutionContext.builder()
+                                        .register(new SharedPojo("toolkit"))
+                                        .build())
+                        .build();
+
+        RuntimeContext callContext =
+                RuntimeContext.builder()
+                        .userId("user-1")
+                        .put(SharedPojo.class, new SharedPojo("from-call"))
+                        .build();
+
+        Method method =
+                ReActAgent.class.getDeclaredMethod(
+                        "buildMergedRuntimeContext", RuntimeContext.class);
+        method.setAccessible(true);
+
+        RuntimeContext merged = (RuntimeContext) method.invoke(agent, callContext);
+        RuntimeContext mergedFromNull = (RuntimeContext) method.invoke(agent, new Object[] {null});
+
+        assertNotNull(merged);
+        assertEquals("user-1", merged.getUserId());
+        assertSame(callContext.get(SharedPojo.class), merged.get(SharedPojo.class));
+        assertEquals("from-call", merged.asToolExecutionContext().get(SharedPojo.class).value);
+        assertNotNull(mergedFromNull);
+        assertSame(agent.getToolExecutionContext(), mergedFromNull.getToolExecutionContext());
     }
 
     private static String lastToolText(ReActAgent agent, String userId, String sessionId) {

--- a/agentscope-core/src/test/java/io/agentscope/core/agent/RuntimeContextTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/agent/RuntimeContextTest.java
@@ -136,6 +136,28 @@ class RuntimeContextTest {
     }
 
     @Test
+    @DisplayName("typed keyed access falls back to assignable singleton values")
+    void keyedTypedAccessFallsBackToAssignableSingleton() {
+        MarkerImpl filesystem = new MarkerImpl("filesystem");
+        RuntimeContext ctx =
+                RuntimeContext.builder().put("filesystem", MarkerImpl.class, filesystem).build();
+
+        assertSame(filesystem, ctx.get("filesystem", Marker.class));
+        assertSame(filesystem, ctx.get("filesystem", MarkerImpl.class));
+        assertNull(ctx.get("missing", Marker.class));
+    }
+
+    @Test
+    @DisplayName("builder(source) tolerates null and preserves empty contexts")
+    void builderCopyHandlesNullSource() {
+        RuntimeContext empty = RuntimeContext.builder((RuntimeContext) null).build();
+
+        assertNull(empty.getSessionId());
+        assertNull(empty.getUserId());
+        assertNull(empty.get("missing", Marker.class));
+    }
+
+    @Test
     @DisplayName("concurrent puts on distinct keys from multiple threads")
     void threadSafety() throws Exception {
         RuntimeContext ctx = RuntimeContext.empty();

--- a/agentscope-core/src/test/java/io/agentscope/core/agent/RuntimeContextTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/agent/RuntimeContextTest.java
@@ -16,6 +16,7 @@
 package io.agentscope.core.agent;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 
@@ -32,6 +33,16 @@ class RuntimeContextTest {
         final String id;
 
         PojoA(String id) {
+            this.id = id;
+        }
+    }
+
+    private interface Marker {}
+
+    private static final class MarkerImpl implements Marker {
+        final String id;
+
+        MarkerImpl(String id) {
             this.id = id;
         }
     }
@@ -99,6 +110,29 @@ class RuntimeContextTest {
         ToolExecutionContext merged =
                 ToolExecutionContext.merge(run.asToolExecutionContext(), agent);
         assertSame(fromRun, merged.get(PojoA.class));
+    }
+
+    @Test
+    @DisplayName("builder(source) preserves typed and string extras")
+    void builderCopyPreservesTypedData() {
+        MarkerImpl filesystem = new MarkerImpl("filesystem");
+        RuntimeContext source =
+                RuntimeContext.builder()
+                        .sessionId("sid-copy")
+                        .userId("user-copy")
+                        .put("plain", "value")
+                        .put(MarkerImpl.class, filesystem)
+                        .build();
+
+        RuntimeContext copy = RuntimeContext.builder(source).build();
+
+        assertEquals("sid-copy", copy.getSessionId());
+        assertEquals("user-copy", copy.getUserId());
+        assertEquals("value", copy.get("plain"));
+        assertSame(filesystem, copy.get(MarkerImpl.class));
+        assertSame(filesystem, copy.get(Marker.class));
+        assertSame(copy, copy.get(RuntimeContext.class));
+        assertInstanceOf(MarkerImpl.class, copy.get(Marker.class));
     }
 
     @Test

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/HarnessAgent.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/HarnessAgent.java
@@ -860,28 +860,26 @@ public class HarnessAgent implements Agent, AutoCloseable {
      * RuntimeContext (consumed by {@code ReActAgent.activateSlotForContext}).
      */
     private RuntimeContext ensureSessionDefaults(RuntimeContext ctx) {
-        String ctxSessionId = ctx.getSessionId();
+        RuntimeContext source = ctx != null ? ctx : RuntimeContext.empty();
+        String ctxSessionId = source.getSessionId();
         if (ctxSessionId == null || ctxSessionId.isBlank()) {
             ctxSessionId = getName();
         }
+        AbstractFilesystem sourceFs = source.get(AbstractFilesystem.class);
         SandboxContext sandboxCtx =
-                ctx.get(SandboxContext.class) != null
-                        ? ctx.get(SandboxContext.class)
+                source.get(SandboxContext.class) != null
+                        ? source.get(SandboxContext.class)
                         : defaultSandboxContext;
         AbstractFilesystem fs = workspaceManager != null ? workspaceManager.getFilesystem() : null;
 
-        if (ctxSessionId.equals(ctx.getSessionId())
-                && sandboxCtx == ctx.get(SandboxContext.class)
-                && (fs == null || fs == ctx.get(AbstractFilesystem.class))) {
-            return ctx;
+        if (ctxSessionId.equals(source.getSessionId())
+                && sandboxCtx == source.get(SandboxContext.class)
+                && (fs == null || sourceFs != null)) {
+            return source;
         }
-        RuntimeContext.Builder b =
-                RuntimeContext.builder()
-                        .sessionId(ctxSessionId)
-                        .userId(ctx.getUserId())
-                        .putAll(ctx.getExtra())
-                        .put(SandboxContext.class, sandboxCtx);
-        if (fs != null) {
+        RuntimeContext.Builder b = RuntimeContext.builder(source).sessionId(ctxSessionId);
+        b.put(SandboxContext.class, sandboxCtx);
+        if (sourceFs == null && fs != null) {
             b.put(AbstractFilesystem.class, fs);
         }
         if (workspaceManager != null) {

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/HarnessAgentTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/HarnessAgentTest.java
@@ -18,6 +18,7 @@ package io.agentscope.harness.agent;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
@@ -26,16 +27,19 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import io.agentscope.core.agent.Agent;
 import io.agentscope.core.agent.RuntimeContext;
 import io.agentscope.core.message.Msg;
 import io.agentscope.core.message.MsgRole;
 import io.agentscope.core.message.TextBlock;
+import io.agentscope.core.middleware.MiddlewareBase;
 import io.agentscope.core.model.ChatResponse;
 import io.agentscope.core.model.Model;
 import io.agentscope.core.model.ToolSchema;
 import io.agentscope.core.state.AgentStateStore;
 import io.agentscope.core.tool.AgentTool;
 import io.agentscope.core.tool.Toolkit;
+import io.agentscope.harness.agent.filesystem.AbstractFilesystem;
 import io.agentscope.harness.agent.filesystem.local.LocalFilesystem;
 import io.agentscope.harness.agent.filesystem.remote.store.InMemoryStore;
 import io.agentscope.harness.agent.filesystem.spec.RemoteFilesystemSpec;
@@ -49,11 +53,13 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.mockito.ArgumentCaptor;
 import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 
 /**
  * Tests for {@link HarnessAgent} workspace wiring: {@code AGENTS.md} context and subagent
@@ -228,6 +234,46 @@ class HarnessAgentTest {
                 "expected workspace hook to wrap AGENTS.md in agents_context");
         assertTrue(
                 combined.contains(marker), "model should see AGENTS.md body in injected context");
+    }
+
+    @Test
+    void runtimeContextConcreteFilesystemSurvivesSessionDefaulting() throws Exception {
+        Files.createDirectories(workspace);
+
+        Model model = stubModel("assistant-done");
+        LocalFilesystem agentFilesystem = new LocalFilesystem(workspace);
+        LocalFilesystem customFilesystem = new LocalFilesystem(workspace);
+        AtomicReference<RuntimeContext> seen = new AtomicReference<>();
+
+        HarnessAgent agent =
+                HarnessAgent.builder()
+                        .name("t")
+                        .model(model)
+                        .workspace(workspace)
+                        .abstractFilesystem(agentFilesystem)
+                        .middleware(
+                                new MiddlewareBase() {
+                                    @Override
+                                    public Mono<String> onSystemPrompt(
+                                            Agent agent, RuntimeContext ctx, String currentPrompt) {
+                                        seen.set(ctx);
+                                        return Mono.just(currentPrompt);
+                                    }
+                                })
+                        .build();
+
+        agent.call(
+                        userText("hi"),
+                        RuntimeContext.builder()
+                                .put(LocalFilesystem.class, customFilesystem)
+                                .build())
+                .block();
+
+        RuntimeContext effective = seen.get();
+        assertNotNull(effective);
+        assertNotNull(effective.getSessionId());
+        assertSame(customFilesystem, effective.get(AbstractFilesystem.class));
+        assertSame(customFilesystem, effective.get(LocalFilesystem.class));
     }
 
     @Test

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/HarnessAgentTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/HarnessAgentTest.java
@@ -18,6 +18,7 @@ package io.agentscope.harness.agent;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -39,12 +40,15 @@ import io.agentscope.core.model.ToolSchema;
 import io.agentscope.core.state.AgentStateStore;
 import io.agentscope.core.tool.AgentTool;
 import io.agentscope.core.tool.Toolkit;
+import io.agentscope.harness.agent.example.support.InMemorySandboxClient;
+import io.agentscope.harness.agent.example.support.InMemorySandboxFilesystemSpec;
 import io.agentscope.harness.agent.filesystem.AbstractFilesystem;
 import io.agentscope.harness.agent.filesystem.local.LocalFilesystem;
 import io.agentscope.harness.agent.filesystem.remote.store.InMemoryStore;
 import io.agentscope.harness.agent.filesystem.spec.RemoteFilesystemSpec;
 import io.agentscope.harness.agent.memory.compaction.CompactionConfig;
 import io.agentscope.harness.agent.middleware.SubagentEntry;
+import io.agentscope.harness.agent.sandbox.SandboxContext;
 import io.agentscope.harness.agent.subagent.AgentSpecLoader;
 import io.agentscope.harness.agent.subagent.SubagentDeclaration;
 import io.agentscope.harness.agent.subagent.WorkspaceMode;
@@ -53,6 +57,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
@@ -274,6 +279,118 @@ class HarnessAgentTest {
         assertNotNull(effective.getSessionId());
         assertSame(customFilesystem, effective.get(AbstractFilesystem.class));
         assertSame(customFilesystem, effective.get(LocalFilesystem.class));
+    }
+
+    @Test
+    void runtimeContextNullInputGetsDefaultSessionAndSandbox() throws Exception {
+        Files.createDirectories(workspace);
+
+        Model model = stubModel("assistant-done");
+        LocalFilesystem agentFilesystem = new LocalFilesystem(workspace);
+        AtomicReference<RuntimeContext> seen = new AtomicReference<>();
+
+        try (HarnessAgent agent =
+                HarnessAgent.builder()
+                        .name("t")
+                        .model(model)
+                        .workspace(workspace)
+                        .abstractFilesystem(agentFilesystem)
+                        .middleware(
+                                new MiddlewareBase() {
+                                    @Override
+                                    public Mono<String> onSystemPrompt(
+                                            Agent agent, RuntimeContext ctx, String currentPrompt) {
+                                        seen.set(ctx);
+                                        return Mono.just(currentPrompt);
+                                    }
+                                })
+                        .build()) {
+            agent.call(userText("hi"), (RuntimeContext) null).block();
+        }
+
+        RuntimeContext effective = seen.get();
+        assertNotNull(effective);
+        assertEquals("t", effective.getSessionId());
+        assertSame(agentFilesystem, effective.get(AbstractFilesystem.class));
+        assertNull(effective.get(SandboxContext.class));
+        assertNull(effective.getUserId());
+    }
+
+    @Test
+    void runtimeContextAlreadyDefaultedReturnsSourceWhenNothingChanges() throws Exception {
+        Files.createDirectories(workspace);
+
+        Model model = stubModel("assistant-done");
+        LocalFilesystem agentFilesystem = new LocalFilesystem(workspace);
+        SandboxContext sandboxContext =
+                SandboxContext.builder().isolationScope(IsolationScope.USER).build();
+        AtomicReference<RuntimeContext> seen = new AtomicReference<>();
+
+        RuntimeContext source =
+                RuntimeContext.builder()
+                        .sessionId("t")
+                        .put(SandboxContext.class, sandboxContext)
+                        .put(AbstractFilesystem.class, agentFilesystem)
+                        .build();
+
+        try (HarnessAgent agent =
+                HarnessAgent.builder()
+                        .name("t")
+                        .model(model)
+                        .workspace(workspace)
+                        .abstractFilesystem(agentFilesystem)
+                        .middleware(
+                                new MiddlewareBase() {
+                                    @Override
+                                    public Mono<String> onSystemPrompt(
+                                            Agent agent, RuntimeContext ctx, String currentPrompt) {
+                                        seen.set(ctx);
+                                        return Mono.just(currentPrompt);
+                                    }
+                                })
+                        .build()) {
+            agent.call(userText("hi"), source).block();
+        }
+
+        assertSame(source, seen.get());
+    }
+
+    @Test
+    void runtimeContextSandboxSpecProvidesDefaultSandboxContext() throws Exception {
+        Files.createDirectories(workspace);
+
+        InMemorySandboxFilesystemSpec spec = new InMemorySandboxFilesystemSpec();
+        spec.isolationScope(IsolationScope.SESSION);
+        InMemorySandboxClient client = spec.getClient();
+        client.resetCounts();
+        Model model = stubModel("assistant-done");
+        AtomicReference<RuntimeContext> seen = new AtomicReference<>();
+        String sessionId = "sandbox-" + UUID.randomUUID();
+
+        try (HarnessAgent agent =
+                HarnessAgent.builder()
+                        .name("t")
+                        .model(model)
+                        .workspace(workspace.toAbsolutePath().normalize().toString())
+                        .filesystem(spec)
+                        .middleware(
+                                new MiddlewareBase() {
+                                    @Override
+                                    public Mono<String> onSystemPrompt(
+                                            Agent agent, RuntimeContext ctx, String currentPrompt) {
+                                        seen.set(ctx);
+                                        return Mono.just(currentPrompt);
+                                    }
+                                })
+                        .build()) {
+            agent.call(userText("hi"), RuntimeContext.builder().sessionId(sessionId).build())
+                    .block();
+        }
+
+        RuntimeContext effective = seen.get();
+        assertNotNull(effective);
+        assertNotNull(effective.get(SandboxContext.class));
+        assertEquals(1, client.getCreateCount());
     }
 
     @Test


### PR DESCRIPTION
## AgentScope-Java Version
2.0.0-SNAPSHOT

## Description
### Background
`RuntimeContext` rebuilds in harness/agent paths were dropping typed custom values such as `AbstractFilesystem`.

### Purpose
Keep caller-provided typed context data intact when the runtime/session context is cloned or defaulted.

### Changes made
- Added `RuntimeContext.builder(RuntimeContext source)` to clone typed and string extras.
- Updated `ReActAgent` and `HarnessAgent` to clone the source context instead of rebuilding a narrow one.
- Added regression tests covering typed runtime-context copies and filesystem survival.

### How to test
- `mvn.cmd -pl 'agentscope-core,agentscope-harness' -am '-Dtest=RuntimeContextTest,HarnessAgentTest' test`

Closes #1810

## Checklist
- [x] Code has been formatted with `mvn spotless:apply`
- [x] All tests are passing (`mvn test`)
- [ ] Javadoc comments are complete and follow project conventions
- [ ] Related documentation has been updated (e.g. links, examples, etc.)
- [x] Code is ready for review