### PR TITLE
fix(harness): report sandbox file sizes in ls

### DIFF
--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/filesystem/sandbox/BaseSandboxFilesystem.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/filesystem/sandbox/BaseSandboxFilesystem.java
@@ -77,13 +77,11 @@ public abstract class BaseSandboxFilesystem implements AbstractSandboxFilesystem
                         + escapedPath
                         + "/*; do "
                         + "  if [ -d \"$f\" ]; then "
-                        + "    mtime=$(stat -c '%Y' \"$f\" 2>/dev/null); "
-                        + "    mtime=${mtime:-0}; "
+                        + "    mtime=$(stat -c '%Y' \"$f\" 2>/dev/null || echo 0); "
                         + "    printf 'DIR:%s\\t%s\\n' \"$f\" \"$mtime\"; "
                         + "  elif [ -f \"$f\" ]; then "
-                        + "    meta=$(stat -c '%s\\t%Y' \"$f\" 2>/dev/null); "
-                        + "    size=${meta%%\\t*}; size=${size:-0}; "
-                        + "    mtime=${meta##*\\t}; mtime=${mtime:-0}; "
+                        + "    size=$(stat -c '%s' \"$f\" 2>/dev/null || echo 0); "
+                        + "    mtime=$(stat -c '%Y' \"$f\" 2>/dev/null || echo 0); "
                         + "    printf 'FILE:%s\\t%s\\t%s\\n' \"$f\" \"$size\" \"$mtime\"; "
                         + "  fi; "
                         + "done 2>/dev/null";
@@ -343,7 +341,11 @@ public abstract class BaseSandboxFilesystem implements AbstractSandboxFilesystem
                         + escapedPath
                         + " -type f -name "
                         + escapedPattern
-                        + " -exec stat -c '%n\\t%s\\t%Y' {} + 2>/dev/null | sort";
+                        + " 2>/dev/null | sort | while IFS= read -r f; do "
+                        + "  size=$(stat -c '%s' \"$f\" 2>/dev/null || echo 0); "
+                        + "  mtime=$(stat -c '%Y' \"$f\" 2>/dev/null || echo 0); "
+                        + "  printf '%s\\t%s\\t%s\\n' \"$f\" \"$size\" \"$mtime\"; "
+                        + "done";
 
         ExecuteResponse result = execute(runtimeContext, cmd, null);
         String output = result.output() != null ? result.output().strip() : "";

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/filesystem/sandbox/BaseSandboxFilesystem.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/filesystem/sandbox/BaseSandboxFilesystem.java
@@ -78,7 +78,7 @@ public abstract class BaseSandboxFilesystem implements AbstractSandboxFilesystem
                         + "/*; do "
                         + "  if [ -d \"$f\" ]; then echo \"DIR:$f\"; "
                         + "  elif [ -f \"$f\" ]; then "
-                        + "    size=$(wc -c < \"$f\" 2>/dev/null | tr -d '[:space:]'); "
+                        + "    size=$(stat -c '%s' \"$f\" 2>/dev/null); "
                         + "    size=${size:-0}; "
                         + "    printf 'FILE:%s\\t%s\\n' \"$f\" \"$size\"; "
                         + "  fi; "

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/filesystem/sandbox/BaseSandboxFilesystem.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/filesystem/sandbox/BaseSandboxFilesystem.java
@@ -77,7 +77,11 @@ public abstract class BaseSandboxFilesystem implements AbstractSandboxFilesystem
                         + escapedPath
                         + "/*; do "
                         + "  if [ -d \"$f\" ]; then echo \"DIR:$f\"; "
-                        + "  elif [ -f \"$f\" ]; then echo \"FILE:$f\"; fi; "
+                        + "  elif [ -f \"$f\" ]; then "
+                        + "    size=$(wc -c < \"$f\" 2>/dev/null | tr -d '[:space:]'); "
+                        + "    size=${size:-0}; "
+                        + "    printf 'FILE:%s\\t%s\\n' \"$f\" \"$size\"; "
+                        + "  fi; "
                         + "done 2>/dev/null";
 
         ExecuteResponse result = execute(runtimeContext, cmd, null);
@@ -88,7 +92,20 @@ public abstract class BaseSandboxFilesystem implements AbstractSandboxFilesystem
                 if (line.startsWith("DIR:")) {
                     entries.add(FileInfo.ofDir(line.substring(4), ""));
                 } else if (line.startsWith("FILE:")) {
-                    entries.add(FileInfo.ofFile(line.substring(5), 0, ""));
+                    String payload = line.substring(5);
+                    int separator = payload.lastIndexOf('\t');
+                    if (separator >= 0) {
+                        String filePath = payload.substring(0, separator);
+                        long size = 0L;
+                        try {
+                            size = Long.parseLong(payload.substring(separator + 1).trim());
+                        } catch (NumberFormatException ignored) {
+                            // fall back to 0 when the sandbox does not return a parseable size
+                        }
+                        entries.add(FileInfo.ofFile(filePath, size, ""));
+                    } else {
+                        entries.add(FileInfo.ofFile(payload, 0, ""));
+                    }
                 }
             }
         }

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/filesystem/sandbox/BaseSandboxFilesystem.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/filesystem/sandbox/BaseSandboxFilesystem.java
@@ -76,11 +76,15 @@ public abstract class BaseSandboxFilesystem implements AbstractSandboxFilesystem
                 "for f in "
                         + escapedPath
                         + "/*; do "
-                        + "  if [ -d \"$f\" ]; then echo \"DIR:$f\"; "
+                        + "  if [ -d \"$f\" ]; then "
+                        + "    mtime=$(stat -c '%Y' \"$f\" 2>/dev/null); "
+                        + "    mtime=${mtime:-0}; "
+                        + "    printf 'DIR:%s\\t%s\\n' \"$f\" \"$mtime\"; "
                         + "  elif [ -f \"$f\" ]; then "
-                        + "    size=$(stat -c '%s' \"$f\" 2>/dev/null); "
-                        + "    size=${size:-0}; "
-                        + "    printf 'FILE:%s\\t%s\\n' \"$f\" \"$size\"; "
+                        + "    meta=$(stat -c '%s\\t%Y' \"$f\" 2>/dev/null); "
+                        + "    size=${meta%%\\t*}; size=${size:-0}; "
+                        + "    mtime=${meta##*\\t}; mtime=${mtime:-0}; "
+                        + "    printf 'FILE:%s\\t%s\\t%s\\n' \"$f\" \"$size\" \"$mtime\"; "
                         + "  fi; "
                         + "done 2>/dev/null";
 
@@ -90,22 +94,18 @@ public abstract class BaseSandboxFilesystem implements AbstractSandboxFilesystem
         if (result.output() != null && !result.output().isBlank()) {
             for (String line : result.output().strip().split("\n")) {
                 if (line.startsWith("DIR:")) {
-                    entries.add(FileInfo.ofDir(line.substring(4), ""));
+                    String payload = line.substring(4);
+                    String[] parts = payload.split("\t", 2);
+                    String dirPath = parts[0];
+                    long mtimeMs = parts.length > 1 ? parseEpochSeconds(parts[1]) : 0L;
+                    entries.add(FileInfo.ofDir(dirPath, mtimeMs));
                 } else if (line.startsWith("FILE:")) {
                     String payload = line.substring(5);
-                    int separator = payload.lastIndexOf('\t');
-                    if (separator >= 0) {
-                        String filePath = payload.substring(0, separator);
-                        long size = 0L;
-                        try {
-                            size = Long.parseLong(payload.substring(separator + 1).trim());
-                        } catch (NumberFormatException ignored) {
-                            // fall back to 0 when the sandbox does not return a parseable size
-                        }
-                        entries.add(FileInfo.ofFile(filePath, size, ""));
-                    } else {
-                        entries.add(FileInfo.ofFile(payload, 0, ""));
-                    }
+                    String[] parts = payload.split("\t", 3);
+                    String filePath = parts[0];
+                    long size = parts.length > 1 ? parseLongSafe(parts[1]) : 0L;
+                    long mtimeMs = parts.length > 2 ? parseEpochSeconds(parts[2]) : 0L;
+                    entries.add(FileInfo.ofFile(filePath, size, mtimeMs));
                 }
             }
         }
@@ -339,7 +339,11 @@ public abstract class BaseSandboxFilesystem implements AbstractSandboxFilesystem
         String escapedPattern = FilesystemUtils.shellQuote(stripRecursivePrefix(pattern));
 
         String cmd =
-                "find " + escapedPath + " -type f -name " + escapedPattern + " 2>/dev/null | sort";
+                "find "
+                        + escapedPath
+                        + " -type f -name "
+                        + escapedPattern
+                        + " -exec stat -c '%n\\t%s\\t%Y' {} + 2>/dev/null | sort";
 
         ExecuteResponse result = execute(runtimeContext, cmd, null);
         String output = result.output() != null ? result.output().strip() : "";
@@ -350,7 +354,16 @@ public abstract class BaseSandboxFilesystem implements AbstractSandboxFilesystem
 
         List<FileInfo> entries = new ArrayList<>();
         for (String line : output.split("\n")) {
-            if (!line.isBlank()) {
+            if (line.isBlank()) {
+                continue;
+            }
+            String[] parts = line.split("\t", 3);
+            if (parts.length >= 3) {
+                String filePath = parts[0].trim();
+                long size = parseLongSafe(parts[1]);
+                long mtimeMs = parseEpochSeconds(parts[2]);
+                entries.add(FileInfo.ofFile(filePath, size, mtimeMs));
+            } else {
                 entries.add(FileInfo.ofFile(line.trim(), 0, ""));
             }
         }
@@ -409,6 +422,19 @@ public abstract class BaseSandboxFilesystem implements AbstractSandboxFilesystem
             return pattern.substring(3);
         }
         return pattern;
+    }
+
+    private static long parseLongSafe(String s) {
+        try {
+            return Long.parseLong(s.trim());
+        } catch (NumberFormatException e) {
+            return 0L;
+        }
+    }
+
+    private static long parseEpochSeconds(String s) {
+        long epochSec = parseLongSafe(s);
+        return epochSec * 1000;
     }
 
     private static String jsonEscape(String s) {

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/filesystem/sandbox/BaseSandboxFilesystemTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/filesystem/sandbox/BaseSandboxFilesystemTest.java
@@ -58,7 +58,7 @@ class BaseSandboxFilesystemTest {
 
             assertTrue(result.isSuccess());
             assertTrue(
-                    filesystem.lastCommand.contains("-exec stat -c"),
+                    filesystem.lastCommand.contains("stat -c"),
                     "glob should use stat for metadata");
             assertEquals(
                     List.of("/workspace/README.md", "/workspace/docs/guide.md"),
@@ -232,7 +232,7 @@ class BaseSandboxFilesystemTest {
                         0,
                         false);
             }
-            if (command.startsWith("find ") && command.contains("-exec stat")) {
+            if (command.startsWith("find ") && command.contains("while IFS=")) {
                 return new ExecuteResponse(
                         "/workspace/README.md\t1024\t1719300000\n"
                                 + "/workspace/docs/guide.md\t512\t1719300000\n",

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/filesystem/sandbox/BaseSandboxFilesystemTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/filesystem/sandbox/BaseSandboxFilesystemTest.java
@@ -73,11 +73,13 @@ class BaseSandboxFilesystemTest {
         assertFalse(result.entries().isEmpty());
         assertTrue(filesystem.lastCommand.startsWith("for f in '/workspace'/*; do"));
         assertTrue(filesystem.lastCommand.contains("stat -c '%s'"));
-        assertEquals(12L, result.entries().stream()
-                .filter(entry -> entry.path().equals("/workspace/readme.txt"))
-                .findFirst()
-                .orElseThrow()
-                .size());
+        assertEquals(
+                12L,
+                result.entries().stream()
+                        .filter(entry -> entry.path().equals("/workspace/readme.txt"))
+                        .findFirst()
+                        .orElseThrow()
+                        .size());
     }
 
     private static final class FakeSandboxFilesystem extends BaseSandboxFilesystem {

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/filesystem/sandbox/BaseSandboxFilesystemTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/filesystem/sandbox/BaseSandboxFilesystemTest.java
@@ -16,6 +16,7 @@
 package io.agentscope.harness.agent.filesystem.sandbox;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.agentscope.core.agent.RuntimeContext;
@@ -62,6 +63,21 @@ class BaseSandboxFilesystemTest {
                 result.matches().stream().map(match -> match.path()).collect(Collectors.toList()));
     }
 
+    @Test
+    void ls_reportsActualFileSizeInsteadOfZero() {
+        FakeSandboxFilesystem filesystem = new FakeSandboxFilesystem();
+
+        var result = filesystem.ls(RT, "/workspace");
+
+        assertTrue(result.isSuccess());
+        assertFalse(result.entries().isEmpty());
+        assertEquals(12L, result.entries().stream()
+                .filter(entry -> entry.path().equals("/workspace/readme.txt"))
+                .findFirst()
+                .orElseThrow()
+                .size());
+    }
+
     private static final class FakeSandboxFilesystem extends BaseSandboxFilesystem {
 
         private String lastCommand;
@@ -75,6 +91,11 @@ class BaseSandboxFilesystemTest {
         public ExecuteResponse execute(
                 RuntimeContext runtimeContext, String command, Integer timeoutSeconds) {
             lastCommand = command;
+            if ("for f in '/workspace'/*; do   if [ -d \"$f\" ]; then echo \"DIR:$f\";   elif [ -f \"$f\" ]; then     size=$(wc -c < \"$f\" 2>/dev/null | tr -d '[:space:]');     size=${size:-0};     printf 'FILE:%s\\t%s\\n' \"$f\" \"$size\";   fi; done 2>/dev/null"
+                    .equals(command)) {
+                return new ExecuteResponse(
+                        "DIR:/workspace/docs\nFILE:/workspace/readme.txt\t12\n", 0, false);
+            }
             if ("find '/workspace' -type f -name '*.md' 2>/dev/null | sort".equals(command)) {
                 return new ExecuteResponse(
                         "/workspace/README.md\n/workspace/docs/guide.md\n", 0, false);

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/filesystem/sandbox/BaseSandboxFilesystemTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/filesystem/sandbox/BaseSandboxFilesystemTest.java
@@ -22,69 +22,199 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import io.agentscope.core.agent.RuntimeContext;
 import io.agentscope.harness.agent.filesystem.model.ExecuteResponse;
 import io.agentscope.harness.agent.filesystem.model.FileDownloadResponse;
+import io.agentscope.harness.agent.filesystem.model.FileInfo;
 import io.agentscope.harness.agent.filesystem.model.FileUploadResponse;
 import io.agentscope.harness.agent.filesystem.model.GlobResult;
+import io.agentscope.harness.agent.filesystem.model.LsResult;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+import org.junit.jupiter.api.io.TempDir;
 
 class BaseSandboxFilesystemTest {
 
     private static final RuntimeContext RT = RuntimeContext.empty();
 
-    @Test
-    void glob_recursivePattern_stripsDoubleStarPrefixBeforeFindName() {
-        FakeSandboxFilesystem filesystem = new FakeSandboxFilesystem();
+    // ================================================================
+    // Unit tests — canned responses, run on all platforms
+    // ================================================================
 
-        GlobResult result = filesystem.glob(RT, "**/*.md", "/workspace");
+    @Nested
+    class CannedResponseTests {
 
-        assertTrue(result.isSuccess());
-        assertEquals(
-                "find '/workspace' -type f -name '*.md' 2>/dev/null | sort",
-                filesystem.lastCommand);
-        assertEquals(
-                List.of("/workspace/README.md", "/workspace/docs/guide.md"),
-                result.matches().stream().map(match -> match.path()).collect(Collectors.toList()));
+        @Test
+        void glob_recursivePattern_stripsDoubleStarPrefixBeforeFindName() {
+            FakeSandboxFilesystem filesystem = new FakeSandboxFilesystem();
+
+            GlobResult result = filesystem.glob(RT, "**/*.md", "/workspace");
+
+            assertTrue(result.isSuccess());
+            assertTrue(
+                    filesystem.lastCommand.contains("-exec stat -c"),
+                    "glob should use stat for metadata");
+            assertEquals(
+                    List.of("/workspace/README.md", "/workspace/docs/guide.md"),
+                    result.matches().stream().map(FileInfo::path).collect(Collectors.toList()));
+        }
+
+        @Test
+        void glob_parsesSize() {
+            FakeSandboxFilesystem filesystem = new FakeSandboxFilesystem();
+
+            GlobResult result = filesystem.glob(RT, "*.md", "/workspace");
+
+            assertTrue(result.isSuccess());
+            assertEquals(
+                    1024L,
+                    result.matches().stream()
+                            .filter(f -> f.path().equals("/workspace/README.md"))
+                            .findFirst()
+                            .orElseThrow()
+                            .size());
+        }
+
+        @Test
+        void glob_parsesModifiedAt() {
+            FakeSandboxFilesystem filesystem = new FakeSandboxFilesystem();
+
+            GlobResult result = filesystem.glob(RT, "*.md", "/workspace");
+
+            assertTrue(result.isSuccess());
+            String modifiedAt =
+                    result.matches().stream()
+                            .filter(f -> f.path().equals("/workspace/README.md"))
+                            .findFirst()
+                            .orElseThrow()
+                            .modifiedAt();
+            assertFalse(modifiedAt.isEmpty(), "modifiedAt should be populated");
+        }
+
+        @Test
+        void ls_reportsFileSizeAndModifiedAt() {
+            FakeSandboxFilesystem filesystem = new FakeSandboxFilesystem();
+
+            LsResult result = filesystem.ls(RT, "/workspace");
+
+            assertTrue(result.isSuccess());
+            assertFalse(result.entries().isEmpty());
+
+            FileInfo file =
+                    result.entries().stream()
+                            .filter(e -> e.path().equals("/workspace/readme.txt"))
+                            .findFirst()
+                            .orElseThrow();
+            assertEquals(12L, file.size());
+            assertFalse(file.modifiedAt().isEmpty(), "file modifiedAt should be populated");
+        }
+
+        @Test
+        void ls_reportsDirModifiedAt() {
+            FakeSandboxFilesystem filesystem = new FakeSandboxFilesystem();
+
+            LsResult result = filesystem.ls(RT, "/workspace");
+
+            assertTrue(result.isSuccess());
+            FileInfo dir =
+                    result.entries().stream()
+                            .filter(e -> e.path().equals("/workspace/docs"))
+                            .findFirst()
+                            .orElseThrow();
+            assertTrue(dir.isDirectory());
+            assertFalse(dir.modifiedAt().isEmpty(), "dir modifiedAt should be populated");
+        }
     }
 
-    @Test
-    void glob_plainPattern_keepsFindNamePatternUnchanged() {
-        FakeSandboxFilesystem filesystem = new FakeSandboxFilesystem();
+    // ================================================================
+    // Integration tests — real shell execution, Linux only
+    // ================================================================
 
-        GlobResult result = filesystem.glob(RT, "*.md", "/workspace");
+    @Nested
+    @EnabledOnOs(OS.LINUX)
+    class LocalShellIntegrationTests {
 
-        assertTrue(result.isSuccess());
-        assertEquals(
-                "find '/workspace' -type f -name '*.md' 2>/dev/null | sort",
-                filesystem.lastCommand);
-        assertEquals(
-                List.of("/workspace/README.md", "/workspace/docs/guide.md"),
-                result.matches().stream().map(match -> match.path()).collect(Collectors.toList()));
+        @TempDir Path tmpDir;
+
+        @Test
+        void ls_returnsRealSizeAndModifiedAt() throws IOException {
+            byte[] content = "hello world\n".getBytes(StandardCharsets.UTF_8);
+            Files.write(tmpDir.resolve("file.txt"), content);
+            Files.createDirectory(tmpDir.resolve("subdir"));
+
+            LocalShellSandboxFilesystem fs = new LocalShellSandboxFilesystem();
+            LsResult result = fs.ls(RT, tmpDir.toString());
+
+            assertTrue(result.isSuccess());
+            assertEquals(2, result.entries().size());
+
+            FileInfo file =
+                    result.entries().stream()
+                            .filter(e -> e.path().endsWith("file.txt"))
+                            .findFirst()
+                            .orElseThrow();
+            assertEquals(content.length, file.size());
+            assertFalse(file.modifiedAt().isEmpty());
+
+            FileInfo dir =
+                    result.entries().stream()
+                            .filter(FileInfo::isDirectory)
+                            .findFirst()
+                            .orElseThrow();
+            assertFalse(dir.modifiedAt().isEmpty());
+        }
+
+        @Test
+        void glob_returnsRealSizeAndModifiedAt() throws IOException {
+            Files.write(tmpDir.resolve("a.md"), "aaa".getBytes(StandardCharsets.UTF_8));
+            Path sub = Files.createDirectory(tmpDir.resolve("sub"));
+            Files.write(sub.resolve("b.md"), "bbbbb".getBytes(StandardCharsets.UTF_8));
+
+            LocalShellSandboxFilesystem fs = new LocalShellSandboxFilesystem();
+            GlobResult result = fs.glob(RT, "**/*.md", tmpDir.toString());
+
+            assertTrue(result.isSuccess());
+            assertEquals(2, result.matches().size());
+
+            FileInfo a =
+                    result.matches().stream()
+                            .filter(f -> f.path().endsWith("a.md"))
+                            .findFirst()
+                            .orElseThrow();
+            assertEquals(3L, a.size());
+            assertFalse(a.modifiedAt().isEmpty());
+
+            FileInfo b =
+                    result.matches().stream()
+                            .filter(f -> f.path().endsWith("b.md"))
+                            .findFirst()
+                            .orElseThrow();
+            assertEquals(5L, b.size());
+            assertFalse(b.modifiedAt().isEmpty());
+        }
+
+        @Test
+        void glob_emptyResultWhenNoMatch() {
+            LocalShellSandboxFilesystem fs = new LocalShellSandboxFilesystem();
+            GlobResult result = fs.glob(RT, "*.xyz", tmpDir.toString());
+            assertTrue(result.isSuccess());
+            assertTrue(result.matches().isEmpty());
+        }
     }
 
-    @Test
-    void ls_reportsActualFileSizeInsteadOfZero() {
-        FakeSandboxFilesystem filesystem = new FakeSandboxFilesystem();
-
-        var result = filesystem.ls(RT, "/workspace");
-
-        assertTrue(result.isSuccess());
-        assertFalse(result.entries().isEmpty());
-        assertTrue(filesystem.lastCommand.startsWith("for f in '/workspace'/*; do"));
-        assertTrue(filesystem.lastCommand.contains("stat -c '%s'"));
-        assertEquals(
-                12L,
-                result.entries().stream()
-                        .filter(entry -> entry.path().equals("/workspace/readme.txt"))
-                        .findFirst()
-                        .orElseThrow()
-                        .size());
-    }
+    // ================================================================
+    // Test helpers
+    // ================================================================
 
     private static final class FakeSandboxFilesystem extends BaseSandboxFilesystem {
 
-        private String lastCommand;
+        String lastCommand;
 
         @Override
         public String id() {
@@ -95,17 +225,56 @@ class BaseSandboxFilesystemTest {
         public ExecuteResponse execute(
                 RuntimeContext runtimeContext, String command, Integer timeoutSeconds) {
             lastCommand = command;
-            if (command.startsWith("for f in ")
-                    && command.contains("stat -c '%s'")
-                    && command.contains("printf 'FILE:%s\\t%s\\n'")) {
+            if (command.startsWith("for f in ") && command.contains("stat -c")) {
                 return new ExecuteResponse(
-                        "DIR:/workspace/docs\nFILE:/workspace/readme.txt\t12\n", 0, false);
+                        "DIR:/workspace/docs\t1719300000\n"
+                                + "FILE:/workspace/readme.txt\t12\t1719300000\n",
+                        0,
+                        false);
             }
-            if ("find '/workspace' -type f -name '*.md' 2>/dev/null | sort".equals(command)) {
+            if (command.startsWith("find ") && command.contains("-exec stat")) {
                 return new ExecuteResponse(
-                        "/workspace/README.md\n/workspace/docs/guide.md\n", 0, false);
+                        "/workspace/README.md\t1024\t1719300000\n"
+                                + "/workspace/docs/guide.md\t512\t1719300000\n",
+                        0,
+                        false);
             }
             return new ExecuteResponse("", 0, false);
+        }
+
+        @Override
+        public List<FileUploadResponse> uploadFiles(
+                RuntimeContext runtimeContext, List<Map.Entry<String, byte[]>> files) {
+            return List.of();
+        }
+
+        @Override
+        public List<FileDownloadResponse> downloadFiles(
+                RuntimeContext runtimeContext, List<String> paths) {
+            return List.of();
+        }
+    }
+
+    private static final class LocalShellSandboxFilesystem extends BaseSandboxFilesystem {
+
+        @Override
+        public String id() {
+            return "local-shell";
+        }
+
+        @Override
+        public ExecuteResponse execute(
+                RuntimeContext runtimeContext, String command, Integer timeoutSeconds) {
+            try {
+                Process p =
+                        new ProcessBuilder("sh", "-c", command).redirectErrorStream(true).start();
+                String output =
+                        new String(p.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
+                int exitCode = p.waitFor();
+                return new ExecuteResponse(output, exitCode, false);
+            } catch (Exception e) {
+                return new ExecuteResponse("execute failed: " + e.getMessage(), 1, false);
+            }
         }
 
         @Override

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/filesystem/sandbox/BaseSandboxFilesystemTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/filesystem/sandbox/BaseSandboxFilesystemTest.java
@@ -71,6 +71,8 @@ class BaseSandboxFilesystemTest {
 
         assertTrue(result.isSuccess());
         assertFalse(result.entries().isEmpty());
+        assertTrue(filesystem.lastCommand.startsWith("for f in '/workspace'/*; do"));
+        assertTrue(filesystem.lastCommand.contains("stat -c '%s'"));
         assertEquals(12L, result.entries().stream()
                 .filter(entry -> entry.path().equals("/workspace/readme.txt"))
                 .findFirst()
@@ -91,8 +93,9 @@ class BaseSandboxFilesystemTest {
         public ExecuteResponse execute(
                 RuntimeContext runtimeContext, String command, Integer timeoutSeconds) {
             lastCommand = command;
-            if ("for f in '/workspace'/*; do   if [ -d \"$f\" ]; then echo \"DIR:$f\";   elif [ -f \"$f\" ]; then     size=$(wc -c < \"$f\" 2>/dev/null | tr -d '[:space:]');     size=${size:-0};     printf 'FILE:%s\\t%s\\n' \"$f\" \"$size\";   fi; done 2>/dev/null"
-                    .equals(command)) {
+            if (command.startsWith("for f in ")
+                    && command.contains("stat -c '%s'")
+                    && command.contains("printf 'FILE:%s\\t%s\\n'")) {
                 return new ExecuteResponse(
                         "DIR:/workspace/docs\nFILE:/workspace/readme.txt\t12\n", 0, false);
             }


### PR DESCRIPTION
## AgentScope-Java Version

2.0.0-SNAPSHOT

## Description

Fix `list_files` in sandbox-backed filesystems so file entries report their real size instead of always showing `0 bytes`.

This change updates the sandbox `ls` output to include file sizes and adds a regression test to prevent the issue from coming back.

Related issue: #1837


Closes #1837