### PR TITLE
fix(middleware): wrap doFlush in Mono.defer to prevent premature evaluation

### DIFF
--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/middleware/MemoryFlushMiddleware.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/middleware/MemoryFlushMiddleware.java
@@ -129,7 +129,7 @@ public class MemoryFlushMiddleware implements MiddlewareBase {
         final RuntimeContext rc = ctx != null ? ctx : RuntimeContext.empty();
         return next.apply(input)
                 .concatWith(
-                        doFlush(agent, rc)
+                        Mono.defer(() -> doFlush(agent, rc))
                                 .subscribeOn(Schedulers.boundedElastic())
                                 .onErrorResume(
                                         e -> {


### PR DESCRIPTION
Fixes #1874

## Problem

`MemoryFlushMiddleware.onAgent()` uses `concatWith(doFlush(agent, rc))`. The `doFlush` method body executes during Flux assembly (not during subscription), because `concatWith` accepts a `Mono` but the method call `doFlush(agent, rc)` is evaluated eagerly to produce that `Mono`.

This means `state.getContext()`, `shouldFlushNow()`, and `MemoryFlushManager` construction all run immediately during assembly — before the upstream Flux has emitted any events. As a result, session offload never executes after the agent turn completes.

## What changed

Wrapped `doFlush` in `Mono.defer()`:

```java
// Before (bug): doFlush body runs during assembly
.concatWith(doFlush(agent, rc).subscribeOn(...))

// After (fix): doFlush body runs only when subscribed (after upstream completes)
.concatWith(Mono.defer(() -> doFlush(agent, rc)).subscribeOn(...))
```

## Validation

- `Mono.defer()` delays the supplier execution until subscription time
- The upstream Flux completes first, then `doFlush` runs — correct ordering
- No behavior change when the upstream is already complete (deferred Mono executes immediately on subscribe)
