### PR TITLE
fix: remove AgentRun sandbox api version prefix

### DIFF
--- a/agentscope-extensions/agentscope-extensions-sandbox/agentscope-extensions-sandbox-agentrun/src/main/java/io/agentscope/extensions/sandbox/agentrun/AgentRunDataPlaneHttp.java
+++ b/agentscope-extensions/agentscope-extensions-sandbox/agentscope-extensions-sandbox-agentrun/src/main/java/io/agentscope/extensions/sandbox/agentrun/AgentRunDataPlaneHttp.java
@@ -93,12 +93,12 @@ final class AgentRunDataPlaneHttp {
             }
         }
 
-        String url = opt.getResolvedDataPlaneBaseUrl() + "/2025-09-10/sandboxes";
+        String url = opt.getResolvedDataPlaneBaseUrl() + "/sandboxes";
         return AgentRunRetry.withRetries(opt.getMaxRetries(), () -> postJson(url, body));
     }
 
     JsonNode getSandbox(String sandboxId) throws IOException {
-        String url = opt.getResolvedDataPlaneBaseUrl() + "/2025-09-10/sandboxes/" + sandboxId;
+        String url = opt.getResolvedDataPlaneBaseUrl() + "/sandboxes/" + sandboxId;
         return AgentRunRetry.withRetries(opt.getMaxRetries(), () -> getJson(url));
     }
 
@@ -107,7 +107,7 @@ final class AgentRunDataPlaneHttp {
      * responses raise.
      */
     void deleteSandbox(String sandboxId) throws IOException {
-        String url = opt.getResolvedDataPlaneBaseUrl() + "/2025-09-10/sandboxes/" + sandboxId;
+        String url = opt.getResolvedDataPlaneBaseUrl() + "/sandboxes/" + sandboxId;
         Request req = baseRequest().url(url).delete().build();
         try (Response res = http.newCall(req).execute()) {
             if (!res.isSuccessful() && res.code() != 404) {

--- a/agentscope-extensions/agentscope-extensions-sandbox/agentscope-extensions-sandbox-agentrun/src/test/java/io/agentscope/extensions/sandbox/agentrun/AgentRunDataPlaneHttpTest.java
+++ b/agentscope-extensions/agentscope-extensions-sandbox/agentscope-extensions-sandbox-agentrun/src/test/java/io/agentscope/extensions/sandbox/agentrun/AgentRunDataPlaneHttpTest.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.extensions.sandbox.agentrun;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+import okhttp3.OkHttpClient;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class AgentRunDataPlaneHttpTest {
+
+    private MockWebServer mockServer;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        mockServer = new MockWebServer();
+        mockServer.start();
+    }
+
+    @AfterEach
+    void tearDown() throws IOException {
+        mockServer.shutdown();
+    }
+
+    @Test
+    void usesSandboxPathsWithoutVersionPrefix() throws Exception {
+        String baseUrl = mockServer.url("/").toString();
+        if (baseUrl.endsWith("/")) {
+            baseUrl = baseUrl.substring(0, baseUrl.length() - 1);
+        }
+
+        AgentRunSandboxClientOptions opt =
+                new AgentRunSandboxClientOptions()
+                        .setApiKey("test-key")
+                        .setAccountId("1234567890")
+                        .setTemplateName("agentscope-default")
+                        .setMcpServerUrl("https://example.com/mcp")
+                        .setDataPlaneBaseUrl(baseUrl)
+                        .setHttpClient(new OkHttpClient());
+
+        AgentRunDataPlaneHttp http = new AgentRunDataPlaneHttp(opt);
+
+        mockServer.enqueue(new MockResponse().setResponseCode(200).setBody("{\"id\":\"sb-1\"}"));
+        JsonNode created = http.createSandbox("sb-1");
+        assertNotNull(created);
+        assertEquals("sb-1", created.get("id").asText());
+        RecordedRequest createReq = mockServer.takeRequest(1, TimeUnit.SECONDS);
+        assertNotNull(createReq);
+        assertEquals("POST", createReq.getMethod());
+        assertEquals("/sandboxes", createReq.getPath());
+        assertEquals("test-key", createReq.getHeader("X-API-Key"));
+        assertEquals("1234567890", createReq.getHeader("X-Acs-Parent-Id"));
+        assertTrue(createReq.getBody().readUtf8().contains("\"sandboxId\":\"sb-1\""));
+
+        mockServer.enqueue(
+                new MockResponse().setResponseCode(200).setBody("{\"status\":\"READY\"}"));
+        JsonNode fetched = http.getSandbox("sb-1");
+        assertNotNull(fetched);
+        assertEquals("READY", fetched.get("status").asText());
+        RecordedRequest getReq = mockServer.takeRequest(1, TimeUnit.SECONDS);
+        assertNotNull(getReq);
+        assertEquals("GET", getReq.getMethod());
+        assertEquals("/sandboxes/sb-1", getReq.getPath());
+
+        mockServer.enqueue(new MockResponse().setResponseCode(204));
+        http.deleteSandbox("sb-1");
+        RecordedRequest deleteReq = mockServer.takeRequest(1, TimeUnit.SECONDS);
+        assertNotNull(deleteReq);
+        assertEquals("DELETE", deleteReq.getMethod());
+        assertEquals("/sandboxes/sb-1", deleteReq.getPath());
+    }
+}


### PR DESCRIPTION
## AgentScope-Java Version

2.0.0-SNAPSHOT

## Description

Fixes #1889.

Background:
AgentRun data-plane sandbox requests were being sent with an incorrect `/2025-09-10` path prefix, which caused sandbox create/get/delete calls to fail with `400 Bad Request: Invalid request uri`.

Purpose:
Align the AgentRun data-plane HTTP client with the actual sandbox API paths and prevent this regression from coming back.

Changes made:
- Removed the hardcoded `/2025-09-10` prefix from AgentRun sandbox URLs.
- Added a regression test to verify `POST /sandboxes`, `GET /sandboxes/{id}`, and `DELETE /sandboxes/{id}` are used.

How to test:
`mvn -pl agentscope-extensions/agentscope-extensions-sandbox/agentscope-extensions-sandbox-agentrun -am "-Dtest=AgentRunDataPlaneHttpTest,AgentRunOptionsValidationTest,AgentRunSandboxStateSerializationTest" test`
