### PR TITLE
fix(harness): normalize Windows list_files paths

### DIFF
--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/workspace/WorkspacePathNormalizer.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/workspace/WorkspacePathNormalizer.java
@@ -88,10 +88,12 @@ public final class WorkspacePathNormalizer {
     }
 
     private static String tryStrip(String path, String prefix) {
-        if (path.startsWith(prefix + "/")) {
-            return path.substring(prefix.length() + 1);
+        String normalizedPath = path.replace('\\', '/');
+        String normalizedPrefix = prefix.replace('\\', '/');
+        if (normalizedPath.startsWith(normalizedPrefix + "/")) {
+            return normalizedPath.substring(normalizedPrefix.length() + 1);
         }
-        if (path.equals(prefix)) {
+        if (normalizedPath.equals(normalizedPrefix)) {
             return ".";
         }
         return null;

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/tool/FilesystemToolTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/tool/FilesystemToolTest.java
@@ -24,6 +24,10 @@ import static org.mockito.Mockito.when;
 import io.agentscope.core.agent.RuntimeContext;
 import io.agentscope.harness.agent.filesystem.AbstractFilesystem;
 import io.agentscope.harness.agent.filesystem.model.EditResult;
+import io.agentscope.harness.agent.filesystem.model.FileInfo;
+import io.agentscope.harness.agent.filesystem.model.LsResult;
+import io.agentscope.harness.agent.workspace.WorkspacePathNormalizer;
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -61,5 +65,24 @@ class FilesystemToolTest {
 
         assertTrue(result.contains("2 replacement"));
         verify(filesystem).edit(RT, "f.txt", "old", "new", true);
+    }
+
+    @Test
+    void listFiles_normalizesWindowsAbsoluteWorkspacePath() {
+        WorkspacePathNormalizer normalizer =
+                WorkspacePathNormalizer.of(
+                        "D:\\workspace\\my-learn\\agentscope-v2\\.agentscope\\workspace");
+        tool = new FilesystemTool(filesystem, normalizer);
+
+        when(filesystem.ls(RT, "memory"))
+                .thenReturn(LsResult.success(List.of(FileInfo.ofDir("memory", ""))));
+
+        String result =
+                tool.listFiles(
+                        RT,
+                        "D:\\workspace\\my-learn\\agentscope-v2\\.agentscope\\workspace\\memory");
+
+        assertTrue(result.contains("[DIR]"));
+        verify(filesystem).ls(RT, "memory");
     }
 }


### PR DESCRIPTION
## AgentScope-Java Version
2.0.0-SNAPSHOT

## Description
This PR fixes Windows path normalization for `list_files` in `agentscope-harness`.

On Windows, absolute workspace paths that use backslashes were not normalized to workspace-relative form before being passed into the filesystem layer. As a result, `list_files` could fall back to the local backend and miss Redis-backed workspace data.

Changes made:
- Normalize `\` and `/` in `WorkspacePathNormalizer#tryStrip`.
- Add a regression test for `FilesystemTool.listFiles()` with a Windows-style absolute workspace path.

Related issue:
- Fixes #1887

How to test:
- `mvn -pl agentscope-harness -am -Dtest=FilesystemToolTest test`