### PR TITLE
fix(dify): handle string query response

### DIFF
--- a/agentscope-extensions/agentscope-extensions-rag/agentscope-extensions-rag-dify/src/main/java/io/agentscope/core/rag/integration/dify/model/DifyResponse.java
+++ b/agentscope-extensions/agentscope-extensions-rag/agentscope-extensions-rag-dify/src/main/java/io/agentscope/core/rag/integration/dify/model/DifyResponse.java
@@ -15,6 +15,7 @@
  */
 package io.agentscope.core.rag.integration.dify.model;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.List;
@@ -23,6 +24,25 @@ import java.util.List;
  * Response model for Dify knowledge base retrieval API.
  *
  * <p>This class maps the JSON response from Dify's retrieve endpoint:
+ * <pre>{@code
+ * {
+ *   "query": "..." ,
+ *   "records": [
+ *     {
+ *       "segment": {
+ *         "id": "...",
+ *         "document_id": "...",
+ *         "content": "...",
+ *         "position": 1,
+ *         "document": { "id": "...", "name": "..." }
+ *       },
+ *       "score": 0.95
+ *     }
+ *   ]
+ * }
+ *
+ * <p>Some Dify deployments return {@code query} as an object with a {@code content} field.
+ * The model keeps that form compatible as well.
  * <pre>{@code
  * {
  *   "query": { "content": "..." },
@@ -69,6 +89,13 @@ public class DifyResponse {
     @JsonIgnoreProperties(ignoreUnknown = true)
     public static class Query {
         private String content;
+
+        @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+        public static Query fromString(String content) {
+            Query query = new Query();
+            query.setContent(content);
+            return query;
+        }
 
         public String getContent() {
             return content;

--- a/agentscope-extensions/agentscope-extensions-rag/agentscope-extensions-rag-dify/src/test/java/io/agentscope/core/rag/integration/dify/DifyRAGClientTest.java
+++ b/agentscope-extensions/agentscope-extensions-rag/agentscope-extensions-rag-dify/src/test/java/io/agentscope/core/rag/integration/dify/DifyRAGClientTest.java
@@ -75,6 +75,31 @@ class DifyRAGClientTest {
                 .setBody(responseBody);
     }
 
+    private MockResponse createSuccessResponseWithQuery(String queryJson) {
+        String responseBody =
+                String.format(
+                        """
+                        {
+                            "query": %s,
+                            "records": [
+                                {
+                                    "segment": {
+                                        "id": "seg-1",
+                                        "content": "Test content",
+                                        "document_id": "doc-1"
+                                    },
+                                    "score": 0.95
+                                }
+                            ]
+                        }
+                        """,
+                        queryJson);
+        return new MockResponse()
+                .setResponseCode(200)
+                .setHeader("Content-Type", "application/json")
+                .setBody(responseBody);
+    }
+
     private MockResponse createEmptyResponse() {
         return new MockResponse()
                 .setResponseCode(200)
@@ -406,6 +431,34 @@ class DifyRAGClientTest {
         assertEquals(1, response.getRecords().size());
         assertEquals("seg-1", response.getRecords().get(0).getSegment().getId());
         assertEquals(0.95, response.getRecords().get(0).getScore(), 0.001);
+    }
+
+    @Test
+    void testParseStringQueryResponse() throws Exception {
+        mockWebServer.enqueue(createSuccessResponseWithQuery("\"ping\""));
+
+        DifyRAGClient client = new DifyRAGClient(createConfig());
+        DifyResponse response = client.retrieve("test query", 5).block();
+
+        assertNotNull(response);
+        assertNotNull(response.getQuery());
+        assertEquals("ping", response.getQuery().getContent());
+        assertNotNull(response.getRecords());
+        assertEquals(1, response.getRecords().size());
+    }
+
+    @Test
+    void testParseObjectQueryResponse() throws Exception {
+        mockWebServer.enqueue(createSuccessResponseWithQuery("{\"content\":\"ping\"}"));
+
+        DifyRAGClient client = new DifyRAGClient(createConfig());
+        DifyResponse response = client.retrieve("test query", 5).block();
+
+        assertNotNull(response);
+        assertNotNull(response.getQuery());
+        assertEquals("ping", response.getQuery().getContent());
+        assertNotNull(response.getRecords());
+        assertEquals(1, response.getRecords().size());
     }
 
     @Test


### PR DESCRIPTION
## AgentScope-Java Version

2.0.0-SNAPSHOT

## Description

### Background
The Dify RAG integration fails against real Dify Cloud (`api.dify.ai`) responses because the top-level `query` field is returned as a JSON string, while `DifyResponse.Query` only supported the object form. This caused `DifyResponse` deserialization to fail and made `kb_search` results/references empty.

### Purpose
Make the Dify response model compatible with both `query: "..."` and `query: { "content": "..." }` payloads so retrieval works reliably with real Dify Cloud deployments.

### Changes
- Add a delegating Jackson creator to `DifyResponse.Query` so string payloads can be deserialized.
- Keep the existing bean-style object mapping so both response shapes remain supported.
- Add regression tests for both string and object `query` payloads.

### How to test
- `mvn -pl agentscope-extensions/agentscope-extensions-rag/agentscope-extensions-rag-dify -am -Dtest=DifyRAGClientTest test`

### Related issue
- Fixes #1917