### PR TITLE
feat(mcp): add httpRequestCustomizer support to McpClientBuilder for dynamic token injection

### DIFF
--- a/agentscope-core/src/main/java/io/agentscope/core/tool/mcp/McpClientBuilder.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/tool/mcp/McpClientBuilder.java
@@ -25,6 +25,7 @@ import io.modelcontextprotocol.client.transport.HttpClientSseClientTransport;
 import io.modelcontextprotocol.client.transport.HttpClientStreamableHttpTransport;
 import io.modelcontextprotocol.client.transport.ServerParameters;
 import io.modelcontextprotocol.client.transport.StdioClientTransport;
+import io.modelcontextprotocol.client.transport.customizer.McpSyncHttpClientRequestCustomizer;
 import io.modelcontextprotocol.json.McpJsonMapper;
 import io.modelcontextprotocol.json.TypeRef;
 import io.modelcontextprotocol.spec.McpClientTransport;
@@ -217,6 +218,53 @@ public class McpClientBuilder {
     public McpClientBuilder customizeStreamableHttpClient(Consumer<HttpClient.Builder> customizer) {
         if (transportConfig instanceof StreamableHttpTransportConfig) {
             ((StreamableHttpTransportConfig) transportConfig).customizeHttpClient(customizer);
+        }
+        return this;
+    }
+
+    /**
+     * Registers a per-request HTTP customizer for dynamic request modification
+     * (only applicable for HTTP transports: SSE and StreamableHTTP).
+     *
+     * <p>Unlike {@link #header(String, String)} which sets static headers at build time,
+     * this customizer is invoked for <strong>every</strong> HTTP request, enabling
+     * dynamic token injection for OAuth/STS scenarios where credentials expire.
+     *
+     * <p>This method delegates directly to the MCP SDK's
+     * {@code httpRequestCustomizer(McpSyncHttpClientRequestCustomizer)} API, which
+     * provides the HTTP method, endpoint URI, request body, and transport context
+     * for each request.
+     *
+     * <p>Example usage with dynamic OAuth token:
+     * <pre>{@code
+     * McpClientWrapper client = McpClientBuilder.create("mcp-server")
+     *         .streamableHttpTransport("https://mcp.example.com/http")
+     *         .httpRequestCustomizer((builder, method, uri, body, ctx) -> {
+     *             String token = tokenService.getToken();
+     *             builder.header("Authorization", "Bearer " + token);
+     *         })
+     *         .buildSync();
+     * }</pre>
+     *
+     * <p>Example with SSE transport:
+     * <pre>{@code
+     * McpClientWrapper client = McpClientBuilder.create("mcp-server")
+     *         .sseTransport("https://mcp.example.com/sse")
+     *         .httpRequestCustomizer((builder, method, uri, body, ctx) -> {
+     *             builder.header("Authorization", "Bearer " + tokenProvider.getToken());
+     *             builder.header("X-Request-Id", UUID.randomUUID().toString());
+     *         })
+     *         .buildAsync()
+     *         .block();
+     * }</pre>
+     *
+     * @param customizer per-request customizer invoked before each HTTP request
+     * @return this builder
+     * @since 2.0.0
+     */
+    public McpClientBuilder httpRequestCustomizer(McpSyncHttpClientRequestCustomizer customizer) {
+        if (transportConfig instanceof HttpTransportConfig) {
+            ((HttpTransportConfig) transportConfig).setHttpRequestCustomizer(customizer);
         }
         return this;
     }
@@ -609,6 +657,7 @@ public class McpClientBuilder {
         protected final String url;
         protected Map<String, String> headers = new HashMap<>();
         protected Map<String, String> queryParams = new HashMap<>();
+        protected McpSyncHttpClientRequestCustomizer httpRequestCustomizer;
 
         protected HttpTransportConfig(String url) {
             this.url = url;
@@ -637,6 +686,10 @@ public class McpClientBuilder {
                 throw new IllegalArgumentException("Query parameters map cannot be null");
             }
             this.queryParams = new HashMap<>(queryParams);
+        }
+
+        public void setHttpRequestCustomizer(McpSyncHttpClientRequestCustomizer customizer) {
+            this.httpRequestCustomizer = customizer;
         }
 
         /**
@@ -743,6 +796,11 @@ public class McpClientBuilder {
                         });
             }
 
+            // Apply per-request HTTP customizer for dynamic token injection, etc.
+            if (httpRequestCustomizer != null) {
+                clientTransportBuilder.httpRequestCustomizer(httpRequestCustomizer);
+            }
+
             return clientTransportBuilder.build();
         }
     }
@@ -782,6 +840,11 @@ public class McpClientBuilder {
                         requestBuilder -> {
                             headers.forEach(requestBuilder::header);
                         });
+            }
+
+            // Apply per-request HTTP customizer for dynamic token injection, etc.
+            if (httpRequestCustomizer != null) {
+                clientTransportBuilder.httpRequestCustomizer(httpRequestCustomizer);
             }
 
             return clientTransportBuilder.build();

--- a/agentscope-core/src/test/java/io/agentscope/core/tool/mcp/McpClientBuilderTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/tool/mcp/McpClientBuilderTest.java
@@ -1297,6 +1297,136 @@ class McpClientBuilderTest {
         assertTrue(syncWrapper instanceof McpSyncClientWrapper);
     }
 
+    // ==================== HttpRequestCustomizer Tests ====================
+
+    @Test
+    void testHttpRequestCustomizer_OnSseTransport() {
+        McpClientBuilder builder =
+                McpClientBuilder.create("http-customizer-sse")
+                        .sseTransport("https://mcp.example.com/sse")
+                        .httpRequestCustomizer(
+                                (builder1, method, uri, body, ctx) -> {
+                                    builder1.header("Authorization", "Bearer dynamic-token");
+                                });
+
+        McpClientWrapper wrapper = builder.buildAsync().block();
+        assertNotNull(wrapper);
+        assertEquals("http-customizer-sse", wrapper.getName());
+    }
+
+    @Test
+    void testHttpRequestCustomizer_OnStreamableHttpTransport() {
+        McpClientBuilder builder =
+                McpClientBuilder.create("http-customizer-streamable")
+                        .streamableHttpTransport("https://mcp.example.com/http")
+                        .httpRequestCustomizer(
+                                (builder1, method, uri, body, ctx) -> {
+                                    builder1.header("X-Custom", "custom-value");
+                                    builder1.header("Authorization", "Bearer token");
+                                });
+
+        McpClientWrapper wrapper = builder.buildSync();
+        assertNotNull(wrapper);
+        assertEquals("http-customizer-streamable", wrapper.getName());
+    }
+
+    @Test
+    void testHttpRequestCustomizer_OnStdioTransport_ShouldBeIgnored() {
+        // httpRequestCustomizer on stdio transport should not cause errors (just ignored)
+        McpClientBuilder builder =
+                McpClientBuilder.create("customizer-stdio")
+                        .stdioTransport("python", "-m", "mcp_server_time")
+                        .httpRequestCustomizer(
+                                (builder1, method, uri, body, ctx) -> {
+                                    builder1.header("Authorization", "Bearer token");
+                                });
+
+        McpClientWrapper wrapper = builder.buildAsync().block();
+        assertNotNull(wrapper);
+    }
+
+    @Test
+    void testHttpRequestCustomizer_CombinedWithHeaders() {
+        McpClientBuilder builder =
+                McpClientBuilder.create("customizer-combined")
+                        .sseTransport("https://mcp.example.com/sse")
+                        .header("X-Static-Header", "static-value")
+                        .httpRequestCustomizer(
+                                (builder1, method, uri, body, ctx) -> {
+                                    builder1.header("X-Dynamic-Header", "dynamic-value");
+                                });
+
+        McpClientWrapper wrapper = builder.buildAsync().block();
+        assertNotNull(wrapper);
+        assertEquals("customizer-combined", wrapper.getName());
+    }
+
+    @Test
+    void testHttpRequestCustomizer_CombinedWithAllFeatures() {
+        McpClientBuilder builder =
+                McpClientBuilder.create("customizer-all-features")
+                        .streamableHttpTransport("https://mcp.example.com/http")
+                        .header("X-Static", "static-value")
+                        .queryParam("env", "prod")
+                        .httpRequestCustomizer(
+                                (builder1, method, uri, body, ctx) -> {
+                                    builder1.header("Authorization", "Bearer dynamic");
+                                    builder1.header("X-Trace-Id", "trace-123");
+                                })
+                        .timeout(Duration.ofSeconds(60));
+
+        McpClientWrapper wrapper = builder.buildSync();
+        assertNotNull(wrapper);
+        assertEquals("customizer-all-features", wrapper.getName());
+    }
+
+    @Test
+    void testHttpRequestCustomizer_FluentApiWithBothTransports() {
+        // Test that httpRequestCustomizer works with SSE and then buildAsync
+        McpClientBuilder builder =
+                McpClientBuilder.create("fluent-customizer")
+                        .sseTransport("https://mcp.example.com/sse")
+                        .httpRequestCustomizer(
+                                (builder1, method, uri, body, ctx) -> {
+                                    // No-op customizer, just verify builder works
+                                });
+
+        assertNotNull(builder);
+        McpClientWrapper wrapper = builder.buildAsync().block();
+        assertNotNull(wrapper);
+    }
+
+    @Test
+    void testHttpRequestCustomizer_MultipleCalls_LastOneWins() {
+        // Multiple calls should overwrite the previous customizer
+        McpClientBuilder builder =
+                McpClientBuilder.create("multi-customizer")
+                        .sseTransport("https://mcp.example.com/sse")
+                        .httpRequestCustomizer(
+                                (builder1, method, uri, body, ctx) -> {
+                                    builder1.header("First", "first-value");
+                                })
+                        .httpRequestCustomizer(
+                                (builder1, method, uri, body, ctx) -> {
+                                    builder1.header("Second", "second-value");
+                                });
+
+        McpClientWrapper wrapper = builder.buildAsync().block();
+        assertNotNull(wrapper);
+    }
+
+    @Test
+    void testHttpRequestCustomizer_WithNullCustomizer() {
+        // Setting null customizer should be allowed (just means no customizer)
+        McpClientBuilder builder =
+                McpClientBuilder.create("null-customizer")
+                        .sseTransport("https://mcp.example.com/sse")
+                        .httpRequestCustomizer(null);
+
+        McpClientWrapper wrapper = builder.buildAsync().block();
+        assertNotNull(wrapper);
+    }
+
     // ==================== Protocol Versions Tests ====================
 
     @Test


### PR DESCRIPTION
## AgentScope-Java Version

2.0.0-SNAPSHOT

## Description

Add `httpRequestCustomizer(McpSyncHttpClientRequestCustomizer)` method to `McpClientBuilder`, enabling per-request HTTP customization for SSE and StreamableHTTP transports.

### Background

Currently `McpClientBuilder` uses `.header()` to set HTTP headers, which delegates to the MCP SDK's `customizeRequest(Consumer<HttpRequest.Builder>)` API. This API has two issues:

1. **The Consumer is executed at build time** — it cannot dynamically update tokens, making it unsuitable for OAuth/STS scenarios where credentials expire.
2. **`customizeRequest` is deprecated in newer MCP SDK** — MCP SDK 2.0 recommends using `httpRequestCustomizer` instead.

### Changes

- `McpClientBuilder.java`: Add `httpRequestCustomizer(McpSyncHttpClientRequestCustomizer)` method, delegating directly to the MCP SDK's existing API (supports both SSE and StreamableHTTP transports).
- `McpClientBuilderTest.java`: Add 8 unit tests covering:
  - SSE transport with httpRequestCustomizer
  - StreamableHTTP transport with httpRequestCustomizer
  - StdIO transport (should be ignored, no error)
  - Combined with static headers
  - Combined with all features
  - Fluent API usage
  - Multiple calls (last one wins)
  - Null customizer

### Usage Example

```java
McpClientWrapper client = McpClientBuilder.create("mcp-server")
    .streamableHttpTransport("https://mcp.example.com/http")
    .httpRequestCustomizer((builder, method, uri, body, ctx) -> {
        String token = tokenService.getToken();
        builder.header("Authorization", "Bearer " + token);
    })
    .buildSync();
```

### Impact

- No MCP SDK version change required (API already available in 0.17.0).
- Backward compatible: `.header()` still works for static scenarios.
- Calling on StdIO transport is silently ignored.

## Checklist

- [x]  Code has been formatted with `mvn spotless:apply`
- [x]  All tests are passing (`mvn test`) — 118 tests passed
- [x]  Javadoc comments are complete and follow project conventions
- [x]  Related documentation has been updated
- [x]  Code is ready for review

Closes #1728