### PR TITLE
fix(dataagent): add ObjectMapper bean for MarketContributionService

### DIFF
--- a/agentscope-examples/agents/agentscope-dataagent/src/main/java/io/agentscope/dataagent/web/config/DataAgentConfig.java
+++ b/agentscope-examples/agents/agentscope-dataagent/src/main/java/io/agentscope/dataagent/web/config/DataAgentConfig.java
@@ -150,10 +150,14 @@ public class DataAgentConfig {
     //  web-layer components that need JSON serialization.
     // -----------------------------------------------------------------
 
+    /**
+     * Provides a shared Jackson {@link ObjectMapper} for components that rely on constructor
+     * injection. Registers any Jackson modules found on the classpath (e.g. Java Time).
+     */
     @Bean
     @ConditionalOnMissingBean(ObjectMapper.class)
     public ObjectMapper objectMapper() {
-        return new ObjectMapper();
+        return new ObjectMapper().findAndRegisterModules();
     }
 
     // -----------------------------------------------------------------

--- a/agentscope-examples/agents/agentscope-dataagent/src/main/java/io/agentscope/dataagent/web/config/DataAgentConfig.java
+++ b/agentscope-examples/agents/agentscope-dataagent/src/main/java/io/agentscope/dataagent/web/config/DataAgentConfig.java
@@ -15,6 +15,7 @@
  */
 package io.agentscope.dataagent.web.config;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.agentscope.core.model.Model;
 import io.agentscope.core.state.AgentStateStore;
 import io.agentscope.core.state.InMemoryAgentStateStore;
@@ -142,6 +143,17 @@ public class DataAgentConfig {
                 .modelName(dashscopeModelName)
                 .stream(dashscopeStream)
                 .build();
+    }
+
+    // -----------------------------------------------------------------
+    //  Jackson ObjectMapper — used by MarketContributionService and other
+    //  web-layer components that need JSON serialization.
+    // -----------------------------------------------------------------
+
+    @Bean
+    @ConditionalOnMissingBean(ObjectMapper.class)
+    public ObjectMapper objectMapper() {
+        return new ObjectMapper();
     }
 
     // -----------------------------------------------------------------


### PR DESCRIPTION
## Title

fix(dataagent): add ObjectMapper bean for MarketContributionService (#1991)

## Description

Closes #1991

**Problem**: `MarketContributionService` requires a bean of type `com.fasterxml.jackson.databind.ObjectMapper` in its constructor (4th parameter), but Spring Boot's Jackson auto-configuration does not register one in this WebFlux application context, causing startup failure:

Parameter 3 of constructor in io.agentscope.dataagent.web.marketplace.MarketContributionService
required a bean of type 'com.fasterxml.jackson.databind.ObjectMapper' that could not be found.

**Root cause**: Other classes in the dataagent module work around this by creating their own `new ObjectMapper()` instances, but `MarketContributionService` was written with constructor injection expecting a Spring-managed `ObjectMapper` bean.

**Fix**: Added an `ObjectMapper` bean definition to `DataAgentConfig` with `@ConditionalOnMissingBean`, so it is compatible with any future auto-configuration that might provide one.

**File changed**: `agentscope-examples/agents/agentscope-dataagent/src/main/java/io/agentscope/dataagent/web/config/DataAgentConfig.java`

## Checklist

Please check the following items before code is ready to be reviewed.

- [x]  Code has been formatted with `mvn spotless:apply`
- [x]  All tests are passing (`mvn test`)
- [x]  Javadoc comments are complete and follow project conventions
- [x]  Related documentation has been updated (e.g. links, examples, etc.)
- [x]  Code is ready for review
