### PR TITLE
fix(model): preserve executionConfig in OllamaOptions fromOptions/toB…

### DIFF
--- a/agentscope-core/src/main/java/io/agentscope/core/model/ollama/OllamaOptions.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/model/ollama/OllamaOptions.java
@@ -344,6 +344,7 @@ public class OllamaOptions {
                 .mirostatEta(fromOptions.getMirostatEta())
                 .penalizeNewline(fromOptions.getPenalizeNewline())
                 .stop(fromOptions.getStop())
+                .executionConfig(fromOptions.getExecutionConfig())
                 .build();
     }
 
@@ -1015,7 +1016,8 @@ public class OllamaOptions {
                 .mirostatTau(this.mirostatTau)
                 .mirostatEta(this.mirostatEta)
                 .penalizeNewline(this.penalizeNewline)
-                .stop(this.stop);
+                .stop(this.stop)
+                .executionConfig(this.executionConfig);
     }
 
     // @formatter:on

--- a/agentscope-core/src/test/java/io/agentscope/core/model/ollama/OllamaOptionsTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/model/ollama/OllamaOptionsTest.java
@@ -282,4 +282,25 @@ class OllamaOptionsTest {
         assertNotNull(options.getThinkOption());
         assertEquals(ThinkOption.ThinkBoolean.ENABLED, options.getThinkOption());
     }
+
+    @Test
+    @DisplayName("Should preserve executionConfig via fromOptions, toBuilder and copy")
+    void testExecutionConfigPreservedOnCopy() {
+        ExecutionConfig executionConfig =
+                ExecutionConfig.builder().timeout(Duration.ofSeconds(30)).maxAttempts(3).build();
+        OllamaOptions original =
+                OllamaOptions.builder().temperature(0.7).executionConfig(executionConfig).build();
+
+        // copy() delegates to fromOptions(OllamaOptions)
+        OllamaOptions copy = original.copy();
+        assertEquals(executionConfig, copy.getExecutionConfig());
+
+        // fromOptions(OllamaOptions) directly
+        OllamaOptions fromOptions = OllamaOptions.fromOptions(original);
+        assertEquals(executionConfig, fromOptions.getExecutionConfig());
+
+        // toBuilder().build() round-trip
+        OllamaOptions rebuilt = original.toBuilder().build();
+        assertEquals(executionConfig, rebuilt.getExecutionConfig());
+    }
 }


### PR DESCRIPTION
…uilder

OllamaOptions.fromOptions(OllamaOptions) and toBuilder() did not copy the executionConfig field, so instances produced via copy(), fromOptions() or toBuilder() silently lost the timeout/retry configuration carried by executionConfig. merge() and toGenerateOptions() already propagate it; align the two copy paths with them and add a regression test covering all three paths (the existing equals()/hashCode() intentionally ignore executionConfig, so the test asserts getExecutionConfig() directly).

Closes #1957

## AgentScope-Java Version

[The version of AgentScope-Java you are working on, e.g. 1.0.12, check your pom.xml dependency version or run `mvn dependency:tree | grep agentscope-parent:pom`(only mac/linux)]

## Description

[Please describe the background, purpose, changes made, and how to test this PR]

## Checklist

Please check the following items before code is ready to be reviewed.

- [ ]  Code has been formatted with `mvn spotless:apply`
- [ ]  All tests are passing (`mvn test`)
- [ ]  Javadoc comments are complete and follow project conventions
- [ ]  Related documentation has been updated (e.g. links, examples, etc.)
- [ ]  Code is ready for review
