### PR TITLE
docs: declare jedis variable in multi-replica production example

### DIFF
--- a/docs/v2/en/docs/others/going-to-production.md
+++ b/docs/v2/en/docs/others/going-to-production.md
@@ -8,6 +8,9 @@ description: "From single-node prototype to multi-replica deployment: component 
 **Fastest path to production**: use `DistributedStore` to configure all distributed components at once:
 
 ```java
+import redis.clients.jedis.JedisPooled;
+
+JedisPooled jedis = new JedisPooled("redis://localhost:6379");
 DistributedStore store = RedisDistributedStore.fromJedis(jedis);
 // or MysqlDistributedStore.create(dataSource);
 // or OssDistributedStore.create(ossClient, bucket, prefix);


### PR DESCRIPTION
Fixes #1864

## Problem

The multi-replica production example uses `jedis` variable without declaring it. Users copying the example get a compilation error.

## What changed

Added `JedisPooled` import and declaration before the first code block:

```java
import redis.clients.jedis.JedisPooled;

JedisPooled jedis = new JedisPooled("redis://localhost:6379");
DistributedStore store = RedisDistributedStore.fromJedis(jedis);
```

One-line fix — no behavior change.