### PR TITLE
fix(core): fix ReActAgent stream event block end ordering

### DIFF
--- a/agentscope-core/src/main/java/io/agentscope/core/ReActAgent.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/ReActAgent.java
@@ -2224,10 +2224,10 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
             }
 
             private void flushAllToolCalls(List<AgentEvent> events) {
-                for (Map.Entry<String, String> tc : new ArrayList<>(startedToolCalls.entrySet())) {
+                for (Map.Entry<String, String> tc : startedToolCalls.entrySet()) {
                     events.add(new ToolCallEndEvent(replyId, tc.getKey(), tc.getValue()));
-                    startedToolCalls.remove(tc.getKey());
                 }
+                startedToolCalls.clear();
             }
 
             private void flushAll(List<AgentEvent> events) {

--- a/agentscope-core/src/main/java/io/agentscope/core/ReActAgent.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/ReActAgent.java
@@ -2091,9 +2091,7 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
                 ReasoningContext context, ModelCallInput mci, boolean withToolEvents) {
 
             String replyId = UUID.randomUUID().toString().replace("-", "");
-            AtomicBoolean textStarted = new AtomicBoolean(false);
-            AtomicBoolean thinkingStarted = new AtomicBoolean(false);
-            Map<String, String> startedToolCalls = new ConcurrentHashMap<>();
+            ModelCallBlockLifecycle blockLifecycle = new ModelCallBlockLifecycle(replyId);
 
             Flux<AgentEvent> modelEvents =
                     mci.model().stream(mci.messages(), mci.tools(), mci.options())
@@ -2114,13 +2112,9 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
                                         for (ContentBlock block : chunk.getContent()) {
                                             emitBlockEvents(
                                                     block,
-                                                    replyId,
                                                     context,
-                                                    textStarted,
-                                                    thinkingStarted,
-                                                    withToolEvents
-                                                            ? startedToolCalls
-                                                            : new ConcurrentHashMap<>(),
+                                                    blockLifecycle,
+                                                    withToolEvents,
                                                     events);
                                         }
                                         return Flux.fromIterable(events);
@@ -2130,17 +2124,7 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
                     Flux.defer(
                             () -> {
                                 List<AgentEvent> events = new ArrayList<>();
-                                if (textStarted.get()) {
-                                    events.add(new TextBlockEndEvent(replyId, "text"));
-                                }
-                                if (thinkingStarted.get()) {
-                                    events.add(new ThinkingBlockEndEvent(replyId, "thinking"));
-                                }
-                                for (Map.Entry<String, String> tc : startedToolCalls.entrySet()) {
-                                    events.add(
-                                            new ToolCallEndEvent(
-                                                    replyId, tc.getKey(), tc.getValue()));
-                                }
+                                blockLifecycle.flushAll(events);
                                 events.add(new ModelCallEndEvent(replyId, context.getChatUsage()));
                                 return Flux.fromIterable(events);
                             });
@@ -2150,43 +2134,106 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
 
         private void emitBlockEvents(
                 ContentBlock block,
-                String replyId,
                 ReasoningContext context,
-                AtomicBoolean textStarted,
-                AtomicBoolean thinkingStarted,
-                Map<String, String> startedToolCalls,
+                ModelCallBlockLifecycle blockLifecycle,
+                boolean withToolEvents,
                 List<AgentEvent> events) {
 
             if (block instanceof TextBlock tb) {
-                if (textStarted.compareAndSet(false, true)) {
-                    events.add(new TextBlockStartEvent(replyId, "text"));
-                }
+                blockLifecycle.startText(events);
                 if (tb.getText() != null && !tb.getText().isEmpty()) {
-                    events.add(new TextBlockDeltaEvent(replyId, "text", tb.getText()));
+                    events.add(
+                            new TextBlockDeltaEvent(blockLifecycle.replyId, "text", tb.getText()));
                 }
             } else if (block instanceof ThinkingBlock tb) {
-                if (thinkingStarted.compareAndSet(false, true)) {
-                    events.add(new ThinkingBlockStartEvent(replyId, "thinking"));
-                }
+                blockLifecycle.startThinking(events);
                 if (tb.getThinking() != null && !tb.getThinking().isEmpty()) {
-                    events.add(new ThinkingBlockDeltaEvent(replyId, "thinking", tb.getThinking()));
+                    events.add(
+                            new ThinkingBlockDeltaEvent(
+                                    blockLifecycle.replyId, "thinking", tb.getThinking()));
                 }
-            } else if (block instanceof ToolUseBlock tub) {
+            } else if (withToolEvents && block instanceof ToolUseBlock tub) {
                 String toolId = resolveToolCallId(tub, context);
                 String toolName = tub.getName();
-                if (toolId != null && startedToolCalls.putIfAbsent(toolId, toolName) == null) {
-                    if (toolName != null && !toolName.startsWith("__")) {
-                        events.add(new ToolCallStartEvent(replyId, toolId, toolName));
-                    }
-                }
+                blockLifecycle.startToolCall(toolId, toolName, events);
                 if (tub.getContent() != null && !tub.getContent().isEmpty()) {
                     events.add(
                             new ToolCallDeltaEvent(
-                                    replyId,
+                                    blockLifecycle.replyId,
                                     toolId != null ? toolId : "",
                                     toolName,
                                     tub.getContent()));
                 }
+            }
+        }
+
+        /**
+         * Tracks block lifecycle within one model-call subscription.
+         *
+         * <p>The model stream is consumed through {@code concatMap}, but the state holders keep the
+         * previous thread-safe shape because model providers may deliver chunk content
+         * unpredictably. This helper only changes when pending end events are flushed; it does not
+         * change the block identity or event payloads.
+         */
+        private final class ModelCallBlockLifecycle {
+            private final String replyId;
+            private final AtomicBoolean textStarted = new AtomicBoolean(false);
+            private final AtomicBoolean thinkingStarted = new AtomicBoolean(false);
+            private final Map<String, String> startedToolCalls = new ConcurrentHashMap<>();
+
+            private ModelCallBlockLifecycle(String replyId) {
+                this.replyId = replyId;
+            }
+
+            private void startText(List<AgentEvent> events) {
+                flushThinking(events);
+                if (textStarted.compareAndSet(false, true)) {
+                    events.add(new TextBlockStartEvent(replyId, "text"));
+                }
+            }
+
+            private void startThinking(List<AgentEvent> events) {
+                if (thinkingStarted.compareAndSet(false, true)) {
+                    events.add(new ThinkingBlockStartEvent(replyId, "thinking"));
+                }
+            }
+
+            private void startToolCall(String toolId, String toolName, List<AgentEvent> events) {
+                if (toolId == null || startedToolCalls.containsKey(toolId)) {
+                    return;
+                }
+                flushText(events);
+                flushThinking(events);
+                flushAllToolCalls(events);
+                boolean visibleTool = toolName != null && !toolName.startsWith("__");
+                if (visibleTool && startedToolCalls.putIfAbsent(toolId, toolName) == null) {
+                    events.add(new ToolCallStartEvent(replyId, toolId, toolName));
+                }
+            }
+
+            private void flushText(List<AgentEvent> events) {
+                if (textStarted.compareAndSet(true, false)) {
+                    events.add(new TextBlockEndEvent(replyId, "text"));
+                }
+            }
+
+            private void flushThinking(List<AgentEvent> events) {
+                if (thinkingStarted.compareAndSet(true, false)) {
+                    events.add(new ThinkingBlockEndEvent(replyId, "thinking"));
+                }
+            }
+
+            private void flushAllToolCalls(List<AgentEvent> events) {
+                for (Map.Entry<String, String> tc : new ArrayList<>(startedToolCalls.entrySet())) {
+                    events.add(new ToolCallEndEvent(replyId, tc.getKey(), tc.getValue()));
+                    startedToolCalls.remove(tc.getKey());
+                }
+            }
+
+            private void flushAll(List<AgentEvent> events) {
+                flushText(events);
+                flushThinking(events);
+                flushAllToolCalls(events);
             }
         }
 
@@ -3002,8 +3049,7 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
                 ReasoningContext context, ModelCallInput mci, GenerateOptions hookOptions) {
 
             String replyId = UUID.randomUUID().toString().replace("-", "");
-            AtomicBoolean textStarted = new AtomicBoolean(false);
-            AtomicBoolean thinkingStarted = new AtomicBoolean(false);
+            ModelCallBlockLifecycle blockLifecycle = new ModelCallBlockLifecycle(replyId);
 
             Flux<AgentEvent> modelEvents =
                     mci.model().stream(mci.messages(), mci.tools(), mci.options())
@@ -3024,28 +3070,22 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
                                         List<AgentEvent> events = new ArrayList<>();
                                         for (ContentBlock block : chunk.getContent()) {
                                             if (block instanceof TextBlock tb) {
-                                                if (textStarted.compareAndSet(false, true)) {
-                                                    events.add(
-                                                            new TextBlockStartEvent(
-                                                                    replyId, "text"));
-                                                }
+                                                blockLifecycle.startText(events);
                                                 if (tb.getText() != null
                                                         && !tb.getText().isEmpty()) {
                                                     events.add(
                                                             new TextBlockDeltaEvent(
-                                                                    replyId, "text", tb.getText()));
+                                                                    blockLifecycle.replyId,
+                                                                    "text",
+                                                                    tb.getText()));
                                                 }
                                             } else if (block instanceof ThinkingBlock tb) {
-                                                if (thinkingStarted.compareAndSet(false, true)) {
-                                                    events.add(
-                                                            new ThinkingBlockStartEvent(
-                                                                    replyId, "thinking"));
-                                                }
+                                                blockLifecycle.startThinking(events);
                                                 if (tb.getThinking() != null
                                                         && !tb.getThinking().isEmpty()) {
                                                     events.add(
                                                             new ThinkingBlockDeltaEvent(
-                                                                    replyId,
+                                                                    blockLifecycle.replyId,
                                                                     "thinking",
                                                                     tb.getThinking()));
                                                 }
@@ -3058,12 +3098,7 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
                     Flux.defer(
                             () -> {
                                 List<AgentEvent> events = new ArrayList<>();
-                                if (textStarted.get()) {
-                                    events.add(new TextBlockEndEvent(replyId, "text"));
-                                }
-                                if (thinkingStarted.get()) {
-                                    events.add(new ThinkingBlockEndEvent(replyId, "thinking"));
-                                }
+                                blockLifecycle.flushAll(events);
                                 events.add(new ModelCallEndEvent(replyId, context.getChatUsage()));
                                 return Flux.fromIterable(events);
                             });

--- a/agentscope-core/src/test/java/io/agentscope/core/agent/ReActAgentNewLoopReplyTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/agent/ReActAgentNewLoopReplyTest.java
@@ -26,6 +26,10 @@ import io.agentscope.core.event.AgentStartEvent;
 import io.agentscope.core.event.ExceedMaxItersEvent;
 import io.agentscope.core.event.ModelCallEndEvent;
 import io.agentscope.core.event.ModelCallStartEvent;
+import io.agentscope.core.event.TextBlockEndEvent;
+import io.agentscope.core.event.TextBlockStartEvent;
+import io.agentscope.core.event.ThinkingBlockEndEvent;
+import io.agentscope.core.event.ThinkingBlockStartEvent;
 import io.agentscope.core.event.ToolCallEndEvent;
 import io.agentscope.core.event.ToolCallStartEvent;
 import io.agentscope.core.event.ToolResultEndEvent;
@@ -34,6 +38,7 @@ import io.agentscope.core.message.ContentBlock;
 import io.agentscope.core.message.Msg;
 import io.agentscope.core.message.MsgRole;
 import io.agentscope.core.message.TextBlock;
+import io.agentscope.core.message.ThinkingBlock;
 import io.agentscope.core.message.ToolResultBlock;
 import io.agentscope.core.message.ToolUseBlock;
 import io.agentscope.core.model.ChatModelBase;
@@ -241,6 +246,173 @@ class ReActAgentNewLoopReplyTest {
         assertEquals(2, overflow.getMaxIters());
     }
 
+    @Test
+    void textStartClosesThinkingBeforeTextBegins() {
+        ChatModelBase model =
+                new ScriptedModel(
+                        List.of(
+                                () ->
+                                        Flux.just(
+                                                chatResponse(
+                                                        ThinkingBlock.builder()
+                                                                .thinking("think")
+                                                                .build(),
+                                                        TextBlock.builder()
+                                                                .text("text")
+                                                                .build()))));
+        ReActAgent agent =
+                ReActAgent.builder().name("asst").model(model).toolkit(new Toolkit()).build();
+
+        List<AgentEvent> events = agent.streamEvents(List.of()).collectList().block();
+        assertNotNull(events);
+
+        int thinkingStart = indexOf(events, ThinkingBlockStartEvent.class);
+        int thinkingEnd = indexOf(events, ThinkingBlockEndEvent.class);
+        int textStart = indexOf(events, TextBlockStartEvent.class);
+        assertTrue(thinkingStart >= 0);
+        assertTrue(thinkingEnd > thinkingStart);
+        assertTrue(textStart > thinkingEnd);
+    }
+
+    @Test
+    void toolCallStartClosesTextThinkingAndPreviousTools() {
+        ChatModelBase model =
+                new ScriptedModel(
+                        List.of(
+                                () ->
+                                        Flux.just(
+                                                chatResponse(
+                                                        ThinkingBlock.builder()
+                                                                .thinking("think")
+                                                                .build(),
+                                                        TextBlock.builder().text("text").build(),
+                                                        ToolUseBlock.builder()
+                                                                .id("tc1")
+                                                                .name("calc")
+                                                                .input(Map.of("query", "1"))
+                                                                .build(),
+                                                        ToolUseBlock.builder()
+                                                                .id("tc2")
+                                                                .name("search")
+                                                                .input(Map.of("query", "2"))
+                                                                .build()))));
+        ReActAgent agent =
+                ReActAgent.builder().name("asst").model(model).toolkit(new Toolkit()).build();
+
+        List<AgentEvent> events = agent.streamEvents(List.of()).collectList().block();
+        assertNotNull(events);
+
+        int thinkingEnd = indexOf(events, ThinkingBlockEndEvent.class);
+        int textStart = indexOf(events, TextBlockStartEvent.class);
+        int textEnd = indexOf(events, TextBlockEndEvent.class);
+        int tool1Start = indexOf(events, ToolCallStartEvent.class);
+        int tool1End = indexOf(events, ToolCallEndEvent.class);
+        int tool2Start = indexOfFrom(events, ToolCallStartEvent.class, tool1Start + 1);
+
+        assertTrue(thinkingEnd >= 0);
+        assertTrue(textStart > thinkingEnd);
+        assertTrue(textEnd > textStart);
+        assertTrue(tool1Start > thinkingEnd);
+        assertTrue(tool1Start > textEnd);
+        assertTrue(tool1End > tool1Start);
+        assertTrue(tool2Start > tool1End);
+    }
+
+    @Test
+    void modelEndFlushesRemainingTextAndThinking() {
+        ChatModelBase model =
+                new ScriptedModel(
+                        List.of(
+                                () ->
+                                        Flux.just(
+                                                chatResponse(
+                                                        ThinkingBlock.builder()
+                                                                .thinking("think")
+                                                                .build(),
+                                                        TextBlock.builder()
+                                                                .text("text")
+                                                                .build()))));
+        ReActAgent agent =
+                ReActAgent.builder().name("asst").model(model).toolkit(new Toolkit()).build();
+
+        List<AgentEvent> events = agent.streamEvents(List.of()).collectList().block();
+        assertNotNull(events);
+
+        int modelEnd = indexOf(events, ModelCallEndEvent.class);
+        int textEnd = indexOf(events, TextBlockEndEvent.class);
+        int thinkingEnd = indexOf(events, ThinkingBlockEndEvent.class);
+        assertTrue(textEnd > 0 && textEnd < modelEnd);
+        assertTrue(thinkingEnd > 0 && thinkingEnd < modelEnd);
+    }
+
+    @Test
+    void consecutiveTextChunksEmitSingleStartAndEnd() {
+        ChatModelBase model =
+                new ScriptedModel(
+                        List.of(
+                                () ->
+                                        Flux.just(
+                                                chatResponse(
+                                                        TextBlock.builder().text("hello").build()),
+                                                chatResponse(
+                                                        TextBlock.builder()
+                                                                .text(" world")
+                                                                .build()))));
+        ReActAgent agent =
+                ReActAgent.builder().name("asst").model(model).toolkit(new Toolkit()).build();
+
+        List<AgentEvent> events = agent.streamEvents(List.of()).collectList().block();
+        assertNotNull(events);
+
+        assertEquals(1L, countOf(events, TextBlockStartEvent.class));
+        assertEquals(1L, countOf(events, TextBlockEndEvent.class));
+        assertTrue(
+                indexOf(events, TextBlockEndEvent.class)
+                        < indexOf(events, ModelCallEndEvent.class));
+    }
+
+    @Test
+    void summaryModelCallClosesThinkingBeforeTextAndFlushesTextBeforeModelEnd() {
+        ChatModelBase model =
+                new ScriptedModel(
+                        List.of(
+                                () -> Flux.just(toolUseResponse("tc", "echo", "x")),
+                                () ->
+                                        Flux.just(
+                                                chatResponse(
+                                                        ThinkingBlock.builder()
+                                                                .thinking("summarizing")
+                                                                .build(),
+                                                        TextBlock.builder()
+                                                                .text("summary")
+                                                                .build()))));
+        ReActAgent agent =
+                ReActAgent.builder()
+                        .name("asst")
+                        .model(model)
+                        .toolkit(toolkitWith(new EchoTool()))
+                        .maxIters(1)
+                        .build();
+
+        List<AgentEvent> events = agent.streamEvents(List.of()).collectList().block();
+        assertNotNull(events);
+
+        int exceed = indexOf(events, ExceedMaxItersEvent.class);
+        int summaryModelStart = indexOfFrom(events, ModelCallStartEvent.class, exceed + 1);
+        int summaryThinkingEnd =
+                indexOfFrom(events, ThinkingBlockEndEvent.class, summaryModelStart);
+        int summaryTextStart = indexOfFrom(events, TextBlockStartEvent.class, summaryModelStart);
+        int summaryTextEnd = indexOfFrom(events, TextBlockEndEvent.class, summaryTextStart);
+        int summaryModelEnd = indexOfFrom(events, ModelCallEndEvent.class, summaryModelStart);
+
+        assertTrue(exceed >= 0);
+        assertTrue(summaryModelStart > exceed);
+        assertTrue(summaryThinkingEnd > summaryModelStart);
+        assertTrue(summaryTextStart > summaryThinkingEnd);
+        assertTrue(summaryTextEnd > summaryTextStart);
+        assertTrue(summaryModelEnd > summaryTextEnd);
+    }
+
     private static int indexOf(List<AgentEvent> events, Class<?> type) {
         return indexOfFrom(events, type, 0);
     }
@@ -252,5 +424,13 @@ class ReActAgentNewLoopReplyTest {
             }
         }
         return -1;
+    }
+
+    private static long countOf(List<AgentEvent> events, Class<?> type) {
+        return events.stream().filter(type::isInstance).count();
+    }
+
+    private static ChatResponse chatResponse(ContentBlock... blocks) {
+        return ChatResponse.builder().content(List.of(blocks)).build();
     }
 }


### PR DESCRIPTION
## Description:
Close #1634 
Fixes ReActAgent `streamEvents` block lifecycle ordering so text, thinking, and tool-call end events are emitted at the correct transition points instead of being deferred until `MODEL_CALL_END`.

## Code Changes & Architecture

1. Fixed model-call block lifecycle ordering:

   - Added `ModelCallBlockLifecycle` to manage active text, thinking, and tool-call blocks within a single model-call stream.
   - Flushes `THINKING_BLOCK_END` before `TEXT_BLOCK_START`.
   - Flushes active `TEXT_BLOCK_END`, `THINKING_BLOCK_END`, and prior `TOOL_CALL_END` events before a new `TOOL_CALL_START`.
   - Flushes any remaining active block ends before `MODEL_CALL_END`.

2. Preserved concurrency-safe state tracking:

   - Kept `AtomicBoolean` for text/thinking lifecycle state.
   - Kept `ConcurrentHashMap` for active tool-call tracking.
   - The fix only changes end-event flush timing, not event payloads or block identity.

3. Extended stream event ordering tests:

   - Added coverage for thinking-to-text transitions.
   - Added coverage for text/thinking-to-tool-call transitions.
   - Added coverage for multiple tool calls.
   - Added coverage for summary model-call ordering.
   - Added coverage to ensure consecutive text chunks do not duplicate start/end events.
   
4. Event output log before and after repair
使用如下输入用例测试（Text+Thinking+mult Tool Call）：“请先讲一个简单的冷笑话，再并行查北京、杭州天气。”
然后这里对输出做了简化，所有 delta 只保留第一个，其它原样输出。
<details>
<summary>修复前</summary>

```
78b07f10652c4aeeb3788170ef1ce6d2
MODEL_CALL_START

8aae44b7fda045cba528caf0979102b1
THINKING_BLOCK_START

9909b0399ead4094bf4516919dffc188
THINKING_BLOCK_DELTA

e0afd2ffeef04cde9cb00f754571fd35
TEXT_BLOCK_START

aae5dc4660a04147acf26d45a2f905eb
TEXT_BLOCK_DELTA

230ba43214354d46942fdf9c426b9d18
TOOL_CALL_START

e5443522eda14fe18d8f5de56f8234a5
TOOL_CALL_DELTA

ce2a278b1b484f4aa479370ec5156891
TOOL_CALL_START

d18763d17e744527b190ec4d1ca4b68c
TOOL_CALL_DELTA

dc758a3d6d3a43509627985b870e354a
TEXT_BLOCK_END

88a43946998a4b9fb21c61f41a6daae2
THINKING_BLOCK_END

f45a5a54c5ce4dc0aa8c47ade4a9ebbb
TOOL_CALL_END

5948d7bc9fa64fb49af86bd8240477bb
TOOL_CALL_END

55bd85d4adb040e8b8b29a6e1ddfad16
MODEL_CALL_END

ccb2012a41ab46af93139e68dc5216de
TOOL_RESULT_START

f62c0bbae6604aad932092eb6b50fdeb
TOOL_RESULT_START

f62b53d4a6db48408088ddaef5496f31
TOOL_RESULT_TEXT_DELTA

7c4d14cdbf8a439da7770a9af120e6e9
TOOL_RESULT_END

b81c2848b3064ed494fbdd3507a5b256
TOOL_RESULT_TEXT_DELTA

bfa2a29443de44ccb076c3f2ba1c9f10
TOOL_RESULT_END

9b919042124e40ecb35050a597b63679
MODEL_CALL_START

034e17b98ee4487e986ec0112d0ae2f6
THINKING_BLOCK_START

c3f298bba93e4bb5ab01d1491fa8285e
THINKING_BLOCK_DELTA

e88f954350334337b4812a1b1dc48e00
TEXT_BLOCK_START

5caad9d12b60443c8d9cf494c067d5da
TEXT_BLOCK_DELTA

0c667f4ccf0242c0b9a7c013761e7d86
TEXT_BLOCK_END

23992edd28b54b4996535241dfa925e9
THINKING_BLOCK_END

ed78e87125d749d29ba593c785141a62
MODEL_CALL_END
```
</details>

<details>
<summary>修复后</summary>

```
944985f3fde04b2e8b9e4fd9f746cc1e
MODEL_CALL_START

fcc2f929327942fa967ddbb2713e87bf
THINKING_BLOCK_START

42d0f4f85c6c47a490ff45603de2b728
THINKING_BLOCK_DELTA

a390f43f3a484ee7b86c125c16dcf063
THINKING_BLOCK_END

1baf71010149409fafcd36cbf256bb97
TEXT_BLOCK_START

67d15091acc64106ad9360909ec07b43
TEXT_BLOCK_DELTA

70c0e5b57aa9430886f3bf3bb1e31ecd
TEXT_BLOCK_END

cb126d6d4b2d4517a22fa9027ec5113a
TOOL_CALL_START

780f61ceba9f44dca1075c0a3a91339c
TOOL_CALL_DELTA

83c6cb62be8d4e4cb9b42140eb5600f5
TOOL_CALL_END

118c541fdbdd4e33b3e7c96afbd201b5
TOOL_CALL_START

7099bd91939d4e9280879bcd87a6bcd7
TOOL_CALL_DELTA

d541ba52bbfa45c4b250922b6c4d1a1d
TOOL_CALL_END

4f2d16bdc4f349228d2b8fbfbdcf9ee0
MODEL_CALL_END

95135746f837497f858c559af718552f
TOOL_RESULT_START

2ad377fd56c24d7a97cbccce1eb7471f
TOOL_RESULT_START

46cc54b143cc458398149379fd8cf1fc
TOOL_RESULT_TEXT_DELTA

c290c5dcd4e7404384d9ae8dc327300f
TOOL_RESULT_END

03377ffdaec74fcda66afc17949c887a
TOOL_RESULT_TEXT_DELTA

f80076da6d634d9eae7c8024c54dfac1
TOOL_RESULT_END

c161f9bd7fe74fcabc6c3ae08bf53ed4
MODEL_CALL_START

808b9d9faf8147d395ba817850631f01
THINKING_BLOCK_START

6ae924698d14461f9db3b082499de3c9
THINKING_BLOCK_DELTA

d66917b7c58e4c7e8c21d0d32a01374b
THINKING_BLOCK_END

d9a2956c122c4096a9417cd96a00b772
TEXT_BLOCK_START

99a8337989ae4a9c9b39eabefdf5ef1a
TEXT_BLOCK_DELTA

c3bb8ec529c34f4e9e7d0d2dafafdfdc
TEXT_BLOCK_END

8a4f58ae9a7543ed8a44692e868be41d
MODEL_CALL_END
```
</details>


## Checklist

Please check the following items before code is ready to be reviewed.

- [ ]  Code has been formatted with `mvn spotless:apply`
- [ ]  All tests are passing (`mvn test`)
- [ ]  Javadoc comments are complete and follow project conventions
- [ ]  Related documentation has been updated (e.g. links, examples, etc.)
- [ ]  Code is ready for review
