### PR TITLE
feat(harness): Add the middleware function for dialogue suggestions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,3 +88,4 @@ logs/
 
 ## oh-my-claudecode
 .omc/
+.codegraph

--- a/agentscope-core/src/main/java/io/agentscope/core/event/AgentEvent.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/event/AgentEvent.java
@@ -67,6 +67,7 @@ import java.util.UUID;
     @JsonSubTypes.Type(value = RequestStopEvent.class, name = "REQUEST_STOP"),
     @JsonSubTypes.Type(value = SubagentExposedEvent.class, name = "SUBAGENT_EXPOSED"),
     @JsonSubTypes.Type(value = HintBlockEvent.class, name = "HINT_BLOCK"),
+    @JsonSubTypes.Type(value = SuggestionResultEvent.class, name = "SUGGESTION_RESULT"),
     @JsonSubTypes.Type(value = CustomEvent.class, name = "CUSTOM")
 })
 public abstract class AgentEvent {

--- a/agentscope-core/src/main/java/io/agentscope/core/event/AgentEventType.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/event/AgentEventType.java
@@ -86,6 +86,9 @@ public enum AgentEventType {
     SUBAGENT_EXPOSED("SUBAGENT_EXPOSED"),
 
     HINT_BLOCK("HINT_BLOCK"),
+
+    SUGGESTION_RESULT("SUGGESTION_RESULT"),
+
     CUSTOM("CUSTOM");
 
     private final String value;

--- a/agentscope-core/src/main/java/io/agentscope/core/event/SuggestionResultEvent.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/event/SuggestionResultEvent.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.core.event;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Terminal, non-streaming suggestion event emitted between {@link AgentResultEvent} and
+ * {@link AgentEndEvent}.
+ *
+ * <p>Carries the final parsed follow-up suggestion list produced by the post-conversation
+ * suggestion middleware. Suggestions are always exposed as an immutable {@link List} of strings —
+ * a failed or skipped generation surfaces as an empty list so consumers can render
+ * "no suggestions" without null checks.
+ *
+ * <p>This event replaces the earlier three-event {@code SuggestionStart / Delta / End} stream:
+ * a single result event is easier to consume for front-ends that only care about the final list.
+ */
+public class SuggestionResultEvent extends AgentEvent {
+
+    private final String replyId;
+
+    @JsonInclude(JsonInclude.Include.ALWAYS)
+    private final List<String> suggestions;
+
+    @JsonCreator
+    public SuggestionResultEvent(
+            @JsonProperty("id") String id,
+            @JsonProperty("createdAt") String createdAt,
+            @JsonProperty("replyId") String replyId,
+            @JsonProperty("suggestions") List<String> suggestions) {
+        super(id, createdAt);
+        this.replyId = replyId;
+        this.suggestions = freeze(suggestions);
+    }
+
+    public SuggestionResultEvent(String replyId, List<String> suggestions) {
+        this.replyId = replyId;
+        this.suggestions = freeze(suggestions);
+    }
+
+    private static List<String> freeze(List<String> in) {
+        if (in == null || in.isEmpty()) {
+            return Collections.emptyList();
+        }
+        return List.copyOf(in);
+    }
+
+    @Override
+    public AgentEventType getType() {
+        return AgentEventType.SUGGESTION_RESULT;
+    }
+
+    public String getReplyId() {
+        return replyId;
+    }
+
+    /** Returns an immutable list of suggestion strings; empty when generation produced nothing. */
+    public List<String> getSuggestions() {
+        return suggestions;
+    }
+}

--- a/agentscope-core/src/test/java/io/agentscope/core/event/AgentEventStreamTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/event/AgentEventStreamTest.java
@@ -95,6 +95,30 @@ class AgentEventStreamTest {
         }
 
         @Test
+        @DisplayName("SUGGESTION_RESULT round-trips through Jackson")
+        void suggestionEventTypeRoundTrip() throws Exception {
+            AgentEventType type = AgentEventType.SUGGESTION_RESULT;
+            String json = mapper.writeValueAsString(type);
+            assertEquals("\"SUGGESTION_RESULT\"", json);
+            assertEquals(type, mapper.readValue(json, AgentEventType.class));
+        }
+
+        @Test
+        @DisplayName("SuggestionResultEvent round-trips via AgentEvent polymorphism")
+        void suggestionResultEventRoundTrip() throws Exception {
+            SuggestionResultEvent event =
+                    new SuggestionResultEvent("r1", java.util.List.of("Ask A", "Ask B"));
+
+            String json = mapper.writeValueAsString(event);
+            AgentEvent parsed = mapper.readValue(json, AgentEvent.class);
+            assertEquals(event.getType(), parsed.getType());
+            assertEquals(event.getClass(), parsed.getClass());
+            assertEquals(
+                    java.util.List.of("Ask A", "Ask B"),
+                    ((SuggestionResultEvent) parsed).getSuggestions());
+        }
+
+        @Test
         @DisplayName("Canonical names round-trip unchanged")
         void javaNativeNamesRoundTrip() throws Exception {
             for (AgentEventType type : AgentEventType.values()) {

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/HarnessAgent.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/HarnessAgent.java
@@ -73,6 +73,7 @@ import io.agentscope.harness.agent.middleware.MemoryMaintenanceMiddleware;
 import io.agentscope.harness.agent.middleware.SandboxLifecycleMiddleware;
 import io.agentscope.harness.agent.middleware.SubagentEntry;
 import io.agentscope.harness.agent.middleware.SubagentsMiddleware;
+import io.agentscope.harness.agent.middleware.SuggestionMiddleware;
 import io.agentscope.harness.agent.middleware.ToolResultEvictionMiddleware;
 import io.agentscope.harness.agent.middleware.WorkspaceContextMiddleware;
 import io.agentscope.harness.agent.sandbox.SandboxContext;
@@ -1038,6 +1039,8 @@ public class HarnessAgent implements Agent, AutoCloseable {
         AbstractFilesystem abstractFilesystem;
         boolean leafSubagent = false;
         boolean agentTracingLogEnabled = true;
+        boolean suggestionsEnabled = false;
+        int suggestionMaxItems = 4;
         CompactionConfig compactionConfig = CompactionConfig.builder().build();
         MemoryConfig memoryConfig = MemoryConfig.defaults();
         ToolResultEvictionConfig toolResultEvictionConfig = ToolResultEvictionConfig.defaults();
@@ -1718,6 +1721,30 @@ public class HarnessAgent implements Agent, AutoCloseable {
             return this;
         }
 
+        /**
+         * Enables the post-conversation {@link SuggestionMiddleware}, which emits
+         * {@code SuggestionStart / SuggestionDelta / SuggestionEnd} events between
+         * {@link io.agentscope.core.event.AgentResultEvent} and
+         * {@link io.agentscope.core.event.AgentEndEvent} so that front-ends can render follow-up
+         * suggestions after each assistant reply. Default is {@code false}.
+         *
+         * <p>The middleware reuses the primary agent {@link Model} configured via
+         * {@link #model(Model)} together with the built-in default prompt template.
+         */
+        public Builder enableSuggestions(boolean enabled) {
+            this.suggestionsEnabled = enabled;
+            return this;
+        }
+
+        /**
+         * Caps the number of suggestions emitted per turn. Values {@code <= 0} restore the
+         * middleware's built-in default.
+         */
+        public Builder suggestionMaxItems(int max) {
+            this.suggestionMaxItems = max;
+            return this;
+        }
+
         /** Skips registration of {@link FilesystemTool}. */
         public Builder disableFilesystemTools() {
             this.disableFilesystemTools = true;
@@ -2174,6 +2201,9 @@ public class HarnessAgent implements Agent, AutoCloseable {
                             new CompactionMiddleware(wsManager, compactionModel, compactionConfig);
                     inner.middleware(compactionHook);
                 }
+            }
+            if (suggestionsEnabled && model != null) {
+                inner.middleware(new SuggestionMiddleware(model, suggestionMaxItems));
             }
             if (!disableToolResultEviction && toolResultEvictionConfig != null) {
                 inner.middleware(

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/middleware/SuggestionMiddleware.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/middleware/SuggestionMiddleware.java
@@ -1,0 +1,457 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.harness.agent.middleware;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.agentscope.core.agent.Agent;
+import io.agentscope.core.agent.RuntimeContext;
+import io.agentscope.core.event.AgentEndEvent;
+import io.agentscope.core.event.AgentEvent;
+import io.agentscope.core.event.AgentResultEvent;
+import io.agentscope.core.event.ExceedMaxItersEvent;
+import io.agentscope.core.event.RequestStopEvent;
+import io.agentscope.core.event.SuggestionResultEvent;
+import io.agentscope.core.message.ContentBlock;
+import io.agentscope.core.message.Msg;
+import io.agentscope.core.message.MsgRole;
+import io.agentscope.core.message.TextBlock;
+import io.agentscope.core.middleware.AgentInput;
+import io.agentscope.core.model.Model;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Function;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+/**
+ * Emits a single {@link SuggestionResultEvent} between {@link AgentResultEvent} and
+ * {@link AgentEndEvent}, carrying up to {@link #maxItems} follow-up suggestions produced by the
+ * configured LLM.
+ *
+ * <h2>Pipeline</h2>
+ * <ol>
+ *   <li><b>Observe upstream</b> — collect the final {@link Msg} from {@link AgentResultEvent},
+ *       buffer the terminal {@link AgentEndEvent} (filtered out and re-emitted at the tail so
+ *       consumers always see it last), and watch for turn-abort signals
+ *       ({@link ExceedMaxItersEvent}, {@link RequestStopEvent}).</li>
+ *   <li><b>Cheap skip gates</b> — before touching the model, short-circuit when:
+ *       <ul>
+ *         <li>upstream errored (no {@link AgentEndEvent}) — return empty, propagate parent flow;</li>
+ *         <li>an abort signal fired — re-emit {@link AgentEndEvent} only;</li>
+ *         <li>the final assistant text is shorter than {@link #MIN_ANCHOR_CHARS} — no useful
+ *             follow-up can be derived from a near-empty reply.</li>
+ *       </ul></li>
+ *   <li><b>Bounded prompt</b> — the final reply is truncated to
+ *       {@link #MAX_REPLY_ANCHOR_CHARS}; the last user turn is extracted from
+ *       {@link AgentInput#msgs()} and truncated to {@link #MAX_USER_INTENT_CHARS}. Both anchors
+ *       are fed to the model so suggestions align with the <em>user's</em> intent, not just the
+ *       assistant's phrasing.</li>
+ *   <li><b>Aggregate → parse → emit</b> — {@link Model#stream} responses are reduced into one
+ *       string, parsed as a strict JSON array (with a lenient line-based fallback), and surfaced
+ *       as one {@link SuggestionResultEvent}. Empty parses suppress the event entirely.</li>
+ *   <li><b>Trailer</b> — the original {@link AgentEndEvent} is re-emitted so the "AgentEndEvent
+ *       is always last" contract of {@code call()} / {@code streamEvents()} holds.</li>
+ * </ol>
+ *
+ * <p>Failure handling is intentionally lenient: any exception in the suggestion path is swallowed
+ * and the original {@link AgentEndEvent} passes through unchanged. This is a strictly additive
+ * feature — the main conversation result is never mutated.
+ */
+public class SuggestionMiddleware implements HarnessRuntimeMiddleware {
+
+    private static final Logger log = LoggerFactory.getLogger(SuggestionMiddleware.class);
+
+    // ---- Cost / precision knobs (all package-private for test override consideration) ----
+
+    /** Skip LLM entirely when the assistant reply is shorter than this many characters. */
+    static final int MIN_ANCHOR_CHARS = 20;
+
+    /** Hard cap for the AGENT REPLY anchor injected into the prompt. */
+    static final int MAX_REPLY_ANCHOR_CHARS = 3000;
+
+    /** Hard cap for the USER INTENT anchor injected into the prompt. */
+    static final int MAX_USER_INTENT_CHARS = 500;
+
+    private static final int DEFAULT_MAX_ITEMS = 4;
+    private static final String TRUNCATE_MARKER = "... [truncated]";
+    private static final String NO_USER_INTENT = "(none)";
+
+    private static final ObjectMapper JSON = new ObjectMapper();
+    private static final TypeReference<List<String>> STRING_LIST_TYPE = new TypeReference<>() {};
+
+    /**
+     * Prompt template with two anchors and a strict output contract.
+     * Placeholders (positional):
+     * <ol>
+     *   <li>{@code %1$s} — USER INTENT (last user turn, truncated)</li>
+     *   <li>{@code %2$s} — AGENT REPLY (final assistant text, truncated)</li>
+     *   <li>{@code %3$d} — max number of suggestions requested</li>
+     * </ol>
+     */
+    private static final String PROMPT_TEMPLATE =
+            """
+            You are proposing follow-up questions the user might ask next in this conversation.
+            Two anchors define the topic — a suggestion that ignores either anchor is unacceptable.
+
+            USER INTENT (what the user just asked — align suggestions with this direction):
+            ---
+            %1$s
+            ---
+
+            AGENT REPLY (what the agent answered — main topic anchor, stay on this subject):
+            ---
+            %2$s
+            ---
+
+            QUALITY LADDER (try each tier in order; only fall back when the previous tier truly
+            yields nothing):
+              TIER 1 (preferred): Sharp, specific follow-ups that dig deeper into the exact
+                subject of the reply — concrete next steps, clarifications on details actually
+                present in the reply, natural extensions of the user's intent above.
+              TIER 2 (acceptable fallback): Broader but still on-topic questions that stay
+                within the same subject area, even if less pointed. Use when TIER 1 candidates
+                feel forced or repetitive.
+              TIER 3 (last resort): Return an empty array [] ONLY if you cannot produce even
+                one suggestion that stays on topic without drifting.
+
+            HARD CONSTRAINTS (apply at every tier):
+            1. Never drift off topic. No unrelated, generic ("tell me more"), meta ("how do
+               you work?"), or off-domain questions.
+            2. Each suggestion MUST be a single natural-language sentence phrased as if the
+               user were typing it in first person to the agent.
+            3. Propose AT MOST %3$d suggestions. Fewer is fine — quality beats quantity, and
+               a shorter on-topic list is better than a padded one.
+
+            OUTPUT FORMAT (STRICT):
+            Return ONLY a JSON array of strings. No prose before or after. No code fences.
+            No numbering. No bullets. No keys. No trailing commas.
+
+            Example shape (content must derive from the anchors above):
+            ["First on-topic follow-up?", "Second on-topic follow-up?"]
+            """;
+
+    private final Model model;
+    private final int maxItems;
+
+    /**
+     * @param model the LLM used to generate suggestions (must be non-null and streaming-capable)
+     */
+    public SuggestionMiddleware(Model model) {
+        this(model, DEFAULT_MAX_ITEMS);
+    }
+
+    /**
+     * @param model the LLM used to generate suggestions
+     * @param maxItems soft cap on emitted suggestions; the middleware will truncate longer lists
+     *     to this size. Values {@code <= 0} fall back to {@link #DEFAULT_MAX_ITEMS}
+     */
+    public SuggestionMiddleware(Model model, int maxItems) {
+        if (model == null) {
+            throw new IllegalArgumentException("SuggestionMiddleware requires a non-null model");
+        }
+        this.model = model;
+        this.maxItems = maxItems > 0 ? maxItems : DEFAULT_MAX_ITEMS;
+    }
+
+    @Override
+    public Flux<AgentEvent> onAgent(
+            Agent agent,
+            RuntimeContext ctx,
+            AgentInput input,
+            Function<AgentInput, Flux<AgentEvent>> next) {
+
+        // Per-invocation state captured by the observer wired into the upstream flow. Using
+        // atomic refs keeps the observer thread-safe with the reactive scheduler; the state is
+        // written under the upstream subscriber's serialized signal delivery.
+        AtomicReference<Msg> finalMsgRef = new AtomicReference<>();
+        AtomicReference<AgentEndEvent> endRef = new AtomicReference<>();
+        AtomicBoolean skipRef = new AtomicBoolean(false);
+
+        // We only observe upstream — we do NOT swallow errors here. Any exception propagates to
+        // the caller unchanged; the deferred trailer below is never subscribed on an errored
+        // upstream, so suggestion generation is naturally skipped in that case.
+        Flux<AgentEvent> upstream =
+                next.apply(input)
+                        .doOnNext(
+                                ev -> {
+                                    if (ev instanceof AgentResultEvent res) {
+                                        finalMsgRef.set(res.getResult());
+                                    } else if (ev instanceof AgentEndEvent end) {
+                                        endRef.set(end);
+                                    } else if (ev instanceof ExceedMaxItersEvent
+                                            || ev instanceof RequestStopEvent) {
+                                        // The turn ended abnormally (max-iters guard tripped or a
+                                        // stop was requested). Follow-ups on a truncated / aborted
+                                        // reply are usually low-quality and often misleading —
+                                        // skip.
+                                        skipRef.set(true);
+                                    }
+                                })
+                        .filter(ev -> !(ev instanceof AgentEndEvent));
+
+        return upstream.concatWith(
+                Flux.defer(
+                        () -> emitTrailer(input, finalMsgRef.get(), endRef.get(), skipRef.get())));
+    }
+
+    // ---- Trailer decision + LLM generation ------------------------------------------------
+
+    private Flux<AgentEvent> emitTrailer(
+            AgentInput input, Msg finalMsg, AgentEndEvent end, boolean skip) {
+        // No AgentEndEvent means upstream errored before completing; nothing to append.
+        if (end == null) {
+            return Flux.empty();
+        }
+        if (skip) {
+            return Flux.<AgentEvent>just(end);
+        }
+        String replyText = extractText(finalMsg);
+        if (replyText.length() < MIN_ANCHOR_CHARS) {
+            // Reply too short (or blank) to base a useful follow-up on. Cheap early-out — no
+            // LLM call, no wasted tokens.
+            return Flux.<AgentEvent>just(end);
+        }
+
+        String userIntent = lastUserText(input);
+        String replyAnchor = truncate(replyText, MAX_REPLY_ANCHOR_CHARS);
+        return buildSuggestionMono(end.getReplyId(), userIntent, replyAnchor)
+                .onErrorResume(
+                        e -> {
+                            log.debug("SuggestionMiddleware suppressed error: {}", e.toString());
+                            return Mono.empty();
+                        })
+                .flux()
+                .concatWith(Flux.just(end));
+    }
+
+    /**
+     * Aggregates the model completion end-to-end and emits at most one {@link SuggestionResultEvent}. Empty parses (blank output or no valid JSON items and no line-based
+     * fallback lines) suppress the event entirely.
+     */
+    private Mono<AgentEvent> buildSuggestionMono(
+            String replyId, String userIntent, String replyAnchor) {
+        String prompt = String.format(PROMPT_TEMPLATE, userIntent, replyAnchor, maxItems);
+        List<Msg> input =
+                List.of(
+                        Msg.builder()
+                                .role(MsgRole.USER)
+                                .content(TextBlock.builder().text(prompt).build())
+                                .build());
+
+        return model.stream(input, null, null)
+                .reduce(
+                        new StringBuilder(),
+                        (sb, resp) -> {
+                            List<ContentBlock> content = resp.getContent();
+                            if (content != null) {
+                                for (ContentBlock block : content) {
+                                    if (block instanceof TextBlock tb) {
+                                        sb.append(tb.getText());
+                                    }
+                                }
+                            }
+                            return sb;
+                        })
+                .map(StringBuilder::toString)
+                .flatMap(
+                        raw -> {
+                            List<String> parsed = parseSuggestions(raw, maxItems);
+                            if (parsed.isEmpty()) {
+                                return Mono.empty();
+                            }
+                            return Mono.just(
+                                    (AgentEvent) new SuggestionResultEvent(replyId, parsed));
+                        });
+    }
+
+    // ---- Anchor extraction ----------------------------------------------------------------
+
+    /**
+     * Extract plain-text content from the final assistant {@link Msg}. Returns an empty string when
+     * the message is null, has no text content, or all text blocks are blank.
+     */
+    private static String extractText(Msg msg) {
+        if (msg == null) {
+            return "";
+        }
+        String text = msg.getTextContent();
+        return text != null ? text.strip() : "";
+    }
+
+    /**
+     * Find the most recent USER message in the current turn's input and return its trimmed,
+     * truncated text. Returns {@link #NO_USER_INTENT} if no usable user text is present so the
+     * prompt template still substitutes cleanly.
+     */
+    private static String lastUserText(AgentInput input) {
+        if (input == null || input.msgs() == null || input.msgs().isEmpty()) {
+            return NO_USER_INTENT;
+        }
+        List<Msg> msgs = input.msgs();
+        for (int i = msgs.size() - 1; i >= 0; i--) {
+            Msg m = msgs.get(i);
+            if (m == null || m.getRole() != MsgRole.USER) {
+                continue;
+            }
+            String text = m.getTextContent();
+            if (text == null) {
+                continue;
+            }
+            String trimmed = text.strip();
+            if (trimmed.isEmpty()) {
+                continue;
+            }
+            return truncate(trimmed, MAX_USER_INTENT_CHARS);
+        }
+        return NO_USER_INTENT;
+    }
+
+    private static String truncate(String s, int max) {
+        if (s == null) {
+            return "";
+        }
+        if (s.length() <= max) {
+            return s;
+        }
+        return s.substring(0, max) + TRUNCATE_MARKER;
+    }
+
+    // ---- Parsing --------------------------------------------------------------------------
+
+    /**
+     * Parse a raw model response into a bounded list of suggestion strings.
+     *
+     * <p>Preferred wire format is a strict JSON array of strings. If the entire trimmed payload
+     * parses as {@code List<String>} via Jackson, that list wins. Otherwise the method falls back
+     * to a line-based scan that strips common list markers (bullets, digits, dashes) and blank
+     * lines. In both paths blank items are dropped and the result is capped at {@code cap} items.
+     * Never returns {@code null}.
+     */
+    static List<String> parseSuggestions(String raw, int cap) {
+        if (raw == null || raw.isBlank()) {
+            return Collections.emptyList();
+        }
+        String trimmed = raw.strip();
+
+        // Preferred: strict JSON array. Some models still wrap the payload in markdown fences,
+        // so we try both the raw trimmed body and a fence-stripped variant.
+        List<String> jsonParsed = tryParseJsonArray(trimmed);
+        if (jsonParsed == null) {
+            String unfenced = stripCodeFence(trimmed);
+            if (!unfenced.equals(trimmed)) {
+                jsonParsed = tryParseJsonArray(unfenced);
+            }
+        }
+        if (jsonParsed != null) {
+            return capNonBlank(jsonParsed, cap);
+        }
+
+        // Fallback: line-based parsing for models that ignore the JSON contract.
+        String[] lines = trimmed.split("\\R");
+        List<String> out = new ArrayList<>(Math.min(lines.length, cap));
+        for (String line : lines) {
+            String cleaned = stripListMarker(line).trim();
+            if (cleaned.isEmpty()) {
+                continue;
+            }
+            out.add(cleaned);
+            if (out.size() >= cap) {
+                break;
+            }
+        }
+        return out;
+    }
+
+    private static List<String> tryParseJsonArray(String s) {
+        if (s.isEmpty() || s.charAt(0) != '[') {
+            return null;
+        }
+        try {
+            return JSON.readValue(s, STRING_LIST_TYPE);
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    private static String stripCodeFence(String s) {
+        String body = s;
+        if (body.startsWith("```")) {
+            int firstNewline = body.indexOf('\n');
+            if (firstNewline > 0) {
+                body = body.substring(firstNewline + 1);
+            }
+        }
+        if (body.endsWith("```")) {
+            body = body.substring(0, body.length() - 3);
+        }
+        return body.strip();
+    }
+
+    private static List<String> capNonBlank(List<String> in, int cap) {
+        List<String> out = new ArrayList<>(Math.min(in.size(), cap));
+        for (String s : in) {
+            if (s == null) {
+                continue;
+            }
+            String v = s.strip();
+            if (v.isEmpty()) {
+                continue;
+            }
+            out.add(v);
+            if (out.size() >= cap) {
+                break;
+            }
+        }
+        return out;
+    }
+
+    private static String stripListMarker(String line) {
+        if (line == null) {
+            return "";
+        }
+        String s = line.strip();
+        // Drop leading bullets: "- ", "* ", "• ".
+        int i = 0;
+        while (i < s.length() && (s.charAt(i) == '-' || s.charAt(i) == '*' || s.charAt(i) == '•')) {
+            i++;
+        }
+        if (i > 0) {
+            return s.substring(i).stripLeading();
+        }
+        // Numbered forms: 1. / 1) / 1 - / 1 followed by space.
+        int digitEnd = 0;
+        while (digitEnd < s.length() && Character.isDigit(s.charAt(digitEnd))) {
+            digitEnd++;
+        }
+        if (digitEnd > 0 && digitEnd < s.length()) {
+            char next = s.charAt(digitEnd);
+            if (next == '.' || next == ')' || next == '-' || next == ' ') {
+                String rest = s.substring(digitEnd + 1).stripLeading();
+                if (next == ' ') {
+                    return stripListMarker(rest);
+                }
+                return rest;
+            }
+        }
+        return s;
+    }
+}

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/middleware/SuggestionMiddlewareTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/middleware/SuggestionMiddlewareTest.java
@@ -1,0 +1,274 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.harness.agent.middleware;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.agentscope.core.event.AgentEndEvent;
+import io.agentscope.core.event.AgentEvent;
+import io.agentscope.core.event.AgentResultEvent;
+import io.agentscope.core.event.ExceedMaxItersEvent;
+import io.agentscope.core.event.RequestStopEvent;
+import io.agentscope.core.event.SuggestionResultEvent;
+import io.agentscope.core.message.Msg;
+import io.agentscope.core.message.MsgRole;
+import io.agentscope.core.message.TextBlock;
+import io.agentscope.core.middleware.AgentInput;
+import io.agentscope.core.model.ChatResponse;
+import io.agentscope.core.model.ChatUsage;
+import io.agentscope.core.model.GenerateOptions;
+import io.agentscope.core.model.Model;
+import io.agentscope.core.model.ToolSchema;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Flux;
+
+/**
+ * Unit tests for {@link SuggestionMiddleware}: exercise the happy path (single
+ * {@link SuggestionResultEvent} between {@link AgentResultEvent} and {@link AgentEndEvent}), the
+ * error-swallowing branch, and the empty-message skip branch.
+ */
+class SuggestionMiddlewareTest {
+
+    private static final String REPLY_ID = "reply-abc";
+
+    @Test
+    @DisplayName(
+            "Happy path (JSON array): emits SuggestionResultEvent before the preserved AgentEnd")
+    void happyPathEmitsResultEvent() {
+        Model model = streamingModel("[\"Ask about X\", \"Explore option Y\", \"Consider Z\"]");
+        SuggestionMiddleware mw = new SuggestionMiddleware(model, 4);
+
+        List<AgentEvent> events = runMiddleware(mw, assistantMsg("Here is your answer."));
+
+        int result = indexOf(events, AgentResultEvent.class);
+        int suggestion = indexOf(events, SuggestionResultEvent.class);
+        int agentEnd = indexOf(events, AgentEndEvent.class);
+        assertTrue(result >= 0, "AgentResultEvent must be present");
+        assertTrue(suggestion > result, "SuggestionResultEvent must follow AgentResult");
+        assertEquals(events.size() - 1, agentEnd, "AgentEndEvent must be the last event");
+
+        SuggestionResultEvent res = (SuggestionResultEvent) events.get(suggestion);
+        assertEquals(
+                List.of("Ask about X", "Explore option Y", "Consider Z"),
+                res.getSuggestions(),
+                "JSON array parsed verbatim");
+        assertEquals(REPLY_ID, res.getReplyId(), "replyId propagated from AgentEndEvent");
+    }
+
+    @Test
+    @DisplayName("Line-based fallback: markdown-wrapped or plain-text output still parses cleanly")
+    void lineFallbackWhenModelIgnoresJsonContract() {
+        Model model =
+                streamingModel(
+                        "1. First on-topic follow-up\n"
+                                + "- Second on-topic follow-up\n"
+                                + "* Third on-topic follow-up");
+        SuggestionMiddleware mw = new SuggestionMiddleware(model, 4);
+
+        List<AgentEvent> events = runMiddleware(mw, assistantMsg("Here is your answer."));
+
+        SuggestionResultEvent res =
+                (SuggestionResultEvent) events.get(indexOf(events, SuggestionResultEvent.class));
+        assertEquals(
+                List.of(
+                        "First on-topic follow-up",
+                        "Second on-topic follow-up",
+                        "Third on-topic follow-up"),
+                res.getSuggestions());
+    }
+
+    @Test
+    @DisplayName("Model failure is swallowed: no SuggestionResult, AgentEndEvent still emitted")
+    void modelErrorDegradesGracefully() {
+        Model failing =
+                new Model() {
+                    @Override
+                    public Flux<ChatResponse> stream(
+                            List<Msg> messages, List<ToolSchema> tools, GenerateOptions options) {
+                        return Flux.error(new RuntimeException("boom"));
+                    }
+
+                    @Override
+                    public String getModelName() {
+                        return "failing-mock";
+                    }
+                };
+        SuggestionMiddleware mw = new SuggestionMiddleware(failing);
+
+        List<AgentEvent> events = runMiddleware(mw, assistantMsg("Non-empty reply."));
+
+        assertFalse(
+                events.stream().anyMatch(e -> e instanceof SuggestionResultEvent),
+                "no SuggestionResult on error");
+        AgentEndEvent last = (AgentEndEvent) events.get(events.size() - 1);
+        assertNotNull(last, "AgentEndEvent still terminates the stream");
+        assertEquals(REPLY_ID, last.getReplyId());
+    }
+
+    @Test
+    @DisplayName("Blank final message: suggestion event skipped entirely")
+    void blankFinalMessageSkipsSuggestion() {
+        Model model = streamingModel("[\"should never be surfaced\"]");
+        SuggestionMiddleware mw = new SuggestionMiddleware(model);
+
+        List<AgentEvent> events = runMiddleware(mw, assistantMsg("   "));
+
+        assertFalse(events.stream().anyMatch(e -> e instanceof SuggestionResultEvent));
+        assertInstanceOf(AgentEndEvent.class, events.get(events.size() - 1), "AgentEndEvent still last");
+    }
+
+    @Test
+    @DisplayName("parseSuggestions caps output and strips numbered / bulleted markers")
+    void parseSuggestionsRespectsCap() {
+        List<String> parsed =
+                SuggestionMiddleware.parseSuggestions(
+                        "1. First\n" + "* Second\n" + "- Third\n" + "Fourth\n" + "Fifth\n", 3);
+        assertEquals(List.of("First", "Second", "Third"), parsed);
+    }
+
+    @Test
+    @DisplayName("parseSuggestions strips ```json fences before parsing")
+    void parseSuggestionsUnfences() {
+        List<String> parsed =
+                SuggestionMiddleware.parseSuggestions("```json\n[\"a\", \"b\"]\n```", 4);
+        assertEquals(List.of("a", "b"), parsed);
+    }
+
+    @Test
+    @DisplayName("ExceedMaxItersEvent upstream triggers skip (no LLM, AgentEnd still emitted)")
+    void exceedMaxItersSkipsLlm() {
+        Model failingIfCalled = neverCalledModel();
+        SuggestionMiddleware mw = new SuggestionMiddleware(failingIfCalled);
+
+        Flux<AgentEvent> core =
+                Flux.just(
+                        new ExceedMaxItersEvent(REPLY_ID, 10, 10),
+                        new AgentResultEvent(assistantMsg("A long enough final reply.")),
+                        (AgentEvent) new AgentEndEvent(REPLY_ID));
+        List<AgentEvent> events = runWith(mw, core);
+
+        assertFalse(events.stream().anyMatch(e -> e instanceof SuggestionResultEvent));
+        assertInstanceOf(AgentEndEvent.class, events.get(events.size() - 1));
+    }
+
+    @Test
+    @DisplayName("RequestStopEvent upstream triggers skip (no LLM, AgentEnd still emitted)")
+    void requestStopSkipsLlm() {
+        Model failingIfCalled = neverCalledModel();
+        SuggestionMiddleware mw = new SuggestionMiddleware(failingIfCalled);
+
+        Flux<AgentEvent> core =
+                Flux.just(
+                        new RequestStopEvent("user"),
+                        new AgentResultEvent(assistantMsg("A long enough final reply.")),
+                        (AgentEvent) new AgentEndEvent(REPLY_ID));
+        List<AgentEvent> events = runWith(mw, core);
+
+        assertFalse(events.stream().anyMatch(e -> e instanceof SuggestionResultEvent));
+        assertInstanceOf(AgentEndEvent.class, events.get(events.size() - 1));
+    }
+
+    @Test
+    @DisplayName("Reply shorter than MIN_ANCHOR_CHARS skips LLM entirely")
+    void shortReplySkipsLlm() {
+        Model failingIfCalled = neverCalledModel();
+        SuggestionMiddleware mw = new SuggestionMiddleware(failingIfCalled);
+
+        List<AgentEvent> events = runMiddleware(mw, assistantMsg("too short"));
+
+        assertFalse(events.stream().anyMatch(e -> e instanceof SuggestionResultEvent));
+        assertInstanceOf(AgentEndEvent.class, events.get(events.size() - 1));
+    }
+
+    // ---- helpers ----
+
+    private static List<AgentEvent> runMiddleware(SuggestionMiddleware mw, Msg finalMsg) {
+        Flux<AgentEvent> core =
+                Flux.just(new AgentResultEvent(finalMsg), (AgentEvent) new AgentEndEvent(REPLY_ID));
+        return runWith(mw, core);
+    }
+
+    private static List<AgentEvent> runWith(SuggestionMiddleware mw, Flux<AgentEvent> core) {
+        List<AgentEvent> events =
+                mw.onAgent(null, null, new AgentInput(List.of()), input -> core)
+                        .collectList()
+                        .block();
+        assertNotNull(events, "stream must complete");
+        return events;
+    }
+
+    /** Model stub that throws if invoked — used to prove a skip branch avoided the LLM call. */
+    private static Model neverCalledModel() {
+        return new Model() {
+            @Override
+            public Flux<ChatResponse> stream(
+                    List<Msg> messages, List<ToolSchema> tools, GenerateOptions options) {
+                throw new AssertionError(
+                        "SuggestionMiddleware must not call the model in a skip branch");
+            }
+
+            @Override
+            public String getModelName() {
+                return "never-called";
+            }
+        };
+    }
+
+    private static Msg assistantMsg(String text) {
+        return Msg.builder()
+                .role(MsgRole.ASSISTANT)
+                .content(TextBlock.builder().text(text).build())
+                .build();
+    }
+
+    private static int indexOf(List<AgentEvent> events, Class<? extends AgentEvent> type) {
+        for (int i = 0; i < events.size(); i++) {
+            if (type.isInstance(events.get(i))) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    /** Model stub streaming a single ChatResponse carrying the given text as one TextBlock. */
+    private static Model streamingModel(String text) {
+        return new Model() {
+            @Override
+            public Flux<ChatResponse> stream(
+                    List<Msg> messages, List<ToolSchema> tools, GenerateOptions options) {
+                ChatResponse resp =
+                        ChatResponse.builder()
+                                .id("msg_" + UUID.randomUUID())
+                                .content(List.of(TextBlock.builder().text(text).build()))
+                                .usage(new ChatUsage(1, 1, 2))
+                                .build();
+                return Flux.just(resp);
+            }
+
+            @Override
+            public String getModelName() {
+                return "stub";
+            }
+        };
+    }
+}


### PR DESCRIPTION


## AgentScope-Java Version

[The version of AgentScope-Java you are working on, e.g. 1.0.12, check your pom.xml dependency version or run `mvn dependency:tree | grep agentscope-parent:pom`(only mac/linux)]

## Description
- Register the SUGGESTION_RESULT event type in AgentEvent
- Add the SuggestionResultEvent event class to carry suggestion results
- Implement the SuggestionMiddleware middleware to generate follow-up question suggestions
- Add configuration options enableSuggestions and suggestionMaxItems
- Integrate the suggestion middleware into HarnessAgent
- Add comprehensive unit tests to verify the suggestion functionality

[Please describe the background, purpose, changes made, and how to test this PR]

## Checklist

Please check the following items before code is ready to be reviewed.

- [ ]  Code has been formatted with `mvn spotless:apply`
- [ ]  All tests are passing (`mvn test`)
- [ ]  Javadoc comments are complete and follow project conventions
- [ ]  Related documentation has been updated (e.g. links, examples, etc.)
- [ ]  Code is ready for review
