### PR TITLE
fix(harness): avoid duplicating GracefulShutdownMiddleware in fromAgent

### DIFF
--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/HarnessAgent.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/HarnessAgent.java
@@ -32,6 +32,7 @@ import io.agentscope.core.model.ExecutionConfig;
 import io.agentscope.core.model.GenerateOptions;
 import io.agentscope.core.model.Model;
 import io.agentscope.core.permission.PermissionContextState;
+import io.agentscope.core.shutdown.GracefulShutdownMiddleware;
 import io.agentscope.core.skill.repository.AgentSkillRepository;
 import io.agentscope.core.state.AgentState;
 import io.agentscope.core.state.AgentStateStore;
@@ -1375,7 +1376,9 @@ public class HarnessAgent implements Agent, AutoCloseable {
             // Keep only observable registrations from the source agent.
             List<MiddlewareBase> copyable = new ArrayList<>(middlewares.size());
             for (MiddlewareBase middleware : middlewares) {
-                if (middleware != null && !(middleware instanceof HarnessRuntimeMiddleware)) {
+                if (middleware != null
+                        && !(middleware instanceof HarnessRuntimeMiddleware)
+                        && !(middleware instanceof GracefulShutdownMiddleware)) {
                     copyable.add(middleware);
                 }
             }

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/HarnessAgentTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/HarnessAgentTest.java
@@ -39,6 +39,7 @@ import io.agentscope.core.middleware.MiddlewareBase;
 import io.agentscope.core.model.ChatResponse;
 import io.agentscope.core.model.Model;
 import io.agentscope.core.model.ToolSchema;
+import io.agentscope.core.shutdown.GracefulShutdownMiddleware;
 import io.agentscope.core.skill.SkillFilter;
 import io.agentscope.core.state.AgentStateStore;
 import io.agentscope.core.tool.AgentTool;
@@ -618,11 +619,19 @@ class HarnessAgentTest {
                 child.getDelegate().getMiddlewares().stream()
                         .filter(m -> m instanceof AgentTraceMiddleware)
                         .count();
+        long gracefulShutdownMiddlewareCount =
+                child.getDelegate().getMiddlewares().stream()
+                        .filter(m -> m instanceof GracefulShutdownMiddleware)
+                        .count();
         assertEquals(1, copiedUserMiddlewareCount, "user middleware should copy once");
         assertEquals(
                 1,
                 agentTraceMiddlewareCount,
                 "runtime AgentTraceMiddleware should not be duplicated when cloning");
+        assertEquals(
+                1,
+                gracefulShutdownMiddlewareCount,
+                "system GracefulShutdownMiddleware should not be duplicated when cloning");
 
         RuntimeContext parentContext = RuntimeContext.builder().sessionId("parent").build();
         HarnessAgent generalPurpose =


### PR DESCRIPTION
## AgentScope-Java Version

2.0.0-SNAPSHOT

## Description

This PR fixes #1950.

Background:
When `HarnessAgent.Builder.fromAgent(ReActAgent)` is used to wrap an existing `ReActAgent`, the source agent's middleware chain currently gets copied into the harness builder. Since `ReActAgent` always adds a system-level `GracefulShutdownMiddleware` during construction, copying that middleware causes the final harness delegate to contain two `GracefulShutdownMiddleware` instances.

Purpose:
Ensure `GracefulShutdownMiddleware` appears exactly once after cloning a `ReActAgent` into a `HarnessAgent`.

Changes made:
- Updated `HarnessAgent.Builder.filterCopyableMiddlewares(...)` to exclude `GracefulShutdownMiddleware`
- Added a regression assertion in `HarnessAgentTest` to verify the cloned delegate contains exactly one `GracefulShutdownMiddleware`

How to test:
- Run `mvn -T1 -pl agentscope-harness -am -Dtest=HarnessAgentTest test`
- Confirm `fromAgent_filtersRuntimeMiddlewareAndStillPropagatesUserMiddleware` passes and the cloned delegate keeps only one `GracefulShutdownMiddleware`

## Checklist

Please check the following items before code is ready to be reviewed.

- [x]  Code has been formatted with `mvn spotless:apply`
- [x]  All tests are passing (`mvn test`)
- [x]  Javadoc comments are complete and follow project conventions
- [x]  Related documentation has been updated (e.g. links, examples, etc.)
- [x]  Code is ready for review