### PR TITLE
fix(shell): escape spaces in skill paths returned by ShellPathPolicy

### DIFF
--- a/agentscope-core/src/main/java/io/agentscope/core/ReActAgent.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/ReActAgent.java
@@ -3395,7 +3395,7 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
                                     .content(TextBlock.builder().text(recoveryText).build())
                                     .build();
                     scope.state.contextMutable().add(recoveryMsg);
-                    return Mono.just(recoveryMsg);
+                    return saveStateToSession(scope).thenReturn(recoveryMsg);
                 });
     }
 

--- a/agentscope-core/src/main/java/io/agentscope/core/ReActAgent.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/ReActAgent.java
@@ -83,6 +83,7 @@ import io.agentscope.core.middleware.MiddlewareBase;
 import io.agentscope.core.middleware.MiddlewareChain;
 import io.agentscope.core.middleware.ModelCallInput;
 import io.agentscope.core.middleware.ReasoningInput;
+import io.agentscope.core.model.ChatResponse;
 import io.agentscope.core.model.ChatUsage;
 import io.agentscope.core.model.ExecutionConfig;
 import io.agentscope.core.model.GenerateOptions;
@@ -2119,7 +2120,7 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
                             rc,
                             MiddlewareBase::onModelCall,
                             modelCallCore)
-                    .apply(new ModelCallInput(messages, tools, options, model))
+                    .apply(new ModelCallInput(messages, tools, options, modelForCall()))
                     .doOnNext(this::publishEvent);
         }
 
@@ -3040,11 +3041,16 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
             List<Msg> messageList = prepareSummaryMessages();
             GenerateOptions generateOptions = buildGenerateOptions();
             ReasoningContext context = new ReasoningContext(getName());
+            Model summaryModel = modelForCall();
             publishEvent(new ExceedMaxItersEvent("", maxIters, maxIters));
 
             return hookDispatcher
                     .firePreSummary(
-                            messageList, generateOptions, model.getModelName(), maxIters, systemMsg)
+                            messageList,
+                            generateOptions,
+                            summaryModel.getModelName(),
+                            maxIters,
+                            systemMsg)
                     .flatMap(
                             preSummaryEvent -> {
                                 List<Msg> effectiveMessages =
@@ -3054,7 +3060,11 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
                                 GenerateOptions effectiveOptions =
                                         preSummaryEvent.getEffectiveGenerateOptions();
 
-                                return summaryStream(context, effectiveMessages, effectiveOptions)
+                                return summaryStream(
+                                                context,
+                                                effectiveMessages,
+                                                effectiveOptions,
+                                                summaryModel)
                                         .then(
                                                 Mono.defer(
                                                         () ->
@@ -3067,7 +3077,7 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
                                                                 .firePostSummary(
                                                                         msg,
                                                                         effectiveOptions,
-                                                                        model.getModelName())
+                                                                        summaryModel.getModelName())
                                                                 .map(
                                                                         postEvent -> {
                                                                             Msg finalMsg =
@@ -3093,10 +3103,14 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
          * @param context   reasoning context for chunk accumulation
          * @param messages  the messages to send to the model
          * @param options   generation options
+         * @param model     the model used for this summary call
          * @return event stream from the summary model call
          */
         Flux<AgentEvent> summaryStream(
-                ReasoningContext context, List<Msg> messages, GenerateOptions options) {
+                ReasoningContext context,
+                List<Msg> messages,
+                GenerateOptions options,
+                Model model) {
 
             Function<ModelCallInput, Flux<AgentEvent>> summaryModelCallCore =
                     mci -> summaryModelCallStream(context, mci, options);
@@ -3132,7 +3146,8 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
                                                                             msg,
                                                                             context,
                                                                             hookOptions,
-                                                                            model.getModelName())
+                                                                            mci.model()
+                                                                                    .getModelName())
                                                                     .contextWrite(
                                                                             ctx ->
                                                                                     ctx.putAll(
@@ -3362,6 +3377,18 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
         // Start with user-configured generateOptions if available
         GenerateOptions baseOptions = generateOptions;
 
+        // Layer the agent-level retry budget underneath explicit per-call settings.
+        if (modelConfig != null) {
+            GenerateOptions retryBudgetOptions =
+                    GenerateOptions.builder()
+                            .executionConfig(
+                                    ExecutionConfig.builder()
+                                            .maxAttempts(modelConfig.maxRetries())
+                                            .build())
+                            .build();
+            baseOptions = GenerateOptions.mergeOptions(baseOptions, retryBudgetOptions);
+        }
+
         // If modelExecutionConfig is set, merge it into the options
         if (modelExecutionConfig != null) {
             GenerateOptions execConfigOptions =
@@ -3370,6 +3397,51 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
         }
 
         return baseOptions != null ? baseOptions : GenerateOptions.builder().build();
+    }
+
+    private Model modelForCall() {
+        Model fallbackModel = modelConfig.fallbackModel();
+        if (fallbackModel == null) {
+            return model;
+        }
+
+        AtomicReference<Model> activeModel = new AtomicReference<>(model);
+        return new Model() {
+            @Override
+            public Flux<ChatResponse> stream(
+                    List<Msg> messages, List<ToolSchema> tools, GenerateOptions options) {
+                Flux<ChatResponse> primaryFlux = model.stream(messages, tools, options);
+                return primaryFlux.switchOnFirst(
+                        (signal, flux) -> {
+                            if (signal.isOnError()) {
+                                Throwable error = signal.getThrowable();
+                                activeModel.set(fallbackModel);
+                                log.warn(
+                                        "Primary model {} failed, switching to fallback {}",
+                                        model.getModelName(),
+                                        fallbackModel.getModelName(),
+                                        error);
+                                return fallbackModel.stream(messages, tools, options);
+                            }
+                            return flux;
+                        });
+            }
+
+            @Override
+            public String getModelName() {
+                return activeModel.get().getModelName();
+            }
+
+            @Override
+            public boolean supportsNativeStructuredOutput() {
+                return activeModel.get().supportsNativeStructuredOutput();
+            }
+
+            @Override
+            public int getContextWindowSize() {
+                return activeModel.get().getContextWindowSize();
+            }
+        };
     }
 
     @Override
@@ -4282,6 +4354,11 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
             b.model = agent.getModel();
             b.maxIters = agent.getMaxIters();
             b.generateOptions = agent.getGenerateOptions();
+            ModelConfig srcModelConfig = agent.getModelConfig();
+            if (srcModelConfig != null) {
+                b.flatMaxRetries = srcModelConfig.maxRetries();
+                b.flatFallbackModel = srcModelConfig.fallbackModel();
+            }
             b.toolkit = agent.getToolkit().copy();
             return b;
         }

--- a/agentscope-core/src/main/java/io/agentscope/core/skill/repository/ClasspathSkillRepository.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/skill/repository/ClasspathSkillRepository.java
@@ -22,10 +22,13 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.file.FileSystem;
+import java.nio.file.FileSystemNotFoundException;
 import java.nio.file.FileSystems;
 import java.nio.file.Path;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -74,11 +77,16 @@ import org.slf4j.LoggerFactory;
  */
 public class ClasspathSkillRepository implements AgentSkillRepository {
 
+    private static final Object FILE_SYSTEM_MONITOR = new Object();
+
+    private static final Map<URI, SharedFileSystemRef> SHARED_FILE_SYSTEMS = new HashMap<>();
+
     private final Logger logger = LoggerFactory.getLogger(ClasspathSkillRepository.class);
 
     private final FileSystem fileSystem;
     private final Path skillBasePath;
     private final boolean isJar;
+    private final URI jarFileSystemUri;
     private final String source;
     private final String resourcePath;
     private final AtomicBoolean closed = new AtomicBoolean(false);
@@ -139,7 +147,8 @@ public class ClasspathSkillRepository implements AgentSkillRepository {
 
             if ("jar".equals(uri.getScheme())) {
                 this.isJar = true;
-                this.fileSystem = FileSystems.newFileSystem(uri, Collections.emptyMap());
+                this.jarFileSystemUri = toFileSystemUri(uri);
+                this.fileSystem = acquireFileSystem(jarFileSystemUri);
                 String schemeSpecificUriPath = uri.getSchemeSpecificPart();
                 String actualResourcePath =
                         schemeSpecificUriPath.substring(schemeSpecificUriPath.lastIndexOf("!") + 1);
@@ -148,6 +157,7 @@ public class ClasspathSkillRepository implements AgentSkillRepository {
             } else {
                 this.isJar = false;
                 this.fileSystem = null;
+                this.jarFileSystemUri = null;
                 this.skillBasePath = Path.of(uri);
             }
             logger.info("is in Jar environment: {}", this.isJar);
@@ -266,6 +276,58 @@ public class ClasspathSkillRepository implements AgentSkillRepository {
         return isJar;
     }
 
+    private static URI toFileSystemUri(URI resourceUri) {
+        String schemeSpecificPart = resourceUri.getSchemeSpecificPart();
+        int lastBang = schemeSpecificPart.lastIndexOf('!');
+        if (lastBang < 0) {
+            return resourceUri;
+        }
+        return URI.create(
+                resourceUri.getScheme() + ":" + schemeSpecificPart.substring(0, lastBang));
+    }
+
+    private static FileSystem acquireFileSystem(URI uri) throws IOException {
+        synchronized (FILE_SYSTEM_MONITOR) {
+            SharedFileSystemRef existingRef = SHARED_FILE_SYSTEMS.get(uri);
+            if (existingRef != null && existingRef.fileSystem.isOpen()) {
+                existingRef.refCount++;
+                return existingRef.fileSystem;
+            }
+            SHARED_FILE_SYSTEMS.remove(uri);
+
+            FileSystem fileSystem;
+            boolean closeWhenUnused = false;
+            try {
+                fileSystem = FileSystems.getFileSystem(uri);
+            } catch (FileSystemNotFoundException ignored) {
+                fileSystem = FileSystems.newFileSystem(uri, Collections.emptyMap());
+                closeWhenUnused = true;
+            }
+
+            SHARED_FILE_SYSTEMS.put(uri, new SharedFileSystemRef(fileSystem, closeWhenUnused));
+            return fileSystem;
+        }
+    }
+
+    private static void releaseFileSystem(URI uri) throws IOException {
+        synchronized (FILE_SYSTEM_MONITOR) {
+            SharedFileSystemRef ref = SHARED_FILE_SYSTEMS.get(uri);
+            if (ref == null) {
+                return;
+            }
+
+            ref.refCount--;
+            if (ref.refCount > 0) {
+                return;
+            }
+
+            SHARED_FILE_SYSTEMS.remove(uri);
+            if (ref.closeWhenUnused && ref.fileSystem.isOpen()) {
+                ref.fileSystem.close();
+            }
+        }
+    }
+
     private void checkNotClosed() {
         if (closed.get()) {
             throw new IllegalStateException("ClasspathSkillRepository has been closed");
@@ -283,12 +345,24 @@ public class ClasspathSkillRepository implements AgentSkillRepository {
         if (!closed.compareAndSet(false, true)) {
             return;
         }
-        if (fileSystem != null) {
+        if (jarFileSystemUri != null) {
             try {
-                fileSystem.close();
+                releaseFileSystem(jarFileSystemUri);
             } catch (IOException e) {
                 throw new RuntimeException("Failed to close classpath file system", e);
             }
+        }
+    }
+
+    private static final class SharedFileSystemRef {
+
+        private final FileSystem fileSystem;
+        private final boolean closeWhenUnused;
+        private int refCount = 1;
+
+        private SharedFileSystemRef(FileSystem fileSystem, boolean closeWhenUnused) {
+            this.fileSystem = fileSystem;
+            this.closeWhenUnused = closeWhenUnused;
         }
     }
 }

--- a/agentscope-core/src/main/java/io/agentscope/core/tool/mcp/McpClientBuilder.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/tool/mcp/McpClientBuilder.java
@@ -25,6 +25,7 @@ import io.modelcontextprotocol.client.transport.HttpClientSseClientTransport;
 import io.modelcontextprotocol.client.transport.HttpClientStreamableHttpTransport;
 import io.modelcontextprotocol.client.transport.ServerParameters;
 import io.modelcontextprotocol.client.transport.StdioClientTransport;
+import io.modelcontextprotocol.client.transport.customizer.McpSyncHttpClientRequestCustomizer;
 import io.modelcontextprotocol.json.McpJsonMapper;
 import io.modelcontextprotocol.json.TypeRef;
 import io.modelcontextprotocol.spec.McpClientTransport;
@@ -217,6 +218,53 @@ public class McpClientBuilder {
     public McpClientBuilder customizeStreamableHttpClient(Consumer<HttpClient.Builder> customizer) {
         if (transportConfig instanceof StreamableHttpTransportConfig) {
             ((StreamableHttpTransportConfig) transportConfig).customizeHttpClient(customizer);
+        }
+        return this;
+    }
+
+    /**
+     * Registers a per-request HTTP customizer for dynamic request modification
+     * (only applicable for HTTP transports: SSE and StreamableHTTP).
+     *
+     * <p>Unlike {@link #header(String, String)} which sets static headers at build time,
+     * this customizer is invoked for <strong>every</strong> HTTP request, enabling
+     * dynamic token injection for OAuth/STS scenarios where credentials expire.
+     *
+     * <p>This method delegates directly to the MCP SDK's
+     * {@code httpRequestCustomizer(McpSyncHttpClientRequestCustomizer)} API, which
+     * provides the HTTP method, endpoint URI, request body, and transport context
+     * for each request.
+     *
+     * <p>Example usage with dynamic OAuth token:
+     * <pre>{@code
+     * McpClientWrapper client = McpClientBuilder.create("mcp-server")
+     *         .streamableHttpTransport("https://mcp.example.com/http")
+     *         .httpRequestCustomizer((builder, method, uri, body, ctx) -> {
+     *             String token = tokenService.getToken();
+     *             builder.header("Authorization", "Bearer " + token);
+     *         })
+     *         .buildSync();
+     * }</pre>
+     *
+     * <p>Example with SSE transport:
+     * <pre>{@code
+     * McpClientWrapper client = McpClientBuilder.create("mcp-server")
+     *         .sseTransport("https://mcp.example.com/sse")
+     *         .httpRequestCustomizer((builder, method, uri, body, ctx) -> {
+     *             builder.header("Authorization", "Bearer " + tokenProvider.getToken());
+     *             builder.header("X-Request-Id", UUID.randomUUID().toString());
+     *         })
+     *         .buildAsync()
+     *         .block();
+     * }</pre>
+     *
+     * @param customizer per-request customizer invoked before each HTTP request
+     * @return this builder
+     * @since 2.0.0
+     */
+    public McpClientBuilder httpRequestCustomizer(McpSyncHttpClientRequestCustomizer customizer) {
+        if (transportConfig instanceof HttpTransportConfig) {
+            ((HttpTransportConfig) transportConfig).setHttpRequestCustomizer(customizer);
         }
         return this;
     }
@@ -609,6 +657,7 @@ public class McpClientBuilder {
         protected final String url;
         protected Map<String, String> headers = new HashMap<>();
         protected Map<String, String> queryParams = new HashMap<>();
+        protected McpSyncHttpClientRequestCustomizer httpRequestCustomizer;
 
         protected HttpTransportConfig(String url) {
             this.url = url;
@@ -637,6 +686,10 @@ public class McpClientBuilder {
                 throw new IllegalArgumentException("Query parameters map cannot be null");
             }
             this.queryParams = new HashMap<>(queryParams);
+        }
+
+        public void setHttpRequestCustomizer(McpSyncHttpClientRequestCustomizer customizer) {
+            this.httpRequestCustomizer = customizer;
         }
 
         /**
@@ -743,6 +796,11 @@ public class McpClientBuilder {
                         });
             }
 
+            // Apply per-request HTTP customizer for dynamic token injection, etc.
+            if (httpRequestCustomizer != null) {
+                clientTransportBuilder.httpRequestCustomizer(httpRequestCustomizer);
+            }
+
             return clientTransportBuilder.build();
         }
     }
@@ -782,6 +840,11 @@ public class McpClientBuilder {
                         requestBuilder -> {
                             headers.forEach(requestBuilder::header);
                         });
+            }
+
+            // Apply per-request HTTP customizer for dynamic token injection, etc.
+            if (httpRequestCustomizer != null) {
+                clientTransportBuilder.httpRequestCustomizer(httpRequestCustomizer);
             }
 
             return clientTransportBuilder.build();

--- a/agentscope-core/src/test/java/io/agentscope/core/agent/ReActAgentNewLoopBuilderTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/agent/ReActAgentNewLoopBuilderTest.java
@@ -111,6 +111,29 @@ class ReActAgentNewLoopBuilderTest {
     }
 
     @Test
+    void fromAgentCopiesModelResilienceConfig() {
+        ChatModelBase model = newFakeModel();
+        ChatModelBase fallback = newFakeModel();
+
+        ReActAgent source =
+                ReActAgent.builder()
+                        .name("source")
+                        .sysPrompt("sys")
+                        .model(model)
+                        .fallbackModel(fallback)
+                        .maxRetries(7)
+                        .toolkit(new Toolkit())
+                        .build();
+
+        ReActAgent copy = ReActAgent.Builder.fromAgent(source).build();
+
+        assertNotNull(copy.getModelConfig());
+        assertEquals(7, copy.getModelConfig().maxRetries());
+        assertSame(fallback, copy.getModelConfig().fallbackModel());
+        assertSame(model, copy.getModel());
+    }
+
+    @Test
     void observeAddsMessagesToState() {
         ReActAgent agent =
                 ReActAgent.builder().name("a").model(newFakeModel()).toolkit(new Toolkit()).build();

--- a/agentscope-core/src/test/java/io/agentscope/core/agent/ReActAgentPerSessionStateTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/agent/ReActAgentPerSessionStateTest.java
@@ -38,6 +38,9 @@ import io.agentscope.core.state.InMemoryAgentStateStore;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import org.junit.jupiter.api.DisplayName;
@@ -114,6 +117,72 @@ class ReActAgentPerSessionStateTest {
         AgentState other = reborn.getAgentState("u1", "other");
         assertFalse(other.getPlanModeContext().isPlanActive());
         assertEquals("", other.getSummary());
+    }
+
+    @Test
+    @DisplayName("user interrupt persists recovery state to the store")
+    void userInterruptPersistsRecoveryState() throws Exception {
+        InMemoryAgentStateStore store = new InMemoryAgentStateStore();
+        CountDownLatch subscribed = new CountDownLatch(1);
+        ReActAgent agent =
+                ReActAgent.builder()
+                        .name("asst")
+                        .sysPrompt("hi")
+                        .model(new DelayedFirstChunkModel(subscribed))
+                        .stateStore(store)
+                        .build();
+        RuntimeContext ctx = RuntimeContext.builder().userId("u1").sessionId("sessA").build();
+
+        CompletableFuture<Msg> future =
+                agent.call(List.of(userMsg("hello")), ctx)
+                        .subscribeOn(Schedulers.parallel())
+                        .toFuture();
+
+        assertTrue(subscribed.await(5, TimeUnit.SECONDS), "model stream should start");
+        agent.interrupt("u1", "sessA");
+
+        Msg reply = future.get(5, TimeUnit.SECONDS);
+        assertEquals(
+                "I noticed that you have interrupted me. What can I do for you?",
+                reply.getTextContent());
+
+        ReActAgent reborn = agent(store);
+        List<String> texts = allText(reborn.getAgentState("u1", "sessA"));
+        assertTrue(texts.contains("hello"), "user input should remain in persisted session state");
+        assertTrue(
+                texts.contains("I noticed that you have interrupted me. What can I do for you?"),
+                "interrupt recovery message should be persisted to the state store");
+    }
+
+    private static final class DelayedFirstChunkModel extends ChatModelBase {
+        private final CountDownLatch subscribed;
+
+        private DelayedFirstChunkModel(CountDownLatch subscribed) {
+            this.subscribed = subscribed;
+        }
+
+        @Override
+        public String getModelName() {
+            return "delayed-first-chunk";
+        }
+
+        @Override
+        protected Flux<ChatResponse> doStream(
+                List<Msg> messages, List<ToolSchema> tools, GenerateOptions options) {
+            return Flux.defer(
+                    () -> {
+                        subscribed.countDown();
+                        return Flux.just(
+                                        ChatResponse.builder()
+                                                .content(
+                                                        List.of(
+                                                                TextBlock.builder()
+                                                                        .text("model reply")
+                                                                        .build()))
+                                                .build())
+                                .delaySubscription(Duration.ofMillis(200));
+                    });
+        }
     }
 
     private static Msg userMsg(String text) {

--- a/agentscope-core/src/test/java/io/agentscope/core/agent/ReActAgentSummarizingTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/agent/ReActAgentSummarizingTest.java
@@ -24,6 +24,10 @@ import io.agentscope.core.agent.test.MockModel;
 import io.agentscope.core.agent.test.MockToolkit;
 import io.agentscope.core.agent.test.TestConstants;
 import io.agentscope.core.agent.test.TestUtils;
+import io.agentscope.core.hook.Hook;
+import io.agentscope.core.hook.HookEvent;
+import io.agentscope.core.hook.PostSummaryEvent;
+import io.agentscope.core.hook.PreSummaryEvent;
 import io.agentscope.core.message.Msg;
 import io.agentscope.core.message.MsgRole;
 import io.agentscope.core.message.TextBlock;
@@ -31,12 +35,18 @@ import io.agentscope.core.message.ToolResultBlock;
 import io.agentscope.core.message.ToolUseBlock;
 import io.agentscope.core.model.ChatResponse;
 import io.agentscope.core.model.ChatUsage;
+import io.agentscope.core.model.GenerateOptions;
+import io.agentscope.core.model.Model;
+import io.agentscope.core.model.ToolSchema;
 import java.lang.reflect.Method;
 import java.time.Duration;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CopyOnWriteArrayList;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 
 /**
  * Unit tests for ReActAgent's summarizing functionality.
@@ -685,6 +695,56 @@ class ReActAgentSummarizingTest {
                 0L, toolId2NonToolRoleCount, "toolId2 should not have non-TOOL result messages");
     }
 
+    @Test
+    @DisplayName("Should report fallback model name in summary hooks")
+    void testSummaryHooksUseFallbackModelName() {
+        List<String> seenModelNames = new CopyOnWriteArrayList<>();
+        Hook captureHook =
+                new Hook() {
+                    @Override
+                    public <T extends HookEvent> Mono<T> onEvent(T event) {
+                        if (event instanceof PreSummaryEvent pre) {
+                            seenModelNames.add("pre:" + pre.getModelName());
+                        } else if (event instanceof PostSummaryEvent post) {
+                            seenModelNames.add("post:" + post.getModelName());
+                        }
+                        return Mono.just(event);
+                    }
+                };
+
+        ReActAgent agent =
+                ReActAgent.builder()
+                        .name("TestAgent")
+                        .sysPrompt("You are a helpful assistant.")
+                        .model(new ThrowingModel("Primary summary model failed"))
+                        .fallbackModel(
+                                new StaticModel("Fallback summary output", "FallbackSummaryModel"))
+                        .toolkit(new MockToolkit())
+                        .hook(captureHook)
+                        .maxIters(1)
+                        .build();
+
+        Msg pendingAssistantMsg =
+                Msg.builder()
+                        .name("TestAgent")
+                        .role(MsgRole.ASSISTANT)
+                        .content(
+                                List.of(
+                                        ToolUseBlock.builder()
+                                                .name("search_tool")
+                                                .id("call_summary_fallback")
+                                                .input(Map.of("query", "weather"))
+                                                .build()))
+                        .build();
+        agent.getAgentState().contextMutable().add(pendingAssistantMsg);
+
+        Msg response = invokeSummarizing(agent);
+        assertNotNull(response, "Summary response should not be null");
+        assertEquals("Fallback summary output", TestUtils.extractTextContent(response));
+        assertEquals(
+                List.of("pre:primary-summary-model", "post:FallbackSummaryModel"), seenModelNames);
+    }
+
     private static Msg invokeSummarizing(ReActAgent agent) {
         try {
             // Create a CallExecution for the default session via activateSlotForContext(null)
@@ -701,6 +761,51 @@ class ReActAgentSummarizingTest {
             return mono.block(Duration.ofMillis(TestConstants.DEFAULT_TEST_TIMEOUT_MS));
         } catch (Exception e) {
             throw new RuntimeException("Failed to invoke summarizing()", e);
+        }
+    }
+
+    private static final class ThrowingModel implements Model {
+        private final String errorMessage;
+
+        private ThrowingModel(String errorMessage) {
+            this.errorMessage = errorMessage;
+        }
+
+        @Override
+        public Flux<ChatResponse> stream(
+                List<Msg> messages, List<ToolSchema> tools, GenerateOptions options) {
+            return Flux.error(new RuntimeException(errorMessage));
+        }
+
+        @Override
+        public String getModelName() {
+            return "primary-summary-model";
+        }
+    }
+
+    private static final class StaticModel implements Model {
+        private final String responseText;
+        private final String modelName;
+
+        private StaticModel(String responseText, String modelName) {
+            this.responseText = responseText;
+            this.modelName = modelName;
+        }
+
+        @Override
+        public Flux<ChatResponse> stream(
+                List<Msg> messages, List<ToolSchema> tools, GenerateOptions options) {
+            return Flux.just(
+                    ChatResponse.builder()
+                            .id("msg_summary")
+                            .content(List.of(TextBlock.builder().text(responseText).build()))
+                            .usage(new ChatUsage(10, 20, 30))
+                            .build());
+        }
+
+        @Override
+        public String getModelName() {
+            return modelName;
         }
     }
 }

--- a/agentscope-core/src/test/java/io/agentscope/core/agent/ReActAgentTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/agent/ReActAgentTest.java
@@ -553,6 +553,32 @@ class ReActAgentTest {
     }
 
     @Test
+    @DisplayName("Should switch to fallback model when primary fails")
+    void testFallbackModel() {
+        String errorMessage = "Primary model unavailable";
+        MockModel primaryModel = new MockModel("").withError(errorMessage);
+        MockModel fallbackModel = new MockModel("Fallback response");
+
+        agent =
+                ReActAgent.builder()
+                        .name(TestConstants.TEST_REACT_AGENT_NAME)
+                        .sysPrompt(TestConstants.DEFAULT_SYS_PROMPT)
+                        .model(primaryModel)
+                        .fallbackModel(fallbackModel)
+                        .toolkit(mockToolkit)
+                        .build();
+
+        Msg userMsg = TestUtils.createUserMessage("User", TestConstants.TEST_USER_INPUT);
+        Msg response =
+                agent.call(userMsg).block(Duration.ofMillis(TestConstants.DEFAULT_TEST_TIMEOUT_MS));
+
+        assertNotNull(response, "Response should not be null");
+        assertEquals("Fallback response", TestUtils.extractTextContent(response));
+        assertEquals(1, primaryModel.getCallCount(), "Primary model should be tried once");
+        assertEquals(1, fallbackModel.getCallCount(), "Fallback model should be called once");
+    }
+
+    @Test
     @DisplayName("Should support streaming responses")
     void testStreaming() {
         // Setup model with multiple response chunks

--- a/agentscope-core/src/test/java/io/agentscope/core/skill/repository/ClasspathSkillRepositoryTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/skill/repository/ClasspathSkillRepositoryTest.java
@@ -215,6 +215,54 @@ class ClasspathSkillRepositoryTest {
     }
 
     @Test
+    @DisplayName("Should reuse JAR file system across repository instances")
+    void testReuseJarFileSystemAcrossRepositories() throws Exception {
+        Path jarPath = createTestJarInFolder("shared-skill", "Shared Skill", "Shared content");
+
+        try (URLClassLoader classLoader = new URLClassLoader(new URL[] {jarPath.toUri().toURL()});
+                ClasspathSkillRepository firstRepository =
+                        new ClasspathSkillRepositoryWithClassLoader("jar-skills", classLoader);
+                ClasspathSkillRepository secondRepository =
+                        new ClasspathSkillRepositoryWithClassLoader("jar-skills", classLoader)) {
+
+            AgentSkill firstSkill = firstRepository.getSkill("shared-skill");
+            AgentSkill secondSkill = secondRepository.getSkill("shared-skill");
+
+            assertEquals("shared-skill", firstSkill.getName());
+            assertEquals("shared-skill", secondSkill.getName());
+
+            firstRepository.close();
+
+            AgentSkill stillAccessible = secondRepository.getSkill("shared-skill");
+            assertEquals("shared-skill", stillAccessible.getName());
+        }
+    }
+
+    @Test
+    @DisplayName("Should reuse JAR file system across different classpath roots in same JAR")
+    void testReuseJarFileSystemAcrossDifferentRootsInSameJar() throws Exception {
+        Path jarPath = createTestJarWithTwoSkillRoots();
+
+        try (URLClassLoader classLoader = new URLClassLoader(new URL[] {jarPath.toUri().toURL()});
+                ClasspathSkillRepository firstRepository =
+                        new ClasspathSkillRepositoryWithClassLoader("jar-skills-a", classLoader);
+                ClasspathSkillRepository secondRepository =
+                        new ClasspathSkillRepositoryWithClassLoader("jar-skills-b", classLoader)) {
+
+            AgentSkill firstSkill = firstRepository.getSkill("skill-a");
+            AgentSkill secondSkill = secondRepository.getSkill("skill-b");
+
+            assertEquals("skill-a", firstSkill.getName());
+            assertEquals("skill-b", secondSkill.getName());
+
+            firstRepository.close();
+
+            AgentSkill stillAccessible = secondRepository.getSkill("skill-b");
+            assertEquals("skill-b", stillAccessible.getName());
+        }
+    }
+
+    @Test
     @DisplayName("Should load skills from Spring Boot Fat JAR (BOOT-INF/classes/)")
     void testLoadFromSpringBootJar() throws Exception {
         Path jarPath = createSpringBootTestJar("sb-skill", "SB Skill", "SB content");
@@ -312,6 +360,37 @@ class ClasspathSkillRepositoryTest {
             assertEquals("nested-lib-skill", skill.getName());
             assertEquals("Nested Lib Skill", skill.getDescription());
             assertTrue(skill.getSkillContent().contains("Nested lib content"));
+        } finally {
+            TestNestedFileSystemProvider.configuredInnerJarPath = null;
+        }
+    }
+
+    @Test
+    @DisplayName("Should reuse nested JAR file system across repository instances")
+    void testReuseNestedJarFileSystemAcrossRepositories() throws Exception {
+        Path outerJarPath =
+                createSpringBootNestedLibTestJar(
+                        "nested-shared-skill", "Nested Shared Skill", "Nested shared content");
+        Path innerJarPath = extractInnerJar(outerJarPath, "BOOT-INF/lib/nested-skill.jar");
+
+        TestNestedFileSystemProvider.configuredInnerJarPath = innerJarPath;
+        try (ClasspathSkillRepository firstRepository =
+                        new ClasspathSkillRepositoryWithClassLoader(
+                                "jar-skills", createNestedJarClassLoader(outerJarPath));
+                ClasspathSkillRepository secondRepository =
+                        new ClasspathSkillRepositoryWithClassLoader(
+                                "jar-skills", createNestedJarClassLoader(outerJarPath))) {
+
+            AgentSkill firstSkill = firstRepository.getSkill("nested-shared-skill");
+            AgentSkill secondSkill = secondRepository.getSkill("nested-shared-skill");
+
+            assertEquals("nested-shared-skill", firstSkill.getName());
+            assertEquals("nested-shared-skill", secondSkill.getName());
+
+            firstRepository.close();
+
+            AgentSkill stillAccessible = secondRepository.getSkill("nested-shared-skill");
+            assertEquals("nested-shared-skill", stillAccessible.getName());
         } finally {
             TestNestedFileSystemProvider.configuredInnerJarPath = null;
         }
@@ -561,6 +640,34 @@ class ClasspathSkillRepositoryTest {
         return jarPath;
     }
 
+    private Path createTestJarWithTwoSkillRoots() throws IOException {
+        Path jarPath = tempDir.resolve("two-skill-roots.jar");
+
+        try (JarOutputStream jos = new JarOutputStream(Files.newOutputStream(jarPath))) {
+            jos.putNextEntry(new JarEntry("jar-skills-a/"));
+            jos.closeEntry();
+            jos.putNextEntry(new JarEntry("jar-skills-a/skill-a/"));
+            jos.closeEntry();
+            jos.putNextEntry(new JarEntry("jar-skills-a/skill-a/SKILL.md"));
+            jos.write(
+                    "---\nname: skill-a\ndescription: Skill A\n---\nContent A"
+                            .getBytes(StandardCharsets.UTF_8));
+            jos.closeEntry();
+
+            jos.putNextEntry(new JarEntry("jar-skills-b/"));
+            jos.closeEntry();
+            jos.putNextEntry(new JarEntry("jar-skills-b/skill-b/"));
+            jos.closeEntry();
+            jos.putNextEntry(new JarEntry("jar-skills-b/skill-b/SKILL.md"));
+            jos.write(
+                    "---\nname: skill-b\ndescription: Skill B\n---\nContent B"
+                            .getBytes(StandardCharsets.UTF_8));
+            jos.closeEntry();
+        }
+
+        return jarPath;
+    }
+
     /**
      * Creates a test JAR file with Spring Boot structure (BOOT-INF/classes/).
      */
@@ -693,6 +800,37 @@ class ClasspathSkillRepositoryTest {
             }
         }
         return innerJarPath;
+    }
+
+    private ClassLoader createNestedJarClassLoader(Path outerJarPath) {
+        return new ClassLoader(ClassLoader.getSystemClassLoader()) {
+            @Override
+            public URL getResource(String name) {
+                if ("jar-skills".equals(name)) {
+                    try {
+                        String nestedUrlStr =
+                                "jar:nested:"
+                                        + outerJarPath.toUri().getRawPath()
+                                        + "/!BOOT-INF/lib/nested-skill.jar!/"
+                                        + name;
+                        return new URL(
+                                null,
+                                nestedUrlStr,
+                                new URLStreamHandler() {
+                                    @Override
+                                    protected URLConnection openConnection(URL u)
+                                            throws IOException {
+                                        throw new UnsupportedOperationException(
+                                                "nested URL for test only");
+                                    }
+                                });
+                    } catch (Exception e) {
+                        throw new RuntimeException(e);
+                    }
+                }
+                return super.getResource(name);
+            }
+        };
     }
 
     /**

--- a/agentscope-core/src/test/java/io/agentscope/core/tool/mcp/McpClientBuilderTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/tool/mcp/McpClientBuilderTest.java
@@ -1297,6 +1297,136 @@ class McpClientBuilderTest {
         assertTrue(syncWrapper instanceof McpSyncClientWrapper);
     }
 
+    // ==================== HttpRequestCustomizer Tests ====================
+
+    @Test
+    void testHttpRequestCustomizer_OnSseTransport() {
+        McpClientBuilder builder =
+                McpClientBuilder.create("http-customizer-sse")
+                        .sseTransport("https://mcp.example.com/sse")
+                        .httpRequestCustomizer(
+                                (builder1, method, uri, body, ctx) -> {
+                                    builder1.header("Authorization", "Bearer dynamic-token");
+                                });
+
+        McpClientWrapper wrapper = builder.buildAsync().block();
+        assertNotNull(wrapper);
+        assertEquals("http-customizer-sse", wrapper.getName());
+    }
+
+    @Test
+    void testHttpRequestCustomizer_OnStreamableHttpTransport() {
+        McpClientBuilder builder =
+                McpClientBuilder.create("http-customizer-streamable")
+                        .streamableHttpTransport("https://mcp.example.com/http")
+                        .httpRequestCustomizer(
+                                (builder1, method, uri, body, ctx) -> {
+                                    builder1.header("X-Custom", "custom-value");
+                                    builder1.header("Authorization", "Bearer token");
+                                });
+
+        McpClientWrapper wrapper = builder.buildSync();
+        assertNotNull(wrapper);
+        assertEquals("http-customizer-streamable", wrapper.getName());
+    }
+
+    @Test
+    void testHttpRequestCustomizer_OnStdioTransport_ShouldBeIgnored() {
+        // httpRequestCustomizer on stdio transport should not cause errors (just ignored)
+        McpClientBuilder builder =
+                McpClientBuilder.create("customizer-stdio")
+                        .stdioTransport("python", "-m", "mcp_server_time")
+                        .httpRequestCustomizer(
+                                (builder1, method, uri, body, ctx) -> {
+                                    builder1.header("Authorization", "Bearer token");
+                                });
+
+        McpClientWrapper wrapper = builder.buildAsync().block();
+        assertNotNull(wrapper);
+    }
+
+    @Test
+    void testHttpRequestCustomizer_CombinedWithHeaders() {
+        McpClientBuilder builder =
+                McpClientBuilder.create("customizer-combined")
+                        .sseTransport("https://mcp.example.com/sse")
+                        .header("X-Static-Header", "static-value")
+                        .httpRequestCustomizer(
+                                (builder1, method, uri, body, ctx) -> {
+                                    builder1.header("X-Dynamic-Header", "dynamic-value");
+                                });
+
+        McpClientWrapper wrapper = builder.buildAsync().block();
+        assertNotNull(wrapper);
+        assertEquals("customizer-combined", wrapper.getName());
+    }
+
+    @Test
+    void testHttpRequestCustomizer_CombinedWithAllFeatures() {
+        McpClientBuilder builder =
+                McpClientBuilder.create("customizer-all-features")
+                        .streamableHttpTransport("https://mcp.example.com/http")
+                        .header("X-Static", "static-value")
+                        .queryParam("env", "prod")
+                        .httpRequestCustomizer(
+                                (builder1, method, uri, body, ctx) -> {
+                                    builder1.header("Authorization", "Bearer dynamic");
+                                    builder1.header("X-Trace-Id", "trace-123");
+                                })
+                        .timeout(Duration.ofSeconds(60));
+
+        McpClientWrapper wrapper = builder.buildSync();
+        assertNotNull(wrapper);
+        assertEquals("customizer-all-features", wrapper.getName());
+    }
+
+    @Test
+    void testHttpRequestCustomizer_FluentApiWithBothTransports() {
+        // Test that httpRequestCustomizer works with SSE and then buildAsync
+        McpClientBuilder builder =
+                McpClientBuilder.create("fluent-customizer")
+                        .sseTransport("https://mcp.example.com/sse")
+                        .httpRequestCustomizer(
+                                (builder1, method, uri, body, ctx) -> {
+                                    // No-op customizer, just verify builder works
+                                });
+
+        assertNotNull(builder);
+        McpClientWrapper wrapper = builder.buildAsync().block();
+        assertNotNull(wrapper);
+    }
+
+    @Test
+    void testHttpRequestCustomizer_MultipleCalls_LastOneWins() {
+        // Multiple calls should overwrite the previous customizer
+        McpClientBuilder builder =
+                McpClientBuilder.create("multi-customizer")
+                        .sseTransport("https://mcp.example.com/sse")
+                        .httpRequestCustomizer(
+                                (builder1, method, uri, body, ctx) -> {
+                                    builder1.header("First", "first-value");
+                                })
+                        .httpRequestCustomizer(
+                                (builder1, method, uri, body, ctx) -> {
+                                    builder1.header("Second", "second-value");
+                                });
+
+        McpClientWrapper wrapper = builder.buildAsync().block();
+        assertNotNull(wrapper);
+    }
+
+    @Test
+    void testHttpRequestCustomizer_WithNullCustomizer() {
+        // Setting null customizer should be allowed (just means no customizer)
+        McpClientBuilder builder =
+                McpClientBuilder.create("null-customizer")
+                        .sseTransport("https://mcp.example.com/sse")
+                        .httpRequestCustomizer(null);
+
+        McpClientWrapper wrapper = builder.buildAsync().block();
+        assertNotNull(wrapper);
+    }
+
     // ==================== Protocol Versions Tests ====================
 
     @Test

--- a/agentscope-examples/agents/agentscope-dataagent/src/main/java/io/agentscope/dataagent/web/config/DataAgentConfig.java
+++ b/agentscope-examples/agents/agentscope-dataagent/src/main/java/io/agentscope/dataagent/web/config/DataAgentConfig.java
@@ -15,6 +15,7 @@
  */
 package io.agentscope.dataagent.web.config;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.agentscope.core.model.Model;
 import io.agentscope.core.state.AgentStateStore;
 import io.agentscope.core.state.InMemoryAgentStateStore;
@@ -142,6 +143,21 @@ public class DataAgentConfig {
                 .modelName(dashscopeModelName)
                 .stream(dashscopeStream)
                 .build();
+    }
+
+    // -----------------------------------------------------------------
+    //  Jackson ObjectMapper — used by MarketContributionService and other
+    //  web-layer components that need JSON serialization.
+    // -----------------------------------------------------------------
+
+    /**
+     * Provides a shared Jackson {@link ObjectMapper} for components that rely on constructor
+     * injection. Registers any Jackson modules found on the classpath (e.g. Java Time).
+     */
+    @Bean
+    @ConditionalOnMissingBean(ObjectMapper.class)
+    public ObjectMapper objectMapper() {
+        return new ObjectMapper().findAndRegisterModules();
     }
 
     // -----------------------------------------------------------------

--- a/agentscope-examples/documentation/src/main/java/io/agentscope/examples/documentation2/harness/memory/MemoryCompactionExample.java
+++ b/agentscope-examples/documentation/src/main/java/io/agentscope/examples/documentation2/harness/memory/MemoryCompactionExample.java
@@ -67,6 +67,14 @@ public class MemoryCompactionExample {
                                 CompactionConfig.builder()
                                         .triggerMessages(6)
                                         .keepMessages(2)
+                                        // keepTokens defaults to dynamic mode (-1), which the
+                                        // middleware resolves from the model context window to a
+                                        // large token budget (e.g. ~8k) that always exceeds this
+                                        // short demo conversation — so the message-count keep
+                                        // window (keepMessages) is never used and compaction never
+                                        // fires. Set keepTokens(0) to force message-count keep mode
+                                        // so compaction actually triggers after a few turns.
+                                        .keepTokens(0)
                                         .build())
                         .memory(
                                 MemoryConfig.builder()
@@ -118,11 +126,20 @@ public class MemoryCompactionExample {
             System.out.println();
         }
 
+        // Wait briefly for the asynchronous memory flush / consolidation to finish
+        // writing before we read the generated files back from disk.
+        Thread.sleep(3000);
+
         // ── Check generated memory files ────────────────────────────────────
 
         System.out.println("── Memory files on disk ──\n");
 
-        Path memoryDir = workspace.resolve("memory");
+        // Memory files are written under the runtime-data namespace derived from the
+        // RuntimeContext (default IsolationScope.USER falls back to sessionId when no
+        // userId is set), e.g. <workspace>/<sessionId>/memory/. Resolve the paths through
+        // the agent's WorkspaceManager so we read from the same location they were written
+        // to, rather than assuming they live directly under the workspace root.
+        Path memoryDir = agent.getWorkspaceManager().getMemoryDir(ctx);
         if (Files.isDirectory(memoryDir)) {
             Files.list(memoryDir).sorted().forEach(p -> System.out.println("  " + p.getFileName()));
         } else {
@@ -141,7 +158,7 @@ public class MemoryCompactionExample {
             }
         }
 
-        Path memoryMd = workspace.resolve("MEMORY.md");
+        Path memoryMd = agent.getWorkspaceManager().resolveRuntimeDataPath(ctx, "MEMORY.md");
         if (Files.exists(memoryMd)) {
             String content = Files.readString(memoryMd);
             System.out.println("\n── MEMORY.md content ──");
@@ -151,9 +168,6 @@ public class MemoryCompactionExample {
                 System.out.println(content);
             }
         }
-
-        // Wait briefly for async flush to complete before printing final state
-        Thread.sleep(3000);
 
         System.out.println("\nWorkspace: " + workspace);
         System.out.println("\n" + "=".repeat(60));

--- a/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-anthropic/src/main/java/io/agentscope/extensions/model/anthropic/formatter/AnthropicResponseParser.java
+++ b/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-anthropic/src/main/java/io/agentscope/extensions/model/anthropic/formatter/AnthropicResponseParser.java
@@ -140,6 +140,16 @@ public class AnthropicResponseParser {
                                     contentBlocks.add(
                                             TextBlock.builder().text(textDelta.text()).build()));
 
+            deltaEvent
+                    .delta()
+                    .thinking()
+                    .ifPresent(
+                            thinkingDelta ->
+                                    contentBlocks.add(
+                                            ThinkingBlock.builder()
+                                                    .thinking(thinkingDelta.thinking())
+                                                    .build()));
+
             // Input JSON delta (tool calling)
             deltaEvent
                     .delta()

--- a/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-anthropic/src/test/java/io/agentscope/extensions/model/anthropic/formatter/AnthropicResponseParserTest.java
+++ b/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-anthropic/src/test/java/io/agentscope/extensions/model/anthropic/formatter/AnthropicResponseParserTest.java
@@ -26,6 +26,7 @@ import static org.mockito.Mockito.when;
 
 import com.anthropic.models.messages.ContentBlock;
 import com.anthropic.models.messages.Message;
+import com.anthropic.models.messages.RawContentBlockDeltaEvent;
 import com.anthropic.models.messages.RawMessageStartEvent;
 import com.anthropic.models.messages.RawMessageStreamEvent;
 import com.anthropic.models.messages.Usage;
@@ -314,6 +315,26 @@ class AnthropicResponseParserTest extends AnthropicFormatterTestBase {
         assertNotNull(response);
         assertEquals("msg_stream_123", response.getId());
         assertTrue(response.getContent().isEmpty()); // MessageStart has no content
+    }
+
+    @Test
+    void testParseStreamEventThinkingDelta() throws Exception {
+        RawContentBlockDeltaEvent deltaEvent =
+                RawContentBlockDeltaEvent.builder()
+                        .index(0)
+                        .thinkingDelta("Let me reason through this.")
+                        .build();
+        RawMessageStreamEvent event = RawMessageStreamEvent.ofContentBlockDelta(deltaEvent);
+
+        Instant startTime = Instant.now();
+        ChatResponse response = invokeParseStreamEvent(event, startTime);
+
+        assertNotNull(response);
+        assertEquals(1, response.getContent().size());
+        ThinkingBlock parsedThinking =
+                assertInstanceOf(ThinkingBlock.class, response.getContent().get(0));
+        assertEquals("Let me reason through this.", parsedThinking.getThinking());
+        assertNull(response.getUsage());
     }
 
     @Test

--- a/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-ollama/src/main/java/io/agentscope/extensions/model/ollama/options/OllamaOptions.java
+++ b/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-ollama/src/main/java/io/agentscope/extensions/model/ollama/options/OllamaOptions.java
@@ -344,6 +344,7 @@ public class OllamaOptions {
                 .mirostatEta(fromOptions.getMirostatEta())
                 .penalizeNewline(fromOptions.getPenalizeNewline())
                 .stop(fromOptions.getStop())
+                .executionConfig(fromOptions.getExecutionConfig())
                 .build();
     }
 
@@ -1015,7 +1016,8 @@ public class OllamaOptions {
                 .mirostatTau(this.mirostatTau)
                 .mirostatEta(this.mirostatEta)
                 .penalizeNewline(this.penalizeNewline)
-                .stop(this.stop);
+                .stop(this.stop)
+                .executionConfig(this.executionConfig);
     }
 
     // @formatter:on

--- a/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-ollama/src/test/java/io/agentscope/extensions/model/ollama/options/OllamaOptionsTest.java
+++ b/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-ollama/src/test/java/io/agentscope/extensions/model/ollama/options/OllamaOptionsTest.java
@@ -282,4 +282,25 @@ class OllamaOptionsTest {
         assertNotNull(options.getThinkOption());
         assertEquals(ThinkOption.ThinkBoolean.ENABLED, options.getThinkOption());
     }
+
+    @Test
+    @DisplayName("Should preserve executionConfig via fromOptions, toBuilder and copy")
+    void testExecutionConfigPreservedOnCopy() {
+        ExecutionConfig executionConfig =
+                ExecutionConfig.builder().timeout(Duration.ofSeconds(30)).maxAttempts(3).build();
+        OllamaOptions original =
+                OllamaOptions.builder().temperature(0.7).executionConfig(executionConfig).build();
+
+        // copy() delegates to fromOptions(OllamaOptions)
+        OllamaOptions copy = original.copy();
+        assertEquals(executionConfig, copy.getExecutionConfig());
+
+        // fromOptions(OllamaOptions) directly
+        OllamaOptions fromOptions = OllamaOptions.fromOptions(original);
+        assertEquals(executionConfig, fromOptions.getExecutionConfig());
+
+        // toBuilder().build() round-trip
+        OllamaOptions rebuilt = original.toBuilder().build();
+        assertEquals(executionConfig, rebuilt.getExecutionConfig());
+    }
 }

--- a/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-a2a/agentscope-extensions-a2a-client/src/main/java/io/agentscope/core/a2a/agent/event/TaskUpdateEventHandler.java
+++ b/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-a2a/agentscope-extensions-a2a-client/src/main/java/io/agentscope/core/a2a/agent/event/TaskUpdateEventHandler.java
@@ -18,6 +18,7 @@ package io.agentscope.core.a2a.agent.event;
 
 import io.a2a.client.TaskUpdateEvent;
 import io.a2a.spec.TaskArtifactUpdateEvent;
+import io.a2a.spec.TaskState;
 import io.a2a.spec.TaskStatus;
 import io.a2a.spec.TaskStatusUpdateEvent;
 import io.a2a.spec.UpdateEvent;
@@ -89,6 +90,22 @@ public class TaskUpdateEventHandler implements ClientEventHandler<TaskUpdateEven
         public void handle(TaskStatusUpdateEvent event, ClientEventContext context) {
             String currentRequestId = context.getCurrentRequestId();
             if (event.isFinal()) {
+                TaskState state = event.getStatus().state();
+                if (!TaskState.COMPLETED.equals(state)) {
+                    String errorMsg =
+                            "A2A task ended with state: "
+                                    + state
+                                    + (event.getStatus().message() != null
+                                            ? ", message: " + event.getStatus().message()
+                                            : "");
+                    LoggerUtil.warn(
+                            log,
+                            "[{}] A2aAgent task ended with non-completed state: {}.",
+                            currentRequestId,
+                            state);
+                    context.getSink().success(Msg.builder().textContent(errorMsg).build());
+                    return;
+                }
                 Msg msg =
                         MessageConvertUtil.convertFromArtifact(
                                 context.getTask().getArtifacts(), context.getAgent().getName());

--- a/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-a2a/agentscope-extensions-a2a-client/src/main/java/io/agentscope/core/a2a/agent/message/MessageConstants.java
+++ b/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-a2a/agentscope-extensions-a2a-client/src/main/java/io/agentscope/core/a2a/agent/message/MessageConstants.java
@@ -42,6 +42,8 @@ public class MessageConstants {
 
     public static final String MSG_ID_METADATA_KEY = "_agentscope_msg_id";
 
+    public static final String MSG_ROLE_METADATA_KEY = "_agentscope_msg_role";
+
     public static final String BLOCK_TYPE_METADATA_KEY = "_agentscope_block_type";
 
     public static final String TOOL_NAME_METADATA_KEY = "_agentscope_tool_name";

--- a/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-a2a/agentscope-extensions-a2a-client/src/main/java/io/agentscope/core/a2a/agent/utils/MessageConvertUtil.java
+++ b/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-a2a/agentscope-extensions-a2a-client/src/main/java/io/agentscope/core/a2a/agent/utils/MessageConvertUtil.java
@@ -129,10 +129,39 @@ public class MessageConvertUtil {
                                                                         MessageConstants
                                                                                 .SOURCE_NAME_METADATA_KEY,
                                                                         msg.getName());
+                                                        if (msg.getRole() != null) {
+                                                            part.getMetadata()
+                                                                    .put(
+                                                                            MessageConstants
+                                                                                    .MSG_ROLE_METADATA_KEY,
+                                                                            msg.getRole().name());
+                                                        }
                                                     })
                                             .toList());
                         });
-        return builder.parts(parts).metadata(metadata).role(Message.Role.USER).build();
+        return builder.parts(parts).metadata(metadata).role(resolveMessageRole(msgs)).build();
+    }
+
+    private static Message.Role resolveMessageRole(List<Msg> msgs) {
+        List<Message.Role> roles =
+                msgs.stream()
+                        .filter(Objects::nonNull)
+                        .map(Msg::getRole)
+                        .filter(Objects::nonNull)
+                        .map(MessageConvertUtil::convertRole)
+                        .distinct()
+                        .toList();
+        if (roles.size() == 1) {
+            return roles.get(0);
+        }
+        return Message.Role.USER;
+    }
+
+    private static Message.Role convertRole(MsgRole role) {
+        if (role == MsgRole.ASSISTANT || role == MsgRole.TOOL) {
+            return Message.Role.AGENT;
+        }
+        return Message.Role.USER;
     }
 
     private static boolean isNotEmptyCollection(Collection<?> collection) {

--- a/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-a2a/agentscope-extensions-a2a-client/src/test/java/io/agentscope/core/a2a/agent/message/MessageConstantsTest.java
+++ b/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-a2a/agentscope-extensions-a2a-client/src/test/java/io/agentscope/core/a2a/agent/message/MessageConstantsTest.java
@@ -51,5 +51,6 @@ class MessageConstantsTest {
         assertNotNull(MessageConstants.TOOL_NAME_METADATA_KEY);
         assertNotNull(MessageConstants.TOOL_CALL_ID_METADATA_KEY);
         assertNotNull(MessageConstants.TOOL_RESULT_OUTPUT_METADATA_KEY);
+        assertEquals("_agentscope_msg_role", MessageConstants.MSG_ROLE_METADATA_KEY);
     }
 }

--- a/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-a2a/agentscope-extensions-a2a-server/pom.xml
+++ b/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-a2a/agentscope-extensions-a2a-server/pom.xml
@@ -52,6 +52,11 @@
             <groupId>io.github.a2asdk</groupId>
             <artifactId>a2a-java-sdk-transport-jsonrpc</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.projectreactor</groupId>
+            <artifactId>reactor-test</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-a2a/agentscope-extensions-a2a-server/src/main/java/io/agentscope/core/a2a/server/executor/AgentScopeAgentExecutor.java
+++ b/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-a2a/agentscope-extensions-a2a-server/src/main/java/io/agentscope/core/a2a/server/executor/AgentScopeAgentExecutor.java
@@ -197,13 +197,17 @@ public class AgentScopeAgentExecutor implements AgentExecutor {
             processStreamingOutput(resultFlux, taskUpdater, context);
         } catch (Exception e) {
             log.error("[{}] Error processing streaming output", context.getTaskId(), e);
-            taskUpdater.fail(
-                    taskUpdater.newAgentMessage(
-                            List.of(
-                                    new TextPart(
-                                            "Error processing streaming output: "
-                                                    + e.getMessage())),
-                            Map.of()));
+            try {
+                taskUpdater.fail(
+                        taskUpdater.newAgentMessage(
+                                List.of(
+                                        new TextPart(
+                                                "Error processing streaming output: "
+                                                        + e.getMessage())),
+                                Map.of()));
+            } catch (IllegalStateException ignored) {
+                // doOnError already transitioned the task to a terminal state; nothing to do.
+            }
         }
     }
 

--- a/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-a2a/agentscope-extensions-a2a-server/src/main/java/io/agentscope/core/a2a/server/transport/jsonrpc/JsonRpcTransportWrapper.java
+++ b/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-a2a/agentscope-extensions-a2a-server/src/main/java/io/agentscope/core/a2a/server/transport/jsonrpc/JsonRpcTransportWrapper.java
@@ -58,6 +58,7 @@ import java.util.concurrent.Flow;
 import org.reactivestreams.FlowAdapters;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import reactor.core.publisher.BufferOverflowStrategy;
 import reactor.core.publisher.Flux;
 
 /**
@@ -76,6 +77,16 @@ import reactor.core.publisher.Flux;
 public class JsonRpcTransportWrapper implements TransportWrapper<String, Object> {
 
     private static final Logger log = LoggerFactory.getLogger(JsonRpcTransportWrapper.class);
+
+    private static final String STREAMING_BACKPRESSURE_BUFFER_SIZE_PROPERTY =
+            "agentscope.a2a.streaming.backpressure-buffer-size";
+
+    private static final int DEFAULT_STREAMING_BACKPRESSURE_BUFFER_SIZE = 8192;
+
+    private static final int STREAMING_BACKPRESSURE_BUFFER_SIZE =
+            Integer.getInteger(
+                    STREAMING_BACKPRESSURE_BUFFER_SIZE_PROPERTY,
+                    DEFAULT_STREAMING_BACKPRESSURE_BUFFER_SIZE);
 
     private final JSONRPCHandler jsonRpcHandler;
 
@@ -160,8 +171,36 @@ public class JsonRpcTransportWrapper implements TransportWrapper<String, Object>
             return Flux.just(generateErrorResponse(request, new UnsupportedOperationError()));
         }
 
-        return Flux.from(FlowAdapters.toPublisher(publisher))
+        String method = (String) context.getState().get(JSONRPCContextKeys.METHOD_NAME_KEY);
+        Object requestId = request.getId();
+        return applyStreamingBackpressureBuffer(
+                        Flux.from(FlowAdapters.toPublisher(publisher)), method, requestId)
                 .delaySubscription(Duration.ofMillis(10));
+    }
+
+    private Flux<? extends JSONRPCResponse<?>> applyStreamingBackpressureBuffer(
+            Flux<? extends JSONRPCResponse<?>> stream, String method, Object requestId) {
+        if (STREAMING_BACKPRESSURE_BUFFER_SIZE <= 0) {
+            return stream.onBackpressureBuffer();
+        }
+        return stream.onBackpressureBuffer(
+                STREAMING_BACKPRESSURE_BUFFER_SIZE,
+                response ->
+                        log.error(
+                                "JsonRpcTransportWrapper.stream backpressure buffer overflow:"
+                                        + " method={}, requestId={}, bufferSize={}, dropped={}",
+                                method,
+                                requestId,
+                                STREAMING_BACKPRESSURE_BUFFER_SIZE,
+                                summarizeResponse(response)),
+                BufferOverflowStrategy.ERROR);
+    }
+
+    private String summarizeResponse(JSONRPCResponse<?> response) {
+        if (response == null) {
+            return "responseType=null";
+        }
+        return "responseType=" + response.getClass().getName();
     }
 
     private JSONRPCResponse<?> handleNonStreamRequest(String body, ServerCallContext context)

--- a/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-a2a/agentscope-extensions-a2a-server/src/main/java/io/agentscope/core/a2a/server/utils/MessageConvertUtil.java
+++ b/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-a2a/agentscope-extensions-a2a-server/src/main/java/io/agentscope/core/a2a/server/utils/MessageConvertUtil.java
@@ -128,6 +128,7 @@ public class MessageConvertUtil {
         Set<String> msgIds = new LinkedHashSet<>();
         Map<String, List<ContentBlock>> partsByMsgId = new HashMap<>();
         Map<String, String> msgIdToName = new HashMap<>();
+        Map<String, MsgRole> msgIdToRole = new HashMap<>();
         message.getParts().stream()
                 .filter(Objects::nonNull)
                 .forEach(
@@ -145,6 +146,10 @@ public class MessageConvertUtil {
                                     .add(PART_PARSER.parse(part));
                             msgIds.add(msgId);
                             msgIdToName.put(msgId, getMsgName(part));
+                            MsgRole role = getMsgRole(part);
+                            if (role != null) {
+                                msgIdToRole.putIfAbsent(msgId, role);
+                            }
                         });
         msgIds.forEach(
                 msgId ->
@@ -152,7 +157,9 @@ public class MessageConvertUtil {
                                 Msg.builder()
                                         .id(msgId)
                                         .name(msgIdToName.get(msgId))
-                                        .role(MsgRole.USER)
+                                        .role(
+                                                msgIdToRole.getOrDefault(
+                                                        msgId, convertRole(message.getRole())))
                                         .content(partsByMsgId.get(msgId))
                                         .metadata(getMsgMetadata(message, msgId))
                                         .build()));
@@ -175,6 +182,28 @@ public class MessageConvertUtil {
             return null;
         }
         return part.getMetadata().get(MessageConstants.SOURCE_NAME_METADATA_KEY).toString();
+    }
+
+    private static MsgRole getMsgRole(Part<?> part) {
+        if (null == part.getMetadata()) {
+            return null;
+        }
+        Object role = part.getMetadata().get(MessageConstants.MSG_ROLE_METADATA_KEY);
+        if (role == null) {
+            return null;
+        }
+        try {
+            return MsgRole.valueOf(role.toString());
+        } catch (IllegalArgumentException ignored) {
+            return null;
+        }
+    }
+
+    private static MsgRole convertRole(Message.Role role) {
+        if (role == Message.Role.AGENT) {
+            return MsgRole.ASSISTANT;
+        }
+        return MsgRole.USER;
     }
 
     @SuppressWarnings("unchecked")

--- a/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-a2a/agentscope-extensions-a2a-server/src/test/java/io/agentscope/core/a2a/server/transport/jsonrpc/JsonRpcTransportWrapperTest.java
+++ b/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-a2a/agentscope-extensions-a2a-server/src/test/java/io/agentscope/core/a2a/server/transport/jsonrpc/JsonRpcTransportWrapperTest.java
@@ -19,6 +19,8 @@ package io.agentscope.core.a2a.server.transport.jsonrpc;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -51,13 +53,16 @@ import io.a2a.spec.TaskResubscriptionRequest;
 import io.a2a.spec.TransportProtocol;
 import io.a2a.transport.jsonrpc.handler.JSONRPCHandler;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Flow;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.reactivestreams.FlowAdapters;
 import reactor.core.publisher.Flux;
+import reactor.test.StepVerifier;
 
 /**
  * Unit tests for JsonRpcTransportWrapper.
@@ -280,6 +285,48 @@ class JsonRpcTransportWrapperTest {
     }
 
     @Nested
+    @DisplayName("Streaming Backpressure Tests")
+    class StreamingBackpressureTests {
+
+        @Test
+        @DisplayName("Should show unbuffered streaming can lose burst responses")
+        void testUnbufferedStreamingBurstDropsResponse() {
+            SendStreamingMessageResponse reasoningResponse =
+                    mock(SendStreamingMessageResponse.class);
+            SendStreamingMessageResponse textResponse = mock(SendStreamingMessageResponse.class);
+
+            Flux<SendStreamingMessageResponse> unbuffered =
+                    Flux.from(
+                            FlowAdapters.toPublisher(
+                                    burstPublisher(List.of(reasoningResponse, textResponse))));
+
+            AssertionError overflowError =
+                    assertThrows(
+                            AssertionError.class,
+                            () ->
+                                    StepVerifier.create(unbuffered, 1)
+                                            .expectNext(reasoningResponse)
+                                            .verifyComplete());
+            assertTrue(
+                    String.valueOf(overflowError.getMessage()).contains("request overflow"),
+                    "Expected request overflow but got: " + overflowError.getMessage());
+
+            Flux<SendStreamingMessageResponse> buffered =
+                    Flux.from(
+                                    FlowAdapters.toPublisher(
+                                            burstPublisher(
+                                                    List.of(reasoningResponse, textResponse))))
+                            .onBackpressureBuffer();
+
+            StepVerifier.create(buffered, 1)
+                    .expectNext(reasoningResponse)
+                    .thenRequest(1)
+                    .expectNext(textResponse)
+                    .verifyComplete();
+        }
+    }
+
+    @Nested
     @DisplayName("Error Handling Tests")
     class ErrorHandlingTests {
 
@@ -369,5 +416,28 @@ class JsonRpcTransportWrapperTest {
             assertNotNull(error);
             assertInstanceOf(InvalidRequestError.class, error);
         }
+    }
+
+    private static <T> Flow.Publisher<T> burstPublisher(List<T> values) {
+        return subscriber ->
+                subscriber.onSubscribe(
+                        new Flow.Subscription() {
+                            private boolean emitted;
+
+                            @Override
+                            public void request(long n) {
+                                if (emitted) {
+                                    return;
+                                }
+                                emitted = true;
+                                for (T value : values) {
+                                    subscriber.onNext(value);
+                                }
+                                subscriber.onComplete();
+                            }
+
+                            @Override
+                            public void cancel() {}
+                        });
     }
 }

--- a/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-a2a/agentscope-extensions-a2a-server/src/test/java/io/agentscope/core/a2a/server/utils/MessageConvertUtilTest.java
+++ b/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-a2a/agentscope-extensions-a2a-server/src/test/java/io/agentscope/core/a2a/server/utils/MessageConvertUtilTest.java
@@ -32,6 +32,7 @@ import io.agentscope.core.message.ContentBlock;
 import io.agentscope.core.message.Msg;
 import io.agentscope.core.message.MsgRole;
 import io.agentscope.core.message.TextBlock;
+import io.agentscope.core.message.ThinkingBlock;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -216,6 +217,70 @@ class MessageConvertUtilTest {
         assertEquals(1, result.get(1).getContent().size());
         assertInstanceOf(TextBlock.class, result.get(1).getContent().get(0));
         assertEquals("text2", ((TextBlock) result.get(1).getContent().get(0)).getText());
+    }
+
+    @Test
+    @DisplayName("Should restore Msg role from part metadata")
+    void testConvertFromMessageToMsgsWithRoleMetadata() {
+        // Given
+        Message message = mock(Message.class);
+
+        Map<String, Object> partMetadata = new HashMap<>();
+        String msgId = "assistant-msg";
+        partMetadata.put(MessageConstants.MSG_ID_METADATA_KEY, msgId);
+        partMetadata.put(MessageConstants.MSG_ROLE_METADATA_KEY, MsgRole.ASSISTANT.name());
+        partMetadata.put(
+                MessageConstants.BLOCK_TYPE_METADATA_KEY,
+                MessageConstants.BlockContent.TYPE_THINKING);
+
+        TextPart part = new TextPart("thinking content", partMetadata);
+
+        when(message.getMetadata()).thenReturn(null);
+        when(message.getRole()).thenReturn(Message.Role.USER);
+        when(message.getParts()).thenReturn(List.of(part));
+
+        // When
+        List<Msg> result = MessageConvertUtil.convertFromMessageToMsgs(message);
+
+        // Then
+        assertNotNull(result);
+        assertEquals(1, result.size());
+        Msg msg = result.get(0);
+        assertEquals(msgId, msg.getId());
+        assertEquals(MsgRole.ASSISTANT, msg.getRole());
+        assertEquals(1, msg.getContent().size());
+        assertInstanceOf(ThinkingBlock.class, msg.getContent().get(0));
+        assertEquals("thinking content", ((ThinkingBlock) msg.getContent().get(0)).getThinking());
+    }
+
+    @Test
+    @DisplayName("Should preserve roles when converting mixed history through A2A message")
+    void testRoundTripMixedHistoryPreservesRoles() {
+        Msg userMsg =
+                Msg.builder()
+                        .id("user-msg")
+                        .role(MsgRole.USER)
+                        .content(List.of(TextBlock.builder().text("please review").build()))
+                        .build();
+        Msg assistantMsg =
+                Msg.builder()
+                        .id("assistant-msg")
+                        .role(MsgRole.ASSISTANT)
+                        .content(List.of(ThinkingBlock.builder().thinking("checking diff").build()))
+                        .build();
+
+        Message message =
+                MessageConvertUtil.convertFromMsgToMessage(
+                        List.of(userMsg, assistantMsg), taskId, contextId);
+        List<Msg> result = MessageConvertUtil.convertFromMessageToMsgs(message);
+
+        assertEquals(Message.Role.USER, message.getRole());
+        assertEquals(2, result.size());
+        assertEquals(MsgRole.USER, result.get(0).getRole());
+        assertEquals(MsgRole.ASSISTANT, result.get(1).getRole());
+        assertInstanceOf(ThinkingBlock.class, result.get(1).getContent().get(0));
+        assertEquals(
+                "checking diff", ((ThinkingBlock) result.get(1).getContent().get(0)).getThinking());
     }
 
     @Test

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/filesystem/local/LocalFilesystem.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/filesystem/local/LocalFilesystem.java
@@ -359,7 +359,10 @@ public class LocalFilesystem implements AbstractFilesystem {
         ReentrantLock lock = fileLocks.computeIfAbsent(lockKey, k -> new ReentrantLock());
         lock.lock();
         try {
-            String content = Files.readString(resolved, StandardCharsets.UTF_8);
+            String content =
+                    Files.readString(resolved, StandardCharsets.UTF_8)
+                            .replace("\r\n", "\n")
+                            .replace("\r", "\n");
             String normalizedOld = oldString.replace("\r\n", "\n").replace("\r", "\n");
             String normalizedNew = newString.replace("\r\n", "\n").replace("\r", "\n");
 

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/gateway/HarnessGateway.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/gateway/HarnessGateway.java
@@ -459,15 +459,38 @@ public final class HarnessGateway implements Gateway, WakeupDispatcher.WakeupTar
     }
 
     /**
-     * Triggers a wakeup-driven run for an idle session. Called by {@link WakeupDispatcher} when a
-     * background task completes or a team message arrives. The agent starts a reasoning round with
-     * no user input; {@link io.agentscope.harness.agent.middleware.InboxMiddleware} drains the
-     * inbox and injects the pending results as context.
+     * {@inheritDoc}
      *
+     * <p>Delegates to {@link #runWakeup(String, String)} with a {@code null} user id.
+     *
+     * @deprecated use {@link #runWakeup(String, String)} so the wakeup-driven round loads agent
+     *     state from the correct {@code (userId, sessionId)} slot. This overload preserves legacy
+     *     anonymous-wakeup behavior.
+     */
+    @Deprecated
+    @Override
+    public Mono<Msg> runWakeup(String sessionId) {
+        return runWakeup(null, sessionId);
+    }
+
+    /**
+     * Triggers a wakeup-driven run for an idle session, propagating the owning user id when
+     * present. Called by {@link WakeupDispatcher} when a background task completes or a team
+     * message arrives. The agent starts a reasoning round with no user input; {@link
+     * io.agentscope.harness.agent.middleware.InboxMiddleware} drains the inbox and injects the
+     * pending results as context.
+     *
+     * <p>When {@code userId} is non-blank it is set on the {@link RuntimeContext}, so the agent
+     * loads state from the same {@code (userId, sessionId)} slot as the original user-driven run
+     * — matching {@code runStream}. A blank or null user id preserves the legacy anonymous
+     * behavior.
+     *
+     * @param userId the owning user id carried by the wakeup entry; may be {@code null} or blank
      * @param sessionId the session to wake up
      * @return the agent's response, or {@link Mono#empty()} if the session is unknown
      */
-    public Mono<Msg> runWakeup(String sessionId) {
+    @Override
+    public Mono<Msg> runWakeup(String userId, String sessionId) {
         String gateKey = sessionToGateKey.get(sessionId);
         if (gateKey == null) {
             log.debug("runWakeup: unknown sessionId={}, skipping", sessionId);
@@ -477,12 +500,15 @@ public final class HarnessGateway implements Gateway, WakeupDispatcher.WakeupTar
         if (ha == null) {
             return Mono.empty();
         }
-        RuntimeContext rtc =
+        RuntimeContext.Builder rtcBuilder =
                 RuntimeContext.builder()
                         .sessionId(sessionId)
                         .put("gateKey", gateKey)
-                        .put("outboundAddress", lastRouteBySession.get(sessionId))
-                        .build();
+                        .put("outboundAddress", lastRouteBySession.get(sessionId));
+        if (userId != null && !userId.isBlank()) {
+            rtcBuilder.userId(userId);
+        }
+        RuntimeContext rtc = rtcBuilder.build();
 
         if (messageBus == null) {
             return withGatedTurn(gateKey, () -> ha.call(List.of(), rtc));

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/gateway/WakeupDispatcher.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/gateway/WakeupDispatcher.java
@@ -61,7 +61,36 @@ public class WakeupDispatcher implements AutoCloseable {
     public interface WakeupTarget {
         boolean isSessionRunning(String sessionId);
 
+        /**
+         * Triggers a wakeup run without an owning user id.
+         *
+         * @param sessionId the session to wake up
+         * @return the agent's response, or {@link Mono#empty()} if the session is unknown
+         * @deprecated implementers should override {@link #runWakeup(String, String)} instead, so
+         *     the dispatcher can propagate the owning user id. Required for runtimes that isolate
+         *     agent state by {@code (userId, sessionId)}: without it, a wakeup-driven round loads
+         *     state from an anonymous slot and the original conversation is lost. This overload is
+         *     retained for backward compatibility and defaults to ignoring the user id.
+         */
+        @Deprecated
         Mono<Msg> runWakeup(String sessionId);
+
+        /**
+         * Triggers a wakeup run for an idle session, carrying the owning user id when present.
+         *
+         * <p>Called by {@link WakeupDispatcher} when a background task completes or a team message
+         * arrives. Implementations should set the user id on the agent runtime context when
+         * non-blank, so agent state is loaded from the same {@code (userId, sessionId)} slot as
+         * the original user-driven run.
+         *
+         * @param userId the owning user id carried by the wakeup entry; {@code null} or blank when
+         *     the producer had none (e.g. single-tenant runtimes)
+         * @param sessionId the session to wake up
+         * @return the agent's response, or {@link Mono#empty()} if the session is unknown
+         */
+        default Mono<Msg> runWakeup(String userId, String sessionId) {
+            return runWakeup(sessionId);
+        }
     }
 
     public WakeupDispatcher(MessageBus messageBus, WakeupTarget target) {
@@ -115,6 +144,7 @@ public class WakeupDispatcher implements AutoCloseable {
     }
 
     private void dispatch(Map<String, Object> payload) {
+        String userId = getString(payload, "userId");
         String sessionId = getString(payload, "sessionId");
         String agentId = getString(payload, "agentId");
 
@@ -131,8 +161,12 @@ public class WakeupDispatcher implements AutoCloseable {
             return;
         }
 
-        log.info("WakeupDispatcher: waking idle session {}, agentId={}", sessionId, agentId);
-        target.runWakeup(sessionId)
+        log.info(
+                "WakeupDispatcher: waking idle session {}, userId={}, agentId={}",
+                sessionId,
+                userId,
+                agentId);
+        target.runWakeup(userId, sessionId)
                 .subscribe(
                         msg ->
                                 log.debug(

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/middleware/MemoryFlushMiddleware.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/middleware/MemoryFlushMiddleware.java
@@ -79,13 +79,30 @@ public class MemoryFlushMiddleware implements HarnessRuntimeMiddleware {
     private final IsolationScope isolationScope;
 
     /**
-     * Per-isolation-key flush timestamps. The key is derived from {@link #isolationScope} and the
-     * per-call {@link RuntimeContext} so the throttle window matches the memory data namespace:
-     * one window per user (USER scope), per session (SESSION scope), or a single shared window
-     * (AGENT / GLOBAL scope).
+     * Process-wide per-isolation-key flush timestamps. Static so that the throttle window
+     * survives across {@code HarnessAgent.Builder.build()} calls — each rebuild creates a new
+     * middleware instance, and an instance-level map would reset to {@link Instant#EPOCH} on
+     * every request, defeating the {@link MemoryConfig.FlushMode#THROTTLED} back-off.
+     *
+     * <p>The key is a composite of {@link IsolationScope} name and the per-call identity
+     * (see {@link #timerKeyFor(RuntimeContext)}) so the shared map correctly isolates throttle
+     * windows across scope dimensions:
+     * <ul>
+     *   <li>{@code USER:<userId>} — one window per user</li>
+     *   <li>{@code SESSION:<sessionId>} — one window per session</li>
+     *   <li>{@code AGENT:} / {@code GLOBAL:} — one shared window across the process
+     *       (prevents concurrent flush races on shared memory files)</li>
+     * </ul>
      */
-    private final ConcurrentHashMap<String, AtomicReference<Instant>> lastFlushAtByKey =
+    static final ConcurrentHashMap<String, AtomicReference<Instant>> SHARED_LAST_FLUSH_AT =
             new ConcurrentHashMap<>();
+
+    /**
+     * Entries in {@link #SHARED_LAST_FLUSH_AT} whose timestamp is older than this threshold
+     * are considered stale and removed on the next cleanup sweep. This bounds the map size in
+     * long-running services with high user/session churn.
+     */
+    static final Duration STALE_ENTRY_MAX_AGE = Duration.ofMinutes(60);
 
     public MemoryFlushMiddleware(WorkspaceManager workspaceManager, Model model) {
         this(
@@ -222,13 +239,38 @@ public class MemoryFlushMiddleware implements HarnessRuntimeMiddleware {
     }
 
     private AtomicReference<Instant> lastFlushAtFor(RuntimeContext rc) {
-        return lastFlushAtByKey.computeIfAbsent(
-                timerKeyFor(rc), k -> new AtomicReference<>(Instant.EPOCH));
+        return SHARED_LAST_FLUSH_AT.computeIfAbsent(
+                compositeTimerKey(rc), k -> new AtomicReference<>(Instant.EPOCH));
     }
 
     /**
-     * Derives the timer map key from the configured {@link IsolationScope} and the per-call
-     * {@link RuntimeContext}, mirroring the memory data namespace:
+     * Removes entries whose timestamp is older than {@link #STALE_ENTRY_MAX_AGE} from
+     * {@link #SHARED_LAST_FLUSH_AT}. This bounds the map size in long-running services with
+     * high user/session churn — stale entries represent keys that have not flushed recently
+     * and are safe to re-create on demand.
+     *
+     * <p>Package-private for unit testing.
+     */
+    static void cleanupStaleEntries() {
+        Instant cutoff = Instant.now().minus(STALE_ENTRY_MAX_AGE);
+        SHARED_LAST_FLUSH_AT.entrySet().removeIf(e -> e.getValue().get().isBefore(cutoff));
+    }
+
+    /**
+     * Builds a composite key from {@link IsolationScope} name and the per-call identity returned
+     * by {@link #timerKeyFor(RuntimeContext)}. The scope prefix ensures that the shared
+     * {@link #SHARED_LAST_FLUSH_AT} map never conflates throttle windows from different
+     * isolation dimensions — e.g. a {@code userId} that happens to equal a {@code sessionId}
+     * must not share a slot.
+     */
+    private String compositeTimerKey(RuntimeContext rc) {
+        return isolationScope.name() + ":" + timerKeyFor(rc);
+    }
+
+    /**
+     * Derives the per-call identity portion of the composite timer key from the configured
+     * {@link IsolationScope} and the {@link RuntimeContext}, mirroring the memory data
+     * namespace:
      * <ul>
      *   <li>{@link IsolationScope#USER} — {@code userId} (empty string for anonymous)</li>
      *   <li>{@link IsolationScope#SESSION} — {@code sessionId} (empty string when absent)</li>

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/middleware/MemoryMaintenanceMiddleware.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/middleware/MemoryMaintenanceMiddleware.java
@@ -78,12 +78,24 @@ public class MemoryMaintenanceMiddleware implements HarnessRuntimeMiddleware {
     private final IsolationScope isolationScope;
 
     /**
-     * Per-isolation-key maintenance timestamps. The key is derived from {@link #isolationScope}
-     * and the per-call {@link RuntimeContext} so the throttle window matches the memory data
-     * namespace (see {@link MemoryFlushMiddleware} for the identical pattern).
+     * Process-wide per-isolation-key maintenance timestamps. Static so that the throttle window
+     * survives across {@code HarnessAgent.Builder.build()} calls — each rebuild creates a new
+     * middleware instance, and an instance-level map would reset to {@link Instant#EPOCH} on
+     * every request, defeating the gap-based throttle.
+     *
+     * <p>The key is a composite of {@link IsolationScope} name and the per-call identity
+     * (see {@link #timerKeyFor(RuntimeContext)}) so the shared map correctly isolates throttle
+     * windows across scope dimensions.
      */
-    private final ConcurrentHashMap<String, AtomicReference<Instant>> lastRunAtByKey =
+    static final ConcurrentHashMap<String, AtomicReference<Instant>> SHARED_LAST_RUN_AT =
             new ConcurrentHashMap<>();
+
+    /**
+     * Entries in {@link #SHARED_LAST_RUN_AT} whose timestamp is older than this threshold
+     * are considered stale and removed on the next cleanup sweep. This bounds the map size
+     * in long-running services with high user/session churn.
+     */
+    static final Duration STALE_ENTRY_MAX_AGE = Duration.ofMinutes(60);
 
     public MemoryMaintenanceMiddleware(
             WorkspaceManager workspaceManager,
@@ -158,14 +170,38 @@ public class MemoryMaintenanceMiddleware implements HarnessRuntimeMiddleware {
     }
 
     private AtomicReference<Instant> lastRunAtFor(RuntimeContext rc) {
-        return lastRunAtByKey.computeIfAbsent(
-                timerKeyFor(rc), k -> new AtomicReference<>(Instant.EPOCH));
+        return SHARED_LAST_RUN_AT.computeIfAbsent(
+                compositeTimerKey(rc), k -> new AtomicReference<>(Instant.EPOCH));
     }
 
     /**
-     * Derives the timer map key from the configured {@link IsolationScope} and the per-call
-     * {@link RuntimeContext}, mirroring the memory data namespace. See
-     * {@link MemoryFlushMiddleware#timerKeyFor(RuntimeContext)} for the same logic.
+     * Removes entries whose timestamp is older than {@link #STALE_ENTRY_MAX_AGE} from
+     * {@link #SHARED_LAST_RUN_AT}. This bounds the map size in long-running services with
+     * high user/session churn — stale entries represent keys that have not run maintenance
+     * recently and are safe to re-create on demand.
+     *
+     * <p>Package-private for unit testing.
+     */
+    static void cleanupStaleEntries() {
+        Instant cutoff = Instant.now().minus(STALE_ENTRY_MAX_AGE);
+        SHARED_LAST_RUN_AT.entrySet().removeIf(e -> e.getValue().get().isBefore(cutoff));
+    }
+
+    /**
+     * Builds a composite key from {@link IsolationScope} name and the per-call identity returned
+     * by {@link #timerKeyFor(RuntimeContext)}. The scope prefix ensures that the shared
+     * {@link #SHARED_LAST_RUN_AT} map never conflates throttle windows from different
+     * isolation dimensions.
+     */
+    private String compositeTimerKey(RuntimeContext rc) {
+        return isolationScope.name() + ":" + timerKeyFor(rc);
+    }
+
+    /**
+     * Derives the per-call identity portion of the composite timer key from the configured
+     * {@link IsolationScope} and the {@link RuntimeContext}, mirroring the memory data
+     * namespace. See {@link MemoryFlushMiddleware#timerKeyFor(RuntimeContext)} for the
+     * identical logic.
      */
     String timerKeyFor(RuntimeContext rc) {
         return switch (isolationScope) {

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/skill/runtime/ShellPathPolicy.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/skill/runtime/ShellPathPolicy.java
@@ -112,9 +112,14 @@ public final class ShellPathPolicy {
 
     private String joinSkills(String skillName) {
         return switch (mode) {
-            case SANDBOX -> sandboxPrefix + "/skills/" + skillName;
+            case SANDBOX -> escapeSpaces(sandboxPrefix + "/skills/" + skillName);
             case LOCAL_WITH_SHELL ->
-                    workspaceRoot.resolve("skills").resolve(skillName).toAbsolutePath().toString();
+                    escapeSpaces(
+                            workspaceRoot
+                                    .resolve("skills")
+                                    .resolve(skillName)
+                                    .toAbsolutePath()
+                                    .toString());
             case NO_SHELL -> null;
         };
     }
@@ -122,21 +127,31 @@ public final class ShellPathPolicy {
     private String joinCache(String sourceNs, String skillName) {
         return switch (mode) {
             case SANDBOX ->
-                    sandboxPrefix
-                            + "/"
-                            + MarketplaceStager.CACHE_DIR
-                            + "/"
-                            + sourceNs
-                            + "/"
-                            + skillName;
+                    escapeSpaces(
+                            sandboxPrefix
+                                    + "/"
+                                    + MarketplaceStager.CACHE_DIR
+                                    + "/"
+                                    + sourceNs
+                                    + "/"
+                                    + skillName);
             case LOCAL_WITH_SHELL ->
-                    workspaceRoot
-                            .resolve(MarketplaceStager.CACHE_DIR)
-                            .resolve(sourceNs)
-                            .resolve(skillName)
-                            .toAbsolutePath()
-                            .toString();
+                    escapeSpaces(
+                            workspaceRoot
+                                    .resolve(MarketplaceStager.CACHE_DIR)
+                                    .resolve(sourceNs)
+                                    .resolve(skillName)
+                                    .toAbsolutePath()
+                                    .toString());
             case NO_SHELL -> null;
         };
+    }
+
+    /**
+     * Escapes space characters with backslash so the path can be safely used in shell commands
+     * by the LLM.
+     */
+    static String escapeSpaces(String value) {
+        return value.indexOf(' ') >= 0 ? value.replace(" ", "\\ ") : value;
     }
 }

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/skill/runtime/ShellPathPolicy.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/skill/runtime/ShellPathPolicy.java
@@ -148,8 +148,10 @@ public final class ShellPathPolicy {
     }
 
     /**
-     * Escapes space characters with backslash so the path can be safely used in shell commands
-     * by the LLM.
+     * Escapes spaces with backslash (e.g. {@code "a b" -> "a\ b"}) so the value can be embedded
+     * unquoted in POSIX shell commands without word-splitting.
+     *
+     * <p>This is not a general-purpose shell escaping routine.
      */
     static String escapeSpaces(String value) {
         return value.indexOf(' ') >= 0 ? value.replace(" ", "\\ ") : value;

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/gateway/WakeupDispatcherTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/gateway/WakeupDispatcherTest.java
@@ -115,6 +115,24 @@ class WakeupDispatcherTest {
         assertEquals("sess-pre", target.wokenSessions.get(0));
     }
 
+    @Test
+    @DisplayName("Wakeup dispatch propagates the owning user id to the target")
+    void wakeupDispatch_propagatesUserId() throws Exception {
+        target.addKnown("sess-user");
+        dispatcher.start();
+
+        messageBus.enqueueWakeup("user-42", "sess-user", "agent-main").block();
+
+        assertTrue(
+                target.awaitWakeup(1, 6, TimeUnit.SECONDS),
+                "Expected runWakeup to be called within 6s");
+        assertEquals("sess-user", target.wokenSessions.get(0));
+        assertEquals(
+                "user-42",
+                target.wokenUsers.get(0),
+                "Dispatcher must forward the userId carried by the wakeup entry");
+    }
+
     // ------------------------------------------------------------------
     //  Test double
     // ------------------------------------------------------------------
@@ -122,6 +140,7 @@ class WakeupDispatcherTest {
     private static class StubTarget implements WakeupDispatcher.WakeupTarget {
 
         final CopyOnWriteArrayList<String> wokenSessions = new CopyOnWriteArrayList<>();
+        final CopyOnWriteArrayList<String> wokenUsers = new CopyOnWriteArrayList<>();
         private final Set<String> runningSessions = ConcurrentHashMap.newKeySet();
         private final Set<String> knownSessions = ConcurrentHashMap.newKeySet();
         private volatile CountDownLatch wakeupLatch = new CountDownLatch(1);
@@ -141,10 +160,16 @@ class WakeupDispatcherTest {
 
         @Override
         public Mono<Msg> runWakeup(String sessionId) {
+            return runWakeup(null, sessionId);
+        }
+
+        @Override
+        public Mono<Msg> runWakeup(String userId, String sessionId) {
             if (!knownSessions.contains(sessionId)) {
                 return Mono.empty();
             }
             wokenSessions.add(sessionId);
+            wokenUsers.add(userId);
             wakeupLatch.countDown();
             return Mono.just(Msg.builder().role(MsgRole.ASSISTANT).textContent("woken").build());
         }

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/middleware/MemoryFlushMiddlewareTriggerTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/middleware/MemoryFlushMiddlewareTriggerTest.java
@@ -24,6 +24,9 @@ import io.agentscope.harness.agent.IsolationScope;
 import io.agentscope.harness.agent.memory.MemoryConfig;
 import io.agentscope.harness.agent.memory.MemoryFlushManager;
 import java.time.Duration;
+import java.time.Instant;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -42,6 +45,13 @@ class MemoryFlushMiddlewareTriggerTest {
             RuntimeContext.builder().userId("userA").sessionId("session1").build();
     private static final RuntimeContext RC_SESSION_2 =
             RuntimeContext.builder().userId("userA").sessionId("session2").build();
+
+    /** Clear the static shared throttle map between tests. */
+    @BeforeEach
+    void resetSharedTimerMap() {
+        MemoryFlushMiddleware.SHARED_LAST_FLUSH_AT.clear();
+        MemoryMaintenanceMiddleware.SHARED_LAST_RUN_AT.clear();
+    }
 
     /** Creates a USER-scope (default) middleware for trigger-gate tests. */
     private static MemoryFlushMiddleware make(MemoryConfig.FlushTrigger trigger) {
@@ -207,5 +217,68 @@ class MemoryFlushMiddlewareTriggerTest {
         assertEquals("userB", mw.timerKeyFor(RC_USER_B));
         assertEquals("", mw.timerKeyFor(RC_ANON), "no userId → empty key");
         assertEquals("", mw.timerKeyFor(null), "null rc → empty key");
+    }
+
+    // ── Cross-instance throttle sharing (the core bug-fix scenario) ──────────
+
+    @Test
+    void throttledMode_crossInstanceSharesOneThrottleSlot() {
+        // Simulates the real-world scenario: HarnessAgent.Builder.build() creates a new
+        // MemoryFlushMiddleware per request. With the instance-level map the bug was that each
+        // new instance started with an empty map → Instant.EPOCH → throttle always bypassed.
+        // Now the static SHARED_LAST_FLUSH_AT persists across instances so the second instance
+        // correctly sees the flush timestamp from the first instance.
+        Duration gap = Duration.ofHours(1);
+        MemoryFlushMiddleware mw1 = make(MemoryConfig.FlushTrigger.throttled(gap));
+        MemoryFlushMiddleware mw2 = make(MemoryConfig.FlushTrigger.throttled(gap));
+
+        assertTrue(mw1.shouldFlushNow(RC_USER_A), "first instance, first call wins");
+        assertFalse(
+                mw2.shouldFlushNow(RC_USER_A),
+                "second instance must respect the throttle window set by the first instance");
+    }
+
+    @Test
+    void throttledMode_crossInstance_differentUsersAreIndependent() {
+        // Cross-instance but different users must not interfere — userB should still win
+        // their own slot even though userA already flushed via a different instance.
+        Duration gap = Duration.ofHours(1);
+        MemoryFlushMiddleware mw1 = make(MemoryConfig.FlushTrigger.throttled(gap));
+        MemoryFlushMiddleware mw2 = make(MemoryConfig.FlushTrigger.throttled(gap));
+
+        assertTrue(mw1.shouldFlushNow(RC_USER_A), "mw1: userA wins");
+        assertTrue(
+                mw2.shouldFlushNow(RC_USER_B),
+                "mw2: userB must still win their own independent slot");
+        assertFalse(mw1.shouldFlushNow(RC_USER_B), "mw1: userB now throttled in their own window");
+    }
+
+    // ── Stale entry eviction ──────────────────────────────────────────────────
+
+    @Test
+    void cleanupStaleEntries_removesOldEntries() {
+        // Seed the map with a stale entry (timestamp = EPOCH, which is way older than 60min)
+        MemoryFlushMiddleware.SHARED_LAST_FLUSH_AT.put(
+                "USER:staleUser", new AtomicReference<>(Instant.EPOCH));
+        assertEquals(1, MemoryFlushMiddleware.SHARED_LAST_FLUSH_AT.size());
+
+        MemoryFlushMiddleware.cleanupStaleEntries();
+
+        assertTrue(
+                MemoryFlushMiddleware.SHARED_LAST_FLUSH_AT.isEmpty(),
+                "stale entry (EPOCH timestamp) should be removed");
+    }
+
+    @Test
+    void cleanupStaleEntries_preservesRecentEntries() {
+        // Seed with a recent entry (timestamp = now)
+        MemoryFlushMiddleware.SHARED_LAST_FLUSH_AT.put(
+                "USER:recentUser", new AtomicReference<>(Instant.now()));
+
+        MemoryFlushMiddleware.cleanupStaleEntries();
+
+        assertTrue(
+                MemoryFlushMiddleware.SHARED_LAST_FLUSH_AT.containsKey("USER:recentUser"),
+                "recent entry should survive cleanup");
     }
 }

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/middleware/MemoryMaintenanceMiddlewareStaleEntryTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/middleware/MemoryMaintenanceMiddlewareStaleEntryTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.harness.agent.middleware;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.Instant;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/** Unit tests for {@link MemoryMaintenanceMiddleware#cleanupStaleEntries()}. */
+class MemoryMaintenanceMiddlewareStaleEntryTest {
+
+    @BeforeEach
+    void resetSharedMap() {
+        MemoryMaintenanceMiddleware.SHARED_LAST_RUN_AT.clear();
+    }
+
+    @Test
+    void cleanupStaleEntries_removesOldEntries() {
+        MemoryMaintenanceMiddleware.SHARED_LAST_RUN_AT.put(
+                "USER:staleUser", new AtomicReference<>(Instant.EPOCH));
+
+        MemoryMaintenanceMiddleware.cleanupStaleEntries();
+
+        assertTrue(
+                MemoryMaintenanceMiddleware.SHARED_LAST_RUN_AT.isEmpty(),
+                "stale entry (EPOCH timestamp) should be removed");
+    }
+
+    @Test
+    void cleanupStaleEntries_preservesRecentEntries() {
+        MemoryMaintenanceMiddleware.SHARED_LAST_RUN_AT.put(
+                "USER:recentUser", new AtomicReference<>(Instant.now()));
+
+        MemoryMaintenanceMiddleware.cleanupStaleEntries();
+
+        assertTrue(
+                MemoryMaintenanceMiddleware.SHARED_LAST_RUN_AT.containsKey("USER:recentUser"),
+                "recent entry should survive cleanup");
+    }
+
+    @Test
+    void cleanupStaleEntries_onlyRemovesStaleEntries() {
+        MemoryMaintenanceMiddleware.SHARED_LAST_RUN_AT.put(
+                "USER:staleUser", new AtomicReference<>(Instant.EPOCH));
+        MemoryMaintenanceMiddleware.SHARED_LAST_RUN_AT.put(
+                "USER:recentUser", new AtomicReference<>(Instant.now()));
+
+        MemoryMaintenanceMiddleware.cleanupStaleEntries();
+
+        assertFalse(
+                MemoryMaintenanceMiddleware.SHARED_LAST_RUN_AT.containsKey("USER:staleUser"),
+                "stale entry should be removed");
+        assertTrue(
+                MemoryMaintenanceMiddleware.SHARED_LAST_RUN_AT.containsKey("USER:recentUser"),
+                "recent entry should survive cleanup");
+    }
+}

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/skill/runtime/SkillRuntimeTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/skill/runtime/SkillRuntimeTest.java
@@ -30,6 +30,8 @@ import io.agentscope.core.skill.SkillFilter;
 import io.agentscope.core.tool.ToolCallParam;
 import io.agentscope.core.tool.Toolkit;
 import io.agentscope.harness.agent.skill.SkillResources;
+import io.agentscope.harness.agent.skill.runtime.MarketplaceStager.StageResult;
+import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -75,6 +77,59 @@ class SkillRuntimeTest {
     }
 
     // =========================================================================
+    //  ShellPathPolicy
+    // =========================================================================
+
+    @Nested
+    class ShellPathPolicyTests {
+
+        @Test
+        void escapeSpacesReplacesWithBackslashSpace() {
+            assertEquals("hello", ShellPathPolicy.escapeSpaces("hello"));
+            assertEquals("hello\\ world", ShellPathPolicy.escapeSpaces("hello world"));
+            assertEquals("V2Ray\\ 代理配置助手", ShellPathPolicy.escapeSpaces("V2Ray 代理配置助手"));
+            assertEquals("a\\ b\\ c", ShellPathPolicy.escapeSpaces("a b c"));
+        }
+
+        @Test
+        void sandboxResolveEscapesSpacesInSkillName() {
+            ShellPathPolicy policy = ShellPathPolicy.sandbox();
+            String result = policy.resolve("V2Ray 代理配置助手", new StageResult.WorkspaceNative());
+            assertEquals("/workspace/skills/V2Ray\\ 代理配置助手", result);
+        }
+
+        @Test
+        void sandboxResolveEscapesSpacesInCachedSkill() {
+            ShellPathPolicy policy = ShellPathPolicy.sandbox();
+            String result = policy.resolve("ignored", new StageResult.Cached("ns", "my skill"));
+            assertEquals("/workspace/.skills-cache/ns/my\\ skill", result);
+        }
+
+        @Test
+        void localWithShellResolveEscapesSpaces() {
+            ShellPathPolicy policy = ShellPathPolicy.localWithShell(Paths.get("/tmp/my workspace"));
+            String result = policy.resolve("my skill", new StageResult.WorkspaceNative());
+            assertEquals("/tmp/my\\ workspace/skills/my\\ skill", result);
+        }
+
+        @Test
+        void noShellAlwaysReturnsNull() {
+            ShellPathPolicy policy = ShellPathPolicy.noShell();
+            assertNull(policy.resolve("any name", new StageResult.WorkspaceNative()));
+            assertNull(policy.resolve("any name", new StageResult.Cached("ns", "name")));
+            assertNull(policy.resolve("any name", StageResult.NONE));
+            assertNull(policy.resolve("any name", null));
+        }
+
+        @Test
+        void nullStageOrNoneReturnsNull() {
+            ShellPathPolicy policy = ShellPathPolicy.sandbox();
+            assertNull(policy.resolve("alpha", null));
+            assertNull(policy.resolve("alpha", StageResult.NONE));
+        }
+    }
+
+    // =========================================================================
     //  SkillPromptBuilder
     // =========================================================================
 
@@ -107,6 +162,17 @@ class SkillRuntimeTest {
             assertTrue(out.contains("<files-root>/workspace/skills/alpha</files-root>"));
             assertTrue(out.contains("## Code Execution"));
             assertTrue(out.contains("<files-root>"));
+        }
+
+        @Test
+        void rendersEscapedFilesRootWhenPathContainsSpaces() {
+            HarnessSkillEntry e =
+                    new HarnessSkillEntry(
+                            skill("V2Ray 代理配置助手", "wkspace"),
+                            null,
+                            "/workspace/skills/V2Ray\\ 代理配置助手");
+            String out = new SkillPromptBuilder().render(SkillCatalog.of(List.of(e)));
+            assertTrue(out.contains("<files-root>/workspace/skills/V2Ray\\ 代理配置助手</files-root>"));
         }
 
         @Test

--- a/docs/v2/en/docs/building-blocks/agent.md
+++ b/docs/v2/en/docs/building-blocks/agent.md
@@ -131,7 +131,7 @@ ReActAgent agent =
 ::::
 
 :::{tip}
-The `ModelRegistry` string form (`<provider>:<model>`) supports `dashscope` / `openai` / `anthropic` / `gemini` / `ollama` and reads the matching API key (`DASHSCOPE_API_KEY` / `OPENAI_API_KEY` / `ANTHROPIC_API_KEY` / `GEMINI_API_KEY`) from the environment. For long-running scenarios that also need a workspace, session persistence, memory compaction, subagents, and so on, use [`HarnessAgent`](../harness/architecture.md) — it is a thin wrapper around `ReActAgent` with a largely identical builder.
+The `ModelRegistry` string form (`<provider>:<model>`) requires the matching model extension module on the classpath. It supports `dashscope` / `openai` / `anthropic` / `gemini` / `ollama` and reads the matching API key (`DASHSCOPE_API_KEY` / `OPENAI_API_KEY` / `ANTHROPIC_API_KEY` / `GEMINI_API_KEY`) from the environment. For long-running scenarios that also need a workspace, session persistence, memory compaction, subagents, and so on, use [`HarnessAgent`](../harness/architecture.md) — it is a thin wrapper around `ReActAgent` with a largely identical builder.
 :::
 
 ### Builder fields

--- a/docs/v2/en/docs/building-blocks/message-and-event.md
+++ b/docs/v2/en/docs/building-blocks/message-and-event.md
@@ -128,7 +128,7 @@ Events are the streaming counterpart of messages. While the agent runs, it emits
 
 ### Event lifecycle
 
-Every event carries `getReplyId()`, tying it to the message being assembled. Within a reply, `getBlockId()` or `getToolCallId()` identifies the content block the event belongs to. Events follow a **start → delta → end** pattern:
+Every event carries `getReplyId()`, tying it to the message being assembled. Within a reply, `getBlockId()` or `getToolCallId()` acts as a correlation key for events that belong to the same content-block lifecycle. Events follow a **start → delta → end** pattern:
 
 ```{mermaid}
 sequenceDiagram
@@ -175,7 +175,7 @@ sequenceDiagram
     Agent->>Client: AgentEndEvent
 ```
 
-All events in one reply share the same `replyId`. Within a reply, `blockId` ties text/thinking/data block events together; `toolCallId` ties tool calls and tool results.
+All events in one reply share the same `replyId`. Within a reply, `blockId` ties text/thinking/data block events together; `toolCallId` ties tool calls and tool results. A `blockId` is scoped to its `replyId` and does not have to be a globally unique generated ID. When a block type can have at most one lifecycle within a reply, an implementation may use a stable type key, such as a fixed key for the text block.
 
 ### Event types
 
@@ -221,14 +221,14 @@ Events are grouped below; unless noted otherwise, every event also carries `getR
     | Method | Type | Description |
     |--------|------|-------------|
     | `getReplyId()` | `String` | Reply message ID |
-    | `getBlockId()` | `String` | Unique text block ID |
+    | `getBlockId()` | `String` | Text-block correlation key within the current reply |
 
     **TextBlockDeltaEvent** — incremental text content arrives.
 
     | Method | Type | Description |
     |--------|------|-------------|
     | `getReplyId()` | `String` | Reply message ID |
-    | `getBlockId()` | `String` | Unique text block ID |
+    | `getBlockId()` | `String` | Text-block correlation key within the current reply |
     | `getDelta()` | `String` | Incremental text content |
 
     **TextBlockEndEvent** — text block completes.
@@ -236,11 +236,11 @@ Events are grouped below; unless noted otherwise, every event also carries `getR
     | Method | Type | Description |
     |--------|------|-------------|
     | `getReplyId()` | `String` | Reply message ID |
-    | `getBlockId()` | `String` | Unique text block ID |
+    | `getBlockId()` | `String` | Text-block correlation key within the current reply |
 :::
 
   :::{dropdown} Thinking streaming events
-**ThinkingBlockStartEvent / ThinkingBlockDeltaEvent / ThinkingBlockEndEvent** — same shape as the text streaming events; specific to the model's chain of thought.
+**ThinkingBlockStartEvent / ThinkingBlockDeltaEvent / ThinkingBlockEndEvent** — same shape as the text streaming events; specific to the model's chain of thought. Its `blockId` has the same reply-scoped correlation-key semantics.
 :::
 
   :::{dropdown} Data streaming events

--- a/docs/v2/en/docs/building-blocks/model.md
+++ b/docs/v2/en/docs/building-blocks/model.md
@@ -5,7 +5,9 @@ description: "Configure and connect LLM model providers in AgentScope Java"
 
 ## Overview
 
-The model layer is two-tiered: at the top sit **Credentials** (`io.agentscope.core.credential`), which carry a provider's API auth fields; below them sit **Chat Models**, the concrete inference implementations attached to a credential.
+The model layer separates shared contracts from provider implementations. `agentscope-core` keeps the common APIs (`Model`, `ChatModelBase`, `Formatter`, `ModelRegistry`, and the `ModelProvider` SPI). OpenAI, DashScope, Gemini, Anthropic, and Ollama implementations live in their own model extension modules.
+
+At runtime, the model layer is two-tiered: at the top sit **Credentials** (based on `io.agentscope.core.credential`), which carry a provider's API auth fields; below them sit **Chat Models**, the concrete inference implementations attached to a credential.
 
 ```text
 CredentialBase/
@@ -21,9 +23,64 @@ A **Credential** carries a provider's API auth fields (`apiKey`, `baseUrl`, …)
 
 This layering matches the natural UX in a frontend — register the credential first, then pick a model under it — so the UI authenticates once and shows everything that provider supports.
 
-## Provider module migration
+## Choose a creation path
 
-Provider-specific model implementations have been moved out of `agentscope-core` into independent extension modules. The core module now keeps the shared model contracts and runtime utilities, while each provider module owns its chat model, credential, formatter, DTO, exception, and SDK/API client code.
+### String model id
+
+For simple non-Spring applications, use a `ModelRegistry` string id such as `dashscope:qwen-plus` or `openai:gpt-4.1-mini`. Add the matching model extension module, set the provider's `API_KEY` in the environment variable, and pass the id directly to the agent:
+
+```java
+ReActAgent agent =
+        ReActAgent.builder()
+                .name("assistant")
+                .model("dashscope:qwen-plus") // resolved internally by ModelRegistry.resolve(modelId)
+                .build();
+```
+
+The extension module is discovered through Java SPI. The model provider reads its standard environment variables such as `DASHSCOPE_API_KEY`, `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, or `GEMINI_API_KEY`. Ollama reads `OLLAMA_BASE_URL` when present and otherwise defaults to the local Ollama endpoint.
+
+### Explicit model builder
+
+When you need a custom API key, base URL, formatter, transport, timeout, generation options, or other provider-specific configuration, build the model explicitly and pass the `Model` instance to the agent:
+
+```java
+import io.agentscope.extensions.model.dashscope.DashScopeChatModel;
+import io.agentscope.extensions.model.dashscope.formatter.DashScopeChatFormatter;
+
+DashScopeChatModel model =
+        DashScopeChatModel.builder()
+                .apiKey(System.getenv("DASHSCOPE_API_KEY"))
+                .modelName("qwen-plus")
+                .stream(true)
+                .formatter(new DashScopeChatFormatter())
+                .build();
+
+ReActAgent agent =
+        ReActAgent.builder()
+                .name("assistant")
+                .model(model)
+                .build();
+```
+
+### Spring Boot applications
+
+For Spring Boot, prefer provider-specific starters such as `agentscope-openai-spring-boot-starter`, `agentscope-dashscope-spring-boot-starter`, `agentscope-gemini-spring-boot-starter`, and `agentscope-anthropic-spring-boot-starter`. These starters directly depend on the matching model extension, create Spring-managed `Model` beans, and leave the generic starter focused on common AgentScope infrastructure. They do not create models through the static `ModelRegistry`; advanced users can always provide their own `Model` bean.
+
+OpenAI example:
+
+```yaml
+agentscope:
+  model:
+    provider: openai
+  openai:
+    api-key: ${OPENAI_API_KEY}
+    model-name: gpt-4.1-mini
+    stream: true
+```
+
+## Model extension modules
+
+Provider-specific model implementations have been moved out of `agentscope-core` into independent extension modules. Each provider module owns its chat model, credential, formatter, DTO, exception, and SDK/API client, etc.
 
 | Provider | Maven artifact | Main package |
 |----------|----------------|--------------|
@@ -53,52 +110,59 @@ Other provider artifacts follow the same pattern: `agentscope-extensions-model-o
 ```xml
 <dependency>
     <groupId>io.agentscope</groupId>
-    <artifactId>agentscope-openai-spring-boot-starter</artifactId>
+    <artifactId>agentscope-dashscope-spring-boot-starter</artifactId>
 </dependency>
 ```
 
-### Non-Spring applications
+## ModelRegistry and ModelCreationContext
 
-When using provider classes directly, add the corresponding extension dependency and update imports. For example:
+`ModelRegistry` is a global registry for model instance creation and lookup, supporting multiple resolution strategies. During resolution, it tries in priority order: named model instances directly registered via `ModelRegistry.register(name, model)`, custom factories registered via `registerFactory(regex, factory)`, and `ModelProvider` implementations automatically discovered from extension modules through the Java SPI mechanism.
+
+For simple scenarios, prefer a string id in the `provider:model` format together with the `API_KEY` environment variable; for fine-grained control, use explicit model builders and `ModelCreationContext` for configuration.
+
+### Advanced integration context
+
+`ModelCreationContext` is for integration layers that must create models dynamically without importing a concrete provider builder, such as multi-tenant gateways, plugin systems, or framework adapters. It can pass common values such as API key, base URL, endpoint path, stream mode, and extension-defined options/components to the SPI provider:
 
 ```java
-import io.agentscope.extensions.model.dashscope.DashScopeChatModel;
-import io.agentscope.extensions.model.dashscope.formatter.DashScopeChatFormatter;
-```
+import io.agentscope.core.model.GenerateOptions;
+import io.agentscope.core.model.Model;
+import io.agentscope.core.model.ModelCreationContext;
+import io.agentscope.core.model.ModelRegistry;
 
-Then create the model with the provider builder and pass the `Model` instance to the agent:
-
-```java
-DashScopeChatModel model =
-        DashScopeChatModel.builder()
-                .apiKey(System.getenv("DASHSCOPE_API_KEY"))
-                .modelName("qwen-plus")
-                .stream(true)
-                .formatter(new DashScopeChatFormatter())
+ModelCreationContext context =
+        ModelCreationContext.builder()
+                .apiKey(tenantApiKey)
+                .baseUrl(tenantBaseUrl)
+                .stream(false)
+                // Extension-defined scalar options, keyed by names the provider documents.
+                .option("contextWindowSize", 128000)
+                // Type-keyed components for richer provider settings, transports, or formatters.
+                .component(
+                        GenerateOptions.class,
+                        GenerateOptions.builder()
+                                .parallelToolCalls(false)
+                                .build())
                 .build();
 
-ReActAgent agent =
-        ReActAgent.builder()
-                .name("assistant")
-                .model(model)
-                .build();
+Model model = ModelRegistry.resolve("openai:gpt-4.1-mini", context);
 ```
 
-### Spring Boot applications
+### Cache policy
 
-For Spring Boot, prefer provider-specific starters such as `agentscope-openai-spring-boot-starter`, `agentscope-dashscope-spring-boot-starter`, `agentscope-gemini-spring-boot-starter`, and `agentscope-anthropic-spring-boot-starter`. These starters directly depend on the matching model extension, create Spring-managed `Model` beans, and leave the generic starter focused on common AgentScope infrastructure.
+`ModelRegistry` caches models resolved from simple `provider:model` strings. Context-aware creation is not cached by default to avoid reusing a model instance with a different tenant's API key, base URL, or stream setting.
 
-OpenAI example:
+| Policy | Behavior |
+|--------|----------|
+| `DEFAULT` | `resolve(String)` keeps legacy model-id caching. `resolve(String, nonEmptyContext)` is not cached. |
+| `DISABLED` | Never cache; every resolution creates a new model instance. |
+| `ENABLED` | Cache only when the caller explicitly opts in. Use `cacheId(...)` for tenant- or configuration-specific identity. |
 
-```yaml
-agentscope:
-  model:
-    provider: openai
-  openai:
-    api-key: ${OPENAI_API_KEY}
-    model-name: gpt-4.1-mini
-    stream: true
-```
+If `CachePolicy.ENABLED` is used with `option(...)` or `component(...)`, the user must provide a `cacheId`.
+
+### ModelProvider SPI
+
+Provider extension modules are discovered with Java SPI through `META-INF/services/io.agentscope.core.model.spi.ModelProvider`. A provider can implement `supports(String, ModelCreationContext)` and `create(String, ModelCreationContext)` to consume context values. Simple providers can keep implementing the original `supports(String)` and `create(String)` methods because the context-aware methods have compatible defaults.
 
 ## Chat model
 
@@ -112,7 +176,7 @@ A **Chat Model** is the LLM driving conversation and tool calling, with input an
 | Gemini | `GeminiChatModel` | Google Gemini; multi-modal |
 | Ollama | `OllamaChatModel` | Locally hosted LLMs; credential optional |
 
-Credential classes: `OpenAICredential`, `AnthropicCredential`, `DashScopeCredential`, `GeminiCredential`, `OllamaCredential`, `DeepSeekCredential`, `KimiCredential`, `XAICredential`.
+Provider credential classes live with their model extension modules, for example `OpenAICredential`, `AnthropicCredential`, `DashScopeCredential`, `GeminiCredential`, and `OllamaCredential`. OpenAI-compatible credentials such as `DeepSeekCredential`, `KimiCredential`, and `XAICredential` remain available from core.
 
 ### Creating a chat model
 
@@ -442,8 +506,8 @@ The `ModelCard` schema is intentionally minimal at this stage; capability flags 
 Call `CredentialBase#listModels()`, returning `Mono<List<ModelCard>>`:
 
 ```java
-import io.agentscope.core.credential.AnthropicCredential;
 import io.agentscope.core.credential.ModelCard;
+import io.agentscope.extensions.model.anthropic.credential.AnthropicCredential;
 import java.util.List;
 
 AnthropicCredential cred = new AnthropicCredential(System.getenv("ANTHROPIC_API_KEY"));

--- a/docs/v2/zh/docs/building-blocks/agent.md
+++ b/docs/v2/zh/docs/building-blocks/agent.md
@@ -131,7 +131,7 @@ ReActAgent agent =
 ::::
 
 :::{tip}
-`ModelRegistry` 的字符串形式（`<provider>:<model>`）支持 `dashscope` / `openai` / `anthropic` / `gemini` / `ollama`，会自动从环境变量读取 API key（`DASHSCOPE_API_KEY` / `OPENAI_API_KEY` / `ANTHROPIC_API_KEY` / `GEMINI_API_KEY`）。需要在长期运行场景下同时获得工作区、会话持久化、记忆压缩、子 agent 等能力，请改用 [`HarnessAgent`](../harness/architecture.md) —— 它对 `ReActAgent` 做了一层薄包装，builder 接口大体一致。
+`ModelRegistry` 的字符串形式（`<provider>:<model>`）需要对应的模型扩展模块在 classpath 中。它支持 `dashscope` / `openai` / `anthropic` / `gemini` / `ollama`，会自动从环境变量读取 API key（`DASHSCOPE_API_KEY` / `OPENAI_API_KEY` / `ANTHROPIC_API_KEY` / `GEMINI_API_KEY`）。需要在长期运行场景下同时获得工作区、会话持久化、记忆压缩、子 agent 等能力，请改用 [`HarnessAgent`](../harness/architecture.md) —— 它对 `ReActAgent` 做了一层薄包装，builder 接口大体一致。
 :::
 
 ### 参数说明

--- a/docs/v2/zh/docs/building-blocks/message-and-event.md
+++ b/docs/v2/zh/docs/building-blocks/message-and-event.md
@@ -128,7 +128,7 @@ if (msg.hasContentBlocks(ToolResultBlock.class)) {
 
 ### 事件生命周期
 
-每个事件都携带 `getReplyId()`，将其关联到正在构建的消息。在一次回复中，`getBlockId()` 或 `getToolCallId()` 标识事件所属的内容块。事件遵循 **start → delta → end** 模式：
+每个事件都携带 `getReplyId()`，将其关联到正在构建的消息。在一次回复中，`getBlockId()` 或 `getToolCallId()` 用作事件关联键，表示事件属于同一个内容块生命周期。事件遵循 **start → delta → end** 模式：
 
 ```{mermaid}
 sequenceDiagram
@@ -175,7 +175,7 @@ sequenceDiagram
     Agent->>Client: AgentEndEvent
 ```
 
-同一次回复中的所有事件共享相同的 `replyId`。在回复内部，用 `blockId` 关联文本/思考/数据块事件，用 `toolCallId` 关联工具调用和工具结果事件。
+同一次回复中的所有事件共享相同的 `replyId`。在回复内部，用 `blockId` 关联文本/思考/数据块事件，用 `toolCallId` 关联工具调用和工具结果事件。`blockId` 是 `replyId` 作用域内的关联键，不要求是全局唯一的随机 ID；当某类内容块在一次回复中最多出现一个生命周期时，实现可以使用稳定的类型标识（如文本块的固定标识）作为 `blockId`。
 
 ### 事件类型
 
@@ -221,14 +221,14 @@ sequenceDiagram
     | 方法 | 类型 | 说明 |
     |------|------|------|
     | `getReplyId()` | `String` | 回复消息 ID |
-    | `getBlockId()` | `String` | 文本块唯一标识符 |
+    | `getBlockId()` | `String` | 文本块在当前回复中的关联键 |
 
     **TextBlockDeltaEvent** — 增量文本内容到达。
 
     | 方法 | 类型 | 说明 |
     |------|------|------|
     | `getReplyId()` | `String` | 回复消息 ID |
-    | `getBlockId()` | `String` | 文本块唯一标识符 |
+    | `getBlockId()` | `String` | 文本块在当前回复中的关联键 |
     | `getDelta()` | `String` | 增量文本内容 |
 
     **TextBlockEndEvent** — 文本块完成。
@@ -236,11 +236,11 @@ sequenceDiagram
     | 方法 | 类型 | 说明 |
     |------|------|------|
     | `getReplyId()` | `String` | 回复消息 ID |
-    | `getBlockId()` | `String` | 文本块唯一标识符 |
+    | `getBlockId()` | `String` | 文本块在当前回复中的关联键 |
 :::
 
   :::{dropdown} 思考流式事件
-**ThinkingBlockStartEvent / ThinkingBlockDeltaEvent / ThinkingBlockEndEvent** —— 与文本流式事件结构对应，仅用于模型的思维链内容。
+**ThinkingBlockStartEvent / ThinkingBlockDeltaEvent / ThinkingBlockEndEvent** —— 与文本流式事件结构对应，仅用于模型的思维链内容；`blockId` 同样表示当前回复中的关联键。
 :::
 
   :::{dropdown} 数据流式事件

--- a/docs/v2/zh/docs/building-blocks/model.md
+++ b/docs/v2/zh/docs/building-blocks/model.md
@@ -5,7 +5,9 @@ description: "在 AgentScope Java 中配置并连接 LLM 模型提供商"
 
 ## 概述
 
-模型层采用两层结构：上层是 **Credential**（`io.agentscope.core.credential`），承载某个提供商的 API 鉴权字段；下层是 **Chat Model**，即在该凭证基础上对接的具体推理模型实现。
+模型层把共享契约和具体模型提供商实现分开。`agentscope-core` 只保留通用 API（`Model`、`ChatModelBase`、`Formatter`、`ModelRegistry` 和 `ModelProvider` SPI）；OpenAI、DashScope、Gemini、Anthropic、Ollama 的具体实现分别位于各自的模型扩展模块中。
+
+运行时模型层采用两层结构：上层是 **Credential**（基于 `io.agentscope.core.credential` 中的通用基类），承载某个提供商的 API 鉴权字段；下层是 **Chat Model**，即在该凭证基础上对接的具体推理模型实现。
 
 ```text
 CredentialBase/
@@ -21,54 +23,30 @@ CredentialBase/
 
 这种分层与前端的自然交互流程一致 —— 先注册凭证，再从凭证下挑选模型 —— 让界面只需鉴权一次，就能展示该提供商支持的所有模型。
 
-## Provider 模块迁移
+## 选择模型创建方式
 
-Provider-specific 的模型实现已经从 `agentscope-core` 迁移到独立 extension module 中。core 现在只保留共享模型契约与运行时工具；每个 provider module 自己维护 chat model、credential、formatter、DTO、异常、SDK/API client 代码。
+### 字符串 model id
 
-| Provider | Maven artifact | 主要包名 |
-|----------|----------------|----------|
-| OpenAI | `agentscope-extensions-model-openai` | `io.agentscope.extensions.model.openai` |
-| DashScope | `agentscope-extensions-model-dashscope` | `io.agentscope.extensions.model.dashscope` |
-| Gemini | `agentscope-extensions-model-gemini` | `io.agentscope.extensions.model.gemini` |
-| Anthropic | `agentscope-extensions-model-anthropic` | `io.agentscope.extensions.model.anthropic` |
-| Ollama | `agentscope-extensions-model-ollama` | `io.agentscope.extensions.model.ollama` |
+简单的非 Spring 应用可以使用 `dashscope:qwen-plus`、`openai:gpt-4.1-mini` 这样的字符串 id。引入对应模型扩展模块，在环境变量中设置提供商的 `API_KEY`，然后直接把 id 传给 agent：
 
-### 迁移步骤
-
-1. 增加对应 provider extension module 依赖。以 DashScope 为例：
-
-```xml
-<dependency>
-    <groupId>io.agentscope</groupId>
-    <artifactId>agentscope-extensions-model-dashscope</artifactId>
-</dependency>
+```java
+ReActAgent agent =
+        ReActAgent.builder()
+                .name("assistant")
+                .model("dashscope:qwen-plus") // 底层由 ModelRegistry.resolve(modelId) 解析
+                .build();
 ```
 
-其他 provider artifact 遵循同样模式：`agentscope-extensions-model-openai`、`agentscope-extensions-model-gemini`、`agentscope-extensions-model-anthropic`、`agentscope-extensions-model-ollama`。
+扩展模块会通过 Java SPI 被自动发现。模型提供商会读取自己的标准环境变量，例如 `DASHSCOPE_API_KEY`、`OPENAI_API_KEY`、`ANTHROPIC_API_KEY`、`GEMINI_API_KEY`。Ollama 会在存在时读取 `OLLAMA_BASE_URL`，否则默认使用本地 Ollama endpoint。
 
-2. 将 provider 模型 import 从 `io.agentscope.core.model.*` 改为 `io.agentscope.extensions.model.<provider>.*`。
-3. 将 provider formatter import 从 `io.agentscope.core.formatter.<provider>.*` 改为 `io.agentscope.extensions.model.<provider>.formatter.*`。
-4. Spring Boot 应用中，改用对应 provider-specific starter 和 `agentscope.<provider>.*` 配置：
+### 显式 Model builder
 
-```xml
-<dependency>
-    <groupId>io.agentscope</groupId>
-    <artifactId>agentscope-openai-spring-boot-starter</artifactId>
-</dependency>
-```
-
-### 非 Spring 应用
-
-直接使用 provider 类时，需要引入对应 extension 依赖，并更新 import。例如：
+需要自定义 API key、base URL、formatter、transport、timeout、生成参数或其他提供商专属配置时，推荐显式构造模型，再把 `Model` 实例传给 agent：
 
 ```java
 import io.agentscope.extensions.model.dashscope.DashScopeChatModel;
 import io.agentscope.extensions.model.dashscope.formatter.DashScopeChatFormatter;
-```
 
-然后通过 provider builder 创建模型，并把 `Model` 实例传给 agent：
-
-```java
 DashScopeChatModel model =
         DashScopeChatModel.builder()
                 .apiKey(System.getenv("DASHSCOPE_API_KEY"))
@@ -86,7 +64,7 @@ ReActAgent agent =
 
 ### Spring Boot 应用
 
-Spring Boot 场景下，优先使用 provider-specific starter，例如 `agentscope-openai-spring-boot-starter`、`agentscope-dashscope-spring-boot-starter`、`agentscope-gemini-spring-boot-starter`、`agentscope-anthropic-spring-boot-starter`。这些 starter 直接依赖对应 model extension，创建 Spring 管理的 `Model` bean，通用的 `agentscope-spring-boot-starter` 继续负责 AgentScope 的公共基础设施。
+Spring Boot 场景下，优先使用特定模型提供商的 starter，例如 `agentscope-openai-spring-boot-starter`、`agentscope-dashscope-spring-boot-starter`、`agentscope-gemini-spring-boot-starter`、`agentscope-anthropic-spring-boot-starter`。这些 starter 直接依赖对应模型扩展模块，创建 Spring 管理的 `Model` bean，通用的 `agentscope-spring-boot-starter` 继续负责 AgentScope 的公共基础设施。它们不会通过静态 `ModelRegistry` 创建模型；高级用户始终可以自定义 `Model` bean。
 
 OpenAI 示例：
 
@@ -100,6 +78,92 @@ agentscope:
     stream: true
 ```
 
+## 模型扩展模块
+
+特定模型提供商的实现已经从 `agentscope-core` 迁移到独立扩展模块中。每个模型适配模块自己维护 chat model、credential、formatter、DTO、异常、SDK/API client 等。
+
+| 提供商 | Maven artifact | 主要包名 |
+|--------|----------------|----------|
+| OpenAI | `agentscope-extensions-model-openai` | `io.agentscope.extensions.model.openai` |
+| DashScope | `agentscope-extensions-model-dashscope` | `io.agentscope.extensions.model.dashscope` |
+| Gemini | `agentscope-extensions-model-gemini` | `io.agentscope.extensions.model.gemini` |
+| Anthropic | `agentscope-extensions-model-anthropic` | `io.agentscope.extensions.model.anthropic` |
+| Ollama | `agentscope-extensions-model-ollama` | `io.agentscope.extensions.model.ollama` |
+
+### 迁移步骤
+
+1. 增加对应模型提供商扩展模块依赖。以 DashScope 为例：
+
+```xml
+<dependency>
+    <groupId>io.agentscope</groupId>
+    <artifactId>agentscope-extensions-model-dashscope</artifactId>
+</dependency>
+```
+
+其他模型扩展 artifact 遵循同样模式：`agentscope-extensions-model-openai`、`agentscope-extensions-model-gemini`、`agentscope-extensions-model-anthropic`、`agentscope-extensions-model-ollama`。
+
+2. 将模型提供商实现的 import 从 `io.agentscope.core.model.*` 改为 `io.agentscope.extensions.model.<provider>.*`。
+3. 将模型提供商 formatter import 从 `io.agentscope.core.formatter.<provider>.*` 改为 `io.agentscope.extensions.model.<provider>.formatter.*`。
+4. Spring Boot 应用中，改用对应提供商 starter 和 `agentscope.<provider>.*` 配置：
+
+```xml
+<dependency>
+    <groupId>io.agentscope</groupId>
+    <artifactId>agentscope-dashscope-spring-boot-starter</artifactId>
+</dependency>
+```
+
+## ModelRegistry 与 ModelCreationContext
+
+`ModelRegistry` 是一个用于模型实例创建与查找的全局注册中心，支持多种解析策略。解析时按优先级依次尝试：通过 `ModelRegistry.register(name, model)` 直接注册的命名模型实例、通过 `registerFactory(regex, factory)` 注册的自定义工厂，以及通过 Java SPI 机制自动发现的扩展模块提供的 `ModelProvider` 实现。
+
+简单场景推荐使用 `provider:model` 格式的 id 和环境变量中的 `API_KEY`；需要精细控制时，则使用显式的模型 Builder 及 `ModelCreationContext` 进行配置。
+
+### 高级集成上下文
+
+`ModelCreationContext` 面向需要动态创建模型、但不方便直接依赖具体提供商 builder 的集成层代码，例如多租户网关、插件系统或框架适配层。它可以把 API key、base URL、endpoint path、stream 模式，以及扩展模块定义的 options/components 传给 SPI 提供商实现：
+
+```java
+import io.agentscope.core.model.GenerateOptions;
+import io.agentscope.core.model.Model;
+import io.agentscope.core.model.ModelCreationContext;
+import io.agentscope.core.model.ModelRegistry;
+
+ModelCreationContext context =
+        ModelCreationContext.builder()
+                .apiKey(tenantApiKey)
+                .baseUrl(tenantBaseUrl)
+                .stream(false)
+                // 扩展模块定义的标量配置，key 由具体模型提供商文档约定。
+                .option("contextWindowSize", 128000)
+                // 以类型为 key 的组件对象，用于传入更复杂的提供商配置、transport 或 formatter。
+                .component(
+                        GenerateOptions.class,
+                        GenerateOptions.builder()
+                                .parallelToolCalls(false)
+                                .build())
+                .build();
+
+Model model = ModelRegistry.resolve("openai:gpt-4.1-mini", context);
+```
+
+### 缓存策略
+
+`ModelRegistry` 会缓存简单`provider:model`解析出的模型。带 context（`ModelCreationContext`）解析出的模型默认不缓存，避免不同租户的 API key、base URL 或 stream 配置复用到同一个模型实例。
+
+| 策略 | 行为 |
+|------|------|
+| `DEFAULT` | `resolve(String)` 保持按 model id 缓存的旧行为；`resolve(String, nonEmptyContext)` 默认不缓存。 |
+| `DISABLED` | 永不缓存，每次解析都会创建新的模型实例。 |
+| `ENABLED` | 显式开启缓存。建议用 `cacheId(...)` 表达租户或配置维度的身份。 |
+
+如果 `CachePolicy.ENABLED` 搭配 `option(...)` 或 `component(...)` 使用，用户必须提供 `cacheId`。
+
+### ModelProvider SPI
+
+模型提供商扩展模块通过 Java SPI 暴露 `META-INF/services/io.agentscope.core.model.spi.ModelProvider`，由 `ModelRegistry` 自动发现。新的模型提供商可以实现 `supports(String, ModelCreationContext)` 和 `create(String, ModelCreationContext)` 来消费 context。简单模型提供商仍可只实现原有的 `supports(String)` 和 `create(String)`，因为 context-aware 方法提供了兼容默认实现。
+
 ## Chat Model
 
 **Chat Model** 是驱动 agent 对话与工具调用的 LLM，输入输出可以是文本之外的多模态内容。AgentScope Java 当前提供以下 Chat Model 类：
@@ -112,7 +176,7 @@ agentscope:
 | Gemini | `GeminiChatModel` | Google Gemini 模型，支持多模态 |
 | Ollama | `OllamaChatModel` | 本地 LLM 托管，凭证可选 |
 
-凭证类：`OpenAICredential`、`AnthropicCredential`、`DashScopeCredential`、`GeminiCredential`、`OllamaCredential`、`DeepSeekCredential`、`KimiCredential`、`XAICredential`。
+模型提供商凭证类随对应模型扩展模块提供，例如 `OpenAICredential`、`AnthropicCredential`、`DashScopeCredential`、`GeminiCredential`、`OllamaCredential`。OpenAI 兼容提供商的 `DeepSeekCredential`、`KimiCredential`、`XAICredential` 仍在 core 模块中可用。
 
 ### 创建 Chat Model
 
@@ -178,7 +242,7 @@ DashScopeChatModel model =
 
 | 字段 | 类型 | 说明 |
 |------|------|------|
-| `apiKey` | `String` | API key（部分 provider 也支持 `credential(...)` 方式注入） |
+| `apiKey` | `String` | API key（部分提供商也支持 `credential(...)` 方式注入） |
 | `modelName` | `String` | 模型标识符（如 `"qwen-plus"`） |
 | `stream` | `boolean` | 是否流式输出 |
 | `defaultOptions` | `GenerateOptions` | 提供商专属生成参数（`temperature`、`maxTokens`、`thinkingBudget`、`parallelToolCalls` 等） |
@@ -442,8 +506,8 @@ ModelCard 字段当前最小化；能力标记（输入/输出 MIME 类型）与
 通过 `CredentialBase#listModels()` 获取 Model Card，返回 `Mono<List<ModelCard>>`：
 
 ```java
-import io.agentscope.core.credential.AnthropicCredential;
 import io.agentscope.core.credential.ModelCard;
+import io.agentscope.extensions.model.anthropic.credential.AnthropicCredential;
 import java.util.List;
 
 AnthropicCredential cred = new AnthropicCredential(System.getenv("ANTHROPIC_API_KEY"));


### PR DESCRIPTION
## AgentScope-Java Version

2.0.0

**Description:**

When a skill name contains spaces (e.g., `V2Ray 代理配置助手`), the `<files-root>` path emitted in `<available_skills>` and the `"Files root: "` line in `load_skill_through_path` responses are both consumed by the LLM to construct shell commands. Without escaping, the space makes the path ambiguous and causes shell execution failures.

`filesRoot` propagates from `ShellPathPolicy` to the LLM prompt through two call sites:

1. **`SkillPromptBuilder`** — renders `<files-root>` inside `<available_skills>`
2. **`SkillLoadTool`** — renders `"Files root: "` in skill/resource load responses

**Changes:**

- **`ShellPathPolicy`**: Added `escapeSpaces()` to replace spaces with `\ ` in both `joinSkills()` and `joinCache()`, covering all three modes (`SANDBOX`, `LOCAL_WITH_SHELL`, `NO_SHELL`).
- **`SkillRuntimeTest`**: Added `ShellPathPolicyTests` with tests for paths with/without spaces, multiple spaces, Chinese characters, sandbox/localWithShell/noShell modes, and null/`NONE` stage inputs. Added a `SkillPromptBuilder` test case for XML rendering with escaped spaces.

## Checklist

Please check the following items before code is ready to be reviewed.

- [x]  Code has been formatted with `mvn spotless:apply`
- [x]  All tests are passing (`mvn test`)
- [x]  Javadoc comments are complete and follow project conventions
- [x]  Related documentation has been updated (e.g. links, examples, etc.)
- [x]  Code is ready for review
