### PR TITLE
fix(mcp): expose streamable HTTP resumable transport options

### DIFF
--- a/agentscope-core/src/main/java/io/agentscope/core/tool/mcp/McpClientBuilder.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/tool/mcp/McpClientBuilder.java
@@ -222,6 +222,33 @@ public class McpClientBuilder {
     }
 
     /**
+     * Enables or disables resumable streams for StreamableHTTP transport.
+     *
+     * @param resumableStreams whether resumable streams should be enabled
+     * @return this builder
+     */
+    public McpClientBuilder resumableStreams(boolean resumableStreams) {
+        if (transportConfig instanceof StreamableHttpTransportConfig) {
+            ((StreamableHttpTransportConfig) transportConfig).resumableStreams(resumableStreams);
+        }
+        return this;
+    }
+
+    /**
+     * Controls whether StreamableHTTP transport opens a connection during startup.
+     *
+     * @param openConnectionOnStartup whether to open the connection during startup
+     * @return this builder
+     */
+    public McpClientBuilder openConnectionOnStartup(boolean openConnectionOnStartup) {
+        if (transportConfig instanceof StreamableHttpTransportConfig) {
+            ((StreamableHttpTransportConfig) transportConfig)
+                    .openConnectionOnStartup(openConnectionOnStartup);
+        }
+        return this;
+    }
+
+    /**
      * Adds an HTTP header (only applicable for HTTP transports).
      *
      * @param key   header name
@@ -750,6 +777,8 @@ public class McpClientBuilder {
     private static class StreamableHttpTransportConfig extends HttpTransportConfig {
         private HttpClientStreamableHttpTransport.Builder clientTransportBuilder = null;
         private Consumer<HttpClient.Builder> httpClientCustomizer = null;
+        private Boolean resumableStreams = null;
+        private Boolean openConnectionOnStartup = null;
 
         public StreamableHttpTransportConfig(String url) {
             super(url);
@@ -764,6 +793,14 @@ public class McpClientBuilder {
             this.httpClientCustomizer = customizer;
         }
 
+        public void resumableStreams(boolean resumableStreams) {
+            this.resumableStreams = resumableStreams;
+        }
+
+        public void openConnectionOnStartup(boolean openConnectionOnStartup) {
+            this.openConnectionOnStartup = openConnectionOnStartup;
+        }
+
         @Override
         public McpClientTransport createTransport() {
             if (clientTransportBuilder == null) {
@@ -773,6 +810,14 @@ public class McpClientBuilder {
             // Apply HTTP client customization if provided
             if (httpClientCustomizer != null) {
                 clientTransportBuilder.customizeClient(httpClientCustomizer);
+            }
+
+            if (resumableStreams != null) {
+                clientTransportBuilder.resumableStreams(resumableStreams);
+            }
+
+            if (openConnectionOnStartup != null) {
+                clientTransportBuilder.openConnectionOnStartup(openConnectionOnStartup);
             }
 
             clientTransportBuilder.endpoint(extractEndpoint());

--- a/agentscope-core/src/test/java/io/agentscope/core/tool/mcp/McpClientBuilderTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/tool/mcp/McpClientBuilderTest.java
@@ -402,6 +402,8 @@ class McpClientBuilderTest {
         McpClientBuilder builder =
                 McpClientBuilder.create("full-http-client")
                         .streamableHttpTransport("https://mcp.higress.ai/http")
+                        .resumableStreams(false)
+                        .openConnectionOnStartup(false)
                         .header("X-API-Key", "secret-key")
                         .header("X-Request-ID", "request-123")
                         .timeout(Duration.ofMinutes(2))
@@ -1059,6 +1061,39 @@ class McpClientBuilderTest {
     }
 
     @Test
+    void testStreamableHttpTransport_ResumableOptions() throws Exception {
+        McpClientBuilder builder =
+                McpClientBuilder.create("streamable-options")
+                        .streamableHttpTransport("https://mcp.example.com/http")
+                        .resumableStreams(false)
+                        .openConnectionOnStartup(false);
+
+        assertEquals(
+                Boolean.FALSE,
+                getTransportConfigFieldValue(builder, "resumableStreams"),
+                "resumableStreams should be stored on streamable HTTP transport config");
+        assertEquals(
+                Boolean.FALSE,
+                getTransportConfigFieldValue(builder, "openConnectionOnStartup"),
+                "openConnectionOnStartup should be stored on streamable HTTP transport config");
+    }
+
+    @Test
+    void testStreamableHttpTransport_ResumableOptionsIgnoredOnSseTransport() throws Exception {
+        McpClientBuilder builder =
+                McpClientBuilder.create("sse-client")
+                        .sseTransport("https://mcp.example.com/sse")
+                        .resumableStreams(false)
+                        .openConnectionOnStartup(false);
+
+        Object transportConfig = getTransportConfig(builder);
+        assertEquals(
+                "SseTransportConfig",
+                transportConfig.getClass().getSimpleName(),
+                "transport type should remain SSE");
+    }
+
+    @Test
     void testCustomizeStreamableHttpClient_MultipleCustomizations() {
         McpClientBuilder builder =
                 McpClientBuilder.create("multi-custom-http")
@@ -1445,5 +1480,19 @@ class McpClientBuilderTest {
                         McpClientBuilder.create("pv-all-null")
                                 .stdioTransport("echo", "test")
                                 .protocolVersions(null, null));
+    }
+
+    private static Object getTransportConfig(McpClientBuilder builder) throws Exception {
+        Field transportConfigField = McpClientBuilder.class.getDeclaredField("transportConfig");
+        transportConfigField.setAccessible(true);
+        return transportConfigField.get(builder);
+    }
+
+    private static Object getTransportConfigFieldValue(McpClientBuilder builder, String fieldName)
+            throws Exception {
+        Object transportConfig = getTransportConfig(builder);
+        Field field = transportConfig.getClass().getDeclaredField(fieldName);
+        field.setAccessible(true);
+        return field.get(transportConfig);
     }
 }

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/tools/McpServerConfig.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/tools/McpServerConfig.java
@@ -69,6 +69,14 @@ public class McpServerConfig {
     @JsonProperty("queryParams")
     private Map<String, String> queryParams;
 
+    /** http: whether StreamableHTTP should use resumable streams. */
+    @JsonProperty("resumableStreams")
+    private Boolean resumableStreams;
+
+    /** http: whether StreamableHTTP should open a connection during startup. */
+    @JsonProperty("openConnectionOnStartup")
+    private Boolean openConnectionOnStartup;
+
     /**
      * Optional allowlist of tools to import from this server. When {@code null} or empty, all
      * tools the server advertises are registered.
@@ -146,6 +154,22 @@ public class McpServerConfig {
 
     public void setEnableTools(List<String> enableTools) {
         this.enableTools = enableTools;
+    }
+
+    public Boolean getResumableStreams() {
+        return resumableStreams;
+    }
+
+    public void setResumableStreams(Boolean resumableStreams) {
+        this.resumableStreams = resumableStreams;
+    }
+
+    public Boolean getOpenConnectionOnStartup() {
+        return openConnectionOnStartup;
+    }
+
+    public void setOpenConnectionOnStartup(Boolean openConnectionOnStartup) {
+        this.openConnectionOnStartup = openConnectionOnStartup;
     }
 
     public Duration getTimeout() {

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/tools/McpServerRegistrar.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/tools/McpServerRegistrar.java
@@ -142,6 +142,12 @@ public final class McpServerRegistrar {
             throw new IllegalArgumentException("http MCP server '" + name + "' requires a 'url'.");
         }
         builder.streamableHttpTransport(cfg.getUrl());
+        if (cfg.getResumableStreams() != null) {
+            builder.resumableStreams(cfg.getResumableStreams());
+        }
+        if (cfg.getOpenConnectionOnStartup() != null) {
+            builder.openConnectionOnStartup(cfg.getOpenConnectionOnStartup());
+        }
         if (cfg.getHeaders() != null && !cfg.getHeaders().isEmpty()) {
             builder.headers(cfg.getHeaders());
         }

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/tools/ToolsConfigLoaderTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/tools/ToolsConfigLoaderTest.java
@@ -107,6 +107,8 @@ class ToolsConfigLoaderTest {
                     "http": {
                       "transport": "http",
                       "url": "https://mcp.example.com/http",
+                      "resumableStreams": false,
+                      "openConnectionOnStartup": false,
                       "headers": { "X-Tenant": "acme" },
                       "queryParams": { "region": "us" }
                     },
@@ -133,6 +135,8 @@ class ToolsConfigLoaderTest {
         McpServerConfig http = cfg.getMcpServers().get("http");
         assertEquals("http", http.getTransport());
         assertEquals("https://mcp.example.com/http", http.getUrl());
+        assertEquals(Boolean.FALSE, http.getResumableStreams());
+        assertEquals(Boolean.FALSE, http.getOpenConnectionOnStartup());
         assertEquals("acme", http.getHeaders().get("X-Tenant"));
         assertEquals("us", http.getQueryParams().get("region"));
 


### PR DESCRIPTION
## Background
Fixes #2003.

When connecting to a Streamable HTTP MCP server that disables SSE and only accepts POST requests, tool calls can hang because AgentScope-Java does not expose the underlying MCP SDK transport options needed to disable resumable SSE-style startup behavior.

## What Changed
- exposed `resumableStreams(boolean)` on `McpClientBuilder` for Streamable HTTP transport
- exposed `openConnectionOnStartup(boolean)` on `McpClientBuilder` for Streamable HTTP transport
- passed both options through to `HttpClientStreamableHttpTransport.Builder`
- added `resumableStreams` and `openConnectionOnStartup` support to `tools.json` MCP server config
- wired the new config fields through `McpServerRegistrar`

## Example
Java API:
```java
McpClientBuilder.create("test")
    .streamableHttpTransport(url)
    .resumableStreams(false)
    .openConnectionOnStartup(false)
    .buildSync();
```
## Testing
mvn -pl "agentscope-core,agentscope-harness" spotless:apply
mvn -pl "agentscope-core,agentscope-harness" "-Dtest=McpClientBuilderTest,ToolsConfigLoaderTest" test
