### PR TITLE
fix(pr1780): harden shell execute and stream context

### DIFF
--- a/agentscope-core/src/main/java/io/agentscope/core/agent/Agent.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/agent/Agent.java
@@ -17,6 +17,8 @@ package io.agentscope.core.agent;
 
 import io.agentscope.core.message.Msg;
 import io.agentscope.core.tool.Toolkit;
+import java.util.List;
+import reactor.core.publisher.Flux;
 
 /**
  * Complete agent interface combining all capabilities.
@@ -96,6 +98,23 @@ public interface Agent extends CallableAgent, StreamableAgent, ObservableAgent {
      */
     default io.agentscope.core.state.AgentState getAgentState() {
         return null;
+    }
+
+    /**
+     * Stream execution events with a per-call {@link RuntimeContext}.
+     *
+     * <p>The default implementation preserves backward compatibility by delegating to
+     * {@link #stream(List, StreamOptions)} when an implementation does not override this overload.
+     * Implementations that need the runtime context during streaming should override this method.
+     *
+     * @param msgs Input messages
+     * @param options Stream configuration options
+     * @param runtimeContext Per-call runtime context, or {@code null}
+     * @return Flux of events emitted during execution
+     */
+    default Flux<Event> stream(
+            List<Msg> msgs, StreamOptions options, RuntimeContext runtimeContext) {
+        return stream(msgs, options);
     }
 
     /**

--- a/agentscope-core/src/test/java/io/agentscope/core/agent/AgentStreamingTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/agent/AgentStreamingTest.java
@@ -47,6 +47,7 @@ class AgentStreamingTest {
     static class TestStreamingAgent extends AgentBase {
         private String responseText = "Test response";
         private boolean shouldFail = false;
+        private final AtomicInteger legacyStreamCallCount = new AtomicInteger();
 
         TestStreamingAgent(String name) {
             super(name);
@@ -58,6 +59,10 @@ class AgentStreamingTest {
 
         void setShouldFail(boolean shouldFail) {
             this.shouldFail = shouldFail;
+        }
+
+        int getLegacyStreamCallCount() {
+            return legacyStreamCallCount.get();
         }
 
         @Override
@@ -73,6 +78,12 @@ class AgentStreamingTest {
                             .content(TextBlock.builder().text(responseText).build())
                             .build();
             return Mono.just(response);
+        }
+
+        @Override
+        public reactor.core.publisher.Flux<Event> stream(List<Msg> msgs, StreamOptions options) {
+            legacyStreamCallCount.incrementAndGet();
+            return super.stream(msgs, options);
         }
 
         @Override
@@ -229,6 +240,29 @@ class AgentStreamingTest {
         assertFalse(events.isEmpty());
         Event lastEvent = events.get(events.size() - 1);
         assertEquals(EventType.AGENT_RESULT, lastEvent.getType());
+    }
+
+    @Test
+    void testThreeArgStreamFallsBackToLegacyImplementation() {
+        TestStreamingAgent agent = new TestStreamingAgent("test-agent");
+        agent.setResponseText("Response");
+
+        List<Msg> inputMsgs =
+                List.of(
+                        Msg.builder()
+                                .name("user")
+                                .role(MsgRole.USER)
+                                .content(List.of(TextBlock.builder().text("Hello").build()))
+                                .build());
+
+        StreamOptions options = StreamOptions.builder().build();
+        RuntimeContext runtimeContext = RuntimeContext.builder().sessionId("sess-1").build();
+
+        List<Event> events = new ArrayList<>();
+        agent.stream(inputMsgs, options, runtimeContext).doOnNext(events::add).blockLast();
+
+        assertFalse(events.isEmpty());
+        assertEquals(1, agent.getLegacyStreamCallCount());
     }
 
     @Test

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/tool/ShellExecuteTool.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/tool/ShellExecuteTool.java
@@ -23,6 +23,7 @@ import io.agentscope.harness.agent.filesystem.sandbox.AbstractSandboxFilesystem;
 import io.agentscope.harness.agent.filesystem.util.FilesystemUtils;
 import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
+import java.util.function.Function;
 
 /**
  * Shell execution tool backed by a {@link AbstractSandboxFilesystem}.
@@ -80,6 +81,11 @@ public class ShellExecuteTool {
     }
 
     private static String validateWorkingDirectory(String workingDirectory) {
+        return validateWorkingDirectory(workingDirectory, Path::of);
+    }
+
+    static String validateWorkingDirectory(
+            String workingDirectory, Function<String, Path> pathParser) {
         if (workingDirectory == null || workingDirectory.isBlank()) {
             throw new IllegalArgumentException("working_directory must not be null or blank");
         }
@@ -92,7 +98,7 @@ public class ShellExecuteTool {
                     "working_directory must be relative: " + workingDirectory);
         }
         try {
-            for (Path segment : Path.of(workingDirectory)) {
+            for (Path segment : pathParser.apply(workingDirectory)) {
                 if ("..".equals(segment.toString())) {
                     throw new IllegalArgumentException(
                             "working_directory may not contain '..': " + workingDirectory);

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/tool/ShellExecuteTool.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/tool/ShellExecuteTool.java
@@ -20,6 +20,9 @@ import io.agentscope.core.tool.Tool;
 import io.agentscope.core.tool.ToolParam;
 import io.agentscope.harness.agent.filesystem.model.ExecuteResponse;
 import io.agentscope.harness.agent.filesystem.sandbox.AbstractSandboxFilesystem;
+import io.agentscope.harness.agent.filesystem.util.FilesystemUtils;
+import java.nio.file.InvalidPathException;
+import java.nio.file.Path;
 
 /**
  * Shell execution tool backed by a {@link AbstractSandboxFilesystem}.
@@ -55,7 +58,11 @@ public class ShellExecuteTool {
                     int timeout) {
         String effectiveCommand = command;
         if (workingDirectory != null && !workingDirectory.isBlank()) {
-            effectiveCommand = "cd " + workingDirectory + " && " + command;
+            effectiveCommand =
+                    "cd "
+                            + FilesystemUtils.shellQuote(validateWorkingDirectory(workingDirectory))
+                            + " && "
+                            + command;
         }
 
         ExecuteResponse result =
@@ -70,5 +77,42 @@ public class ShellExecuteTool {
             sb.append("\n(output was truncated)");
         }
         return sb.toString();
+    }
+
+    private static String validateWorkingDirectory(String workingDirectory) {
+        if (workingDirectory == null || workingDirectory.isBlank()) {
+            throw new IllegalArgumentException("working_directory must not be null or blank");
+        }
+        if (workingDirectory.indexOf('\0') >= 0) {
+            throw new IllegalArgumentException(
+                    "working_directory must not contain null bytes: " + workingDirectory);
+        }
+        if (isAbsoluteWorkingDirectory(workingDirectory)) {
+            throw new IllegalArgumentException(
+                    "working_directory must be relative: " + workingDirectory);
+        }
+        try {
+            for (Path segment : Path.of(workingDirectory)) {
+                if ("..".equals(segment.toString())) {
+                    throw new IllegalArgumentException(
+                            "working_directory may not contain '..': " + workingDirectory);
+                }
+            }
+        } catch (InvalidPathException e) {
+            throw new IllegalArgumentException("Invalid working_directory: " + workingDirectory, e);
+        }
+        return workingDirectory;
+    }
+
+    private static boolean isAbsoluteWorkingDirectory(String workingDirectory) {
+        return workingDirectory.startsWith("/")
+                || workingDirectory.startsWith("\\")
+                || isWindowsDriveAbsolute(workingDirectory);
+    }
+
+    private static boolean isWindowsDriveAbsolute(String workingDirectory) {
+        return workingDirectory.length() >= 2
+                && Character.isLetter(workingDirectory.charAt(0))
+                && workingDirectory.charAt(1) == ':';
     }
 }

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/tool/ShellExecuteToolTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/tool/ShellExecuteToolTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.harness.agent.tool;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.same;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.agentscope.core.agent.RuntimeContext;
+import io.agentscope.harness.agent.filesystem.model.ExecuteResponse;
+import io.agentscope.harness.agent.filesystem.sandbox.AbstractSandboxFilesystem;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+class ShellExecuteToolTest {
+
+    @Test
+    void executeQuotesWorkingDirectoryBeforeShellCommand() {
+        AbstractSandboxFilesystem sandbox = mock(AbstractSandboxFilesystem.class);
+        ShellExecuteTool tool = new ShellExecuteTool(sandbox);
+        RuntimeContext runtimeContext = RuntimeContext.builder().sessionId("sess-1").build();
+
+        when(sandbox.execute(any(), anyString(), anyInt()))
+                .thenReturn(new ExecuteResponse("hello", 0, false));
+
+        String result = tool.execute(runtimeContext, "pwd", "nested dir/o'clock", 15);
+
+        assertEquals("Exit code: 0\n\nhello", result);
+
+        ArgumentCaptor<String> commandCaptor = ArgumentCaptor.forClass(String.class);
+        verify(sandbox).execute(same(runtimeContext), commandCaptor.capture(), eq(15));
+        assertEquals("cd 'nested dir/o'\\''clock' && pwd", commandCaptor.getValue());
+    }
+
+    @Test
+    void executeRejectsUnsafeWorkingDirectoryValues() {
+        ShellExecuteTool tool = new ShellExecuteTool(mock(AbstractSandboxFilesystem.class));
+        RuntimeContext runtimeContext = RuntimeContext.empty();
+
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> tool.execute(runtimeContext, "pwd", "/tmp", 15));
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> tool.execute(runtimeContext, "pwd", "C:\\tmp", 15));
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> tool.execute(runtimeContext, "pwd", "\\\\server\\share", 15));
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> tool.execute(runtimeContext, "pwd", "safe\0dir", 15));
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> tool.execute(runtimeContext, "pwd", "../outside", 15));
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> tool.execute(runtimeContext, "pwd", "safe/../../outside", 15));
+    }
+}

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/tool/ShellExecuteToolTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/tool/ShellExecuteToolTest.java
@@ -29,6 +29,8 @@ import static org.mockito.Mockito.when;
 import io.agentscope.core.agent.RuntimeContext;
 import io.agentscope.harness.agent.filesystem.model.ExecuteResponse;
 import io.agentscope.harness.agent.filesystem.sandbox.AbstractSandboxFilesystem;
+import java.nio.file.InvalidPathException;
+import java.nio.file.Path;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
@@ -75,5 +77,59 @@ class ShellExecuteToolTest {
         assertThrows(
                 IllegalArgumentException.class,
                 () -> tool.execute(runtimeContext, "pwd", "safe/../../outside", 15));
+    }
+
+    @Test
+    void executeLeavesCommandUnchangedWhenWorkingDirectoryIsMissing() {
+        AbstractSandboxFilesystem sandbox = mock(AbstractSandboxFilesystem.class);
+        ShellExecuteTool tool = new ShellExecuteTool(sandbox);
+        RuntimeContext runtimeContext = RuntimeContext.builder().sessionId("sess-1").build();
+
+        when(sandbox.execute(any(), anyString(), anyInt()))
+                .thenReturn(new ExecuteResponse(null, 0, false));
+
+        String result = tool.execute(runtimeContext, "pwd", null, 15);
+
+        assertEquals("Exit code: 0\n", result);
+
+        ArgumentCaptor<String> commandCaptor = ArgumentCaptor.forClass(String.class);
+        verify(sandbox).execute(same(runtimeContext), commandCaptor.capture(), eq(15));
+        assertEquals("pwd", commandCaptor.getValue());
+    }
+
+    @Test
+    void executeAppendsTruncatedMarkerWhenSandboxResultIsTruncated() {
+        AbstractSandboxFilesystem sandbox = mock(AbstractSandboxFilesystem.class);
+        ShellExecuteTool tool = new ShellExecuteTool(sandbox);
+        RuntimeContext runtimeContext = RuntimeContext.builder().sessionId("sess-1").build();
+
+        when(sandbox.execute(any(), anyString(), anyInt()))
+                .thenReturn(new ExecuteResponse("hello", 0, true));
+
+        String result = tool.execute(runtimeContext, "pwd", "nested dir", 15);
+
+        assertEquals("Exit code: 0\n\nhello\n(output was truncated)", result);
+    }
+
+    @Test
+    void validateWorkingDirectoryRejectsNullOrBlank() {
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> ShellExecuteTool.validateWorkingDirectory(null, Path::of));
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> ShellExecuteTool.validateWorkingDirectory("   ", Path::of));
+    }
+
+    @Test
+    void validateWorkingDirectoryWrapsParserFailures() {
+        assertThrows(
+                IllegalArgumentException.class,
+                () ->
+                        ShellExecuteTool.validateWorkingDirectory(
+                                "safe/path",
+                                value -> {
+                                    throw new InvalidPathException(value, "forced failure");
+                                }));
     }
 }


### PR DESCRIPTION
## AgentScope-Java Version

2.0.0-SNAPSHOT

## Description

This PR hardens two areas highlighted in review feedback:

- `ShellExecuteTool` now validates `working_directory` before building the shell command.
- It rejects absolute paths, `..` traversal, and null bytes.
- It also quotes the directory path before prepending `cd`, which avoids shell parsing issues.
- Added regression coverage for safe quoting and unsafe path rejection.

- `Agent` adds a new default `stream(List<Msg>, StreamOptions, RuntimeContext)` overload.
- The default implementation preserves backward compatibility by delegating to the legacy two-argument `stream(...)`.
- Added a regression test proving the new overload falls back to the old path.

Validation:

- `mvn -pl agentscope-harness,agentscope-core -Dtest=ShellExecuteToolTest,AgentStreamingTest test`
- `mvn -pl agentscope-harness,agentscope-core spotless:check`
- `mvn -pl agentscope-harness,agentscope-core spotless:apply`

## Checklist

- [x] Code has been formatted with `mvn spotless:apply`
- [x] All tests are passing (`mvn test`)
- [x] Javadoc comments are complete and follow project conventions
- [ ] Related documentation has been updated (e.g. links, examples, etc.)
- [x] Code is ready for review

Close https://github.com/agentscope-ai/agentscope-java/issues/1777