### PR TITLE
feat(core): add DynamicSkillMiddleware factory to ReActAgent.Builder

### DIFF
--- a/agentscope-core/src/main/java/io/agentscope/core/ReActAgent.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/ReActAgent.java
@@ -3627,6 +3627,21 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
          */
         private Path skillWorkDir;
 
+        /**
+         * Optional factory for custom {@link DynamicSkillMiddleware} subclass. When set, the
+         * factory is invoked inside {@link #build()} with the deep-copied {@link Toolkit} so the
+         * custom middleware shares the same toolkit instance used by the agent.
+         *
+         * <p>This is useful when you need a middleware that calls the agent's toolkit for
+         * per-request tool registration (e.g. binding skill-load tools). By receiving the
+         * deep-copied toolkit directly, the custom middleware avoids the state-mismatch problem
+         * of constructing the middleware externally before {@code build()} runs.
+         *
+         * <p>When {@code null} (the default), {@link #build()} creates a standard
+         * {@link DynamicSkillMiddleware} if skill repositories have been registered.
+         */
+        private Function<Toolkit, DynamicSkillMiddleware> dynamicSkillMiddlewareFactory;
+
         private Builder() {}
 
         /**
@@ -4153,6 +4168,33 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
         }
 
         /**
+         * Provides a factory that creates a custom {@link DynamicSkillMiddleware} instance inside
+         * {@link #build()} instead of the default. The factory receives the deep-copied
+         * {@link Toolkit} that the agent will use, so custom subclasses can safely reference it.
+         *
+         * <p>Example usage:
+         * <pre>{@code
+         * ReActAgent.builder()
+         *     .dynamicSkillMiddleware(agentToolkit ->
+         *             new MyCustomMiddleware(skillRepos, agentToolkit, skillFilter))
+         *     .build();
+         * }</pre>
+         *
+         * <p>When this factory is set, the builder's own {@code skillRepositories} list is
+         * ignored — the factory is fully responsible for providing the middleware. Pass
+         * {@code null} (the default) to let {@link #build()} create a standard
+         * {@link DynamicSkillMiddleware} from the registered skill repositories.
+         *
+         * @param factory a function that accepts the deep-copied {@link Toolkit} and returns a
+         *                {@link DynamicSkillMiddleware} instance; may be {@code null}
+         * @return this builder instance for method chaining
+         */
+        public Builder dynamicSkillMiddleware(Function<Toolkit, DynamicSkillMiddleware> factory) {
+            this.dynamicSkillMiddlewareFactory = factory;
+            return this;
+        }
+
+        /**
          * Returns a new {@link Builder} pre-populated with the given agent's observable
          * configuration: name, description, system prompt, model, maxIters, generateOptions, and
          * a defensive copy of the toolkit.
@@ -4329,14 +4371,22 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
             if (skillBox != null) {
                 configureSkillBox(agentToolkit);
             }
-            if (!skillRepositories.isEmpty() && dynamicSkillsEnabled) {
-                middlewares.add(
-                        new DynamicSkillMiddleware(
-                                List.copyOf(skillRepositories),
-                                agentToolkit,
-                                skillFilter != null ? skillFilter : SkillFilter.all(),
-                                skillCodeExecutionEnabled,
-                                skillWorkDir));
+            if (dynamicSkillsEnabled) {
+                DynamicSkillMiddleware mw = null;
+                if (dynamicSkillMiddlewareFactory != null) {
+                    mw = dynamicSkillMiddlewareFactory.apply(agentToolkit);
+                } else if (!skillRepositories.isEmpty()) {
+                    mw =
+                            new DynamicSkillMiddleware(
+                                    List.copyOf(skillRepositories),
+                                    agentToolkit,
+                                    skillFilter != null ? skillFilter : SkillFilter.all(),
+                                    skillCodeExecutionEnabled,
+                                    skillWorkDir);
+                }
+                if (mw != null) {
+                    middlewares.add(mw);
+                }
             }
 
             ReActAgent agent = new ReActAgent(this, agentToolkit);

--- a/agentscope-core/src/test/java/io/agentscope/core/agent/ReActAgentNewLoopBuilderTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/agent/ReActAgentNewLoopBuilderTest.java
@@ -17,6 +17,7 @@ package io.agentscope.core.agent;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -29,6 +30,9 @@ import io.agentscope.core.model.ChatResponse;
 import io.agentscope.core.model.GenerateOptions;
 import io.agentscope.core.model.ToolSchema;
 import io.agentscope.core.shutdown.GracefulShutdownMiddleware;
+import io.agentscope.core.skill.DynamicSkillMiddleware;
+import io.agentscope.core.skill.SkillFilter;
+import io.agentscope.core.skill.repository.AgentSkillRepository;
 import io.agentscope.core.state.AgentState;
 import io.agentscope.core.tool.Toolkit;
 import java.util.List;
@@ -122,5 +126,46 @@ class ReActAgentNewLoopBuilderTest {
         StepVerifier.create(agent.observe(List.of(m2))).verifyComplete();
 
         assertEquals(2, agent.getAgentState().getContext().size());
+    }
+
+    @Test
+    void dynamicSkillMiddlewareFactoryReceivesDeepCopiedToolkit() {
+        Toolkit originalToolkit = new Toolkit();
+
+        class CapturingMiddleware extends DynamicSkillMiddleware {
+            final Toolkit capturedToolkit;
+
+            CapturingMiddleware(
+                    List<AgentSkillRepository> repos, Toolkit toolkit, SkillFilter filter) {
+                super(repos, toolkit, filter);
+                this.capturedToolkit = toolkit;
+            }
+        }
+
+        ReActAgent agent =
+                ReActAgent.builder()
+                        .name("test")
+                        .sysPrompt("sys")
+                        .model(newFakeModel())
+                        .toolkit(originalToolkit)
+                        .dynamicSkillMiddleware(
+                                agentToolkit -> {
+                                    CapturingMiddleware mw =
+                                            new CapturingMiddleware(
+                                                    List.of(), agentToolkit, SkillFilter.all());
+                                    return mw;
+                                })
+                        .build();
+
+        List<MiddlewareBase> mws = agent.getMiddlewares();
+        CapturingMiddleware mw =
+                (CapturingMiddleware)
+                        mws.stream()
+                                .filter(m -> m instanceof CapturingMiddleware)
+                                .findFirst()
+                                .orElseThrow(() -> new AssertionError("factory not invoked"));
+
+        assertNotSame(originalToolkit, mw.capturedToolkit);
+        assertSame(agent.getToolkit(), mw.capturedToolkit);
     }
 }


### PR DESCRIPTION
## AgentScope-Java Version

2.0.0-SNAPSHOT

## Description

### Background

When building a `ReActAgent` with a custom subclass of `DynamicSkillMiddleware` (e.g. `CustomAwareSkillMiddleware`), the custom middleware must be constructed externally and passed via `.middleware(...)`. However, `ReActAgent.Builder.build()` internally deep-copies the `Toolkit` (`Toolkit agentToolkit = this.toolkit.copy()`) and registers hooks/meta-tools on the copy. The externally constructed middleware holds a reference to the original (pre-copy) `Toolkit`, while the agent uses the deep-copied `agentToolkit` — creating a state mismatch.

### Changes Made

Added a `dynamicSkillMiddleware(Function<Toolkit, DynamicSkillMiddleware>)` method to `ReActAgent.Builder` that accepts a factory function. The factory is invoked inside `build()` with the deep-copied `agentToolkit`, so custom subclasses receive the exact same `Toolkit` instance used by the agent.

- New field: `Function<Toolkit, DynamicSkillMiddleware> dynamicSkillMiddlewareFactory`
- New builder method: `Builder dynamicSkillMiddleware(Function<Toolkit, DynamicSkillMiddleware> factory)`
- Modified `build()`: when `dynamicSkillMiddlewareFactory` is set, it takes precedence over the default `DynamicSkillMiddleware` construction; otherwise the existing behavior is preserved.

### How to Test

1. Create a custom `DynamicSkillMiddleware` subclass
2. Use the new builder method:
   ```java
   ReActAgent.builder()
       .dynamicSkillMiddleware(agentToolkit ->
               new MyCustomMiddleware(repositories, agentToolkit, filter))
       .build();
   ```
3. Verify the middleware receives the deep-copied toolkit (same instance as the agent's internal toolkit)

## Checklist

- [x] Code has been formatted with `mvn spotless:apply`
- [x] All tests are passing (`mvn test`)
- [x] Javadoc comments are complete and follow project conventions
- [ ] Related documentation has been updated (e.g. links, examples, etc.)
- [x] Code is ready for review