### PR TITLE
feat(model): expose cached prompt tokens in ChatUsage

### DIFF
--- a/agentscope-core/src/main/java/io/agentscope/core/formatter/openai/OpenAIResponseParser.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/formatter/openai/OpenAIResponseParser.java
@@ -580,4 +580,11 @@ public class OpenAIResponseParser {
                 .finishReason(finishReason)
                 .build();
     }
+
+    private static Integer getCachedTokens(OpenAIUsage usage) {
+        if (usage.getPromptTokensDetails() != null) {
+            return usage.getPromptTokensDetails().getCachedTokens();
+        }
+        return null;
+    }
 }

--- a/agentscope-core/src/main/java/io/agentscope/core/formatter/openai/OpenAIResponseParser.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/formatter/openai/OpenAIResponseParser.java
@@ -113,6 +113,7 @@ public class OpenAIResponseParser {
                                 .time(
                                         Duration.between(startTime, Instant.now()).toMillis()
                                                 / 1000.0)
+                                .cachedTokens(getCachedTokens(openAIUsage))
                                 .build();
             }
 
@@ -346,6 +347,7 @@ public class OpenAIResponseParser {
                                 .time(
                                         Duration.between(startTime, Instant.now()).toMillis()
                                                 / 1000.0)
+                                .cachedTokens(getCachedTokens(openAIUsage))
                                 .build();
             }
 

--- a/agentscope-core/src/main/java/io/agentscope/core/model/ChatUsage.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/model/ChatUsage.java
@@ -51,6 +51,17 @@ public class ChatUsage {
     }
 
     /**
+     * Backward-compatible constructor without cached tokens.
+     *
+     * @param inputTokens the number of tokens used for the input/prompt
+     * @param outputTokens the number of tokens used for the output/generated response
+     * @param time the execution time in seconds
+     */
+    public ChatUsage(int inputTokens, int outputTokens, double time) {
+        this(inputTokens, outputTokens, time, null);
+    }
+
+    /**
      * Gets the number of input tokens used.
      *
      * @return the number of tokens used for the input/prompt

--- a/agentscope-core/src/main/java/io/agentscope/core/model/ChatUsage.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/model/ChatUsage.java
@@ -15,6 +15,9 @@
  */
 package io.agentscope.core.model;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 /**
  * Represents token usage information for chat completion responses.
  *
@@ -26,6 +29,7 @@ public class ChatUsage {
     private final int inputTokens;
     private final int outputTokens;
     private final double time;
+    private final Integer cachedTokens;
 
     /**
      * Creates a new ChatUsage instance.
@@ -34,10 +38,16 @@ public class ChatUsage {
      * @param outputTokens the number of tokens used for the output/generated response
      * @param time the execution time in seconds
      */
-    public ChatUsage(int inputTokens, int outputTokens, double time) {
+    @JsonCreator
+    public ChatUsage(
+            @JsonProperty("inputTokens") int inputTokens,
+            @JsonProperty("outputTokens") int outputTokens,
+            @JsonProperty("time") double time,
+            @JsonProperty("cachedTokens") Integer cachedTokens) {
         this.inputTokens = inputTokens;
         this.outputTokens = outputTokens;
         this.time = time;
+        this.cachedTokens = cachedTokens;
     }
 
     /**
@@ -77,6 +87,15 @@ public class ChatUsage {
     }
 
     /**
+     * Gets the number of cached prompt tokens.
+     *
+     * @return the number of cached tokens, or null if not reported by the provider
+     */
+    public Integer getCachedTokens() {
+        return cachedTokens;
+    }
+
+    /**
      * Creates a new builder for ChatUsage.
      *
      * @return a new Builder instance
@@ -92,6 +111,7 @@ public class ChatUsage {
         private int inputTokens;
         private int outputTokens;
         private double time;
+        private Integer cachedTokens;
 
         /**
          * Sets the number of input tokens.
@@ -127,12 +147,23 @@ public class ChatUsage {
         }
 
         /**
+         * Sets the number of cached prompt tokens.
+         *
+         * @param cachedTokens the number of cached tokens
+         * @return this builder instance
+         */
+        public Builder cachedTokens(Integer cachedTokens) {
+            this.cachedTokens = cachedTokens;
+            return this;
+        }
+
+        /**
          * Builds a new ChatUsage instance with the set values.
          *
          * @return a new ChatUsage instance
          */
         public ChatUsage build() {
-            return new ChatUsage(inputTokens, outputTokens, time);
+            return new ChatUsage(inputTokens, outputTokens, time, cachedTokens);
         }
     }
 }


### PR DESCRIPTION
Fixes #1854

## Problem

The OpenAI API returns `cached_tokens` in `usage.prompt_tokens_details.cached_tokens` for requests that hit the KV cache. The SDK already parses this into `OpenAIUsage.PromptTokensDetails.cachedTokens`, but `ChatUsage` does not expose it — users have no way to know how many tokens were served from cache.

## What changed

1. `ChatUsage.java` — added `cachedTokens` field (nullable `Integer`, null when provider does not report it), with getter and builder method
2. `OpenAIResponseParser.java` — extract `cachedTokens` from `OpenAIUsage.getPromptTokensDetails()` in both `parseCompletionResponse` and streaming paths, via a small `getCachedTokens()` helper

Fully backward compatible — `cachedTokens` defaults to `null`, existing code is unaffected.

## Validation

- `mvn compile -pl agentscope-core` — pass
- `cachedTokens` is null when `prompt_tokens_details` is absent (most providers)
- `cachedTokens` is populated when OpenAI returns it (e.g. repeated prompts with prompt caching enabled)