### PR TITLE
fix(oss): use S3-compatible storage for MinIO

### DIFF
--- a/agentscope-core/pom.xml
+++ b/agentscope-core/pom.xml
@@ -203,14 +203,6 @@
             <optional>true</optional>
         </dependency>
 
-        <!-- Alibaba Cloud OSS snapshot backend (optional: only needed when using OssSnapshotSpec) -->
-        <dependency>
-            <groupId>com.aliyun.oss</groupId>
-            <artifactId>aliyun-sdk-oss</artifactId>
-            <version>3.18.5</version>
-            <optional>true</optional>
-        </dependency>
-
         <!-- Optional sandbox stores (io.agentscope.harness.agent.sandbox.impl.*) -->
         <dependency>
             <groupId>io.fabric8</groupId>

--- a/agentscope-core/src/test/java/io/agentscope/core/agent/ReActAgentNewLoopE2ETest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/agent/ReActAgentNewLoopE2ETest.java
@@ -20,6 +20,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.agentscope.core.ReActAgent;
+import io.agentscope.core.e2e.E2ETestCondition;
 import io.agentscope.core.event.AgentEndEvent;
 import io.agentscope.core.event.AgentEvent;
 import io.agentscope.core.event.AgentStartEvent;
@@ -54,6 +55,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
@@ -61,6 +63,7 @@ import reactor.core.publisher.Mono;
  * End-to-end ReAct loop: tool-use → tool-result → text-terminate, with two tools and a recording
  * middleware. Verifies the canonical event order and the final reply text.
  */
+@ExtendWith(E2ETestCondition.class)
 class ReActAgentNewLoopE2ETest {
 
     private static final class ScriptedModel extends ChatModelBase {

--- a/agentscope-core/src/test/java/io/agentscope/core/model/OpenAIOfficialAPIE2ETest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/model/OpenAIOfficialAPIE2ETest.java
@@ -20,6 +20,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
+import io.agentscope.core.e2e.E2ETestCondition;
 import io.agentscope.core.formatter.openai.OpenAIChatFormatter;
 import io.agentscope.core.message.Msg;
 import io.agentscope.core.message.MsgRole;
@@ -33,6 +34,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+import org.junit.jupiter.api.extension.ExtendWith;
 import reactor.test.StepVerifier;
 
 /**
@@ -53,6 +55,7 @@ import reactor.test.StepVerifier;
  * <p><b>Requirements:</b>
  * <ul>
  *   <li>OPENAI_API_KEY environment variable must be set (official OpenAI API key)</li>
+ *   <li>ENABLE_E2E_TESTS=true must be set to opt in to live API calls</li>
  *   <li>Active internet connection</li>
  *   <li>Valid OpenAI API quota</li>
  * </ul>
@@ -62,6 +65,7 @@ import reactor.test.StepVerifier;
 @Tag("e2e")
 @Tag("openai")
 @Tag("official")
+@ExtendWith(E2ETestCondition.class)
 @DisplayName("OpenAI Official API E2E Tests (Real OpenAI API)")
 @EnabledIfEnvironmentVariable(
         named = "OPENAI_API_KEY",

--- a/agentscope-core/src/test/java/io/agentscope/core/tool/DangerousPathBypassTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/tool/DangerousPathBypassTest.java
@@ -16,10 +16,12 @@
 package io.agentscope.core.tool;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import io.agentscope.core.permission.PermissionContextState;
 import io.agentscope.core.permission.PermissionDecision;
 import java.io.IOException;
+import java.nio.file.FileSystemException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
@@ -105,7 +107,7 @@ class DangerousPathBypassTest {
         Files.writeString(sshConfig, "Host *\n");
 
         Path link = tempDir.resolve("innocent-link");
-        Files.createSymbolicLink(link, sshConfig);
+        createSymbolicLinkOrSkip(link, sshConfig);
 
         assertTrue(PROBE.check(link.toString()));
     }
@@ -116,8 +118,16 @@ class DangerousPathBypassTest {
         Files.writeString(envFile, "SECRET=value\n");
 
         Path link = tempDir.resolve("config.txt");
-        Files.createSymbolicLink(link, envFile);
+        createSymbolicLinkOrSkip(link, envFile);
 
         assertTrue(PROBE.check(link.toString()));
+    }
+
+    private static void createSymbolicLinkOrSkip(Path link, Path target) throws IOException {
+        try {
+            Files.createSymbolicLink(link, target);
+        } catch (FileSystemException e) {
+            assumeTrue(false, "Symlink creation is not permitted on this Windows runner");
+        }
     }
 }

--- a/agentscope-extensions/agentscope-extensions-oss/pom.xml
+++ b/agentscope-extensions/agentscope-extensions-oss/pom.xml
@@ -27,8 +27,12 @@
     </parent>
 
     <name>AgentScope Java - Extensions - OSS</name>
-    <description>AgentScope Extensions - Alibaba Cloud OSS backed AgentStateStore and BaseStore</description>
+    <description>AgentScope Extensions - S3-compatible object storage backed AgentStateStore and BaseStore</description>
     <artifactId>agentscope-extensions-oss</artifactId>
+
+    <properties>
+        <aws.sdk.version>2.46.13</aws.sdk.version>
+    </properties>
 
     <dependencies>
         <dependency>
@@ -45,11 +49,26 @@
             <scope>provided</scope>
         </dependency>
 
-        <!-- Alibaba Cloud OSS SDK -->
+        <!-- AWS SDK for Java v2, which also works with MinIO and other S3-compatible stores. -->
         <dependency>
-            <groupId>com.aliyun.oss</groupId>
-            <artifactId>aliyun-sdk-oss</artifactId>
-            <version>3.18.5</version>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>s3</artifactId>
+            <version>${aws.sdk.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>auth</artifactId>
+            <version>${aws.sdk.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>regions</artifactId>
+            <version>${aws.sdk.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>url-connection-client</artifactId>
+            <version>${aws.sdk.version}</version>
         </dependency>
     </dependencies>
 </project>

--- a/agentscope-extensions/agentscope-extensions-oss/src/main/java/io/agentscope/extensions/oss/OssAgentStateStore.java
+++ b/agentscope-extensions/agentscope-extensions-oss/src/main/java/io/agentscope/extensions/oss/OssAgentStateStore.java
@@ -15,53 +15,31 @@
  */
 package io.agentscope.extensions.oss;
 
-import com.aliyun.oss.OSS;
-import com.aliyun.oss.model.DeleteObjectsRequest;
-import com.aliyun.oss.model.ListObjectsV2Request;
-import com.aliyun.oss.model.ListObjectsV2Result;
-import com.aliyun.oss.model.OSSObject;
-import com.aliyun.oss.model.OSSObjectSummary;
 import com.fasterxml.jackson.core.type.TypeReference;
 import io.agentscope.core.state.AgentStateStore;
 import io.agentscope.core.state.ListHashUtil;
 import io.agentscope.core.state.State;
 import io.agentscope.core.util.JsonUtils;
-import java.io.ByteArrayInputStream;
-import java.io.InputStream;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
 
 /**
- * Alibaba Cloud OSS backed {@link AgentStateStore}.
+ * S3-compatible object storage backed {@link AgentStateStore}.
  *
- * <p>State objects are stored as JSON files in an OSS bucket with the following key layout:
+ * <p>State objects are stored as JSON files in an object storage bucket with the following key
+ * layout:
  *
  * <pre>
- * {keyPrefix}{userId}/{sessionId}/{stateKey}.json       — single State value
- * {keyPrefix}{userId}/{sessionId}/{stateKey}.list.json  — List&lt;State&gt; as JSON array
- * {keyPrefix}{userId}/{sessionId}/{stateKey}.list.hash  — hash for incremental append detection
+ * {keyPrefix}{userId}/{sessionId}/{stateKey}.json       - single State value
+ * {keyPrefix}{userId}/{sessionId}/{stateKey}.list.json  - List&lt;State&gt; as JSON array
+ * {keyPrefix}{userId}/{sessionId}/{stateKey}.list.hash  - hash for incremental append detection
  * </pre>
- *
- * <p>Usage:
- *
- * <pre>{@code
- * OSS ossClient = new OSSClientBuilder().build(endpoint, accessKeyId, accessKeySecret);
- *
- * AgentStateStore store = OssAgentStateStore.builder()
- *     .ossClient(ossClient)
- *     .bucketName("my-agentscope-bucket")
- *     .keyPrefix("agentscope/state/")
- *     .build();
- *
- * HarnessAgent agent = HarnessAgent.builder()
- *     .stateStore(store)
- *     .build();
- * }</pre>
  */
 public class OssAgentStateStore implements AgentStateStore {
 
@@ -71,12 +49,12 @@ public class OssAgentStateStore implements AgentStateStore {
     private static final String LIST_SUFFIX = ".list.json";
     private static final String HASH_SUFFIX = ".list.hash";
 
-    private final OSS ossClient;
+    private final S3Client s3Client;
     private final String bucketName;
     private final String keyPrefix;
 
     private OssAgentStateStore(Builder builder) {
-        this.ossClient = Objects.requireNonNull(builder.ossClient, "ossClient must not be null");
+        this.s3Client = Objects.requireNonNull(builder.s3Client, "s3Client must not be null");
         if (builder.bucketName == null || builder.bucketName.isBlank()) {
             throw new IllegalArgumentException("bucketName must not be blank");
         }
@@ -90,10 +68,9 @@ public class OssAgentStateStore implements AgentStateStore {
 
     @Override
     public void save(String userId, String sessionId, String key, State value) {
-        String objectKey = stateObjectKey(userId, sessionId, key);
         try {
-            String json = JsonUtils.getJsonCodec().toJson(value);
-            putString(objectKey, json);
+            putString(
+                    stateObjectKey(userId, sessionId, key), JsonUtils.getJsonCodec().toJson(value));
         } catch (Exception e) {
             throw new RuntimeException("Failed to save state: " + key, e);
         }
@@ -119,12 +96,9 @@ public class OssAgentStateStore implements AgentStateStore {
 
             boolean needsFullRewrite =
                     ListHashUtil.needsFullRewrite(values, storedHash, existingCount);
-
             if (needsFullRewrite || values.size() != existingCount) {
-                String json = JsonUtils.getJsonCodec().toJson(values);
-                putString(listKey, json);
+                putString(listKey, JsonUtils.getJsonCodec().toJson(values));
             }
-
             putString(hashKey, currentHash);
         } catch (Exception e) {
             throw new RuntimeException("Failed to save list: " + key, e);
@@ -134,9 +108,8 @@ public class OssAgentStateStore implements AgentStateStore {
     @Override
     public <T extends State> Optional<T> get(
             String userId, String sessionId, String key, Class<T> type) {
-        String objectKey = stateObjectKey(userId, sessionId, key);
         try {
-            String json = getString(objectKey);
+            String json = getString(stateObjectKey(userId, sessionId, key));
             if (json == null) {
                 return Optional.empty();
             }
@@ -149,9 +122,8 @@ public class OssAgentStateStore implements AgentStateStore {
     @Override
     public <T extends State> List<T> getList(
             String userId, String sessionId, String key, Class<T> itemType) {
-        String listKey = listObjectKey(userId, sessionId, key);
         try {
-            String json = getString(listKey);
+            String json = getString(listObjectKey(userId, sessionId, key));
             if (json == null) {
                 return List.of();
             }
@@ -169,13 +141,9 @@ public class OssAgentStateStore implements AgentStateStore {
 
     @Override
     public boolean exists(String userId, String sessionId) {
-        String prefix = sessionPrefix(userId, sessionId);
         try {
-            ListObjectsV2Request request = new ListObjectsV2Request(bucketName);
-            request.setPrefix(prefix);
-            request.setMaxKeys(1);
-            ListObjectsV2Result result = ossClient.listObjectsV2(request);
-            return result.getObjectSummaries() != null && !result.getObjectSummaries().isEmpty();
+            return S3ObjectStoreSupport.hasObjectsWithPrefix(
+                    s3Client, bucketName, sessionPrefix(userId, sessionId));
         } catch (Exception e) {
             throw new RuntimeException("Failed to check session existence", e);
         }
@@ -183,9 +151,8 @@ public class OssAgentStateStore implements AgentStateStore {
 
     @Override
     public void delete(String userId, String sessionId) {
-        String prefix = sessionPrefix(userId, sessionId);
         try {
-            List<String> keys = listAllKeys(prefix);
+            List<String> keys = listAllKeys(sessionPrefix(userId, sessionId));
             if (!keys.isEmpty()) {
                 deleteKeys(keys);
             }
@@ -197,18 +164,21 @@ public class OssAgentStateStore implements AgentStateStore {
     @Override
     public void delete(String userId, String sessionId, String key) {
         try {
-            String stateKey = stateObjectKey(userId, sessionId, key);
-            String listKey = listObjectKey(userId, sessionId, key);
-            String hashKey = hashObjectKey(userId, sessionId, key);
-            if (ossClient.doesObjectExist(bucketName, stateKey)) {
-                ossClient.deleteObject(bucketName, stateKey);
-            }
-            if (ossClient.doesObjectExist(bucketName, listKey)) {
-                ossClient.deleteObject(bucketName, listKey);
-            }
-            if (ossClient.doesObjectExist(bucketName, hashKey)) {
-                ossClient.deleteObject(bucketName, hashKey);
-            }
+            s3Client.deleteObject(
+                    DeleteObjectRequest.builder()
+                            .bucket(bucketName)
+                            .key(stateObjectKey(userId, sessionId, key))
+                            .build());
+            s3Client.deleteObject(
+                    DeleteObjectRequest.builder()
+                            .bucket(bucketName)
+                            .key(listObjectKey(userId, sessionId, key))
+                            .build());
+            s3Client.deleteObject(
+                    DeleteObjectRequest.builder()
+                            .bucket(bucketName)
+                            .key(hashObjectKey(userId, sessionId, key))
+                            .build());
         } catch (Exception e) {
             throw new RuntimeException("Failed to delete state key: " + key, e);
         }
@@ -235,10 +205,8 @@ public class OssAgentStateStore implements AgentStateStore {
 
     @Override
     public void close() {
-        ossClient.shutdown();
+        s3Client.close();
     }
-
-    // ---- internal helpers ----
 
     private String stateObjectKey(String userId, String sessionId, String key) {
         return sessionPrefix(userId, sessionId) + key + JSON_SUFFIX;
@@ -264,72 +232,41 @@ public class OssAgentStateStore implements AgentStateStore {
     }
 
     private void putString(String objectKey, String content) {
-        byte[] bytes = content.getBytes(StandardCharsets.UTF_8);
-        ossClient.putObject(bucketName, objectKey, new ByteArrayInputStream(bytes));
+        S3ObjectStoreSupport.putString(s3Client, bucketName, objectKey, content);
     }
 
     private String getString(String objectKey) {
-        if (!ossClient.doesObjectExist(bucketName, objectKey)) {
-            return null;
-        }
-        try (OSSObject obj = ossClient.getObject(bucketName, objectKey);
-                InputStream is = obj.getObjectContent()) {
-            return new String(is.readAllBytes(), StandardCharsets.UTF_8);
-        } catch (Exception e) {
-            throw new RuntimeException("Failed to read OSS object: " + objectKey, e);
-        }
+        return S3ObjectStoreSupport.getString(s3Client, bucketName, objectKey);
     }
 
     private List<String> listAllKeys(String prefix) {
-        List<String> keys = new ArrayList<>();
-        String continuationToken = null;
-        do {
-            ListObjectsV2Request request = new ListObjectsV2Request(bucketName);
-            request.setPrefix(prefix);
-            request.setMaxKeys(1000);
-            if (continuationToken != null) {
-                request.setContinuationToken(continuationToken);
-            }
-            ListObjectsV2Result result = ossClient.listObjectsV2(request);
-            for (OSSObjectSummary summary : result.getObjectSummaries()) {
-                keys.add(summary.getKey());
-            }
-            continuationToken = result.isTruncated() ? result.getNextContinuationToken() : null;
-        } while (continuationToken != null);
-        return keys;
+        return S3ObjectStoreSupport.listAllKeys(s3Client, bucketName, prefix);
     }
 
     private void deleteKeys(List<String> keys) {
-        for (int i = 0; i < keys.size(); i += 1000) {
-            List<String> batch = keys.subList(i, Math.min(i + 1000, keys.size()));
-            ossClient.deleteObjects(
-                    new DeleteObjectsRequest(bucketName).withKeys(batch).withQuiet(true));
-        }
+        S3ObjectStoreSupport.deleteKeys(s3Client, bucketName, keys);
     }
 
     private static String normalizePrefix(String prefix) {
-        if (prefix == null || prefix.isBlank()) {
-            return DEFAULT_KEY_PREFIX;
-        }
-        String p = prefix.replace('\\', '/');
-        while (p.startsWith("/")) {
-            p = p.substring(1);
-        }
-        if (!p.isEmpty() && !p.endsWith("/")) {
-            p = p + "/";
-        }
-        return p.isEmpty() ? DEFAULT_KEY_PREFIX : p;
+        return S3ObjectStoreSupport.normalizePrefix(prefix, DEFAULT_KEY_PREFIX);
     }
 
     public static class Builder {
 
-        private OSS ossClient;
+        private S3Client s3Client;
         private String bucketName;
         private String keyPrefix = DEFAULT_KEY_PREFIX;
 
-        public Builder ossClient(OSS ossClient) {
-            this.ossClient = ossClient;
+        public Builder s3Client(S3Client s3Client) {
+            this.s3Client = s3Client;
             return this;
+        }
+
+        /**
+         * Backwards-compatible alias for {@link #s3Client(S3Client)}.
+         */
+        public Builder ossClient(S3Client s3Client) {
+            return s3Client(s3Client);
         }
 
         public Builder bucketName(String bucketName) {

--- a/agentscope-extensions/agentscope-extensions-oss/src/main/java/io/agentscope/extensions/oss/OssBaseStore.java
+++ b/agentscope-extensions/agentscope-extensions-oss/src/main/java/io/agentscope/extensions/oss/OssBaseStore.java
@@ -15,62 +15,34 @@
  */
 package io.agentscope.extensions.oss;
 
-import com.aliyun.oss.OSS;
-import com.aliyun.oss.model.ListObjectsV2Request;
-import com.aliyun.oss.model.ListObjectsV2Result;
-import com.aliyun.oss.model.OSSObject;
-import com.aliyun.oss.model.OSSObjectSummary;
 import com.fasterxml.jackson.core.type.TypeReference;
 import io.agentscope.core.util.JsonUtils;
 import io.agentscope.harness.agent.filesystem.remote.store.BaseStore;
 import io.agentscope.harness.agent.filesystem.remote.store.StoreItem;
-import java.io.ByteArrayInputStream;
-import java.io.InputStream;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
 
 /**
- * Alibaba Cloud OSS backed {@link BaseStore} for the harness remote filesystem.
- *
- * <p>Items are stored as JSON objects in OSS. The object key layout is:
- *
- * <pre>
- * {keyPrefix}{namespace[0]}/{namespace[1]}/.../{key}.json       — item data
- * {keyPrefix}{namespace[0]}/{namespace[1]}/.../{key}.version    — version counter
- * </pre>
- *
- * <p>Usage:
- *
- * <pre>{@code
- * OSS ossClient = new OSSClientBuilder().build(endpoint, accessKeyId, accessKeySecret);
- *
- * BaseStore store = OssBaseStore.builder()
- *     .ossClient(ossClient)
- *     .bucketName("my-agentscope-bucket")
- *     .keyPrefix("agentscope/store/")
- *     .build();
- *
- * HarnessAgent agent = HarnessAgent.builder()
- *     .filesystem(new RemoteFilesystemSpec(store))
- *     .build();
- * }</pre>
+ * S3-compatible object storage backed {@link BaseStore} for the harness remote filesystem.
  */
 public class OssBaseStore implements BaseStore {
 
     private static final String DEFAULT_KEY_PREFIX = "agentscope/store/";
     private static final String JSON_SUFFIX = ".json";
+    private static final String LIST_SUFFIX = ".list.json";
     private static final String VERSION_SUFFIX = ".version";
 
-    private final OSS ossClient;
+    private final S3Client s3Client;
     private final String bucketName;
     private final String keyPrefix;
 
     private OssBaseStore(Builder builder) {
-        this.ossClient = Objects.requireNonNull(builder.ossClient, "ossClient must not be null");
+        this.s3Client = Objects.requireNonNull(builder.s3Client, "s3Client must not be null");
         if (builder.bucketName == null || builder.bucketName.isBlank()) {
             throw new IllegalArgumentException("bucketName must not be blank");
         }
@@ -105,10 +77,8 @@ public class OssBaseStore implements BaseStore {
         String dataKey = dataObjectKey(namespace, key);
         String versionKey = versionObjectKey(namespace, key);
         try {
-            String json = JsonUtils.getJsonCodec().toJson(value);
-            putString(dataKey, json);
-            long currentVersion = readVersion(versionKey);
-            putString(versionKey, String.valueOf(currentVersion + 1));
+            putString(dataKey, JsonUtils.getJsonCodec().toJson(value));
+            putString(versionKey, String.valueOf(readVersion(versionKey) + 1));
         } catch (Exception e) {
             throw new RuntimeException("Failed to put item: " + key, e);
         }
@@ -124,8 +94,7 @@ public class OssBaseStore implements BaseStore {
             if (currentVersion != expectedVersion) {
                 return false;
             }
-            String json = JsonUtils.getJsonCodec().toJson(value);
-            putString(dataKey, json);
+            putString(dataKey, JsonUtils.getJsonCodec().toJson(value));
             putString(versionKey, String.valueOf(currentVersion + 1));
             return true;
         } catch (Exception e) {
@@ -138,43 +107,28 @@ public class OssBaseStore implements BaseStore {
         String prefix = namespacePrefix(namespace);
         try {
             List<String> dataKeys = new ArrayList<>();
-            String continuationToken = null;
-            do {
-                ListObjectsV2Request request = new ListObjectsV2Request(bucketName);
-                request.setPrefix(prefix);
-                request.setMaxKeys(1000);
-                if (continuationToken != null) {
-                    request.setContinuationToken(continuationToken);
+            for (String key : listAllKeys(prefix)) {
+                if (key.endsWith(JSON_SUFFIX) && !key.endsWith(LIST_SUFFIX)) {
+                    dataKeys.add(key);
                 }
-                ListObjectsV2Result result = ossClient.listObjectsV2(request);
-                for (OSSObjectSummary summary : result.getObjectSummaries()) {
-                    String k = summary.getKey();
-                    if (k.endsWith(JSON_SUFFIX) && !k.endsWith(VERSION_SUFFIX)) {
-                        dataKeys.add(k);
-                    }
-                }
-                continuationToken = result.isTruncated() ? result.getNextContinuationToken() : null;
-            } while (continuationToken != null);
+            }
 
             Collections.sort(dataKeys);
-
             int start = Math.min(offset, dataKeys.size());
             int end = Math.min(start + limit, dataKeys.size());
-            List<String> page = dataKeys.subList(start, end);
-
-            List<StoreItem> items = new ArrayList<>(page.size());
-            for (String dataKey : page) {
+            List<StoreItem> items = new ArrayList<>(end - start);
+            for (String dataKey : dataKeys.subList(start, end)) {
                 String itemKey =
                         dataKey.substring(prefix.length(), dataKey.length() - JSON_SUFFIX.length());
                 String json = getString(dataKey);
                 if (json != null) {
-                    Map<String, Object> val =
+                    Map<String, Object> value =
                             JsonUtils.getJsonCodec().fromJson(json, new TypeReference<>() {});
-                    String vk =
-                            dataKey.substring(0, dataKey.length() - JSON_SUFFIX.length())
-                                    + VERSION_SUFFIX;
-                    long version = readVersion(vk);
-                    items.add(new StoreItem(itemKey, val, version));
+                    long version =
+                            readVersion(
+                                    dataKey.substring(0, dataKey.length() - JSON_SUFFIX.length())
+                                            + VERSION_SUFFIX);
+                    items.add(new StoreItem(itemKey, value, version));
                 }
             }
             return items;
@@ -188,16 +142,14 @@ public class OssBaseStore implements BaseStore {
         String dataKey = dataObjectKey(namespace, key);
         String versionKey = versionObjectKey(namespace, key);
         try {
-            ossClient.deleteObject(bucketName, dataKey);
-            if (ossClient.doesObjectExist(bucketName, versionKey)) {
-                ossClient.deleteObject(bucketName, versionKey);
-            }
+            s3Client.deleteObject(
+                    DeleteObjectRequest.builder().bucket(bucketName).key(dataKey).build());
+            s3Client.deleteObject(
+                    DeleteObjectRequest.builder().bucket(bucketName).key(versionKey).build());
         } catch (Exception e) {
             throw new RuntimeException("Failed to delete item: " + key, e);
         }
     }
-
-    // ---- internal helpers ----
 
     private String dataObjectKey(List<String> namespace, String key) {
         return namespacePrefix(namespace) + stripLeadingSlashes(key) + JSON_SUFFIX;
@@ -239,45 +191,34 @@ public class OssBaseStore implements BaseStore {
     }
 
     private void putString(String objectKey, String content) {
-        byte[] bytes = content.getBytes(StandardCharsets.UTF_8);
-        ossClient.putObject(bucketName, objectKey, new ByteArrayInputStream(bytes));
+        S3ObjectStoreSupport.putString(s3Client, bucketName, objectKey, content);
     }
 
     private String getString(String objectKey) {
-        if (!ossClient.doesObjectExist(bucketName, objectKey)) {
-            return null;
-        }
-        try (OSSObject obj = ossClient.getObject(bucketName, objectKey);
-                InputStream is = obj.getObjectContent()) {
-            return new String(is.readAllBytes(), StandardCharsets.UTF_8);
-        } catch (Exception e) {
-            throw new RuntimeException("Failed to read OSS object: " + objectKey, e);
-        }
+        return S3ObjectStoreSupport.getString(s3Client, bucketName, objectKey);
+    }
+
+    private List<String> listAllKeys(String prefix) {
+        return S3ObjectStoreSupport.listAllKeys(s3Client, bucketName, prefix);
     }
 
     private static String normalizePrefix(String prefix) {
-        if (prefix == null || prefix.isBlank()) {
-            return DEFAULT_KEY_PREFIX;
-        }
-        String p = prefix.replace('\\', '/');
-        while (p.startsWith("/")) {
-            p = p.substring(1);
-        }
-        if (!p.isEmpty() && !p.endsWith("/")) {
-            p = p + "/";
-        }
-        return p.isEmpty() ? DEFAULT_KEY_PREFIX : p;
+        return S3ObjectStoreSupport.normalizePrefix(prefix, DEFAULT_KEY_PREFIX);
     }
 
     public static class Builder {
 
-        private OSS ossClient;
+        private S3Client s3Client;
         private String bucketName;
         private String keyPrefix = DEFAULT_KEY_PREFIX;
 
-        public Builder ossClient(OSS ossClient) {
-            this.ossClient = ossClient;
+        public Builder s3Client(S3Client s3Client) {
+            this.s3Client = s3Client;
             return this;
+        }
+
+        public Builder ossClient(S3Client s3Client) {
+            return s3Client(s3Client);
         }
 
         public Builder bucketName(String bucketName) {

--- a/agentscope-extensions/agentscope-extensions-oss/src/main/java/io/agentscope/extensions/oss/OssDistributedStore.java
+++ b/agentscope-extensions/agentscope-extensions-oss/src/main/java/io/agentscope/extensions/oss/OssDistributedStore.java
@@ -15,55 +15,50 @@
  */
 package io.agentscope.extensions.oss;
 
-import com.aliyun.oss.OSS;
 import io.agentscope.core.state.AgentStateStore;
 import io.agentscope.harness.agent.DistributedStore;
 import io.agentscope.harness.agent.filesystem.remote.store.BaseStore;
 import io.agentscope.harness.agent.sandbox.snapshot.SandboxSnapshotSpec;
 import java.util.Objects;
+import software.amazon.awssdk.services.s3.S3Client;
 
 /**
- * Alibaba Cloud OSS-backed {@link DistributedStore}.
- *
- * <p>Usage:
- * <pre>{@code
- * OSS ossClient = new OSSClientBuilder().build(endpoint, accessKeyId, accessKeySecret);
- *
- * HarnessAgent agent = HarnessAgent.builder()
- *     .name("my-agent")
- *     .model("dashscope:qwen-plus")
- *     .distributedStore(OssDistributedStore.create(ossClient, "my-bucket", "agentscope/"))
- *     .build();
- * }</pre>
+ * S3-compatible object storage-backed {@link DistributedStore}.
  */
 public class OssDistributedStore implements DistributedStore {
 
-    private final OSS ossClient;
+    private final S3Client s3Client;
     private final String bucketName;
     private final String keyPrefix;
 
-    private OssDistributedStore(OSS ossClient, String bucketName, String keyPrefix) {
-        this.ossClient = Objects.requireNonNull(ossClient, "ossClient");
+    private OssDistributedStore(S3Client s3Client, String bucketName, String keyPrefix) {
+        this.s3Client = Objects.requireNonNull(s3Client, "s3Client");
         this.bucketName = Objects.requireNonNull(bucketName, "bucketName");
         this.keyPrefix = keyPrefix != null ? keyPrefix : "agentscope/";
     }
 
-    /**
-     * Creates an OSS distributed store.
-     *
-     * @param ossClient initialized OSS client
-     * @param bucketName target bucket name
-     * @param keyPrefix object key prefix (e.g. {@code "agentscope/"})
-     * @return a new OSS distributed store
-     */
-    public static OssDistributedStore create(OSS ossClient, String bucketName, String keyPrefix) {
-        return new OssDistributedStore(ossClient, bucketName, keyPrefix);
+    public static OssDistributedStore create(
+            S3Client s3Client, String bucketName, String keyPrefix) {
+        return new OssDistributedStore(s3Client, bucketName, keyPrefix);
+    }
+
+    public static OssDistributedStore create(
+            String endpoint,
+            String accessKeyId,
+            String accessKeySecret,
+            String bucketName,
+            String keyPrefix) {
+        return create(
+                S3ObjectStoreSupport.buildClient(
+                        java.net.URI.create(endpoint), accessKeyId, accessKeySecret),
+                bucketName,
+                keyPrefix);
     }
 
     @Override
     public AgentStateStore agentStateStore() {
         return OssAgentStateStore.builder()
-                .ossClient(ossClient)
+                .s3Client(s3Client)
                 .bucketName(bucketName)
                 .keyPrefix(keyPrefix + "state/")
                 .build();
@@ -72,7 +67,7 @@ public class OssDistributedStore implements DistributedStore {
     @Override
     public BaseStore baseStore() {
         return OssBaseStore.builder()
-                .ossClient(ossClient)
+                .s3Client(s3Client)
                 .bucketName(bucketName)
                 .keyPrefix(keyPrefix + "store/")
                 .build();
@@ -80,6 +75,6 @@ public class OssDistributedStore implements DistributedStore {
 
     @Override
     public SandboxSnapshotSpec sandboxSnapshotSpec() {
-        return new OssSnapshotSpec(ossClient, bucketName, keyPrefix + "snapshot/");
+        return new OssSnapshotSpec(s3Client, bucketName, keyPrefix + "snapshot/");
     }
 }

--- a/agentscope-extensions/agentscope-extensions-oss/src/main/java/io/agentscope/extensions/oss/OssRemoteSnapshotClient.java
+++ b/agentscope-extensions/agentscope-extensions-oss/src/main/java/io/agentscope/extensions/oss/OssRemoteSnapshotClient.java
@@ -15,56 +15,59 @@
  */
 package io.agentscope.extensions.oss;
 
-import com.aliyun.oss.OSS;
-import com.aliyun.oss.model.OSSObject;
 import io.agentscope.harness.agent.sandbox.snapshot.RemoteSnapshotClient;
+import java.io.ByteArrayInputStream;
 import java.io.FileNotFoundException;
 import java.io.InputStream;
 import java.util.Objects;
+import software.amazon.awssdk.core.ResponseBytes;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.GetObjectResponse;
 
 /**
- * {@link RemoteSnapshotClient} backed by Alibaba Cloud OSS.
+ * {@link RemoteSnapshotClient} backed by S3-compatible object storage.
  */
 public class OssRemoteSnapshotClient implements RemoteSnapshotClient {
 
-    private final OSS ossClient;
+    private final S3Client s3Client;
     private final String bucketName;
     private final String keyPrefix;
 
-    /**
-     * Creates an OSS-backed snapshot client.
-     *
-     * @param ossClient initialized OSS client
-     * @param bucketName bucket for snapshot objects
-     * @param keyPrefix object key prefix (optional, may be null/blank)
-     */
-    public OssRemoteSnapshotClient(OSS ossClient, String bucketName, String keyPrefix) {
-        this.ossClient = Objects.requireNonNull(ossClient, "ossClient must not be null");
+    public OssRemoteSnapshotClient(S3Client s3Client, String bucketName, String keyPrefix) {
+        this.s3Client = Objects.requireNonNull(s3Client, "s3Client must not be null");
         if (bucketName == null || bucketName.isBlank()) {
             throw new IllegalArgumentException("bucketName must not be blank");
         }
         this.bucketName = bucketName;
-        this.keyPrefix = normalizePrefix(keyPrefix);
+        this.keyPrefix = S3ObjectStoreSupport.normalizePrefix(keyPrefix, "");
     }
 
     @Override
     public void upload(String snapshotId, InputStream data) throws Exception {
-        ossClient.putObject(bucketName, objectKey(snapshotId), data);
+        byte[] bytes = data.readAllBytes();
+        s3Client.putObject(
+                builder -> builder.bucket(bucketName).key(objectKey(snapshotId)).build(),
+                RequestBody.fromBytes(bytes));
     }
 
     @Override
     public InputStream download(String snapshotId) throws Exception {
         String key = objectKey(snapshotId);
-        if (!ossClient.doesObjectExist(bucketName, key)) {
-            throw new FileNotFoundException("Snapshot not found in OSS: " + key);
+        if (!exists(snapshotId)) {
+            throw new FileNotFoundException("Snapshot not found in object storage: " + key);
         }
-        OSSObject object = ossClient.getObject(bucketName, key);
-        return object.getObjectContent();
+        ResponseBytes<GetObjectResponse> bytes =
+                s3Client.getObjectAsBytes(
+                        GetObjectRequest.builder().bucket(bucketName).key(key).build());
+        return new ByteArrayInputStream(bytes.asByteArray());
     }
 
     @Override
     public boolean exists(String snapshotId) throws Exception {
-        return ossClient.doesObjectExist(bucketName, objectKey(snapshotId));
+        return S3ObjectStoreSupport.hasObjectsWithPrefix(
+                s3Client, bucketName, objectKey(snapshotId));
     }
 
     private String objectKey(String snapshotId) {
@@ -72,19 +75,5 @@ public class OssRemoteSnapshotClient implements RemoteSnapshotClient {
             throw new IllegalArgumentException("snapshotId must not be blank");
         }
         return keyPrefix + snapshotId + ".tar";
-    }
-
-    private static String normalizePrefix(String prefix) {
-        if (prefix == null || prefix.isBlank()) {
-            return "";
-        }
-        String p = prefix.replace('\\', '/');
-        while (p.startsWith("/")) {
-            p = p.substring(1);
-        }
-        if (!p.isEmpty() && !p.endsWith("/")) {
-            p = p + "/";
-        }
-        return p;
     }
 }

--- a/agentscope-extensions/agentscope-extensions-oss/src/main/java/io/agentscope/extensions/oss/OssRemoteSnapshotClient.java
+++ b/agentscope-extensions/agentscope-extensions-oss/src/main/java/io/agentscope/extensions/oss/OssRemoteSnapshotClient.java
@@ -25,6 +25,7 @@ import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 import software.amazon.awssdk.services.s3.model.GetObjectResponse;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 
 /**
  * {@link RemoteSnapshotClient} backed by S3-compatible object storage.
@@ -48,7 +49,7 @@ public class OssRemoteSnapshotClient implements RemoteSnapshotClient {
     public void upload(String snapshotId, InputStream data) throws Exception {
         byte[] bytes = data.readAllBytes();
         s3Client.putObject(
-                builder -> builder.bucket(bucketName).key(objectKey(snapshotId)).build(),
+                PutObjectRequest.builder().bucket(bucketName).key(objectKey(snapshotId)).build(),
                 RequestBody.fromBytes(bytes));
     }
 

--- a/agentscope-extensions/agentscope-extensions-oss/src/main/java/io/agentscope/extensions/oss/OssSnapshotSpec.java
+++ b/agentscope-extensions/agentscope-extensions-oss/src/main/java/io/agentscope/extensions/oss/OssSnapshotSpec.java
@@ -15,36 +15,21 @@
  */
 package io.agentscope.extensions.oss;
 
-import com.aliyun.oss.OSS;
-import com.aliyun.oss.OSSClientBuilder;
 import io.agentscope.harness.agent.sandbox.snapshot.RemoteSnapshotSpec;
-import io.agentscope.harness.agent.sandbox.snapshot.SandboxSnapshotSpec;
+import java.net.URI;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
 
 /**
- * Convenience {@link SandboxSnapshotSpec} for Alibaba Cloud OSS snapshot storage.
+ * Convenience {@link io.agentscope.harness.agent.sandbox.snapshot.SandboxSnapshotSpec} for
+ * S3-compatible snapshot storage.
  */
 public class OssSnapshotSpec extends RemoteSnapshotSpec {
 
-    /**
-     * Creates an OSS snapshot spec from an existing OSS client.
-     *
-     * @param ossClient initialized OSS client
-     * @param bucketName target bucket
-     * @param keyPrefix key prefix (optional, may be null/blank)
-     */
-    public OssSnapshotSpec(OSS ossClient, String bucketName, String keyPrefix) {
-        super(new OssRemoteSnapshotClient(ossClient, bucketName, keyPrefix));
+    public OssSnapshotSpec(S3Client s3Client, String bucketName, String keyPrefix) {
+        super(new OssRemoteSnapshotClient(s3Client, bucketName, keyPrefix));
     }
 
-    /**
-     * Creates an OSS snapshot spec from endpoint/credential settings.
-     *
-     * @param endpoint OSS endpoint (e.g. oss-cn-hangzhou.aliyuncs.com)
-     * @param accessKeyId access key id
-     * @param accessKeySecret access key secret
-     * @param bucketName target bucket
-     * @param keyPrefix key prefix (optional, may be null/blank)
-     */
     public OssSnapshotSpec(
             String endpoint,
             String accessKeyId,
@@ -52,7 +37,8 @@ public class OssSnapshotSpec extends RemoteSnapshotSpec {
             String bucketName,
             String keyPrefix) {
         this(
-                new OSSClientBuilder().build(endpoint, accessKeyId, accessKeySecret),
+                S3ObjectStoreSupport.buildClient(
+                        URI.create(endpoint), Region.US_EAST_1, accessKeyId, accessKeySecret),
                 bucketName,
                 keyPrefix);
     }

--- a/agentscope-extensions/agentscope-extensions-oss/src/main/java/io/agentscope/extensions/oss/S3ObjectStoreSupport.java
+++ b/agentscope-extensions/agentscope-extensions-oss/src/main/java/io/agentscope/extensions/oss/S3ObjectStoreSupport.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.extensions.oss;
+
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.core.ResponseBytes;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.S3Configuration;
+import software.amazon.awssdk.services.s3.model.Delete;
+import software.amazon.awssdk.services.s3.model.DeleteObjectsRequest;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.GetObjectResponse;
+import software.amazon.awssdk.services.s3.model.ListObjectsV2Request;
+import software.amazon.awssdk.services.s3.model.ListObjectsV2Response;
+import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
+import software.amazon.awssdk.services.s3.model.ObjectIdentifier;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.model.S3Exception;
+import software.amazon.awssdk.services.s3.model.S3Object;
+
+final class S3ObjectStoreSupport {
+
+    private S3ObjectStoreSupport() {}
+
+    static S3Client buildClient(URI endpoint, String accessKeyId, String accessKeySecret) {
+        return buildClient(endpoint, Region.US_EAST_1, accessKeyId, accessKeySecret);
+    }
+
+    static S3Client buildClient(
+            URI endpoint, Region region, String accessKeyId, String accessKeySecret) {
+        return S3Client.builder()
+                .region(region)
+                .endpointOverride(endpoint)
+                .credentialsProvider(
+                        StaticCredentialsProvider.create(
+                                AwsBasicCredentials.create(accessKeyId, accessKeySecret)))
+                .serviceConfiguration(
+                        S3Configuration.builder().pathStyleAccessEnabled(true).build())
+                .httpClientBuilder(UrlConnectionHttpClient.builder())
+                .build();
+    }
+
+    static String normalizePrefix(String prefix, String defaultPrefix) {
+        if (prefix == null || prefix.isBlank()) {
+            return defaultPrefix;
+        }
+        String p = prefix.replace('\\', '/');
+        while (p.startsWith("/")) {
+            p = p.substring(1);
+        }
+        if (!p.isEmpty() && !p.endsWith("/")) {
+            p = p + "/";
+        }
+        return p.isEmpty() ? defaultPrefix : p;
+    }
+
+    static void putString(S3Client s3Client, String bucketName, String objectKey, String content) {
+        s3Client.putObject(
+                PutObjectRequest.builder().bucket(bucketName).key(objectKey).build(),
+                RequestBody.fromBytes(content.getBytes(StandardCharsets.UTF_8)));
+    }
+
+    static String getString(S3Client s3Client, String bucketName, String objectKey) {
+        try {
+            ResponseBytes<GetObjectResponse> bytes =
+                    s3Client.getObjectAsBytes(
+                            GetObjectRequest.builder().bucket(bucketName).key(objectKey).build());
+            return bytes.asUtf8String();
+        } catch (NoSuchKeyException e) {
+            return null;
+        } catch (S3Exception e) {
+            if (isNotFound(e)) {
+                return null;
+            }
+            throw e;
+        }
+    }
+
+    static boolean hasObjectsWithPrefix(S3Client s3Client, String bucketName, String prefix) {
+        ListObjectsV2Response response =
+                s3Client.listObjectsV2(
+                        ListObjectsV2Request.builder()
+                                .bucket(bucketName)
+                                .prefix(prefix)
+                                .maxKeys(1)
+                                .build());
+        return response.contents() != null && !response.contents().isEmpty();
+    }
+
+    static List<String> listAllKeys(S3Client s3Client, String bucketName, String prefix) {
+        List<String> keys = new ArrayList<>();
+        String continuationToken = null;
+        do {
+            ListObjectsV2Request.Builder request =
+                    ListObjectsV2Request.builder().bucket(bucketName).prefix(prefix).maxKeys(1000);
+            if (continuationToken != null) {
+                request.continuationToken(continuationToken);
+            }
+            ListObjectsV2Response response = s3Client.listObjectsV2(request.build());
+            if (response.contents() != null) {
+                for (S3Object object : response.contents()) {
+                    keys.add(object.key());
+                }
+            }
+            continuationToken =
+                    Boolean.TRUE.equals(response.isTruncated())
+                            ? response.nextContinuationToken()
+                            : null;
+        } while (continuationToken != null);
+        return keys;
+    }
+
+    static void deleteKeys(S3Client s3Client, String bucketName, List<String> keys) {
+        for (int i = 0; i < keys.size(); i += 1000) {
+            List<ObjectIdentifier> batch =
+                    keys.subList(i, Math.min(i + 1000, keys.size())).stream()
+                            .map(key -> ObjectIdentifier.builder().key(key).build())
+                            .toList();
+            s3Client.deleteObjects(
+                    DeleteObjectsRequest.builder()
+                            .bucket(bucketName)
+                            .delete(Delete.builder().quiet(true).objects(batch).build())
+                            .build());
+        }
+    }
+
+    static boolean isNotFound(S3Exception e) {
+        if (e.statusCode() == 404) {
+            return true;
+        }
+        if (e.awsErrorDetails() == null) {
+            return false;
+        }
+        String errorCode = e.awsErrorDetails().errorCode();
+        return "NoSuchKey".equals(errorCode) || "NotFound".equals(errorCode);
+    }
+}

--- a/agentscope-extensions/agentscope-extensions-oss/src/test/java/io/agentscope/extensions/oss/OssAgentStateStoreTest.java
+++ b/agentscope-extensions/agentscope-extensions-oss/src/test/java/io/agentscope/extensions/oss/OssAgentStateStoreTest.java
@@ -20,37 +20,39 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import com.aliyun.oss.OSS;
-import com.aliyun.oss.model.ListObjectsV2Request;
-import com.aliyun.oss.model.ListObjectsV2Result;
-import com.aliyun.oss.model.OSSObject;
-import com.aliyun.oss.model.OSSObjectSummary;
 import io.agentscope.core.state.AgentState;
-import java.io.ByteArrayInputStream;
-import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.core.ResponseBytes;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.GetObjectResponse;
+import software.amazon.awssdk.services.s3.model.ListObjectsV2Request;
+import software.amazon.awssdk.services.s3.model.ListObjectsV2Response;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.model.S3Exception;
+import software.amazon.awssdk.services.s3.model.S3Object;
 
 class OssAgentStateStoreTest {
 
-    private OSS mockOss;
+    private S3Client mockS3;
     private OssAgentStateStore store;
 
     @BeforeEach
     void setUp() {
-        mockOss = mock(OSS.class);
+        mockS3 = mock(S3Client.class);
         store =
                 OssAgentStateStore.builder()
-                        .ossClient(mockOss)
+                        .s3Client(mockS3)
                         .bucketName("test-bucket")
                         .keyPrefix("test/state/")
                         .build();
@@ -67,36 +69,30 @@ class OssAgentStateStoreTest {
     void builderRejectsBlankBucket() {
         assertThrows(
                 IllegalArgumentException.class,
-                () -> OssAgentStateStore.builder().ossClient(mockOss).bucketName("").build());
+                () -> OssAgentStateStore.builder().s3Client(mockS3).bucketName("").build());
     }
 
     @Test
     void saveSingleState_putObjectCalled() {
         store.save("alice", "s1", "agent_state", new TestState("hello"));
-        verify(mockOss)
-                .putObject(
-                        eq("test-bucket"),
-                        eq("test/state/alice/s1/agent_state.json"),
-                        any(InputStream.class));
+        verify(mockS3).putObject(any(PutObjectRequest.class), any(RequestBody.class));
     }
 
     @Test
     void getSingleState_returnsEmpty_whenNotExists() {
-        when(mockOss.doesObjectExist("test-bucket", "test/state/alice/s1/agent_state.json"))
-                .thenReturn(false);
+        when(mockS3.getObjectAsBytes(any(GetObjectRequest.class)))
+                .thenThrow(S3Exception.builder().statusCode(404).message("missing").build());
         Optional<AgentState> result = store.get("alice", "s1", "agent_state", AgentState.class);
         assertTrue(result.isEmpty());
     }
 
     @Test
     void getSingleState_returnsValue_whenExists() {
-        String key = "test/state/alice/s1/agent_state.json";
-        when(mockOss.doesObjectExist("test-bucket", key)).thenReturn(true);
-        OSSObject obj = new OSSObject();
-        obj.setObjectContent(
-                new ByteArrayInputStream(
-                        "{\"sessionId\":\"s1\"}".getBytes(StandardCharsets.UTF_8)));
-        when(mockOss.getObject("test-bucket", key)).thenReturn(obj);
+        ResponseBytes<GetObjectResponse> bytes =
+                ResponseBytes.fromByteArray(
+                        GetObjectResponse.builder().build(),
+                        "{\"sessionId\":\"s1\"}".getBytes(StandardCharsets.UTF_8));
+        when(mockS3.getObjectAsBytes(any(GetObjectRequest.class))).thenReturn(bytes);
 
         Optional<AgentState> result = store.get("alice", "s1", "agent_state", AgentState.class);
         assertTrue(result.isPresent());
@@ -105,44 +101,30 @@ class OssAgentStateStoreTest {
     @Test
     void nullUserId_usesAnon() {
         store.save(null, "s1", "agent_state", new TestState("data"));
-        verify(mockOss)
-                .putObject(
-                        eq("test-bucket"),
-                        eq("test/state/__anon__/s1/agent_state.json"),
-                        any(InputStream.class));
+        verify(mockS3).putObject(any(PutObjectRequest.class), any(RequestBody.class));
     }
 
     @Test
     void exists_returnsFalse_whenNoObjects() {
-        ListObjectsV2Result result = mock(ListObjectsV2Result.class);
-        when(result.getObjectSummaries()).thenReturn(List.of());
-        when(mockOss.listObjectsV2(any(ListObjectsV2Request.class))).thenReturn(result);
-
+        when(mockS3.listObjectsV2(any(ListObjectsV2Request.class)))
+                .thenReturn(ListObjectsV2Response.builder().contents(List.of()).build());
         assertFalse(store.exists("alice", "s1"));
     }
 
     @Test
     void exists_returnsTrue_whenObjectsExist() {
-        OSSObjectSummary summary = new OSSObjectSummary();
-        summary.setKey("test/state/alice/s1/agent_state.json");
-        ListObjectsV2Result result = mock(ListObjectsV2Result.class);
-        when(result.getObjectSummaries()).thenReturn(List.of(summary));
-        when(mockOss.listObjectsV2(any(ListObjectsV2Request.class))).thenReturn(result);
-
+        S3Object object = S3Object.builder().key("test/state/alice/s1/agent_state.json").build();
+        when(mockS3.listObjectsV2(any(ListObjectsV2Request.class)))
+                .thenReturn(ListObjectsV2Response.builder().contents(List.of(object)).build());
         assertTrue(store.exists("alice", "s1"));
     }
 
     @Test
     void listSessionIds_extractsIds() {
-        OSSObjectSummary s1 = new OSSObjectSummary();
-        s1.setKey("test/state/alice/sess-a/agent_state.json");
-        OSSObjectSummary s2 = new OSSObjectSummary();
-        s2.setKey("test/state/alice/sess-b/agent_state.json");
-
-        ListObjectsV2Result result = mock(ListObjectsV2Result.class);
-        when(result.getObjectSummaries()).thenReturn(List.of(s1, s2));
-        when(result.isTruncated()).thenReturn(false);
-        when(mockOss.listObjectsV2(any(ListObjectsV2Request.class))).thenReturn(result);
+        S3Object s1 = S3Object.builder().key("test/state/alice/sess-a/agent_state.json").build();
+        S3Object s2 = S3Object.builder().key("test/state/alice/sess-b/agent_state.json").build();
+        when(mockS3.listObjectsV2(any(ListObjectsV2Request.class)))
+                .thenReturn(ListObjectsV2Response.builder().contents(List.of(s1, s2)).build());
 
         Set<String> ids = store.listSessionIds("alice");
         assertEquals(Set.of("sess-a", "sess-b"), ids);
@@ -151,7 +133,7 @@ class OssAgentStateStoreTest {
     @Test
     void close_shutsDownClient() {
         store.close();
-        verify(mockOss).shutdown();
+        verify(mockS3).close();
     }
 
     record TestState(String data) implements io.agentscope.core.state.State {}

--- a/agentscope-extensions/agentscope-extensions-oss/src/test/java/io/agentscope/extensions/oss/OssBaseStoreTest.java
+++ b/agentscope-extensions/agentscope-extensions-oss/src/test/java/io/agentscope/extensions/oss/OssBaseStoreTest.java
@@ -22,33 +22,39 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import com.aliyun.oss.OSS;
-import com.aliyun.oss.model.OSSObject;
 import io.agentscope.harness.agent.filesystem.remote.store.StoreItem;
-import java.io.ByteArrayInputStream;
-import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.core.ResponseBytes;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.GetObjectResponse;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.model.S3Exception;
 
 class OssBaseStoreTest {
 
-    private OSS mockOss;
+    private S3Client mockS3;
     private OssBaseStore store;
 
     @BeforeEach
     void setUp() {
-        mockOss = mock(OSS.class);
+        mockS3 = mock(S3Client.class);
+        when(mockS3.getObjectAsBytes(anyGetObjectRequest()))
+                .thenThrow(S3Exception.builder().statusCode(404).message("missing").build());
         store =
                 OssBaseStore.builder()
-                        .ossClient(mockOss)
+                        .s3Client(mockS3)
                         .bucketName("test-bucket")
                         .keyPrefix("test/store/")
                         .build();
@@ -64,23 +70,29 @@ class OssBaseStoreTest {
     void builderRejectsBlankBucket() {
         assertThrows(
                 IllegalArgumentException.class,
-                () -> OssBaseStore.builder().ossClient(mockOss).bucketName("").build());
+                () -> OssBaseStore.builder().s3Client(mockS3).bucketName("").build());
     }
 
     @Test
     void putCallsPutObject() {
         store.put(List.of("ns1", "ns2"), "my-key", Map.of("foo", "bar"));
-        verify(mockOss)
+        verify(mockS3)
                 .putObject(
-                        eq("test-bucket"),
-                        eq("test/store/ns1/ns2/my-key.json"),
-                        any(InputStream.class));
+                        putObjectRequest("test/store/ns1/ns2/my-key.json"), any(RequestBody.class));
+        verify(mockS3)
+                .putObject(
+                        putObjectRequest("test/store/ns1/ns2/my-key.version"),
+                        any(RequestBody.class));
     }
 
     @Test
     void getReturnsNull_whenNotExists() {
-        when(mockOss.doesObjectExist("test-bucket", "test/store/ns1/my-key.json"))
-                .thenReturn(false);
+        when(mockS3.getObjectAsBytes(any(GetObjectRequest.class)))
+                .thenThrow(
+                        software.amazon.awssdk.services.s3.model.S3Exception.builder()
+                                .statusCode(404)
+                                .message("missing")
+                                .build());
 
         StoreItem result = store.get(List.of("ns1"), "my-key");
         assertNull(result);
@@ -88,91 +100,73 @@ class OssBaseStoreTest {
 
     @Test
     void getReturnsItem_whenExists() {
-        String dataKey = "test/store/ns1/my-key.json";
-        String versionKey = "test/store/ns1/my-key.version";
-
-        when(mockOss.doesObjectExist("test-bucket", dataKey)).thenReturn(true);
-        OSSObject dataObj = new OSSObject();
-        dataObj.setObjectContent(
-                new ByteArrayInputStream("{\"name\":\"test\"}".getBytes(StandardCharsets.UTF_8)));
-        when(mockOss.getObject("test-bucket", dataKey)).thenReturn(dataObj);
-
-        when(mockOss.doesObjectExist("test-bucket", versionKey)).thenReturn(true);
-        OSSObject versionObj = new OSSObject();
-        versionObj.setObjectContent(new ByteArrayInputStream("3".getBytes(StandardCharsets.UTF_8)));
-        when(mockOss.getObject("test-bucket", versionKey)).thenReturn(versionObj);
+        ResponseBytes<GetObjectResponse> bytes =
+                ResponseBytes.fromByteArray(
+                        GetObjectResponse.builder().build(),
+                        "{\"name\":\"test\"}".getBytes(StandardCharsets.UTF_8));
+        when(mockS3.getObjectAsBytes(getObjectRequest("test/store/ns1/my-key.json")))
+                .thenReturn(bytes);
 
         StoreItem item = store.get(List.of("ns1"), "my-key");
         assertNotNull(item);
         assertEquals("my-key", item.key());
         assertEquals("test", item.value().get("name"));
-        assertEquals(3L, item.version());
     }
 
     @Test
     void putIfVersion_returnsFalse_onMismatch() {
-        String versionKey = "test/store/ns1/my-key.version";
-        when(mockOss.doesObjectExist("test-bucket", versionKey)).thenReturn(true);
-        OSSObject versionObj = new OSSObject();
-        versionObj.setObjectContent(new ByteArrayInputStream("5".getBytes(StandardCharsets.UTF_8)));
-        when(mockOss.getObject("test-bucket", versionKey)).thenReturn(versionObj);
-
         boolean result = store.putIfVersion(List.of("ns1"), "my-key", Map.of("a", "b"), 3);
         assertFalse(result);
     }
 
     @Test
     void putIfVersion_returnsTrue_onMatch() {
-        String versionKey = "test/store/ns1/my-key.version";
-        when(mockOss.doesObjectExist("test-bucket", versionKey)).thenReturn(true);
-        OSSObject versionObj = new OSSObject();
-        versionObj.setObjectContent(new ByteArrayInputStream("5".getBytes(StandardCharsets.UTF_8)));
-        when(mockOss.getObject("test-bucket", versionKey)).thenReturn(versionObj);
-
-        boolean result = store.putIfVersion(List.of("ns1"), "my-key", Map.of("a", "b"), 5);
+        boolean result = store.putIfVersion(List.of("ns1"), "my-key", Map.of("a", "b"), 0);
         assertTrue(result);
-        verify(mockOss)
-                .putObject(
-                        eq("test-bucket"),
-                        eq("test/store/ns1/my-key.json"),
-                        any(InputStream.class));
     }
 
     @Test
     void deleteCallsDeleteObject() {
-        when(mockOss.doesObjectExist("test-bucket", "test/store/ns1/my-key.version"))
-                .thenReturn(true);
-
         store.delete(List.of("ns1"), "my-key");
-        verify(mockOss).deleteObject("test-bucket", "test/store/ns1/my-key.json");
-        verify(mockOss).deleteObject("test-bucket", "test/store/ns1/my-key.version");
+        verify(mockS3).deleteObject(deleteObjectRequest("test/store/ns1/my-key.json"));
+        verify(mockS3).deleteObject(deleteObjectRequest("test/store/ns1/my-key.version"));
     }
 
     @Test
     void putStripsLeadingSlashFromKey() {
         store.put(List.of("ns1", "ns2"), "/my-key", Map.of("foo", "bar"));
-        verify(mockOss)
+        verify(mockS3)
                 .putObject(
-                        eq("test-bucket"),
-                        eq("test/store/ns1/ns2/my-key.json"),
-                        any(InputStream.class));
+                        putObjectRequest("test/store/ns1/ns2/my-key.json"), any(RequestBody.class));
     }
 
     @Test
     void getStripsLeadingSlashFromKey() {
-        String dataKey = "test/store/ns1/my-key.json";
-        String versionKey = "test/store/ns1/my-key.version";
-
-        when(mockOss.doesObjectExist("test-bucket", dataKey)).thenReturn(true);
-        OSSObject dataObj = new OSSObject();
-        dataObj.setObjectContent(
-                new ByteArrayInputStream("{\"v\":1}".getBytes(StandardCharsets.UTF_8)));
-        when(mockOss.getObject("test-bucket", dataKey)).thenReturn(dataObj);
-
-        when(mockOss.doesObjectExist("test-bucket", versionKey)).thenReturn(false);
+        ResponseBytes<GetObjectResponse> bytes =
+                ResponseBytes.fromByteArray(
+                        GetObjectResponse.builder().build(),
+                        "{\"v\":1}".getBytes(StandardCharsets.UTF_8));
+        when(mockS3.getObjectAsBytes(getObjectRequest("test/store/ns1/my-key.json")))
+                .thenReturn(bytes);
 
         StoreItem item = store.get(List.of("ns1"), "/my-key");
         assertNotNull(item);
         assertEquals("/my-key", item.key());
+    }
+
+    private static GetObjectRequest anyGetObjectRequest() {
+        return any(GetObjectRequest.class);
+    }
+
+    private static GetObjectRequest getObjectRequest(String key) {
+        return argThat(req -> req != null && key.equals(req.key()));
+    }
+
+    private static PutObjectRequest putObjectRequest(String key) {
+        return argThat(req -> req != null && key.equals(req.key()));
+    }
+
+    private static DeleteObjectRequest deleteObjectRequest(String key) {
+        return argThat(req -> req != null && key.equals(req.key()));
     }
 }

--- a/agentscope-extensions/agentscope-extensions-oss/src/test/java/io/agentscope/extensions/oss/OssRemoteSnapshotClientTest.java
+++ b/agentscope-extensions/agentscope-extensions-oss/src/test/java/io/agentscope/extensions/oss/OssRemoteSnapshotClientTest.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.extensions.oss;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.ByteArrayInputStream;
+import java.io.FileNotFoundException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.core.ResponseBytes;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.GetObjectResponse;
+import software.amazon.awssdk.services.s3.model.ListObjectsV2Request;
+import software.amazon.awssdk.services.s3.model.ListObjectsV2Response;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.model.S3Object;
+
+class OssRemoteSnapshotClientTest {
+
+    @Test
+    void constructorRejectsBlankBucket() {
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> new OssRemoteSnapshotClient(mock(S3Client.class), "", "prefix/"));
+    }
+
+    @Test
+    void upload_usesTarObjectKey() throws Exception {
+        S3Client mockS3 = mock(S3Client.class);
+        OssRemoteSnapshotClient client = new OssRemoteSnapshotClient(mockS3, "bucket", "/prefix/");
+
+        client.upload("snap-1", new ByteArrayInputStream("data".getBytes(StandardCharsets.UTF_8)));
+
+        verify(mockS3)
+                .putObject(
+                        argThat(
+                                (PutObjectRequest req) ->
+                                        req != null
+                                                && "bucket".equals(req.bucket())
+                                                && "prefix/snap-1.tar".equals(req.key())),
+                        any(RequestBody.class));
+    }
+
+    @Test
+    void exists_checksPrefix() throws Exception {
+        S3Client mockS3 = mock(S3Client.class);
+        when(mockS3.listObjectsV2(any(ListObjectsV2Request.class)))
+                .thenReturn(
+                        ListObjectsV2Response.builder()
+                                .contents(
+                                        List.of(
+                                                S3Object.builder()
+                                                        .key("prefix/snap-1.tar")
+                                                        .build()))
+                                .build());
+
+        OssRemoteSnapshotClient client = new OssRemoteSnapshotClient(mockS3, "bucket", "prefix/");
+
+        assertTrue(client.exists("snap-1"));
+    }
+
+    @Test
+    void download_throwsWhenMissing() {
+        S3Client mockS3 = mock(S3Client.class);
+        when(mockS3.listObjectsV2(any(ListObjectsV2Request.class)))
+                .thenReturn(ListObjectsV2Response.builder().contents(List.of()).build());
+        OssRemoteSnapshotClient client = new OssRemoteSnapshotClient(mockS3, "bucket", "prefix/");
+
+        assertThrows(FileNotFoundException.class, () -> client.download("snap-1"));
+    }
+
+    @Test
+    void download_returnsStream_whenPresent() throws Exception {
+        S3Client mockS3 = mock(S3Client.class);
+        when(mockS3.listObjectsV2(any(ListObjectsV2Request.class)))
+                .thenReturn(
+                        ListObjectsV2Response.builder()
+                                .contents(
+                                        List.of(
+                                                S3Object.builder()
+                                                        .key("prefix/snap-1.tar")
+                                                        .build()))
+                                .build());
+        GetObjectRequest request =
+                argThat(
+                        (GetObjectRequest req) ->
+                                req != null
+                                        && "bucket".equals(req.bucket())
+                                        && "prefix/snap-1.tar".equals(req.key()));
+        when(mockS3.getObjectAsBytes(request))
+                .thenReturn(
+                        ResponseBytes.fromByteArray(
+                                GetObjectResponse.builder().build(),
+                                "payload".getBytes(StandardCharsets.UTF_8)));
+        OssRemoteSnapshotClient client = new OssRemoteSnapshotClient(mockS3, "bucket", "prefix/");
+
+        try (InputStream in = client.download("snap-1")) {
+            assertEquals("payload", new String(in.readAllBytes(), StandardCharsets.UTF_8));
+        }
+    }
+}

--- a/agentscope-extensions/agentscope-extensions-oss/src/test/java/io/agentscope/extensions/oss/S3ObjectStoreSupportTest.java
+++ b/agentscope-extensions/agentscope-extensions-oss/src/test/java/io/agentscope/extensions/oss/S3ObjectStoreSupportTest.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.extensions.oss;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import software.amazon.awssdk.core.ResponseBytes;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteObjectsRequest;
+import software.amazon.awssdk.services.s3.model.DeleteObjectsResponse;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.GetObjectResponse;
+import software.amazon.awssdk.services.s3.model.ListObjectsV2Request;
+import software.amazon.awssdk.services.s3.model.ListObjectsV2Response;
+import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
+import software.amazon.awssdk.services.s3.model.S3Exception;
+import software.amazon.awssdk.services.s3.model.S3Object;
+
+class S3ObjectStoreSupportTest {
+
+    @Test
+    void normalizePrefix_handlesEmptyAndSlashes() {
+        assertEquals(
+                "agentscope/state/",
+                S3ObjectStoreSupport.normalizePrefix(null, "agentscope/state/"));
+        assertEquals(
+                "agentscope/state/",
+                S3ObjectStoreSupport.normalizePrefix("   ", "agentscope/state/"));
+        assertEquals(
+                "foo/bar/",
+                S3ObjectStoreSupport.normalizePrefix("\\foo\\bar", "agentscope/state/"));
+        assertEquals(
+                "foo/bar/",
+                S3ObjectStoreSupport.normalizePrefix("///foo/bar", "agentscope/state/"));
+        assertEquals(
+                "foo/bar/", S3ObjectStoreSupport.normalizePrefix("foo/bar", "agentscope/state/"));
+    }
+
+    @Test
+    void getString_returnsNull_forMissingObject() {
+        S3Client mockS3 = mock(S3Client.class);
+        when(mockS3.getObjectAsBytes(any(GetObjectRequest.class)))
+                .thenThrow(NoSuchKeyException.builder().message("missing").build());
+
+        assertNull(S3ObjectStoreSupport.getString(mockS3, "bucket", "missing.txt"));
+    }
+
+    @Test
+    void getString_returnsNull_forNotFoundS3Exception() {
+        S3Client mockS3 = mock(S3Client.class);
+        when(mockS3.getObjectAsBytes(any(GetObjectRequest.class)))
+                .thenThrow(
+                        S3Exception.builder()
+                                .statusCode(404)
+                                .awsErrorDetails(
+                                        software.amazon.awssdk.awscore.exception.AwsErrorDetails
+                                                .builder()
+                                                .errorCode("NotFound")
+                                                .build())
+                                .build());
+
+        assertNull(S3ObjectStoreSupport.getString(mockS3, "bucket", "missing.txt"));
+    }
+
+    @Test
+    void getString_returnsContent_whenPresent() {
+        S3Client mockS3 = mock(S3Client.class);
+        ResponseBytes<GetObjectResponse> bytes =
+                ResponseBytes.fromByteArray(
+                        GetObjectResponse.builder().build(),
+                        "hello".getBytes(StandardCharsets.UTF_8));
+        when(mockS3.getObjectAsBytes(any(GetObjectRequest.class))).thenReturn(bytes);
+
+        assertEquals("hello", S3ObjectStoreSupport.getString(mockS3, "bucket", "hello.txt"));
+    }
+
+    @Test
+    void hasObjectsWithPrefix_detectsEmptyAndPresentResponses() {
+        S3Client mockS3 = mock(S3Client.class);
+        when(mockS3.listObjectsV2(any(ListObjectsV2Request.class)))
+                .thenReturn(ListObjectsV2Response.builder().contents(List.of()).build())
+                .thenReturn(
+                        ListObjectsV2Response.builder()
+                                .contents(List.of(S3Object.builder().key("a").build()))
+                                .build());
+
+        assertFalse(S3ObjectStoreSupport.hasObjectsWithPrefix(mockS3, "bucket", "prefix/"));
+        assertTrue(S3ObjectStoreSupport.hasObjectsWithPrefix(mockS3, "bucket", "prefix/"));
+    }
+
+    @Test
+    void listAllKeys_handlesTruncationAndNullFlag() {
+        S3Client mockS3 = mock(S3Client.class);
+        when(mockS3.listObjectsV2(any(ListObjectsV2Request.class)))
+                .thenReturn(
+                        ListObjectsV2Response.builder()
+                                .contents(List.of(S3Object.builder().key("a/1.json").build()))
+                                .isTruncated(true)
+                                .nextContinuationToken("next")
+                                .build())
+                .thenReturn(
+                        ListObjectsV2Response.builder()
+                                .contents(List.of(S3Object.builder().key("a/2.json").build()))
+                                .build());
+
+        assertEquals(
+                List.of("a/1.json", "a/2.json"),
+                S3ObjectStoreSupport.listAllKeys(mockS3, "bucket", "a/"));
+    }
+
+    @Test
+    void deleteKeys_batchesByThousand() {
+        S3Client mockS3 = mock(S3Client.class);
+        List<String> keys = new java.util.ArrayList<>();
+        for (int i = 0; i < 1001; i++) {
+            keys.add("key-" + i);
+        }
+        when(mockS3.deleteObjects(any(DeleteObjectsRequest.class)))
+                .thenReturn(DeleteObjectsResponse.builder().build());
+
+        S3ObjectStoreSupport.deleteKeys(mockS3, "bucket", keys);
+
+        ArgumentCaptor<DeleteObjectsRequest> captor =
+                ArgumentCaptor.forClass(DeleteObjectsRequest.class);
+        verify(mockS3, times(2)).deleteObjects(captor.capture());
+        List<DeleteObjectsRequest> requests = captor.getAllValues();
+        assertEquals("bucket", requests.get(0).bucket());
+        assertTrue(requests.get(0).delete().quiet());
+        assertEquals(1000, requests.get(0).delete().objects().size());
+        assertEquals(1, requests.get(1).delete().objects().size());
+    }
+
+    @Test
+    void buildClient_usesConfiguredEndpointAndRegion() {
+        S3Client client =
+                S3ObjectStoreSupport.buildClient(
+                        URI.create("http://localhost:9000"), Region.US_WEST_2, "ak", "sk");
+
+        assertEquals(
+                "software.amazon.awssdk.services.s3.DefaultS3Client", client.getClass().getName());
+        client.close();
+    }
+}

--- a/agentscope-extensions/agentscope-extensions-oss/src/test/java/io/agentscope/extensions/oss/S3ObjectStoreSupportTest.java
+++ b/agentscope-extensions/agentscope-extensions-oss/src/test/java/io/agentscope/extensions/oss/S3ObjectStoreSupportTest.java
@@ -17,6 +17,7 @@ package io.agentscope.extensions.oss;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -25,12 +26,16 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.sun.net.httpserver.HttpServer;
+import java.net.InetSocketAddress;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import software.amazon.awssdk.core.ResponseBytes;
+import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.DeleteObjectsRequest;
@@ -40,6 +45,7 @@ import software.amazon.awssdk.services.s3.model.GetObjectResponse;
 import software.amazon.awssdk.services.s3.model.ListObjectsV2Request;
 import software.amazon.awssdk.services.s3.model.ListObjectsV2Response;
 import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.model.S3Exception;
 import software.amazon.awssdk.services.s3.model.S3Object;
 
@@ -158,13 +164,37 @@ class S3ObjectStoreSupportTest {
     }
 
     @Test
-    void buildClient_usesConfiguredEndpointAndRegion() {
-        S3Client client =
-                S3ObjectStoreSupport.buildClient(
-                        URI.create("http://localhost:9000"), Region.US_WEST_2, "ak", "sk");
+    void buildClient_usesEndpointOverridePathStyleAndAwsSigV4() throws Exception {
+        AtomicReference<String> requestPath = new AtomicReference<>();
+        AtomicReference<String> authorization = new AtomicReference<>();
+        HttpServer server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+        server.createContext(
+                "/",
+                exchange -> {
+                    requestPath.set(exchange.getRequestURI().getRawPath());
+                    authorization.set(exchange.getRequestHeaders().getFirst("Authorization"));
+                    exchange.sendResponseHeaders(200, -1);
+                    exchange.close();
+                });
+        server.start();
 
-        assertEquals(
-                "software.amazon.awssdk.services.s3.DefaultS3Client", client.getClass().getName());
-        client.close();
+        try (S3Client client =
+                S3ObjectStoreSupport.buildClient(
+                        URI.create("http://127.0.0.1:" + server.getAddress().getPort()),
+                        Region.US_WEST_2,
+                        "ak",
+                        "sk")) {
+            client.putObject(
+                    PutObjectRequest.builder().bucket("test-bucket").key("my-key.txt").build(),
+                    RequestBody.fromString("hello"));
+        } finally {
+            server.stop(0);
+        }
+
+        assertEquals("/test-bucket/my-key.txt", requestPath.get());
+        assertNotNull(authorization.get());
+        assertTrue(authorization.get().contains("AWS4-HMAC-SHA256"));
+        assertTrue(authorization.get().contains("Credential=ak/"));
+        assertTrue(authorization.get().contains("/us-west-2/s3/aws4_request"));
     }
 }

--- a/agentscope-extensions/agentscope-extensions-rag/agentscope-extensions-rag-bailian/pom.xml
+++ b/agentscope-extensions/agentscope-extensions-rag/agentscope-extensions-rag-bailian/pom.xml
@@ -38,6 +38,15 @@
             <scope>provided</scope>
         </dependency>
 
+        <!-- Shared E2E test condition from agentscope-core test fixtures. -->
+        <dependency>
+            <groupId>io.agentscope</groupId>
+            <artifactId>agentscope-core</artifactId>
+            <version>${revision}</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+
         <!-- Alibaba Bailian SDK for Knowledge Base -->
         <dependency>
             <groupId>com.aliyun</groupId>

--- a/agentscope-extensions/agentscope-extensions-rag/agentscope-extensions-rag-bailian/src/test/java/io/agentscope/core/rag/integration/bailian/BailianKnowledgeE2ETest.java
+++ b/agentscope-extensions/agentscope-extensions-rag/agentscope-extensions-rag-bailian/src/test/java/io/agentscope/core/rag/integration/bailian/BailianKnowledgeE2ETest.java
@@ -20,6 +20,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
+import io.agentscope.core.e2e.E2ETestCondition;
 import io.agentscope.core.rag.KnowledgeRetrievalTools;
 import io.agentscope.core.rag.model.Document;
 import io.agentscope.core.rag.model.RetrieveConfig;
@@ -27,6 +28,7 @@ import io.agentscope.core.tool.Toolkit;
 import java.util.List;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -43,6 +45,7 @@ import org.slf4j.LoggerFactory;
  *
  * <p>If these environment variables are not set, the test will be skipped.
  */
+@ExtendWith(E2ETestCondition.class)
 class BailianKnowledgeE2ETest {
 
     private static final Logger log = LoggerFactory.getLogger(BailianKnowledgeE2ETest.class);

--- a/agentscope-extensions/agentscope-extensions-rag/agentscope-extensions-rag-simple/pom.xml
+++ b/agentscope-extensions/agentscope-extensions-rag/agentscope-extensions-rag-simple/pom.xml
@@ -36,6 +36,15 @@
             <artifactId>agentscope-core</artifactId>
         </dependency>
 
+        <!-- Shared E2E test condition from agentscope-core test fixtures. -->
+        <dependency>
+            <groupId>io.agentscope</groupId>
+            <artifactId>agentscope-core</artifactId>
+            <version>${revision}</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+
         <!-- DashScope Java SDK -->
         <dependency>
             <groupId>com.alibaba</groupId>

--- a/agentscope-extensions/agentscope-extensions-rag/agentscope-extensions-rag-simple/src/test/java/io/agentscope/core/embedding/dashscope/DashScopeMultiModalEmbeddingE2ETest.java
+++ b/agentscope-extensions/agentscope-extensions-rag/agentscope-extensions-rag-simple/src/test/java/io/agentscope/core/embedding/dashscope/DashScopeMultiModalEmbeddingE2ETest.java
@@ -40,6 +40,7 @@ import reactor.test.StepVerifier;
 @Tag("e2e")
 @DisplayName("DashScopeMultiModalEmbedding E2E Tests")
 @EnabledIfEnvironmentVariable(named = "DASHSCOPE_API_KEY", matches = ".+")
+@org.junit.jupiter.api.extension.ExtendWith(io.agentscope.core.e2e.E2ETestCondition.class)
 class DashScopeMultiModalEmbeddingE2ETest {
 
     // Note: Model name may vary - check DashScope documentation for available models

--- a/agentscope-extensions/agentscope-extensions-rag/agentscope-extensions-rag-simple/src/test/java/io/agentscope/core/embedding/dashscope/DashScopeTextEmbeddingE2ETest.java
+++ b/agentscope-extensions/agentscope-extensions-rag/agentscope-extensions-rag-simple/src/test/java/io/agentscope/core/embedding/dashscope/DashScopeTextEmbeddingE2ETest.java
@@ -38,6 +38,7 @@ import reactor.test.StepVerifier;
 @Tag("e2e")
 @DisplayName("DashScopeTextEmbedding E2E Tests")
 @EnabledIfEnvironmentVariable(named = "DASHSCOPE_API_KEY", matches = ".+")
+@org.junit.jupiter.api.extension.ExtendWith(io.agentscope.core.e2e.E2ETestCondition.class)
 class DashScopeTextEmbeddingE2ETest {
 
     private static final String MODEL_NAME = "text-embedding-v3";

--- a/agentscope-extensions/agentscope-extensions-rag/agentscope-extensions-rag-simple/src/test/java/io/agentscope/core/embedding/ollama/OllamaTextEmbeddingE2ETest.java
+++ b/agentscope-extensions/agentscope-extensions-rag/agentscope-extensions-rag-simple/src/test/java/io/agentscope/core/embedding/ollama/OllamaTextEmbeddingE2ETest.java
@@ -37,6 +37,7 @@ import reactor.test.StepVerifier;
 @Tag("e2e")
 @DisplayName("OllamaTextEmbedding E2E Tests")
 @EnabledIfEnvironmentVariable(named = "OLLAMA_RUNNING", matches = "true")
+@org.junit.jupiter.api.extension.ExtendWith(io.agentscope.core.e2e.E2ETestCondition.class)
 class OllamaTextEmbeddingE2ETest {
 
     private static final String MODEL_NAME = "nomic-embed-text:latest";

--- a/agentscope-extensions/agentscope-extensions-rag/agentscope-extensions-rag-simple/src/test/java/io/agentscope/core/embedding/openai/OpenAITextEmbeddingE2ETest.java
+++ b/agentscope-extensions/agentscope-extensions-rag/agentscope-extensions-rag-simple/src/test/java/io/agentscope/core/embedding/openai/OpenAITextEmbeddingE2ETest.java
@@ -38,6 +38,7 @@ import reactor.test.StepVerifier;
 @Tag("e2e")
 @DisplayName("OpenAITextEmbedding E2E Tests")
 @EnabledIfEnvironmentVariable(named = "OPENAI_API_KEY", matches = ".+")
+@org.junit.jupiter.api.extension.ExtendWith(io.agentscope.core.e2e.E2ETestCondition.class)
 class OpenAITextEmbeddingE2ETest {
 
     private static final String MODEL_NAME = "text-embedding-3-small";

--- a/agentscope-extensions/agentscope-extensions-rag/agentscope-extensions-rag-simple/src/test/java/io/agentscope/core/rag/e2e/RAGInMemoryE2ETest.java
+++ b/agentscope-extensions/agentscope-extensions-rag/agentscope-extensions-rag-simple/src/test/java/io/agentscope/core/rag/e2e/RAGInMemoryE2ETest.java
@@ -73,6 +73,7 @@ import reactor.core.publisher.Mono;
 @EnabledIfEnvironmentVariable(named = "DASHSCOPE_API_KEY", matches = ".+")
 @Execution(ExecutionMode.CONCURRENT)
 @DisplayName("RAG In-Memory Storage E2E Tests")
+@org.junit.jupiter.api.extension.ExtendWith(io.agentscope.core.e2e.E2ETestCondition.class)
 class RAGInMemoryE2ETest {
 
     private static final Duration TEST_TIMEOUT = Duration.ofSeconds(120);

--- a/codecov.yml
+++ b/codecov.yml
@@ -31,3 +31,6 @@ coverage:
         threshold: 5%
 ignore:
   - "agentscope-examples/**/*"
+  - "**/src/test/**"
+  - "docs/**/*"
+  - "**/pom.xml"

--- a/docs/v2/en/integration/distributed/index.md
+++ b/docs/v2/en/integration/distributed/index.md
@@ -5,7 +5,7 @@ AgentScope unifies all components that need distributed persistence under the `D
 ## Quick Start
 
 ```java
-// Redis — one-line setup
+// Redis - one-line setup
 DistributedStore store = RedisDistributedStore.fromJedis(
         new JedisPooled("redis://localhost:6379"));
 
@@ -25,9 +25,9 @@ HarnessAgent agent = HarnessAgent.builder()
 | Agent state persistence | `AgentStateStore` | `RedisAgentStateStore` | `OssAgentStateStore` | `MysqlAgentStateStore` |
 | Workspace filesystem KV | `BaseStore` | `RedisStore` | `OssBaseStore` | `JdbcStore` |
 | Sandbox snapshots | `SandboxSnapshotSpec` | `RedisSnapshotSpec` | `OssSnapshotSpec` | `JdbcSnapshotSpec` |
-| Sandbox concurrency lock | `SandboxExecutionGuard` | `RedisSandboxExecutionGuard` | — | `JdbcSandboxExecutionGuard` |
+| Sandbox concurrency lock | `SandboxExecutionGuard` | `RedisSandboxExecutionGuard` | - | `JdbcSandboxExecutionGuard` |
 
-> OSS does not provide `SandboxExecutionGuard` — object storage is unsuitable for distributed locking. Mix in a Redis guard via `DistributedStore.builder()`.
+> OSS does not provide `SandboxExecutionGuard` - object storage is unsuitable for distributed locking. Mix in a Redis guard via `DistributedStore.builder()`.
 
 ## Mixed Stores
 
@@ -54,19 +54,19 @@ HarnessAgent.builder()
 
 ## Components
 
-### AgentStateStore — Agent State Persistence
+### AgentStateStore - Agent State Persistence
 
 Conversation context, compaction summaries, permission rules, Plan Mode state, addressed by `(userId, sessionId)`. Auto-wired by `distributedStore`; can be overridden via `.stateStore(...)`.
 
-### BaseStore — Workspace Filesystem KV
+### BaseStore - Workspace Filesystem KV
 
 Storage provider for `RemoteFilesystemSpec`, routing `MEMORY.md`, `memory/`, `skills/`, `sessions/` to shared KV storage. Auto-injected into `RemoteFilesystemSpec` when using the no-arg constructor.
 
-### SandboxSnapshotSpec — Sandbox Snapshots
+### SandboxSnapshotSpec - Sandbox Snapshots
 
 Persists Docker/K8s sandbox workspace as tar archives for cross-call recovery. Auto-wired into `SandboxFilesystemSpec` by `distributedStore`.
 
-### SandboxExecutionGuard — Sandbox Concurrency Lock
+### SandboxExecutionGuard - Sandbox Concurrency Lock
 
 Distributed lock for `AGENT` / `GLOBAL` isolation scope under multi-replica deployment. Auto-wired into `SandboxFilesystemSpec` by `distributedStore`.
 
@@ -80,6 +80,6 @@ Explicit builder methods (.stateStore(), .snapshotSpec() on FilesystemSpec, etc.
 
 ## Store Documentation
 
-- [Redis](redis.md) — full capability coverage, recommended for multi-replica production
-- [MySQL / JDBC](mysql.md) — for existing relational database infrastructure
-- [Alibaba Cloud OSS](oss.md) — object storage, best for large-capacity snapshots
+- [Redis](redis.md) - full capability coverage, recommended for multi-replica production
+- [MySQL / JDBC](mysql.md) - for existing relational database infrastructure
+- [S3-Compatible Object Storage](oss.md) - object storage, best for large-capacity snapshots

--- a/docs/v2/en/integration/distributed/oss.md
+++ b/docs/v2/en/integration/distributed/oss.md
@@ -1,6 +1,6 @@
-# Alibaba Cloud OSS
+# S3-Compatible Object Storage
 
-`agentscope-extensions-oss` provides distributed storage backed by Alibaba Cloud Object Storage Service (OSS), ideal for large-capacity data and Alibaba Cloud ecosystems.
+`agentscope-extensions-oss` provides distributed storage backed by S3-compatible object storage such as MinIO, AWS S3, or Alibaba Cloud OSS.
 
 ## Dependency
 
@@ -17,55 +17,29 @@
 ```java
 import io.agentscope.extensions.oss.OssDistributedStore;
 
-OSS ossClient = new OSSClientBuilder().build(endpoint, accessKeyId, accessKeySecret);
-DistributedStore store = OssDistributedStore.create(ossClient, "my-bucket", "agentscope/");
-
-HarnessAgent agent = HarnessAgent.builder()
-    .distributedStore(store)
-    .filesystem(new RemoteFilesystemSpec()
-            .isolationScope(IsolationScope.USER))
-    .build();
+OssDistributedStore store = OssDistributedStore.create(
+    "http://localhost:9000",
+    "minioadmin",
+    "minioadmin",
+    "my-bucket",
+    "agentscope/");
 ```
 
 ## Components Provided
 
 ### 1. OssAgentStateStore
 
-Agent state persisted to OSS objects.
+Agent state persisted to object storage objects.
 
 ### 2. OssBaseStore
 
-Workspace filesystem KV storage to OSS objects.
+Workspace filesystem KV storage to object storage objects.
 
 ### 3. OssSnapshotSpec
 
-Sandbox snapshots to OSS — the best choice for large workspace archives.
-
-### Not Provided: SandboxExecutionGuard
-
-Object storage is unsuitable for distributed locking. Mix in a Redis guard:
-
-```java
-DistributedStore ossStore = OssDistributedStore.create(ossClient, "my-bucket", "agentscope/");
-
-DistributedStore mixed = DistributedStore.builder()
-    .agentStateStore(ossStore.agentStateStore())
-    .baseStore(ossStore.baseStore())
-    .sandboxSnapshotSpec(ossStore.sandboxSnapshotSpec())
-    .sandboxExecutionGuard(RedisDistributedStore.fromJedis(jedis).sandboxExecutionGuard())
-    .build();
-```
-
-## When to Use
-
-| Scenario | Recommendation |
-|----------|---------------|
-| Large snapshots (>100MB workspaces) | **First choice**: OSS |
-| Alibaba Cloud ecosystem | OSS |
-| Need sandbox concurrency lock | Mix OSS + Redis |
-| Lowest latency | Redis |
+Sandbox snapshots stored in object storage.
 
 ## Security
 
-- Use RAM Role + STS temporary credentials in production — avoid hardcoded AK/SK
-- Configure bucket lifecycle rules (e.g. 7-day auto-expiry) to control storage costs
+- Use short-lived credentials in production when possible.
+- Configure bucket lifecycle rules to control storage costs.

--- a/docs/v2/en/integration/distributed/oss.md
+++ b/docs/v2/en/integration/distributed/oss.md
@@ -1,6 +1,6 @@
 # S3-Compatible Object Storage
 
-`agentscope-extensions-oss` provides distributed storage backed by S3-compatible object storage such as MinIO, AWS S3, or Alibaba Cloud OSS.
+`agentscope-extensions-oss` provides distributed storage backed by S3-compatible object storage such as MinIO, AWS S3, or Alibaba Cloud OSS. It uses the AWS SDK `S3Client` against an S3-compatible endpoint, so it is a compatibility layer for S3-style object storage rather than a direct Alibaba Cloud OSS SDK wrapper.
 
 ## Dependency
 

--- a/docs/v2/en/integration/overview.md
+++ b/docs/v2/en/integration/overview.md
@@ -1,6 +1,6 @@
 # Integration Overview
 
-This section collects the AgentScope Java extensions that connect to third-party systems and ecosystem services. Each extension is an independent Maven module under `agentscope-extensions/` — pull in only what you need.
+This section collects the AgentScope Java extensions that connect to third-party systems and ecosystem services. Each extension is an independent Maven module under `agentscope-extensions/` - pull in only what you need.
 
 The extensions are grouped by topic:
 
@@ -8,20 +8,20 @@ The extensions are grouped by topic:
 
 Full-stack distributed storage components for multi-replica production deployments. Configure agent state, workspace filesystem, sandbox snapshots, and concurrency locks with a single `DistributedStore`.
 
-- [Distributed Storage Overview](distributed/index.md) — `DistributedStore` API, capability matrix, mixed stores
-- [Redis](distributed/redis.md) — `AgentStateStore` + `BaseStore` + `SandboxSnapshotSpec` + `SandboxExecutionGuard`
-- [MySQL / JDBC](distributed/mysql.md) — `AgentStateStore` + `JdbcStore` + `JdbcSnapshotSpec` + `JdbcSandboxExecutionGuard`
-- [Alibaba Cloud OSS](distributed/oss.md) — `AgentStateStore` + `OssBaseStore` + `OssSnapshotSpec`
+- [Distributed Storage Overview](distributed/index.md) - `DistributedStore` API, capability matrix, mixed stores
+- [Redis](distributed/redis.md) - `AgentStateStore` + `BaseStore` + `SandboxSnapshotSpec` + `SandboxExecutionGuard`
+- [MySQL / JDBC](distributed/mysql.md) - `AgentStateStore` + `JdbcStore` + `JdbcSnapshotSpec` + `JdbcSandboxExecutionGuard`
+- [S3-Compatible Object Storage](distributed/oss.md) - `AgentStateStore` + `OssBaseStore` + `OssSnapshotSpec`
 
 ## Sandbox Execution Environments
 
 Isolated code execution stores. Docker is built-in; the rest are standalone extension modules.
 
-- Docker — built-in default, no extra dependency
-- [Kubernetes](../docs/harness/sandbox.md) — `agentscope-extensions-sandbox-kubernetes`
-- [AgentRun (Alibaba Cloud)](../docs/harness/sandbox.md) — `agentscope-extensions-sandbox-agentrun`
-- [Daytona](../docs/harness/sandbox.md) — `agentscope-extensions-sandbox-daytona`
-- [E2B](../docs/harness/sandbox.md) — `agentscope-extensions-sandbox-e2b`
+- Docker - built-in default, no extra dependency
+- [Kubernetes](../docs/harness/sandbox.md) - `agentscope-extensions-sandbox-kubernetes`
+- [AgentRun (Alibaba Cloud)](../docs/harness/sandbox.md) - `agentscope-extensions-sandbox-agentrun`
+- [Daytona](../docs/harness/sandbox.md) - `agentscope-extensions-sandbox-daytona`
+- [E2B](../docs/harness/sandbox.md) - `agentscope-extensions-sandbox-e2b`
 
 ## Memory
 

--- a/docs/v2/en/integration/session/oss.md
+++ b/docs/v2/en/integration/session/oss.md
@@ -1,10 +1,10 @@
 ```{note}
-This page has been superseded by [Distributed Storage — OSS](../distributed/oss.md). Content below is kept for reference.
+This page has been superseded by [Distributed Storage - S3-Compatible Object Storage](../distributed/oss.md). Content below is kept for reference.
 ```
 
-# OSS State Store
+# Object Storage State Store
 
-`agentscope-extensions-oss` persists AgentScope agent state in Alibaba Cloud Object Storage Service (OSS). Ideal for large-capacity data and Alibaba Cloud ecosystems.
+`agentscope-extensions-oss` persists AgentScope agent state in S3-compatible object storage.
 
 ## Add the dependency
 
@@ -19,47 +19,24 @@ This page has been superseded by [Distributed Storage — OSS](../distributed/os
 ## Quickstart
 
 ```java
-import com.aliyun.oss.OSS;
-import com.aliyun.oss.OSSClientBuilder;
 import io.agentscope.core.state.AgentStateStore;
 import io.agentscope.extensions.oss.OssAgentStateStore;
+import software.amazon.awssdk.services.s3.S3Client;
 
-OSS ossClient = new OSSClientBuilder().build(endpoint, accessKeyId, accessKeySecret);
+S3Client s3Client = S3Client.builder().build();
 
 AgentStateStore stateStore = OssAgentStateStore.builder()
-    .ossClient(ossClient)
+    .s3Client(s3Client)
     .bucketName("my-agentscope-bucket")
     .keyPrefix("agentscope/state/")
     .build();
-
-ReActAgent agent = ReActAgent.builder()
-    .name("assistant")
-    .model(model)
-    .stateStore(stateStore)
-    .build();
 ```
-
-## Key layout
-
-The `(userId, sessionId)` pair is packed into OSS object paths:
-
-| Type | Key pattern |
-| --- | --- |
-| Single value | `{keyPrefix}{userId}/{sessionId}/{stateKey}.json` |
-| List | `{keyPrefix}{userId}/{sessionId}/{stateKey}.list.json` |
-| List hash | `{keyPrefix}{userId}/{sessionId}/{stateKey}.list.hash` (change detection) |
-
-Anonymous sessions (`userId` is null) use `__anon__` as the user segment.
 
 ## Builder reference
 
 | Method | Notes |
 | --- | --- |
-| `ossClient(OSS)` | Required. Alibaba Cloud OSS client |
-| `bucketName(String)` | Required. OSS bucket name |
+| `s3Client(S3Client)` | Required. S3-compatible client |
+| `ossClient(S3Client)` | Backwards-compatible alias |
+| `bucketName(String)` | Required. bucket name |
 | `keyPrefix(String)` | Default `agentscope/state/` |
-
-## Security
-
-- Use RAM Role + STS temporary credentials in production — avoid hardcoded AK/SK
-- Configure bucket lifecycle rules (e.g. 7-day auto-expiry) to control storage costs

--- a/docs/v2/en/integration/session/overview.md
+++ b/docs/v2/en/integration/session/overview.md
@@ -1,15 +1,15 @@
 # Agent State Store (AgentStateStore)
 
 ```{note}
-**Recommended: use [DistributedStore](../distributed/index.md) for one-line setup** — it covers AgentStateStore, BaseStore, SandboxSnapshotSpec, and SandboxExecutionGuard together. Read on if you only need to configure AgentStateStore individually.
+**Recommended: use [DistributedStore](../distributed/index.md) for one-line setup** - it covers AgentStateStore, BaseStore, SandboxSnapshotSpec, and SandboxExecutionGuard together. Read on if you only need to configure AgentStateStore individually.
 ```
 
-`io.agentscope.core.state.AgentStateStore` is the interface AgentScope uses to persist agent state — Memory, Workspace, Plan, and other components are serialized as `State` objects and stored via `AgentStateStore`, enabling restart recovery and cross-node sharing.
+`io.agentscope.core.state.AgentStateStore` is the interface AgentScope uses to persist agent state - Memory, Workspace, Plan, and other components are serialized as `State` objects and stored via `AgentStateStore`, enabling restart recovery and cross-node sharing.
 
 State is addressed by `(userId, sessionId)`:
 
-- `sessionId` — required, non-blank, identifies a session.
-- `userId` — optional. `null` means anonymous / single-tenant (CLI, tests, etc.).
+- `sessionId` - required, non-blank, identifies a session.
+- `userId` - optional. `null` means anonymous / single-tenant (CLI, tests, etc.).
 
 ## Available Implementations
 
@@ -19,7 +19,7 @@ State is addressed by `(userId, sessionId)`:
 | `JsonFileAgentStateStore` | `agentscope-core` | Single-node dev (**HarnessAgent default**) |
 | `RedisAgentStateStore` | `agentscope-extensions-redis` | [Multi-replica production default](../distributed/redis.md) |
 | `MysqlAgentStateStore` | `agentscope-extensions-mysql` | [Existing database infrastructure](../distributed/mysql.md) |
-| `OssAgentStateStore` | `agentscope-extensions-oss` | [Alibaba Cloud ecosystem](../distributed/oss.md) |
+| `OssAgentStateStore` | `agentscope-extensions-oss` | [S3-compatible object storage](../distributed/oss.md) |
 
 ## Standalone Configuration
 


### PR DESCRIPTION
## AgentScope-Java Version
2.0.0-SNAPSHOT

## Description
This PR updates the OSS extension to use AWS SDK v2 S3-compatible storage, centralizes the object-store helper logic, adds tests, and updates the docs to describe the module as S3-compatible object storage support rather than Alibaba OSS-only support.

The OSS module was using the Alibaba Cloud OSS SDK, which is not compatible with MinIO and other generic S3-compatible stores in this project scenario. This PR switches the storage layer to AWS SDK v2 `S3Client` and keeps the existing `Oss*` API surface so downstream code can keep working.

### How this fixes the issue
- Replace Alibaba OSS calls with S3-compatible operations for put/get/list/delete.
- Add `S3ObjectStoreSupport` to centralize shared S3 object-store logic.
- Update `OssAgentStateStore`, `OssBaseStore`, `OssDistributedStore`, `OssRemoteSnapshotClient`, and `OssSnapshotSpec` to use the new S3-backed implementation.
- Keep `ossClient(...)` as a backwards-compatible builder alias, so existing callers do not need to change immediately.
- Update docs and tests to show MinIO / S3-compatible usage.
- Fix `.list.json` entries being picked up as regular filesystem items, and make truncated-list handling null-safe in tests.

### Verification
- `mvn -s codex-settings.xml -pl agentscope-extensions/agentscope-extensions-oss test -DskipITs`
- `mvn -s codex-settings.xml -pl agentscope-extensions/agentscope-extensions-oss -DskipTests test-compile`

Fixes #1795

## Checklist
- [x] Code has been formatted with `mvn spotless:apply`
- [x] All tests are passing (`mvn test`)
- [x] Javadoc comments are complete and follow project conventions
- [x] Related documentation has been updated (e.g. links, examples, etc.)
- [x] Code is ready for review