### PR TITLE
fix:SandboxBackedFilesystem download files Error. Coreutils' `base64` wraps stdout at 76 chars by default; use …

### DIFF
--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/filesystem/sandbox/SandboxBackedFilesystem.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/filesystem/sandbox/SandboxBackedFilesystem.java
@@ -146,11 +146,8 @@ public class SandboxBackedFilesystem extends BaseSandboxFilesystem implements Sa
                 ExecResult result = active.exec(runtimeContext, cmd, null);
                 if (result.ok()) {
                     byte[] decoded =
-                            Base64.getDecoder()
-                                    .decode(
-                                            result.stdout()
-                                                    .trim()
-                                                    .getBytes(StandardCharsets.UTF_8));
+                            Base64.getMimeDecoder()
+                                    .decode(result.stdout().getBytes(StandardCharsets.UTF_8));
                     results.add(FileDownloadResponse.success(path, decoded));
                 } else {
                     results.add(FileDownloadResponse.fail(path, result.combinedOutput()));


### PR DESCRIPTION
…the MIME decoder so embedded newlines/whitespace are tolerated across distributions.

## AgentScope-Java Version

2.0.0-SNAPSHOT

## Description

when I download file in docker sandbox via SandboxBackedFilesystem（MacOs）,i get a error below:
       java.lang.IllegalArgumentException: Illegal base64 character a
	at java.base/java.util.Base64$Decoder.decode0(Base64.java:852) ~[na:na]
	at java.base/java.util.Base64$Decoder.decode(Base64.java:570) ~[na:na]
	at io.agentscope.harness.agent.filesystem.sandbox.SandboxBackedFilesystem.downloadFiles(SandboxBackedFilesystem.java:144) ~[classes/:na]

so I fix the decode type in this pr. GNU coreutils' `base64` wraps stdout at 76 chars by default; use the MIME decoder so embedded newlines/whitespace are tolerated across distributions.
## Checklist

Please check the following items before code is ready to be reviewed.

- [ok ]  Code has been formatted with `mvn spotless:apply`
- [ok ]  All tests are passing (`mvn test`)
- [ok ]  Javadoc comments are complete and follow project conventions
- [ok ]  Related documentation has been updated (e.g. links, examples, etc.)
- [ok]  Code is ready for review
