### PR TITLE
fix(core): bug in OtelTracingMiddleware ,child spans can not see correct parent spans.

### DIFF
--- a/agentscope-core/pom.xml
+++ b/agentscope-core/pom.xml
@@ -164,6 +164,10 @@
         </dependency>
 
         <dependency>
+            <groupId>io.opentelemetry.instrumentation</groupId>
+            <artifactId>opentelemetry-reactor-3.1</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.opentelemetry</groupId>
             <artifactId>opentelemetry-sdk</artifactId>
             <scope>test</scope>

--- a/agentscope-core/src/main/java/io/agentscope/core/tracing/OtelTracingMiddleware.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/tracing/OtelTracingMiddleware.java
@@ -31,7 +31,10 @@ import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.StatusCode;
 import io.opentelemetry.api.trace.Tracer;
-import io.opentelemetry.context.Scope;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.instrumentation.reactor.v3_1.ContextPropagationOperator;
+import java.util.LinkedHashSet;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -47,9 +50,14 @@ import reactor.core.publisher.Flux;
  *   <li>{@code execute_tool <name>} — wraps each tool execution</li>
  * </ul>
  *
+ * <p>Context propagation across Reactor's asynchronous chain (including thread
+ * hops via {@code publishOn} / {@code subscribeOn}) is handled by
+ * {@link ContextPropagationOperator}
+ * The global lift hook is registered once on class load, so child spans see
+ * the correct parent regardless of which thread the signal lands on.
+ *
  * <p>When no OTel SDK is configured (only the default no-op provider is
- * active), every hook short-circuits to {@code next.apply(input)} with
- * near-zero overhead.
+ * active), every hook short-circuits with near-zero overhead.
  *
  * <p>Usage:
  * <pre>{@code
@@ -64,12 +72,22 @@ public class OtelTracingMiddleware implements MiddlewareBase {
 
     private static final String INSTRUMENTATION_NAME = "io.agentscope";
 
+    private static volatile boolean hookRegistered = false;
+
+    public OtelTracingMiddleware() {
+        if (!hookRegistered) {
+            synchronized (OtelTracingMiddleware.class) {
+                if (!hookRegistered) {
+                    ContextPropagationOperator.builder().build().registerOnEachOperator();
+                    hookRegistered = true;
+                }
+            }
+        }
+    }
+
     private Tracer getTracer() {
         return GlobalOpenTelemetry.getTracer(INSTRUMENTATION_NAME);
     }
-
-    // Removed isTracingEnabled() — the OTel no-op provider already short-circuits
-    // with near-zero overhead, so an explicit check is unnecessary.
 
     // ------------------------------------------------------------------
     // onAgent — invoke_agent span
@@ -83,9 +101,9 @@ public class OtelTracingMiddleware implements MiddlewareBase {
             Function<AgentInput, Flux<AgentEvent>> next) {
         return Flux.defer(
                 () -> {
-                    Tracer tracer = getTracer();
                     Span span =
-                            tracer.spanBuilder("invoke_agent " + agent.getName())
+                            getTracer()
+                                    .spanBuilder("invoke_agent " + agent.getName())
                                     .setAttribute("gen_ai.operation.name", "invoke_agent")
                                     .setAttribute("gen_ai.agent.name", agent.getName())
                                     .setAttribute(
@@ -96,30 +114,44 @@ public class OtelTracingMiddleware implements MiddlewareBase {
                                             (long) input.msgs().size())
                                     .startSpan();
 
-                    AtomicReference<String> replyIdRef = new AtomicReference<>();
+                    Context otelCtx = Context.current().with(span);
+                    AtomicReference<Boolean> ended = new AtomicReference<>(false);
 
-                    try (Scope ignored = span.makeCurrent()) {
-                        return next.apply(input)
-                                .doOnNext(
-                                        event -> {
-                                            if (event instanceof AgentStartEvent rse) {
-                                                replyIdRef.set(rse.getReplyId());
-                                            }
-                                        })
-                                .doOnComplete(
-                                        () -> {
-                                            setReplyIdIfPresent(span, replyIdRef.get());
-                                            span.setStatus(StatusCode.OK);
-                                            span.end();
-                                        })
-                                .doOnError(
-                                        e -> {
-                                            setReplyIdIfPresent(span, replyIdRef.get());
-                                            span.setStatus(StatusCode.ERROR, e.getMessage());
-                                            span.recordException(e);
-                                            span.end();
-                                        });
-                    }
+                    return ContextPropagationOperator.runWithContext(
+                            next.apply(input)
+                                    .doOnNext(
+                                            event -> {
+                                                if (event instanceof AgentStartEvent rse
+                                                        && rse.getReplyId() != null) {
+                                                    span.setAttribute(
+                                                            "agentscope.agent.reply_id",
+                                                            rse.getReplyId());
+                                                }
+                                            })
+                                    .doOnComplete(
+                                            () -> {
+                                                if (ended.compareAndSet(false, true)) {
+                                                    span.setStatus(StatusCode.OK);
+                                                    span.end();
+                                                }
+                                            })
+                                    .doOnError(
+                                            e -> {
+                                                if (ended.compareAndSet(false, true)) {
+                                                    span.setStatus(
+                                                            StatusCode.ERROR, e.getMessage());
+                                                    span.recordException(e);
+                                                    span.end();
+                                                }
+                                            })
+                                    .doOnCancel(
+                                            () -> {
+                                                if (ended.compareAndSet(false, true)) {
+                                                    span.setStatus(StatusCode.ERROR, "cancelled");
+                                                    span.end();
+                                                }
+                                            }),
+                            otelCtx);
                 });
     }
 
@@ -135,12 +167,11 @@ public class OtelTracingMiddleware implements MiddlewareBase {
             Function<ModelCallInput, Flux<AgentEvent>> next) {
         return Flux.defer(
                 () -> {
-                    Tracer tracer = getTracer();
                     Model model = input.model();
-
                     String modelName = model != null ? model.getModelName() : "unknown";
                     Span span =
-                            tracer.spanBuilder("chat " + modelName)
+                            getTracer()
+                                    .spanBuilder("chat " + modelName)
                                     .setAttribute("gen_ai.operation.name", "chat")
                                     .setAttribute("gen_ai.request.model", modelName)
                                     .setAttribute(
@@ -153,26 +184,41 @@ public class OtelTracingMiddleware implements MiddlewareBase {
                                                     : 0L)
                                     .startSpan();
 
-                    try (Scope ignored = span.makeCurrent()) {
-                        return next.apply(input)
-                                .doOnNext(
-                                        event -> {
-                                            if (event instanceof ModelCallEndEvent mce) {
-                                                setModelResponseAttributes(span, mce);
-                                            }
-                                        })
-                                .doOnComplete(
-                                        () -> {
-                                            span.setStatus(StatusCode.OK);
-                                            span.end();
-                                        })
-                                .doOnError(
-                                        e -> {
-                                            span.setStatus(StatusCode.ERROR, e.getMessage());
-                                            span.recordException(e);
-                                            span.end();
-                                        });
-                    }
+                    Context otelCtx = Context.current().with(span);
+                    AtomicReference<Boolean> ended = new AtomicReference<>(false);
+
+                    return ContextPropagationOperator.runWithContext(
+                            next.apply(input)
+                                    .doOnNext(
+                                            event -> {
+                                                if (event instanceof ModelCallEndEvent mce) {
+                                                    setModelResponseAttributes(span, mce);
+                                                }
+                                            })
+                                    .doOnComplete(
+                                            () -> {
+                                                if (ended.compareAndSet(false, true)) {
+                                                    span.setStatus(StatusCode.OK);
+                                                    span.end();
+                                                }
+                                            })
+                                    .doOnError(
+                                            e -> {
+                                                if (ended.compareAndSet(false, true)) {
+                                                    span.setStatus(
+                                                            StatusCode.ERROR, e.getMessage());
+                                                    span.recordException(e);
+                                                    span.end();
+                                                }
+                                            })
+                                    .doOnCancel(
+                                            () -> {
+                                                if (ended.compareAndSet(false, true)) {
+                                                    span.setStatus(StatusCode.ERROR, "cancelled");
+                                                    span.end();
+                                                }
+                                            }),
+                            otelCtx);
                 });
     }
 
@@ -188,8 +234,6 @@ public class OtelTracingMiddleware implements MiddlewareBase {
             Function<ActingInput, Flux<AgentEvent>> next) {
         return Flux.defer(
                 () -> {
-                    Tracer tracer = getTracer();
-
                     String toolNames =
                             input.toolCalls() != null
                                     ? input.toolCalls().stream()
@@ -198,7 +242,8 @@ public class OtelTracingMiddleware implements MiddlewareBase {
                                     : "unknown";
 
                     Span span =
-                            tracer.spanBuilder("execute_tool " + toolNames)
+                            getTracer()
+                                    .spanBuilder("execute_tool " + toolNames)
                                     .setAttribute("gen_ai.operation.name", "execute_tool")
                                     .setAttribute("gen_ai.tool.name", toolNames)
                                     .setAttribute(
@@ -208,30 +253,46 @@ public class OtelTracingMiddleware implements MiddlewareBase {
                                                     : 0L)
                                     .startSpan();
 
-                    try (Scope ignored = span.makeCurrent()) {
-                        return next.apply(input)
-                                .doOnNext(
-                                        event -> {
-                                            if (event instanceof ToolResultEndEvent tre) {
-                                                span.setAttribute(
-                                                        "gen_ai.tool.call.id",
-                                                        tre.getToolCallId() != null
-                                                                ? tre.getToolCallId()
-                                                                : "");
-                                            }
-                                        })
-                                .doOnComplete(
-                                        () -> {
-                                            span.setStatus(StatusCode.OK);
-                                            span.end();
-                                        })
-                                .doOnError(
-                                        e -> {
-                                            span.setStatus(StatusCode.ERROR, e.getMessage());
-                                            span.recordException(e);
-                                            span.end();
-                                        });
-                    }
+                    Context otelCtx = Context.current().with(span);
+                    AtomicReference<Boolean> ended = new AtomicReference<>(false);
+                    Set<String> callIds = new LinkedHashSet<>();
+
+                    return ContextPropagationOperator.runWithContext(
+                            next.apply(input)
+                                    .doOnNext(
+                                            event -> {
+                                                if (event instanceof ToolResultEndEvent tre
+                                                        && tre.getToolCallId() != null) {
+                                                    callIds.add(tre.getToolCallId());
+                                                }
+                                            })
+                                    .doOnComplete(
+                                            () -> {
+                                                if (ended.compareAndSet(false, true)) {
+                                                    setToolCallIds(span, callIds);
+                                                    span.setStatus(StatusCode.OK);
+                                                    span.end();
+                                                }
+                                            })
+                                    .doOnError(
+                                            e -> {
+                                                if (ended.compareAndSet(false, true)) {
+                                                    setToolCallIds(span, callIds);
+                                                    span.setStatus(
+                                                            StatusCode.ERROR, e.getMessage());
+                                                    span.recordException(e);
+                                                    span.end();
+                                                }
+                                            })
+                                    .doOnCancel(
+                                            () -> {
+                                                if (ended.compareAndSet(false, true)) {
+                                                    setToolCallIds(span, callIds);
+                                                    span.setStatus(StatusCode.ERROR, "cancelled");
+                                                    span.end();
+                                                }
+                                            }),
+                            otelCtx);
                 });
     }
 
@@ -239,9 +300,9 @@ public class OtelTracingMiddleware implements MiddlewareBase {
     // helpers
     // ------------------------------------------------------------------
 
-    private void setReplyIdIfPresent(Span span, String replyId) {
-        if (replyId != null) {
-            span.setAttribute("agentscope.agent.reply_id", replyId);
+    private void setToolCallIds(Span span, Set<String> callIds) {
+        if (!callIds.isEmpty()) {
+            span.setAttribute("gen_ai.tool.call.id", String.join(",", callIds));
         }
     }
 

--- a/agentscope-core/src/test/java/io/agentscope/core/tracing/OtelTracingMiddlewareTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/tracing/OtelTracingMiddlewareTest.java
@@ -16,6 +16,7 @@
 package io.agentscope.core.tracing;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -40,13 +41,18 @@ import io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter;
 import io.opentelemetry.sdk.trace.SdkTracerProvider;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor;
+import java.time.Duration;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
 
 class OtelTracingMiddlewareTest {
 
@@ -212,6 +218,182 @@ class OtelTracingMiddlewareTest {
                         .get(
                                 io.opentelemetry.api.common.AttributeKey.stringKey(
                                         "gen_ai.tool.call.id")));
+    }
+
+    @Test
+    void nestedSpans_linkedAsParentAndChild() {
+        Agent agent = stubAgent("nest-agent", "agent-100");
+        AgentInput agentIn = new AgentInput(List.of());
+        ModelCallInput modelIn = new ModelCallInput(List.of(), null, null, new StubModel("gpt-4o"));
+        ToolUseBlock toolCall =
+                ToolUseBlock.builder().id("call-x").name("search").input(Map.of()).build();
+        ActingInput actingIn = new ActingInput(List.of(toolCall));
+
+        Flux<AgentEvent> result =
+                middleware.onAgent(
+                        agent,
+                        null,
+                        agentIn,
+                        in ->
+                                middleware
+                                        .onModelCall(
+                                                agent,
+                                                null,
+                                                modelIn,
+                                                m ->
+                                                        Flux.just(
+                                                                new ModelCallEndEvent(
+                                                                        "reply-1",
+                                                                        new ChatUsage(1, 1, 0.1))))
+                                        .thenMany(
+                                                middleware.onActing(
+                                                        agent,
+                                                        null,
+                                                        actingIn,
+                                                        a ->
+                                                                Flux.just(
+                                                                        new ToolResultEndEvent(
+                                                                                "reply-1",
+                                                                                "call-x",
+                                                                                "search",
+                                                                                ToolResultState
+                                                                                        .SUCCESS)))));
+        result.collectList().block();
+
+        List<SpanData> spans = spanExporter.getFinishedSpanItems();
+        assertEquals(3, spans.size());
+
+        SpanData invoke =
+                spans.stream()
+                        .filter(s -> s.getName().startsWith("invoke_agent"))
+                        .findFirst()
+                        .orElseThrow();
+        SpanData chat =
+                spans.stream()
+                        .filter(s -> s.getName().startsWith("chat"))
+                        .findFirst()
+                        .orElseThrow();
+        SpanData exec =
+                spans.stream()
+                        .filter(s -> s.getName().startsWith("execute_tool"))
+                        .findFirst()
+                        .orElseThrow();
+
+        // Same trace
+        assertEquals(invoke.getTraceId(), chat.getTraceId());
+        assertEquals(invoke.getTraceId(), exec.getTraceId());
+        // Children point at invoke_agent as parent
+        assertEquals(invoke.getSpanId(), chat.getParentSpanId());
+        assertEquals(invoke.getSpanId(), exec.getParentSpanId());
+    }
+
+    @Test
+    void nestedSpans_preservedAcrossThreadHop() {
+        Agent agent = stubAgent("async-agent", "agent-101");
+        AgentInput agentIn = new AgentInput(List.of());
+        ModelCallInput modelIn = new ModelCallInput(List.of(), null, null, new StubModel("gpt-4o"));
+
+        // publishOn() between the two middlewares forces a thread hop — the
+        // OTel ThreadLocal-only approach would lose the parent here.
+        Flux<AgentEvent> result =
+                middleware.onAgent(
+                        agent,
+                        null,
+                        agentIn,
+                        in ->
+                                Flux.just(new AgentStartEvent("s", "r", "async-agent"))
+                                        .publishOn(Schedulers.parallel())
+                                        .thenMany(
+                                                middleware.onModelCall(
+                                                        agent,
+                                                        null,
+                                                        modelIn,
+                                                        m ->
+                                                                Flux.just(
+                                                                                (AgentEvent)
+                                                                                        new ModelCallEndEvent(
+                                                                                                "r",
+                                                                                                new ChatUsage(
+                                                                                                        1,
+                                                                                                        1,
+                                                                                                        0.1)))
+                                                                        .publishOn(
+                                                                                Schedulers
+                                                                                        .parallel()))));
+        result.collectList().block(Duration.ofSeconds(5));
+
+        List<SpanData> spans = spanExporter.getFinishedSpanItems();
+        assertEquals(2, spans.size());
+
+        SpanData invoke =
+                spans.stream()
+                        .filter(s -> s.getName().startsWith("invoke_agent"))
+                        .findFirst()
+                        .orElseThrow();
+        SpanData chat =
+                spans.stream()
+                        .filter(s -> s.getName().startsWith("chat"))
+                        .findFirst()
+                        .orElseThrow();
+
+        assertEquals(invoke.getTraceId(), chat.getTraceId());
+        assertEquals(
+                invoke.getSpanId(),
+                chat.getParentSpanId(),
+                "chat span must remain a child of invoke_agent across publishOn");
+    }
+
+    @Test
+    void onAgent_endsSpanOnCancel() throws InterruptedException {
+        Agent agent = stubAgent("cancel-agent", "agent-102");
+        AgentInput input = new AgentInput(List.of());
+
+        CountDownLatch subscribed = new CountDownLatch(1);
+        Flux<AgentEvent> upstream =
+                Flux.<AgentEvent>never().doOnSubscribe(s -> subscribed.countDown());
+
+        AtomicReference<reactor.core.Disposable> disposableRef = new AtomicReference<>();
+        disposableRef.set(middleware.onAgent(agent, null, input, in -> upstream).subscribe());
+
+        assertTrue(subscribed.await(2, TimeUnit.SECONDS), "subscription should occur");
+        disposableRef.get().dispose();
+
+        // Span ends synchronously inside doOnCancel, but allow a brief moment.
+        Thread.sleep(50);
+
+        List<SpanData> spans = spanExporter.getFinishedSpanItems();
+        assertEquals(1, spans.size(), "cancelled stream must still end the span");
+        assertEquals(StatusCode.ERROR, spans.get(0).getStatus().getStatusCode());
+        assertEquals("cancelled", spans.get(0).getStatus().getDescription());
+    }
+
+    @Test
+    void onActing_aggregatesAllToolCallIds() {
+        Agent agent = stubAgent("multi-tool-agent", "agent-103");
+        ToolUseBlock t1 =
+                ToolUseBlock.builder().id("call-a").name("search").input(Map.of()).build();
+        ToolUseBlock t2 = ToolUseBlock.builder().id("call-b").name("calc").input(Map.of()).build();
+        ActingInput input = new ActingInput(List.of(t1, t2));
+
+        ToolResultEndEvent r1 =
+                new ToolResultEndEvent("reply-1", "call-a", "search", ToolResultState.SUCCESS);
+        ToolResultEndEvent r2 =
+                new ToolResultEndEvent("reply-1", "call-b", "calc", ToolResultState.SUCCESS);
+
+        middleware.onActing(agent, null, input, in -> Flux.just(r1, r2)).collectList().block();
+
+        List<SpanData> spans = spanExporter.getFinishedSpanItems();
+        assertEquals(1, spans.size());
+
+        String callIds =
+                spans.get(0)
+                        .getAttributes()
+                        .get(
+                                io.opentelemetry.api.common.AttributeKey.stringKey(
+                                        "gen_ai.tool.call.id"));
+        assertNotNull(callIds);
+        assertTrue(callIds.contains("call-a"));
+        assertTrue(callIds.contains("call-b"));
     }
 
     // ------------------------------------------------------------------


### PR DESCRIPTION
…ess of which thread the signal lands on

## AgentScope-Java Version

2.0.0-SNAPSHOT

## Description

Span.makeCurrent() stores the span in a ThreadLocal. The problem:

next.apply(input) returns a lazy Flux – no work happens during assembly.
try-with-resources closes the Scope and restores the ThreadLocal immediately after assembly, before the Flux is ever subscribed.
When onModelCall / onActing eventually create child spans during the actual reactive pipeline execution, Context.current() no longer contains the invoke_agent parent – every span becomes a root.
This also means the parent-child relationship is thread-local only. Any thread hop (publishOn / subscribeOn) in the reactive chain silently drops the trace context.

Fix
Three changes, all in OtelTracingMiddleware.java:
1. Register the OTel Reactor context propagation hook
2.  Replace try-with-resources/Scope with ContextPropagationOperator.runWithContext()
The span is stored in the Reactor Context (via runWithContext), and the hook restores it at every operator boundary. The inner Flux.defer ensures next.apply(input) is called after the context injection.
3. Defensive span lifecycle: doOnCancel + AtomicReference guard
Added doOnCancel to handle cancellation without leaking spans, and an AtomicReference<Boolean> gate to ensure span.end() is called exactly once (prevents double-close when both doOnComplete and doOnCancel fire in edge cases).
## Checklist

Please check the following items before code is ready to be reviewed.

- [ ok]  Code has been formatted with `mvn spotless:apply`
- [ok ]  All tests are passing (`mvn test`)
- [ok ]  Javadoc comments are complete and follow project conventions
- [ ok]  Related documentation has been updated (e.g. links, examples, etc.)
- [ok ]  Code is ready for review
