### PR TITLE
docs: fix MiddlewareBase hook signatures in middleware docs

### DIFF
--- a/docs/v2/en/docs/building-blocks/agent.md
+++ b/docs/v2/en/docs/building-blocks/agent.md
@@ -314,7 +314,7 @@ Msg result = agent.call(List.of(new UserMessage("Hi.")), ctx).block();
 ### Who reads it
 
 - **Tools** (`@Tool` methods and `ToolBase.callAsync`) — see [Tool — Receiving context](./tool.md#receiving-context).
-- **Middleware** (every `MiddlewareBase` hook) — call `agent.getRuntimeContext()`. See [Middleware — Reading RuntimeContext](./middleware.md#reading-runtimecontext).
+- **Middleware** (every `MiddlewareBase` hook) — received as the second parameter `ctx`. See [Middleware — Reading RuntimeContext](./middleware.md#reading-runtimecontext).
 - **All threads within the same call** — the internal maps are `ConcurrentMap`s, so hooks and tools can read/write the same instance to coordinate.
 
 ### Relation to persistence

--- a/docs/v2/en/docs/building-blocks/middleware.md
+++ b/docs/v2/en/docs/building-blocks/middleware.md
@@ -122,6 +122,7 @@ Each onion hook receives a `next` function — calling `next.apply(input)` enter
 
 ```java
 import io.agentscope.core.agent.Agent;
+import io.agentscope.core.agent.RuntimeContext;
 import io.agentscope.core.event.AgentEvent;
 import io.agentscope.core.middleware.ActingInput;
 import io.agentscope.core.middleware.AgentInput;
@@ -137,7 +138,7 @@ public class FullObservabilityMiddleware implements MiddlewareBase {
 
     @Override
     public Flux<AgentEvent> onAgent(
-            Agent agent, AgentInput input, Function<AgentInput, Flux<AgentEvent>> next) {
+            Agent agent, RuntimeContext ctx, AgentInput input, Function<AgentInput, Flux<AgentEvent>> next) {
         System.out.println("[agent] start for " + agent.getName());
         return next.apply(input)
                 .doOnComplete(() -> System.out.println("[agent] end for " + agent.getName()));
@@ -145,20 +146,20 @@ public class FullObservabilityMiddleware implements MiddlewareBase {
 
     @Override
     public Flux<AgentEvent> onReasoning(
-            Agent agent, ReasoningInput input, Function<ReasoningInput, Flux<AgentEvent>> next) {
+            Agent agent, RuntimeContext ctx, ReasoningInput input, Function<ReasoningInput, Flux<AgentEvent>> next) {
         System.out.println("[reasoning] start");
         return next.apply(input).doOnComplete(() -> System.out.println("[reasoning] end"));
     }
 
     @Override
     public Flux<AgentEvent> onModelCall(
-            Agent agent, ModelCallInput input, Function<ModelCallInput, Flux<AgentEvent>> next) {
+            Agent agent, RuntimeContext ctx, ModelCallInput input, Function<ModelCallInput, Flux<AgentEvent>> next) {
         System.out.println("[model_call] " + input.model().getClass().getSimpleName());
         return next.apply(input).doOnComplete(() -> System.out.println("[model_call] done"));
     }
 
     @Override
-    public Mono<String> onSystemPrompt(Agent agent, String currentPrompt) {
+    public Mono<String> onSystemPrompt(Agent agent, RuntimeContext ctx, String currentPrompt) {
         System.out.println("[system_prompt] length=" + currentPrompt.length());
         return Mono.just(currentPrompt);
     }
@@ -181,7 +182,7 @@ Runnable examples: `agentscope-examples/documentation/.../middleware/CustomizedM
 
 ### Reading RuntimeContext
 
-Every `MiddlewareBase` hook receives the `Agent` as the first argument. Calling `agent.getRuntimeContext()` returns the [`RuntimeContext`](./agent.md#runtimecontext-per-call-context) bound for this `call` / `stream` — you can read session fields and typed/string attributes, and you can write back to it to forward values to downstream hooks and tools.
+Every `MiddlewareBase` hook receives the [`RuntimeContext`](./agent.md#runtimecontext-per-call-context) bound for this `call` / `stream` as the second argument — you can read session fields and typed/string attributes, and you can write back to it to forward values to downstream hooks and tools.
 
 ```java
 import io.agentscope.core.agent.Agent;
@@ -197,16 +198,13 @@ public class RequestContextMiddleware implements MiddlewareBase {
 
     @Override
     public Flux<AgentEvent> onAgent(
-            Agent agent, AgentInput input, Function<AgentInput, Flux<AgentEvent>> next) {
-        RuntimeContext rc = agent.getRuntimeContext();
-        if (rc != null) {
-            System.out.printf(
-                    "[req] user=%s session=%s reqId=%s%n",
-                    rc.getUserId(),
-                    rc.getSessionId(),
-                    rc.get("request_id"));
-            rc.put("trace_id", java.util.UUID.randomUUID().toString());  // visible to later hooks / tools
-        }
+            Agent agent, RuntimeContext ctx, AgentInput input, Function<AgentInput, Flux<AgentEvent>> next) {
+        System.out.printf(
+                "[req] user=%s session=%s reqId=%s%n",
+                ctx.getUserId(),
+                ctx.getSessionId(),
+                ctx.get("request_id"));
+        ctx.put("trace_id", java.util.UUID.randomUUID().toString());  // visible to later hooks / tools
         return next.apply(input);
     }
 }
@@ -214,7 +212,6 @@ public class RequestContextMiddleware implements MiddlewareBase {
 
 Things to keep in mind:
 
-- `agent.getRuntimeContext()` is only non-null during a `call`; outside a call it returns `null`.
 - The same `RuntimeContext` instance is shared by every hook and tool in the reply; its maps are thread-safe, so `put` from any hook is safe.
 - Don't cache per-request state on middleware instance fields — a middleware instance is typically reused across agents / calls. Use `RuntimeContext` or Reactor's `contextWrite` instead.
 - If the builder also has a global `toolExecutionContext`, the framework merges it after the per-call context when dispatching to tools (per-call wins on key collisions).

--- a/docs/v2/zh/docs/building-blocks/agent.md
+++ b/docs/v2/zh/docs/building-blocks/agent.md
@@ -314,7 +314,7 @@ Msg result = agent.call(List.of(new UserMessage("Hi.")), ctx).block();
 ### 谁能读到
 
 - **Tool**（`@Tool` 方法或 `ToolBase.callAsync`）—— 见 [Tool — 接收 Context](./tool.md#接收-context)。
-- **Middleware**（`MiddlewareBase` 所有 hook）—— 通过 `agent.getRuntimeContext()` 取当前实例。详见 [Middleware — 读取 RuntimeContext](./middleware.md#读取-runtimecontext)。
+- **Middleware**（`MiddlewareBase` 所有 hook）—— 作为第二个参数 `ctx` 直接传入。详见 [Middleware — 读取 RuntimeContext](./middleware.md#读取-runtimecontext)。
 - **同一次调用的所有线程**—— `RuntimeContext` 内部使用 `ConcurrentMap`，hook / tool 之间可以读写同一实例做协调。
 
 ### 与持久化的关系

--- a/docs/v2/zh/docs/building-blocks/middleware.md
+++ b/docs/v2/zh/docs/building-blocks/middleware.md
@@ -122,6 +122,7 @@ ReActAgent agent =
 
 ```java
 import io.agentscope.core.agent.Agent;
+import io.agentscope.core.agent.RuntimeContext;
 import io.agentscope.core.event.AgentEvent;
 import io.agentscope.core.middleware.ActingInput;
 import io.agentscope.core.middleware.AgentInput;
@@ -137,7 +138,7 @@ public class FullObservabilityMiddleware implements MiddlewareBase {
 
     @Override
     public Flux<AgentEvent> onAgent(
-            Agent agent, AgentInput input, Function<AgentInput, Flux<AgentEvent>> next) {
+            Agent agent, RuntimeContext ctx, AgentInput input, Function<AgentInput, Flux<AgentEvent>> next) {
         System.out.println("[agent] start for " + agent.getName());
         return next.apply(input)
                 .doOnComplete(() -> System.out.println("[agent] end for " + agent.getName()));
@@ -145,20 +146,20 @@ public class FullObservabilityMiddleware implements MiddlewareBase {
 
     @Override
     public Flux<AgentEvent> onReasoning(
-            Agent agent, ReasoningInput input, Function<ReasoningInput, Flux<AgentEvent>> next) {
+            Agent agent, RuntimeContext ctx, ReasoningInput input, Function<ReasoningInput, Flux<AgentEvent>> next) {
         System.out.println("[reasoning] start");
         return next.apply(input).doOnComplete(() -> System.out.println("[reasoning] end"));
     }
 
     @Override
     public Flux<AgentEvent> onModelCall(
-            Agent agent, ModelCallInput input, Function<ModelCallInput, Flux<AgentEvent>> next) {
+            Agent agent, RuntimeContext ctx, ModelCallInput input, Function<ModelCallInput, Flux<AgentEvent>> next) {
         System.out.println("[model_call] " + input.model().getClass().getSimpleName());
         return next.apply(input).doOnComplete(() -> System.out.println("[model_call] done"));
     }
 
     @Override
-    public Mono<String> onSystemPrompt(Agent agent, String currentPrompt) {
+    public Mono<String> onSystemPrompt(Agent agent, RuntimeContext ctx, String currentPrompt) {
         System.out.println("[system_prompt] length=" + currentPrompt.length());
         return Mono.just(currentPrompt);
     }
@@ -181,7 +182,7 @@ public class FullObservabilityMiddleware implements MiddlewareBase {
 
 ### 读取 RuntimeContext
 
-`MiddlewareBase` 的所有 hook 都把 `Agent` 作为首个参数传进来。通过 `agent.getRuntimeContext()` 可拿到本次 `call` / `stream` 绑定的 [`RuntimeContext`](./agent.md#runtimecontext-per-call-上下文)——既能读会话字段，也能按类型 / 按 key 取属性，还能反向写入来给下游 hook 和 tool 传值。
+`MiddlewareBase` 的所有 hook 都将本次 `call` / `stream` 绑定的 [`RuntimeContext`](./agent.md#runtimecontext-per-call-上下文) 作为第二个参数直接传入——既能读会话字段，也能按类型 / 按 key 取属性，还能反向写入来给下游 hook 和 tool 传值。
 
 ```java
 import io.agentscope.core.agent.Agent;
@@ -197,16 +198,13 @@ public class RequestContextMiddleware implements MiddlewareBase {
 
     @Override
     public Flux<AgentEvent> onAgent(
-            Agent agent, AgentInput input, Function<AgentInput, Flux<AgentEvent>> next) {
-        RuntimeContext rc = agent.getRuntimeContext();
-        if (rc != null) {
-            System.out.printf(
-                    "[req] user=%s session=%s reqId=%s%n",
-                    rc.getUserId(),
-                    rc.getSessionId(),
-                    rc.get("request_id"));
-            rc.put("trace_id", java.util.UUID.randomUUID().toString());  // 后续 hook / tool 可读
-        }
+            Agent agent, RuntimeContext ctx, AgentInput input, Function<AgentInput, Flux<AgentEvent>> next) {
+        System.out.printf(
+                "[req] user=%s session=%s reqId=%s%n",
+                ctx.getUserId(),
+                ctx.getSessionId(),
+                ctx.get("request_id"));
+        ctx.put("trace_id", java.util.UUID.randomUUID().toString());  // 后续 hook / tool 可读
         return next.apply(input);
     }
 }
@@ -214,7 +212,6 @@ public class RequestContextMiddleware implements MiddlewareBase {
 
 注意点：
 
-- `agent.getRuntimeContext()` 只在 `call` 期间非 null；未运行时调用返回 `null`。
 - 同一份 `RuntimeContext` 在整个 reply 内被各层 hook / tool 共享，使用线程安全的内部 map，可以安全地 `put` 写入。
 - 不要把请求级状态缓存到 middleware 实例字段——一个 middleware 实例通常被多个 agent / call 复用；要么放进 `RuntimeContext`，要么用 Reactor `contextWrite`。
 - 若 builder 上同时配置了全局 `toolExecutionContext`，框架在分发给 tool 时会把它合并到 per-call context 之后（per-call 优先级更高）。


### PR DESCRIPTION
All `MiddlewareBase` hooks pass `RuntimeContext` as the second parameter — the interface signature is:

    onAgent(Agent agent, RuntimeContext ctx, AgentInput input, ...)

The docs used the wrong signature (missing `RuntimeContext ctx`) and instructed readers to call `agent.getRuntimeContext()` instead, which would cause a compile error when copy-pasting the example since `Agent` interface does not expose that method.

Changes (zh and en):
- Add `RuntimeContext ctx` to all hook signatures in both example classes
- Add missing `import io.agentscope.core.agent.RuntimeContext`
- Update prose to say "received as the second parameter `ctx`"
- Remove misleading note that `agent.getRuntimeContext()` returns null outside a call