### PR TITLE
fix(sandbox): support nested JSON and banner prefix in AgentRun MCP response

### DIFF
--- a/agentscope-extensions/agentscope-extensions-sandbox/agentscope-extensions-sandbox-agentrun/src/main/java/io/agentscope/extensions/sandbox/agentrun/AgentRunMcpChannel.java
+++ b/agentscope-extensions/agentscope-extensions-sandbox/agentscope-extensions-sandbox-agentrun/src/main/java/io/agentscope/extensions/sandbox/agentrun/AgentRunMcpChannel.java
@@ -226,26 +226,34 @@ final class AgentRunMcpChannel implements AutoCloseable {
     /**
      * Parses an AgentRun exec MCP response. AgentRun returns either a JSON object such as
      * {@code {"exitCode":0,"stdout":"...","stderr":"..."}} or a plain stdout/stderr string. We
-     * accept both shapes.
+     * accept both shapes, including the nested format {@code {"result":{"exitCode":...}}} and
+     * responses with markdown banner prefixes before the JSON payload.
      */
     private static ExecResult parseExecPayload(String text) {
         if (text == null) {
             return new ExecResult(0, "", "");
         }
         String trimmed = text.strip();
-        if (trimmed.startsWith("{")) {
+
+        int braceIdx = trimmed.indexOf('{');
+        if (braceIdx >= 0) {
+            String jsonText = braceIdx == 0 ? trimmed : trimmed.substring(braceIdx);
             try {
-                JsonNode node = JSON.readTree(trimmed);
-                int exit =
-                        node.has("exitCode")
-                                ? node.path("exitCode").asInt(0)
-                                : node.path("exit_code").asInt(0);
-                String stdout =
-                        node.has("stdout")
-                                ? node.path("stdout").asText("")
-                                : node.path("output").asText("");
-                String stderr = node.path("stderr").asText("");
-                return new ExecResult(exit, stdout, stderr);
+                JsonNode node = JSON.readTree(jsonText);
+                JsonNode result = node.path("result");
+                JsonNode source = result.isObject() ? result : node;
+                if (source.has("exitCode") || source.has("exit_code")) {
+                    int exit =
+                            source.has("exitCode")
+                                    ? source.path("exitCode").asInt(0)
+                                    : source.path("exit_code").asInt(0);
+                    String stdout =
+                            source.has("stdout")
+                                    ? source.path("stdout").asText("")
+                                    : source.path("output").asText("");
+                    String stderr = source.path("stderr").asText("");
+                    return new ExecResult(exit, stdout, stderr);
+                }
             } catch (Exception ignore) {
                 // fall through to plain-text handling
             }


### PR DESCRIPTION
## Summary

- Support nested JSON format (`{"result":{"exitCode":...}}`) in `parseExecPayload()`
- Handle markdown banner prefixes before JSON payload by locating first `{`
- Only treat as exec result when `exitCode`/`exit_code` is present in the resolved object

## Problem

`AgentRunMcpChannel.parseExecPayload()` assumed flat JSON and required text to start with `{`. The AgentRun MCP server (protocol `2025-03-26`) returns:

1. **Nested format** — `exitCode`/`stdout`/`stderr` inside a `result` sub-object
2. **Banner prefix** — markdown headers before the JSON payload

When parsing fails, the entire MCP response text (including banner) is returned as stdout, causing `glob()` to treat banner lines as file paths and triggering `InvalidPathException` on Windows.

Fixes #1908

## Test Plan

- [ ] Unit test: flat JSON `{"exitCode":0,"stdout":"ok","stderr":""}` still parses correctly
- [ ] Unit test: nested JSON `{"result":{"exitCode":1,"stdout":"","stderr":"err"}}` parses correctly
- [ ] Unit test: banner + JSON `### process_exec_cmd\n...\n{"exitCode":0,...}` parses correctly
- [ ] Unit test: plain text falls back to `ExecResult(0, text, "")`