### PR TITLE
fix(tracing): fix orphan spans in OtelTracingMiddleware by reading parent OTel Context from Reactor ContextView

### DIFF
--- a/agentscope-core/src/main/java/io/agentscope/core/tracing/OtelTracingMiddleware.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/tracing/OtelTracingMiddleware.java
@@ -33,12 +33,13 @@ import io.opentelemetry.api.trace.StatusCode;
 import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.reactor.v3_1.ContextPropagationOperator;
-import java.util.LinkedHashSet;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import reactor.core.publisher.Flux;
+import reactor.util.context.ContextView;
 
 /**
  * Middleware that adds OpenTelemetry tracing to the agent lifecycle.
@@ -99,11 +100,13 @@ public class OtelTracingMiddleware implements MiddlewareBase {
             RuntimeContext ctx,
             AgentInput input,
             Function<AgentInput, Flux<AgentEvent>> next) {
-        return Flux.defer(
-                () -> {
+        return Flux.deferContextual(
+                ctxView -> {
+                    Context parentContext = resolveOtelContext(ctxView);
                     Span span =
                             getTracer()
                                     .spanBuilder("invoke_agent " + agent.getName())
+                                    .setParent(parentContext)
                                     .setAttribute("gen_ai.operation.name", "invoke_agent")
                                     .setAttribute("gen_ai.agent.name", agent.getName())
                                     .setAttribute(
@@ -114,7 +117,7 @@ public class OtelTracingMiddleware implements MiddlewareBase {
                                             (long) input.msgs().size())
                                     .startSpan();
 
-                    Context otelCtx = Context.current().with(span);
+                    Context otelCtx = span.storeInContext(parentContext);
                     AtomicReference<Boolean> ended = new AtomicReference<>(false);
 
                     return ContextPropagationOperator.runWithContext(
@@ -165,13 +168,15 @@ public class OtelTracingMiddleware implements MiddlewareBase {
             RuntimeContext ctx,
             ModelCallInput input,
             Function<ModelCallInput, Flux<AgentEvent>> next) {
-        return Flux.defer(
-                () -> {
+        return Flux.deferContextual(
+                ctxView -> {
+                    Context parentContext = resolveOtelContext(ctxView);
                     Model model = input.model();
                     String modelName = model != null ? model.getModelName() : "unknown";
                     Span span =
                             getTracer()
                                     .spanBuilder("chat " + modelName)
+                                    .setParent(parentContext)
                                     .setAttribute("gen_ai.operation.name", "chat")
                                     .setAttribute("gen_ai.request.model", modelName)
                                     .setAttribute(
@@ -184,7 +189,7 @@ public class OtelTracingMiddleware implements MiddlewareBase {
                                                     : 0L)
                                     .startSpan();
 
-                    Context otelCtx = Context.current().with(span);
+                    Context otelCtx = span.storeInContext(parentContext);
                     AtomicReference<Boolean> ended = new AtomicReference<>(false);
 
                     return ContextPropagationOperator.runWithContext(
@@ -232,18 +237,21 @@ public class OtelTracingMiddleware implements MiddlewareBase {
             RuntimeContext ctx,
             ActingInput input,
             Function<ActingInput, Flux<AgentEvent>> next) {
-        return Flux.defer(
-                () -> {
+        return Flux.deferContextual(
+                ctxView -> {
+                    Context parentContext = resolveOtelContext(ctxView);
                     String toolNames =
                             input.toolCalls() != null
                                     ? input.toolCalls().stream()
                                             .map(ToolUseBlock::getName)
                                             .collect(Collectors.joining(", "))
                                     : "unknown";
+                    String spanName = buildToolSpanName(input);
 
                     Span span =
                             getTracer()
-                                    .spanBuilder("execute_tool " + toolNames)
+                                    .spanBuilder("execute_tool " + spanName)
+                                    .setParent(parentContext)
                                     .setAttribute("gen_ai.operation.name", "execute_tool")
                                     .setAttribute("gen_ai.tool.name", toolNames)
                                     .setAttribute(
@@ -253,9 +261,9 @@ public class OtelTracingMiddleware implements MiddlewareBase {
                                                     : 0L)
                                     .startSpan();
 
-                    Context otelCtx = Context.current().with(span);
+                    Context otelCtx = span.storeInContext(parentContext);
                     AtomicReference<Boolean> ended = new AtomicReference<>(false);
-                    Set<String> callIds = new LinkedHashSet<>();
+                    Set<String> callIds = ConcurrentHashMap.newKeySet();
 
                     return ContextPropagationOperator.runWithContext(
                             next.apply(input)
@@ -299,6 +307,26 @@ public class OtelTracingMiddleware implements MiddlewareBase {
     // ------------------------------------------------------------------
     // helpers
     // ------------------------------------------------------------------
+
+    // Reads OTel Context from Reactor ContextView first; falls back to ThreadLocal
+    // Context.current()
+    // so spans created inside a reactive pipeline can find their parent even after a thread hop.
+    private Context resolveOtelContext(ContextView ctxView) {
+        return ContextPropagationOperator.getOpenTelemetryContextFromContextView(
+                ctxView, Context.current());
+    }
+
+    // Uses the first tool name as the span name; appends "(+N more)" for batches to cap
+    // cardinality.
+    // Full tool name list is still available in the gen_ai.tool.name attribute.
+    private static String buildToolSpanName(ActingInput input) {
+        if (input.toolCalls() == null || input.toolCalls().isEmpty()) {
+            return "unknown";
+        }
+        String first = input.toolCalls().get(0).getName();
+        int rest = input.toolCalls().size() - 1;
+        return rest > 0 ? first + " (+" + rest + " more)" : first;
+    }
 
     private void setToolCallIds(Span span, Set<String> callIds) {
         if (!callIds.isEmpty()) {

--- a/agentscope-core/src/test/java/io/agentscope/core/tracing/OtelTracingMiddlewareTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/tracing/OtelTracingMiddlewareTest.java
@@ -396,6 +396,57 @@ class OtelTracingMiddlewareTest {
         assertTrue(callIds.contains("call-b"));
     }
 
+    @Test
+    void onActing_multiTool_spanNameTruncatedButAttributeContainsAll() {
+        Agent agent = stubAgent("multi-tool-agent2", "agent-104");
+        ToolUseBlock t1 = ToolUseBlock.builder().id("c1").name("search").input(Map.of()).build();
+        ToolUseBlock t2 = ToolUseBlock.builder().id("c2").name("calc").input(Map.of()).build();
+        ToolUseBlock t3 = ToolUseBlock.builder().id("c3").name("fetchUrl").input(Map.of()).build();
+        ActingInput input = new ActingInput(List.of(t1, t2, t3));
+
+        ToolResultEndEvent r1 =
+                new ToolResultEndEvent("reply-1", "c1", "search", ToolResultState.SUCCESS);
+        ToolResultEndEvent r2 =
+                new ToolResultEndEvent("reply-1", "c2", "calc", ToolResultState.SUCCESS);
+        ToolResultEndEvent r3 =
+                new ToolResultEndEvent("reply-1", "c3", "fetchUrl", ToolResultState.SUCCESS);
+
+        middleware.onActing(agent, null, input, in -> Flux.just(r1, r2, r3)).collectList().block();
+
+        List<SpanData> spans = spanExporter.getFinishedSpanItems();
+        assertEquals(1, spans.size());
+
+        SpanData span = spans.get(0);
+        // span name uses first tool + count suffix to cap cardinality
+        assertEquals("execute_tool search (+2 more)", span.getName());
+        // gen_ai.tool.name attribute still has all names
+        String toolNames =
+                span.getAttributes()
+                        .get(
+                                io.opentelemetry.api.common.AttributeKey.stringKey(
+                                        "gen_ai.tool.name"));
+        assertNotNull(toolNames);
+        assertTrue(toolNames.contains("search"));
+        assertTrue(toolNames.contains("calc"));
+        assertTrue(toolNames.contains("fetchUrl"));
+    }
+
+    @Test
+    void onActing_singleTool_spanNameIsToolName() {
+        Agent agent = stubAgent("single-tool-agent", "agent-105");
+        ToolUseBlock t1 = ToolUseBlock.builder().id("c1").name("myTool").input(Map.of()).build();
+        ActingInput input = new ActingInput(List.of(t1));
+
+        ToolResultEndEvent r1 =
+                new ToolResultEndEvent("reply-1", "c1", "myTool", ToolResultState.SUCCESS);
+
+        middleware.onActing(agent, null, input, in -> Flux.just(r1)).collectList().block();
+
+        List<SpanData> spans = spanExporter.getFinishedSpanItems();
+        assertEquals(1, spans.size());
+        assertEquals("execute_tool myTool", spans.get(0).getName());
+    }
+
     // ------------------------------------------------------------------
     // helpers
     // ------------------------------------------------------------------


### PR DESCRIPTION
## AgentScope-Java Version

2.0.0-SNAPSHOT

## Description

**Background**

`OtelTracingMiddleware` was producing orphan spans: `chat <model>` and `execute_tool <name>` spans appeared as disconnected root spans in OTLP backends (e.g. Langfuse) instead of being nested under `invoke_agent`. Additionally, any `SpanProcessor` that reads the parent `Context` in `onStart` (e.g. to inject business metadata) received an empty context.

Closes #1938

**Root cause**

All three hooks (`onAgent`, `onModelCall`, `onActing`) used `Flux.defer` + `Context.current()` (ThreadLocal) to resolve the parent OTel Context. Inside a Reactor pipeline, the parent span is stored in **Reactor Context** (written by `ContextPropagationOperator.runWithContext`), not in ThreadLocal. After any thread hop (`publishOn`/`subscribeOn`), `Context.current()` returns an empty context, so child spans had no parent.

**Fix**

Switch all three hooks from `Flux.defer` to `Flux.deferContextual`, and resolve the parent context via `ContextPropagationOperator.getOpenTelemetryContextFromContextView(ctxView, Context.current())` — this reads from Reactor Context first and falls back to ThreadLocal. Then call `spanBuilder.setParent(parentContext)` explicitly and build the child context with `span.storeInContext(parentContext)`.

This is the same pattern used in the now-deprecated `TelemetryTracer.callModel`.

**Additional improvements**

- `onActing`: replaced `LinkedHashSet` with `ConcurrentHashMap.newKeySet()` for `callIds` (defensive thread safety)
- `onActing`: span name now uses `<firstTool> (+N more)` for batch tool calls to cap cardinality; full tool names are preserved in the `gen_ai.tool.name` attribute
- Added `resolveOtelContext` and `buildToolSpanName` helpers with clarifying comments

**How to test**

Configure any OTLP backend (e.g. Langfuse). Add `OtelTracingMiddleware` to a `ReActAgent`. Invoke the agent and verify:
1. `chat <model>` and `execute_tool <name>` spans appear nested under `invoke_agent`
2. All three spans share the same `traceId`
3. Any `SpanProcessor` that reads parent context in `onStart` correctly receives business metadata

## Checklist

- [x] Code has been formatted with `mvn spotless:apply`
- [x] All tests are passing (`mvn test`)
- [x] Javadoc comments are complete and follow project conventions
- [x] Related documentation has been updated (e.g. links, examples, etc.)
- [x] Code is ready for review