### PR TITLE
fix(event): generate unique blockId for text and thinking stream events

### DIFF
--- a/agentscope-core/src/main/java/io/agentscope/core/ReActAgent.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/ReActAgent.java
@@ -2177,7 +2177,9 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
                 if (tb.getThinking() != null && !tb.getThinking().isEmpty()) {
                     events.add(
                             new ThinkingBlockDeltaEvent(
-                                    blockLifecycle.replyId, "thinking", tb.getThinking()));
+                                    blockLifecycle.replyId,
+                                    blockLifecycle.thinkingBlockId(),
+                                    tb.getThinking()));
                 }
             } else if (withToolEvents && block instanceof ToolUseBlock tub) {
                 String toolId = resolveToolCallId(tub, context);
@@ -2209,6 +2211,8 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
             private final Map<String, String> startedToolCalls = new ConcurrentHashMap<>();
             private final AtomicInteger textBlockCounter = new AtomicInteger(0);
             private volatile String currentTextBlockId;
+            private final AtomicInteger thinkingBlockCounter = new AtomicInteger(0);
+            private volatile String currentThinkingBlockId;
 
             private ModelCallBlockLifecycle(String replyId) {
                 this.replyId = replyId;
@@ -2228,8 +2232,13 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
 
             private void startThinking(List<AgentEvent> events) {
                 if (thinkingStarted.compareAndSet(false, true)) {
-                    events.add(new ThinkingBlockStartEvent(replyId, "thinking"));
+                    currentThinkingBlockId = replyId + "_thinking_" + thinkingBlockCounter.incrementAndGet();
+                    events.add(new ThinkingBlockStartEvent(replyId, currentThinkingBlockId));
                 }
+            }
+
+            String thinkingBlockId() {
+                return currentThinkingBlockId;
             }
 
             private void startToolCall(String toolId, String toolName, List<AgentEvent> events) {
@@ -2253,7 +2262,7 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
 
             private void flushThinking(List<AgentEvent> events) {
                 if (thinkingStarted.compareAndSet(true, false)) {
-                    events.add(new ThinkingBlockEndEvent(replyId, "thinking"));
+                    events.add(new ThinkingBlockEndEvent(replyId, currentThinkingBlockId));
                 }
             }
 
@@ -3156,7 +3165,8 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
                                                                             new ThinkingBlockDeltaEvent(
                                                                                     blockLifecycle
                                                                                             .replyId,
-                                                                                    "thinking",
+                                                                                    blockLifecycle
+                                                                                            .thinkingBlockId(),
                                                                                     tb
                                                                                             .getThinking()));
                                                                 }

--- a/agentscope-core/src/main/java/io/agentscope/core/ReActAgent.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/ReActAgent.java
@@ -134,6 +134,7 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -2166,7 +2167,10 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
                 blockLifecycle.startText(events);
                 if (tb.getText() != null && !tb.getText().isEmpty()) {
                     events.add(
-                            new TextBlockDeltaEvent(blockLifecycle.replyId, "text", tb.getText()));
+                            new TextBlockDeltaEvent(
+                                    blockLifecycle.replyId,
+                                    blockLifecycle.textBlockId(),
+                                    tb.getText()));
                 }
             } else if (block instanceof ThinkingBlock tb) {
                 blockLifecycle.startThinking(events);
@@ -2203,6 +2207,8 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
             private final AtomicBoolean textStarted = new AtomicBoolean(false);
             private final AtomicBoolean thinkingStarted = new AtomicBoolean(false);
             private final Map<String, String> startedToolCalls = new ConcurrentHashMap<>();
+            private final AtomicInteger textBlockCounter = new AtomicInteger(0);
+            private volatile String currentTextBlockId;
 
             private ModelCallBlockLifecycle(String replyId) {
                 this.replyId = replyId;
@@ -2211,8 +2217,13 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
             private void startText(List<AgentEvent> events) {
                 flushThinking(events);
                 if (textStarted.compareAndSet(false, true)) {
-                    events.add(new TextBlockStartEvent(replyId, "text"));
+                    currentTextBlockId = replyId + "_text_" + textBlockCounter.incrementAndGet();
+                    events.add(new TextBlockStartEvent(replyId, currentTextBlockId));
                 }
+            }
+
+            String textBlockId() {
+                return currentTextBlockId;
             }
 
             private void startThinking(List<AgentEvent> events) {
@@ -2236,7 +2247,7 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
 
             private void flushText(List<AgentEvent> events) {
                 if (textStarted.compareAndSet(true, false)) {
-                    events.add(new TextBlockEndEvent(replyId, "text"));
+                    events.add(new TextBlockEndEvent(replyId, currentTextBlockId));
                 }
             }
 
@@ -3130,7 +3141,8 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
                                                                             new TextBlockDeltaEvent(
                                                                                     blockLifecycle
                                                                                             .replyId,
-                                                                                    "text",
+                                                                                    blockLifecycle
+                                                                                            .textBlockId(),
                                                                                     tb.getText()));
                                                                 }
                                                             } else if (block

--- a/agentscope-core/src/main/java/io/agentscope/core/ReActAgent.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/ReActAgent.java
@@ -2232,7 +2232,8 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
 
             private void startThinking(List<AgentEvent> events) {
                 if (thinkingStarted.compareAndSet(false, true)) {
-                    currentThinkingBlockId = replyId + "_thinking_" + thinkingBlockCounter.incrementAndGet();
+                    currentThinkingBlockId =
+                            replyId + "_thinking_" + thinkingBlockCounter.incrementAndGet();
                     events.add(new ThinkingBlockStartEvent(replyId, currentThinkingBlockId));
                 }
             }


### PR DESCRIPTION
## Problem

Text and Thinking block stream events used hardcoded block IDs (`"text"` and `"thinking"`) instead of unique identifiers. When a single model response contained multiple text or thinking blocks (e.g., text → tool call → text), all blocks shared the same ID, making it impossible for clients to correlate start/delta/end events to the correct block.

## Fix

Generate unique block IDs using `replyId + "_text_" + counter` and `replyId + "_thinking_" + counter`:

- **TextBlock**: `replyId + "_text_" + textBlockCounter.incrementAndGet()`
- **ThinkingBlock**: `replyId + "_thinking_" + thinkingBlockCounter.incrementAndGet()`

Both patterns are applied consistently to Start, Delta, and End events in:
- `emitBlockEvents()` — main model call stream
- `summaryModelCallStream()` — summary model call stream

Per maintainer feedback (@yulindong), ThinkingBlock was included in the same fix.

## Test plan

- [ ] Build passes: `mvn compile -pl agentscope-core`
- [ ] Existing event tests pass