### PR TITLE
fix(filesystem): treat "." as root equivalent in CompositeFilesystem

### DIFF
--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/filesystem/CompositeFilesystem.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/filesystem/CompositeFilesystem.java
@@ -188,9 +188,9 @@ public class CompositeFilesystem implements AbstractFilesystem {
             return LsResult.success(remapped);
         }
 
-        if ("/".equals(path)) {
+        if ("/".equals(path) || ".".equals(path)) {
             List<FileInfo> results = new ArrayList<>();
-            LsResult defaultResult = defaultBackend.ls(runtimeContext, path);
+            LsResult defaultResult = defaultBackend.ls(runtimeContext, "/");
             if (defaultResult.isSuccess() && defaultResult.entries() != null) {
                 results.addAll(defaultResult.entries());
             }
@@ -269,7 +269,7 @@ public class CompositeFilesystem implements AbstractFilesystem {
             }
         }
 
-        if (path == null || "/".equals(path)) {
+        if (path == null || "/".equals(path) || ".".equals(path)) {
             List<GrepMatch> allMatches = new ArrayList<>();
             GrepResult defaultResult = defaultBackend.grep(runtimeContext, pattern, path, glob);
             if (!defaultResult.isSuccess()) {
@@ -332,7 +332,7 @@ public class CompositeFilesystem implements AbstractFilesystem {
 
         // Non-root path that didn't match any route: delegate to default backend only.
         // Route scanning only makes sense for root-level recursive globs.
-        if (path != null && !"/".equals(path)) {
+        if (path != null && !"/".equals(path) && !".".equals(path)) {
             return defaultBackend.glob(runtimeContext, pattern, path);
         }
 


### PR DESCRIPTION
## Summary

- `WorkspacePathNormalizer.tryStrip()` returns `"."` when the input path equals the workspace root prefix, but `CompositeFilesystem.ls()`, `grep()`, and `glob()` only merged routed virtual directories (e.g. `skills/`, `memory/`, `knowledge/`) when the path was exactly `"/"`.
- This caused `list_files` at the workspace root to return `"Empty or not a directory"`, making the agent unable to browse the workspace.
- Fix: treat `"."` as equivalent to `"/"` in all three methods.

Fixes #1737