### PR TITLE
fix(workspace): prevent OverlayFilesystem lower layer from shadowing workspace AGENTS.md

### DIFF
--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/workspace/WorkspaceManager.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/workspace/WorkspaceManager.java
@@ -845,7 +845,11 @@ public class WorkspaceManager implements AutoCloseable {
         if (filesystem == null) {
             return "";
         }
-        ReadResult r = filesystem.read(rc, filePath, 0, 0);
+        AbstractFilesystem target = filesystem;
+        if (filesystem instanceof OverlayFilesystem overlay) {
+            target = overlay.upper();
+        }
+        ReadResult r = target.read(rc, filePath, 0, 0);
         if (!r.isSuccess() || r.fileData() == null) {
             return "";
         }


### PR DESCRIPTION
## Problem

`WorkspaceManager.readTextThroughFilesystem` calls `filesystem.read()` on the raw `OverlayFilesystem`, which checks its upper (workspace) layer first and then **penetrates to the lower (project root) layer**. When the project root contains an `AGENTS.md` (e.g. opencode config), it shadows the workspace's own `AGENTS.md`.

### Root cause chain

1. Upper layer applies namespace prefix (`{ns}/AGENTS.md`) → not found
2. `OverlayFilesystem.read` falls through to lower layer (`{user.dir}/AGENTS.md`) → project root's AGENTS.md found
3. `readWithOverride` sees non-empty filesystem result → returns immediately, never reaching the local workspace fallback

## Fix

`readTextThroughFilesystem` now only consults the `OverlayFilesystem.upper()` layer for workspace-managed files. Non-overlay filesystem backends (e.g. `RemoteFilesystemSpec`, `SandboxBackedFilesystem`) are unaffected — they don't use an overlay, so `target` === `filesystem`.

The two-layer read architecture (filesystem first, local workspace fallback) is preserved for all backends.

## Testing

- `mvn spotless:apply` — pass
- `mvn test -pl agentscope-harness -am` — 566 tests, 0 failures