### PR TITLE
fix(kubernetes): fix WebSocket race in hydrateWithArchive causing exit=null

### DIFF
--- a/agentscope-extensions/agentscope-extensions-sandbox/agentscope-extensions-sandbox-kubernetes/src/main/java/io/agentscope/extensions/sandbox/kubernetes/Fabric8KubernetesPodRuntime.java
+++ b/agentscope-extensions/agentscope-extensions-sandbox/agentscope-extensions-sandbox-kubernetes/src/main/java/io/agentscope/extensions/sandbox/kubernetes/Fabric8KubernetesPodRuntime.java
@@ -45,7 +45,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -174,7 +173,7 @@ public class Fabric8KubernetesPodRuntime {
         // Phase 1: Stream archive to a temp file via stdin.
         // "cat" exits immediately on EOF — no post-EOF work, no SIGKILL race.
         ByteArrayOutputStream errBuf = new ByteArrayOutputStream();
-        CompletableFuture<Integer> uploadExit;
+        Integer uploadCode;
         try (ExecWatch watch =
                 pod(state)
                         .redirectingInput()
@@ -183,22 +182,21 @@ public class Fabric8KubernetesPodRuntime {
             try (OutputStream stdin = watch.getInput()) {
                 archive.transferTo(stdin);
             }
-            uploadExit = watch.exitCode();
-        }
-        try {
-            Integer code = uploadExit.get(TAR_TIMEOUT_SECONDS + 10L, TimeUnit.SECONDS);
-            if (code == null || code != 0) {
+            try {
+                uploadCode = watch.exitCode().get(TAR_TIMEOUT_SECONDS + 10L, TimeUnit.SECONDS);
+            } catch (java.util.concurrent.TimeoutException e) {
                 throw new SandboxException.SandboxRuntimeException(
                         SandboxErrorCode.WORKSPACE_ARCHIVE_READ_ERROR,
-                        "archive upload failed (exit="
-                                + code
-                                + "): "
-                                + errBuf.toString(StandardCharsets.UTF_8));
+                        "archive upload to pod timed out");
             }
-        } catch (java.util.concurrent.TimeoutException e) {
+        }
+        if (uploadCode == null || uploadCode != 0) {
             throw new SandboxException.SandboxRuntimeException(
                     SandboxErrorCode.WORKSPACE_ARCHIVE_READ_ERROR,
-                    "archive upload to pod timed out");
+                    "archive upload failed (exit="
+                            + uploadCode
+                            + "): "
+                            + errBuf.toString(StandardCharsets.UTF_8));
         }
 
         // Phase 2: Extract from the temp file — no stdin involved, no race.

--- a/agentscope-extensions/agentscope-extensions-sandbox/agentscope-extensions-sandbox-kubernetes/src/test/java/io/agentscope/extensions/sandbox/kubernetes/Fabric8KubernetesPodRuntimeTest.java
+++ b/agentscope-extensions/agentscope-extensions-sandbox/agentscope-extensions-sandbox-kubernetes/src/test/java/io/agentscope/extensions/sandbox/kubernetes/Fabric8KubernetesPodRuntimeTest.java
@@ -16,22 +16,30 @@
 package io.agentscope.extensions.sandbox.kubernetes;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 
+import io.agentscope.harness.agent.sandbox.SandboxException;
 import io.agentscope.harness.agent.sandbox.WorkspaceSpec;
 import io.fabric8.kubernetes.api.model.EnvVar;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.PodList;
 import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.dsl.ContainerResource;
+import io.fabric8.kubernetes.client.dsl.ExecWatch;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
 import io.fabric8.kubernetes.client.dsl.PodResource;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.OutputStream;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -129,5 +137,105 @@ class Fabric8KubernetesPodRuntimeTest {
         String name = Fabric8KubernetesPodRuntime.buildPodName(longId);
         assertTrue(name.length() <= 63);
         assertTrue(name.startsWith("as-sbx-"));
+    }
+
+    // -------------------------------------------------------------------------
+    //  hydrateWithArchive / tarWorkspaceIn
+    // -------------------------------------------------------------------------
+
+    private KubernetesSandboxState createK8sState() {
+        KubernetesSandboxState state = new KubernetesSandboxState();
+        state.setSessionId("test-session");
+        state.setNamespace("default");
+        state.setPodName("test-pod");
+        state.setContainerName("workspace");
+        state.setImage("ubuntu:22.04");
+        state.setWorkspaceRoot("/opt");
+        return state;
+    }
+
+    @Test
+    void tarWorkspaceIn_success_exitCodeZero() throws Exception {
+        ContainerResource container = mock(ContainerResource.class);
+        doReturn(container).when(podResource).inContainer(anyString());
+
+        // Hydrate chain: container.redirectingInput().writingError().exec()
+        ContainerResource redirecting = mock(ContainerResource.class);
+        ContainerResource writingErr = mock(ContainerResource.class);
+        ExecWatch uploadWatch = mock(ExecWatch.class);
+        doReturn(redirecting).when(container).redirectingInput();
+        doReturn(writingErr).when(redirecting).writingError(any(ByteArrayOutputStream.class));
+        doReturn(uploadWatch).when(writingErr).exec(anyString(), anyString(), anyString());
+        doReturn(mock(OutputStream.class)).when(uploadWatch).getInput();
+        doReturn(CompletableFuture.completedFuture(0)).when(uploadWatch).exitCode();
+
+        // Exec chain for mkdir / tar / rm
+        ExecWatch execWatch = mock(ExecWatch.class);
+        ContainerResource writingOut = mock(ContainerResource.class);
+        ContainerResource writingErrExec = mock(ContainerResource.class);
+        doReturn(writingOut).when(container).writingOutput(any(ByteArrayOutputStream.class));
+        doReturn(writingErrExec).when(writingOut).writingError(any(ByteArrayOutputStream.class));
+        doReturn(execWatch).when(writingErrExec).exec(anyString(), anyString(), anyString());
+        doReturn(CompletableFuture.completedFuture(0)).when(execWatch).exitCode();
+
+        runtime.tarWorkspaceIn(createK8sState(), new ByteArrayInputStream("data".getBytes()));
+    }
+
+    @Test
+    void tarWorkspaceIn_uploadExitNull_throwsException() {
+        ContainerResource container = mock(ContainerResource.class);
+        doReturn(container).when(podResource).inContainer(anyString());
+
+        ContainerResource redirecting = mock(ContainerResource.class);
+        ContainerResource writingErr = mock(ContainerResource.class);
+        ExecWatch uploadWatch = mock(ExecWatch.class);
+        doReturn(redirecting).when(container).redirectingInput();
+        doReturn(writingErr).when(redirecting).writingError(any(ByteArrayOutputStream.class));
+        doReturn(uploadWatch).when(writingErr).exec(anyString(), anyString(), anyString());
+        doReturn(mock(OutputStream.class)).when(uploadWatch).getInput();
+        doReturn(CompletableFuture.completedFuture(null)).when(uploadWatch).exitCode();
+
+        ExecWatch execWatch = mock(ExecWatch.class);
+        ContainerResource writingOut = mock(ContainerResource.class);
+        ContainerResource writingErrExec = mock(ContainerResource.class);
+        doReturn(writingOut).when(container).writingOutput(any(ByteArrayOutputStream.class));
+        doReturn(writingErrExec).when(writingOut).writingError(any(ByteArrayOutputStream.class));
+        doReturn(execWatch).when(writingErrExec).exec(anyString(), anyString(), anyString());
+        doReturn(CompletableFuture.completedFuture(0)).when(execWatch).exitCode();
+
+        assertThrows(
+                SandboxException.SandboxRuntimeException.class,
+                () ->
+                        runtime.tarWorkspaceIn(
+                                createK8sState(), new ByteArrayInputStream("data".getBytes())));
+    }
+
+    @Test
+    void tarWorkspaceIn_uploadExitNonZero_throwsException() {
+        ContainerResource container = mock(ContainerResource.class);
+        doReturn(container).when(podResource).inContainer(anyString());
+
+        ContainerResource redirecting = mock(ContainerResource.class);
+        ContainerResource writingErr = mock(ContainerResource.class);
+        ExecWatch uploadWatch = mock(ExecWatch.class);
+        doReturn(redirecting).when(container).redirectingInput();
+        doReturn(writingErr).when(redirecting).writingError(any(ByteArrayOutputStream.class));
+        doReturn(uploadWatch).when(writingErr).exec(anyString(), anyString(), anyString());
+        doReturn(mock(OutputStream.class)).when(uploadWatch).getInput();
+        doReturn(CompletableFuture.completedFuture(1)).when(uploadWatch).exitCode();
+
+        ExecWatch execWatch = mock(ExecWatch.class);
+        ContainerResource writingOut = mock(ContainerResource.class);
+        ContainerResource writingErrExec = mock(ContainerResource.class);
+        doReturn(writingOut).when(container).writingOutput(any(ByteArrayOutputStream.class));
+        doReturn(writingErrExec).when(writingOut).writingError(any(ByteArrayOutputStream.class));
+        doReturn(execWatch).when(writingErrExec).exec(anyString(), anyString(), anyString());
+        doReturn(CompletableFuture.completedFuture(0)).when(execWatch).exitCode();
+
+        assertThrows(
+                SandboxException.SandboxRuntimeException.class,
+                () ->
+                        runtime.tarWorkspaceIn(
+                                createK8sState(), new ByteArrayInputStream("data".getBytes())));
     }
 }


### PR DESCRIPTION
Move watch.exitCode().get() inside the try (ExecWatch) block so the
process exit code is retrieved before watch.close() closes the WebSocket.
Previously the exit code Future was captured inside the block but .get()
was called outside, creating a race where the exit code is lost and the
future completes with null.

Fixes #1902

## AgentScope-Java Version

commit 5dc62907 on branch fix/hydrate-archive-websocket-race

## Description

`Fabric8KubernetesPodRuntime.hydrateWithArchive()` has a race condition
between WebSocket close and exit code retrieval. The exit code
`CompletableFuture<Integer>` is captured inside the `try (ExecWatch)` block,
but `.get()` is called **after** the block exits. By that time,
`watch.close()` (via try-with-resources) has already closed the WebSocket
channel, so the `cat` process's exit code is lost and the future completes
with `null`, producing `archive upload failed (exit=null)`.

The fix moves `watch.exitCode().get(TAR_TIMEOUT_SECONDS + 10L, TimeUnit.SECONDS)`
inside the `try` block, ensuring the exit code is awaited before the
WebSocket is closed. A `TimeoutException` is also caught inside the block
so it can be rethrown as a proper `SandboxRuntimeException`.

## Checklist

Please check the following items before code is ready to be reviewed.

- [x]  Code has been formatted with `mvn spotless:apply`
- [ ]  All tests are passing (`mvn test`)
- [x]  Javadoc comments are complete and follow project conventions
- [ ]  Related documentation has been updated (e.g. links, examples, etc.)
- [x]  Code is ready for review