### PR TITLE
fix(model): anthropic stream thinking event

### DIFF
--- a/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-anthropic/src/main/java/io/agentscope/extensions/model/anthropic/formatter/AnthropicResponseParser.java
+++ b/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-anthropic/src/main/java/io/agentscope/extensions/model/anthropic/formatter/AnthropicResponseParser.java
@@ -140,6 +140,16 @@ public class AnthropicResponseParser {
                                     contentBlocks.add(
                                             TextBlock.builder().text(textDelta.text()).build()));
 
+            deltaEvent
+                    .delta()
+                    .thinking()
+                    .ifPresent(
+                            thinkingDelta ->
+                                    contentBlocks.add(
+                                            ThinkingBlock.builder()
+                                                    .thinking(thinkingDelta.thinking())
+                                                    .build()));
+
             // Input JSON delta (tool calling)
             deltaEvent
                     .delta()

--- a/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-anthropic/src/test/java/io/agentscope/extensions/model/anthropic/formatter/AnthropicResponseParserTest.java
+++ b/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-anthropic/src/test/java/io/agentscope/extensions/model/anthropic/formatter/AnthropicResponseParserTest.java
@@ -26,6 +26,7 @@ import static org.mockito.Mockito.when;
 
 import com.anthropic.models.messages.ContentBlock;
 import com.anthropic.models.messages.Message;
+import com.anthropic.models.messages.RawContentBlockDeltaEvent;
 import com.anthropic.models.messages.RawMessageStartEvent;
 import com.anthropic.models.messages.RawMessageStreamEvent;
 import com.anthropic.models.messages.Usage;
@@ -314,6 +315,26 @@ class AnthropicResponseParserTest extends AnthropicFormatterTestBase {
         assertNotNull(response);
         assertEquals("msg_stream_123", response.getId());
         assertTrue(response.getContent().isEmpty()); // MessageStart has no content
+    }
+
+    @Test
+    void testParseStreamEventThinkingDelta() throws Exception {
+        RawContentBlockDeltaEvent deltaEvent =
+                RawContentBlockDeltaEvent.builder()
+                        .index(0)
+                        .thinkingDelta("Let me reason through this.")
+                        .build();
+        RawMessageStreamEvent event = RawMessageStreamEvent.ofContentBlockDelta(deltaEvent);
+
+        Instant startTime = Instant.now();
+        ChatResponse response = invokeParseStreamEvent(event, startTime);
+
+        assertNotNull(response);
+        assertEquals(1, response.getContent().size());
+        ThinkingBlock parsedThinking =
+                assertInstanceOf(ThinkingBlock.class, response.getContent().get(0));
+        assertEquals("Let me reason through this.", parsedThinking.getThinking());
+        assertNull(response.getUsage());
     }
 
     @Test


### PR DESCRIPTION
Summary
  Fixes #1636 by parsing Anthropic streaming thinking_delta events into AgentScope ThinkingBlock content blocks. Non-streaming thinking blocks were already supported; this adds
  parity for streamed responses.

  Changes

  - Added delta().thinking() handling in AnthropicResponseParser.parseStreamEvent(...).
  - Converts Anthropic ThinkingDelta content into io.agentscope.core.message.ThinkingBlock.
  - Added regression coverage for streaming thinking deltas using RawContentBlockDeltaEvent.builder().thinkingDelta(...).
