### PR TITLE
Normalize \r\n to \n for file content in LocalFilesystem.edit()

### DIFF
--- a/agentscope-dependencies-bom/pom.xml
+++ b/agentscope-dependencies-bom/pom.xml
@@ -60,7 +60,7 @@
     </developers>
 
     <properties>
-        <revision>2.0.0-SNAPSHOT</revision>
+        <revision>2.0.0-RC3</revision>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <java.version>17</java.version>

--- a/agentscope-distribution/agentscope-bom/pom.xml
+++ b/agentscope-distribution/agentscope-bom/pom.xml
@@ -59,7 +59,7 @@
     </developers>
 
     <properties>
-        <revision>2.0.0-SNAPSHOT</revision>
+        <revision>2.0.0-RC3</revision>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <java.version>17</java.version>

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/filesystem/local/LocalFilesystem.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/filesystem/local/LocalFilesystem.java
@@ -359,7 +359,8 @@ public class LocalFilesystem implements AbstractFilesystem {
         ReentrantLock lock = fileLocks.computeIfAbsent(lockKey, k -> new ReentrantLock());
         lock.lock();
         try {
-            String content = Files.readString(resolved, StandardCharsets.UTF_8);
+            String content = Files.readString(resolved, StandardCharsets.UTF_8)
+                    .replace("\r\n", "\n").replace("\r", "\n");
             String normalizedOld = oldString.replace("\r\n", "\n").replace("\r", "\n");
             String normalizedNew = newString.replace("\r\n", "\n").replace("\r", "\n");
 

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/filesystem/local/LocalFilesystem.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/filesystem/local/LocalFilesystem.java
@@ -359,8 +359,10 @@ public class LocalFilesystem implements AbstractFilesystem {
         ReentrantLock lock = fileLocks.computeIfAbsent(lockKey, k -> new ReentrantLock());
         lock.lock();
         try {
-            String content = Files.readString(resolved, StandardCharsets.UTF_8)
-                    .replace("\r\n", "\n").replace("\r", "\n");
+            String content =
+                    Files.readString(resolved, StandardCharsets.UTF_8)
+                            .replace("\r\n", "\n")
+                            .replace("\r", "\n");
             String normalizedOld = oldString.replace("\r\n", "\n").replace("\r", "\n");
             String normalizedNew = newString.replace("\r\n", "\n").replace("\r", "\n");
 

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <name>AgentScope Java - Parent</name>
 
     <properties>
-        <revision>2.0.0-SNAPSHOT</revision>
+        <revision>2.0.0-RC3</revision>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <java.version>17</java.version>


### PR DESCRIPTION
## AgentScope-Java Version

2.0.0-RC4

## Description

Problem
In LocalFilesystem.edit(), the oldString and newString parameters are normalized from \r\n to \n before performing string replacement, but the file content itself is not normalized. This causes edit() to silently fail (return 0 occurrences) on files with Windows-style (\r\n) line endings, because the replacement target uses \n while the actual content still contains \r\n.

Fix
Apply the same \r\n → \n normalization to the file content read from disk, ensuring consistent line-ending handling across all three strings (content, oldString, newString).

Change
LocalFilesystem.java:362 — chain .replace("\r\n", "\n").replace("\r", "\n") onto the Files.readString() call so that content is normalized identically to oldString and newString.

// Before
String content = Files.readString(resolved, StandardCharsets.UTF_8);
String normalizedOld = oldString.replace("\r\n", "\n").replace("\r", "\n");
String normalizedNew = newString.replace("\r\n", "\n").replace("\r", "\n");

// After
String content = Files.readString(resolved, StandardCharsets.UTF_8)
                .replace("\r\n", "\n")
                .replace("\r", "\n");
String normalizedOld = oldString.replace("\r\n", "\n").replace("\r", "\n");
String normalizedNew = newString.replace("\r\n", "\n").replace("\r", "\n");

Why This Matters
Cross-platform correctness: files created on Windows often have \r\n endings.
Without this fix, edit() returns "String not found" or 0 occurrences on such files even when the search string is correct.
The read() method already handles this implicitly via content.split("\n", -1), but edit() relied on exact substring matching and therefore needs explicit normalization.
The modified code at LocalFilesystem.java:362 now reads:

String content = Files.readString(resolved, StandardCharsets.UTF_8)
                .replace("\r\n", "\n")
                .replace("\r", "\n");

## Checklist

Please check the following items before code is ready to be reviewed.

- [x]  Code has been formatted with `mvn spotless:apply`
- [x]  All tests are passing (`mvn test`)
- [x]  Javadoc comments are complete and follow project conventions
- [x]  Related documentation has been updated (e.g. links, examples, etc.)
- [x]  Code is ready for review
