### PR TITLE
fix(shell): validate working_directory to prevent namespace escape

### DIFF
--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/tool/ShellExecuteTool.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/tool/ShellExecuteTool.java
@@ -55,7 +55,12 @@ public class ShellExecuteTool {
                     int timeout) {
         String effectiveCommand = command;
         if (workingDirectory != null && !workingDirectory.isBlank()) {
-            effectiveCommand = "cd " + workingDirectory + " && " + command;
+            String wd = workingDirectory.strip();
+            if (wd.startsWith("/") || wd.startsWith("~") || wd.contains("..")) {
+                return "Error: working_directory must be a relative path within the workspace"
+                        + " (absolute paths, '~', and '..' are not allowed).";
+            }
+            effectiveCommand = "cd '" + wd.replace("'", "'\\''") + "' && " + command;
         }
 
         ExecuteResponse result =


### PR DESCRIPTION
## Summary

- `ShellExecuteTool.execute()` blindly prepended `cd <working_directory> &&` to shell commands without any validation. An LLM-supplied absolute path, `~`, or `..` could escape the namespace-scoped workspace directory.
- Now rejects absolute paths, home-dir expansion (`~`), and parent-directory traversal (`..`).
- Shell-quotes the path to prevent injection via special characters.

**Security**: This is a namespace escape vulnerability — the LLM could execute commands outside the user's sandboxed workspace.

Fixes #1777