### PR TITLE
docs(model): remove invalid ChatResponse.isLast references

### DIFF
--- a/docs/v2/en/docs/building-blocks/model.md
+++ b/docs/v2/en/docs/building-blocks/model.md
@@ -130,18 +130,13 @@ model.stream(
                 List.of(new UserMessage("Count from 1 to 5.")),
                 /* tools = */ List.of(),
                 GenerateOptions.builder().build())
-        .doOnNext(chunk -> {
-            // chunk.isLast() == true marks the final accumulated content
-            if (chunk.isLast()) {
-                System.out.println("Final: " + chunk.getContent());
-            } else {
-                System.out.println("Delta: " + chunk.getContent());
-            }
-        })
-        .blockLast();
+        .doOnNext(chunk -> System.out.println("Delta: " + chunk.getContent()))
+        .last()
+        .doOnNext(chunk -> System.out.println("Final: " + chunk.getContent()))
+        .block();
 ```
 
-A `ChatResponse` carries a list of content blocks (`TextBlock`, `ThinkingBlock`, `ToolUseBlock`, `DataBlock`), an `isLast()` flag, and a `ChatUsage` recording token counts and timing.
+A `ChatResponse` carries a list of content blocks (`TextBlock`, `ThinkingBlock`, `ToolUseBlock`, `DataBlock`) and a `ChatUsage` recording token counts and timing.
 
 In practice you usually call models indirectly via `ReActAgent`. For lightweight direct invocation, see `agentscope-examples/documentation/.../model/ModelRegistryExample.java`.
 

--- a/docs/v2/en/docs/building-blocks/model.md
+++ b/docs/v2/en/docs/building-blocks/model.md
@@ -130,10 +130,9 @@ model.stream(
                 List.of(new UserMessage("Count from 1 to 5.")),
                 /* tools = */ List.of(),
                 GenerateOptions.builder().build())
-        .doOnNext(chunk -> System.out.println("Delta: " + chunk.getContent()))
-        .last()
-        .doOnNext(chunk -> System.out.println("Final: " + chunk.getContent()))
-        .block();
+        .doOnNext(chunk -> System.out.println("Chunk: " + chunk.getContent()))
+        .doOnComplete(() -> System.out.println("Stream completed"))
+        .blockLast();
 ```
 
 A `ChatResponse` carries a list of content blocks (`TextBlock`, `ThinkingBlock`, `ToolUseBlock`, `DataBlock`) and a `ChatUsage` recording token counts and timing.

--- a/docs/v2/zh/docs/building-blocks/model.md
+++ b/docs/v2/zh/docs/building-blocks/model.md
@@ -130,18 +130,13 @@ model.stream(
                 List.of(new UserMessage("Count from 1 to 5.")),
                 /* tools = */ List.of(),
                 GenerateOptions.builder().build())
-        .doOnNext(chunk -> {
-            // chunk.isLast() == true 时表示最终累积内容
-            if (chunk.isLast()) {
-                System.out.println("Final: " + chunk.getContent());
-            } else {
-                System.out.println("Delta: " + chunk.getContent());
-            }
-        })
-        .blockLast();
+        .doOnNext(chunk -> System.out.println("Delta: " + chunk.getContent()))
+        .last()
+        .doOnNext(chunk -> System.out.println("Final: " + chunk.getContent()))
+        .block();
 ```
 
-`ChatResponse` 包含若干 content block（`TextBlock`、`ThinkingBlock`、`ToolUseBlock`、`DataBlock`）、一个 `isLast()` 标志，以及记录 token 数与耗时的 `ChatUsage`。
+`ChatResponse` 包含若干 content block（`TextBlock`、`ThinkingBlock`、`ToolUseBlock`、`DataBlock`）以及记录 token 数与耗时的 `ChatUsage`。
 
 实际开发中通常不需要直接调模型，而是通过 `ReActAgent` 调度；要直连模型做轻量调用时，推荐参考 `agentscope-examples/documentation/.../model/ModelRegistryExample.java`。
 

--- a/docs/v2/zh/docs/building-blocks/model.md
+++ b/docs/v2/zh/docs/building-blocks/model.md
@@ -130,10 +130,9 @@ model.stream(
                 List.of(new UserMessage("Count from 1 to 5.")),
                 /* tools = */ List.of(),
                 GenerateOptions.builder().build())
-        .doOnNext(chunk -> System.out.println("Delta: " + chunk.getContent()))
-        .last()
-        .doOnNext(chunk -> System.out.println("Final: " + chunk.getContent()))
-        .block();
+        .doOnNext(chunk -> System.out.println("Chunk: " + chunk.getContent()))
+        .doOnComplete(() -> System.out.println("Stream completed"))
+        .blockLast();
 ```
 
 `ChatResponse` 包含若干 content block（`TextBlock`、`ThinkingBlock`、`ToolUseBlock`、`DataBlock`）以及记录 token 数与耗时的 `ChatUsage`。


### PR DESCRIPTION
## AgentScope-Java Version

v2.0.0-RC4

## Description

This PR updates documentation to remove references to `ChatResponse.isLast()`, which is not part of the current API.


### Changes
- Removed outdated `ChatResponse.isLast()` mentions in model-related docs
- Aligned examples and explanations with actual API behavior
- Improved doc accuracy to avoid user confusion

### Validation
- Verified documentation consistency with current code usage
- No production code changes

## Checklist

Please check the following items before code is ready to be reviewed.

- [x]  Code has been formatted with `mvn spotless:apply`
- [x]  All tests are passing (`mvn test`)
- [x]  Javadoc comments are complete and follow project conventions
- [x]  Related documentation has been updated (e.g. links, examples, etc.)
- [x]  Code is ready for review

## Related Issue
* Fixes issue https://github.com/agentscope-ai/agentscope-java/issues/1785