### PR TITLE
fix(a2a): preserve AgentScope message roles across A2A conversion

### DIFF
--- a/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-a2a/agentscope-extensions-a2a-client/src/main/java/io/agentscope/core/a2a/agent/message/MessageConstants.java
+++ b/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-a2a/agentscope-extensions-a2a-client/src/main/java/io/agentscope/core/a2a/agent/message/MessageConstants.java
@@ -42,6 +42,8 @@ public class MessageConstants {
 
     public static final String MSG_ID_METADATA_KEY = "_agentscope_msg_id";
 
+    public static final String MSG_ROLE_METADATA_KEY = "_agentscope_msg_role";
+
     public static final String BLOCK_TYPE_METADATA_KEY = "_agentscope_block_type";
 
     public static final String TOOL_NAME_METADATA_KEY = "_agentscope_tool_name";

--- a/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-a2a/agentscope-extensions-a2a-client/src/main/java/io/agentscope/core/a2a/agent/utils/MessageConvertUtil.java
+++ b/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-a2a/agentscope-extensions-a2a-client/src/main/java/io/agentscope/core/a2a/agent/utils/MessageConvertUtil.java
@@ -129,10 +129,39 @@ public class MessageConvertUtil {
                                                                         MessageConstants
                                                                                 .SOURCE_NAME_METADATA_KEY,
                                                                         msg.getName());
+                                                        if (msg.getRole() != null) {
+                                                            part.getMetadata()
+                                                                    .put(
+                                                                            MessageConstants
+                                                                                    .MSG_ROLE_METADATA_KEY,
+                                                                            msg.getRole().name());
+                                                        }
                                                     })
                                             .toList());
                         });
-        return builder.parts(parts).metadata(metadata).role(Message.Role.USER).build();
+        return builder.parts(parts).metadata(metadata).role(resolveMessageRole(msgs)).build();
+    }
+
+    private static Message.Role resolveMessageRole(List<Msg> msgs) {
+        List<Message.Role> roles =
+                msgs.stream()
+                        .filter(Objects::nonNull)
+                        .map(Msg::getRole)
+                        .filter(Objects::nonNull)
+                        .map(MessageConvertUtil::convertRole)
+                        .distinct()
+                        .toList();
+        if (roles.size() == 1) {
+            return roles.get(0);
+        }
+        return Message.Role.USER;
+    }
+
+    private static Message.Role convertRole(MsgRole role) {
+        if (role == MsgRole.ASSISTANT || role == MsgRole.TOOL) {
+            return Message.Role.AGENT;
+        }
+        return Message.Role.USER;
     }
 
     private static boolean isNotEmptyCollection(Collection<?> collection) {

--- a/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-a2a/agentscope-extensions-a2a-client/src/test/java/io/agentscope/core/a2a/agent/message/MessageConstantsTest.java
+++ b/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-a2a/agentscope-extensions-a2a-client/src/test/java/io/agentscope/core/a2a/agent/message/MessageConstantsTest.java
@@ -51,5 +51,6 @@ class MessageConstantsTest {
         assertNotNull(MessageConstants.TOOL_NAME_METADATA_KEY);
         assertNotNull(MessageConstants.TOOL_CALL_ID_METADATA_KEY);
         assertNotNull(MessageConstants.TOOL_RESULT_OUTPUT_METADATA_KEY);
+        assertEquals("_agentscope_msg_role", MessageConstants.MSG_ROLE_METADATA_KEY);
     }
 }

--- a/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-a2a/agentscope-extensions-a2a-server/src/main/java/io/agentscope/core/a2a/server/utils/MessageConvertUtil.java
+++ b/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-a2a/agentscope-extensions-a2a-server/src/main/java/io/agentscope/core/a2a/server/utils/MessageConvertUtil.java
@@ -128,6 +128,7 @@ public class MessageConvertUtil {
         Set<String> msgIds = new LinkedHashSet<>();
         Map<String, List<ContentBlock>> partsByMsgId = new HashMap<>();
         Map<String, String> msgIdToName = new HashMap<>();
+        Map<String, MsgRole> msgIdToRole = new HashMap<>();
         message.getParts().stream()
                 .filter(Objects::nonNull)
                 .forEach(
@@ -145,6 +146,10 @@ public class MessageConvertUtil {
                                     .add(PART_PARSER.parse(part));
                             msgIds.add(msgId);
                             msgIdToName.put(msgId, getMsgName(part));
+                            MsgRole role = getMsgRole(part);
+                            if (role != null) {
+                                msgIdToRole.putIfAbsent(msgId, role);
+                            }
                         });
         msgIds.forEach(
                 msgId ->
@@ -152,7 +157,9 @@ public class MessageConvertUtil {
                                 Msg.builder()
                                         .id(msgId)
                                         .name(msgIdToName.get(msgId))
-                                        .role(MsgRole.USER)
+                                        .role(
+                                                msgIdToRole.getOrDefault(
+                                                        msgId, convertRole(message.getRole())))
                                         .content(partsByMsgId.get(msgId))
                                         .metadata(getMsgMetadata(message, msgId))
                                         .build()));
@@ -175,6 +182,28 @@ public class MessageConvertUtil {
             return null;
         }
         return part.getMetadata().get(MessageConstants.SOURCE_NAME_METADATA_KEY).toString();
+    }
+
+    private static MsgRole getMsgRole(Part<?> part) {
+        if (null == part.getMetadata()) {
+            return null;
+        }
+        Object role = part.getMetadata().get(MessageConstants.MSG_ROLE_METADATA_KEY);
+        if (role == null) {
+            return null;
+        }
+        try {
+            return MsgRole.valueOf(role.toString());
+        } catch (IllegalArgumentException ignored) {
+            return null;
+        }
+    }
+
+    private static MsgRole convertRole(Message.Role role) {
+        if (role == Message.Role.AGENT) {
+            return MsgRole.ASSISTANT;
+        }
+        return MsgRole.USER;
     }
 
     @SuppressWarnings("unchecked")

--- a/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-a2a/agentscope-extensions-a2a-server/src/test/java/io/agentscope/core/a2a/server/utils/MessageConvertUtilTest.java
+++ b/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-a2a/agentscope-extensions-a2a-server/src/test/java/io/agentscope/core/a2a/server/utils/MessageConvertUtilTest.java
@@ -32,6 +32,7 @@ import io.agentscope.core.message.ContentBlock;
 import io.agentscope.core.message.Msg;
 import io.agentscope.core.message.MsgRole;
 import io.agentscope.core.message.TextBlock;
+import io.agentscope.core.message.ThinkingBlock;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -216,6 +217,70 @@ class MessageConvertUtilTest {
         assertEquals(1, result.get(1).getContent().size());
         assertInstanceOf(TextBlock.class, result.get(1).getContent().get(0));
         assertEquals("text2", ((TextBlock) result.get(1).getContent().get(0)).getText());
+    }
+
+    @Test
+    @DisplayName("Should restore Msg role from part metadata")
+    void testConvertFromMessageToMsgsWithRoleMetadata() {
+        // Given
+        Message message = mock(Message.class);
+
+        Map<String, Object> partMetadata = new HashMap<>();
+        String msgId = "assistant-msg";
+        partMetadata.put(MessageConstants.MSG_ID_METADATA_KEY, msgId);
+        partMetadata.put(MessageConstants.MSG_ROLE_METADATA_KEY, MsgRole.ASSISTANT.name());
+        partMetadata.put(
+                MessageConstants.BLOCK_TYPE_METADATA_KEY,
+                MessageConstants.BlockContent.TYPE_THINKING);
+
+        TextPart part = new TextPart("thinking content", partMetadata);
+
+        when(message.getMetadata()).thenReturn(null);
+        when(message.getRole()).thenReturn(Message.Role.USER);
+        when(message.getParts()).thenReturn(List.of(part));
+
+        // When
+        List<Msg> result = MessageConvertUtil.convertFromMessageToMsgs(message);
+
+        // Then
+        assertNotNull(result);
+        assertEquals(1, result.size());
+        Msg msg = result.get(0);
+        assertEquals(msgId, msg.getId());
+        assertEquals(MsgRole.ASSISTANT, msg.getRole());
+        assertEquals(1, msg.getContent().size());
+        assertInstanceOf(ThinkingBlock.class, msg.getContent().get(0));
+        assertEquals("thinking content", ((ThinkingBlock) msg.getContent().get(0)).getThinking());
+    }
+
+    @Test
+    @DisplayName("Should preserve roles when converting mixed history through A2A message")
+    void testRoundTripMixedHistoryPreservesRoles() {
+        Msg userMsg =
+                Msg.builder()
+                        .id("user-msg")
+                        .role(MsgRole.USER)
+                        .content(List.of(TextBlock.builder().text("please review").build()))
+                        .build();
+        Msg assistantMsg =
+                Msg.builder()
+                        .id("assistant-msg")
+                        .role(MsgRole.ASSISTANT)
+                        .content(List.of(ThinkingBlock.builder().thinking("checking diff").build()))
+                        .build();
+
+        Message message =
+                MessageConvertUtil.convertFromMsgToMessage(
+                        List.of(userMsg, assistantMsg), taskId, contextId);
+        List<Msg> result = MessageConvertUtil.convertFromMessageToMsgs(message);
+
+        assertEquals(Message.Role.USER, message.getRole());
+        assertEquals(2, result.size());
+        assertEquals(MsgRole.USER, result.get(0).getRole());
+        assertEquals(MsgRole.ASSISTANT, result.get(1).getRole());
+        assertInstanceOf(ThinkingBlock.class, result.get(1).getContent().get(0));
+        assertEquals(
+                "checking diff", ((ThinkingBlock) result.get(1).getContent().get(0)).getThinking());
     }
 
     @Test


### PR DESCRIPTION
## AgentScope-Java Version

latest

## Description

#1996 

This PR fixes an A2A message conversion issue where AgentScope messages restored on the server side were always assigned `MsgRole.USER`.

When the A2A client sends conversation history, multiple AgentScope `Msg`s are flattened into a single A2A `Message.parts` list. Since the top-level A2A `Message.role` can only represent one role, the original per-message AgentScope role can be lost.

This can cause assistant-only blocks such as `ThinkingBlock` to be restored as USER content and fail validation.

## Checklist

Please check the following items before code is ready to be reviewed.

- [ ]  Code has been formatted with `mvn spotless:apply`
- [ ]  All tests are passing (`mvn test`)
- [ ]  Javadoc comments are complete and follow project conventions
- [ ]  Related documentation has been updated (e.g. links, examples, etc.)
- [ ]  Code is ready for review
