### PR TITLE
fix(harness): propagate userId through wakeup dispatch

### DIFF
--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/gateway/HarnessGateway.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/gateway/HarnessGateway.java
@@ -459,15 +459,38 @@ public final class HarnessGateway implements Gateway, WakeupDispatcher.WakeupTar
     }
 
     /**
-     * Triggers a wakeup-driven run for an idle session. Called by {@link WakeupDispatcher} when a
-     * background task completes or a team message arrives. The agent starts a reasoning round with
-     * no user input; {@link io.agentscope.harness.agent.middleware.InboxMiddleware} drains the
-     * inbox and injects the pending results as context.
+     * {@inheritDoc}
      *
+     * <p>Delegates to {@link #runWakeup(String, String)} with a {@code null} user id.
+     *
+     * @deprecated use {@link #runWakeup(String, String)} so the wakeup-driven round loads agent
+     *     state from the correct {@code (userId, sessionId)} slot. This overload preserves legacy
+     *     anonymous-wakeup behavior.
+     */
+    @Deprecated
+    @Override
+    public Mono<Msg> runWakeup(String sessionId) {
+        return runWakeup(null, sessionId);
+    }
+
+    /**
+     * Triggers a wakeup-driven run for an idle session, propagating the owning user id when
+     * present. Called by {@link WakeupDispatcher} when a background task completes or a team
+     * message arrives. The agent starts a reasoning round with no user input; {@link
+     * io.agentscope.harness.agent.middleware.InboxMiddleware} drains the inbox and injects the
+     * pending results as context.
+     *
+     * <p>When {@code userId} is non-blank it is set on the {@link RuntimeContext}, so the agent
+     * loads state from the same {@code (userId, sessionId)} slot as the original user-driven run
+     * — matching {@code runStream}. A blank or null user id preserves the legacy anonymous
+     * behavior.
+     *
+     * @param userId the owning user id carried by the wakeup entry; may be {@code null} or blank
      * @param sessionId the session to wake up
      * @return the agent's response, or {@link Mono#empty()} if the session is unknown
      */
-    public Mono<Msg> runWakeup(String sessionId) {
+    @Override
+    public Mono<Msg> runWakeup(String userId, String sessionId) {
         String gateKey = sessionToGateKey.get(sessionId);
         if (gateKey == null) {
             log.debug("runWakeup: unknown sessionId={}, skipping", sessionId);
@@ -477,12 +500,15 @@ public final class HarnessGateway implements Gateway, WakeupDispatcher.WakeupTar
         if (ha == null) {
             return Mono.empty();
         }
-        RuntimeContext rtc =
+        RuntimeContext.Builder rtcBuilder =
                 RuntimeContext.builder()
                         .sessionId(sessionId)
                         .put("gateKey", gateKey)
-                        .put("outboundAddress", lastRouteBySession.get(sessionId))
-                        .build();
+                        .put("outboundAddress", lastRouteBySession.get(sessionId));
+        if (userId != null && !userId.isBlank()) {
+            rtcBuilder.userId(userId);
+        }
+        RuntimeContext rtc = rtcBuilder.build();
 
         if (messageBus == null) {
             return withGatedTurn(gateKey, () -> ha.call(List.of(), rtc));

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/gateway/WakeupDispatcher.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/gateway/WakeupDispatcher.java
@@ -61,7 +61,36 @@ public class WakeupDispatcher implements AutoCloseable {
     public interface WakeupTarget {
         boolean isSessionRunning(String sessionId);
 
+        /**
+         * Triggers a wakeup run without an owning user id.
+         *
+         * @param sessionId the session to wake up
+         * @return the agent's response, or {@link Mono#empty()} if the session is unknown
+         * @deprecated implementers should override {@link #runWakeup(String, String)} instead, so
+         *     the dispatcher can propagate the owning user id. Required for runtimes that isolate
+         *     agent state by {@code (userId, sessionId)}: without it, a wakeup-driven round loads
+         *     state from an anonymous slot and the original conversation is lost. This overload is
+         *     retained for backward compatibility and defaults to ignoring the user id.
+         */
+        @Deprecated
         Mono<Msg> runWakeup(String sessionId);
+
+        /**
+         * Triggers a wakeup run for an idle session, carrying the owning user id when present.
+         *
+         * <p>Called by {@link WakeupDispatcher} when a background task completes or a team message
+         * arrives. Implementations should set the user id on the agent runtime context when
+         * non-blank, so agent state is loaded from the same {@code (userId, sessionId)} slot as
+         * the original user-driven run.
+         *
+         * @param userId the owning user id carried by the wakeup entry; {@code null} or blank when
+         *     the producer had none (e.g. single-tenant runtimes)
+         * @param sessionId the session to wake up
+         * @return the agent's response, or {@link Mono#empty()} if the session is unknown
+         */
+        default Mono<Msg> runWakeup(String userId, String sessionId) {
+            return runWakeup(sessionId);
+        }
     }
 
     public WakeupDispatcher(MessageBus messageBus, WakeupTarget target) {
@@ -115,6 +144,7 @@ public class WakeupDispatcher implements AutoCloseable {
     }
 
     private void dispatch(Map<String, Object> payload) {
+        String userId = getString(payload, "userId");
         String sessionId = getString(payload, "sessionId");
         String agentId = getString(payload, "agentId");
 
@@ -131,8 +161,12 @@ public class WakeupDispatcher implements AutoCloseable {
             return;
         }
 
-        log.info("WakeupDispatcher: waking idle session {}, agentId={}", sessionId, agentId);
-        target.runWakeup(sessionId)
+        log.info(
+                "WakeupDispatcher: waking idle session {}, userId={}, agentId={}",
+                sessionId,
+                userId,
+                agentId);
+        target.runWakeup(userId, sessionId)
                 .subscribe(
                         msg ->
                                 log.debug(

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/gateway/WakeupDispatcherTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/gateway/WakeupDispatcherTest.java
@@ -115,6 +115,24 @@ class WakeupDispatcherTest {
         assertEquals("sess-pre", target.wokenSessions.get(0));
     }
 
+    @Test
+    @DisplayName("Wakeup dispatch propagates the owning user id to the target")
+    void wakeupDispatch_propagatesUserId() throws Exception {
+        target.addKnown("sess-user");
+        dispatcher.start();
+
+        messageBus.enqueueWakeup("user-42", "sess-user", "agent-main").block();
+
+        assertTrue(
+                target.awaitWakeup(1, 6, TimeUnit.SECONDS),
+                "Expected runWakeup to be called within 6s");
+        assertEquals("sess-user", target.wokenSessions.get(0));
+        assertEquals(
+                "user-42",
+                target.wokenUsers.get(0),
+                "Dispatcher must forward the userId carried by the wakeup entry");
+    }
+
     // ------------------------------------------------------------------
     //  Test double
     // ------------------------------------------------------------------
@@ -122,6 +140,7 @@ class WakeupDispatcherTest {
     private static class StubTarget implements WakeupDispatcher.WakeupTarget {
 
         final CopyOnWriteArrayList<String> wokenSessions = new CopyOnWriteArrayList<>();
+        final CopyOnWriteArrayList<String> wokenUsers = new CopyOnWriteArrayList<>();
         private final Set<String> runningSessions = ConcurrentHashMap.newKeySet();
         private final Set<String> knownSessions = ConcurrentHashMap.newKeySet();
         private volatile CountDownLatch wakeupLatch = new CountDownLatch(1);
@@ -141,10 +160,16 @@ class WakeupDispatcherTest {
 
         @Override
         public Mono<Msg> runWakeup(String sessionId) {
+            return runWakeup(null, sessionId);
+        }
+
+        @Override
+        public Mono<Msg> runWakeup(String userId, String sessionId) {
             if (!knownSessions.contains(sessionId)) {
                 return Mono.empty();
             }
             wokenSessions.add(sessionId);
+            wokenUsers.add(userId);
             wakeupLatch.countDown();
             return Mono.just(Msg.builder().role(MsgRole.ASSISTANT).textContent("woken").build());
         }


### PR DESCRIPTION
Resolves #2000.

## Summary
`WakeupDispatcher.dispatch` discarded the `userId` that `enqueueWakeup` had already stored in the wakeup queue. In runtimes isolating agent state by `(userId, sessionId)`, the wakeup round built a `RuntimeContext` without a userId, loaded state from an anonymous slot, lost the original conversation, and the provider returned `400 "No user query found in messages."` This forwards the userId end-to-end.

## Changes
- `WakeupTarget`: add `default runWakeup(userId, sessionId)` delegating to the legacy overload; mark `runWakeup(sessionId)` `@Deprecated`.
- `WakeupDispatcher.dispatch`: read `userId` from the wakeup payload and forward it to the target.
- `HarnessGateway`: override the new overload; set `rtc.userId(...)` when non-blank (matching `runStream`). Blank/null userId keeps the legacy anonymous behaviour — no regression for single-tenant runtimes.

## Backward compatibility
The single-arg `runWakeup(String)` stays on the interface (`@Deprecated`, with a default that delegates to it), so existing `WakeupTarget` implementations — including external ones — compile and behave as before. The dispatcher now calls the user-id-aware overload, which `HarnessGateway` overrides; any implementation that does not override it falls back via the default.

## Tests
- Added `WakeupDispatcherTest#wakeupDispatch_propagatesUserId`: enqueues a wakeup with a userId and asserts the target receives it.
- All existing `WakeupDispatcherTest` cases pass unchanged (StubTarget unchanged).

```
mvn test -pl agentscope-harness -Dtest=WakeupDispatcherTest
# Tests run: 5, Failures: 0, Errors: 0, Skipped: 0
```

`HarnessGateway.runWakeup`'s userId->rtc assignment mirrors the production-proven `runStream` pattern (`if (!isBlank) rtcBuilder.userId(...)`); kept the PR focused without a dedicated gateway integration test, but happy to add one if reviewers want end-to-end rtc coverage. Spotless applied; only the three intended files are in the diff.