### PR TITLE
fix(agentrun): unwrap data envelopes

### DIFF
--- a/agentscope-extensions/agentscope-extensions-sandbox/agentscope-extensions-sandbox-agentrun/src/main/java/io/agentscope/extensions/sandbox/agentrun/AgentRunDataPlaneHttp.java
+++ b/agentscope-extensions/agentscope-extensions-sandbox/agentscope-extensions-sandbox-agentrun/src/main/java/io/agentscope/extensions/sandbox/agentrun/AgentRunDataPlaneHttp.java
@@ -102,6 +102,13 @@ final class AgentRunDataPlaneHttp {
         return AgentRunRetry.withRetries(opt.getMaxRetries(), () -> getJson(url));
     }
 
+    private JsonNode unwrapData(JsonNode node) {
+        if (node != null && node.hasNonNull("data")) {
+            return node.get("data");
+        }
+        return node;
+    }
+
     /**
      * Deletes the sandbox. Returns silently on HTTP 404 (already gone). All other non-2xx
      * responses raise.
@@ -195,7 +202,7 @@ final class AgentRunDataPlaneHttp {
             if (text.isBlank()) {
                 return json.createObjectNode();
             }
-            return json.readTree(text);
+            return unwrapData(json.readTree(text));
         }
     }
 
@@ -208,7 +215,7 @@ final class AgentRunDataPlaneHttp {
                         SandboxErrorCode.WORKSPACE_START_ERROR,
                         "AgentRun HTTP " + res.code() + " " + res.message() + ": " + text);
             }
-            return json.readTree(text);
+            return unwrapData(json.readTree(text));
         }
     }
 }

--- a/agentscope-extensions/agentscope-extensions-sandbox/agentscope-extensions-sandbox-agentrun/src/test/java/io/agentscope/extensions/sandbox/agentrun/AgentRunDataPlaneHttpTest.java
+++ b/agentscope-extensions/agentscope-extensions-sandbox/agentscope-extensions-sandbox-agentrun/src/test/java/io/agentscope/extensions/sandbox/agentrun/AgentRunDataPlaneHttpTest.java
@@ -63,7 +63,8 @@ class AgentRunDataPlaneHttpTest {
 
         AgentRunDataPlaneHttp http = new AgentRunDataPlaneHttp(opt);
 
-        mockServer.enqueue(new MockResponse().setResponseCode(200).setBody("{\"id\":\"sb-1\"}"));
+        mockServer.enqueue(
+                new MockResponse().setResponseCode(200).setBody("{\"data\":{\"id\":\"sb-1\"}}"));
         JsonNode created = http.createSandbox("sb-1");
         assertNotNull(created);
         assertEquals("sb-1", created.get("id").asText());
@@ -76,7 +77,9 @@ class AgentRunDataPlaneHttpTest {
         assertTrue(createReq.getBody().readUtf8().contains("\"sandboxId\":\"sb-1\""));
 
         mockServer.enqueue(
-                new MockResponse().setResponseCode(200).setBody("{\"status\":\"READY\"}"));
+                new MockResponse()
+                        .setResponseCode(200)
+                        .setBody("{\"data\":{\"status\":\"READY\"}}"));
         JsonNode fetched = http.getSandbox("sb-1");
         assertNotNull(fetched);
         assertEquals("READY", fetched.get("status").asText());

--- a/agentscope-extensions/agentscope-extensions-sandbox/agentscope-extensions-sandbox-agentrun/src/test/java/io/agentscope/extensions/sandbox/agentrun/AgentRunDataPlaneHttpTest.java
+++ b/agentscope-extensions/agentscope-extensions-sandbox/agentscope-extensions-sandbox-agentrun/src/test/java/io/agentscope/extensions/sandbox/agentrun/AgentRunDataPlaneHttpTest.java
@@ -95,4 +95,33 @@ class AgentRunDataPlaneHttpTest {
         assertEquals("DELETE", deleteReq.getMethod());
         assertEquals("/sandboxes/sb-1", deleteReq.getPath());
     }
+
+    @Test
+    void acceptsResponsesWithoutDataEnvelope() throws Exception {
+        String baseUrl = mockServer.url("/").toString();
+        if (baseUrl.endsWith("/")) {
+            baseUrl = baseUrl.substring(0, baseUrl.length() - 1);
+        }
+
+        AgentRunSandboxClientOptions opt =
+                new AgentRunSandboxClientOptions()
+                        .setApiKey("test-key")
+                        .setTemplateName("agentscope-default")
+                        .setMcpServerUrl("https://example.com/mcp")
+                        .setDataPlaneBaseUrl(baseUrl)
+                        .setHttpClient(new OkHttpClient());
+
+        AgentRunDataPlaneHttp http = new AgentRunDataPlaneHttp(opt);
+
+        mockServer.enqueue(new MockResponse().setResponseCode(200).setBody("{\"id\":\"sb-2\"}"));
+        JsonNode created = http.createSandbox("sb-2");
+        assertNotNull(created);
+        assertEquals("sb-2", created.get("id").asText());
+
+        mockServer.enqueue(
+                new MockResponse().setResponseCode(200).setBody("{\"status\":\"RUNNING\"}"));
+        JsonNode fetched = http.getSandbox("sb-2");
+        assertNotNull(fetched);
+        assertEquals("RUNNING", fetched.get("status").asText());
+    }
 }


### PR DESCRIPTION
## AgentScope-Java Version
2.0.0-SNAPSHOT

## Description
This PR fixes AgentRun data-plane JSON handling when successful responses are wrapped in a `data` envelope.

Background:
- `AgentRunDataPlaneHttp` previously parsed response JSON from the root node.
- AgentRun create/get responses return payloads under `data`, so fields like `id` and `status` were not visible to the client code.

Changes made:
- Added `unwrapData(...)` in `AgentRunDataPlaneHttp` and applied it in `getJson()` and `postJson()`.
- Updated `AgentRunDataPlaneHttpTest` to mock wrapped responses and verify parsing still works.

Related issues:
- Closes #1907
- Related to #1889

How to test:
- `mvn -pl agentscope-extensions/agentscope-extensions-sandbox/agentscope-extensions-sandbox-agentrun -am -Dtest=AgentRunDataPlaneHttpTest test`
