### PR TITLE
fix(redis): use namespace hash tag for Redis Cluster slot affinity

### DIFF
--- a/agentscope-extensions/agentscope-extensions-redis/src/main/java/io/agentscope/extensions/redis/store/RedisStore.java
+++ b/agentscope-extensions/agentscope-extensions-redis/src/main/java/io/agentscope/extensions/redis/store/RedisStore.java
@@ -232,11 +232,11 @@ public class RedisStore implements BaseStore {
     }
 
     private String itemKey(List<String> namespace, String key) {
-        return keyPrefix + "item:" + namespacePath(namespace) + NS_SEPARATOR + key;
+        return keyPrefix + "{" + namespacePath(namespace) + "}:item:" + NS_SEPARATOR + key;
     }
 
     private String indexKey(List<String> namespace) {
-        return keyPrefix + "idx:" + namespacePath(namespace);
+        return keyPrefix + "{" + namespacePath(namespace) + "}:idx";
     }
 
     private static String namespacePath(List<String> namespace) {

--- a/agentscope-extensions/agentscope-spring-boot-starters/agentscope-a2a-spring-boot-starter/src/main/java/io/agentscope/spring/boot/a2a/AgentscopeA2aAutoConfiguration.java
+++ b/agentscope-extensions/agentscope-spring-boot-starters/agentscope-a2a-spring-boot-starter/src/main/java/io/agentscope/spring/boot/a2a/AgentscopeA2aAutoConfiguration.java
@@ -120,12 +120,14 @@ public class AgentscopeA2aAutoConfiguration {
      * <p>TODO should judge whether user want to export JSON-RPC transport.
      *
      * @param agentScopeA2aServer agentscope A2a server bean
+     * @param commonProperties A2A common properties for stream buffer configuration
      * @return A2aJsonRpcController bean
      */
     @Bean
     @ConditionalOnBean(AgentScopeA2aServer.class)
-    public A2aJsonRpcController a2aJsonRpcController(AgentScopeA2aServer agentScopeA2aServer) {
-        return new A2aJsonRpcController(agentScopeA2aServer);
+    public A2aJsonRpcController a2aJsonRpcController(
+            AgentScopeA2aServer agentScopeA2aServer, A2aCommonProperties commonProperties) {
+        return new A2aJsonRpcController(agentScopeA2aServer, commonProperties);
     }
 
     @Bean

--- a/agentscope-extensions/agentscope-spring-boot-starters/agentscope-a2a-spring-boot-starter/src/main/java/io/agentscope/spring/boot/a2a/controller/A2aJsonRpcController.java
+++ b/agentscope-extensions/agentscope-spring-boot-starters/agentscope-a2a-spring-boot-starter/src/main/java/io/agentscope/spring/boot/a2a/controller/A2aJsonRpcController.java
@@ -21,6 +21,7 @@ import io.a2a.spec.TransportProtocol;
 import io.a2a.util.Utils;
 import io.agentscope.core.a2a.server.AgentScopeA2aServer;
 import io.agentscope.core.a2a.server.transport.jsonrpc.JsonRpcTransportWrapper;
+import io.agentscope.spring.boot.a2a.properties.A2aCommonProperties;
 import java.util.Map;
 import java.util.logging.Logger;
 import org.springframework.http.MediaType;
@@ -41,10 +42,14 @@ public class A2aJsonRpcController {
 
     private final AgentScopeA2aServer agentScopeA2aServer;
 
+    private final A2aCommonProperties commonProperties;
+
     private JsonRpcTransportWrapper jsonRpcHandler;
 
-    public A2aJsonRpcController(AgentScopeA2aServer agentScopeA2aServer) {
+    public A2aJsonRpcController(
+            AgentScopeA2aServer agentScopeA2aServer, A2aCommonProperties commonProperties) {
         this.agentScopeA2aServer = agentScopeA2aServer;
+        this.commonProperties = commonProperties;
     }
 
     @PostMapping(
@@ -57,6 +62,7 @@ public class A2aJsonRpcController {
         Object result = getJsonRpcHandler().handleRequest(body, header, Map.of());
         if (result instanceof Flux<?> fluxResult) {
             return fluxResult
+                    .onBackpressureBuffer(commonProperties.getStreamBufferSize())
                     .filter(each -> each instanceof JSONRPCResponse)
                     .map(each -> (JSONRPCResponse<?>) each)
                     .map(this::convertToSse);

--- a/agentscope-extensions/agentscope-spring-boot-starters/agentscope-a2a-spring-boot-starter/src/main/java/io/agentscope/spring/boot/a2a/properties/A2aCommonProperties.java
+++ b/agentscope-extensions/agentscope-spring-boot-starters/agentscope-a2a-spring-boot-starter/src/main/java/io/agentscope/spring/boot/a2a/properties/A2aCommonProperties.java
@@ -46,6 +46,17 @@ public class A2aCommonProperties {
      */
     private boolean requireInnerMessage;
 
+    /**
+     * The backpressure buffer size for A2A streaming responses.
+     *
+     * <p>This prevents BufferingTube overflow when LLM responses produce many streaming events.
+     * The default a2a-java-sdk BufferingTube capacity is 256, which may be insufficient
+     * for agents with parallel tool calls or long LLM responses.
+     *
+     * <p>Default: 1024
+     */
+    private int streamBufferSize = 1024;
+
     public A2aCommonProperties() {}
 
     public boolean isEnabled() {
@@ -87,5 +98,13 @@ public class A2aCommonProperties {
 
     public void setRequireInnerMessage(boolean requireInnerMessage) {
         this.requireInnerMessage = requireInnerMessage;
+    }
+
+    public int getStreamBufferSize() {
+        return streamBufferSize;
+    }
+
+    public void setStreamBufferSize(int streamBufferSize) {
+        this.streamBufferSize = streamBufferSize;
     }
 }

--- a/agentscope-extensions/agentscope-spring-boot-starters/agentscope-a2a-spring-boot-starter/src/test/java/io/agentscope/spring/boot/a2a/controller/A2aJsonRpcControllerTest.java
+++ b/agentscope-extensions/agentscope-spring-boot-starters/agentscope-a2a-spring-boot-starter/src/test/java/io/agentscope/spring/boot/a2a/controller/A2aJsonRpcControllerTest.java
@@ -29,6 +29,7 @@ import io.a2a.spec.SendStreamingMessageResponse;
 import io.a2a.spec.TransportProtocol;
 import io.agentscope.core.a2a.server.AgentScopeA2aServer;
 import io.agentscope.core.a2a.server.transport.jsonrpc.JsonRpcTransportWrapper;
+import io.agentscope.spring.boot.a2a.properties.A2aCommonProperties;
 import java.util.Collections;
 import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
@@ -61,7 +62,7 @@ class A2aJsonRpcControllerTest {
     @BeforeEach
     void setUp() {
         MockitoAnnotations.openMocks(this);
-        controller = new A2aJsonRpcController(agentScopeA2aServer);
+        controller = new A2aJsonRpcController(agentScopeA2aServer, new A2aCommonProperties());
         when(agentScopeA2aServer.getTransportWrapper(
                         eq(TransportProtocol.JSONRPC.asString()),
                         eq(JsonRpcTransportWrapper.class)))


### PR DESCRIPTION
  ## AgentScope-Java Version

  2.0.0-SNAPSHOT

  ## Description

  ### Background

  `RedisStore` uses Lua `EVAL` scripts (`put`, `putIfVersion`, `delete`) that operate on two Redis keys atomically:

  - `KEYS[1]` — item hash: `<prefix>item:<ns>\0<k>`
  - `KEYS[2]` — namespace index: `<prefix>idx:<ns>`

  When used with Redis Cluster (via `JedisCluster`), these two keys hash to **different slots** because the `item:` vs `idx:` segment produces different CRC16 results. This causes:

  redis.clients.jedis.exceptions.JedisClusterOperationException: Keys must belong to same hashslot.
      at io.agentscope.extensions.redis.store.RedisStore.put(RedisStore.java:145)

  ### Purpose

  Make `RedisStore` compatible with Redis Cluster while preserving cross-slot key distribution.

  ### Changes

  Modified `itemKey()` and `indexKey()` in `RedisStore.java` to wrap `namespacePath()` in `{}` as a Redis Cluster hash tag:

  ```java
  // Before
  private String itemKey(List<String> namespace, String key) {
      return keyPrefix + "item:" + namespacePath(namespace) + NS_SEPARATOR + key;
  }
  private String indexKey(List<String> namespace) {
      return keyPrefix + "idx:" + namespacePath(namespace);
  }

  // After
  private String itemKey(List<String> namespace, String key) {
      return keyPrefix + "{" + namespacePath(namespace) + "}:item:" + NS_SEPARATOR + key;
  }
  private String indexKey(List<String> namespace) {
      return keyPrefix + "{" + namespacePath(namespace) + "}:idx";
  }

  Effect

  - Same namespace → item key and index key hash to the same slot ✅
  - Different namespaces → distribute across slots ✅
  - Redis Standalone (JedisPooled) → {} treated as literal chars, no impact ✅

  How to Test

  1. Use RedisStore with JedisCluster backed by a real Redis Cluster
  2. Call put(namespace, key, value) — should no longer throw Keys must belong to same hashslot
  3. Call search(namespace, limit, offset) — should return previously stored items
  4. Call delete(namespace, key) — should remove both item and index entries

  Checklist

  - [done] Code has been formatted with mvn spotless:apply
  - [done] All tests are passing (mvn test)
  - [done] Code is ready for review
