### PR TITLE
fix(filesystem): use MIME Base64 decoder for sandbox file downloads

### DIFF
--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/filesystem/sandbox/SandboxBackedFilesystem.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/filesystem/sandbox/SandboxBackedFilesystem.java
@@ -146,7 +146,7 @@ public class SandboxBackedFilesystem extends BaseSandboxFilesystem implements Sa
                 ExecResult result = active.exec(runtimeContext, cmd, null);
                 if (result.ok()) {
                     byte[] decoded =
-                            Base64.getDecoder()
+                            Base64.getMimeDecoder()
                                     .decode(
                                             result.stdout()
                                                     .trim()


### PR DESCRIPTION
Fixes #1860

## Problem

`SandboxBackedFilesystem.downloadFiles()` runs the Linux `base64` command to encode file content. The command inserts line breaks every 76 characters by default. The code used `Base64.getDecoder()` which rejects input containing `\n` or `\r`, causing `IllegalArgumentException: Illegal base64 character a` on larger files.

## What changed

One line: `Base64.getDecoder()` → `Base64.getMimeDecoder()`

The MIME decoder (RFC 2045) ignores line breaks and other non-base64 characters, which is exactly what the Linux `base64` command output contains.

## Validation

- `Base64.getMimeDecoder()` is a drop-in replacement — same `decode()` API
- Handles all outputs from Linux `base64` command (with or without line breaks)
- No behavior change for small files (no line breaks in output)