### PR TITLE
feat(state): add spawn registry to ToolContextState for managing subagent.

### DIFF
--- a/agentscope-core/src/main/java/io/agentscope/core/state/ToolContextState.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/state/ToolContextState.java
@@ -26,7 +26,9 @@ import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Schedulers;
@@ -43,13 +45,14 @@ import reactor.core.scheduler.Schedulers;
  * {@code activatedGroups}) participate in JSON serialization. The in-memory LRU cache itself is
  * runtime state and is reconstructed empty on deserialization.
  */
-@JsonPropertyOrder({"max_cache_files", "max_cache_bytes", "activated_groups"})
+@JsonPropertyOrder({"max_cache_files", "max_cache_bytes", "activated_groups", "spawn_registry"})
 public final class ToolContextState {
 
     private final int maxCacheFiles;
     private final double maxCacheBytes;
     private final List<ReadCacheEntry> readFileCache = new ArrayList<>();
     private final List<String> activatedGroups;
+    private final Map<String, SpawnEntry> spawnRegistry;
 
     private ToolContextState(Builder builder) {
         if (builder.maxCacheFiles <= 1) {
@@ -61,13 +64,15 @@ public final class ToolContextState {
         this.maxCacheFiles = builder.maxCacheFiles;
         this.maxCacheBytes = builder.maxCacheBytes;
         this.activatedGroups = new ArrayList<>(builder.activatedGroups);
+        this.spawnRegistry = new LinkedHashMap<>(builder.spawnRegistry);
     }
 
     @JsonCreator
     static ToolContextState fromJson(
             @JsonProperty("max_cache_files") Integer maxCacheFiles,
             @JsonProperty("max_cache_bytes") Double maxCacheBytes,
-            @JsonProperty("activated_groups") List<String> activatedGroups) {
+            @JsonProperty("activated_groups") List<String> activatedGroups,
+            @JsonProperty("spawn_registry") Map<String, SpawnEntry> spawnRegistry) {
         Builder b = builder();
         if (maxCacheFiles != null) {
             b.maxCacheFiles(maxCacheFiles);
@@ -77,6 +82,9 @@ public final class ToolContextState {
         }
         if (activatedGroups != null) {
             activatedGroups.forEach(b::addActivatedGroup);
+        }
+        if (spawnRegistry != null) {
+            b.spawnRegistry.putAll(spawnRegistry);
         }
         return b.build();
     }
@@ -113,6 +121,59 @@ public final class ToolContextState {
         this.activatedGroups.clear();
         if (groups != null) {
             this.activatedGroups.addAll(groups);
+        }
+    }
+
+    @JsonProperty("spawn_registry")
+    public Map<String, SpawnEntry> getSpawnRegistry() {
+        return Map.copyOf(spawnRegistry);
+    }
+
+    /**
+     * Register a spawned subagent entry so it survives session restore and cross-replica routing.
+     *
+     * @param key the agent key (e.g. {@code agent:general-purpose:uuid})
+     * @param entry the serializable spawn metadata
+     */
+    public void putSpawnEntry(String key, SpawnEntry entry) {
+        if (key != null && entry != null) {
+            this.spawnRegistry.put(key, entry);
+        }
+    }
+
+    /**
+     * Remove a spawn entry by key.
+     */
+    public void removeSpawnEntry(String key) {
+        if (key != null) {
+            this.spawnRegistry.remove(key);
+        }
+    }
+
+    /**
+     * Serializable metadata for a spawned subagent, persisted alongside the parent agent's state
+     * so that {@code agent_send} can lazily rebuild the live {@code Agent} instance after session
+     * restore or on a different replica.
+     */
+    public record SpawnEntry(
+            @JsonProperty("key") String key,
+            @JsonProperty("agent_id") String agentId,
+            @JsonProperty("session_id") String sessionId,
+            @JsonProperty("label") String label,
+            @JsonProperty("depth") int depth) {
+
+        @JsonCreator
+        public SpawnEntry(
+                @JsonProperty("key") String key,
+                @JsonProperty("agent_id") String agentId,
+                @JsonProperty("session_id") String sessionId,
+                @JsonProperty("label") String label,
+                @JsonProperty("depth") int depth) {
+            this.key = key;
+            this.agentId = agentId;
+            this.sessionId = sessionId;
+            this.label = label;
+            this.depth = depth;
         }
     }
 
@@ -205,6 +266,7 @@ public final class ToolContextState {
         private int maxCacheFiles = 100;
         private double maxCacheBytes = 25_000;
         private final List<String> activatedGroups = new ArrayList<>();
+        private final Map<String, SpawnEntry> spawnRegistry = new LinkedHashMap<>();
 
         private Builder() {}
 

--- a/agentscope-core/src/test/java/io/agentscope/core/state/ToolContextStateTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/state/ToolContextStateTest.java
@@ -16,13 +16,18 @@
 package io.agentscope.core.state;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import io.agentscope.core.util.JsonUtils;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.attribute.FileTime;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import org.junit.jupiter.api.Test;
@@ -176,5 +181,102 @@ class ToolContextStateTest {
 
         // All 30 entries should fit under the 50-file cap
         assertEquals(30, ctx.getReadFileCache().size());
+    }
+
+    // ==================== Spawn Registry Tests ====================
+
+    @Test
+    void spawnRegistryDefaultsToEmpty() {
+        ToolContextState ctx = ToolContextState.builder().build();
+        assertNotNull(ctx.getSpawnRegistry());
+        assertTrue(ctx.getSpawnRegistry().isEmpty());
+    }
+
+    @Test
+    void putAndGetSpawnEntry() {
+        ToolContextState ctx = ToolContextState.builder().build();
+        ToolContextState.SpawnEntry entry =
+                new ToolContextState.SpawnEntry(
+                        "agent:gp:abc", "general-purpose", "sub-abc", "researcher", 1);
+
+        ctx.putSpawnEntry("agent:gp:abc", entry);
+
+        Map<String, ToolContextState.SpawnEntry> registry = ctx.getSpawnRegistry();
+        assertEquals(1, registry.size());
+        ToolContextState.SpawnEntry got = registry.get("agent:gp:abc");
+        assertNotNull(got);
+        assertEquals("general-purpose", got.agentId());
+        assertEquals("sub-abc", got.sessionId());
+        assertEquals("researcher", got.label());
+        assertEquals(1, got.depth());
+    }
+
+    @Test
+    void removeSpawnEntry() {
+        ToolContextState ctx = ToolContextState.builder().build();
+        ctx.putSpawnEntry(
+                "agent:gp:abc",
+                new ToolContextState.SpawnEntry(
+                        "agent:gp:abc", "general-purpose", "sub-abc", null, 1));
+
+        ctx.removeSpawnEntry("agent:gp:abc");
+        assertTrue(ctx.getSpawnRegistry().isEmpty());
+    }
+
+    @Test
+    void spawnEntryNullKeyIgnored() {
+        ToolContextState ctx = ToolContextState.builder().build();
+        ctx.putSpawnEntry(
+                null,
+                new ToolContextState.SpawnEntry(
+                        "agent:gp:abc", "general-purpose", "sub-abc", null, 1));
+        assertTrue(ctx.getSpawnRegistry().isEmpty());
+    }
+
+    @Test
+    void spawnRegistrySerializationRoundTrip() {
+        ToolContextState ctx = ToolContextState.builder().build();
+        ctx.putSpawnEntry(
+                "agent:gp:abc",
+                new ToolContextState.SpawnEntry(
+                        "agent:gp:abc", "general-purpose", "sub-abc", "researcher", 1));
+        ctx.putSpawnEntry(
+                "agent:coder:def",
+                new ToolContextState.SpawnEntry("agent:coder:def", "coder", "sub-def", null, 2));
+
+        String json = JsonUtils.getJsonCodec().toJson(ctx);
+        assertNotNull(json);
+        assertTrue(json.contains("spawn_registry"));
+        assertTrue(json.contains("general-purpose"));
+        assertTrue(json.contains("researcher"));
+
+        ToolContextState restored = JsonUtils.getJsonCodec().fromJson(json, ToolContextState.class);
+        assertNotNull(restored);
+        Map<String, ToolContextState.SpawnEntry> registry = restored.getSpawnRegistry();
+        assertEquals(2, registry.size());
+
+        ToolContextState.SpawnEntry e1 = registry.get("agent:gp:abc");
+        assertNotNull(e1);
+        assertEquals("general-purpose", e1.agentId());
+        assertEquals("sub-abc", e1.sessionId());
+        assertEquals("researcher", e1.label());
+        assertEquals(1, e1.depth());
+
+        ToolContextState.SpawnEntry e2 = registry.get("agent:coder:def");
+        assertNotNull(e2);
+        assertEquals("coder", e2.agentId());
+        assertNull(e2.label());
+        assertEquals(2, e2.depth());
+    }
+
+    @Test
+    void spawnRegistryBackwardCompatibility() {
+        String jsonWithoutRegistry =
+                "{\"max_cache_files\":100,\"max_cache_bytes\":25000.0,\"activated_groups\":[]}";
+        ToolContextState restored =
+                JsonUtils.getJsonCodec().fromJson(jsonWithoutRegistry, ToolContextState.class);
+        assertNotNull(restored);
+        assertNotNull(restored.getSpawnRegistry());
+        assertTrue(restored.getSpawnRegistry().isEmpty());
     }
 }

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/tool/AgentSpawnTool.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/tool/AgentSpawnTool.java
@@ -290,6 +290,7 @@ public class AgentSpawnTool {
         if (canonLabel != null) {
             labelToKey.put(canonLabel.toLowerCase(), key);
         }
+        persistSpawnEntry(parentState, key, agentId, sessionId, canonLabel, nextDepth);
 
         // Propagate plan mode: if parent is in plan mode, force child into read-only mode too.
         if (parentState != null
@@ -422,6 +423,7 @@ public class AgentSpawnTool {
 
     @Tool(
             name = "agent_send",
+            stateInjected = true,
             description =
                     """
                     Send a message to an existing subagent. Use the exact string from the \
@@ -431,6 +433,7 @@ public class AgentSpawnTool {
                     """)
     public Mono<String> agentSend(
             RuntimeContext runtimeContext,
+            AgentState parentState,
             @ToolParam(
                             name = "agent_key",
                             description =
@@ -476,14 +479,21 @@ public class AgentSpawnTool {
         } else {
             key = labelToKey.get(label.trim().toLowerCase());
             if (key == null) {
+                key = tryResolveLabelFromState(parentState, label.trim());
+            }
+            if (key == null) {
                 return Mono.just("Error: Unknown label: " + label.trim());
             }
         }
 
-        SpawnedAgent spawned = agentsByKey.get(key);
-        if (spawned == null) {
+        SpawnedAgent resolved = agentsByKey.get(key);
+        if (resolved == null) {
+            resolved = tryRestoreFromState(parentState, key, runtimeContext);
+        }
+        if (resolved == null) {
             return Mono.just("Error: Unknown agent_key: " + key);
         }
+        final SpawnedAgent spawned = resolved;
 
         long timeoutMs = resolveTimeoutMs(timeoutSeconds, DEFAULT_TIMEOUT_SECONDS);
         String currentUserId = runtimeContext != null ? runtimeContext.getUserId() : null;
@@ -790,6 +800,73 @@ public class AgentSpawnTool {
             log.warn("agent execution failed: agentId={}", agentId, reportable);
             sink.success(header + "\nstatus: error\nerror: " + errStr);
         }
+    }
+
+    private void persistSpawnEntry(
+            AgentState parentState,
+            String key,
+            String agentId,
+            String sessionId,
+            String label,
+            int depth) {
+        if (parentState == null) {
+            return;
+        }
+        parentState
+                .getToolContext()
+                .putSpawnEntry(
+                        key,
+                        new io.agentscope.core.state.ToolContextState.SpawnEntry(
+                                key, agentId, sessionId, label, depth));
+    }
+
+    private String tryResolveLabelFromState(AgentState parentState, String label) {
+        if (parentState == null) {
+            return null;
+        }
+        String lowerLabel = label.toLowerCase();
+        for (io.agentscope.core.state.ToolContextState.SpawnEntry entry :
+                parentState.getToolContext().getSpawnRegistry().values()) {
+            if (entry.label() != null && entry.label().toLowerCase().equals(lowerLabel)) {
+                return entry.key();
+            }
+        }
+        return null;
+    }
+
+    private SpawnedAgent tryRestoreFromState(
+            AgentState parentState, String key, RuntimeContext runtimeContext) {
+        if (parentState == null) {
+            return null;
+        }
+        io.agentscope.core.state.ToolContextState.SpawnEntry entry =
+                parentState.getToolContext().getSpawnRegistry().get(key);
+        if (entry == null) {
+            return null;
+        }
+        Optional<Agent> agentOpt =
+                agentManager.createAgentIfPresent(entry.agentId(), runtimeContext);
+        if (agentOpt.isEmpty()) {
+            log.warn(
+                    "Failed to restore subagent from state: agentId={} not found in registry",
+                    entry.agentId());
+            return null;
+        }
+        SpawnedAgent restored =
+                new SpawnedAgent(
+                        key,
+                        entry.agentId(),
+                        entry.sessionId(),
+                        entry.label(),
+                        agentOpt.get(),
+                        entry.depth());
+        agentsByKey.put(key, restored);
+        if (entry.label() != null) {
+            labelToKey.put(entry.label().toLowerCase(), key);
+        }
+        log.info(
+                "Restored subagent from persisted state: key={}, agentId={}", key, entry.agentId());
+        return restored;
     }
 
     private static String textOf(Msg msg) {


### PR DESCRIPTION
This pull request introduces a persistent spawn registry to the `ToolContextState`, allowing spawned subagent metadata to be serialized, restored, and used for cross-replica routing and session recovery. 

It updates both the core state model and the agent harness to support registering, looking up, and restoring subagents from state, and adds comprehensive tests to ensure correct behavior and backward compatibility.

### Core State Model: Persistent Spawn Registry

* Added a `spawnRegistry` field to `ToolContextState`, with serialization/deserialization support and a new `SpawnEntry` 

### Agent Harness: Subagent Registration and Restoration

* Modified `AgentSpawnTool` to persist subagent spawn entries in the parent's `ToolContextState` on spawn, and to restore subagents from state if not found in memory during `agent_send`. 
