### PR TITLE
fix(model): disable native structured output for DashScope (#1852)

### DIFF
--- a/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-dashscope/src/main/java/io/agentscope/extensions/model/dashscope/DashScopeChatModel.java
+++ b/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-dashscope/src/main/java/io/agentscope/extensions/model/dashscope/DashScopeChatModel.java
@@ -390,9 +390,33 @@ public class DashScopeChatModel extends ChatModelBase {
         return modelName;
     }
 
+    /**
+     * DashScope does not support native schema-constrained structured output.
+     *
+     * <p>The DashScope native text-generation protocol
+     * ({@code /api/v1/services/aigc/text-generation/generation}) only accepts
+     * {@code response_format: {"type": "json_object"}} and does <b>not</b> support
+     * {@code {"type": "json_schema", ...}}. Sending a json_schema payload is either
+     * ignored or rejected with HTTP 400. Because the native structured-output path
+     * ({@link io.agentscope.core.ReActAgent}) relies on {@code response_format} carrying
+     * the JSON Schema (and does not inject the schema into the prompt), it cannot produce
+     * schema-conforming output on this channel.
+     *
+     * <p>Returning {@code false} routes structured-output calls to the tool-based fallback
+     * path ({@code doFallbackStructuredCall}), which uses Qwen function-calling to return
+     * reliable, schema-conforming results. This also keeps
+     * {@link #supportsNativeStructuredOutputWithTools()} consistent, since it falls back to
+     * this method.
+     *
+     * <p>Do not flip this back to {@code true} without first wiring json_object support into
+     * the request and handling DashScope's "messages must contain the word json" requirement
+     * — see issue #1852.
+     *
+     * @return always {@code false} for the DashScope native channel
+     */
     @Override
     public boolean supportsNativeStructuredOutput() {
-        return true;
+        return false;
     }
 
     public static class Builder {

--- a/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-dashscope/src/test/java/io/agentscope/extensions/model/dashscope/DashScopeChatModelTest.java
+++ b/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-dashscope/src/test/java/io/agentscope/extensions/model/dashscope/DashScopeChatModelTest.java
@@ -111,6 +111,22 @@ class DashScopeChatModelTest {
         assertNotNull(customModel, "Custom model should be created");
     }
 
+    @Test
+    @DisplayName("Should report native structured output as unsupported (issue #1852)")
+    void testNativeStructuredOutputUnsupported() {
+        // DashScope's native text-generation protocol only accepts
+        // response_format {"type":"json_object"} and not {"type":"json_schema"},
+        // so native schema-constrained structured output must be disabled. This
+        // routes structured calls to the tool-based fallback path. Do not flip
+        // this expectation without wiring json_object support — see issue #1852.
+        assertFalse(
+                model.supportsNativeStructuredOutput(),
+                "DashScope must not advertise native structured output");
+        assertFalse(
+                model.supportsNativeStructuredOutputWithTools(),
+                "DashScope must not advertise native structured output with tools");
+    }
+
     // ========== Streaming Configuration Tests ==========
 
     @Test


### PR DESCRIPTION
## AgentScope-Java Version

main (`2.0.0-SNAPSHOT`)

## Description

### Background
When using structured output (`ReActAgent.call(msgs, MyClass.class, ctx)` or the
JsonNode schema overload) with `DashScopeChatModel`, the returned
`Msg.hasStructuredData()` was always `false` and `getStructuredData(...)` returned
nothing. The same code works on `OpenAIChatModel`.

### Root cause
`DashScopeChatModel.supportsNativeStructuredOutput()` returned `true`, so `ReActAgent`
took the **native** structured-output path, which relies on `response_format` carrying
the JSON Schema. But the DashScope native text-generation protocol
(`/api/v1/services/aigc/text-generation/generation`) only supports
`response_format: {"type":"json_object"}` and **not** `{"type":"json_schema"}`. The
schema was never honored, the model returned natural-language text,
`wrapNativeStructuredResult` failed to parse it as JSON (logged a WARN), and no
`STRUCTURED_OUTPUT` metadata was attached.

> Note: simply wiring `response_format` through (mirroring the OpenAI channel) does
> **not** fix this — DashScope's native endpoint does not accept `json_schema`, so it
> would be ignored or rejected with HTTP 400.

### Changes
- `supportsNativeStructuredOutput()` now returns `false`, routing structured-output
  calls to the **tool-based fallback path** (`doFallbackStructuredCall`), which uses
  Qwen function-calling and returns reliable, schema-conforming results.
  `supportsNativeStructuredOutputWithTools()` stays consistent since it falls back to
  this method.
- Added Javadoc documenting why native structured output is unsupported on the
  DashScope native protocol (and a pointer not to flip it back without proper
  `json_object` wiring).
- Added a regression test asserting both flags are `false`.

### How to test
`ReActAgent.call(msgs, SomeClass.class, ctx)` on a `DashScopeChatModel` now returns a
`Msg` with `hasStructuredData() == true` and the parsed object available via
`getStructuredData(...)`.

Unit test: `DashScopeChatModelTest#testNativeStructuredOutputUnsupported`.

## Checklist

- [x] Code has been formatted with `mvn spotless:apply`
- [x] All tests are passing (`DashScopeChatModelTest`: 54 passed)
- [x] Javadoc comments are complete and follow project conventions
- [ ] Related documentation has been updated (e.g. links, examples, etc.)
- [x] Code is ready for review

🤖 Generated with [Claude Code](https://claude.com/claude-code)
