### PR TITLE
fix(model): delegate supportsNativeStructuredOutput to formatter

### DIFF
--- a/agentscope-core/src/main/java/io/agentscope/core/formatter/openai/DeepSeekFormatter.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/formatter/openai/DeepSeekFormatter.java
@@ -78,6 +78,11 @@ public class DeepSeekFormatter extends OpenAIChatFormatter {
         return false;
     }
 
+    @Override
+    public boolean supportsNativeStructuredOutput() {
+        return false;
+    }
+
     /**
      * Apply DeepSeek-specific message format fixes.
      *

--- a/agentscope-core/src/main/java/io/agentscope/core/formatter/openai/DeepSeekMultiAgentFormatter.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/formatter/openai/DeepSeekMultiAgentFormatter.java
@@ -93,4 +93,9 @@ public class DeepSeekMultiAgentFormatter extends OpenAIMultiAgentFormatter {
     protected boolean supportsStrict() {
         return false;
     }
+
+    @Override
+    public boolean supportsNativeStructuredOutput() {
+        return false;
+    }
 }

--- a/agentscope-core/src/main/java/io/agentscope/core/formatter/openai/GLMFormatter.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/formatter/openai/GLMFormatter.java
@@ -65,6 +65,11 @@ public class GLMFormatter extends OpenAIChatFormatter {
     }
 
     @Override
+    public boolean supportsNativeStructuredOutput() {
+        return false;
+    }
+
+    @Override
     public void applyToolChoice(OpenAIRequest request, ToolChoice toolChoice) {
         applyGLMToolChoice(request, toolChoice);
     }

--- a/agentscope-core/src/main/java/io/agentscope/core/formatter/openai/GLMMultiAgentFormatter.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/formatter/openai/GLMMultiAgentFormatter.java
@@ -63,6 +63,11 @@ public class GLMMultiAgentFormatter extends OpenAIMultiAgentFormatter {
     }
 
     @Override
+    public boolean supportsNativeStructuredOutput() {
+        return false;
+    }
+
+    @Override
     public void applyToolChoice(OpenAIRequest request, ToolChoice toolChoice) {
         GLMFormatter.applyGLMToolChoice(request, toolChoice);
     }

--- a/agentscope-core/src/main/java/io/agentscope/core/formatter/openai/OpenAIChatFormatter.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/formatter/openai/OpenAIChatFormatter.java
@@ -197,6 +197,19 @@ public class OpenAIChatFormatter extends OpenAIBaseFormatter {
         return true;
     }
 
+    /**
+     * Whether this formatter's backend supports native structured output via
+     * {@code response_format} with {@code json_schema}.
+     *
+     * <p>Subclasses should override this to return {@code false} for providers that don't
+     * support {@code response_format} (e.g., DeepSeek, GLM).
+     *
+     * @return true if native structured output is supported, false otherwise
+     */
+    public boolean supportsNativeStructuredOutput() {
+        return true;
+    }
+
     @Override
     public void applyToolChoice(OpenAIRequest request, ToolChoice toolChoice) {
         // Only apply tool_choice if tools are present

--- a/agentscope-core/src/main/java/io/agentscope/core/model/OpenAIChatModel.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/model/OpenAIChatModel.java
@@ -193,7 +193,10 @@ public class OpenAIChatModel extends ChatModelBase {
 
     @Override
     public boolean supportsNativeStructuredOutput() {
-        return true;
+        if (formatter instanceof OpenAIChatFormatter openAiFormatter) {
+            return openAiFormatter.supportsNativeStructuredOutput();
+        }
+        return false;
     }
 
     /**


### PR DESCRIPTION
## Summary

- `OpenAIChatModel.supportsNativeStructuredOutput()` hardcoded `true`, but many OpenAI-compatible backends (DeepSeek, vLLM, Ollama, GLM) don't support `response_format` with `json_schema`. This caused `agent.call(msg, OutputClass.class)` to fail with HTTP 400 on these backends.
- Added `supportsNativeStructuredOutput()` to `OpenAIChatFormatter` (default `true`) and overrode to `false` in `DeepSeekFormatter`, `DeepSeekMultiAgentFormatter`, `GLMFormatter`, and `GLMMultiAgentFormatter`.
- `OpenAIChatModel` now delegates to the formatter, so the agent automatically falls back to the `generate_response` tool approach for unsupported backends.

Fixes #1742
Fixes #1720