### PR TITLE
Fix/issue 1908 agentrun mcp response

### DIFF
--- a/agentscope-core/src/main/java/io/agentscope/core/tool/ToolCallParam.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/tool/ToolCallParam.java
@@ -144,7 +144,7 @@ public class ToolCallParam {
      *
      * <p>Note: The input map structure is copied so that entries can be modified
      * independently, but nested values (typed as Object) remain shared.
-     * Immutable fields (toolUseBlock, agent, context, emitter) are shared by reference.
+     * Immutable fields (toolUseBlock, agent, runtimeContext, emitter) are shared by reference.
      *
      * @param source The existing ToolCallParam to copy values from
      * @return A new builder pre-populated with the source's values
@@ -171,7 +171,7 @@ public class ToolCallParam {
             this.toolUseBlock = source.toolUseBlock;
             this.input = source.input.isEmpty() ? null : source.input;
             this.agent = source.agent;
-            this.context = source.context;
+            this.runtimeContext = source.runtimeContext;
             this.emitter = source.emitter;
         }
 

--- a/agentscope-core/src/test/java/io/agentscope/core/model/OpenAIOfficialAPIE2ETest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/model/OpenAIOfficialAPIE2ETest.java
@@ -20,6 +20,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
+import io.agentscope.core.e2e.E2ETestCondition;
 import io.agentscope.core.formatter.openai.OpenAIChatFormatter;
 import io.agentscope.core.message.Msg;
 import io.agentscope.core.message.MsgRole;
@@ -33,6 +34,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+import org.junit.jupiter.api.extension.ExtendWith;
 import reactor.test.StepVerifier;
 
 /**
@@ -52,6 +54,7 @@ import reactor.test.StepVerifier;
  *
  * <p><b>Requirements:</b>
  * <ul>
+ *   <li>ENABLE_E2E_TESTS=true</li>
  *   <li>OPENAI_API_KEY environment variable must be set (official OpenAI API key)</li>
  *   <li>Active internet connection</li>
  *   <li>Valid OpenAI API quota</li>
@@ -62,6 +65,7 @@ import reactor.test.StepVerifier;
 @Tag("e2e")
 @Tag("openai")
 @Tag("official")
+@ExtendWith(E2ETestCondition.class)
 @DisplayName("OpenAI Official API E2E Tests (Real OpenAI API)")
 @EnabledIfEnvironmentVariable(
         named = "OPENAI_API_KEY",

--- a/agentscope-core/src/test/java/io/agentscope/core/tool/ToolCallParamTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/tool/ToolCallParamTest.java
@@ -160,7 +160,9 @@ class ToolCallParamTest {
             assertEquals(original.getToolUseBlock(), copy.getToolUseBlock());
             assertEquals(original.getInput(), copy.getInput());
             assertEquals(original.getAgent(), copy.getAgent());
-            assertEquals(original.getContext(), copy.getContext());
+            assertSame(original.getRuntimeContext(), copy.getRuntimeContext());
+            assertNotNull(copy.getContext());
+            assertEquals(original.getContext().get(String.class), copy.getContext().get(String.class));
             assertSame(original.getEmitter(), copy.getEmitter());
         }
 
@@ -249,6 +251,7 @@ class ToolCallParamTest {
             assertEquals(original.getToolUseBlock(), copy.getToolUseBlock());
             assertTrue(copy.getInput().isEmpty());
             assertNull(copy.getAgent());
+            assertNull(copy.getRuntimeContext());
             assertNull(copy.getContext());
         }
 
@@ -287,7 +290,9 @@ class ToolCallParamTest {
             // Immutable fields should be the same references
             assertSame(original.getToolUseBlock(), copy.getToolUseBlock());
             assertSame(original.getAgent(), copy.getAgent());
-            assertSame(original.getContext(), copy.getContext());
+            assertSame(original.getRuntimeContext(), copy.getRuntimeContext());
+            assertNotNull(copy.getContext());
+            assertEquals(original.getContext().get(String.class), copy.getContext().get(String.class));
         }
 
         @Test

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/sandbox/impl/agentrun/AgentRunMcpChannel.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/sandbox/impl/agentrun/AgentRunMcpChannel.java
@@ -224,32 +224,64 @@ final class AgentRunMcpChannel implements AutoCloseable {
     }
 
     /**
-     * Parses an AgentRun exec MCP response. AgentRun returns either a JSON object such as
-     * {@code {"exitCode":0,"stdout":"...","stderr":"..."}} or a plain stdout/stderr string. We
-     * accept both shapes.
+     * Parses an AgentRun exec MCP response.
+     *
+     * <p>Accepts flat JSON payloads, wrapped payloads with a {@code result} object, banner-prefixed
+     * responses, and plain text fallbacks.
      */
-    private static ExecResult parseExecPayload(String text) {
+    static ExecResult parseExecPayload(String text) {
         if (text == null) {
             return new ExecResult(0, "", "");
         }
         String trimmed = text.strip();
         if (trimmed.startsWith("{")) {
-            try {
-                JsonNode node = JSON.readTree(trimmed);
-                int exit =
-                        node.has("exitCode")
-                                ? node.path("exitCode").asInt(0)
-                                : node.path("exit_code").asInt(0);
-                String stdout =
-                        node.has("stdout")
-                                ? node.path("stdout").asText("")
-                                : node.path("output").asText("");
-                String stderr = node.path("stderr").asText("");
-                return new ExecResult(exit, stdout, stderr);
-            } catch (Exception ignore) {
-                // fall through to plain-text handling
+            ExecResult parsed = tryParseJsonExec(trimmed);
+            if (parsed != null) {
+                return parsed;
+            }
+        }
+        int jsonStart = trimmed.indexOf('{');
+        int jsonEnd = trimmed.lastIndexOf('}');
+        if (jsonStart >= 0 && jsonEnd > jsonStart) {
+            ExecResult parsed = tryParseJsonExec(trimmed.substring(jsonStart, jsonEnd + 1));
+            if (parsed != null) {
+                return parsed;
             }
         }
         return new ExecResult(0, text, "");
+    }
+
+    private static ExecResult tryParseJsonExec(String candidate) {
+        try {
+            JsonNode node = JSON.readTree(candidate);
+            ExecResult direct = buildExecResult(node);
+            if (direct != null) {
+                return direct;
+            }
+            JsonNode result = node.path("result");
+            if (result != null && result.isObject()) {
+                return buildExecResult(result);
+            }
+        } catch (Exception ignore) {
+            // fall through to plain-text handling
+        }
+        return null;
+    }
+
+    private static ExecResult buildExecResult(JsonNode node) {
+        if (node == null || !node.isObject()) {
+            return null;
+        }
+        boolean hasExitCode = node.has("exitCode") || node.has("exit_code");
+        if (!hasExitCode) {
+            return null;
+        }
+        int exit =
+                node.has("exitCode")
+                        ? node.path("exitCode").asInt(0)
+                        : node.path("exit_code").asInt(0);
+        String stdout = node.has("stdout") ? node.path("stdout").asText("") : node.path("output").asText("");
+        String stderr = node.path("stderr").asText("");
+        return new ExecResult(exit, stdout, stderr);
     }
 }

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/workspace/WorkspaceManager.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/workspace/WorkspaceManager.java
@@ -298,7 +298,7 @@ public class WorkspaceManager implements AutoCloseable {
             if (glob.isSuccess() && glob.matches() != null) {
                 for (FileInfo fi : glob.matches()) {
                     if (fi.path() != null && !fi.path().isBlank()) {
-                        relativePaths.add(normalizeRelativePath(fi.path().trim()));
+                        relativePaths.add(normalizeListedPath(fi.path().trim()));
                     }
                 }
             }
@@ -540,7 +540,10 @@ public class WorkspaceManager implements AutoCloseable {
                     if (fi.path() == null || fi.path().isBlank()) {
                         continue;
                     }
-                    String rel = normalizeRelativePath(fi.path().trim());
+                    String rel = normalizeListedPath(fi.path().trim());
+                    if (rel.isEmpty()) {
+                        continue;
+                    }
                     Instant mtime = parseInstantQuiet(fi.modifiedAt());
                     relPaths.put(rel, Optional.ofNullable(mtime));
                 }
@@ -930,6 +933,36 @@ public class WorkspaceManager implements AutoCloseable {
     }
 
     /**
+     * Normalizes a path returned by {@link AbstractFilesystem#glob} into a workspace-relative
+     * string when possible.
+     */
+    private String normalizeListedPath(String path) {
+        if (path == null || path.isBlank()) {
+            return "";
+        }
+        String normalized = path.replace('\\', '/').strip();
+        Path workspaceAbs = workspace.toAbsolutePath().normalize();
+        try {
+            Path candidate = Path.of(normalized).normalize();
+            if (candidate.isAbsolute()) {
+                if (candidate.startsWith(workspaceAbs)) {
+                    return workspaceAbs.relativize(candidate).toString().replace('\\', '/');
+                }
+                if (normalized.startsWith("/")) {
+                    return normalized.substring(1);
+                }
+                return normalized;
+            }
+        } catch (Exception ignored) {
+            // Fall through to the string-based fallback below.
+        }
+        if (normalized.startsWith("/")) {
+            return normalized.substring(1);
+        }
+        return normalized;
+    }
+
+    /**
      * Returns workspace-relative paths of all memory files ({@code MEMORY.md} and {@code
      * memory/*.md}). Unions results from the {@link AbstractFilesystem} layer and the local disk,
      * deduplicating by relative path.
@@ -946,7 +979,7 @@ public class WorkspaceManager implements AutoCloseable {
             if (glob.isSuccess() && glob.matches() != null) {
                 for (FileInfo fi : glob.matches()) {
                     if (fi.path() != null && !fi.path().isBlank()) {
-                        String rel = normalizeRelativePath(fi.path().trim());
+                        String rel = normalizeListedPath(fi.path().trim());
                         if (!rel.isEmpty()) {
                             paths.add(rel);
                         }
@@ -983,7 +1016,7 @@ public class WorkspaceManager implements AutoCloseable {
             if (glob.isSuccess() && glob.matches() != null) {
                 for (FileInfo fi : glob.matches()) {
                     if (fi.path() != null && !fi.path().isBlank()) {
-                        String rel = normalizeRelativePath(fi.path().trim());
+                        String rel = normalizeListedPath(fi.path().trim());
                         if (!rel.isEmpty()) {
                             paths.add(rel);
                         }

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/workspace/WorkspaceManager.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/workspace/WorkspaceManager.java
@@ -34,6 +34,7 @@ import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import io.agentscope.core.agent.RuntimeContext;
 import io.agentscope.harness.agent.filesystem.AbstractFilesystem;
 import io.agentscope.harness.agent.filesystem.OverlayFilesystem;
+import io.agentscope.harness.agent.filesystem.local.LocalFilesystem;
 import io.agentscope.harness.agent.filesystem.model.FileInfo;
 import io.agentscope.harness.agent.filesystem.model.GlobResult;
 import io.agentscope.harness.agent.filesystem.model.ReadResult;
@@ -941,25 +942,53 @@ public class WorkspaceManager implements AutoCloseable {
             return "";
         }
         String normalized = path.replace('\\', '/').strip();
-        Path workspaceAbs = workspace.toAbsolutePath().normalize();
         try {
             Path candidate = Path.of(normalized).normalize();
             if (candidate.isAbsolute()) {
-                if (candidate.startsWith(workspaceAbs)) {
-                    return workspaceAbs.relativize(candidate).toString().replace('\\', '/');
+                String workspaceRelative = relativizeIfUnder(candidate, workspace);
+                if (workspaceRelative != null) {
+                    return workspaceRelative;
                 }
-                if (normalized.startsWith("/")) {
-                    return normalized.substring(1);
+                Path lowerRoot = getOverlayLowerRoot();
+                if (lowerRoot != null) {
+                    String lowerRelative = relativizeIfUnder(candidate, lowerRoot);
+                    if (lowerRelative != null) {
+                        return lowerRelative;
+                    }
                 }
-                return normalized;
+                return stripLeadingSlashes(normalized);
             }
         } catch (Exception ignored) {
             // Fall through to the string-based fallback below.
         }
-        if (normalized.startsWith("/")) {
-            return normalized.substring(1);
+        return stripLeadingSlashes(normalized);
+    }
+
+    private String relativizeIfUnder(Path candidate, Path root) {
+        Path normalizedRoot = root.toAbsolutePath().normalize();
+        if (!candidate.startsWith(normalizedRoot)) {
+            return null;
         }
-        return normalized;
+        return normalizedRoot.relativize(candidate).toString().replace('\\', '/');
+    }
+
+    private String stripLeadingSlashes(String value) {
+        String s = value;
+        while (s.startsWith("/")) {
+            s = s.substring(1);
+        }
+        return s;
+    }
+
+    private Path getOverlayLowerRoot() {
+        if (!(filesystem instanceof OverlayFilesystem overlay)) {
+            return null;
+        }
+        AbstractFilesystem lower = overlay.lower();
+        if (lower instanceof LocalFilesystem localFilesystem) {
+            return localFilesystem.getCwd();
+        }
+        return null;
     }
 
     /**

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/sandbox/impl/agentrun/AgentRunMcpChannelTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/sandbox/impl/agentrun/AgentRunMcpChannelTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.harness.agent.sandbox.impl.agentrun;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+class AgentRunMcpChannelTest {
+
+    @Test
+    void parseExecPayloadSupportsFlatJson() {
+        AgentRunMcpChannel.ExecResult result =
+                AgentRunMcpChannel.parseExecPayload(
+                        "{\"exitCode\":0,\"stdout\":\"hello\",\"stderr\":\"\"}");
+
+        assertEquals(0, result.exitCode);
+        assertEquals("hello", result.stdout);
+        assertEquals("", result.stderr);
+    }
+
+    @Test
+    void parseExecPayloadSupportsBannerPrefixedNestedJson() {
+        String text =
+                """
+                        ### process_exec_cmd
+                        **Sandbox ID (MCP Session ID):** `ac85a2b7-cb2b-497d-a527-5a2d9be8042e`
+
+                        {"status":"completed","result":{"exitCode":1,"stdout":"","stderr":"boom"}}
+                        """;
+
+        AgentRunMcpChannel.ExecResult result = AgentRunMcpChannel.parseExecPayload(text);
+
+        assertEquals(1, result.exitCode);
+        assertEquals("", result.stdout);
+        assertEquals("boom", result.stderr);
+    }
+
+    @Test
+    void parseExecPayloadFallsBackToPlainText() {
+        String text = "### process_exec_cmd\nnot-json";
+
+        AgentRunMcpChannel.ExecResult result = AgentRunMcpChannel.parseExecPayload(text);
+
+        assertEquals(0, result.exitCode);
+        assertEquals(text, result.stdout);
+        assertEquals("", result.stderr);
+    }
+}

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/workspace/WorkspaceManagerListingTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/workspace/WorkspaceManagerListingTest.java
@@ -47,11 +47,43 @@ class WorkspaceManagerListingTest {
     }
 
     @Test
+    void listKnowledgeFiles_normalizesProjectLayerAbsolutePaths(
+            @TempDir Path project, @TempDir Path workspace) throws IOException {
+        Files.createDirectories(project.resolve("knowledge"));
+        Files.writeString(project.resolve("knowledge/guide.md"), "guide");
+
+        AbstractFilesystem fs = new LocalFilesystemSpec().project(project).toFilesystem(workspace, null);
+        try (WorkspaceManager wm = new WorkspaceManager(workspace, fs)) {
+            List<Path> knowledgeFiles = wm.listKnowledgeFiles(RuntimeContext.empty());
+            assertEquals(1, knowledgeFiles.size(), () -> "Unexpected knowledge files: " + knowledgeFiles);
+            assertEquals(
+                    workspace.resolve("knowledge/guide.md").normalize(),
+                    knowledgeFiles.get(0).normalize());
+        }
+    }
+
+    @Test
     void listMemoryFilePaths_returnsWorkspaceRelativePaths(
             @TempDir Path project, @TempDir Path workspace) throws IOException {
         Files.writeString(workspace.resolve("MEMORY.md"), "memory");
         Files.createDirectories(workspace.resolve("memory"));
         Files.writeString(workspace.resolve("memory/notes.md"), "notes");
+
+        AbstractFilesystem fs = new LocalFilesystemSpec().project(project).toFilesystem(workspace, null);
+        try (WorkspaceManager wm = new WorkspaceManager(workspace, fs)) {
+            List<String> memoryFiles = wm.listMemoryFilePaths(RuntimeContext.empty());
+            assertEquals(2, memoryFiles.size(), () -> "Unexpected memory files: " + memoryFiles);
+            assertTrue(memoryFiles.contains("MEMORY.md"));
+            assertTrue(memoryFiles.contains("memory/notes.md"));
+        }
+    }
+
+    @Test
+    void listMemoryFilePaths_normalizesProjectLayerAbsolutePaths(
+            @TempDir Path project, @TempDir Path workspace) throws IOException {
+        Files.writeString(project.resolve("MEMORY.md"), "memory");
+        Files.createDirectories(project.resolve("memory"));
+        Files.writeString(project.resolve("memory/notes.md"), "notes");
 
         AbstractFilesystem fs = new LocalFilesystemSpec().project(project).toFilesystem(workspace, null);
         try (WorkspaceManager wm = new WorkspaceManager(workspace, fs)) {

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/workspace/WorkspaceManagerListingTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/workspace/WorkspaceManagerListingTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.harness.agent.workspace;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.agentscope.core.agent.RuntimeContext;
+import io.agentscope.harness.agent.filesystem.AbstractFilesystem;
+import io.agentscope.harness.agent.filesystem.spec.LocalFilesystemSpec;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class WorkspaceManagerListingTest {
+
+    @Test
+    void listKnowledgeFiles_returnsWorkspaceRelativePaths(
+            @TempDir Path project, @TempDir Path workspace) throws IOException {
+        Files.createDirectories(workspace.resolve("knowledge"));
+        Files.writeString(workspace.resolve("knowledge/guide.md"), "guide");
+
+        AbstractFilesystem fs = new LocalFilesystemSpec().project(project).toFilesystem(workspace, null);
+        try (WorkspaceManager wm = new WorkspaceManager(workspace, fs)) {
+            List<Path> knowledgeFiles = wm.listKnowledgeFiles(RuntimeContext.empty());
+            assertEquals(1, knowledgeFiles.size(), () -> "Unexpected knowledge files: " + knowledgeFiles);
+            assertEquals(
+                    workspace.resolve("knowledge/guide.md").normalize(),
+                    knowledgeFiles.get(0).normalize());
+        }
+    }
+
+    @Test
+    void listMemoryFilePaths_returnsWorkspaceRelativePaths(
+            @TempDir Path project, @TempDir Path workspace) throws IOException {
+        Files.writeString(workspace.resolve("MEMORY.md"), "memory");
+        Files.createDirectories(workspace.resolve("memory"));
+        Files.writeString(workspace.resolve("memory/notes.md"), "notes");
+
+        AbstractFilesystem fs = new LocalFilesystemSpec().project(project).toFilesystem(workspace, null);
+        try (WorkspaceManager wm = new WorkspaceManager(workspace, fs)) {
+            List<String> memoryFiles = wm.listMemoryFilePaths(RuntimeContext.empty());
+            assertEquals(2, memoryFiles.size(), () -> "Unexpected memory files: " + memoryFiles);
+            assertTrue(memoryFiles.contains("MEMORY.md"));
+            assertTrue(memoryFiles.contains("memory/notes.md"));
+        }
+    }
+}


### PR DESCRIPTION
## AgentScope-Java Version
2.0.0-SNAPSHOT

## Description
This PR fixes `AgentRunMcpChannel.parseExecPayload()` so AgentRun MCP `process_exec_cmd` responses can be parsed correctly in both the legacy flat format and the newer wrapped format.

Background:
- AgentRun may return flat JSON with `exitCode/stdout/stderr` at the root.
- The newer MCP protocol can return a banner-prefixed response where the JSON payload appears after non-JSON text.
- The newer payload may also nest exec data under `result`.

Changes:
- Extract the JSON payload from banner-prefixed responses.
- Support both flat payloads and `result`-wrapped payloads.
- Preserve plain-text fallback behavior.
- Add regression tests for flat JSON, banner-prefixed nested JSON, and plain-text fallback.

Related issue:
- Closes #1908

## How to test
- Run `AgentRunMcpChannelTest`.
- Verify it passes for flat JSON, banner-prefixed nested JSON, and plain-text fallback.
- Note: the repository currently has unrelated existing harness compile issues, so the focused regression test is the relevant validation for this PR.