### PR TITLE
fix(examples): make MemoryCompactionExample show memory files and fire compaction

### DIFF
--- a/agentscope-examples/documentation/src/main/java/io/agentscope/examples/documentation2/harness/memory/MemoryCompactionExample.java
+++ b/agentscope-examples/documentation/src/main/java/io/agentscope/examples/documentation2/harness/memory/MemoryCompactionExample.java
@@ -67,6 +67,14 @@ public class MemoryCompactionExample {
                                 CompactionConfig.builder()
                                         .triggerMessages(6)
                                         .keepMessages(2)
+                                        // keepTokens defaults to dynamic mode (-1), which the
+                                        // middleware resolves from the model context window to a
+                                        // large token budget (e.g. ~8k) that always exceeds this
+                                        // short demo conversation — so the message-count keep
+                                        // window (keepMessages) is never used and compaction never
+                                        // fires. Set keepTokens(0) to force message-count keep mode
+                                        // so compaction actually triggers after a few turns.
+                                        .keepTokens(0)
                                         .build())
                         .memory(
                                 MemoryConfig.builder()
@@ -118,11 +126,20 @@ public class MemoryCompactionExample {
             System.out.println();
         }
 
+        // Wait briefly for the asynchronous memory flush / consolidation to finish
+        // writing before we read the generated files back from disk.
+        Thread.sleep(3000);
+
         // ── Check generated memory files ────────────────────────────────────
 
         System.out.println("── Memory files on disk ──\n");
 
-        Path memoryDir = workspace.resolve("memory");
+        // Memory files are written under the runtime-data namespace derived from the
+        // RuntimeContext (default IsolationScope.USER falls back to sessionId when no
+        // userId is set), e.g. <workspace>/<sessionId>/memory/. Resolve the paths through
+        // the agent's WorkspaceManager so we read from the same location they were written
+        // to, rather than assuming they live directly under the workspace root.
+        Path memoryDir = agent.getWorkspaceManager().getMemoryDir(ctx);
         if (Files.isDirectory(memoryDir)) {
             Files.list(memoryDir).sorted().forEach(p -> System.out.println("  " + p.getFileName()));
         } else {
@@ -141,7 +158,7 @@ public class MemoryCompactionExample {
             }
         }
 
-        Path memoryMd = workspace.resolve("MEMORY.md");
+        Path memoryMd = agent.getWorkspaceManager().resolveRuntimeDataPath(ctx, "MEMORY.md");
         if (Files.exists(memoryMd)) {
             String content = Files.readString(memoryMd);
             System.out.println("\n── MEMORY.md content ──");
@@ -151,9 +168,6 @@ public class MemoryCompactionExample {
                 System.out.println(content);
             }
         }
-
-        // Wait briefly for async flush to complete before printing final state
-        Thread.sleep(3000);
 
         System.out.println("\nWorkspace: " + workspace);
         System.out.println("\n" + "=".repeat(60));


### PR DESCRIPTION
## What

`MemoryCompactionExample` is meant to demonstrate two things (per its Javadoc):
conversation compaction, and the two-layer memory files it produces. In practice
neither was observable when running the example:

1. The "Check generated memory files" section always printed
   `(memory/ directory not yet created)` and never showed any file content.
2. Compaction never fired — the printed context size kept growing across turns and
   `★ compaction fired!` was never reached — despite the Javadoc stating
   `triggerMessages=6, keepMessages=2` should fire compaction after a few turns.

## Root cause

**(1) Memory files** are written through `WorkspaceManager`, which applies a
runtime-data namespace from the `RuntimeContext`. The default `IsolationScope.USER`
falls back to the `sessionId` when no `userId` is set, so files land under
`<workspace>/<sessionId>/memory/` and `<workspace>/<sessionId>/MEMORY.md`. The
example read them from the workspace root, so the lookup never matched. The check
also ran before the asynchronous flush was awaited.

**(2) Compaction** uses `keepTokens`, which defaults to dynamic mode (`-1`).
`CompactionMiddleware` resolves it from the model context window (qwen-plus =
131072) to `min(8000, max(2000, usable * 0.25)) = 8000` tokens. Because
`keepTokens > 0`, the cutoff logic uses the token-based keep window and ignores
`keepMessages`. This short demo conversation is only ~1,000 tokens — far below the
8,000-token keep window — so the cutoff resolves to 0 and compaction is skipped
every time.

## Fix

- Resolve memory-file paths through the namespace-aware `WorkspaceManager`
  (`getMemoryDir(ctx)` / `resolveRuntimeDataPath(ctx, "MEMORY.md")`), and move the
  existing `Thread.sleep(3000)` before the file check.
- Add `.keepTokens(0)` to force message-count keep mode, so compaction triggers
  after a few turns as the Javadoc describes.

## Verification

Ran the example with `qwen-plus` before and after.

Memory files — after:
── Memory files on disk ──
  2026-07-01.md
── MEMORY.md content ──
- Paris is the capital city of France.
- Tokyo, Japan has a population of approximately 14 million people.

Compaction — after:
Compaction triggered: total=25 msgs / 1087 tokens, cutoff=23, keeping=2 msgs
Compaction complete: 25 msgs → 1 summary + 2 tail = 3 total
  context: 24 → 4 messages ★ compaction fired!