### PR TITLE
fix(core): persist agent state on user interrupt recovery

### DIFF
--- a/agentscope-core/src/main/java/io/agentscope/core/ReActAgent.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/ReActAgent.java
@@ -3395,7 +3395,7 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
                                     .content(TextBlock.builder().text(recoveryText).build())
                                     .build();
                     scope.state.contextMutable().add(recoveryMsg);
-                    return Mono.just(recoveryMsg);
+                    return saveStateToSession(scope).thenReturn(recoveryMsg);
                 });
     }
 

--- a/agentscope-core/src/test/java/io/agentscope/core/agent/ReActAgentPerSessionStateTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/agent/ReActAgentPerSessionStateTest.java
@@ -38,6 +38,9 @@ import io.agentscope.core.state.InMemoryAgentStateStore;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import org.junit.jupiter.api.DisplayName;
@@ -114,6 +117,72 @@ class ReActAgentPerSessionStateTest {
         AgentState other = reborn.getAgentState("u1", "other");
         assertFalse(other.getPlanModeContext().isPlanActive());
         assertEquals("", other.getSummary());
+    }
+
+    @Test
+    @DisplayName("user interrupt persists recovery state to the store")
+    void userInterruptPersistsRecoveryState() throws Exception {
+        InMemoryAgentStateStore store = new InMemoryAgentStateStore();
+        CountDownLatch subscribed = new CountDownLatch(1);
+        ReActAgent agent =
+                ReActAgent.builder()
+                        .name("asst")
+                        .sysPrompt("hi")
+                        .model(new DelayedFirstChunkModel(subscribed))
+                        .stateStore(store)
+                        .build();
+        RuntimeContext ctx = RuntimeContext.builder().userId("u1").sessionId("sessA").build();
+
+        CompletableFuture<Msg> future =
+                agent.call(List.of(userMsg("hello")), ctx)
+                        .subscribeOn(Schedulers.parallel())
+                        .toFuture();
+
+        assertTrue(subscribed.await(5, TimeUnit.SECONDS), "model stream should start");
+        agent.interrupt("u1", "sessA");
+
+        Msg reply = future.get(5, TimeUnit.SECONDS);
+        assertEquals(
+                "I noticed that you have interrupted me. What can I do for you?",
+                reply.getTextContent());
+
+        ReActAgent reborn = agent(store);
+        List<String> texts = allText(reborn.getAgentState("u1", "sessA"));
+        assertTrue(texts.contains("hello"), "user input should remain in persisted session state");
+        assertTrue(
+                texts.contains("I noticed that you have interrupted me. What can I do for you?"),
+                "interrupt recovery message should be persisted to the state store");
+    }
+
+    private static final class DelayedFirstChunkModel extends ChatModelBase {
+        private final CountDownLatch subscribed;
+
+        private DelayedFirstChunkModel(CountDownLatch subscribed) {
+            this.subscribed = subscribed;
+        }
+
+        @Override
+        public String getModelName() {
+            return "delayed-first-chunk";
+        }
+
+        @Override
+        protected Flux<ChatResponse> doStream(
+                List<Msg> messages, List<ToolSchema> tools, GenerateOptions options) {
+            return Flux.defer(
+                    () -> {
+                        subscribed.countDown();
+                        return Flux.just(
+                                        ChatResponse.builder()
+                                                .content(
+                                                        List.of(
+                                                                TextBlock.builder()
+                                                                        .text("model reply")
+                                                                        .build()))
+                                                .build())
+                                .delaySubscription(Duration.ofMillis(200));
+                    });
+        }
     }
 
     private static Msg userMsg(String text) {


### PR DESCRIPTION
## Background

Fixes #2007.

When a `USER interrupt` happens during an in-flight `ReActAgent` call, the recovery message is appended to the current session `AgentState`, but that state was not persisted to `AgentStateStore` before returning. As a result, a fresh agent instance reloading the same `(userId, sessionId)` could miss the interrupt recovery state.

## What Changed

- persist session state in the `USER interrupt` recovery path before returning the recovery message
- keep the change scoped to `ReActAgent` without altering the generic `AgentBase` interrupt semantics
- add a regression test covering real in-flight user interruption with state-store reload verification

## Testing

- `mvn -pl agentscope-core -Dtest=ReActAgentPerSessionStateTest test`

## Notes

- the fix is intentionally minimal and only targets the missing persistence in the user-interrupt recovery flow
- existing normal `call()` persistence behavior is unchanged