### PR TITLE
fix(nacos): change matchIfMissing to false in auto-configurations

### DIFF
--- a/agentscope-extensions/agentscope-spring-boot-starters/agentscope-nacos-spring-boot-starter/src/main/java/io/agentscope/spring/boot/nacos/AgentscopeA2aNacosAutoConfiguration.java
+++ b/agentscope-extensions/agentscope-spring-boot-starters/agentscope-nacos-spring-boot-starter/src/main/java/io/agentscope/spring/boot/nacos/AgentscopeA2aNacosAutoConfiguration.java
@@ -54,7 +54,7 @@ import org.springframework.context.annotation.Bean;
         prefix = NacosConstants.A2A_NACOS_PREFIX,
         name = "enabled",
         havingValue = "true",
-        matchIfMissing = true)
+        matchIfMissing = false)
 public class AgentscopeA2aNacosAutoConfiguration implements Closeable {
 
     private static final Logger log =
@@ -112,7 +112,7 @@ public class AgentscopeA2aNacosAutoConfiguration implements Closeable {
             prefix = NacosConstants.A2A_NACOS_DISCOVERY_PREFIX,
             name = "enabled",
             havingValue = "true",
-            matchIfMissing = true)
+            matchIfMissing = false)
     public AgentCardResolver nacosAgentCardResolver() {
         return new NacosAgentCardResolver(a2aService);
     }
@@ -128,7 +128,7 @@ public class AgentscopeA2aNacosAutoConfiguration implements Closeable {
             prefix = NacosConstants.A2A_NACOS_REGISTRY_PREFIX,
             name = "enabled",
             havingValue = "true",
-            matchIfMissing = true)
+            matchIfMissing = false)
     public AgentRegistry nacosAgentRegistry(AgentScopeA2aNacosProperties a2aNacosProperties) {
         return NacosAgentRegistry.builder(a2aService)
                 .nacosA2aProperties(buildNacosA2aProperties(a2aNacosProperties))

--- a/agentscope-extensions/agentscope-spring-boot-starters/agentscope-nacos-spring-boot-starter/src/main/java/io/agentscope/spring/boot/nacos/AgentscopeNacosPromptAutoConfiguration.java
+++ b/agentscope-extensions/agentscope-spring-boot-starters/agentscope-nacos-spring-boot-starter/src/main/java/io/agentscope/spring/boot/nacos/AgentscopeNacosPromptAutoConfiguration.java
@@ -54,7 +54,7 @@ import org.springframework.context.annotation.Bean;
         prefix = NacosConstants.NACOS_PROMPT_PREFIX,
         name = "enabled",
         havingValue = "true",
-        matchIfMissing = true)
+        matchIfMissing = false)
 public class AgentscopeNacosPromptAutoConfiguration {
 
     @Bean(name = "agentscopePromptAiService")

--- a/agentscope-extensions/agentscope-spring-boot-starters/agentscope-nacos-spring-boot-starter/src/main/java/io/agentscope/spring/boot/nacos/AgentscopeNacosReActAgentAutoConfiguration.java
+++ b/agentscope-extensions/agentscope-spring-boot-starters/agentscope-nacos-spring-boot-starter/src/main/java/io/agentscope/spring/boot/nacos/AgentscopeNacosReActAgentAutoConfiguration.java
@@ -55,7 +55,7 @@ import org.springframework.context.annotation.Scope;
         prefix = NacosConstants.NACOS_PROMPT_PREFIX,
         name = "enabled",
         havingValue = "true",
-        matchIfMissing = true)
+        matchIfMissing = false)
 public class AgentscopeNacosReActAgentAutoConfiguration {
 
     private static final Logger log =


### PR DESCRIPTION
## Summary

- All three Nacos auto-configuration classes (`AgentscopeNacosPromptAutoConfiguration`, `AgentscopeNacosReActAgentAutoConfiguration`, `AgentscopeA2aNacosAutoConfiguration`) used `matchIfMissing = true`, causing them to activate by default even without Nacos AI Service.
- This leads to startup failures for projects that include the `nacos-spring-boot-starter` dependency but don't have Nacos configured.
- Changed all 5 `matchIfMissing` occurrences from `true` to `false` so auto-configurations only activate when explicitly enabled.

**Breaking change**: users who rely on implicit Nacos activation must now add `agentscope.nacos.*.enabled=true` to their config.

Fixes #1707