### PR TITLE
fix(formatter): preserve multimodal DataBlock handling

### DIFF
--- a/agentscope-core/src/main/java/io/agentscope/core/formatter/AbstractBaseFormatter.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/formatter/AbstractBaseFormatter.java
@@ -132,9 +132,7 @@ public abstract class AbstractBaseFormatter<TReq, TResp, TParams>
      */
     protected boolean hasMediaContent(Msg msg) {
         for (ContentBlock block : msg.getContent()) {
-            if (block instanceof ImageBlock
-                    || block instanceof AudioBlock
-                    || block instanceof VideoBlock) {
+            if (MediaUtils.inferMediaKind(block) != null) {
                 return true;
             }
         }
@@ -207,15 +205,20 @@ public abstract class AbstractBaseFormatter<TReq, TResp, TParams>
         List<String> textualOutput = new ArrayList<>();
 
         for (ContentBlock block : output) {
-            if (block instanceof TextBlock tb) {
+            ContentBlock normalizedBlock = MediaUtils.normalizeMediaBlock(block);
+            if (normalizedBlock == null) {
+                continue;
+            }
+
+            if (normalizedBlock instanceof TextBlock tb) {
                 textualOutput.add(tb.getText());
-            } else if (block instanceof ImageBlock ib) {
+            } else if (normalizedBlock instanceof ImageBlock ib) {
                 String reference = convertMediaBlockToTextReference(ib, "image");
                 textualOutput.add(reference);
-            } else if (block instanceof AudioBlock ab) {
+            } else if (normalizedBlock instanceof AudioBlock ab) {
                 String reference = convertMediaBlockToTextReference(ab, "audio");
                 textualOutput.add(reference);
-            } else if (block instanceof VideoBlock vb) {
+            } else if (normalizedBlock instanceof VideoBlock vb) {
                 String reference = convertMediaBlockToTextReference(vb, "video");
                 textualOutput.add(reference);
             }

--- a/agentscope-core/src/main/java/io/agentscope/core/formatter/MediaUtils.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/formatter/MediaUtils.java
@@ -15,6 +15,14 @@
  */
 package io.agentscope.core.formatter;
 
+import io.agentscope.core.message.AudioBlock;
+import io.agentscope.core.message.Base64Source;
+import io.agentscope.core.message.ContentBlock;
+import io.agentscope.core.message.DataBlock;
+import io.agentscope.core.message.ImageBlock;
+import io.agentscope.core.message.Source;
+import io.agentscope.core.message.URLSource;
+import io.agentscope.core.message.VideoBlock;
 import java.awt.Graphics2D;
 import java.awt.image.BufferedImage;
 import java.io.ByteArrayInputStream;
@@ -30,6 +38,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Base64;
 import java.util.List;
+import java.util.Locale;
 import javax.imageio.ImageIO;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -39,6 +48,16 @@ import org.slf4j.LoggerFactory;
  * Provides methods for processing images, audio, and other media types.
  */
 public class MediaUtils {
+
+    /**
+     * Canonical media kinds used to adapt unified {@link DataBlock} instances back to the legacy
+     * media-specific block types expected by provider formatters.
+     */
+    public enum MediaKind {
+        IMAGE,
+        AUDIO,
+        VIDEO
+    }
 
     private static final Logger log = LoggerFactory.getLogger(MediaUtils.class);
 
@@ -275,6 +294,122 @@ public class MediaUtils {
 
             default -> "application/octet-stream";
         };
+    }
+
+    /**
+     * Infer the media kind from a content block.
+     *
+     * @param block the content block
+     * @return image, audio, or video kind; {@code null} if the block is not media or cannot be
+     *     classified
+     */
+    public static MediaKind inferMediaKind(ContentBlock block) {
+        if (block instanceof ImageBlock) {
+            return MediaKind.IMAGE;
+        } else if (block instanceof AudioBlock) {
+            return MediaKind.AUDIO;
+        } else if (block instanceof VideoBlock) {
+            return MediaKind.VIDEO;
+        } else if (block instanceof DataBlock dataBlock) {
+            return inferMediaKind(dataBlock.getSource(), dataBlock.getName());
+        }
+        return null;
+    }
+
+    /**
+     * Infer the media kind from a source object.
+     *
+     * @param source the source to inspect
+     * @return image, audio, or video kind; {@code null} if the source cannot be classified
+     */
+    public static MediaKind inferMediaKind(Source source) {
+        return inferMediaKind(source, null);
+    }
+
+    /**
+     * Infer the media kind from a source object with an optional fallback path/name.
+     *
+     * @param source the source to inspect
+     * @param fallbackPath a file path or file name used when the source metadata is ambiguous
+     * @return image, audio, or video kind; {@code null} if the source cannot be classified
+     */
+    public static MediaKind inferMediaKind(Source source, String fallbackPath) {
+        if (source == null) {
+            return null;
+        }
+
+        String mediaType = null;
+        if (source instanceof URLSource urlSource) {
+            mediaType = determineMediaType(urlSource.getUrl());
+        } else if (source instanceof Base64Source base64Source) {
+            mediaType = base64Source.getMediaType();
+        }
+
+        MediaKind kind = inferMediaKindFromMediaType(mediaType);
+        if (kind != null) {
+            return kind;
+        }
+
+        if (fallbackPath != null && !fallbackPath.isBlank()) {
+            return inferMediaKindFromMediaType(determineMediaType(fallbackPath));
+        }
+
+        return null;
+    }
+
+    /**
+     * Convert a unified {@link DataBlock} back into the legacy media-specific block type expected
+     * by provider formatters.
+     *
+     * @param dataBlock the unified data block
+     * @return an {@link ImageBlock}, {@link AudioBlock}, or {@link VideoBlock}; {@code null} when
+     *     the media kind cannot be inferred
+     */
+    public static ContentBlock toLegacyMediaBlock(DataBlock dataBlock) {
+        if (dataBlock == null) {
+            return null;
+        }
+        MediaKind kind = inferMediaKind(dataBlock.getSource(), dataBlock.getName());
+        if (kind == null) {
+            return null;
+        }
+
+        return switch (kind) {
+            case IMAGE -> ImageBlock.builder().source(dataBlock.getSource()).build();
+            case AUDIO -> AudioBlock.builder().source(dataBlock.getSource()).build();
+            case VIDEO -> VideoBlock.builder().source(dataBlock.getSource()).build();
+        };
+    }
+
+    /**
+     * Normalize a content block so formatter code can keep working with the legacy media-specific
+     * block types.
+     *
+     * @param block the original content block
+     * @return the original block, a legacy media block derived from {@link DataBlock}, or
+     *     {@code null} if the block cannot be normalized
+     */
+    public static ContentBlock normalizeMediaBlock(ContentBlock block) {
+        if (block instanceof DataBlock dataBlock) {
+            return toLegacyMediaBlock(dataBlock);
+        }
+        return block;
+    }
+
+    private static MediaKind inferMediaKindFromMediaType(String mediaType) {
+        if (mediaType == null || mediaType.isBlank()) {
+            return null;
+        }
+
+        String lower = mediaType.toLowerCase(Locale.ROOT);
+        if (lower.startsWith("image/")) {
+            return MediaKind.IMAGE;
+        } else if (lower.startsWith("audio/")) {
+            return MediaKind.AUDIO;
+        } else if (lower.startsWith("video/")) {
+            return MediaKind.VIDEO;
+        }
+        return null;
     }
 
     /**

--- a/agentscope-core/src/main/java/io/agentscope/core/formatter/anthropic/AnthropicConversationMerger.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/formatter/anthropic/AnthropicConversationMerger.java
@@ -15,6 +15,7 @@
  */
 package io.agentscope.core.formatter.anthropic;
 
+import io.agentscope.core.formatter.MediaUtils;
 import io.agentscope.core.message.ContentBlock;
 import io.agentscope.core.message.HintBlock;
 import io.agentscope.core.message.ImageBlock;
@@ -43,13 +44,18 @@ public class AnthropicConversationMerger {
 
         for (Msg msg : messages) {
             for (ContentBlock block : msg.getContent()) {
-                if (block instanceof TextBlock tb) {
+                ContentBlock normalizedBlock = MediaUtils.normalizeMediaBlock(block);
+                if (normalizedBlock == null) {
+                    continue;
+                }
+
+                if (normalizedBlock instanceof TextBlock tb) {
                     String msgName = msg.getName() != null ? msg.getName() : msg.getRole().name();
                     accumulatedText.add(msgName + ": " + tb.getText());
-                } else if (block instanceof HintBlock hb) {
+                } else if (normalizedBlock instanceof HintBlock hb) {
                     String msgName = msg.getName() != null ? msg.getName() : msg.getRole().name();
                     accumulatedText.add(msgName + ": " + hb.getHint());
-                } else if (block instanceof ImageBlock ib) {
+                } else if (normalizedBlock instanceof ImageBlock ib) {
                     // Add accumulated text before image
                     if (!accumulatedText.isEmpty()) {
                         conversationBlocks.add(String.join("\n", accumulatedText));

--- a/agentscope-core/src/main/java/io/agentscope/core/formatter/anthropic/AnthropicMessageConverter.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/formatter/anthropic/AnthropicMessageConverter.java
@@ -23,6 +23,7 @@ import com.anthropic.models.messages.MessageParam.Role;
 import com.anthropic.models.messages.TextBlockParam;
 import com.anthropic.models.messages.ToolResultBlockParam;
 import com.anthropic.models.messages.ToolUseBlockParam;
+import io.agentscope.core.formatter.MediaUtils;
 import io.agentscope.core.message.ContentBlock;
 import io.agentscope.core.message.HintBlock;
 import io.agentscope.core.message.ImageBlock;
@@ -125,22 +126,27 @@ public class AnthropicMessageConverter {
         List<ContentBlockParam> contentBlocks = new ArrayList<>();
 
         for (ContentBlock block : blocks) {
-            if (block instanceof TextBlock tb) {
+            ContentBlock normalizedBlock = MediaUtils.normalizeMediaBlock(block);
+            if (normalizedBlock == null) {
+                continue;
+            }
+
+            if (normalizedBlock instanceof TextBlock tb) {
                 contentBlocks.add(
                         ContentBlockParam.ofText(
                                 TextBlockParam.builder().text(tb.getText()).build()));
-            } else if (block instanceof HintBlock hb) {
+            } else if (normalizedBlock instanceof HintBlock hb) {
                 contentBlocks.add(
                         ContentBlockParam.ofText(
                                 TextBlockParam.builder().text(hb.getHint()).build()));
-            } else if (block instanceof ThinkingBlock thinkingBlock) {
+            } else if (normalizedBlock instanceof ThinkingBlock thinkingBlock) {
                 // Anthropic supports thinking blocks natively
                 contentBlocks.add(
                         ContentBlockParam.ofText(
                                 TextBlockParam.builder()
                                         .text(thinkingBlock.getThinking())
                                         .build()));
-            } else if (block instanceof ImageBlock ib) {
+            } else if (normalizedBlock instanceof ImageBlock ib) {
                 try {
                     ImageBlockParam imageParam = mediaConverter.convertImageBlock(ib);
                     contentBlocks.add(ContentBlockParam.ofImage(imageParam));
@@ -198,11 +204,16 @@ public class AnthropicMessageConverter {
             List<?> outputList = (List<?>) output;
             for (Object item : outputList) {
                 if (item instanceof ContentBlock cb) {
-                    if (cb instanceof TextBlock tb) {
+                    ContentBlock normalizedBlock = MediaUtils.normalizeMediaBlock(cb);
+                    if (normalizedBlock == null) {
+                        continue;
+                    }
+
+                    if (normalizedBlock instanceof TextBlock tb) {
                         blocks.add(
                                 ToolResultBlockParam.Content.Block.ofText(
                                         TextBlockParam.builder().text(tb.getText()).build()));
-                    } else if (cb instanceof ImageBlock ib) {
+                    } else if (normalizedBlock instanceof ImageBlock ib) {
                         try {
                             ImageBlockParam imageParam = mediaConverter.convertImageBlock(ib);
                             blocks.add(ToolResultBlockParam.Content.Block.ofImage(imageParam));

--- a/agentscope-core/src/main/java/io/agentscope/core/formatter/anthropic/AnthropicMultiAgentFormatter.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/formatter/anthropic/AnthropicMultiAgentFormatter.java
@@ -20,6 +20,8 @@ import com.anthropic.models.messages.ImageBlockParam;
 import com.anthropic.models.messages.Message;
 import com.anthropic.models.messages.MessageParam;
 import com.anthropic.models.messages.TextBlockParam;
+import io.agentscope.core.formatter.MediaUtils;
+import io.agentscope.core.message.ContentBlock;
 import io.agentscope.core.message.ImageBlock;
 import io.agentscope.core.message.Msg;
 import io.agentscope.core.message.MsgRole;
@@ -196,7 +198,11 @@ public class AnthropicMultiAgentFormatter extends AnthropicBaseFormatter {
             if (block instanceof String text) {
                 contentBlocks.add(
                         ContentBlockParam.ofText(TextBlockParam.builder().text(text).build()));
-            } else if (block instanceof ImageBlock ib) {
+            } else if (block instanceof ContentBlock contentBlock) {
+                ContentBlock normalizedBlock = MediaUtils.normalizeMediaBlock(contentBlock);
+                if (!(normalizedBlock instanceof ImageBlock ib)) {
+                    continue;
+                }
                 try {
                     ImageBlockParam imageParam = mediaConverter.convertImageBlock(ib);
                     contentBlocks.add(ContentBlockParam.ofImage(imageParam));

--- a/agentscope-core/src/main/java/io/agentscope/core/formatter/dashscope/DashScopeConversationMerger.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/formatter/dashscope/DashScopeConversationMerger.java
@@ -15,6 +15,7 @@
  */
 package io.agentscope.core.formatter.dashscope;
 
+import io.agentscope.core.formatter.MediaUtils;
 import io.agentscope.core.formatter.dashscope.dto.DashScopeContentPart;
 import io.agentscope.core.formatter.dashscope.dto.DashScopeMessage;
 import io.agentscope.core.message.AudioBlock;
@@ -92,12 +93,17 @@ public class DashScopeConversationMerger {
 
             List<ContentBlock> blocks = msg.getContent();
             for (ContentBlock block : blocks) {
-                if (block instanceof TextBlock tb) {
+                ContentBlock normalizedBlock = MediaUtils.normalizeMediaBlock(block);
+                if (normalizedBlock == null) {
+                    continue;
+                }
+
+                if (normalizedBlock instanceof TextBlock tb) {
                     textAccumulator.append(name).append(": ").append(tb.getText()).append("\n");
-                } else if (block instanceof HintBlock hb) {
+                } else if (normalizedBlock instanceof HintBlock hb) {
                     textAccumulator.append(name).append(": ").append(hb.getHint()).append("\n");
 
-                } else if (block instanceof ImageBlock imageBlock) {
+                } else if (normalizedBlock instanceof ImageBlock imageBlock) {
                     // Preserve images for multimodal content
                     try {
                         DashScopeContentPart imageContent =
@@ -109,7 +115,7 @@ public class DashScopeConversationMerger {
                         textAccumulator.append(name).append(": [Image - processing failed]\n");
                     }
 
-                } else if (block instanceof VideoBlock videoBlock) {
+                } else if (normalizedBlock instanceof VideoBlock videoBlock) {
                     try {
                         String videoUrl = mediaConverter.convertVideoBlockToUrl(videoBlock);
                         // Add video URL to text
@@ -197,12 +203,17 @@ public class DashScopeConversationMerger {
             String name = nameExtractor.apply(msg);
 
             for (ContentBlock block : msg.getContent()) {
-                if (block instanceof TextBlock tb) {
+                ContentBlock normalizedBlock = MediaUtils.normalizeMediaBlock(block);
+                if (normalizedBlock == null) {
+                    continue;
+                }
+
+                if (normalizedBlock instanceof TextBlock tb) {
                     accumulatedText.add(name + ": " + tb.getText());
-                } else if (block instanceof HintBlock hb) {
+                } else if (normalizedBlock instanceof HintBlock hb) {
                     accumulatedText.add(name + ": " + hb.getHint());
 
-                } else if (block instanceof ImageBlock imageBlock) {
+                } else if (normalizedBlock instanceof ImageBlock imageBlock) {
                     // Flush accumulated text before adding image
                     if (!accumulatedText.isEmpty()) {
                         content.add(DashScopeContentPart.text(String.join("\n", accumulatedText)));
@@ -221,7 +232,7 @@ public class DashScopeConversationMerger {
                                         "[Image - processing failed: " + e.getMessage() + "]"));
                     }
 
-                } else if (block instanceof AudioBlock audioBlock) {
+                } else if (normalizedBlock instanceof AudioBlock audioBlock) {
                     // Flush accumulated text before adding audio
                     if (!accumulatedText.isEmpty()) {
                         content.add(DashScopeContentPart.text(String.join("\n", accumulatedText)));
@@ -240,7 +251,7 @@ public class DashScopeConversationMerger {
                                         "[Audio - processing failed: " + e.getMessage() + "]"));
                     }
 
-                } else if (block instanceof VideoBlock videoBlock) {
+                } else if (normalizedBlock instanceof VideoBlock videoBlock) {
                     // Flush accumulated text before adding video
                     if (!accumulatedText.isEmpty()) {
                         content.add(DashScopeContentPart.text(String.join("\n", accumulatedText)));

--- a/agentscope-core/src/main/java/io/agentscope/core/formatter/dashscope/DashScopeMessageConverter.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/formatter/dashscope/DashScopeMessageConverter.java
@@ -15,6 +15,7 @@
  */
 package io.agentscope.core.formatter.dashscope;
 
+import io.agentscope.core.formatter.MediaUtils;
 import io.agentscope.core.formatter.dashscope.dto.DashScopeContentPart;
 import io.agentscope.core.formatter.dashscope.dto.DashScopeMessage;
 import io.agentscope.core.message.AudioBlock;
@@ -98,9 +99,14 @@ public class DashScopeMessageConverter {
         List<DashScopeContentPart> contents = new ArrayList<>();
 
         for (ContentBlock block : msg.getContent()) {
-            if (block instanceof TextBlock tb) {
+            ContentBlock normalizedBlock = MediaUtils.normalizeMediaBlock(block);
+            if (normalizedBlock == null) {
+                continue;
+            }
+
+            if (normalizedBlock instanceof TextBlock tb) {
                 contents.add(DashScopeContentPart.text(tb.getText()));
-            } else if (block instanceof ImageBlock imageBlock) {
+            } else if (normalizedBlock instanceof ImageBlock imageBlock) {
                 try {
                     contents.add(mediaConverter.convertImageBlockToContentPart(imageBlock));
                 } catch (Exception e) {
@@ -109,7 +115,7 @@ public class DashScopeMessageConverter {
                             DashScopeContentPart.text(
                                     "[Image - processing failed: " + e.getMessage() + "]"));
                 }
-            } else if (block instanceof VideoBlock videoBlock) {
+            } else if (normalizedBlock instanceof VideoBlock videoBlock) {
                 try {
                     contents.add(mediaConverter.convertVideoBlockToContentPart(videoBlock));
                 } catch (Exception e) {
@@ -118,7 +124,7 @@ public class DashScopeMessageConverter {
                             DashScopeContentPart.text(
                                     "[Video - processing failed: " + e.getMessage() + "]"));
                 }
-            } else if (block instanceof AudioBlock audioBlock) {
+            } else if (normalizedBlock instanceof AudioBlock audioBlock) {
                 try {
                     contents.add(mediaConverter.convertAudioBlockToContentPart(audioBlock));
                 } catch (Exception e) {
@@ -127,11 +133,11 @@ public class DashScopeMessageConverter {
                             DashScopeContentPart.text(
                                     "[Audio - processing failed: " + e.getMessage() + "]"));
                 }
-            } else if (block instanceof HintBlock hb) {
+            } else if (normalizedBlock instanceof HintBlock hb) {
                 contents.add(DashScopeContentPart.text(hb.getHint()));
-            } else if (block instanceof ThinkingBlock) {
+            } else if (normalizedBlock instanceof ThinkingBlock) {
                 log.debug("Skipping ThinkingBlock when formatting for DashScope");
-            } else if (block instanceof ToolResultBlock toolResult) {
+            } else if (normalizedBlock instanceof ToolResultBlock toolResult) {
                 String toolResultText = toolResultConverter.apply(toolResult.getOutput());
                 if (!toolResultText.isEmpty()) {
                     contents.add(DashScopeContentPart.text(toolResultText));
@@ -284,9 +290,7 @@ public class DashScopeMessageConverter {
             return false;
         }
         for (ContentBlock block : blocks) {
-            if (block instanceof ImageBlock
-                    || block instanceof AudioBlock
-                    || block instanceof VideoBlock) {
+            if (MediaUtils.inferMediaKind(block) != null) {
                 return true;
             }
         }
@@ -302,9 +306,14 @@ public class DashScopeMessageConverter {
     private List<DashScopeContentPart> convertContentBlocks(List<ContentBlock> blocks) {
         List<DashScopeContentPart> content = new ArrayList<>();
         for (ContentBlock block : blocks) {
-            if (block instanceof TextBlock tb) {
+            ContentBlock normalizedBlock = MediaUtils.normalizeMediaBlock(block);
+            if (normalizedBlock == null) {
+                continue;
+            }
+
+            if (normalizedBlock instanceof TextBlock tb) {
                 content.add(DashScopeContentPart.text(tb.getText()));
-            } else if (block instanceof ImageBlock ib) {
+            } else if (normalizedBlock instanceof ImageBlock ib) {
                 try {
                     content.add(mediaConverter.convertImageBlockToContentPart(ib));
                 } catch (Exception e) {
@@ -313,7 +322,7 @@ public class DashScopeMessageConverter {
                             DashScopeContentPart.text(
                                     "[Image - processing failed: " + e.getMessage() + "]"));
                 }
-            } else if (block instanceof AudioBlock ab) {
+            } else if (normalizedBlock instanceof AudioBlock ab) {
                 try {
                     content.add(mediaConverter.convertAudioBlockToContentPart(ab));
                 } catch (Exception e) {
@@ -322,7 +331,7 @@ public class DashScopeMessageConverter {
                             DashScopeContentPart.text(
                                     "[Audio - processing failed: " + e.getMessage() + "]"));
                 }
-            } else if (block instanceof VideoBlock vb) {
+            } else if (normalizedBlock instanceof VideoBlock vb) {
                 try {
                     content.add(mediaConverter.convertVideoBlockToContentPart(vb));
                 } catch (Exception e) {

--- a/agentscope-core/src/main/java/io/agentscope/core/formatter/gemini/GeminiConversationMerger.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/formatter/gemini/GeminiConversationMerger.java
@@ -17,6 +17,7 @@ package io.agentscope.core.formatter.gemini;
 
 import com.google.genai.types.Content;
 import com.google.genai.types.Part;
+import io.agentscope.core.formatter.MediaUtils;
 import io.agentscope.core.message.AudioBlock;
 import io.agentscope.core.message.ContentBlock;
 import io.agentscope.core.message.HintBlock;
@@ -95,21 +96,26 @@ public class GeminiConversationMerger {
 
             List<ContentBlock> blocks = msg.getContent();
             for (ContentBlock block : blocks) {
-                if (block instanceof TextBlock tb) {
+                ContentBlock normalizedBlock = MediaUtils.normalizeMediaBlock(block);
+                if (normalizedBlock == null) {
+                    continue;
+                }
+
+                if (normalizedBlock instanceof TextBlock tb) {
                     accumulatedText.add(name + ": " + tb.getText());
-                } else if (block instanceof HintBlock hb) {
+                } else if (normalizedBlock instanceof HintBlock hb) {
                     accumulatedText.add(name + ": " + hb.getHint());
 
-                } else if (block instanceof ThinkingBlock) {
+                } else if (normalizedBlock instanceof ThinkingBlock) {
                     // Skip ThinkingBlock - not sent to API
                     log.debug("Skipping ThinkingBlock in multi-agent merge");
 
-                } else if (block instanceof ToolResultBlock trb) {
+                } else if (normalizedBlock instanceof ToolResultBlock trb) {
                     // Convert tool result to text and accumulate
                     String toolResultText = toolResultConverter.apply(trb.getOutput());
                     accumulatedText.add("Tool: " + trb.getName() + "\n" + toolResultText);
 
-                } else if (block instanceof ImageBlock ib) {
+                } else if (normalizedBlock instanceof ImageBlock ib) {
                     // Flush accumulated text as a Part
                     if (!accumulatedText.isEmpty()) {
                         parts.add(Part.builder().text(String.join("\n", accumulatedText)).build());
@@ -118,7 +124,7 @@ public class GeminiConversationMerger {
                     // Add image as separate Part
                     parts.add(mediaConverter.convertToInlineDataPart(ib));
 
-                } else if (block instanceof AudioBlock ab) {
+                } else if (normalizedBlock instanceof AudioBlock ab) {
                     // Flush accumulated text as a Part
                     if (!accumulatedText.isEmpty()) {
                         parts.add(Part.builder().text(String.join("\n", accumulatedText)).build());
@@ -127,7 +133,7 @@ public class GeminiConversationMerger {
                     // Add audio as separate Part
                     parts.add(mediaConverter.convertToInlineDataPart(ab));
 
-                } else if (block instanceof VideoBlock vb) {
+                } else if (normalizedBlock instanceof VideoBlock vb) {
                     // Flush accumulated text as a Part
                     if (!accumulatedText.isEmpty()) {
                         parts.add(Part.builder().text(String.join("\n", accumulatedText)).build());

--- a/agentscope-core/src/main/java/io/agentscope/core/formatter/gemini/GeminiMessageConverter.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/formatter/gemini/GeminiMessageConverter.java
@@ -19,6 +19,7 @@ import com.google.genai.types.Content;
 import com.google.genai.types.FunctionCall;
 import com.google.genai.types.FunctionResponse;
 import com.google.genai.types.Part;
+import io.agentscope.core.formatter.MediaUtils;
 import io.agentscope.core.message.AudioBlock;
 import io.agentscope.core.message.Base64Source;
 import io.agentscope.core.message.ContentBlock;
@@ -89,10 +90,15 @@ public class GeminiMessageConverter {
             List<Part> parts = new ArrayList<>();
 
             for (ContentBlock block : msg.getContent()) {
-                if (block instanceof TextBlock tb) {
+                ContentBlock normalizedBlock = MediaUtils.normalizeMediaBlock(block);
+                if (normalizedBlock == null) {
+                    continue;
+                }
+
+                if (normalizedBlock instanceof TextBlock tb) {
                     parts.add(Part.builder().text(tb.getText()).build());
 
-                } else if (block instanceof ToolUseBlock tub) {
+                } else if (normalizedBlock instanceof ToolUseBlock tub) {
                     // Prioritize using content field (raw arguments string), fallback to input map
                     Map<String, Object> args;
                     if (tub.getContent() != null && !tub.getContent().isEmpty()) {
@@ -135,7 +141,7 @@ public class GeminiMessageConverter {
 
                     parts.add(partBuilder.build());
 
-                } else if (block instanceof ToolResultBlock trb) {
+                } else if (normalizedBlock instanceof ToolResultBlock trb) {
                     // IMPORTANT: Tool result as independent Content with "user" role
                     String textOutput = convertToolResultToString(trb.getOutput());
 
@@ -163,19 +169,19 @@ public class GeminiMessageConverter {
                     // Skip adding to current message parts
                     continue;
 
-                } else if (block instanceof ImageBlock ib) {
+                } else if (normalizedBlock instanceof ImageBlock ib) {
                     parts.add(mediaConverter.convertToInlineDataPart(ib));
 
-                } else if (block instanceof AudioBlock ab) {
+                } else if (normalizedBlock instanceof AudioBlock ab) {
                     parts.add(mediaConverter.convertToInlineDataPart(ab));
 
-                } else if (block instanceof VideoBlock vb) {
+                } else if (normalizedBlock instanceof VideoBlock vb) {
                     parts.add(mediaConverter.convertToInlineDataPart(vb));
 
-                } else if (block instanceof HintBlock hb) {
+                } else if (normalizedBlock instanceof HintBlock hb) {
                     parts.add(Part.builder().text(hb.getHint()).build());
 
-                } else if (block instanceof ThinkingBlock) {
+                } else if (normalizedBlock instanceof ThinkingBlock) {
                     log.debug("Skipping ThinkingBlock when formatting message for Gemini API");
                     continue;
 
@@ -223,18 +229,23 @@ public class GeminiMessageConverter {
         List<String> textualOutput = new ArrayList<>();
 
         for (ContentBlock block : output) {
-            if (block instanceof TextBlock tb) {
+            ContentBlock normalizedBlock = MediaUtils.normalizeMediaBlock(block);
+            if (normalizedBlock == null) {
+                continue;
+            }
+
+            if (normalizedBlock instanceof TextBlock tb) {
                 textualOutput.add(tb.getText());
 
-            } else if (block instanceof ImageBlock ib) {
+            } else if (normalizedBlock instanceof ImageBlock ib) {
                 String reference = convertMediaBlockToTextReference(ib, "image");
                 textualOutput.add(reference);
 
-            } else if (block instanceof AudioBlock ab) {
+            } else if (normalizedBlock instanceof AudioBlock ab) {
                 String reference = convertMediaBlockToTextReference(ab, "audio");
                 textualOutput.add(reference);
 
-            } else if (block instanceof VideoBlock vb) {
+            } else if (normalizedBlock instanceof VideoBlock vb) {
                 String reference = convertMediaBlockToTextReference(vb, "video");
                 textualOutput.add(reference);
             }
@@ -296,11 +307,12 @@ public class GeminiMessageConverter {
      * @return The source object
      */
     private Source extractSourceFromBlock(ContentBlock block) {
-        if (block instanceof ImageBlock ib) {
+        ContentBlock normalizedBlock = MediaUtils.normalizeMediaBlock(block);
+        if (normalizedBlock instanceof ImageBlock ib) {
             return ib.getSource();
-        } else if (block instanceof AudioBlock ab) {
+        } else if (normalizedBlock instanceof AudioBlock ab) {
             return ab.getSource();
-        } else if (block instanceof VideoBlock vb) {
+        } else if (normalizedBlock instanceof VideoBlock vb) {
             return vb.getSource();
         }
         throw new IllegalArgumentException("Unsupported block type: " + block.getClass());

--- a/agentscope-core/src/main/java/io/agentscope/core/formatter/ollama/OllamaChatFormatter.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/formatter/ollama/OllamaChatFormatter.java
@@ -16,6 +16,7 @@
 package io.agentscope.core.formatter.ollama;
 
 import io.agentscope.core.formatter.AbstractBaseFormatter;
+import io.agentscope.core.formatter.MediaUtils;
 import io.agentscope.core.formatter.ollama.dto.OllamaFunction;
 import io.agentscope.core.formatter.ollama.dto.OllamaMessage;
 import io.agentscope.core.formatter.ollama.dto.OllamaRequest;
@@ -127,18 +128,23 @@ public class OllamaChatFormatter
         MessageContent messageContent = new MessageContent();
 
         for (ContentBlock block : contentBlocks) {
-            if (block instanceof TextBlock) {
-                messageContent.textBlocks.add(block);
-            } else if (block instanceof ToolUseBlock) {
-                messageContent.toolUseBlocks.add(block);
-            } else if (block instanceof ToolResultBlock) {
-                messageContent.toolResultBlocks.add(block);
-            } else if (block instanceof ImageBlock) {
-                processImageBlock((ImageBlock) block, messageContent.images);
+            ContentBlock normalizedBlock = MediaUtils.normalizeMediaBlock(block);
+            if (normalizedBlock == null) {
+                continue;
+            }
+
+            if (normalizedBlock instanceof TextBlock) {
+                messageContent.textBlocks.add(normalizedBlock);
+            } else if (normalizedBlock instanceof ToolUseBlock) {
+                messageContent.toolUseBlocks.add(normalizedBlock);
+            } else if (normalizedBlock instanceof ToolResultBlock) {
+                messageContent.toolResultBlocks.add(normalizedBlock);
+            } else if (normalizedBlock instanceof ImageBlock imageBlock) {
+                processImageBlock(imageBlock, messageContent.images);
             } else {
                 log.warn(
                         "Unsupported block type {} in the message, skipped.",
-                        block.getClass().getSimpleName());
+                        normalizedBlock.getClass().getSimpleName());
             }
         }
 
@@ -178,13 +184,18 @@ public class OllamaChatFormatter
         List<ContentBlock> multimodalData = new ArrayList<>();
 
         for (ContentBlock outputBlock : toolResultBlock.getOutput()) {
-            if (outputBlock instanceof TextBlock) {
+            ContentBlock normalizedOutput = MediaUtils.normalizeMediaBlock(outputBlock);
+            if (normalizedOutput == null) {
+                continue;
+            }
+
+            if (normalizedOutput instanceof TextBlock) {
                 if (textualOutput.length() > 0) {
                     textualOutput.append("\n");
                 }
-                textualOutput.append(((TextBlock) outputBlock).getText());
-            } else if (outputBlock instanceof ImageBlock) {
-                multimodalData.add(outputBlock);
+                textualOutput.append(((TextBlock) normalizedOutput).getText());
+            } else if (normalizedOutput instanceof ImageBlock) {
+                multimodalData.add(normalizedOutput);
             }
         }
 
@@ -210,8 +221,8 @@ public class OllamaChatFormatter
             List<OllamaMessage> result) {
         List<ContentBlock> promotedBlocks = new ArrayList<>();
         for (ContentBlock multimodalBlock : multimodalData) {
-            if (multimodalBlock instanceof ImageBlock) {
-                ImageBlock imageBlock = (ImageBlock) multimodalBlock;
+            ContentBlock normalizedBlock = MediaUtils.normalizeMediaBlock(multimodalBlock);
+            if (normalizedBlock instanceof ImageBlock imageBlock) {
                 // Add text block with image information
                 String imageUrl = imageBlock.getSource().toString();
                 if (imageBlock.getSource() instanceof URLSource) {
@@ -379,13 +390,14 @@ public class OllamaChatFormatter
      */
     private ImageBlock extractImageBlockFromMsg(Msg msg) {
         for (ContentBlock block : msg.getContent()) {
-            if (block instanceof ImageBlock) {
-                return (ImageBlock) block;
-            } else if (block instanceof ToolResultBlock) {
-                ToolResultBlock toolResult = (ToolResultBlock) block;
+            ContentBlock normalizedBlock = MediaUtils.normalizeMediaBlock(block);
+            if (normalizedBlock instanceof ImageBlock imageBlock) {
+                return imageBlock;
+            } else if (normalizedBlock instanceof ToolResultBlock toolResult) {
                 for (ContentBlock outputBlock : toolResult.getOutput()) {
-                    if (outputBlock instanceof ImageBlock) {
-                        return (ImageBlock) outputBlock;
+                    ContentBlock normalizedOutput = MediaUtils.normalizeMediaBlock(outputBlock);
+                    if (normalizedOutput instanceof ImageBlock imageBlock) {
+                        return imageBlock;
                     }
                 }
             }

--- a/agentscope-core/src/main/java/io/agentscope/core/formatter/ollama/OllamaConversationMerger.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/formatter/ollama/OllamaConversationMerger.java
@@ -15,6 +15,7 @@
  */
 package io.agentscope.core.formatter.ollama;
 
+import io.agentscope.core.formatter.MediaUtils;
 import io.agentscope.core.formatter.ollama.dto.OllamaMessage;
 import io.agentscope.core.message.Base64Source;
 import io.agentscope.core.message.ContentBlock;
@@ -62,16 +63,20 @@ public class OllamaConversationMerger {
             String name = nameExtractor.apply(msg);
 
             for (ContentBlock block : msg.getContent()) {
-                if (block instanceof TextBlock) {
+                ContentBlock normalizedBlock = MediaUtils.normalizeMediaBlock(block);
+                if (normalizedBlock == null) {
+                    continue;
+                }
+
+                if (normalizedBlock instanceof TextBlock) {
                     textAccumulator
                             .append(name)
                             .append(": ")
-                            .append(((TextBlock) block).getText())
+                            .append(((TextBlock) normalizedBlock).getText())
                             .append("\n");
-                } else if (block instanceof HintBlock hb) {
+                } else if (normalizedBlock instanceof HintBlock hb) {
                     textAccumulator.append(name).append(": ").append(hb.getHint()).append("\n");
-                } else if (block instanceof ImageBlock) {
-                    ImageBlock imageBlock = (ImageBlock) block;
+                } else if (normalizedBlock instanceof ImageBlock imageBlock) {
                     if (imageBlock.getSource() instanceof Base64Source) {
                         Base64Source source = (Base64Source) imageBlock.getSource();
                         images.add(source.getData());

--- a/agentscope-core/src/main/java/io/agentscope/core/formatter/ollama/OllamaMessageConverter.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/formatter/ollama/OllamaMessageConverter.java
@@ -15,6 +15,7 @@
  */
 package io.agentscope.core.formatter.ollama;
 
+import io.agentscope.core.formatter.MediaUtils;
 import io.agentscope.core.formatter.ollama.dto.OllamaFunction;
 import io.agentscope.core.formatter.ollama.dto.OllamaMessage;
 import io.agentscope.core.formatter.ollama.dto.OllamaToolCall;
@@ -107,10 +108,14 @@ public class OllamaMessageConverter {
         List<OllamaToolCall> toolCalls = new ArrayList<>();
 
         for (ContentBlock block : msg.getContent()) {
-            if (block instanceof TextBlock) {
-                textContent.append(((TextBlock) block).getText());
-            } else if (block instanceof ImageBlock) {
-                ImageBlock imageBlock = (ImageBlock) block;
+            ContentBlock normalizedBlock = MediaUtils.normalizeMediaBlock(block);
+            if (normalizedBlock == null) {
+                continue;
+            }
+
+            if (normalizedBlock instanceof TextBlock tb) {
+                textContent.append(tb.getText());
+            } else if (normalizedBlock instanceof ImageBlock imageBlock) {
                 try {
                     String base64Image = mediaConverter.convertImageBlockToBase64(imageBlock);
                     images.add(base64Image);
@@ -162,11 +167,16 @@ public class OllamaMessageConverter {
         return msg.getContent().stream()
                 .flatMap(
                         block -> {
-                            if (block instanceof TextBlock tb) {
+                            ContentBlock normalizedBlock = MediaUtils.normalizeMediaBlock(block);
+                            if (normalizedBlock == null) {
+                                return Stream.empty();
+                            }
+
+                            if (normalizedBlock instanceof TextBlock tb) {
                                 return Stream.of(tb.getText());
-                            } else if (block instanceof HintBlock hb) {
+                            } else if (normalizedBlock instanceof HintBlock hb) {
                                 return Stream.of(hb.getHint());
-                            } else if (block instanceof ToolResultBlock toolResult) {
+                            } else if (normalizedBlock instanceof ToolResultBlock toolResult) {
                                 return toolResult.getOutput().stream()
                                         .filter(output -> output instanceof TextBlock)
                                         .map(output -> ((TextBlock) output).getText());
@@ -186,11 +196,16 @@ public class OllamaMessageConverter {
         return blocks.stream()
                 .flatMap(
                         block -> {
-                            if (block instanceof TextBlock tb) {
+                            ContentBlock normalizedBlock = MediaUtils.normalizeMediaBlock(block);
+                            if (normalizedBlock == null) {
+                                return Stream.empty();
+                            }
+
+                            if (normalizedBlock instanceof TextBlock tb) {
                                 return Stream.of(tb.getText());
-                            } else if (block instanceof HintBlock hb) {
+                            } else if (normalizedBlock instanceof HintBlock hb) {
                                 return Stream.of(hb.getHint());
-                            } else if (block instanceof ToolResultBlock toolResult) {
+                            } else if (normalizedBlock instanceof ToolResultBlock toolResult) {
                                 return toolResult.getOutput().stream()
                                         .filter(output -> output instanceof TextBlock)
                                         .map(output -> ((TextBlock) output).getText());
@@ -210,8 +225,8 @@ public class OllamaMessageConverter {
         List<String> imagePaths = new ArrayList<>();
 
         for (ContentBlock block : blocks) {
-            if (block instanceof ImageBlock) {
-                ImageBlock imageBlock = (ImageBlock) block;
+            ContentBlock normalizedBlock = MediaUtils.normalizeMediaBlock(block);
+            if (normalizedBlock instanceof ImageBlock imageBlock) {
                 if (imageBlock.getSource() != null) {
                     // Extract the URL path from the source
                     String imagePath = imageBlock.getSource().toString();

--- a/agentscope-core/src/main/java/io/agentscope/core/formatter/ollama/OllamaMultiAgentFormatter.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/formatter/ollama/OllamaMultiAgentFormatter.java
@@ -16,6 +16,7 @@
 package io.agentscope.core.formatter.ollama;
 
 import io.agentscope.core.formatter.AbstractBaseFormatter;
+import io.agentscope.core.formatter.MediaUtils;
 import io.agentscope.core.formatter.ollama.dto.OllamaMessage;
 import io.agentscope.core.formatter.ollama.dto.OllamaRequest;
 import io.agentscope.core.formatter.ollama.dto.OllamaResponse;
@@ -227,13 +228,14 @@ public class OllamaMultiAgentFormatter
      */
     private ImageBlock extractImageBlockFromMsg(Msg msg) {
         for (ContentBlock block : msg.getContent()) {
-            if (block instanceof ImageBlock) {
-                return (ImageBlock) block;
-            } else if (block instanceof ToolResultBlock) {
-                ToolResultBlock toolResult = (ToolResultBlock) block;
+            ContentBlock normalizedBlock = MediaUtils.normalizeMediaBlock(block);
+            if (normalizedBlock instanceof ImageBlock imageBlock) {
+                return imageBlock;
+            } else if (normalizedBlock instanceof ToolResultBlock toolResult) {
                 for (ContentBlock outputBlock : toolResult.getOutput()) {
-                    if (outputBlock instanceof ImageBlock) {
-                        return (ImageBlock) outputBlock;
+                    ContentBlock normalizedOutput = MediaUtils.normalizeMediaBlock(outputBlock);
+                    if (normalizedOutput instanceof ImageBlock imageBlock) {
+                        return imageBlock;
                     }
                 }
             }
@@ -408,13 +410,19 @@ public class OllamaMultiAgentFormatter
                         List<ContentBlock> multimodalOutputs = new ArrayList<>();
 
                         for (ContentBlock outputBlock : toolResultBlock.getOutput()) {
-                            if (outputBlock instanceof TextBlock) {
+                            ContentBlock normalizedOutput =
+                                    MediaUtils.normalizeMediaBlock(outputBlock);
+                            if (normalizedOutput == null) {
+                                continue;
+                            }
+
+                            if (normalizedOutput instanceof TextBlock) {
                                 if (textualOutput.length() > 0) {
                                     textualOutput.append("\n");
                                 }
-                                textualOutput.append(((TextBlock) outputBlock).getText());
-                            } else if (outputBlock instanceof ImageBlock) {
-                                multimodalOutputs.add(outputBlock);
+                                textualOutput.append(((TextBlock) normalizedOutput).getText());
+                            } else if (normalizedOutput instanceof ImageBlock) {
+                                multimodalOutputs.add(normalizedOutput);
                             }
                         }
 
@@ -428,8 +436,9 @@ public class OllamaMultiAgentFormatter
                             // Add special text to content that can be detected by
                             // isToolResultWithImages
                             for (ContentBlock multimodalBlock : multimodalOutputs) {
-                                if (multimodalBlock instanceof ImageBlock) {
-                                    ImageBlock imageBlock = (ImageBlock) multimodalBlock;
+                                ContentBlock normalizedMultimodal =
+                                        MediaUtils.normalizeMediaBlock(multimodalBlock);
+                                if (normalizedMultimodal instanceof ImageBlock imageBlock) {
                                     String imageUrl = imageBlock.getSource().toString();
                                     if (imageBlock.getSource() instanceof URLSource) {
                                         imageUrl = ((URLSource) imageBlock.getSource()).getUrl();
@@ -460,14 +469,20 @@ public class OllamaMultiAgentFormatter
     public String convertToolResultToString(List<ContentBlock> blocks) {
         StringBuilder sb = new StringBuilder();
         for (ContentBlock block : blocks) {
-            if (block instanceof TextBlock) {
-                sb.append(((TextBlock) block).getText());
-            } else if (block instanceof ToolResultBlock) {
+            ContentBlock normalizedBlock = MediaUtils.normalizeMediaBlock(block);
+            if (normalizedBlock == null) {
+                continue;
+            }
+
+            if (normalizedBlock instanceof TextBlock) {
+                sb.append(((TextBlock) normalizedBlock).getText());
+            } else if (normalizedBlock instanceof ToolResultBlock) {
                 // Extract text from the output blocks of ToolResultBlock
-                List<ContentBlock> outputBlocks = ((ToolResultBlock) block).getOutput();
+                List<ContentBlock> outputBlocks = ((ToolResultBlock) normalizedBlock).getOutput();
                 for (ContentBlock outputBlock : outputBlocks) {
-                    if (outputBlock instanceof TextBlock) {
-                        sb.append(((TextBlock) outputBlock).getText());
+                    ContentBlock normalizedOutput = MediaUtils.normalizeMediaBlock(outputBlock);
+                    if (normalizedOutput instanceof TextBlock) {
+                        sb.append(((TextBlock) normalizedOutput).getText());
                     }
                 }
             }

--- a/agentscope-core/src/main/java/io/agentscope/core/formatter/openai/OpenAIConversationMerger.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/formatter/openai/OpenAIConversationMerger.java
@@ -15,6 +15,7 @@
  */
 package io.agentscope.core.formatter.openai;
 
+import io.agentscope.core.formatter.MediaUtils;
 import io.agentscope.core.formatter.openai.dto.OpenAIContentPart;
 import io.agentscope.core.formatter.openai.dto.OpenAIMessage;
 import io.agentscope.core.message.AudioBlock;
@@ -118,18 +119,23 @@ public class OpenAIConversationMerger {
             blocks = new ArrayList<>();
         }
         for (ContentBlock block : blocks) {
-            if (block instanceof TextBlock tb) {
+            ContentBlock normalizedBlock = MediaUtils.normalizeMediaBlock(block);
+            if (normalizedBlock == null) {
+                continue;
+            }
+
+            if (normalizedBlock instanceof TextBlock tb) {
                 if (includePrefix) {
                     appendNamePrefix(textBuffer, agentName);
                 }
                 textBuffer.append(tb.getText()).append("\n");
-            } else if (block instanceof HintBlock hb) {
+            } else if (normalizedBlock instanceof HintBlock hb) {
                 if (includePrefix) {
                     appendNamePrefix(textBuffer, agentName);
                 }
                 textBuffer.append(hb.getHint()).append("\n");
 
-            } else if (block instanceof ImageBlock imageBlock) {
+            } else if (normalizedBlock instanceof ImageBlock imageBlock) {
                 // Flush existing text to a content part
                 if (textBuffer.length() > 0) {
                     allParts.add(OpenAIContentPart.text(textBuffer.toString()));
@@ -162,7 +168,7 @@ public class OpenAIConversationMerger {
                             .append("]\n");
                 }
 
-            } else if (block instanceof VideoBlock videoBlock) {
+            } else if (normalizedBlock instanceof VideoBlock videoBlock) {
                 // Flush existing text to a content part
                 if (textBuffer.length() > 0) {
                     allParts.add(OpenAIContentPart.text(textBuffer.toString()));
@@ -195,7 +201,7 @@ public class OpenAIConversationMerger {
                             .append("]\n");
                 }
 
-            } else if (block instanceof AudioBlock audioBlock) {
+            } else if (normalizedBlock instanceof AudioBlock audioBlock) {
                 // Flush existing text
                 if (textBuffer.length() > 0) {
                     allParts.add(OpenAIContentPart.text(textBuffer.toString()));
@@ -258,7 +264,7 @@ public class OpenAIConversationMerger {
                             .append("]\n");
                 }
 
-            } else if (block instanceof ThinkingBlock thinkingBlock) {
+            } else if (normalizedBlock instanceof ThinkingBlock thinkingBlock) {
                 // Include ThinkingBlock in conversation history for models that support reasoning
                 if (includePrefix) {
                     appendNamePrefix(textBuffer, agentName);
@@ -272,7 +278,7 @@ public class OpenAIConversationMerger {
                         textBuffer.append("[Thinking]: ").append(thinking).append("\n");
                     }
                 }
-            } else if (block instanceof ToolResultBlock toolResult) {
+            } else if (normalizedBlock instanceof ToolResultBlock toolResult) {
                 // Use provided converter to handle multimodal content in tool results
                 String resultText = toolResultConverter.apply(toolResult.getOutput());
                 String finalResultText =

--- a/agentscope-core/src/main/java/io/agentscope/core/formatter/openai/OpenAIMessageConverter.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/formatter/openai/OpenAIMessageConverter.java
@@ -15,6 +15,7 @@
  */
 package io.agentscope.core.formatter.openai;
 
+import io.agentscope.core.formatter.MediaUtils;
 import io.agentscope.core.formatter.openai.dto.OpenAIContentPart;
 import io.agentscope.core.formatter.openai.dto.OpenAIFunction;
 import io.agentscope.core.formatter.openai.dto.OpenAIMessage;
@@ -161,9 +162,14 @@ public class OpenAIMessageConverter {
         List<OpenAIContentPart> contentParts = new ArrayList<>();
 
         for (ContentBlock block : blocks) {
-            if (block instanceof TextBlock tb) {
+            ContentBlock normalizedBlock = MediaUtils.normalizeMediaBlock(block);
+            if (normalizedBlock == null) {
+                continue;
+            }
+
+            if (normalizedBlock instanceof TextBlock tb) {
                 contentParts.add(OpenAIContentPart.text(tb.getText()));
-            } else if (block instanceof ImageBlock ib) {
+            } else if (normalizedBlock instanceof ImageBlock ib) {
                 try {
                     Source source = ib.getSource();
                     if (source == null) {
@@ -180,7 +186,7 @@ public class OpenAIMessageConverter {
                             OpenAIContentPart.text(
                                     "[Image - processing failed: " + errorMsg + "]"));
                 }
-            } else if (block instanceof AudioBlock ab) {
+            } else if (normalizedBlock instanceof AudioBlock ab) {
                 try {
                     // OpenAI expects base64 audio in input_audio format
                     Source source = ab.getSource();
@@ -228,11 +234,11 @@ public class OpenAIMessageConverter {
                             OpenAIContentPart.text(
                                     "[Audio - processing failed: " + errorMsg + "]"));
                 }
-            } else if (block instanceof HintBlock hb) {
+            } else if (normalizedBlock instanceof HintBlock hb) {
                 contentParts.add(OpenAIContentPart.text(hb.getHint()));
-            } else if (block instanceof ThinkingBlock) {
+            } else if (normalizedBlock instanceof ThinkingBlock) {
                 log.debug("Skipping ThinkingBlock when formatting for OpenAI");
-            } else if (block instanceof VideoBlock vb) {
+            } else if (normalizedBlock instanceof VideoBlock vb) {
                 try {
                     Source source = vb.getSource();
                     if (source == null) {
@@ -249,9 +255,9 @@ public class OpenAIMessageConverter {
                             OpenAIContentPart.text(
                                     "[Video - processing failed: " + errorMsg + "]"));
                 }
-            } else if (block instanceof ToolUseBlock) {
+            } else if (normalizedBlock instanceof ToolUseBlock) {
                 log.warn("ToolUseBlock is not supported in user messages");
-            } else if (block instanceof ToolResultBlock) {
+            } else if (normalizedBlock instanceof ToolResultBlock) {
                 log.warn("ToolResultBlock is not supported in user messages");
             }
         }
@@ -430,9 +436,7 @@ public class OpenAIMessageConverter {
             return false;
         }
         for (ContentBlock block : blocks) {
-            if (block instanceof ImageBlock
-                    || block instanceof AudioBlock
-                    || block instanceof VideoBlock) {
+            if (MediaUtils.inferMediaKind(block) != null) {
                 return true;
             }
         }

--- a/agentscope-core/src/test/java/io/agentscope/core/formatter/AbstractBaseFormatterTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/formatter/AbstractBaseFormatterTest.java
@@ -22,10 +22,14 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import io.agentscope.core.message.Base64Source;
 import io.agentscope.core.message.ContentBlock;
 import io.agentscope.core.message.DataBlock;
+import io.agentscope.core.message.HintBlock;
+import io.agentscope.core.message.MessageMetadataKeys;
 import io.agentscope.core.message.Msg;
 import io.agentscope.core.message.MsgRole;
 import io.agentscope.core.message.Source;
 import io.agentscope.core.message.TextBlock;
+import io.agentscope.core.message.ThinkingBlock;
+import io.agentscope.core.message.ToolResultBlock;
 import io.agentscope.core.message.URLSource;
 import io.agentscope.core.model.ChatResponse;
 import io.agentscope.core.model.GenerateOptions;
@@ -35,7 +39,10 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Instant;
 import java.util.Base64;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -165,6 +172,62 @@ class AbstractBaseFormatterTest {
                         List.of(DataBlock.builder().source(new Source() {}).build())));
     }
 
+    @Test
+    @DisplayName("Should extract text content and honor formatter helpers")
+    void testExtractTextAndHelpers() {
+        ToolResultBlock toolResult =
+                ToolResultBlock.builder()
+                        .id("call_1")
+                        .name("tool")
+                        .output(List.of(TextBlock.builder().text("tool output").build()))
+                        .build();
+
+        Map<String, Object> metadata = new HashMap<>();
+        metadata.put(MessageMetadataKeys.BYPASS_MULTIAGENT_HISTORY_MERGE, true);
+
+        Msg textMsg =
+                Msg.builder()
+                        .content(
+                                List.of(
+                                        TextBlock.builder().text("hello").build(),
+                                        new HintBlock(null, "hint"),
+                                        ThinkingBlock.builder().thinking("skip me").build()))
+                        .role(MsgRole.ASSISTANT)
+                        .build();
+
+        Msg toolMsg =
+                Msg.builder()
+                        .role(MsgRole.TOOL)
+                        .metadata(metadata)
+                        .content(List.of(toolResult))
+                        .build();
+
+        assertEquals("hello\nhint", formatter.renderText(textMsg));
+        assertEquals("tool output", formatter.renderText(toolMsg));
+        assertEquals("Assistant", formatter.renderRoleLabel(MsgRole.ASSISTANT));
+        assertTrue(formatter.shouldBypassHistory(toolMsg));
+        assertFalse(
+                formatter.shouldBypassHistory(
+                        Msg.builder()
+                                .role(MsgRole.USER)
+                                .content(List.of(TextBlock.builder().text("x").build()))
+                                .build()));
+        assertEquals(
+                0.7,
+                formatter.optionOrDefault(
+                        GenerateOptions.builder().temperature(0.7).build(),
+                        GenerateOptions.builder().temperature(0.5).build(),
+                        GenerateOptions::getTemperature),
+                1e-6);
+        assertEquals(
+                0.5,
+                formatter.optionOrDefault(
+                        null,
+                        GenerateOptions.builder().temperature(0.5).build(),
+                        GenerateOptions::getTemperature),
+                1e-6);
+    }
+
     private static final class TestFormatter extends AbstractBaseFormatter<Object, Object, Object> {
 
         @Override
@@ -190,6 +253,26 @@ class AbstractBaseFormatterTest {
 
         String renderToolResult(List<ContentBlock> output) {
             return convertToolResultToString(output);
+        }
+
+        String renderText(Msg msg) {
+            return extractTextContent(msg);
+        }
+
+        String renderRoleLabel(MsgRole role) {
+            return formatRoleLabel(role);
+        }
+
+        @Override
+        protected boolean shouldBypassHistory(Msg msg) {
+            return super.shouldBypassHistory(msg);
+        }
+
+        <T> T optionOrDefault(
+                GenerateOptions options,
+                GenerateOptions defaultOptions,
+                Function<GenerateOptions, T> getter) {
+            return getOptionOrDefault(options, defaultOptions, getter);
         }
     }
 }

--- a/agentscope-core/src/test/java/io/agentscope/core/formatter/AbstractBaseFormatterTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/formatter/AbstractBaseFormatterTest.java
@@ -1,0 +1,195 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.core.formatter;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.agentscope.core.message.Base64Source;
+import io.agentscope.core.message.ContentBlock;
+import io.agentscope.core.message.DataBlock;
+import io.agentscope.core.message.Msg;
+import io.agentscope.core.message.MsgRole;
+import io.agentscope.core.message.Source;
+import io.agentscope.core.message.TextBlock;
+import io.agentscope.core.message.URLSource;
+import io.agentscope.core.model.ChatResponse;
+import io.agentscope.core.model.GenerateOptions;
+import io.agentscope.core.model.ToolSchema;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.Base64;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+@Tag("unit")
+@DisplayName("AbstractBaseFormatter Unit Tests")
+class AbstractBaseFormatterTest {
+
+    private final TestFormatter formatter = new TestFormatter();
+
+    @Test
+    @DisplayName("Should detect media content from DataBlock audio and video")
+    void testHasMediaContentWithDataBlocks() {
+        Msg textOnly =
+                Msg.builder()
+                        .role(MsgRole.USER)
+                        .content(List.of(TextBlock.builder().text("hello").build()))
+                        .build();
+
+        Msg audioMsg =
+                Msg.builder()
+                        .role(MsgRole.USER)
+                        .content(
+                                List.of(
+                                        DataBlock.builder()
+                                                .source(
+                                                        URLSource.builder()
+                                                                .url(
+                                                                        "https://example.com/audio.wav")
+                                                                .build())
+                                                .build()))
+                        .build();
+
+        Msg videoMsg =
+                Msg.builder()
+                        .role(MsgRole.USER)
+                        .content(
+                                List.of(
+                                        DataBlock.builder()
+                                                .source(
+                                                        URLSource.builder()
+                                                                .url(
+                                                                        "https://example.com/video.mp4")
+                                                                .build())
+                                                .build()))
+                        .build();
+
+        Msg unknownMsg =
+                Msg.builder()
+                        .role(MsgRole.USER)
+                        .content(List.of(DataBlock.builder().source(new Source() {}).build()))
+                        .build();
+
+        assertFalse(formatter.hasMedia(textOnly));
+        assertTrue(formatter.hasMedia(audioMsg));
+        assertTrue(formatter.hasMedia(videoMsg));
+        assertFalse(formatter.hasMedia(unknownMsg));
+    }
+
+    @Test
+    @DisplayName("Should return text directly for a single tool result item")
+    void testConvertToolResultToStringSingleText() {
+        String result =
+                formatter.renderToolResult(
+                        List.of(TextBlock.builder().text("single output").build()));
+
+        assertEquals("single output", result);
+    }
+
+    @Test
+    @DisplayName("Should convert a single base64 audio result to a temp file reference")
+    void testConvertToolResultToStringSingleBase64Audio() throws IOException {
+        String base64Audio = Base64.getEncoder().encodeToString("audio-bytes".getBytes());
+        DataBlock audioData =
+                DataBlock.builder()
+                        .source(
+                                Base64Source.builder()
+                                        .mediaType("audio/wav")
+                                        .data(base64Audio)
+                                        .build())
+                        .build();
+
+        String result = formatter.renderToolResult(List.of(audioData));
+
+        assertTrue(result.startsWith("The returned audio can be found at: "));
+        String path = result.substring("The returned audio can be found at: ".length());
+        assertTrue(Files.exists(Path.of(path)));
+        Files.deleteIfExists(Path.of(path));
+    }
+
+    @Test
+    @DisplayName("Should format multiple mixed tool result items")
+    void testConvertToolResultToStringMultipleItems() {
+        String result =
+                formatter.renderToolResult(
+                        List.of(
+                                TextBlock.builder().text("first").build(),
+                                DataBlock.builder()
+                                        .source(
+                                                URLSource.builder()
+                                                        .url("https://example.com/audio.wav")
+                                                        .build())
+                                        .build(),
+                                DataBlock.builder()
+                                        .source(
+                                                URLSource.builder()
+                                                        .url("https://example.com/video.mp4")
+                                                        .build())
+                                        .build(),
+                                DataBlock.builder().source(new Source() {}).build()));
+
+        assertEquals(
+                "- first\n"
+                        + "- The returned audio can be found at: https://example.com/audio.wav\n"
+                        + "- The returned video can be found at: https://example.com/video.mp4",
+                result);
+    }
+
+    @Test
+    @DisplayName("Should ignore null and unknown tool result blocks")
+    void testConvertToolResultToStringEmptyAndUnknown() {
+        assertEquals("", formatter.renderToolResult(null));
+        assertEquals("", formatter.renderToolResult(List.of()));
+        assertEquals(
+                "",
+                formatter.renderToolResult(
+                        List.of(DataBlock.builder().source(new Source() {}).build())));
+    }
+
+    private static final class TestFormatter extends AbstractBaseFormatter<Object, Object, Object> {
+
+        @Override
+        protected List<Object> doFormat(List<Msg> msgs) {
+            return List.of();
+        }
+
+        @Override
+        public void applyTools(Object request, List<ToolSchema> tools) {}
+
+        @Override
+        public void applyOptions(
+                Object request, GenerateOptions options, GenerateOptions defaultOptions) {}
+
+        @Override
+        public ChatResponse parseResponse(Object response, Instant receivedAt) {
+            return null;
+        }
+
+        boolean hasMedia(Msg msg) {
+            return hasMediaContent(msg);
+        }
+
+        String renderToolResult(List<ContentBlock> output) {
+            return convertToolResultToString(output);
+        }
+    }
+}

--- a/agentscope-core/src/test/java/io/agentscope/core/formatter/MediaUtilsTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/formatter/MediaUtilsTest.java
@@ -22,6 +22,11 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import io.agentscope.core.message.Base64Source;
+import io.agentscope.core.message.ContentBlock;
+import io.agentscope.core.message.DataBlock;
+import io.agentscope.core.message.ImageBlock;
+import io.agentscope.core.message.URLSource;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
@@ -195,6 +200,38 @@ class MediaUtilsTest {
         assertEquals("application/octet-stream", MediaUtils.determineMediaType("file"));
         assertEquals("application/octet-stream", MediaUtils.determineMediaType(null));
         assertEquals("application/octet-stream", MediaUtils.determineMediaType(""));
+    }
+
+    @Test
+    @DisplayName("Should infer media kind from DataBlock")
+    void testInferMediaKindFromDataBlock() {
+        DataBlock imageData =
+                DataBlock.builder()
+                        .source(URLSource.builder().url("https://example.com/image.png").build())
+                        .build();
+
+        ContentBlock normalized = MediaUtils.normalizeMediaBlock(imageData);
+
+        assertNotNull(normalized);
+        assertTrue(normalized instanceof ImageBlock);
+    }
+
+    @Test
+    @DisplayName("Should preserve base64 DataBlock as legacy image block")
+    void testNormalizeBase64DataBlock() {
+        DataBlock dataBlock =
+                DataBlock.builder()
+                        .source(
+                                Base64Source.builder()
+                                        .mediaType("image/png")
+                                        .data("iVBORw0KGgo=")
+                                        .build())
+                        .build();
+
+        ContentBlock normalized = MediaUtils.normalizeMediaBlock(dataBlock);
+
+        assertNotNull(normalized);
+        assertTrue(normalized instanceof ImageBlock);
     }
 
     @Test

--- a/agentscope-core/src/test/java/io/agentscope/core/formatter/MediaUtilsTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/formatter/MediaUtilsTest.java
@@ -23,6 +23,7 @@ import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.sun.net.httpserver.HttpServer;
 import io.agentscope.core.message.AudioBlock;
 import io.agentscope.core.message.Base64Source;
 import io.agentscope.core.message.ContentBlock;
@@ -34,6 +35,9 @@ import io.agentscope.core.message.URLSource;
 import io.agentscope.core.message.VideoBlock;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Base64;
@@ -421,6 +425,62 @@ class MediaUtilsTest {
         String url = "src/test/java/io/agentscope/core/formatter/MediaUtilsTest.java";
 
         assertNotNull(MediaUtils.urlToInputStream(url));
+    }
+
+    @Test
+    @DisplayName("Should download and encode remote content via HTTP")
+    void testDownloadUrlToBase64AndProtocolDataUrlWithHttpServer() throws IOException {
+        byte[] payload = "hello world".getBytes(StandardCharsets.UTF_8);
+        HttpServer server = HttpServer.create(new InetSocketAddress("localhost", 0), 0);
+        server.createContext(
+                "/image.png",
+                exchange -> {
+                    exchange.getResponseHeaders().add("Content-Type", "image/png");
+                    exchange.sendResponseHeaders(200, payload.length);
+                    try (OutputStream os = exchange.getResponseBody()) {
+                        os.write(payload);
+                    }
+                });
+        server.start();
+
+        try {
+            String url = "http://localhost:" + server.getAddress().getPort() + "/image.png";
+
+            String base64 = MediaUtils.downloadUrlToBase64(url);
+            assertEquals(Base64.getEncoder().encodeToString(payload), base64);
+
+            try (InputStream inputStream = MediaUtils.urlToInputStream(url)) {
+                assertEquals(
+                        "hello world",
+                        new String(inputStream.readAllBytes(), StandardCharsets.UTF_8));
+            }
+
+            String dataUrl = MediaUtils.urlToBase64DataUrl(url);
+            assertTrue(dataUrl.startsWith("data:image/png;base64,"));
+        } finally {
+            server.stop(0);
+        }
+    }
+
+    @Test
+    @DisplayName("Should throw when remote download returns a non-200 status")
+    void testDownloadUrlToBase64HttpError() throws IOException {
+        HttpServer server = HttpServer.create(new InetSocketAddress("localhost", 0), 0);
+        server.createContext(
+                "/missing.png",
+                exchange -> {
+                    exchange.sendResponseHeaders(404, -1);
+                    exchange.close();
+                });
+        server.start();
+
+        try {
+            String url = "http://localhost:" + server.getAddress().getPort() + "/missing.png";
+
+            assertThrows(IOException.class, () -> MediaUtils.downloadUrlToBase64(url));
+        } finally {
+            server.stop(0);
+        }
     }
 
     @Test

--- a/agentscope-core/src/test/java/io/agentscope/core/formatter/MediaUtilsTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/formatter/MediaUtilsTest.java
@@ -19,14 +19,19 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import io.agentscope.core.message.AudioBlock;
 import io.agentscope.core.message.Base64Source;
 import io.agentscope.core.message.ContentBlock;
 import io.agentscope.core.message.DataBlock;
 import io.agentscope.core.message.ImageBlock;
+import io.agentscope.core.message.Source;
+import io.agentscope.core.message.TextBlock;
 import io.agentscope.core.message.URLSource;
+import io.agentscope.core.message.VideoBlock;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
@@ -217,21 +222,81 @@ class MediaUtilsTest {
     }
 
     @Test
-    @DisplayName("Should preserve base64 DataBlock as legacy image block")
-    void testNormalizeBase64DataBlock() {
-        DataBlock dataBlock =
+    @DisplayName("Should infer media kind from legacy audio and video blocks")
+    void testInferMediaKindFromLegacyAudioAndVideoBlocks() {
+        AudioBlock audioBlock =
+                AudioBlock.builder()
+                        .source(URLSource.builder().url("https://example.com/audio.wav").build())
+                        .build();
+
+        VideoBlock videoBlock =
+                VideoBlock.builder()
+                        .source(URLSource.builder().url("https://example.com/video.mp4").build())
+                        .build();
+
+        assertEquals(MediaUtils.MediaKind.AUDIO, MediaUtils.inferMediaKind(audioBlock));
+        assertEquals(MediaUtils.MediaKind.VIDEO, MediaUtils.inferMediaKind(videoBlock));
+    }
+
+    @Test
+    @DisplayName("Should infer audio and video DataBlock kinds from base64 sources")
+    void testInferMediaKindFromBase64DataBlocks() {
+        DataBlock audioData =
                 DataBlock.builder()
                         .source(
                                 Base64Source.builder()
-                                        .mediaType("image/png")
-                                        .data("iVBORw0KGgo=")
+                                        .mediaType("audio/wav")
+                                        .data(
+                                                "UklGRiQAAABXQVZFZm10IBAAAAABAAEAQB8AAAB9AAACABAAZGF0YQAAAAA=")
                                         .build())
                         .build();
 
-        ContentBlock normalized = MediaUtils.normalizeMediaBlock(dataBlock);
+        DataBlock videoData =
+                DataBlock.builder()
+                        .source(
+                                Base64Source.builder()
+                                        .mediaType("video/mp4")
+                                        .data("ZmlsZS1kYXRh")
+                                        .build())
+                        .build();
 
-        assertNotNull(normalized);
-        assertTrue(normalized instanceof ImageBlock);
+        assertEquals(MediaUtils.MediaKind.AUDIO, MediaUtils.inferMediaKind(audioData));
+        assertEquals(MediaUtils.MediaKind.VIDEO, MediaUtils.inferMediaKind(videoData));
+
+        assertTrue(MediaUtils.toLegacyMediaBlock(audioData) instanceof AudioBlock);
+        assertTrue(MediaUtils.toLegacyMediaBlock(videoData) instanceof VideoBlock);
+
+        assertTrue(MediaUtils.normalizeMediaBlock(audioData) instanceof AudioBlock);
+        assertTrue(MediaUtils.normalizeMediaBlock(videoData) instanceof VideoBlock);
+    }
+
+    @Test
+    @DisplayName("Should fall back to file name when source media type is ambiguous")
+    void testInferMediaKindFromFallbackName() {
+        DataBlock audioData =
+                DataBlock.builder().source(new Source() {}).name("recording.wav").build();
+        DataBlock videoData = DataBlock.builder().source(new Source() {}).name("clip.mp4").build();
+
+        assertEquals(MediaUtils.MediaKind.AUDIO, MediaUtils.inferMediaKind(audioData));
+        assertEquals(MediaUtils.MediaKind.VIDEO, MediaUtils.inferMediaKind(videoData));
+        assertTrue(MediaUtils.toLegacyMediaBlock(audioData) instanceof AudioBlock);
+        assertTrue(MediaUtils.toLegacyMediaBlock(videoData) instanceof VideoBlock);
+    }
+
+    @Test
+    @DisplayName("Should return null for unknown media kinds and preserve non-Data blocks")
+    void testUnknownMediaKindsAndNormalizeIdentity() {
+        DataBlock unknownData = DataBlock.builder().source(new Source() {}).build();
+        TextBlock textBlock = TextBlock.builder().text("hello").build();
+
+        assertNull(MediaUtils.inferMediaKind((Source) null));
+        assertNull(MediaUtils.inferMediaKind((ContentBlock) null));
+        assertNull(MediaUtils.inferMediaKind(unknownData));
+        assertNull(MediaUtils.toLegacyMediaBlock(null));
+        assertNull(MediaUtils.normalizeMediaBlock(null));
+        assertNull(MediaUtils.toLegacyMediaBlock(unknownData));
+        assertNull(MediaUtils.normalizeMediaBlock(unknownData));
+        assertSame(textBlock, MediaUtils.normalizeMediaBlock(textBlock));
     }
 
     @Test

--- a/agentscope-core/src/test/java/io/agentscope/core/formatter/anthropic/AnthropicConversationMergerTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/formatter/anthropic/AnthropicConversationMergerTest.java
@@ -18,9 +18,11 @@ package io.agentscope.core.formatter.anthropic;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import io.agentscope.core.message.DataBlock;
 import io.agentscope.core.message.ImageBlock;
 import io.agentscope.core.message.Msg;
 import io.agentscope.core.message.MsgRole;
+import io.agentscope.core.message.Source;
 import io.agentscope.core.message.TextBlock;
 import io.agentscope.core.message.URLSource;
 import java.util.List;
@@ -86,6 +88,36 @@ class AnthropicConversationMergerTest extends AnthropicFormatterTestBase {
         List<Object> result =
                 AnthropicConversationMerger.mergeConversation(
                         List.of(msg1, msg2, msg3), "# Prompt\n");
+
+        assertTrue(result.size() >= 2);
+        assertTrue(result.stream().anyMatch(obj -> obj instanceof String));
+        assertTrue(result.stream().anyMatch(obj -> obj instanceof ImageBlock));
+    }
+
+    @Test
+    void testMergeConversationWithDataBlockImage() {
+        DataBlock unknownBlock = DataBlock.builder().source(new Source() {}).build();
+        DataBlock imageBlock =
+                DataBlock.builder()
+                        .source(URLSource.builder().url("https://example.com/image.png").build())
+                        .build();
+
+        Msg msg1 =
+                Msg.builder()
+                        .role(MsgRole.USER)
+                        .name("User")
+                        .content(List.of(TextBlock.builder().text("What is this?").build()))
+                        .build();
+
+        Msg msg2 =
+                Msg.builder()
+                        .role(MsgRole.USER)
+                        .name("User")
+                        .content(List.of(unknownBlock, imageBlock))
+                        .build();
+
+        List<Object> result =
+                AnthropicConversationMerger.mergeConversation(List.of(msg1, msg2), "# Prompt\n");
 
         assertTrue(result.size() >= 2);
         assertTrue(result.stream().anyMatch(obj -> obj instanceof String));

--- a/agentscope-core/src/test/java/io/agentscope/core/formatter/anthropic/AnthropicMessageConverterTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/formatter/anthropic/AnthropicMessageConverterTest.java
@@ -25,9 +25,11 @@ import com.anthropic.models.messages.ToolResultBlockParam;
 import com.anthropic.models.messages.ToolUseBlockParam;
 import io.agentscope.core.message.Base64Source;
 import io.agentscope.core.message.ContentBlock;
+import io.agentscope.core.message.DataBlock;
 import io.agentscope.core.message.ImageBlock;
 import io.agentscope.core.message.Msg;
 import io.agentscope.core.message.MsgRole;
+import io.agentscope.core.message.Source;
 import io.agentscope.core.message.TextBlock;
 import io.agentscope.core.message.ThinkingBlock;
 import io.agentscope.core.message.ToolResultBlock;
@@ -359,6 +361,40 @@ class AnthropicMessageConverterTest extends AnthropicFormatterTestBase {
                                 List.of(
                                         TextBlock.builder().text("Look at this:").build(),
                                         ImageBlock.builder().source(imageSource).build(),
+                                        TextBlock.builder().text("What is it?").build()))
+                        .build();
+
+        List<MessageParam> result = converter.convert(List.of(msg));
+
+        assertEquals(1, result.size());
+        List<ContentBlockParam> blocks = result.get(0).content().asBlockParams();
+        assertEquals(3, blocks.size());
+        assertTrue(blocks.get(0).isText());
+        assertTrue(blocks.get(1).isImage());
+        assertTrue(blocks.get(2).isText());
+    }
+
+    @Test
+    void testConvertMixedContentBlocksWithDataBlock() {
+        DataBlock unknownBlock = DataBlock.builder().source(new Source() {}).build();
+        DataBlock imageBlock =
+                DataBlock.builder()
+                        .source(
+                                Base64Source.builder()
+                                        .data("ZmFrZSBpbWFnZSBjb250ZW50")
+                                        .mediaType("image/png")
+                                        .build())
+                        .build();
+
+        Msg msg =
+                Msg.builder()
+                        .name("User")
+                        .role(MsgRole.USER)
+                        .content(
+                                List.of(
+                                        TextBlock.builder().text("Look at this:").build(),
+                                        unknownBlock,
+                                        imageBlock,
                                         TextBlock.builder().text("What is it?").build()))
                         .build();
 

--- a/agentscope-core/src/test/java/io/agentscope/core/formatter/anthropic/AnthropicMessageConverterTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/formatter/anthropic/AnthropicMessageConverterTest.java
@@ -270,6 +270,44 @@ class AnthropicMessageConverterTest extends AnthropicFormatterTestBase {
     }
 
     @Test
+    void testConvertToolResultBlockWithDataBlockImage() {
+        DataBlock imageBlock =
+                DataBlock.builder()
+                        .source(
+                                Base64Source.builder()
+                                        .mediaType("image/png")
+                                        .data("iVBORw0KGgo=")
+                                        .build())
+                        .build();
+
+        Msg msg =
+                Msg.builder()
+                        .name("Tool")
+                        .role(MsgRole.TOOL)
+                        .content(
+                                List.of(
+                                        ToolResultBlock.builder()
+                                                .id("call_456")
+                                                .name("search")
+                                                .output(
+                                                        List.of(
+                                                                TextBlock.builder()
+                                                                        .text("Tool output")
+                                                                        .build(),
+                                                                imageBlock))
+                                                .build()))
+                        .build();
+
+        List<MessageParam> result = converter.convert(List.of(msg));
+
+        assertEquals(1, result.size());
+        assertEquals(MessageParam.Role.USER, result.get(0).role());
+        List<ContentBlockParam> blocks = result.get(0).content().asBlockParams();
+        assertEquals(1, blocks.size());
+        assertTrue(blocks.get(0).isToolResult());
+    }
+
+    @Test
     void testConvertToolResultBlockWithTextBlock() {
         TextBlock textBlock = TextBlock.builder().text("Tool output").build();
         Msg msg =

--- a/agentscope-core/src/test/java/io/agentscope/core/formatter/dashscope/DashScopeMessageConverterTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/formatter/dashscope/DashScopeMessageConverterTest.java
@@ -753,6 +753,38 @@ class DashScopeMessageConverterTest {
     }
 
     @Test
+    void testToolResultWithDataBlockImage() {
+        DataBlock imageBlock =
+                DataBlock.builder()
+                        .source(
+                                Base64Source.builder()
+                                        .mediaType("image/png")
+                                        .data("iVBORw0KGgo=")
+                                        .build())
+                        .build();
+
+        ToolResultBlock toolResult =
+                ToolResultBlock.builder()
+                        .id("call_456")
+                        .name("get_image")
+                        .output(
+                                List.of(
+                                        TextBlock.builder().text("Here is a cat image").build(),
+                                        imageBlock))
+                        .build();
+
+        Msg msg = Msg.builder().role(MsgRole.TOOL).content(List.of(toolResult)).build();
+        DashScopeMessage dsMsg = converter.convertToMessage(msg, true);
+
+        assertEquals("tool", dsMsg.getRole());
+        assertEquals("call_456", dsMsg.getToolCallId());
+        assertTrue(dsMsg.isMultimodal());
+        assertEquals(2, dsMsg.getContentAsList().size());
+        assertEquals("Here is a cat image", dsMsg.getContentAsList().get(0).getText());
+        assertNotNull(dsMsg.getContentAsList().get(1).getImage());
+    }
+
+    @Test
     void testToolResultWithTextImageAudioBlocks() {
         // Test that tool result with TextBlock + ImageBlock + AudioBlock returns 3 content parts
         DashScopeMessageConverter conv =

--- a/agentscope-core/src/test/java/io/agentscope/core/formatter/dashscope/DashScopeMessageConverterTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/formatter/dashscope/DashScopeMessageConverterTest.java
@@ -29,6 +29,7 @@ import io.agentscope.core.message.DataBlock;
 import io.agentscope.core.message.ImageBlock;
 import io.agentscope.core.message.Msg;
 import io.agentscope.core.message.MsgRole;
+import io.agentscope.core.message.Source;
 import io.agentscope.core.message.TextBlock;
 import io.agentscope.core.message.ThinkingBlock;
 import io.agentscope.core.message.ToolResultBlock;
@@ -382,6 +383,38 @@ class DashScopeMessageConverterTest {
         assertEquals("描述这张图：", parts.get(0).getText());
         assertNotNull(parts.get(1).getImage());
         assertTrue(parts.get(1).getImage().startsWith("data:image/png;base64,"));
+    }
+
+    @Test
+    void testConvertMessageWithUnknownDataBlockSkipped() {
+        DataBlock unknownBlock = DataBlock.builder().source(new Source() {}).build();
+        DataBlock imageBlock =
+                DataBlock.builder()
+                        .source(
+                                Base64Source.builder()
+                                        .mediaType("image/png")
+                                        .data("iVBORw0KGgo=")
+                                        .build())
+                        .build();
+
+        Msg msg =
+                Msg.builder()
+                        .role(MsgRole.USER)
+                        .content(
+                                List.of(
+                                        TextBlock.builder().text("look").build(),
+                                        unknownBlock,
+                                        imageBlock))
+                        .build();
+
+        DashScopeMessage dsMsg = converter.convertToMessage(msg, true);
+
+        assertEquals("user", dsMsg.getRole());
+        assertTrue(dsMsg.isMultimodal());
+        List<DashScopeContentPart> parts = dsMsg.getContentAsList();
+        assertEquals(2, parts.size());
+        assertEquals("look", parts.get(0).getText());
+        assertNotNull(parts.get(1).getImage());
     }
 
     @Test

--- a/agentscope-core/src/test/java/io/agentscope/core/formatter/dashscope/DashScopeMessageConverterTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/formatter/dashscope/DashScopeMessageConverterTest.java
@@ -23,7 +23,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import io.agentscope.core.formatter.dashscope.dto.DashScopeContentPart;
 import io.agentscope.core.formatter.dashscope.dto.DashScopeMessage;
 import io.agentscope.core.message.AudioBlock;
+import io.agentscope.core.message.Base64Source;
 import io.agentscope.core.message.ContentBlock;
+import io.agentscope.core.message.DataBlock;
 import io.agentscope.core.message.ImageBlock;
 import io.agentscope.core.message.Msg;
 import io.agentscope.core.message.MsgRole;
@@ -352,6 +354,34 @@ class DashScopeMessageConverterTest {
         assertEquals("http://example.com/image.png", dsMsg.getContentAsList().get(0).getImage());
         assertEquals("https://example.com/image.png", dsMsg.getContentAsList().get(1).getImage());
         assertEquals("oss://example.com/image.png", dsMsg.getContentAsList().get(2).getImage());
+    }
+
+    @Test
+    void testConvertMessageWithMixedTextAndDataBlockImage() {
+        Msg msg =
+                Msg.builder()
+                        .role(MsgRole.USER)
+                        .content(
+                                List.of(
+                                        TextBlock.builder().text("描述这张图：").build(),
+                                        DataBlock.builder()
+                                                .source(
+                                                        Base64Source.builder()
+                                                                .mediaType("image/png")
+                                                                .data("iVBORw0KGgo=")
+                                                                .build())
+                                                .build()))
+                        .build();
+
+        DashScopeMessage dsMsg = converter.convertToMessage(msg, true);
+
+        assertEquals("user", dsMsg.getRole());
+        assertTrue(dsMsg.isMultimodal());
+        List<DashScopeContentPart> parts = dsMsg.getContentAsList();
+        assertEquals(2, parts.size());
+        assertEquals("描述这张图：", parts.get(0).getText());
+        assertNotNull(parts.get(1).getImage());
+        assertTrue(parts.get(1).getImage().startsWith("data:image/png;base64,"));
     }
 
     @Test

--- a/agentscope-core/src/test/java/io/agentscope/core/formatter/gemini/GeminiConversationMergerTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/formatter/gemini/GeminiConversationMergerTest.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.core.formatter.gemini;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.google.genai.types.Content;
+import io.agentscope.core.message.Base64Source;
+import io.agentscope.core.message.DataBlock;
+import io.agentscope.core.message.HintBlock;
+import io.agentscope.core.message.Msg;
+import io.agentscope.core.message.MsgRole;
+import io.agentscope.core.message.TextBlock;
+import io.agentscope.core.message.ToolResultBlock;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class GeminiConversationMergerTest {
+
+    private static final String IMAGE_BASE64 = "iVBORw0KGgo=";
+    private static final String AUDIO_BASE64 = "UklGRg==";
+    private static final String VIDEO_BASE64 = "AAAA";
+
+    private final GeminiConversationMerger merger =
+            new GeminiConversationMerger("# Conversation History\n");
+
+    @Test
+    @DisplayName("Should merge text, tool results and media into a single history content")
+    void testMergeWithTextToolResultAndMedia() {
+        Msg msg =
+                Msg.builder()
+                        .role(MsgRole.ASSISTANT)
+                        .name("Alice")
+                        .content(
+                                List.of(
+                                        TextBlock.builder().text("Hello").build(),
+                                        new HintBlock(null, "Need a quick answer"),
+                                        ToolResultBlock.builder()
+                                                .name("search")
+                                                .output(
+                                                        List.of(
+                                                                TextBlock.builder()
+                                                                        .text("Result")
+                                                                        .build()))
+                                                .build(),
+                                        DataBlock.builder()
+                                                .source(
+                                                        Base64Source.builder()
+                                                                .mediaType("image/png")
+                                                                .data(IMAGE_BASE64)
+                                                                .build())
+                                                .build(),
+                                        DataBlock.builder()
+                                                .source(
+                                                        Base64Source.builder()
+                                                                .mediaType("audio/wav")
+                                                                .data(AUDIO_BASE64)
+                                                                .build())
+                                                .build(),
+                                        DataBlock.builder()
+                                                .source(
+                                                        Base64Source.builder()
+                                                                .mediaType("video/mp4")
+                                                                .data(VIDEO_BASE64)
+                                                                .build())
+                                                .build()))
+                        .build();
+
+        Content result =
+                merger.mergeToContent(
+                        List.of(msg),
+                        value -> value.getName() != null ? value.getName() : "Unknown",
+                        blocks -> "tool output",
+                        "# Prompt\n");
+
+        assertNotNull(result);
+        assertEquals("user", result.role().get());
+        assertTrue(result.parts().isPresent());
+        assertTrue(result.parts().get().size() >= 4);
+        assertTrue(result.parts().get().get(0).text().get().startsWith("# Prompt\n<history>"));
+        assertTrue(result.parts().get().get(0).text().get().contains("Alice: Hello"));
+        assertTrue(result.parts().get().get(0).text().get().contains("Alice: Need a quick answer"));
+        assertTrue(
+                result.parts()
+                        .get()
+                        .get(result.parts().get().size() - 1)
+                        .text()
+                        .get()
+                        .endsWith("</history>"));
+    }
+
+    @Test
+    @DisplayName("Should wrap history when media comes first")
+    void testMergeWithMediaFirst() {
+        Msg mediaMsg =
+                Msg.builder()
+                        .role(MsgRole.USER)
+                        .name("Alice")
+                        .content(
+                                List.of(
+                                        DataBlock.builder()
+                                                .source(
+                                                        Base64Source.builder()
+                                                                .mediaType("image/png")
+                                                                .data(IMAGE_BASE64)
+                                                                .build())
+                                                .build()))
+                        .build();
+
+        Msg textMsg =
+                Msg.builder()
+                        .role(MsgRole.ASSISTANT)
+                        .name("Bob")
+                        .content(List.of(TextBlock.builder().text("After the image").build()))
+                        .build();
+
+        Content result =
+                merger.mergeToContent(
+                        List.of(mediaMsg, textMsg),
+                        value -> value.getName() != null ? value.getName() : "Unknown",
+                        blocks -> "tool output",
+                        "# Prompt\n");
+
+        assertNotNull(result);
+        assertEquals("user", result.role().get());
+        assertTrue(result.parts().isPresent());
+        assertTrue(result.parts().get().size() >= 3);
+        assertTrue(result.parts().get().get(0).text().get().startsWith("# Prompt\n<history>"));
+        assertTrue(
+                result.parts()
+                        .get()
+                        .get(result.parts().get().size() - 1)
+                        .text()
+                        .get()
+                        .endsWith("</history>"));
+    }
+}

--- a/agentscope-core/src/test/java/io/agentscope/core/formatter/gemini/GeminiMessageConverterTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/formatter/gemini/GeminiMessageConverterTest.java
@@ -25,6 +25,7 @@ import com.google.genai.types.Content;
 import com.google.genai.types.Part;
 import io.agentscope.core.message.AudioBlock;
 import io.agentscope.core.message.Base64Source;
+import io.agentscope.core.message.DataBlock;
 import io.agentscope.core.message.ImageBlock;
 import io.agentscope.core.message.Msg;
 import io.agentscope.core.message.MsgRole;
@@ -503,6 +504,31 @@ class GeminiMessageConverterTest {
 
         assertEquals(1, result.size());
         assertNotNull(result.get(0).parts().get().get(0));
+    }
+
+    @Test
+    @DisplayName("Should convert DataBlock image to inline data part")
+    void testConvertDataBlockImage() {
+        String base64Data = Base64.getEncoder().encodeToString("fake image".getBytes());
+
+        DataBlock imageBlock =
+                DataBlock.builder()
+                        .source(
+                                Base64Source.builder()
+                                        .mediaType("image/png")
+                                        .data(base64Data)
+                                        .build())
+                        .build();
+
+        Msg msg =
+                Msg.builder().name("user").content(List.of(imageBlock)).role(MsgRole.USER).build();
+
+        List<Content> result = converter.convertMessages(List.of(msg));
+
+        assertEquals(1, result.size());
+        Content content = result.get(0);
+        assertEquals(1, content.parts().get().size());
+        assertNotNull(content.parts().get().get(0));
     }
 
     @Test

--- a/agentscope-core/src/test/java/io/agentscope/core/formatter/ollama/OllamaChatFormatterTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/formatter/ollama/OllamaChatFormatterTest.java
@@ -438,6 +438,91 @@ class OllamaChatFormatterTest {
     }
 
     @Test
+    @DisplayName("Should format messages with promote tool result DataBlock images")
+    void testFormatMessagesWithPromoteToolResultDataBlockImages() {
+        OllamaChatFormatter formatterWithPromote = new OllamaChatFormatter(true);
+
+        Msg systemMsg =
+                Msg.builder()
+                        .role(MsgRole.SYSTEM)
+                        .name("system")
+                        .content(TextBlock.builder().text("You're a helpful assistant.").build())
+                        .build();
+
+        Msg assistantToolCall =
+                Msg.builder()
+                        .role(MsgRole.ASSISTANT)
+                        .name("assistant")
+                        .content(
+                                Arrays.asList(
+                                        ToolUseBlock.builder()
+                                                .id("1")
+                                                .name("get_capital")
+                                                .input(Collections.singletonMap("country", "Japan"))
+                                                .build()))
+                        .build();
+
+        DataBlock dataBlock =
+                DataBlock.builder()
+                        .source(
+                                Base64Source.builder()
+                                        .mediaType("image/png")
+                                        .data("iVBORw0KGgo=")
+                                        .build())
+                        .build();
+
+        Msg toolResultMsg =
+                Msg.builder()
+                        .role(MsgRole.TOOL)
+                        .name("system")
+                        .content(
+                                Arrays.asList(
+                                        ToolResultBlock.builder()
+                                                .id("1")
+                                                .name("get_capital")
+                                                .output(
+                                                        Arrays.asList(
+                                                                TextBlock.builder()
+                                                                        .text(
+                                                                                "The capital is"
+                                                                                        + " Tokyo.")
+                                                                        .build(),
+                                                                dataBlock))
+                                                .build()))
+                        .build();
+
+        Msg assistantResponse =
+                Msg.builder()
+                        .role(MsgRole.ASSISTANT)
+                        .name("assistant")
+                        .content(TextBlock.builder().text("The capital of Japan is Tokyo.").build())
+                        .build();
+
+        List<OllamaMessage> formatted =
+                formatterWithPromote.format(
+                        concatLists(
+                                List.of(systemMsg),
+                                List.of(assistantToolCall),
+                                List.of(toolResultMsg),
+                                List.of(assistantResponse)));
+
+        assertTrue(formatted.size() >= 5);
+        assertEquals("tool", formatted.get(2).getRole());
+        assertNotNull(formatted.get(2).getContent());
+        assertTrue(formatted.get(2).getContent().contains("The capital is Tokyo."));
+        assertTrue(
+                formatted.stream()
+                        .anyMatch(
+                                message ->
+                                        "user".equals(message.getRole())
+                                                && message.getContent() != null
+                                                && message.getContent()
+                                                        .contains(
+                                                                "image contents from the tool"
+                                                                        + " result")));
+    }
+
+    @Test
     @DisplayName("Should parse response correctly")
     void testParseResponse() {
         // Arrange

--- a/agentscope-core/src/test/java/io/agentscope/core/formatter/ollama/OllamaChatFormatterTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/formatter/ollama/OllamaChatFormatterTest.java
@@ -23,6 +23,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import io.agentscope.core.formatter.ollama.dto.OllamaMessage;
 import io.agentscope.core.formatter.ollama.dto.OllamaRequest;
 import io.agentscope.core.formatter.ollama.dto.OllamaResponse;
+import io.agentscope.core.message.Base64Source;
+import io.agentscope.core.message.DataBlock;
 import io.agentscope.core.message.ImageBlock;
 import io.agentscope.core.message.Msg;
 import io.agentscope.core.message.MsgRole;
@@ -524,6 +526,34 @@ class OllamaChatFormatterTest {
         assertEquals(model, request.getModel());
         assertEquals(messages, request.getMessages());
         assertEquals(stream, request.getStream());
+    }
+
+    @Test
+    @DisplayName("Should format user message with DataBlock image")
+    void testFormatUserMessageWithDataBlockImage() {
+        Msg userMsg =
+                Msg.builder()
+                        .role(MsgRole.USER)
+                        .content(
+                                Arrays.asList(
+                                        TextBlock.builder().text("Describe this image:").build(),
+                                        DataBlock.builder()
+                                                .source(
+                                                        Base64Source.builder()
+                                                                .mediaType("image/png")
+                                                                .data("iVBORw0KGgo=")
+                                                                .build())
+                                                .build()))
+                        .build();
+
+        List<OllamaMessage> formatted = formatter.format(List.of(userMsg));
+
+        assertEquals(1, formatted.size());
+        assertEquals("user", formatted.get(0).getRole());
+        assertEquals("Describe this image:", formatted.get(0).getContent());
+        assertNotNull(formatted.get(0).getImages());
+        assertEquals(1, formatted.get(0).getImages().size());
+        assertEquals("iVBORw0KGgo=", formatted.get(0).getImages().get(0));
     }
 
     // Helper method to concatenate lists

--- a/agentscope-core/src/test/java/io/agentscope/core/formatter/ollama/OllamaConversationMergerTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/formatter/ollama/OllamaConversationMergerTest.java
@@ -21,7 +21,9 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.agentscope.core.formatter.ollama.dto.OllamaMessage;
+import io.agentscope.core.message.Base64Source;
 import io.agentscope.core.message.ContentBlock;
+import io.agentscope.core.message.DataBlock;
 import io.agentscope.core.message.Msg;
 import io.agentscope.core.message.MsgRole;
 import io.agentscope.core.message.TextBlock;
@@ -282,5 +284,41 @@ class OllamaConversationMergerTest {
 
         // Assert
         assertEquals("user", merged.getRole());
+    }
+
+    @Test
+    @DisplayName("Should merge DataBlock image as legacy image content")
+    void testMergeDataBlockImage() {
+        DataBlock dataBlock =
+                DataBlock.builder()
+                        .source(
+                                Base64Source.builder()
+                                        .mediaType("image/png")
+                                        .data("iVBORw0KGgo=")
+                                        .build())
+                        .build();
+
+        Msg msg =
+                Msg.builder()
+                        .name("Alice")
+                        .content(
+                                Arrays.asList(
+                                        TextBlock.builder().text("Look at this").build(),
+                                        dataBlock))
+                        .build();
+        List<Msg> msgs = Arrays.asList(msg);
+
+        Function<Msg, String> nameExtractor = m -> m.getName() != null ? m.getName() : "Unknown";
+        Function<List<ContentBlock>, String> toolResultConverter = blocks -> "Converted";
+
+        OllamaMessage merged =
+                merger.mergeToMessage(msgs, nameExtractor, toolResultConverter, "History:");
+
+        assertNotNull(merged);
+        assertTrue(merged.getContent().contains("Alice: Look at this"));
+        assertTrue(merged.getContent().contains("Alice: [Image]"));
+        assertNotNull(merged.getImages());
+        assertEquals(1, merged.getImages().size());
+        assertEquals("iVBORw0KGgo=", merged.getImages().get(0));
     }
 }

--- a/agentscope-core/src/test/java/io/agentscope/core/formatter/ollama/OllamaMessageConverterTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/formatter/ollama/OllamaMessageConverterTest.java
@@ -28,6 +28,7 @@ import io.agentscope.core.message.MsgRole;
 import io.agentscope.core.message.TextBlock;
 import io.agentscope.core.message.ToolResultBlock;
 import io.agentscope.core.message.ToolUseBlock;
+import io.agentscope.core.message.URLSource;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -167,6 +168,33 @@ class OllamaMessageConverterTest {
         assertEquals("tool", ollamaMsg.getRole());
         assertEquals("Tool result output", ollamaMsg.getContent());
         assertEquals("call123", ollamaMsg.getToolCallId());
+        assertEquals("test_tool", ollamaMsg.getName());
+    }
+
+    @Test
+    @DisplayName("Should convert tool result message with DataBlock image")
+    void testConvertToolResultMessageWithDataBlockImage() {
+        DataBlock dataBlock =
+                DataBlock.builder()
+                        .source(URLSource.builder().url("https://example.com/image.png").build())
+                        .build();
+
+        ToolResultBlock toolResult =
+                new ToolResultBlock(
+                        "call456",
+                        "test_tool",
+                        List.of(TextBlock.builder().text("Tool result output").build(), dataBlock),
+                        null);
+        Msg msg = Msg.builder().role(MsgRole.TOOL).content(toolResult).build();
+
+        OllamaMessage ollamaMsg = converter.convertMessage(msg);
+
+        assertNotNull(ollamaMsg);
+        assertEquals("tool", ollamaMsg.getRole());
+        assertTrue(ollamaMsg.getContent().contains("Tool result output"));
+        assertTrue(ollamaMsg.getContent().contains("The returned image can be found at:"));
+        assertTrue(ollamaMsg.getContent().contains("image.png"));
+        assertEquals("call456", ollamaMsg.getToolCallId());
         assertEquals("test_tool", ollamaMsg.getName());
     }
 

--- a/agentscope-core/src/test/java/io/agentscope/core/formatter/ollama/OllamaMessageConverterTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/formatter/ollama/OllamaMessageConverterTest.java
@@ -18,8 +18,11 @@ package io.agentscope.core.formatter.ollama;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.agentscope.core.formatter.ollama.dto.OllamaMessage;
+import io.agentscope.core.message.Base64Source;
+import io.agentscope.core.message.DataBlock;
 import io.agentscope.core.message.Msg;
 import io.agentscope.core.message.MsgRole;
 import io.agentscope.core.message.TextBlock;
@@ -88,6 +91,38 @@ class OllamaMessageConverterTest {
         assertNotNull(ollamaMsg);
         assertEquals("assistant", ollamaMsg.getRole());
         assertEquals("I'm doing well, thank you!", ollamaMsg.getContent());
+    }
+
+    @Test
+    @DisplayName("Should convert user message with DataBlock image")
+    void testConvertUserMessageWithDataBlockImage() {
+        String base64Data = "iVBORw0KGgo=";
+        DataBlock dataBlock =
+                DataBlock.builder()
+                        .source(
+                                Base64Source.builder()
+                                        .mediaType("image/png")
+                                        .data(base64Data)
+                                        .build())
+                        .build();
+
+        Msg msg =
+                Msg.builder()
+                        .role(MsgRole.USER)
+                        .content(
+                                Arrays.asList(
+                                        TextBlock.builder().text("Look at this").build(),
+                                        dataBlock))
+                        .build();
+
+        OllamaMessage ollamaMsg = converter.convertMessage(msg);
+
+        assertNotNull(ollamaMsg);
+        assertEquals("user", ollamaMsg.getRole());
+        assertEquals("Look at this", ollamaMsg.getContent());
+        assertNotNull(ollamaMsg.getImages());
+        assertEquals(1, ollamaMsg.getImages().size());
+        assertTrue(ollamaMsg.getImages().contains(base64Data));
     }
 
     @Test

--- a/agentscope-core/src/test/java/io/agentscope/core/formatter/ollama/OllamaMultiAgentFormatterTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/formatter/ollama/OllamaMultiAgentFormatterTest.java
@@ -23,7 +23,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import io.agentscope.core.formatter.ollama.dto.OllamaMessage;
 import io.agentscope.core.formatter.ollama.dto.OllamaRequest;
 import io.agentscope.core.formatter.ollama.dto.OllamaResponse;
+import io.agentscope.core.message.Base64Source;
 import io.agentscope.core.message.ContentBlock;
+import io.agentscope.core.message.DataBlock;
 import io.agentscope.core.message.ImageBlock;
 import io.agentscope.core.message.Msg;
 import io.agentscope.core.message.MsgRole;
@@ -757,6 +759,34 @@ class OllamaMultiAgentFormatterTest {
 
         // Assert
         assertEquals("Result: 42", result);
+    }
+
+    @Test
+    @DisplayName("Should format tool result with DataBlock image")
+    void testFormatToolResultWithDataBlockImage() {
+        ToolResultBlock toolResult =
+                ToolResultBlock.builder()
+                        .id("call123")
+                        .name("get_image")
+                        .output(
+                                List.of(
+                                        TextBlock.builder().text("Image ready").build(),
+                                        DataBlock.builder()
+                                                .source(
+                                                        Base64Source.builder()
+                                                                .mediaType("image/png")
+                                                                .data("iVBORw0KGgo=")
+                                                                .build())
+                                                .build()))
+                        .build();
+
+        Msg toolMsg = Msg.builder().role(MsgRole.TOOL).content(toolResult).build();
+
+        List<OllamaMessage> formatted = formatter.format(List.of(toolMsg));
+
+        assertEquals(1, formatted.size());
+        assertEquals("tool", formatted.get(0).getRole());
+        assertEquals("Image ready", formatted.get(0).getContent());
     }
 
     // Helper method to concatenate lists

--- a/agentscope-core/src/test/java/io/agentscope/core/formatter/openai/OpenAIConversationMergerTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/formatter/openai/OpenAIConversationMergerTest.java
@@ -24,6 +24,7 @@ import io.agentscope.core.formatter.openai.dto.OpenAIMessage;
 import io.agentscope.core.message.AudioBlock;
 import io.agentscope.core.message.Base64Source;
 import io.agentscope.core.message.ContentBlock;
+import io.agentscope.core.message.DataBlock;
 import io.agentscope.core.message.ImageBlock;
 import io.agentscope.core.message.Msg;
 import io.agentscope.core.message.MsgRole;
@@ -131,6 +132,48 @@ class OpenAIConversationMergerTest {
         List<OpenAIContentPart> content = result.getContentAsList();
         assertNotNull(content);
         assertTrue(!content.isEmpty(), "Should contain content parts");
+    }
+
+    @Test
+    @DisplayName("Should handle DataBlock ImageBlock in conversation")
+    void testMergeWithDataBlockImageBlock() {
+        List<Msg> messages = new ArrayList<>();
+
+        DataBlock unknownBlock = DataBlock.builder().source(new Source() {}).build();
+        DataBlock imageBlock =
+                DataBlock.builder()
+                        .source(
+                                Base64Source.builder()
+                                        .data(
+                                                "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==")
+                                        .mediaType("image/png")
+                                        .build())
+                        .build();
+
+        Msg msg =
+                Msg.builder()
+                        .role(MsgRole.USER)
+                        .name("Alice")
+                        .content(
+                                List.of(
+                                        TextBlock.builder().text("Here's an image:").build(),
+                                        unknownBlock,
+                                        imageBlock))
+                        .build();
+
+        messages.add(msg);
+
+        OpenAIMessage result =
+                merger.mergeToUserMessage(
+                        messages, msg2 -> msg2.getRole().toString(), blocks -> "Tool result");
+
+        assertNotNull(result);
+        assertEquals("user", result.getRole());
+        assertTrue(result.isMultimodal(), "Should be multimodal");
+        List<OpenAIContentPart> content = result.getContentAsList();
+        assertNotNull(content);
+        assertTrue(content.size() >= 2);
+        assertTrue(content.stream().anyMatch(part -> part.getImageUrl() != null));
     }
 
     @Test

--- a/agentscope-core/src/test/java/io/agentscope/core/formatter/openai/OpenAIMessageConverterTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/formatter/openai/OpenAIMessageConverterTest.java
@@ -28,6 +28,7 @@ import io.agentscope.core.message.Base64Source;
 import io.agentscope.core.message.ContentBlock;
 import io.agentscope.core.message.DataBlock;
 import io.agentscope.core.message.ImageBlock;
+import io.agentscope.core.message.MessageMetadataKeys;
 import io.agentscope.core.message.Msg;
 import io.agentscope.core.message.MsgRole;
 import io.agentscope.core.message.Source;
@@ -225,6 +226,25 @@ class OpenAIMessageConverterTest {
         assertNotNull(result);
         assertEquals("system", result.getRole());
         assertEquals("You are a helpful assistant", result.getContentAsString());
+    }
+
+    @Test
+    @DisplayName("Should apply cache control metadata to converted messages")
+    void testCacheControlFromMetadata() {
+        Map<String, Object> metadata = new HashMap<>();
+        metadata.put(MessageMetadataKeys.CACHE_CONTROL, true);
+
+        Msg msg =
+                Msg.builder()
+                        .role(MsgRole.USER)
+                        .metadata(metadata)
+                        .content(List.of(TextBlock.builder().text("Cache me").build()))
+                        .build();
+
+        OpenAIMessage result = converter.convertToMessage(msg, false);
+
+        assertNotNull(result);
+        assertNotNull(result.getCacheControl());
     }
 
     @Test

--- a/agentscope-core/src/test/java/io/agentscope/core/formatter/openai/OpenAIMessageConverterTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/formatter/openai/OpenAIMessageConverterTest.java
@@ -26,9 +26,11 @@ import io.agentscope.core.formatter.openai.dto.OpenAIReasoningDetail;
 import io.agentscope.core.message.AudioBlock;
 import io.agentscope.core.message.Base64Source;
 import io.agentscope.core.message.ContentBlock;
+import io.agentscope.core.message.DataBlock;
 import io.agentscope.core.message.ImageBlock;
 import io.agentscope.core.message.Msg;
 import io.agentscope.core.message.MsgRole;
+import io.agentscope.core.message.Source;
 import io.agentscope.core.message.TextBlock;
 import io.agentscope.core.message.ThinkingBlock;
 import io.agentscope.core.message.ToolResultBlock;
@@ -330,6 +332,43 @@ class OpenAIMessageConverterTest {
         List<OpenAIContentPart> content = result.getContentAsList();
         assertNotNull(content);
         assertTrue(content.size() >= 2, "Should contain both text and image");
+    }
+
+    @Test
+    @DisplayName("Should normalize DataBlock multimodal content and skip unknown blocks")
+    void testDataBlockMultimodalContent() {
+        DataBlock unknownBlock = DataBlock.builder().source(new Source() {}).build();
+        DataBlock imageBlock =
+                DataBlock.builder()
+                        .source(
+                                Base64Source.builder()
+                                        .data(
+                                                "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==")
+                                        .mediaType("image/png")
+                                        .build())
+                        .build();
+
+        Msg msg =
+                Msg.builder()
+                        .role(MsgRole.USER)
+                        .content(
+                                List.of(
+                                        TextBlock.builder().text("See this image").build(),
+                                        unknownBlock,
+                                        imageBlock))
+                        .build();
+
+        OpenAIMessage result = converter.convertToMessage(msg, true);
+
+        assertNotNull(result);
+        assertEquals("user", result.getRole());
+        assertTrue(result.isMultimodal());
+        List<OpenAIContentPart> parts = result.getContentAsList();
+        assertNotNull(parts);
+        assertEquals(2, parts.size());
+        assertEquals("See this image", parts.get(0).getText());
+        assertNotNull(parts.get(1).getImageUrl());
+        assertTrue(parts.get(1).getImageUrl().getUrl().startsWith("data:image/png;base64,"));
     }
 
     @Test


### PR DESCRIPTION
## AgentScope-Java Version

2.0.0-SNAPSHOT

## Description

### Background
In the multimodal message pipeline, `DataBlock(image/png)` could be normalized incorrectly and end up being treated as plain text, which breaks legacy media block handling for providers.

### Changes
- Added unified media normalization in `MediaUtils`.
- Updated formatter/converter logic for OpenAI, Anthropic, DashScope, Gemini, and Ollama to preserve multimodal `DataBlock` handling.
- Adjusted base formatter media detection to use the unified media kind logic.
- Added/updated regression tests for media normalization and Ollama/DashScope formatter paths.

### Testing
- `mvn -pl agentscope-core -Dtest=OllamaMessageConverterTest,OllamaChatFormatterTest,OllamaConversationMergerTest,OllamaMultiAgentFormatterTest test`

### Related Issues
- Fixes #1782

## Checklist

- [x] Code has been formatted with `mvn spotless:apply`
- [x] All tests are passing (`mvn test`)
- [x] Javadoc comments are complete and follow project conventions
- [x] Related documentation has been updated (e.g. links, examples, etc.)
- [x] Code is ready for review