### PR TITLE
fix(a2a): add configurable stream-buffer-size for A2A streaming

### DIFF
--- a/agentscope-extensions/agentscope-spring-boot-starters/agentscope-a2a-spring-boot-starter/src/main/java/io/agentscope/spring/boot/a2a/AgentscopeA2aAutoConfiguration.java
+++ b/agentscope-extensions/agentscope-spring-boot-starters/agentscope-a2a-spring-boot-starter/src/main/java/io/agentscope/spring/boot/a2a/AgentscopeA2aAutoConfiguration.java
@@ -120,12 +120,14 @@ public class AgentscopeA2aAutoConfiguration {
      * <p>TODO should judge whether user want to export JSON-RPC transport.
      *
      * @param agentScopeA2aServer agentscope A2a server bean
+     * @param commonProperties A2A common properties for stream buffer configuration
      * @return A2aJsonRpcController bean
      */
     @Bean
     @ConditionalOnBean(AgentScopeA2aServer.class)
-    public A2aJsonRpcController a2aJsonRpcController(AgentScopeA2aServer agentScopeA2aServer) {
-        return new A2aJsonRpcController(agentScopeA2aServer);
+    public A2aJsonRpcController a2aJsonRpcController(
+            AgentScopeA2aServer agentScopeA2aServer, A2aCommonProperties commonProperties) {
+        return new A2aJsonRpcController(agentScopeA2aServer, commonProperties);
     }
 
     @Bean

--- a/agentscope-extensions/agentscope-spring-boot-starters/agentscope-a2a-spring-boot-starter/src/main/java/io/agentscope/spring/boot/a2a/controller/A2aJsonRpcController.java
+++ b/agentscope-extensions/agentscope-spring-boot-starters/agentscope-a2a-spring-boot-starter/src/main/java/io/agentscope/spring/boot/a2a/controller/A2aJsonRpcController.java
@@ -21,6 +21,7 @@ import io.a2a.spec.TransportProtocol;
 import io.a2a.util.Utils;
 import io.agentscope.core.a2a.server.AgentScopeA2aServer;
 import io.agentscope.core.a2a.server.transport.jsonrpc.JsonRpcTransportWrapper;
+import io.agentscope.spring.boot.a2a.properties.A2aCommonProperties;
 import java.util.Map;
 import java.util.logging.Logger;
 import org.springframework.http.MediaType;
@@ -41,10 +42,14 @@ public class A2aJsonRpcController {
 
     private final AgentScopeA2aServer agentScopeA2aServer;
 
+    private final A2aCommonProperties commonProperties;
+
     private JsonRpcTransportWrapper jsonRpcHandler;
 
-    public A2aJsonRpcController(AgentScopeA2aServer agentScopeA2aServer) {
+    public A2aJsonRpcController(
+            AgentScopeA2aServer agentScopeA2aServer, A2aCommonProperties commonProperties) {
         this.agentScopeA2aServer = agentScopeA2aServer;
+        this.commonProperties = commonProperties;
     }
 
     @PostMapping(
@@ -57,6 +62,7 @@ public class A2aJsonRpcController {
         Object result = getJsonRpcHandler().handleRequest(body, header, Map.of());
         if (result instanceof Flux<?> fluxResult) {
             return fluxResult
+                    .onBackpressureBuffer(commonProperties.getStreamBufferSize())
                     .filter(each -> each instanceof JSONRPCResponse)
                     .map(each -> (JSONRPCResponse<?>) each)
                     .map(this::convertToSse);

--- a/agentscope-extensions/agentscope-spring-boot-starters/agentscope-a2a-spring-boot-starter/src/main/java/io/agentscope/spring/boot/a2a/properties/A2aCommonProperties.java
+++ b/agentscope-extensions/agentscope-spring-boot-starters/agentscope-a2a-spring-boot-starter/src/main/java/io/agentscope/spring/boot/a2a/properties/A2aCommonProperties.java
@@ -46,6 +46,17 @@ public class A2aCommonProperties {
      */
     private boolean requireInnerMessage;
 
+    /**
+     * The backpressure buffer size for A2A streaming responses.
+     *
+     * <p>This prevents BufferingTube overflow when LLM responses produce many streaming events.
+     * The default a2a-java-sdk BufferingTube capacity is 256, which may be insufficient
+     * for agents with parallel tool calls or long LLM responses.
+     *
+     * <p>Default: 1024
+     */
+    private int streamBufferSize = 1024;
+
     public A2aCommonProperties() {}
 
     public boolean isEnabled() {
@@ -87,5 +98,13 @@ public class A2aCommonProperties {
 
     public void setRequireInnerMessage(boolean requireInnerMessage) {
         this.requireInnerMessage = requireInnerMessage;
+    }
+
+    public int getStreamBufferSize() {
+        return streamBufferSize;
+    }
+
+    public void setStreamBufferSize(int streamBufferSize) {
+        this.streamBufferSize = streamBufferSize;
     }
 }

--- a/agentscope-extensions/agentscope-spring-boot-starters/agentscope-a2a-spring-boot-starter/src/test/java/io/agentscope/spring/boot/a2a/controller/A2aJsonRpcControllerTest.java
+++ b/agentscope-extensions/agentscope-spring-boot-starters/agentscope-a2a-spring-boot-starter/src/test/java/io/agentscope/spring/boot/a2a/controller/A2aJsonRpcControllerTest.java
@@ -29,6 +29,7 @@ import io.a2a.spec.SendStreamingMessageResponse;
 import io.a2a.spec.TransportProtocol;
 import io.agentscope.core.a2a.server.AgentScopeA2aServer;
 import io.agentscope.core.a2a.server.transport.jsonrpc.JsonRpcTransportWrapper;
+import io.agentscope.spring.boot.a2a.properties.A2aCommonProperties;
 import java.util.Collections;
 import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
@@ -61,7 +62,7 @@ class A2aJsonRpcControllerTest {
     @BeforeEach
     void setUp() {
         MockitoAnnotations.openMocks(this);
-        controller = new A2aJsonRpcController(agentScopeA2aServer);
+        controller = new A2aJsonRpcController(agentScopeA2aServer, new A2aCommonProperties());
         when(agentScopeA2aServer.getTransportWrapper(
                         eq(TransportProtocol.JSONRPC.asString()),
                         eq(JsonRpcTransportWrapper.class)))


### PR DESCRIPTION
   Fixes #1821

  ## Problem

  When using A2A streaming with parallel tool calls, the A2A SSE response throws                                                                                 
  `IllegalStateException: overflow buffer is full` from mutiny-zero's BufferingTube.

  The a2a-java-sdk's `AsyncUtils.DEFAULT_TUBE_BUFFER_SIZE = 256` is insufficient
  when an agent produces many streaming events (e.g., multiple MCP tools executing
  in parallel or long LLM responses).

  ## Root Cause

  The `A2aJsonRpcController` does not apply any `onBackpressureBuffer()` to the Flux chain,
  so it relies entirely on the a2a-java-sdk default capacity of 256, which can overflow
  when the producer is faster than the consumer.

  ## Solution

  1. Added `streamBufferSize` property to `A2aCommonProperties` (default: 1024)
  2. Applied `onBackpressureBuffer(properties.getStreamBufferSize())` in `A2aJsonRpcController`

  ## Configuration

  Users can now configure the buffer size in their `application.yaml`:

  ```yaml
  agentscope:
    a2a:
      server:
        stream-buffer-size: 2048  # default is 1024

  Changes

  - A2aCommonProperties.java: Added streamBufferSize property with getter/setter
  - A2aJsonRpcController.java: Inject A2aCommonProperties and apply onBackpressureBuffer()
  - AgentscopeA2aAutoConfiguration.java: Updated bean creation to pass properties
  - A2aJsonRpcControllerTest.java: Updated test to include properties

  Checklist

  - [done] Code has been formatted with mvn spotless:apply
  - [done] All tests are passing (mvn test)
  - [done] Javadoc comments are complete and follow project conventions
  - [done] Related documentation has been updated
  - [done] Code is ready for review
