### PR TITLE
docs(context): fix multi-replica Redis example - declare jedis, add stateStore

### DIFF
--- a/docs/v2/en/docs/building-blocks/context.md
+++ b/docs/v2/en/docs/building-blocks/context.md
@@ -99,13 +99,14 @@ HarnessAgent agent = HarnessAgent.builder()
     .build();
 
 // Production multi-replica — use DistributedStore
-RedisClient client = RedisClient.create("redis://redis.prod:6379");
+JedisPooled jedis = new JedisPooled("redis://redis.prod:6379");
 HarnessAgent agent = HarnessAgent.builder()
-    .name("MyAgent")
-    .model(model)
-    .workspace(workspace)
-    .distributedStore(RedisDistributedStore.fromJedis(jedis))
-    .build();
+        .name("MyAgent")
+        .model(model)
+        .workspace(workspace)
+        .stateStore(new RedisAgentStateStore(jedis))
+        .distributedStore(RedisDistributedStore.fromJedis(jedis))
+        .build();
 ```
 
 :::{warning}

--- a/docs/v2/zh/docs/building-blocks/context.md
+++ b/docs/v2/zh/docs/building-blocks/context.md
@@ -99,13 +99,14 @@ HarnessAgent agent = HarnessAgent.builder()
     .build();
 
 // 多副本生产:使用 DistributedStore
-RedisClient client = RedisClient.create("redis://redis.prod:6379");
+JedisPooled jedis = new JedisPooled("redis://redis.prod:6379");
 HarnessAgent agent = HarnessAgent.builder()
-    .name("MyAgent")
-    .model(model)
-    .workspace(workspace)
-    .distributedStore(RedisDistributedStore.fromJedis(jedis))
-    .build();
+        .name("MyAgent")
+        .model(model)
+        .workspace(workspace)
+        .stateStore(new RedisAgentStateStore(jedis))
+        .distributedStore(RedisDistributedStore.fromJedis(jedis))
+        .build();
 ```
 
 :::{warning}


### PR DESCRIPTION
## AgentScope-Java Version

2.0.0-SNAPSHOT

## Description

This PR fixes the multi-replica Redis example in `docs/v2/zh/docs/building-blocks/context.md` and `docs/v2/en/docs/building-blocks/context.md`, tracked by issue #1864.

The original example contained:
- An undeclared `jedis` variable (would not compile)
- An unused `RedisClient client = ...` line
- Missing `stateStore` configuration, which defeats the purpose of multi-replica setup

Changes made:
- Replaced the invalid `RedisClient` line with a declared `JedisPooled jedis = ...`
- Added `.stateStore(new RedisAgentStateStore(jedis))` for complete state sharing
- Applied the same fix in both Chinese and English docs

Closes #1864

