### PR TITLE
fix(agui): propagate run input and frontend tools

### DIFF
--- a/agentscope-core/src/main/java/io/agentscope/core/agent/StreamableAgent.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/agent/StreamableAgent.java
@@ -166,6 +166,24 @@ public interface StreamableAgent {
     Flux<Event> stream(List<Msg> msgs, StreamOptions options);
 
     /**
+     * Stream execution events with a caller-supplied per-call runtime context.
+     *
+     * <p>Implementations that do not consume {@link RuntimeContext} can rely on this default
+     * bridge and continue using the original two-argument stream method.
+     *
+     * @param msgs Input messages
+     * @param options Stream configuration options
+     * @param context Runtime metadata for this call
+     * @return Flux of events emitted during execution
+     * @deprecated since 2.0.0, for removal. Use {@code ReActAgent#streamEvents(...)} for the
+     *     fine-grained {@code AgentEvent} stream.
+     */
+    @Deprecated(since = "2.0.0", forRemoval = true)
+    default Flux<Event> stream(List<Msg> msgs, StreamOptions options, RuntimeContext context) {
+        return stream(msgs, options);
+    }
+
+    /**
      * Stream execution events with structured output support.
      *
      * @param msgs Input messages

--- a/agentscope-core/src/test/java/io/agentscope/core/agent/StreamableAgentTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/agent/StreamableAgentTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.core.agent;
+
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.agentscope.core.message.Msg;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Flux;
+
+/** Tests for {@link StreamableAgent}. */
+class StreamableAgentTest {
+
+    @Test
+    void testRuntimeContextStreamDelegatesToLegacyStreamByDefault() {
+        TestStreamableAgent agent = new TestStreamableAgent();
+        List<Msg> messages = List.of();
+        StreamOptions options = StreamOptions.defaults();
+        RuntimeContext context = RuntimeContext.builder().sessionId("thread-1").build();
+
+        Flux<Event> events = agent.stream(messages, options, context);
+
+        assertSame(agent.events, events);
+        assertSame(messages, agent.lastMessages);
+        assertSame(options, agent.lastOptions);
+    }
+
+    private static final class TestStreamableAgent implements StreamableAgent {
+
+        private final Flux<Event> events = Flux.empty();
+        private List<Msg> lastMessages;
+        private StreamOptions lastOptions;
+
+        @Override
+        public Flux<Event> stream(List<Msg> msgs, StreamOptions options) {
+            lastMessages = msgs;
+            lastOptions = options;
+            return events;
+        }
+
+        @Override
+        public Flux<Event> stream(List<Msg> msgs, StreamOptions options, Class<?> structuredModel) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Flux<Event> stream(List<Msg> msgs, StreamOptions options, JsonNode schema) {
+            throw new UnsupportedOperationException();
+        }
+    }
+}

--- a/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/main/java/io/agentscope/core/agui/adapter/AguiAgentAdapter.java
+++ b/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/main/java/io/agentscope/core/agui/adapter/AguiAgentAdapter.java
@@ -18,19 +18,28 @@ package io.agentscope.core.agui.adapter;
 import io.agentscope.core.agent.Agent;
 import io.agentscope.core.agent.Event;
 import io.agentscope.core.agent.EventType;
+import io.agentscope.core.agent.RuntimeContext;
 import io.agentscope.core.agent.StreamOptions;
 import io.agentscope.core.agui.converter.AguiMessageConverter;
+import io.agentscope.core.agui.converter.AguiToolConverter;
 import io.agentscope.core.agui.event.AguiEvent;
 import io.agentscope.core.agui.model.RunAgentInput;
+import io.agentscope.core.agui.model.ToolMergeMode;
 import io.agentscope.core.message.ContentBlock;
 import io.agentscope.core.message.Msg;
 import io.agentscope.core.message.TextBlock;
 import io.agentscope.core.message.ThinkingBlock;
 import io.agentscope.core.message.ToolResultBlock;
 import io.agentscope.core.message.ToolUseBlock;
+import io.agentscope.core.model.ToolSchema;
+import io.agentscope.core.tool.AgentTool;
+import io.agentscope.core.tool.SchemaOnlyTool;
+import io.agentscope.core.tool.Toolkit;
 import io.agentscope.core.util.JsonException;
 import io.agentscope.core.util.JsonUtils;
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -63,9 +72,18 @@ import reactor.core.publisher.Flux;
  */
 public class AguiAgentAdapter {
 
+    public static final String RUNTIME_CONTEXT_THREAD_ID_KEY = "agui.threadId";
+    public static final String RUNTIME_CONTEXT_RUN_ID_KEY = "agui.runId";
+    public static final String RUNTIME_CONTEXT_MESSAGES_KEY = "agui.messages";
+    public static final String RUNTIME_CONTEXT_TOOLS_KEY = "agui.tools";
+    public static final String RUNTIME_CONTEXT_CONTEXT_KEY = "agui.context";
+    public static final String RUNTIME_CONTEXT_STATE_KEY = "agui.state";
+    public static final String RUNTIME_CONTEXT_FORWARDED_PROPS_KEY = "agui.forwardedProps";
+
     private final Agent agent;
     private final AguiAdapterConfig config;
     private final AguiMessageConverter messageConverter;
+    private final AguiToolConverter toolConverter;
 
     /**
      * Creates a new AguiAgentAdapter.
@@ -77,6 +95,7 @@ public class AguiAgentAdapter {
         this.agent = Objects.requireNonNull(agent, "agent cannot be null");
         this.config = Objects.requireNonNull(config, "config cannot be null");
         this.messageConverter = new AguiMessageConverter();
+        this.toolConverter = new AguiToolConverter();
     }
 
     /**
@@ -106,32 +125,103 @@ public class AguiAgentAdapter {
 
                     // Track state for event conversion
                     EventConversionState state = new EventConversionState(threadId, runId);
+                    RuntimeContext runtimeContext = buildRuntimeContext(input);
+                    ToolInjection toolInjection = ToolInjection.empty();
+                    Flux<Event> agentEvents;
+                    try {
+                        toolInjection = injectFrontendTools(input);
+                        agentEvents = agent.stream(msgs, options, runtimeContext);
+                        if (agentEvents == null) {
+                            agentEvents = agent.stream(msgs, options);
+                        }
+                        agentEvents = Objects.requireNonNull(agentEvents, "agent stream is null");
+                    } catch (Throwable error) {
+                        toolInjection.close();
+                        return Flux.concat(
+                                Flux.just(new AguiEvent.RunStarted(threadId, runId)),
+                                errorEvents(threadId, runId, error));
+                    }
+
+                    ToolInjection activeToolInjection = toolInjection;
 
                     return Flux.concat(
                                     // Emit RUN_STARTED
                                     Flux.just(new AguiEvent.RunStarted(threadId, runId)),
                                     // Stream agent events and convert to AG-UI events
                                     // Use concatMapIterable to preserve strict event ordering
-                                    agent.stream(msgs, options)
-                                            .concatMapIterable(event -> convertEvent(event, state)),
+                                    agentEvents.concatMapIterable(
+                                            event -> convertEvent(event, state)),
                                     // Emit any pending end events and RUN_FINISHED
                                     Flux.defer(() -> finishRun(state)))
-                            .onErrorResume(
-                                    error -> {
-                                        // On error, emit RawEvent with error info followed by
-                                        // RunFinished
-                                        String errorMessage =
-                                                error.getMessage() != null
-                                                        ? error.getMessage()
-                                                        : error.getClass().getSimpleName();
-                                        return Flux.just(
-                                                new AguiEvent.Raw(
-                                                        threadId,
-                                                        runId,
-                                                        Map.of("error", errorMessage)),
-                                                new AguiEvent.RunFinished(threadId, runId));
-                                    });
+                            .doFinally(signalType -> activeToolInjection.close())
+                            .onErrorResume(error -> errorEvents(threadId, runId, error));
                 });
+    }
+
+    private RuntimeContext buildRuntimeContext(RunAgentInput input) {
+        return RuntimeContext.builder()
+                .sessionId(input.getThreadId())
+                .put(RunAgentInput.class, input)
+                .put(RUNTIME_CONTEXT_THREAD_ID_KEY, input.getThreadId())
+                .put(RUNTIME_CONTEXT_RUN_ID_KEY, input.getRunId())
+                .put(RUNTIME_CONTEXT_MESSAGES_KEY, input.getMessages())
+                .put(RUNTIME_CONTEXT_TOOLS_KEY, input.getTools())
+                .put(RUNTIME_CONTEXT_CONTEXT_KEY, input.getContext())
+                .put(RUNTIME_CONTEXT_STATE_KEY, input.getState())
+                .put(RUNTIME_CONTEXT_FORWARDED_PROPS_KEY, input.getForwardedProps())
+                .build();
+    }
+
+    private ToolInjection injectFrontendTools(RunAgentInput input) {
+        if (!input.hasTools()) {
+            return ToolInjection.empty();
+        }
+
+        ToolMergeMode mergeMode =
+                config.getToolMergeMode() != null
+                        ? config.getToolMergeMode()
+                        : ToolMergeMode.MERGE_FRONTEND_PRIORITY;
+        if (mergeMode == ToolMergeMode.AGENT_ONLY) {
+            return ToolInjection.empty();
+        }
+
+        Toolkit toolkit = agent.getToolkit();
+        if (toolkit == null) {
+            return ToolInjection.empty();
+        }
+
+        Map<String, AgentTool> previousTools = new LinkedHashMap<>();
+        if (mergeMode == ToolMergeMode.FRONTEND_ONLY) {
+            for (String toolName : toolkit.getToolNames()) {
+                AgentTool previousTool = toolkit.getTool(toolName);
+                if (previousTool != null) {
+                    previousTools.put(toolName, previousTool);
+                    toolkit.removeTool(toolName);
+                }
+            }
+        }
+
+        List<SchemaOnlyTool> registeredTools = new ArrayList<>();
+        for (ToolSchema schema : toolConverter.toToolSchemaList(input.getTools())) {
+            AgentTool previousTool = toolkit.getTool(schema.getName());
+            if (previousTool != null) {
+                previousTools.putIfAbsent(schema.getName(), previousTool);
+            }
+
+            SchemaOnlyTool frontendTool = new SchemaOnlyTool(schema);
+            toolkit.registerAgentTool(frontendTool);
+            registeredTools.add(frontendTool);
+        }
+
+        return new ToolInjection(toolkit, registeredTools, previousTools);
+    }
+
+    private Flux<AguiEvent> errorEvents(String threadId, String runId, Throwable error) {
+        String errorMessage =
+                error.getMessage() != null ? error.getMessage() : error.getClass().getSimpleName();
+        return Flux.just(
+                new AguiEvent.Raw(threadId, runId, Map.of("error", errorMessage)),
+                new AguiEvent.RunFinished(threadId, runId));
     }
 
     /**
@@ -375,6 +465,45 @@ public class AguiAgentAdapter {
             return JsonUtils.getJsonCodec().toJson(input);
         } catch (JsonException e) {
             return "{}";
+        }
+    }
+
+    private static class ToolInjection {
+        private static final ToolInjection EMPTY =
+                new ToolInjection(null, Collections.emptyList(), Collections.emptyMap());
+
+        private final Toolkit toolkit;
+        private final List<SchemaOnlyTool> registeredTools;
+        private final Map<String, AgentTool> previousTools;
+
+        ToolInjection(
+                Toolkit toolkit,
+                List<SchemaOnlyTool> registeredTools,
+                Map<String, AgentTool> previousTools) {
+            this.toolkit = toolkit;
+            this.registeredTools = registeredTools;
+            this.previousTools = previousTools;
+        }
+
+        static ToolInjection empty() {
+            return EMPTY;
+        }
+
+        void close() {
+            if (toolkit == null) {
+                return;
+            }
+
+            for (int i = registeredTools.size() - 1; i >= 0; i--) {
+                SchemaOnlyTool tool = registeredTools.get(i);
+                toolkit.removeToolIfSame(tool.getName(), tool);
+            }
+
+            for (Map.Entry<String, AgentTool> entry : previousTools.entrySet()) {
+                if (toolkit.getTool(entry.getKey()) == null) {
+                    toolkit.registerAgentTool(entry.getValue());
+                }
+            }
         }
     }
 

--- a/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/main/java/io/agentscope/core/agui/processor/AguiRequestProcessor.java
+++ b/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/main/java/io/agentscope/core/agui/processor/AguiRequestProcessor.java
@@ -194,6 +194,7 @@ public class AguiRequestProcessor {
                 .messages(List.of(lastUserMessage))
                 .tools(input.getTools())
                 .context(input.getContext())
+                .state(input.getState())
                 .forwardedProps(input.getForwardedProps())
                 .build();
     }

--- a/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/test/java/io/agentscope/core/agui/adapter/AguiAgentAdapterTest.java
+++ b/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/test/java/io/agentscope/core/agui/adapter/AguiAgentAdapterTest.java
@@ -182,6 +182,149 @@ class AguiAgentAdapterTest {
     }
 
     @Test
+    void testRunEmitsErrorEventsWhenStreamThrowsBeforeReturningFlux() {
+        when(mockAgent.stream(anyList(), any(StreamOptions.class), any(RuntimeContext.class)))
+                .thenThrow(new RuntimeException());
+
+        RunAgentInput input =
+                RunAgentInput.builder()
+                        .threadId("thread-error")
+                        .runId("run-error")
+                        .messages(List.of(AguiMessage.userMessage("msg-1", "Hello")))
+                        .build();
+
+        List<AguiEvent> events = adapter.run(input).collectList().block();
+
+        assertNotNull(events);
+        assertEquals(3, events.size());
+        assertInstanceOf(AguiEvent.RunStarted.class, events.get(0));
+        AguiEvent.Raw raw = assertInstanceOf(AguiEvent.Raw.class, events.get(1));
+        assertEquals(Map.of("error", "RuntimeException"), raw.rawEvent());
+        assertInstanceOf(AguiEvent.RunFinished.class, events.get(2));
+    }
+
+    @Test
+    void testRunIgnoresFrontendToolsWhenAgentHasNoToolkit() {
+        when(mockAgent.getToolkit()).thenReturn(null);
+        when(mockAgent.stream(anyList(), any(StreamOptions.class), any(RuntimeContext.class)))
+                .thenReturn(Flux.empty());
+
+        RunAgentInput input =
+                RunAgentInput.builder()
+                        .threadId("thread-no-toolkit")
+                        .runId("run-no-toolkit")
+                        .messages(List.of(AguiMessage.userMessage("msg-1", "Hello")))
+                        .tools(List.of(frontendTool("frontend_lookup")))
+                        .build();
+
+        List<AguiEvent> events = adapter.run(input).collectList().block();
+
+        assertNotNull(events);
+        assertEquals(2, events.size());
+        assertInstanceOf(AguiEvent.RunStarted.class, events.get(0));
+        assertInstanceOf(AguiEvent.RunFinished.class, events.get(1));
+    }
+
+    @Test
+    void testRunUsesFrontendPriorityWhenToolMergeModeIsNull() {
+        Toolkit toolkit = new Toolkit();
+        when(mockAgent.getToolkit()).thenReturn(toolkit);
+        when(mockAgent.stream(anyList(), any(StreamOptions.class), any(RuntimeContext.class)))
+                .thenAnswer(
+                        invocation -> {
+                            assertInstanceOf(
+                                    SchemaOnlyTool.class, toolkit.getTool("frontend_lookup"));
+                            return Flux.empty();
+                        });
+
+        AguiAgentAdapter nullMergeModeAdapter =
+                new AguiAgentAdapter(
+                        mockAgent, AguiAdapterConfig.builder().toolMergeMode(null).build());
+        RunAgentInput input =
+                RunAgentInput.builder()
+                        .threadId("thread-null-merge-mode")
+                        .runId("run-null-merge-mode")
+                        .messages(List.of(AguiMessage.userMessage("msg-1", "Hello")))
+                        .tools(List.of(frontendTool("frontend_lookup")))
+                        .build();
+
+        nullMergeModeAdapter.run(input).collectList().block();
+
+        assertNull(toolkit.getTool("frontend_lookup"));
+    }
+
+    @Test
+    void testRunWithFrontendOnlyTemporarilyReplacesToolkitAndRestoresAgentTools() {
+        Toolkit toolkit = new Toolkit();
+        SchemaOnlyTool existingTool = schemaOnlyTool("agent_lookup");
+        SchemaOnlyTool existingSharedTool = schemaOnlyTool("shared_lookup");
+        toolkit.registerAgentTool(existingTool);
+        toolkit.registerAgentTool(existingSharedTool);
+        when(mockAgent.getToolkit()).thenReturn(toolkit);
+        when(mockAgent.stream(anyList(), any(StreamOptions.class), any(RuntimeContext.class)))
+                .thenAnswer(
+                        invocation -> {
+                            assertNull(toolkit.getTool("agent_lookup"));
+                            assertInstanceOf(
+                                    SchemaOnlyTool.class, toolkit.getTool("frontend_lookup"));
+                            assertInstanceOf(
+                                    SchemaOnlyTool.class, toolkit.getTool("shared_lookup"));
+                            assertNotSame(existingSharedTool, toolkit.getTool("shared_lookup"));
+                            return Flux.empty();
+                        });
+
+        AguiAgentAdapter frontendOnlyAdapter =
+                new AguiAgentAdapter(
+                        mockAgent,
+                        AguiAdapterConfig.builder()
+                                .toolMergeMode(ToolMergeMode.FRONTEND_ONLY)
+                                .build());
+        RunAgentInput input =
+                RunAgentInput.builder()
+                        .threadId("thread-frontend-only")
+                        .runId("run-frontend-only")
+                        .messages(List.of(AguiMessage.userMessage("msg-1", "Hello")))
+                        .tools(
+                                List.of(
+                                        frontendTool("frontend_lookup"),
+                                        frontendTool("shared_lookup")))
+                        .build();
+
+        frontendOnlyAdapter.run(input).collectList().block();
+
+        assertSame(existingTool, toolkit.getTool("agent_lookup"));
+        assertSame(existingSharedTool, toolkit.getTool("shared_lookup"));
+        assertNull(toolkit.getTool("frontend_lookup"));
+    }
+
+    @Test
+    void testRunKeepsToolThatReplacesInjectedFrontendToolBeforeCleanup() {
+        Toolkit toolkit = new Toolkit();
+        SchemaOnlyTool existingTool = schemaOnlyTool("shared_lookup");
+        SchemaOnlyTool replacementTool = schemaOnlyTool("shared_lookup");
+        toolkit.registerAgentTool(existingTool);
+        when(mockAgent.getToolkit()).thenReturn(toolkit);
+        when(mockAgent.stream(anyList(), any(StreamOptions.class), any(RuntimeContext.class)))
+                .thenAnswer(
+                        invocation -> {
+                            toolkit.registerAgentTool(replacementTool);
+                            return Flux.empty();
+                        });
+
+        RunAgentInput input =
+                RunAgentInput.builder()
+                        .threadId("thread-replaced-tool")
+                        .runId("run-replaced-tool")
+                        .messages(List.of(AguiMessage.userMessage("msg-1", "Hello")))
+                        .tools(List.of(frontendTool("shared_lookup")))
+                        .build();
+
+        adapter.run(input).collectList().block();
+
+        assertSame(replacementTool, toolkit.getTool("shared_lookup"));
+    }
+
+    @Test
     void testRunReturnsRunStartedAndFinishedEvents() {
         // Agent returns empty stream
         when(mockAgent.stream(anyList(), any(StreamOptions.class))).thenReturn(Flux.empty());

--- a/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/test/java/io/agentscope/core/agui/adapter/AguiAgentAdapterTest.java
+++ b/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/test/java/io/agentscope/core/agui/adapter/AguiAgentAdapterTest.java
@@ -18,6 +18,9 @@ package io.agentscope.core.agui.adapter;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
@@ -27,20 +30,27 @@ import static org.mockito.Mockito.when;
 import io.agentscope.core.agent.Agent;
 import io.agentscope.core.agent.Event;
 import io.agentscope.core.agent.EventType;
+import io.agentscope.core.agent.RuntimeContext;
 import io.agentscope.core.agent.StreamOptions;
 import io.agentscope.core.agui.event.AguiEvent;
 import io.agentscope.core.agui.model.AguiMessage;
+import io.agentscope.core.agui.model.AguiTool;
 import io.agentscope.core.agui.model.RunAgentInput;
+import io.agentscope.core.agui.model.ToolMergeMode;
 import io.agentscope.core.message.Msg;
 import io.agentscope.core.message.MsgRole;
 import io.agentscope.core.message.TextBlock;
 import io.agentscope.core.message.ThinkingBlock;
 import io.agentscope.core.message.ToolResultBlock;
 import io.agentscope.core.message.ToolUseBlock;
+import io.agentscope.core.model.ToolSchema;
+import io.agentscope.core.tool.SchemaOnlyTool;
+import io.agentscope.core.tool.Toolkit;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import reactor.core.publisher.Flux;
 import reactor.test.StepVerifier;
 
@@ -57,6 +67,118 @@ class AguiAgentAdapterTest {
     void setUp() {
         mockAgent = mock(Agent.class);
         adapter = new AguiAgentAdapter(mockAgent, AguiAdapterConfig.defaultConfig());
+    }
+
+    @Test
+    void testRunInjectsRunInputIntoRuntimeContext() {
+        ArgumentCaptor<RuntimeContext> contextCaptor =
+                ArgumentCaptor.forClass(RuntimeContext.class);
+        when(mockAgent.stream(anyList(), any(StreamOptions.class), contextCaptor.capture()))
+                .thenReturn(Flux.empty());
+
+        RunAgentInput input =
+                RunAgentInput.builder()
+                        .threadId("thread-ctx")
+                        .runId("run-ctx")
+                        .messages(List.of(AguiMessage.userMessage("msg-1", "Hello")))
+                        .tools(List.of(frontendTool("frontend_lookup")))
+                        .context(List.of())
+                        .state(Map.of("cursor", 12))
+                        .forwardedProps(Map.of("tenant", "demo"))
+                        .build();
+
+        adapter.run(input).collectList().block();
+
+        RuntimeContext context = contextCaptor.getValue();
+        assertEquals("thread-ctx", context.getSessionId());
+        assertSame(input, context.get(RunAgentInput.class));
+        assertEquals("thread-ctx", context.get("agui.threadId"));
+        assertEquals("run-ctx", context.get("agui.runId"));
+        assertSame(input.getMessages(), context.get("agui.messages"));
+        assertSame(input.getTools(), context.get("agui.tools"));
+        assertSame(input.getContext(), context.get("agui.context"));
+        assertSame(input.getState(), context.get("agui.state"));
+        assertSame(input.getForwardedProps(), context.get("agui.forwardedProps"));
+    }
+
+    @Test
+    void testRunRegistersFrontendToolsForRunAndCleansUp() {
+        Toolkit toolkit = new Toolkit();
+        when(mockAgent.getToolkit()).thenReturn(toolkit);
+        when(mockAgent.stream(anyList(), any(StreamOptions.class), any(RuntimeContext.class)))
+                .thenAnswer(
+                        invocation -> {
+                            assertInstanceOf(
+                                    SchemaOnlyTool.class, toolkit.getTool("frontend_lookup"));
+                            assertTrue(toolkit.isExternalTool("frontend_lookup"));
+                            return Flux.empty();
+                        });
+
+        RunAgentInput input =
+                RunAgentInput.builder()
+                        .threadId("thread-tools")
+                        .runId("run-tools")
+                        .messages(List.of(AguiMessage.userMessage("msg-1", "Hello")))
+                        .tools(List.of(frontendTool("frontend_lookup")))
+                        .build();
+
+        adapter.run(input).collectList().block();
+
+        assertNull(toolkit.getTool("frontend_lookup"));
+    }
+
+    @Test
+    void testRunRestoresAgentToolWhenFrontendToolHasSameName() {
+        Toolkit toolkit = new Toolkit();
+        SchemaOnlyTool existingTool = schemaOnlyTool("shared_lookup");
+        toolkit.registerAgentTool(existingTool);
+        when(mockAgent.getToolkit()).thenReturn(toolkit);
+        when(mockAgent.stream(anyList(), any(StreamOptions.class), any(RuntimeContext.class)))
+                .thenAnswer(
+                        invocation -> {
+                            assertInstanceOf(
+                                    SchemaOnlyTool.class, toolkit.getTool("shared_lookup"));
+                            assertNotSame(existingTool, toolkit.getTool("shared_lookup"));
+                            return Flux.empty();
+                        });
+
+        RunAgentInput input =
+                RunAgentInput.builder()
+                        .threadId("thread-tools")
+                        .runId("run-tools")
+                        .messages(List.of(AguiMessage.userMessage("msg-1", "Hello")))
+                        .tools(List.of(frontendTool("shared_lookup")))
+                        .build();
+
+        adapter.run(input).collectList().block();
+
+        assertSame(existingTool, toolkit.getTool("shared_lookup"));
+    }
+
+    @Test
+    void testRunDoesNotRegisterFrontendToolsWhenAgentOnly() {
+        Toolkit toolkit = new Toolkit();
+        when(mockAgent.getToolkit()).thenReturn(toolkit);
+        when(mockAgent.stream(anyList(), any(StreamOptions.class), any(RuntimeContext.class)))
+                .thenReturn(Flux.empty());
+
+        AguiAgentAdapter agentOnlyAdapter =
+                new AguiAgentAdapter(
+                        mockAgent,
+                        AguiAdapterConfig.builder()
+                                .toolMergeMode(ToolMergeMode.AGENT_ONLY)
+                                .build());
+        RunAgentInput input =
+                RunAgentInput.builder()
+                        .threadId("thread-agent-only")
+                        .runId("run-agent-only")
+                        .messages(List.of(AguiMessage.userMessage("msg-1", "Hello")))
+                        .tools(List.of(frontendTool("frontend_lookup")))
+                        .build();
+
+        agentOnlyAdapter.run(input).collectList().block();
+
+        assertNull(toolkit.getTool("frontend_lookup"));
     }
 
     @Test
@@ -1695,5 +1817,26 @@ class AguiAgentAdapterTest {
         assertTrue(
                 !hasReasoningMessageStart,
                 "Should NOT have ReasoningMessageStart for null thinking");
+    }
+
+    private static AguiTool frontendTool(String name) {
+        return new AguiTool(
+                name,
+                "Frontend tool",
+                Map.of("type", "object", "properties", Map.of("query", Map.of("type", "string"))));
+    }
+
+    private static SchemaOnlyTool schemaOnlyTool(String name) {
+        return new SchemaOnlyTool(
+                ToolSchema.builder()
+                        .name(name)
+                        .description("Existing tool")
+                        .parameters(
+                                Map.of(
+                                        "type",
+                                        "object",
+                                        "properties",
+                                        Map.of("query", Map.of("type", "string"))))
+                        .build());
     }
 }

--- a/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/test/java/io/agentscope/core/agui/adapter/AguiAgentAdapterTest.java
+++ b/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/test/java/io/agentscope/core/agui/adapter/AguiAgentAdapterTest.java
@@ -48,6 +48,7 @@ import io.agentscope.core.tool.SchemaOnlyTool;
 import io.agentscope.core.tool.Toolkit;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -294,6 +295,37 @@ class AguiAgentAdapterTest {
 
         assertSame(existingTool, toolkit.getTool("agent_lookup"));
         assertSame(existingSharedTool, toolkit.getTool("shared_lookup"));
+        assertNull(toolkit.getTool("frontend_lookup"));
+    }
+
+    @Test
+    void testRunWithFrontendOnlySkipsToolNameThatNoLongerResolves() {
+        Toolkit toolkit = new GhostToolNameToolkit();
+        when(mockAgent.getToolkit()).thenReturn(toolkit);
+        when(mockAgent.stream(anyList(), any(StreamOptions.class), any(RuntimeContext.class)))
+                .thenAnswer(
+                        invocation -> {
+                            assertInstanceOf(
+                                    SchemaOnlyTool.class, toolkit.getTool("frontend_lookup"));
+                            return Flux.empty();
+                        });
+
+        AguiAgentAdapter frontendOnlyAdapter =
+                new AguiAgentAdapter(
+                        mockAgent,
+                        AguiAdapterConfig.builder()
+                                .toolMergeMode(ToolMergeMode.FRONTEND_ONLY)
+                                .build());
+        RunAgentInput input =
+                RunAgentInput.builder()
+                        .threadId("thread-frontend-only-ghost")
+                        .runId("run-frontend-only-ghost")
+                        .messages(List.of(AguiMessage.userMessage("msg-1", "Hello")))
+                        .tools(List.of(frontendTool("frontend_lookup")))
+                        .build();
+
+        frontendOnlyAdapter.run(input).collectList().block();
+
         assertNull(toolkit.getTool("frontend_lookup"));
     }
 
@@ -1981,5 +2013,13 @@ class AguiAgentAdapterTest {
                                         "properties",
                                         Map.of("query", Map.of("type", "string"))))
                         .build());
+    }
+
+    private static final class GhostToolNameToolkit extends Toolkit {
+
+        @Override
+        public Set<String> getToolNames() {
+            return Set.of("ghost_lookup");
+        }
     }
 }

--- a/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/test/java/io/agentscope/core/agui/processor/AguiRequestProcessorTest.java
+++ b/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/test/java/io/agentscope/core/agui/processor/AguiRequestProcessorTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.core.agui.processor;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+
+import io.agentscope.core.agui.model.AguiMessage;
+import io.agentscope.core.agui.model.RunAgentInput;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+/** Unit tests for AguiRequestProcessor. */
+class AguiRequestProcessorTest {
+
+    @Test
+    void extractLatestUserMessagePreservesFullRunInputMetadata() {
+        AguiRequestProcessor processor =
+                AguiRequestProcessor.builder().agentResolver(mock(AgentResolver.class)).build();
+        AguiMessage firstUser = AguiMessage.userMessage("msg-1", "first");
+        AguiMessage lastUser = AguiMessage.userMessage("msg-3", "last");
+        RunAgentInput input =
+                RunAgentInput.builder()
+                        .threadId("thread-1")
+                        .runId("run-1")
+                        .messages(
+                                List.of(
+                                        firstUser,
+                                        AguiMessage.assistantMessage("msg-2", "ok"),
+                                        lastUser))
+                        .state(Map.of("cursor", 8))
+                        .forwardedProps(Map.of("agentId", "agent-a"))
+                        .build();
+
+        RunAgentInput extracted = processor.extractLatestUserMessage(input);
+
+        assertEquals(List.of(lastUser), extracted.getMessages());
+        assertEquals(input.getState(), extracted.getState());
+        assertEquals(input.getForwardedProps(), extracted.getForwardedProps());
+    }
+}


### PR DESCRIPTION
## Summary
- propagate the full AG-UI RunAgentInput through RuntimeContext, including typed RunAgentInput and agui.* fields
- register frontend-declared AG-UI tools as temporary SchemaOnlyTool entries according to ToolMergeMode, then clean up or restore toolkit state after the run
- preserve state when AguiRequestProcessor extracts the latest user message for server-side memory

## Testing
- JAVA_HOME=/opt/homebrew/opt/openjdk@17/libexec/openjdk.jdk/Contents/Home PATH=/opt/homebrew/opt/openjdk@17/libexec/openjdk.jdk/Contents/Home/bin:$PATH mvn -pl agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui -am -Dtest=AguiAgentAdapterTest,AguiRequestProcessorTest -DfailIfNoTests=false -Dsurefire.failIfNoSpecifiedTests=false test
- JAVA_HOME=/opt/homebrew/opt/openjdk@17/libexec/openjdk.jdk/Contents/Home PATH=/opt/homebrew/opt/openjdk@17/libexec/openjdk.jdk/Contents/Home/bin:$PATH mvn -pl agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui -am test -DskipITs