### PR TITLE
feat: support knownSkillNames in NacosSkillRepository

### DIFF
--- a/agentscope-extensions/agentscope-extensions-nacos/agentscope-extensions-nacos-skill/src/main/java/io/agentscope/core/nacos/skill/NacosSkillRepository.java
+++ b/agentscope-extensions/agentscope-extensions-nacos/agentscope-extensions-nacos-skill/src/main/java/io/agentscope/core/nacos/skill/NacosSkillRepository.java
@@ -53,10 +53,17 @@ import org.slf4j.LoggerFactory;
  *
  * <p><strong>Capabilities:</strong> Read operations work: {@link #getSkill(String)}, {@link
  * #skillExists(String)}, {@link #getRepositoryInfo()}, {@link #getSource()}, {@link
- * #isWriteable()} (always {@code false}). Listing and writes are unsupported: {@link
- * #getAllSkillNames()} and {@link #getAllSkills()} return empty results; {@link #save(List,
- * boolean)} and {@link #delete(String)} do nothing; {@link #setWriteable(boolean)} is ignored. These
- * paths log a warning.
+ * #isWriteable()} (always {@code false}). Writes are unsupported: {@link #save(List, boolean)} and
+ * {@link #delete(String)} do nothing; {@link #setWriteable(boolean)} is ignored. These paths log a
+ * warning.
+ *
+ * <p><strong>Listing:</strong> Nacos AI Service has no "list all skills" API. When constructed
+ * without {@code knownSkillNames}, {@link #getAllSkillNames()} and {@link #getAllSkills()} return
+ * empty results and log a warning. Pass a non-empty {@code knownSkillNames} list to the
+ * {@link #NacosSkillRepository(AiService, String, Properties, List)} constructor to enable
+ * enumeration — {@link #getAllSkills()} will then fetch each skill via {@link #getSkill(String)}
+ * in sequence (one network call per skill; prefer {@code MysqlSkillRepository} for large
+ * catalogues).
  *
  * <p><strong>Version and label resolution:</strong> Independently for version and for label, the
  * first non-blank value wins, in order: (1) {@link Properties} from {@link
@@ -98,25 +105,39 @@ public class NacosSkillRepository implements AgentSkillRepository {
     private final String location;
     private final String skillVersion;
     private final String skillLabel;
+    private final List<String> knownSkillNames;
 
     /**
      * Same as {@link #NacosSkillRepository(AiService, String, Properties)} with {@code properties
      * == null}.
      */
     public NacosSkillRepository(AiService aiService, String namespaceId) {
-        this(aiService, namespaceId, null);
+        this(aiService, namespaceId, null, Collections.emptyList());
+    }
+
+    /**
+     * Same as {@link #NacosSkillRepository(AiService, String, Properties, List)} with an empty
+     * {@code knownSkillNames}.
+     */
+    public NacosSkillRepository(AiService aiService, String namespaceId, Properties properties) {
+        this(aiService, namespaceId, properties, Collections.emptyList());
     }
 
     /**
      * Creates a repository for the given Nacos namespace; resolves skill version and label once
      * (see class Javadoc for precedence).
      *
-     * @param aiService   the Nacos AI service (must not be null)
-     * @param namespaceId the Nacos namespace id (blank treated as {@code public})
-     * @param properties  optional application properties (e.g. from {@code application.properties});
-     *                    may be {@code null}
+     * @param aiService        the Nacos AI service (must not be null)
+     * @param namespaceId      the Nacos namespace id (blank treated as {@code public})
+     * @param properties       optional application properties; may be {@code null}
+     * @param knownSkillNames  skill names to expose via {@link #getAllSkillNames()} and
+     *                         {@link #getAllSkills()}; pass empty list to keep the no-op behaviour
      */
-    public NacosSkillRepository(AiService aiService, String namespaceId, Properties properties) {
+    public NacosSkillRepository(
+            AiService aiService,
+            String namespaceId,
+            Properties properties,
+            List<String> knownSkillNames) {
         if (aiService == null) {
             throw new IllegalArgumentException("AiService cannot be null");
         }
@@ -135,12 +156,15 @@ public class NacosSkillRepository implements AgentSkillRepository {
                         getProperties(properties, SKILL_LABEL_PATH),
                         System.getProperty(SKILL_LABEL_PATH),
                         System.getenv(ENV_SKILL_LABEL_PATH));
+        this.knownSkillNames =
+                knownSkillNames == null ? Collections.emptyList() : List.copyOf(knownSkillNames);
         log.info(
                 "NacosSkillRepository initialized for namespace: {}, skillVersion: {},"
-                        + " skillLabel: {}",
+                        + " skillLabel: {}, knownSkillNames: {}",
                 this.namespaceId,
                 StringUtils.isBlank(skillVersion) ? "(none)" : skillVersion,
-                StringUtils.isBlank(skillLabel) ? "(none)" : skillLabel);
+                StringUtils.isBlank(skillLabel) ? "(none)" : skillLabel,
+                this.knownSkillNames.isEmpty() ? "(none)" : this.knownSkillNames);
     }
 
     @Override
@@ -204,14 +228,33 @@ public class NacosSkillRepository implements AgentSkillRepository {
 
     @Override
     public List<String> getAllSkillNames() {
-        log.warn("NacosSkillRepository is read-only, getAllSkillNames returns empty list");
-        return Collections.emptyList();
+        if (knownSkillNames.isEmpty()) {
+            log.warn(
+                    "NacosSkillRepository: no knownSkillNames configured, returning empty list."
+                            + " Pass knownSkillNames to the constructor to enable enumeration.");
+            return Collections.emptyList();
+        }
+        return knownSkillNames;
     }
 
     @Override
     public List<AgentSkill> getAllSkills() {
-        log.warn("NacosSkillRepository is read-only, getAllSkills returns empty list");
-        return Collections.emptyList();
+        if (knownSkillNames.isEmpty()) {
+            log.warn(
+                    "NacosSkillRepository: no knownSkillNames configured, returning empty list."
+                            + " Pass knownSkillNames to the constructor to enable enumeration.");
+            return Collections.emptyList();
+        }
+        // one network call per skill — prefer MysqlSkillRepository for large catalogues
+        List<AgentSkill> result = new ArrayList<>(knownSkillNames.size());
+        for (String name : knownSkillNames) {
+            try {
+                result.add(getSkill(name));
+            } catch (Exception e) {
+                log.warn("NacosSkillRepository: failed to load skill '{}', skipping", name, e);
+            }
+        }
+        return result;
     }
 
     @Override

--- a/agentscope-extensions/agentscope-extensions-nacos/agentscope-extensions-nacos-skill/src/test/java/io/agentscope/core/nacos/skill/NacosSkillRepositoryTest.java
+++ b/agentscope-extensions/agentscope-extensions-nacos/agentscope-extensions-nacos-skill/src/test/java/io/agentscope/core/nacos/skill/NacosSkillRepositoryTest.java
@@ -419,6 +419,15 @@ class NacosSkillRepositoryTest {
     }
 
     @Test
+    @DisplayName("null knownSkillNames is treated the same as empty list")
+    void testNullKnownSkillNamesTreatedAsEmpty() {
+        NacosSkillRepository repo = new NacosSkillRepository(aiService, "public", null, null);
+
+        assertTrue(repo.getAllSkillNames().isEmpty());
+        assertTrue(repo.getAllSkills().isEmpty());
+    }
+
+    @Test
     @DisplayName("getAllSkillNames returns knownSkillNames when configured")
     void testGetAllSkillNamesWithKnownNames() {
         NacosSkillRepository repo =

--- a/agentscope-extensions/agentscope-extensions-nacos/agentscope-extensions-nacos-skill/src/test/java/io/agentscope/core/nacos/skill/NacosSkillRepositoryTest.java
+++ b/agentscope-extensions/agentscope-extensions-nacos/agentscope-extensions-nacos-skill/src/test/java/io/agentscope/core/nacos/skill/NacosSkillRepositoryTest.java
@@ -418,6 +418,50 @@ class NacosSkillRepositoryTest {
         assertFalse(repository.delete("any-skill"));
     }
 
+    @Test
+    @DisplayName("getAllSkillNames returns knownSkillNames when configured")
+    void testGetAllSkillNamesWithKnownNames() {
+        NacosSkillRepository repo =
+                new NacosSkillRepository(aiService, "public", null, List.of("skill-a", "skill-b"));
+
+        List<String> names = repo.getAllSkillNames();
+
+        assertEquals(List.of("skill-a", "skill-b"), names);
+    }
+
+    @Test
+    @DisplayName("getAllSkills fetches each knownSkillName and returns loaded skills")
+    void testGetAllSkillsWithKnownNames() throws Exception {
+        NacosSkillRepository repo =
+                new NacosSkillRepository(aiService, "public", null, List.of("skill-a", "skill-b"));
+        when(aiService.downloadSkillZip("skill-a"))
+                .thenReturn(createSkillZip("skill-a", "Desc A", "Content A", null, (String) null));
+        when(aiService.downloadSkillZip("skill-b"))
+                .thenReturn(createSkillZip("skill-b", "Desc B", "Content B", null, (String) null));
+
+        List<AgentSkill> skills = repo.getAllSkills();
+
+        assertEquals(2, skills.size());
+        assertEquals("skill-a", skills.get(0).getName());
+        assertEquals("skill-b", skills.get(1).getName());
+    }
+
+    @Test
+    @DisplayName("getAllSkills skips skills that fail to load and returns the rest")
+    void testGetAllSkillsSkipsFailedSkill() throws Exception {
+        NacosSkillRepository repo =
+                new NacosSkillRepository(aiService, "public", null, List.of("good", "bad"));
+        when(aiService.downloadSkillZip("good"))
+                .thenReturn(createSkillZip("good", "Desc", "Content", null, (String) null));
+        when(aiService.downloadSkillZip("bad"))
+                .thenThrow(new NacosException(NacosException.NOT_FOUND, "not found"));
+
+        List<AgentSkill> skills = repo.getAllSkills();
+
+        assertEquals(1, skills.size());
+        assertEquals("good", skills.get(0).getName());
+    }
+
     private static byte[] createSkillZip(
             String name,
             String description,


### PR DESCRIPTION
## AgentScope-Java Version

2.0.0-SNAPSHOT

## Description

**Background**

Nacos AI Service has no "list all skills" API. `NacosSkillRepository.getAllSkillNames()`
and `getAllSkills()` previously returned empty results unconditionally, making it
impossible to enumerate skills when using a Nacos-backed repository.

**Changes**

Added a new four-arg constructor:

    NacosSkillRepository(AiService, String namespaceId, Properties, List<String> knownSkillNames)

- `getAllSkillNames()` returns the configured list when `knownSkillNames` is non-empty;
  falls back to the original empty-list + warning behaviour when it is empty.
- `getAllSkills()` fetches each known skill via `getSkill()` in sequence, skipping any
  that fail to load (logged as WARN). One network call per skill — callers with large
  catalogues should prefer `MysqlSkillRepository`.
- The existing two-arg and three-arg constructors delegate to the new constructor with
  an empty list, preserving full backward compatibility.

**How to test**

```java
List<String> names = List.of("skill-a", "skill-b");
NacosSkillRepository repo = new NacosSkillRepository(aiService, namespaceId, null, names);

repo.getAllSkillNames(); // ["skill-a", "skill-b"]
repo.getAllSkills();     // fetches each from Nacos and returns loaded AgentSkill list

Checklist

- [x] Code has been formatted with mvn spotless:apply
- [x] All tests are passing (mvn test) — 33 tests, 0 failures
- [x] Javadoc comments are complete and follow project conventions
- [ ] Related documentation has been updated (e.g. links, examples, etc.)
- [x] Code is ready for review