### PR TITLE
fix(reme): align ReMe client with 0.4.x job APIs

### DIFF
--- a/agentscope-core/src/test/java/io/agentscope/core/tool/DangerousPathBypassTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/tool/DangerousPathBypassTest.java
@@ -20,10 +20,12 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import io.agentscope.core.permission.PermissionContextState;
 import io.agentscope.core.permission.PermissionDecision;
 import java.io.IOException;
+import java.nio.file.FileSystemException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
+import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import reactor.core.publisher.Mono;
@@ -105,7 +107,7 @@ class DangerousPathBypassTest {
         Files.writeString(sshConfig, "Host *\n");
 
         Path link = tempDir.resolve("innocent-link");
-        Files.createSymbolicLink(link, sshConfig);
+        createSymlinkOrSkip(link, sshConfig);
 
         assertTrue(PROBE.check(link.toString()));
     }
@@ -116,8 +118,16 @@ class DangerousPathBypassTest {
         Files.writeString(envFile, "SECRET=value\n");
 
         Path link = tempDir.resolve("config.txt");
-        Files.createSymbolicLink(link, envFile);
+        createSymlinkOrSkip(link, envFile);
 
         assertTrue(PROBE.check(link.toString()));
+    }
+
+    private static void createSymlinkOrSkip(Path link, Path target) throws IOException {
+        try {
+            Files.createSymbolicLink(link, target);
+        } catch (UnsupportedOperationException | SecurityException | FileSystemException e) {
+            Assumptions.abort("Symbolic links are not permitted in this environment: " + e);
+        }
     }
 }

--- a/agentscope-extensions/agentscope-extensions-mem/agentscope-extensions-reme/src/main/java/io/agentscope/core/memory/reme/ReMeAddRequest.java
+++ b/agentscope-extensions/agentscope-extensions-mem/agentscope-extensions-reme/src/main/java/io/agentscope/core/memory/reme/ReMeAddRequest.java
@@ -18,53 +18,103 @@ package io.agentscope.core.memory.reme;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.List;
+import java.util.Map;
 
 /**
- * Request object for adding memories to ReMe API.
+ * Request object for recording messages through ReMe's {@code auto_memory} job.
  *
- * <p>This request is sent to the ReMe API's {@code POST /summary_personal_memory} endpoint
- * to record new memories. ReMe will process the trajectories and extract memorable information.
+ * <p>ReMe 0.4.x accepts a flat message list plus a session identifier instead of the
+ * legacy personal-memory trajectory payload.
  */
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class ReMeAddRequest {
 
-    /** Workspace identifier for memory organization. */
-    @JsonProperty("workspace_id")
-    private String workspaceId;
+    /** Messages to append into the ReMe session. */
+    private List<ReMeMessage> messages;
 
-    /** List of trajectories (conversation sequences) to process. */
-    private List<ReMeTrajectory> trajectories;
+    /** ReMe session identifier. */
+    @JsonProperty("session_id")
+    private String sessionId;
+
+    /** Optional hint forwarded to ReMe's memory evolution step. */
+    @JsonProperty("memory_hint")
+    private String memoryHint;
+
+    /** Optional job metadata. */
+    private Map<String, Object> metadata;
 
     /** Default constructor for Jackson. */
     public ReMeAddRequest() {}
 
     /**
-     * Creates a new ReMeAddRequest with specified workspace ID and trajectories.
+     * Creates a new ReMeAddRequest.
      *
-     * @param workspaceId The workspace identifier
-     * @param trajectories The list of trajectories
+     * @param messages Messages to record
+     * @param sessionId ReMe session ID
+     * @param memoryHint Optional memory hint
+     * @param metadata Optional metadata
      */
-    public ReMeAddRequest(String workspaceId, List<ReMeTrajectory> trajectories) {
-        this.workspaceId = workspaceId;
-        this.trajectories = trajectories;
+    public ReMeAddRequest(
+            List<ReMeMessage> messages,
+            String sessionId,
+            String memoryHint,
+            Map<String, Object> metadata) {
+        this.messages = messages;
+        this.sessionId = sessionId;
+        this.memoryHint = memoryHint;
+        this.metadata = metadata;
     }
 
-    // Getters and Setters
+    public List<ReMeMessage> getMessages() {
+        return messages;
+    }
 
+    public void setMessages(List<ReMeMessage> messages) {
+        this.messages = messages;
+    }
+
+    public String getSessionId() {
+        return sessionId;
+    }
+
+    public void setSessionId(String sessionId) {
+        this.sessionId = sessionId;
+    }
+
+    public String getMemoryHint() {
+        return memoryHint;
+    }
+
+    public void setMemoryHint(String memoryHint) {
+        this.memoryHint = memoryHint;
+    }
+
+    public Map<String, Object> getMetadata() {
+        return metadata;
+    }
+
+    public void setMetadata(Map<String, Object> metadata) {
+        this.metadata = metadata;
+    }
+
+    /**
+     * Legacy accessor kept for source compatibility.
+     *
+     * @deprecated ReMe 0.4.x uses {@code session_id}; use {@link #getSessionId()} instead.
+     */
+    @Deprecated
     public String getWorkspaceId() {
-        return workspaceId;
+        return sessionId;
     }
 
+    /**
+     * Legacy mutator kept for source compatibility.
+     *
+     * @deprecated ReMe 0.4.x uses {@code session_id}; use {@link #setSessionId(String)} instead.
+     */
+    @Deprecated
     public void setWorkspaceId(String workspaceId) {
-        this.workspaceId = workspaceId;
-    }
-
-    public List<ReMeTrajectory> getTrajectories() {
-        return trajectories;
-    }
-
-    public void setTrajectories(List<ReMeTrajectory> trajectories) {
-        this.trajectories = trajectories;
+        this.sessionId = workspaceId;
     }
 
     /**
@@ -78,21 +128,44 @@ public class ReMeAddRequest {
 
     /** Builder for ReMeAddRequest. */
     public static class Builder {
-        private String workspaceId;
-        private List<ReMeTrajectory> trajectories;
+        private List<ReMeMessage> messages;
+        private String sessionId;
+        private String memoryHint;
+        private Map<String, Object> metadata;
 
-        public Builder workspaceId(String workspaceId) {
-            this.workspaceId = workspaceId;
+        public Builder messages(List<ReMeMessage> messages) {
+            this.messages = messages;
             return this;
         }
 
-        public Builder trajectories(List<ReMeTrajectory> trajectories) {
-            this.trajectories = trajectories;
+        public Builder sessionId(String sessionId) {
+            this.sessionId = sessionId;
+            return this;
+        }
+
+        public Builder memoryHint(String memoryHint) {
+            this.memoryHint = memoryHint;
+            return this;
+        }
+
+        public Builder metadata(Map<String, Object> metadata) {
+            this.metadata = metadata;
+            return this;
+        }
+
+        /**
+         * Legacy builder alias kept for source compatibility.
+         *
+         * @deprecated ReMe 0.4.x uses {@code session_id}; use {@link #sessionId(String)}.
+         */
+        @Deprecated
+        public Builder workspaceId(String workspaceId) {
+            this.sessionId = workspaceId;
             return this;
         }
 
         public ReMeAddRequest build() {
-            return new ReMeAddRequest(workspaceId, trajectories);
+            return new ReMeAddRequest(messages, sessionId, memoryHint, metadata);
         }
     }
 }

--- a/agentscope-extensions/agentscope-extensions-mem/agentscope-extensions-reme/src/main/java/io/agentscope/core/memory/reme/ReMeAddResponse.java
+++ b/agentscope-extensions/agentscope-extensions-mem/agentscope-extensions-reme/src/main/java/io/agentscope/core/memory/reme/ReMeAddResponse.java
@@ -17,28 +17,10 @@ package io.agentscope.core.memory.reme;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import java.util.List;
 import java.util.Map;
 
 /**
- * Response object from ReMe's add memory API.
- *
- * <p>This response is returned from the {@code POST /summary_personal_memory} endpoint
- * after successfully adding memories. The actual response format is:
- * <pre>{@code
- * {
- *   "answer": "",
- *   "success": true,
- *   "metadata": {
- *     "memory_list": [...],
- *     "deleted_memory_ids": [],
- *     "update_result": {
- *       "deleted_count": 0,
- *       "inserted_count": 1
- *     }
- *   }
- * }
- * }</pre>
+ * Response object from ReMe's {@code auto_memory} job.
  */
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class ReMeAddResponse {
@@ -94,220 +76,83 @@ public class ReMeAddResponse {
                 + '}';
     }
 
-    /** Metadata object containing memory list and update results. */
+    /** Metadata returned by ReMe's job runtime. */
     @JsonInclude(JsonInclude.Include.NON_NULL)
     public static class Metadata {
-        @JsonProperty("memory_list")
-        private List<MemoryItem> memoryList;
+        private String path;
 
-        @JsonProperty("deleted_memory_ids")
-        private List<String> deletedMemoryIds;
+        private Boolean created;
 
-        @JsonProperty("update_result")
-        private UpdateResult updateResult;
+        private Boolean modified;
 
-        public List<MemoryItem> getMemoryList() {
-            return memoryList;
+        @JsonProperty("n_messages")
+        private Integer nMessages;
+
+        @JsonProperty("source_conversation")
+        private String sourceConversation;
+
+        private Map<String, Object> index;
+
+        public String getPath() {
+            return path;
         }
 
-        public void setMemoryList(List<MemoryItem> memoryList) {
-            this.memoryList = memoryList;
+        public void setPath(String path) {
+            this.path = path;
         }
 
-        public List<String> getDeletedMemoryIds() {
-            return deletedMemoryIds;
+        public Boolean getCreated() {
+            return created;
         }
 
-        public void setDeletedMemoryIds(List<String> deletedMemoryIds) {
-            this.deletedMemoryIds = deletedMemoryIds;
+        public void setCreated(Boolean created) {
+            this.created = created;
         }
 
-        public UpdateResult getUpdateResult() {
-            return updateResult;
+        public Boolean getModified() {
+            return modified;
         }
 
-        public void setUpdateResult(UpdateResult updateResult) {
-            this.updateResult = updateResult;
+        public void setModified(Boolean modified) {
+            this.modified = modified;
+        }
+
+        public Integer getNMessages() {
+            return nMessages;
+        }
+
+        public void setNMessages(Integer nMessages) {
+            this.nMessages = nMessages;
+        }
+
+        public String getSourceConversation() {
+            return sourceConversation;
+        }
+
+        public void setSourceConversation(String sourceConversation) {
+            this.sourceConversation = sourceConversation;
+        }
+
+        public Map<String, Object> getIndex() {
+            return index;
+        }
+
+        public void setIndex(Map<String, Object> index) {
+            this.index = index;
         }
 
         @Override
         public String toString() {
             return "Metadata{"
-                    + "memoryList="
-                    + (memoryList != null ? memoryList.size() + " items" : "null")
-                    + ", deletedMemoryIds="
-                    + (deletedMemoryIds != null ? deletedMemoryIds.size() + " items" : "null")
-                    + ", updateResult="
-                    + updateResult
-                    + '}';
-        }
-    }
-
-    /** Represents a single memory item in the response. */
-    @JsonInclude(JsonInclude.Include.NON_NULL)
-    public static class MemoryItem {
-        @JsonProperty("workspace_id")
-        private String workspaceId;
-
-        @JsonProperty("memory_id")
-        private String memoryId;
-
-        @JsonProperty("memory_type")
-        private String memoryType;
-
-        @JsonProperty("when_to_use")
-        private String whenToUse;
-
-        private String content;
-
-        private Double score;
-
-        @JsonProperty("time_created")
-        private String timeCreated;
-
-        @JsonProperty("time_modified")
-        private String timeModified;
-
-        private String author;
-
-        private Map<String, Object> metadata;
-
-        private String target;
-
-        @JsonProperty("reflection_subject")
-        private String reflectionSubject;
-
-        // Getters and Setters
-
-        public String getWorkspaceId() {
-            return workspaceId;
-        }
-
-        public void setWorkspaceId(String workspaceId) {
-            this.workspaceId = workspaceId;
-        }
-
-        public String getMemoryId() {
-            return memoryId;
-        }
-
-        public void setMemoryId(String memoryId) {
-            this.memoryId = memoryId;
-        }
-
-        public String getMemoryType() {
-            return memoryType;
-        }
-
-        public void setMemoryType(String memoryType) {
-            this.memoryType = memoryType;
-        }
-
-        public String getWhenToUse() {
-            return whenToUse;
-        }
-
-        public void setWhenToUse(String whenToUse) {
-            this.whenToUse = whenToUse;
-        }
-
-        public String getContent() {
-            return content;
-        }
-
-        public void setContent(String content) {
-            this.content = content;
-        }
-
-        public Double getScore() {
-            return score;
-        }
-
-        public void setScore(Double score) {
-            this.score = score;
-        }
-
-        public String getTimeCreated() {
-            return timeCreated;
-        }
-
-        public void setTimeCreated(String timeCreated) {
-            this.timeCreated = timeCreated;
-        }
-
-        public String getTimeModified() {
-            return timeModified;
-        }
-
-        public void setTimeModified(String timeModified) {
-            this.timeModified = timeModified;
-        }
-
-        public String getAuthor() {
-            return author;
-        }
-
-        public void setAuthor(String author) {
-            this.author = author;
-        }
-
-        public Map<String, Object> getMetadata() {
-            return metadata;
-        }
-
-        public void setMetadata(Map<String, Object> metadata) {
-            this.metadata = metadata;
-        }
-
-        public String getTarget() {
-            return target;
-        }
-
-        public void setTarget(String target) {
-            this.target = target;
-        }
-
-        public String getReflectionSubject() {
-            return reflectionSubject;
-        }
-
-        public void setReflectionSubject(String reflectionSubject) {
-            this.reflectionSubject = reflectionSubject;
-        }
-    }
-
-    /** Update result information. */
-    @JsonInclude(JsonInclude.Include.NON_NULL)
-    public static class UpdateResult {
-        @JsonProperty("deleted_count")
-        private Integer deletedCount;
-
-        @JsonProperty("inserted_count")
-        private Integer insertedCount;
-
-        public Integer getDeletedCount() {
-            return deletedCount;
-        }
-
-        public void setDeletedCount(Integer deletedCount) {
-            this.deletedCount = deletedCount;
-        }
-
-        public Integer getInsertedCount() {
-            return insertedCount;
-        }
-
-        public void setInsertedCount(Integer insertedCount) {
-            this.insertedCount = insertedCount;
-        }
-
-        @Override
-        public String toString() {
-            return "UpdateResult{"
-                    + "deletedCount="
-                    + deletedCount
-                    + ", insertedCount="
-                    + insertedCount
+                    + "path='"
+                    + path
+                    + '\''
+                    + ", created="
+                    + created
+                    + ", modified="
+                    + modified
+                    + ", nMessages="
+                    + nMessages
                     + '}';
         }
     }

--- a/agentscope-extensions/agentscope-extensions-mem/agentscope-extensions-reme/src/main/java/io/agentscope/core/memory/reme/ReMeClient.java
+++ b/agentscope-extensions/agentscope-extensions-mem/agentscope-extensions-reme/src/main/java/io/agentscope/core/memory/reme/ReMeClient.java
@@ -33,8 +33,8 @@ import reactor.core.scheduler.Schedulers;
 public class ReMeClient {
 
     private static final MediaType JSON = MediaType.parse("application/json; charset=utf-8");
-    private static final String SUMMARY_ENDPOINT = "/summary_personal_memory";
-    private static final String RETRIEVE_ENDPOINT = "/retrieve_personal_memory";
+    private static final String AUTO_MEMORY_ENDPOINT = "/auto_memory";
+    private static final String SEARCH_ENDPOINT = "/search";
 
     private final OkHttpClient httpClient;
     private final String apiBaseUrl;
@@ -73,7 +73,7 @@ public class ReMeClient {
      * <p>This is a generic method that handles HTTP communication, JSON serialization,
      * error handling, and response parsing for all POST endpoints.
      *
-     * @param endpoint The API endpoint path (e.g., "/summary_personal_memory")
+     * @param endpoint The API endpoint path (e.g., "/auto_memory")
      * @param request The request object to serialize as JSON
      * @param responseType The class of the response type
      * @param operationName A human-readable name for the operation (for error messages)
@@ -131,37 +131,33 @@ public class ReMeClient {
     }
 
     /**
-     * Adds memories to ReMe by sending trajectories for processing.
+     * Records messages through ReMe's {@code auto_memory} job.
      *
-     * <p>This method calls the {@code POST /summary_personal_memory} endpoint. ReMe will
-     * process the trajectories and extract memorable information.
+     * <p>This method calls the {@code POST /auto_memory} endpoint.
      *
      * <p>The operation is performed asynchronously on the bounded elastic scheduler
      * to avoid blocking the caller thread.
      *
-     * @param request The add request containing trajectories and workspace ID
+     * @param request The auto-memory request
      * @return A Mono emitting the response
      */
     public Mono<ReMeAddResponse> add(ReMeAddRequest request) {
-        return executePost(
-                SUMMARY_ENDPOINT, request, ReMeAddResponse.class, "summary_personal_memory");
+        return executePost(AUTO_MEMORY_ENDPOINT, request, ReMeAddResponse.class, "auto_memory");
     }
 
     /**
      * Searches memories in ReMe using the provided query.
      *
-     * <p>This method calls the {@code POST /retrieve_personal_memory} endpoint to find
-     * memories relevant to the query string.
+     * <p>This method calls the {@code POST /search} endpoint.
      *
      * <p>The operation is performed asynchronously on the bounded elastic scheduler
      * to avoid blocking the caller thread.
      *
-     * @param request The search request containing query, workspace ID, and topK
+     * @param request The search request containing query and search parameters
      * @return A Mono emitting the search response with relevant memories
      */
     public Mono<ReMeSearchResponse> search(ReMeSearchRequest request) {
-        return executePost(
-                RETRIEVE_ENDPOINT, request, ReMeSearchResponse.class, "retrieve_personal_memory");
+        return executePost(SEARCH_ENDPOINT, request, ReMeSearchResponse.class, "search");
     }
 
     /**

--- a/agentscope-extensions/agentscope-extensions-mem/agentscope-extensions-reme/src/main/java/io/agentscope/core/memory/reme/ReMeLongTermMemory.java
+++ b/agentscope-extensions/agentscope-extensions-mem/agentscope-extensions-reme/src/main/java/io/agentscope/core/memory/reme/ReMeLongTermMemory.java
@@ -34,20 +34,21 @@ import reactor.core.publisher.Mono;
  * <p><b>Key Features:</b>
  * <ul>
  *   <li>LLM-powered memory extraction and inference
- *   <li>Workspace-based memory isolation
- *   <li>Automatic memory summarization from conversation trajectories
+ *   <li>Session-based memory recording for ReMe 0.4.x
+ *   <li>Automatic memory summarization from conversation messages
  *   <li>Reactive, non-blocking operations
  * </ul>
  *
- * <p><b>Memory Isolation:</b>
- * Memories are organized by userId (mapped to ReMe's workspace_id), enabling
- * multi-tenant scenarios where different users maintain separate memory contexts.
+ * <p><b>Session Mapping:</b>
+ * ReMe 0.4.x records messages into a {@code session_id}. For backward compatibility,
+ * the builder still accepts {@code userId}, which is treated as the session ID when
+ * {@code sessionId} is not explicitly configured.
  *
  * <p><b>Usage Example:</b>
  * <pre>{@code
  * // Create memory instance
  * ReMeLongTermMemory memory = ReMeLongTermMemory.builder()
- *     .userId("task_workspace")
+ *     .sessionId("task-session")
  *     .apiBaseUrl("http://localhost:8002")
  *     .build();
  *
@@ -66,30 +67,29 @@ import reactor.core.publisher.Mono;
 public class ReMeLongTermMemory implements LongTermMemory {
 
     private final ReMeClient client;
-    private final String userId;
+    private final String sessionId;
 
     /**
      * Private constructor - use Builder instead.
      */
     private ReMeLongTermMemory(Builder builder) {
-        // Validate required fields before creating ReMeClient
-        if (builder.userId == null || builder.userId.isEmpty()) {
-            throw new IllegalArgumentException("userId is required");
-        }
         if (builder.apiBaseUrl == null || builder.apiBaseUrl.isEmpty()) {
             throw new IllegalArgumentException("apiBaseUrl is required");
         }
+        String resolvedSessionId = firstNonBlank(builder.sessionId, builder.userId);
+        if (resolvedSessionId == null) {
+            throw new IllegalArgumentException("sessionId or userId is required");
+        }
 
         this.client = new ReMeClient(builder.apiBaseUrl, builder.timeout);
-        this.userId = builder.userId;
+        this.sessionId = resolvedSessionId;
     }
 
     /**
      * Records messages to long-term memory.
      *
-     * <p>This method converts messages to ReMe trajectory format and sends them to
-     * the ReMe API for processing. ReMe will extract and store memorable information
-     * from the conversation.
+     * <p>This method converts messages to ReMe's message format and sends them to
+     * the ReMe API for processing.
      *
      * <p>Only USER and ASSISTANT messages are recorded. For ASSISTANT messages,
      * only those without ToolUseBlock (pure assistant replies) are kept, filtering
@@ -152,16 +152,9 @@ public class ReMeLongTermMemory implements LongTermMemory {
             return Mono.empty();
         }
 
-        // Create trajectory with messages
-        ReMeTrajectory trajectory = ReMeTrajectory.builder().messages(remeMessages).build();
-
         // Build request
-        // Note: userId is used as workspaceId for ReMe API
         ReMeAddRequest request =
-                ReMeAddRequest.builder()
-                        .workspaceId(userId)
-                        .trajectories(List.of(trajectory))
-                        .build();
+                ReMeAddRequest.builder().sessionId(sessionId).messages(remeMessages).build();
 
         // Send to ReMe API
         return client.add(request).then();
@@ -201,8 +194,6 @@ public class ReMeLongTermMemory implements LongTermMemory {
      * Returns memory fragments as a newline-separated string, or empty string if no
      * relevant memories are found.
      *
-     * <p>Only memories from the configured workspace are returned.
-     *
      * @param msg The message to use as a search query
      * @return A Mono emitting the retrieved memory text (may be empty)
      */
@@ -217,16 +208,12 @@ public class ReMeLongTermMemory implements LongTermMemory {
             return Mono.just("");
         }
 
-        // Build search request
-        // Note: userId is used as workspaceId for ReMe API
-        ReMeSearchRequest request =
-                ReMeSearchRequest.builder().workspaceId(userId).query(query).topK(5).build();
+        ReMeSearchRequest request = ReMeSearchRequest.builder().query(query).limit(5).build();
 
         // Search and convert response to string
         return client.search(request)
                 .map(
                         response -> {
-                            // Use answer field if available, otherwise use memory_list
                             if (response.getAnswer() != null && !response.getAnswer().isEmpty()) {
                                 return response.getAnswer();
                             }
@@ -257,17 +244,32 @@ public class ReMeLongTermMemory implements LongTermMemory {
      */
     public static class Builder {
         private String userId;
+        private String sessionId;
         private String apiBaseUrl;
         private Duration timeout = Duration.ofSeconds(60);
 
         /**
-         * Sets the userId.
+         * Sets a legacy userId alias.
          *
-         * @param userId The userId
+         * <p>ReMe 0.4.x no longer uses {@code workspace_id}; this value is treated as the
+         * session ID when {@link #sessionId(String)} is not provided.
+         *
+         * @param userId The legacy userId alias
          * @return This builder
          */
         public Builder userId(String userId) {
             this.userId = userId;
+            return this;
+        }
+
+        /**
+         * Sets the ReMe session ID used by ReMe 0.4.x.
+         *
+         * @param sessionId The session ID
+         * @return This builder
+         */
+        public Builder sessionId(String sessionId) {
+            this.sessionId = sessionId;
             return this;
         }
 
@@ -302,5 +304,15 @@ public class ReMeLongTermMemory implements LongTermMemory {
         public ReMeLongTermMemory build() {
             return new ReMeLongTermMemory(this);
         }
+    }
+
+    private static String firstNonBlank(String first, String second) {
+        if (first != null && !first.isBlank()) {
+            return first;
+        }
+        if (second != null && !second.isBlank()) {
+            return second;
+        }
+        return null;
     }
 }

--- a/agentscope-extensions/agentscope-extensions-mem/agentscope-extensions-reme/src/main/java/io/agentscope/core/memory/reme/ReMeSearchRequest.java
+++ b/agentscope-extensions/agentscope-extensions-mem/agentscope-extensions-reme/src/main/java/io/agentscope/core/memory/reme/ReMeSearchRequest.java
@@ -15,48 +15,59 @@
  */
 package io.agentscope.core.memory.reme;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Map;
 
 /**
  * Request object for searching memories in ReMe API.
  *
- * <p>This request is sent to the ReMe API's {@code POST /retrieve_personal_memory} endpoint
- * to retrieve relevant memories based on a query string.
+ * <p>This request is sent to the ReMe API's {@code POST /search} endpoint.
  */
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class ReMeSearchRequest {
-
-    /** Workspace identifier for memory organization. */
-    @JsonProperty("workspace_id")
-    private String workspaceId;
 
     /** The search query string. */
     private String query;
 
     /** Maximum number of results to return. */
-    @JsonProperty("top_k")
-    private Integer topK;
+    private Integer limit;
+
+    /** Minimum search score accepted by ReMe. */
+    @JsonProperty("min_score")
+    private Double minScore;
+
+    /** Optional job metadata. */
+    private Map<String, Object> metadata;
+
+    /**
+     * Legacy field kept only for source compatibility. It is not serialized because
+     * ReMe 0.4.x search is no longer scoped by workspace ID.
+     */
+    @JsonIgnore private String workspaceId;
 
     /** Default constructor for Jackson. */
     public ReMeSearchRequest() {
-        this.topK = 5; // Default value
+        this.limit = 5;
+        this.minScore = 0.0;
     }
 
     /**
-     * Creates a new ReMeSearchRequest with specified workspace ID, query, and topK.
+     * Creates a new ReMeSearchRequest.
      *
-     * @param workspaceId The workspace identifier
      * @param query The search query
-     * @param topK Maximum number of results
+     * @param limit Maximum number of results
+     * @param minScore Minimum accepted score
+     * @param metadata Optional metadata
      */
-    public ReMeSearchRequest(String workspaceId, String query, Integer topK) {
-        this.workspaceId = workspaceId;
+    public ReMeSearchRequest(
+            String query, Integer limit, Double minScore, Map<String, Object> metadata) {
         this.query = query;
-        this.topK = topK;
+        this.limit = limit;
+        this.minScore = minScore;
+        this.metadata = metadata;
     }
-
-    // Getters and Setters
 
     public String getWorkspaceId() {
         return workspaceId;
@@ -74,12 +85,48 @@ public class ReMeSearchRequest {
         this.query = query;
     }
 
-    public Integer getTopK() {
-        return topK;
+    public Integer getLimit() {
+        return limit;
     }
 
+    public void setLimit(Integer limit) {
+        this.limit = limit;
+    }
+
+    public Double getMinScore() {
+        return minScore;
+    }
+
+    public void setMinScore(Double minScore) {
+        this.minScore = minScore;
+    }
+
+    public Map<String, Object> getMetadata() {
+        return metadata;
+    }
+
+    public void setMetadata(Map<String, Object> metadata) {
+        this.metadata = metadata;
+    }
+
+    /**
+     * Legacy accessor kept for source compatibility.
+     *
+     * @deprecated Use {@link #getLimit()} instead.
+     */
+    @Deprecated
+    public Integer getTopK() {
+        return limit;
+    }
+
+    /**
+     * Legacy mutator kept for source compatibility.
+     *
+     * @deprecated Use {@link #setLimit(Integer)} instead.
+     */
+    @Deprecated
     public void setTopK(Integer topK) {
-        this.topK = topK;
+        this.limit = topK;
     }
 
     /**
@@ -95,7 +142,9 @@ public class ReMeSearchRequest {
     public static class Builder {
         private String workspaceId;
         private String query;
-        private Integer topK = 5;
+        private Integer limit = 5;
+        private Double minScore = 0.0;
+        private Map<String, Object> metadata;
 
         public Builder workspaceId(String workspaceId) {
             this.workspaceId = workspaceId;
@@ -107,13 +156,36 @@ public class ReMeSearchRequest {
             return this;
         }
 
+        public Builder limit(Integer limit) {
+            this.limit = limit;
+            return this;
+        }
+
+        public Builder minScore(Double minScore) {
+            this.minScore = minScore;
+            return this;
+        }
+
+        public Builder metadata(Map<String, Object> metadata) {
+            this.metadata = metadata;
+            return this;
+        }
+
+        /**
+         * Legacy builder alias kept for source compatibility.
+         *
+         * @deprecated Use {@link #limit(Integer)} instead.
+         */
+        @Deprecated
         public Builder topK(Integer topK) {
-            this.topK = topK;
+            this.limit = topK;
             return this;
         }
 
         public ReMeSearchRequest build() {
-            return new ReMeSearchRequest(workspaceId, query, topK);
+            ReMeSearchRequest request = new ReMeSearchRequest(query, limit, minScore, metadata);
+            request.setWorkspaceId(workspaceId);
+            return request;
         }
     }
 }

--- a/agentscope-extensions/agentscope-extensions-mem/agentscope-extensions-reme/src/main/java/io/agentscope/core/memory/reme/ReMeSearchResponse.java
+++ b/agentscope-extensions/agentscope-extensions-mem/agentscope-extensions-reme/src/main/java/io/agentscope/core/memory/reme/ReMeSearchResponse.java
@@ -24,25 +24,6 @@ import java.util.stream.Collectors;
 
 /**
  * Response object from ReMe's search memory API.
- *
- * <p>This response is returned from the {@code POST /retrieve_personal_memory} endpoint
- * after performing a memory search. The actual response format is:
- * <pre>{@code
- * {
- *   "answer": "string",
- *   "success": true,
- *   "metadata": {
- *     "memory_list": [
- *       {
- *         "workspace_id": "...",
- *         "memory_id": "...",
- *         "content": "...",
- *         ...
- *       }
- *     ]
- *   }
- * }
- * }</pre>
  */
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class ReMeSearchResponse {
@@ -86,16 +67,12 @@ public class ReMeSearchResponse {
     }
 
     /**
-     * Gets the list of memory fragments from metadata as strings.
-     *
-     * <p>This method extracts the content from each memory item for backward compatibility.
-     *
-     * @return List of memory content strings, or empty list if not available
+     * Extracts search result text fragments.
      */
     public List<String> getMemories() {
-        if (metadata != null && metadata.getMemoryList() != null) {
-            return metadata.getMemoryList().stream()
-                    .map(MemoryItem::getContent)
+        if (metadata != null && metadata.getResults() != null) {
+            return metadata.getResults().stream()
+                    .map(SearchResult::getText)
                     .filter(Objects::nonNull)
                     .collect(Collectors.toList());
         }
@@ -115,135 +92,82 @@ public class ReMeSearchResponse {
                 + '}';
     }
 
-    /** Metadata object containing memory list. */
+    /** Metadata returned by ReMe's search job. */
     @JsonInclude(JsonInclude.Include.NON_NULL)
     public static class Metadata {
-        @JsonProperty("memory_list")
-        private List<MemoryItem> memoryList;
+        private List<SearchResult> results;
 
-        public List<MemoryItem> getMemoryList() {
-            return memoryList;
+        private Map<String, Object> counts;
+
+        @JsonProperty("link_expansion")
+        private Map<String, Object> linkExpansion;
+
+        public List<SearchResult> getResults() {
+            return results;
         }
 
-        public void setMemoryList(List<MemoryItem> memoryList) {
-            this.memoryList = memoryList;
+        public void setResults(List<SearchResult> results) {
+            this.results = results;
+        }
+
+        public Map<String, Object> getCounts() {
+            return counts;
+        }
+
+        public void setCounts(Map<String, Object> counts) {
+            this.counts = counts;
+        }
+
+        public Map<String, Object> getLinkExpansion() {
+            return linkExpansion;
+        }
+
+        public void setLinkExpansion(Map<String, Object> linkExpansion) {
+            this.linkExpansion = linkExpansion;
         }
 
         @Override
         public String toString() {
             return "Metadata{"
-                    + "memoryList="
-                    + (memoryList != null ? memoryList.size() + " items" : "null")
+                    + "results="
+                    + (results != null ? results.size() + " items" : "null")
                     + '}';
         }
     }
 
-    /** Represents a single memory item in the response. */
+    /** Represents a single search hit in the response. */
     @JsonInclude(JsonInclude.Include.NON_NULL)
-    public static class MemoryItem {
-        @JsonProperty("workspace_id")
-        private String workspaceId;
+    public static class SearchResult {
+        private String id;
 
-        @JsonProperty("memory_id")
-        private String memoryId;
-
-        @JsonProperty("memory_type")
-        private String memoryType;
-
-        @JsonProperty("when_to_use")
-        private String whenToUse;
-
-        private String content;
-
-        private Double score;
-
-        @JsonProperty("time_created")
-        private String timeCreated;
-
-        @JsonProperty("time_modified")
-        private String timeModified;
-
-        private String author;
+        private String text;
 
         private Map<String, Object> metadata;
 
-        private String target;
+        private String path;
 
-        @JsonProperty("reflection_subject")
-        private String reflectionSubject;
+        @JsonProperty("start_line")
+        private Integer startLine;
 
-        // Getters and Setters
+        @JsonProperty("end_line")
+        private Integer endLine;
 
-        public String getWorkspaceId() {
-            return workspaceId;
+        private Map<String, Object> scores;
+
+        public String getId() {
+            return id;
         }
 
-        public void setWorkspaceId(String workspaceId) {
-            this.workspaceId = workspaceId;
+        public void setId(String id) {
+            this.id = id;
         }
 
-        public String getMemoryId() {
-            return memoryId;
+        public String getText() {
+            return text;
         }
 
-        public void setMemoryId(String memoryId) {
-            this.memoryId = memoryId;
-        }
-
-        public String getMemoryType() {
-            return memoryType;
-        }
-
-        public void setMemoryType(String memoryType) {
-            this.memoryType = memoryType;
-        }
-
-        public String getWhenToUse() {
-            return whenToUse;
-        }
-
-        public void setWhenToUse(String whenToUse) {
-            this.whenToUse = whenToUse;
-        }
-
-        public String getContent() {
-            return content;
-        }
-
-        public void setContent(String content) {
-            this.content = content;
-        }
-
-        public Double getScore() {
-            return score;
-        }
-
-        public void setScore(Double score) {
-            this.score = score;
-        }
-
-        public String getTimeCreated() {
-            return timeCreated;
-        }
-
-        public void setTimeCreated(String timeCreated) {
-            this.timeCreated = timeCreated;
-        }
-
-        public String getTimeModified() {
-            return timeModified;
-        }
-
-        public void setTimeModified(String timeModified) {
-            this.timeModified = timeModified;
-        }
-
-        public String getAuthor() {
-            return author;
-        }
-
-        public void setAuthor(String author) {
-            this.author = author;
+        public void setText(String text) {
+            this.text = text;
         }
 
         public Map<String, Object> getMetadata() {
@@ -254,20 +178,36 @@ public class ReMeSearchResponse {
             this.metadata = metadata;
         }
 
-        public String getTarget() {
-            return target;
+        public String getPath() {
+            return path;
         }
 
-        public void setTarget(String target) {
-            this.target = target;
+        public void setPath(String path) {
+            this.path = path;
         }
 
-        public String getReflectionSubject() {
-            return reflectionSubject;
+        public Integer getStartLine() {
+            return startLine;
         }
 
-        public void setReflectionSubject(String reflectionSubject) {
-            this.reflectionSubject = reflectionSubject;
+        public void setStartLine(Integer startLine) {
+            this.startLine = startLine;
+        }
+
+        public Integer getEndLine() {
+            return endLine;
+        }
+
+        public void setEndLine(Integer endLine) {
+            this.endLine = endLine;
+        }
+
+        public Map<String, Object> getScores() {
+            return scores;
+        }
+
+        public void setScores(Map<String, Object> scores) {
+            this.scores = scores;
         }
     }
 }

--- a/agentscope-extensions/agentscope-extensions-mem/agentscope-extensions-reme/src/test/java/io/agentscope/core/memory/reme/ReMeClientTest.java
+++ b/agentscope-extensions/agentscope-extensions-mem/agentscope-extensions-reme/src/test/java/io/agentscope/core/memory/reme/ReMeClientTest.java
@@ -22,6 +22,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import io.agentscope.core.util.JsonException;
 import java.time.Duration;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
@@ -42,7 +43,6 @@ class ReMeClientTest {
         mockServer = new MockWebServer();
         mockServer.start();
         String baseUrl = mockServer.url("/").toString();
-        // Remove trailing slash
         if (baseUrl.endsWith("/")) {
             baseUrl = baseUrl.substring(0, baseUrl.length() - 1);
         }
@@ -61,70 +61,50 @@ class ReMeClientTest {
 
     @Test
     void testConstructorWithBaseUrl() {
-        String baseUrl = "http://localhost:8002";
-        ReMeClient client = new ReMeClient(baseUrl);
-        assertNotNull(client);
-        client.shutdown();
+        ReMeClient baseClient = new ReMeClient("http://localhost:8002");
+        assertNotNull(baseClient);
+        baseClient.shutdown();
     }
 
     @Test
     void testConstructorWithTrailingSlash() {
-        String baseUrl = "http://localhost:8002/";
-        ReMeClient client = new ReMeClient(baseUrl);
-        assertNotNull(client);
-        client.shutdown();
+        ReMeClient slashClient = new ReMeClient("http://localhost:8002/");
+        assertNotNull(slashClient);
+        slashClient.shutdown();
     }
 
     @Test
     void testConstructorWithCustomTimeout() {
-        String baseUrl = "http://localhost:8002";
-        ReMeClient client = new ReMeClient(baseUrl, Duration.ofSeconds(30));
-        assertNotNull(client);
-        client.shutdown();
+        ReMeClient timeoutClient = new ReMeClient("http://localhost:8002", Duration.ofSeconds(30));
+        assertNotNull(timeoutClient);
+        timeoutClient.shutdown();
     }
 
     @Test
     void testAddRequestSuccess() throws Exception {
-        // Mock successful response matching actual API format
-        String responseJson =
-                "{\"answer\":\"\",\"success\":true,\"metadata\":{\"memory_list\":[{"
-                    + "\"workspace_id\":\"task_workspace\",\"memory_id\":\"test_memory_id\",\"memory_type\":\"personal\",\"when_to_use\":\"coffee,"
-                    + " morning, work\",\"content\":\"user drinks coffee in the morning while"
-                    + " working\",\"score\":0.0,\"time_created\":\"2025-12-10"
-                    + " 10:30:43\",\"time_modified\":\"2025-12-10"
-                    + " 10:30:43\",\"author\":\"test-author\",\"metadata\":{\"keywords\":\"coffee,"
-                    + " morning, work\",\"time_info\":\"\",\"source_message\":\"I like to drink"
-                    + " coffee while working in the"
-                    + " morning\",\"observation_type\":\"personal_info_with_time\"},"
-                    + "\"target\":\"user\",\"reflection_subject\":\"\"}],\"deleted_memory_ids\":[],"
-                    + "\"update_result\":{\"deleted_count\":0,\"inserted_count\":1}}}";
-
-        mockServer.enqueue(new MockResponse().setBody(responseJson).setResponseCode(200));
-
-        // Create request
-        ReMeMessage message1 =
-                ReMeMessage.builder()
-                        .role("user")
-                        .content("I like to drink coffee while working in the morning")
-                        .build();
-        ReMeMessage message2 =
-                ReMeMessage.builder()
-                        .role("assistant")
-                        .content(
-                                "I understand, you prefer to start your workday with coffee to stay"
-                                        + " energized")
-                        .build();
-
-        ReMeTrajectory trajectory =
-                ReMeTrajectory.builder().messages(List.of(message1, message2)).build();
+        mockServer.enqueue(
+                new MockResponse()
+                        .setBody(
+                                "{\"answer\":\"\",\"success\":true,\"metadata\":{\"path\":\"daily/2026-07-04/task-session.md\",\"created\":true,\"modified\":true,\"n_messages\":2,\"source_conversation\":\"session/dialog/task-session.jsonl\",\"index\":{\"updated\":true}}}")
+                        .setResponseCode(200));
 
         ReMeAddRequest request =
                 ReMeAddRequest.builder()
-                        .workspaceId("task_workspace")
-                        .trajectories(List.of(trajectory))
+                        .sessionId("task-session")
+                        .messages(
+                                List.of(
+                                        ReMeMessage.builder()
+                                                .role("user")
+                                                .content("I like coffee in the morning")
+                                                .build(),
+                                        ReMeMessage.builder()
+                                                .role("assistant")
+                                                .content("Noted. You prefer coffee while working.")
+                                                .build()))
+                        .memoryHint("preference memory")
+                        .metadata(Map.of("tenant", "demo"))
                         .build();
 
-        // Execute and verify
         StepVerifier.create(client.add(request))
                 .assertNext(
                         response -> {
@@ -132,49 +112,64 @@ class ReMeClientTest {
                             assertEquals(true, response.getSuccess());
                             assertEquals("", response.getAnswer());
                             assertNotNull(response.getMetadata());
-                            assertNotNull(response.getMetadata().getMemoryList());
-                            assertEquals(1, response.getMetadata().getMemoryList().size());
-                            ReMeAddResponse.MemoryItem memory =
-                                    response.getMetadata().getMemoryList().get(0);
-                            assertEquals("task_workspace", memory.getWorkspaceId());
                             assertEquals(
-                                    "user drinks coffee in the morning while working",
-                                    memory.getContent());
-                            assertNotNull(response.getMetadata().getUpdateResult());
+                                    "daily/2026-07-04/task-session.md",
+                                    response.getMetadata().getPath());
+                            assertEquals(true, response.getMetadata().getCreated());
+                            assertEquals(true, response.getMetadata().getModified());
+                            assertEquals(2, response.getMetadata().getNMessages());
                             assertEquals(
-                                    1, response.getMetadata().getUpdateResult().getInsertedCount());
+                                    "session/dialog/task-session.jsonl",
+                                    response.getMetadata().getSourceConversation());
+                            assertEquals(true, response.getMetadata().getIndex().get("updated"));
                         })
                 .verifyComplete();
 
-        // Verify request
         RecordedRequest recordedRequest = mockServer.takeRequest();
         assertEquals("POST", recordedRequest.getMethod());
-        assertEquals("/summary_personal_memory", recordedRequest.getPath());
+        assertEquals("/auto_memory", recordedRequest.getPath());
         assertTrue(recordedRequest.getHeader("Content-Type").contains("application/json"));
 
-        // Verify request body
         String requestBody = recordedRequest.getBody().readUtf8();
-        assertTrue(requestBody.contains("\"workspace_id\":\"task_workspace\""));
-        assertTrue(requestBody.contains("\"trajectories\""));
+        assertTrue(requestBody.contains("\"session_id\":\"task-session\""));
+        assertTrue(requestBody.contains("\"messages\""));
+        assertTrue(requestBody.contains("\"memory_hint\":\"preference memory\""));
+        assertTrue(requestBody.contains("\"tenant\":\"demo\""));
         assertTrue(requestBody.contains("\"role\":\"user\""));
-        assertTrue(requestBody.contains("\"content\":\"I like to drink coffee"));
+        assertTrue(requestBody.contains("\"role\":\"assistant\""));
     }
 
     @Test
-    void testAddRequestWithEmptyResponse() throws Exception {
-        // Mock empty response body (should return empty object)
-        mockServer.enqueue(new MockResponse().setBody("").setResponseCode(200));
-
-        ReMeMessage message = ReMeMessage.builder().role("user").content("Test").build();
-        ReMeTrajectory trajectory = ReMeTrajectory.builder().messages(List.of(message)).build();
+    void testAddRequestWithLegacyWorkspaceAlias() throws Exception {
+        mockServer.enqueue(new MockResponse().setBody("{}").setResponseCode(200));
 
         ReMeAddRequest request =
                 ReMeAddRequest.builder()
-                        .workspaceId("test_workspace")
-                        .trajectories(List.of(trajectory))
+                        .workspaceId("legacy-workspace")
+                        .messages(
+                                List.of(ReMeMessage.builder().role("user").content("Test").build()))
                         .build();
 
-        // Should handle empty response gracefully
+        StepVerifier.create(client.add(request))
+                .assertNext(response -> assertNotNull(response))
+                .verifyComplete();
+
+        RecordedRequest recordedRequest = mockServer.takeRequest();
+        String requestBody = recordedRequest.getBody().readUtf8();
+        assertTrue(requestBody.contains("\"session_id\":\"legacy-workspace\""));
+    }
+
+    @Test
+    void testAddRequestWithEmptyResponse() {
+        mockServer.enqueue(new MockResponse().setBody("").setResponseCode(200));
+
+        ReMeAddRequest request =
+                ReMeAddRequest.builder()
+                        .sessionId("test-session")
+                        .messages(
+                                List.of(ReMeMessage.builder().role("user").content("Test").build()))
+                        .build();
+
         StepVerifier.create(client.add(request))
                 .assertNext(response -> assertNotNull(response))
                 .verifyComplete();
@@ -185,20 +180,18 @@ class ReMeClientTest {
         mockServer.enqueue(
                 new MockResponse().setBody("{\"error\":\"Bad request\"}").setResponseCode(400));
 
-        ReMeMessage message = ReMeMessage.builder().role("user").content("Test").build();
-        ReMeTrajectory trajectory = ReMeTrajectory.builder().messages(List.of(message)).build();
-
         ReMeAddRequest request =
                 ReMeAddRequest.builder()
-                        .workspaceId("test_workspace")
-                        .trajectories(List.of(trajectory))
+                        .sessionId("test-session")
+                        .messages(
+                                List.of(ReMeMessage.builder().role("user").content("Test").build()))
                         .build();
 
         StepVerifier.create(client.add(request))
                 .expectErrorMatches(
                         error ->
                                 error.getMessage().contains("failed with status 400")
-                                        && error.getMessage().contains("summary_personal_memory"))
+                                        && error.getMessage().contains("auto_memory"))
                 .verify();
     }
 
@@ -206,13 +199,11 @@ class ReMeClientTest {
     void testAddRequestInvalidJson() {
         mockServer.enqueue(new MockResponse().setBody("invalid json").setResponseCode(200));
 
-        ReMeMessage message = ReMeMessage.builder().role("user").content("Test").build();
-        ReMeTrajectory trajectory = ReMeTrajectory.builder().messages(List.of(message)).build();
-
         ReMeAddRequest request =
                 ReMeAddRequest.builder()
-                        .workspaceId("test_workspace")
-                        .trajectories(List.of(trajectory))
+                        .sessionId("test-session")
+                        .messages(
+                                List.of(ReMeMessage.builder().role("user").content("Test").build()))
                         .build();
 
         StepVerifier.create(client.add(request))
@@ -225,82 +216,21 @@ class ReMeClientTest {
 
     @Test
     void testSearchRequestSuccess() throws Exception {
-        // Mock successful search response matching actual API format
-        String responseJson =
-                "{\"answer\":\"user drinks coffee in the morning while working\",\"success\":true,"
-                    + "\"metadata\":{\"memory_list\":[{\"workspace_id\":\"task_workspace\","
-                    + "\"memory_id\":\"test_memory_id\",\"memory_type\":\"personal\",\"when_to_use\":\"coffee,"
-                    + " morning, work\",\"content\":\"user drinks coffee in the morning while"
-                    + " working\",\"score\":0.048747035796754684,\"time_created\":\"2025-12-10"
-                    + " 10:30:43\",\"time_modified\":\"2025-12-10"
-                    + " 10:30:43\",\"author\":\"test-author\",\"metadata\":{\"keywords\":\"coffee,"
-                    + " morning, work\",\"time_info\":\"\",\"source_message\":\"I like to drink"
-                    + " coffee while working in the"
-                    + " morning\",\"observation_type\":\"personal_info_with_time\"},"
-                    + "\"target\":\"user\",\"reflection_subject\":\"\"}]}}";
-
-        mockServer.enqueue(new MockResponse().setBody(responseJson).setResponseCode(200));
-
-        // Create request
-        ReMeSearchRequest request =
-                ReMeSearchRequest.builder()
-                        .workspaceId("task_workspace")
-                        .query("What are the user's work habits?")
-                        .topK(5)
-                        .build();
-
-        // Execute and verify
-        StepVerifier.create(client.search(request))
-                .assertNext(
-                        response -> {
-                            assertNotNull(response);
-                            assertEquals(true, response.getSuccess());
-                            assertEquals(
-                                    "user drinks coffee in the morning while working",
-                                    response.getAnswer());
-                            assertNotNull(response.getMetadata());
-                            assertNotNull(response.getMetadata().getMemoryList());
-                            assertEquals(1, response.getMetadata().getMemoryList().size());
-                            ReMeSearchResponse.MemoryItem memory =
-                                    response.getMetadata().getMemoryList().get(0);
-                            assertEquals("task_workspace", memory.getWorkspaceId());
-                            assertEquals(
-                                    "user drinks coffee in the morning while working",
-                                    memory.getContent());
-                            // Test backward compatibility - getMemories() should extract content
-                            assertNotNull(response.getMemories());
-                            assertEquals(1, response.getMemories().size());
-                            assertEquals(
-                                    "user drinks coffee in the morning while working",
-                                    response.getMemories().get(0));
-                        })
-                .verifyComplete();
-
-        // Verify request
-        RecordedRequest recordedRequest = mockServer.takeRequest();
-        assertEquals("POST", recordedRequest.getMethod());
-        assertEquals("/retrieve_personal_memory", recordedRequest.getPath());
-        assertTrue(recordedRequest.getHeader("Content-Type").contains("application/json"));
-
-        // Verify request body
-        String requestBody = recordedRequest.getBody().readUtf8();
-        assertTrue(requestBody.contains("\"workspace_id\":\"task_workspace\""));
-        assertTrue(requestBody.contains("\"query\":\"What are the user's work habits?\""));
-        assertTrue(requestBody.contains("\"top_k\":5"));
-    }
-
-    @Test
-    void testSearchRequestEmptyResults() throws Exception {
-        String responseJson =
-                "{\"answer\":\"\",\"success\":true,\"metadata\":{\"memory_list\":[]}}";
-
-        mockServer.enqueue(new MockResponse().setBody(responseJson).setResponseCode(200));
+        mockServer.enqueue(
+                new MockResponse()
+                        .setBody(
+                                "{\"answer\":\"\",\"success\":true,\"metadata\":{\"results\":[{\"id\":\"chunk-1\",\"text\":\"User"
+                                    + " likes"
+                                    + " coffee\",\"metadata\":{\"source\":\"daily\"},\"path\":\"daily/2026-07-04.md\",\"start_line\":12,\"end_line\":13,\"scores\":{\"hybrid\":0.91}}],\"counts\":{\"results\":1},\"link_expansion\":{\"enabled\":false}}}")
+                        .setResponseCode(200));
 
         ReMeSearchRequest request =
                 ReMeSearchRequest.builder()
-                        .workspaceId("test_workspace")
-                        .query("test query")
-                        .topK(5)
+                        .query("What are the user's preferences?")
+                        .limit(5)
+                        .minScore(0.2)
+                        .metadata(Map.of("scope", "demo"))
+                        .workspaceId("ignored-workspace")
                         .build();
 
         StepVerifier.create(client.search(request))
@@ -310,41 +240,67 @@ class ReMeClientTest {
                             assertEquals(true, response.getSuccess());
                             assertEquals("", response.getAnswer());
                             assertNotNull(response.getMetadata());
-                            assertNotNull(response.getMetadata().getMemoryList());
-                            assertEquals(0, response.getMetadata().getMemoryList().size());
-                            assertEquals(0, response.getMemories().size());
+                            assertEquals(1, response.getMetadata().getResults().size());
+                            ReMeSearchResponse.SearchResult result =
+                                    response.getMetadata().getResults().get(0);
+                            assertEquals("chunk-1", result.getId());
+                            assertEquals("User likes coffee", result.getText());
+                            assertEquals("daily/2026-07-04.md", result.getPath());
+                            assertEquals(12, result.getStartLine());
+                            assertEquals(13, result.getEndLine());
+                            assertEquals(0.91, result.getScores().get("hybrid"));
+                            assertEquals(List.of("User likes coffee"), response.getMemories());
                         })
                 .verifyComplete();
+
+        RecordedRequest recordedRequest = mockServer.takeRequest();
+        assertEquals("POST", recordedRequest.getMethod());
+        assertEquals("/search", recordedRequest.getPath());
+        String requestBody = recordedRequest.getBody().readUtf8();
+        assertTrue(requestBody.contains("\"query\":\"What are the user's preferences?\""));
+        assertTrue(requestBody.contains("\"limit\":5"));
+        assertTrue(requestBody.contains("\"min_score\":0.2"));
+        assertTrue(requestBody.contains("\"scope\":\"demo\""));
+        assertTrue(!requestBody.contains("workspace_id"));
     }
 
     @Test
-    void testSearchRequestWithDefaultTopK() throws Exception {
-        String responseJson =
-                "{\"answer\":\"Memory"
-                    + " 1\",\"success\":true,\"metadata\":{\"memory_list\":[{\"workspace_id\":\"test_workspace\",\"memory_id\":\"mem1\",\"content\":\"Memory"
-                    + " 1\"}]}}";
+    void testSearchRequestEmptyResults() {
+        mockServer.enqueue(
+                new MockResponse()
+                        .setBody(
+                                "{\"answer\":\"\",\"success\":true,\"metadata\":{\"results\":[],\"counts\":{\"results\":0}}}")
+                        .setResponseCode(200));
 
-        mockServer.enqueue(new MockResponse().setBody(responseJson).setResponseCode(200));
-
-        ReMeSearchRequest request =
-                ReMeSearchRequest.builder()
-                        .workspaceId("test_workspace")
-                        .query("test")
-                        .build(); // topK not set, should use default
+        ReMeSearchRequest request = ReMeSearchRequest.builder().query("test query").build();
 
         StepVerifier.create(client.search(request))
                 .assertNext(
                         response -> {
                             assertNotNull(response);
                             assertEquals(true, response.getSuccess());
-                            assertEquals("Memory 1", response.getAnswer());
+                            assertEquals("", response.getAnswer());
+                            assertNotNull(response.getMetadata());
+                            assertEquals(0, response.getMetadata().getResults().size());
+                            assertEquals(0, response.getMemories().size());
                         })
                 .verifyComplete();
+    }
 
-        // Verify default topK is used
+    @Test
+    void testSearchRequestWithDefaultLimit() throws Exception {
+        mockServer.enqueue(new MockResponse().setBody("{}").setResponseCode(200));
+
+        ReMeSearchRequest request = ReMeSearchRequest.builder().query("test").build();
+
+        StepVerifier.create(client.search(request))
+                .assertNext(response -> assertNotNull(response))
+                .verifyComplete();
+
         RecordedRequest recordedRequest = mockServer.takeRequest();
         String requestBody = recordedRequest.getBody().readUtf8();
-        assertTrue(requestBody.contains("\"top_k\":5")); // Default value
+        assertTrue(requestBody.contains("\"limit\":5"));
+        assertTrue(requestBody.contains("\"min_score\":0.0"));
     }
 
     @Test
@@ -352,18 +308,13 @@ class ReMeClientTest {
         mockServer.enqueue(
                 new MockResponse().setBody("{\"error\":\"Not found\"}").setResponseCode(404));
 
-        ReMeSearchRequest request =
-                ReMeSearchRequest.builder()
-                        .workspaceId("test_workspace")
-                        .query("test query")
-                        .topK(5)
-                        .build();
+        ReMeSearchRequest request = ReMeSearchRequest.builder().query("test query").build();
 
         StepVerifier.create(client.search(request))
                 .expectErrorMatches(
                         error ->
                                 error.getMessage().contains("failed with status 404")
-                                        && error.getMessage().contains("retrieve_personal_memory"))
+                                        && error.getMessage().contains("search"))
                 .verify();
     }
 
@@ -371,8 +322,7 @@ class ReMeClientTest {
     void testSearchRequestInvalidJson() {
         mockServer.enqueue(new MockResponse().setBody("not valid json").setResponseCode(200));
 
-        ReMeSearchRequest request =
-                ReMeSearchRequest.builder().workspaceId("test_workspace").query("test").build();
+        ReMeSearchRequest request = ReMeSearchRequest.builder().query("test").build();
 
         StepVerifier.create(client.search(request))
                 .expectErrorMatches(
@@ -383,189 +333,34 @@ class ReMeClientTest {
     }
 
     @Test
-    void testSearchRequestWithMultipleMemories() throws Exception {
-        String responseJson =
-                "{\"answer\":\"First memory fragment. Second memory fragment. Third memory"
-                    + " fragment\",\"success\":true,\"metadata\":{\"memory_list\":[{"
-                    + "\"workspace_id\":\"test_workspace\",\"memory_id\":\"mem1\",\"content\":\"First"
-                    + " memory fragment\",\"score\":0.9"
-                    + "},{\"workspace_id\":\"test_workspace\",\"memory_id\":\"mem2\",\"content\":\"Second"
-                    + " memory fragment\",\"score\":0.8"
-                    + "},{\"workspace_id\":\"test_workspace\",\"memory_id\":\"mem3\",\"content\":\"Third"
-                    + " memory fragment\",\"score\":0.7}]}}";
-
-        mockServer.enqueue(new MockResponse().setBody(responseJson).setResponseCode(200));
-
-        ReMeSearchRequest request =
-                ReMeSearchRequest.builder()
-                        .workspaceId("test_workspace")
-                        .query("test query")
-                        .topK(10)
-                        .build();
-
-        StepVerifier.create(client.search(request))
-                .assertNext(
-                        response -> {
-                            assertNotNull(response);
-                            assertEquals(true, response.getSuccess());
-                            assertNotNull(response.getMetadata());
-                            assertNotNull(response.getMetadata().getMemoryList());
-                            assertEquals(3, response.getMetadata().getMemoryList().size());
-                            // Test backward compatibility
-                            assertNotNull(response.getMemories());
-                            assertEquals(3, response.getMemories().size());
-                            assertEquals("First memory fragment", response.getMemories().get(0));
-                            assertEquals("Second memory fragment", response.getMemories().get(1));
-                            assertEquals("Third memory fragment", response.getMemories().get(2));
-                        })
-                .verifyComplete();
-    }
-
-    @Test
     void testShutdown() {
-        ReMeClient client = new ReMeClient("http://localhost:8002");
-        // Should not throw exception
-        client.shutdown();
-    }
-
-    @Test
-    void testRequestBodySerialization() throws Exception {
-        mockServer.enqueue(
-                new MockResponse()
-                        .setBody(
-                                "{\"answer\":\"\",\"success\":true,\"metadata\":{\"memory_list\":[],\"deleted_memory_ids\":[],\"update_result\":{\"deleted_count\":0,\"inserted_count\":0}}}")
-                        .setResponseCode(200));
-
-        ReMeMessage message1 = ReMeMessage.builder().role("user").content("Test message 1").build();
-        ReMeMessage message2 =
-                ReMeMessage.builder().role("assistant").content("Test response 1").build();
-        ReMeMessage message3 = ReMeMessage.builder().role("user").content("Test message 2").build();
-
-        ReMeTrajectory trajectory =
-                ReMeTrajectory.builder().messages(List.of(message1, message2, message3)).build();
-
-        ReMeAddRequest request =
-                ReMeAddRequest.builder()
-                        .workspaceId("test_workspace")
-                        .trajectories(List.of(trajectory))
-                        .build();
-
-        StepVerifier.create(client.add(request))
-                .assertNext(response -> assertNotNull(response))
-                .verifyComplete();
-
-        // Verify request body contains expected fields
-        RecordedRequest recordedRequest = mockServer.takeRequest();
-        String requestBody = recordedRequest.getBody().readUtf8();
-        assertTrue(requestBody.contains("\"workspace_id\":\"test_workspace\""));
-        assertTrue(requestBody.contains("\"trajectories\""));
-        assertTrue(requestBody.contains("\"role\":\"user\""));
-        assertTrue(requestBody.contains("\"role\":\"assistant\""));
-        assertTrue(requestBody.contains("\"content\":\"Test message 1\""));
-        assertTrue(requestBody.contains("\"content\":\"Test response 1\""));
-        assertTrue(requestBody.contains("\"content\":\"Test message 2\""));
-    }
-
-    @Test
-    void testSearchRequestBodySerialization() throws Exception {
-        mockServer.enqueue(
-                new MockResponse()
-                        .setBody(
-                                "{\"answer\":\"Memory"
-                                    + " 1\",\"success\":true,\"metadata\":{\"memory_list\":[{\"workspace_id\":\"test_workspace\",\"memory_id\":\"mem1\",\"content\":\"Memory"
-                                    + " 1\"}]}}")
-                        .setResponseCode(200));
-
-        ReMeSearchRequest request =
-                ReMeSearchRequest.builder()
-                        .workspaceId("test_workspace")
-                        .query("What are the user preferences?")
-                        .topK(10)
-                        .build();
-
-        StepVerifier.create(client.search(request))
-                .assertNext(response -> assertNotNull(response))
-                .verifyComplete();
-
-        // Verify request body contains expected fields
-        RecordedRequest recordedRequest = mockServer.takeRequest();
-        String requestBody = recordedRequest.getBody().readUtf8();
-        assertTrue(requestBody.contains("\"workspace_id\":\"test_workspace\""));
-        assertTrue(requestBody.contains("\"query\":\"What are the user preferences?\""));
-        assertTrue(requestBody.contains("\"top_k\":10"));
+        ReMeClient shutdownClient = new ReMeClient("http://localhost:8002");
+        shutdownClient.shutdown();
     }
 
     @Test
     void testHttpTimeout() {
-        // Create client with very short timeout
         String baseUrl = mockServer.url("/").toString();
         if (baseUrl.endsWith("/")) {
             baseUrl = baseUrl.substring(0, baseUrl.length() - 1);
         }
         ReMeClient shortTimeoutClient = new ReMeClient(baseUrl, Duration.ofMillis(1));
 
-        // Enqueue delayed response
         mockServer.enqueue(
                 new MockResponse()
-                        .setBody("{\"status\":\"success\"}")
+                        .setBody("{}")
                         .setResponseCode(200)
                         .setBodyDelay(1000, TimeUnit.MILLISECONDS));
 
-        ReMeMessage message = ReMeMessage.builder().role("user").content("Test").build();
-        ReMeTrajectory trajectory = ReMeTrajectory.builder().messages(List.of(message)).build();
-
         ReMeAddRequest request =
                 ReMeAddRequest.builder()
-                        .workspaceId("test_workspace")
-                        .trajectories(List.of(trajectory))
+                        .sessionId("test-session")
+                        .messages(
+                                List.of(ReMeMessage.builder().role("user").content("Test").build()))
                         .build();
 
-        // Should timeout
         StepVerifier.create(shortTimeoutClient.add(request)).expectError().verify();
 
         shortTimeoutClient.shutdown();
-    }
-
-    @Test
-    void testMultipleTrajectoriesInAddRequest() throws Exception {
-        String responseJson =
-                "{\"answer\":\"\",\"success\":true,\"metadata\":{\"memory_list\":[],\"deleted_memory_ids\":[],\"update_result\":{\"deleted_count\":0,\"inserted_count\":2}}}";
-
-        mockServer.enqueue(new MockResponse().setBody(responseJson).setResponseCode(200));
-
-        // Create multiple trajectories
-        ReMeMessage msg1 = ReMeMessage.builder().role("user").content("Message 1").build();
-        ReMeMessage msg2 = ReMeMessage.builder().role("assistant").content("Response 1").build();
-        ReMeTrajectory trajectory1 = ReMeTrajectory.builder().messages(List.of(msg1, msg2)).build();
-
-        ReMeMessage msg3 = ReMeMessage.builder().role("user").content("Message 2").build();
-        ReMeMessage msg4 = ReMeMessage.builder().role("assistant").content("Response 2").build();
-        ReMeTrajectory trajectory2 = ReMeTrajectory.builder().messages(List.of(msg3, msg4)).build();
-
-        ReMeAddRequest request =
-                ReMeAddRequest.builder()
-                        .workspaceId("test_workspace")
-                        .trajectories(List.of(trajectory1, trajectory2))
-                        .build();
-
-        StepVerifier.create(client.add(request))
-                .assertNext(
-                        response -> {
-                            assertNotNull(response);
-                            assertEquals(true, response.getSuccess());
-                            assertNotNull(response.getMetadata());
-                            assertNotNull(response.getMetadata().getUpdateResult());
-                            assertEquals(
-                                    2, response.getMetadata().getUpdateResult().getInsertedCount());
-                        })
-                .verifyComplete();
-
-        // Verify request contains both trajectories
-        RecordedRequest recordedRequest = mockServer.takeRequest();
-        String requestBody = recordedRequest.getBody().readUtf8();
-        assertTrue(requestBody.contains("\"trajectories\""));
-        // Should contain messages from both trajectories
-        assertTrue(requestBody.contains("\"content\":\"Message 1\""));
-        assertTrue(requestBody.contains("\"content\":\"Message 2\""));
     }
 }

--- a/agentscope-extensions/agentscope-extensions-mem/agentscope-extensions-reme/src/test/java/io/agentscope/core/memory/reme/ReMeLongTermMemoryTest.java
+++ b/agentscope-extensions/agentscope-extensions-mem/agentscope-extensions-reme/src/test/java/io/agentscope/core/memory/reme/ReMeLongTermMemoryTest.java
@@ -45,7 +45,6 @@ class ReMeLongTermMemoryTest {
         mockServer = new MockWebServer();
         mockServer.start();
         baseUrl = mockServer.url("/").toString();
-        // Remove trailing slash
         if (baseUrl.endsWith("/")) {
             baseUrl = baseUrl.substring(0, baseUrl.length() - 1);
         }
@@ -59,9 +58,17 @@ class ReMeLongTermMemoryTest {
     }
 
     @Test
-    void testBuilderWithUserId() {
+    void testBuilderWithSessionId() {
         ReMeLongTermMemory memory =
-                ReMeLongTermMemory.builder().userId("task_workspace").apiBaseUrl(baseUrl).build();
+                ReMeLongTermMemory.builder().sessionId("task-session").apiBaseUrl(baseUrl).build();
+
+        assertNotNull(memory);
+    }
+
+    @Test
+    void testBuilderWithLegacyUserId() {
+        ReMeLongTermMemory memory =
+                ReMeLongTermMemory.builder().userId("legacy-user").apiBaseUrl(baseUrl).build();
 
         assertNotNull(memory);
     }
@@ -70,7 +77,7 @@ class ReMeLongTermMemoryTest {
     void testBuilderWithCustomTimeout() {
         ReMeLongTermMemory memory =
                 ReMeLongTermMemory.builder()
-                        .userId("task_workspace")
+                        .sessionId("task-session")
                         .apiBaseUrl(baseUrl)
                         .timeout(Duration.ofSeconds(30))
                         .build();
@@ -79,13 +86,13 @@ class ReMeLongTermMemoryTest {
     }
 
     @Test
-    void testBuilderRequiresUserId() {
+    void testBuilderRequiresSessionOrUserId() {
         IllegalArgumentException exception =
                 assertThrows(
                         IllegalArgumentException.class,
                         () -> ReMeLongTermMemory.builder().apiBaseUrl(baseUrl).build());
 
-        assertEquals("userId is required", exception.getMessage());
+        assertEquals("sessionId or userId is required", exception.getMessage());
     }
 
     @Test
@@ -93,57 +100,21 @@ class ReMeLongTermMemoryTest {
         IllegalArgumentException exception =
                 assertThrows(
                         IllegalArgumentException.class,
-                        () -> ReMeLongTermMemory.builder().userId("task_workspace").build());
+                        () -> ReMeLongTermMemory.builder().sessionId("task-session").build());
 
         assertEquals("apiBaseUrl is required", exception.getMessage());
     }
 
     @Test
-    void testBuilderWithEmptyUserId() {
-        IllegalArgumentException exception =
-                assertThrows(
-                        IllegalArgumentException.class,
-                        () -> ReMeLongTermMemory.builder().userId("").apiBaseUrl(baseUrl).build());
-
-        assertEquals("userId is required", exception.getMessage());
-    }
-
-    @Test
-    void testBuilderWithEmptyApiBaseUrl() {
-        IllegalArgumentException exception =
-                assertThrows(
-                        IllegalArgumentException.class,
-                        () ->
-                                ReMeLongTermMemory.builder()
-                                        .userId("task_workspace")
-                                        .apiBaseUrl("")
-                                        .build());
-
-        assertEquals("apiBaseUrl is required", exception.getMessage());
-    }
-
-    @Test
-    void testRecordWithValidMessages() {
-        // Mock response with complete ReMeAddResponse structure
-        String responseJson =
-                "{\"answer\":\"\",\"success\":true,\"metadata\":{\"memory_list\":[{"
-                    + "\"workspace_id\":\"task_workspace\","
-                    + "\"memory_id\":\"688e9ef5904e4c8b8d60ef6ffff77c75\",\"memory_type\":\"personal\",\"when_to_use\":\"coffee,"
-                    + " morning, work\",\"content\":\"user drinks coffee in the morning while"
-                    + " working\",\"score\":0.048747035796754684,\"time_created\":\"2025-12-10"
-                    + " 10:30:43\",\"time_modified\":\"2025-12-10 10:30:43\","
-                    + "\"author\":\"qwen3-30b-a3b-thinking-2507\",\"metadata\":{\"keywords\":\"coffee,"
-                    + " morning, work\",\"time_info\":\"\",\"source_message\":\"I like to drink"
-                    + " coffee while working in the"
-                    + " morning\",\"observation_type\":\"personal_info_with_time\","
-                    + "\"match_event_flag\":\"0\",\"match_msg_flag\":\"0\"},\"target\":\"user\","
-                    + "\"reflection_subject\":\"\"}],\"deleted_memory_ids\":[],\"update_result\":{"
-                    + "\"deleted_count\":0,\"inserted_count\":1}}}";
-
-        mockServer.enqueue(new MockResponse().setBody(responseJson).setResponseCode(200));
+    void testRecordWithValidMessages() throws Exception {
+        mockServer.enqueue(
+                new MockResponse()
+                        .setBody(
+                                "{\"answer\":\"\",\"success\":true,\"metadata\":{\"path\":\"daily/2026-07-04/task-session.md\",\"created\":true,\"modified\":true,\"n_messages\":2}}")
+                        .setResponseCode(200));
 
         ReMeLongTermMemory memory =
-                ReMeLongTermMemory.builder().userId("task_workspace").apiBaseUrl(baseUrl).build();
+                ReMeLongTermMemory.builder().sessionId("task-session").apiBaseUrl(baseUrl).build();
 
         List<Msg> messages = new ArrayList<>();
         messages.add(
@@ -159,170 +130,110 @@ class ReMeLongTermMemoryTest {
                         .role(MsgRole.ASSISTANT)
                         .content(
                                 TextBlock.builder()
-                                        .text(
-                                                "I understand, you prefer to start your workday"
-                                                        + " with coffee to stay energized")
+                                        .text("Noted. You prefer coffee while working.")
                                         .build())
                         .build());
 
         StepVerifier.create(memory.record(messages)).verifyComplete();
 
-        // Verify response parsing by directly testing ReMeClient
-        ReMeClient client = new ReMeClient(baseUrl);
-        ReMeMessage remeMsg1 =
-                ReMeMessage.builder()
-                        .role("user")
-                        .content("I like to drink coffee while working in the morning")
-                        .build();
-        ReMeMessage remeMsg2 =
-                ReMeMessage.builder()
-                        .role("assistant")
-                        .content(
-                                "I understand, you prefer to start your workday with coffee to stay"
-                                        + " energized")
-                        .build();
-        ReMeTrajectory trajectory =
-                ReMeTrajectory.builder().messages(List.of(remeMsg1, remeMsg2)).build();
-        ReMeAddRequest addRequest =
-                ReMeAddRequest.builder()
-                        .workspaceId("task_workspace")
-                        .trajectories(List.of(trajectory))
-                        .build();
+        RecordedRequest recordedRequest = mockServer.takeRequest();
+        assertEquals("POST", recordedRequest.getMethod());
+        assertEquals("/auto_memory", recordedRequest.getPath());
+        String requestBody = recordedRequest.getBody().readUtf8();
+        assertTrue(requestBody.contains("\"session_id\":\"task-session\""));
+        assertTrue(requestBody.contains("\"messages\""));
+        assertTrue(
+                requestBody.contains(
+                        "\"content\":\"I like to drink coffee while working in the morning\""));
+        assertTrue(requestBody.contains("\"content\":\"Noted. You prefer coffee while working.\""));
+    }
 
-        mockServer.enqueue(new MockResponse().setBody(responseJson).setResponseCode(200));
+    @Test
+    void testRecordUsesLegacyUserIdAsSessionId() throws Exception {
+        mockServer.enqueue(new MockResponse().setBody("{}").setResponseCode(200));
 
-        StepVerifier.create(client.add(addRequest))
-                .assertNext(
-                        response -> {
-                            // Verify top-level fields
-                            assertNotNull(response);
-                            assertEquals("", response.getAnswer());
-                            assertEquals(true, response.getSuccess());
-                            assertNotNull(response.getMetadata());
+        ReMeLongTermMemory memory =
+                ReMeLongTermMemory.builder().userId("legacy-user").apiBaseUrl(baseUrl).build();
 
-                            // Verify metadata fields
-                            ReMeAddResponse.Metadata metadata = response.getMetadata();
-                            assertNotNull(metadata.getMemoryList());
-                            assertEquals(1, metadata.getMemoryList().size());
-                            assertNotNull(metadata.getDeletedMemoryIds());
-                            assertEquals(0, metadata.getDeletedMemoryIds().size());
-                            assertNotNull(metadata.getUpdateResult());
-
-                            // Verify update_result
-                            ReMeAddResponse.UpdateResult updateResult = metadata.getUpdateResult();
-                            assertEquals(0, updateResult.getDeletedCount());
-                            assertEquals(1, updateResult.getInsertedCount());
-
-                            // Verify memory_list item
-                            ReMeAddResponse.MemoryItem memoryItem = metadata.getMemoryList().get(0);
-                            assertEquals("task_workspace", memoryItem.getWorkspaceId());
-                            assertEquals(
-                                    "688e9ef5904e4c8b8d60ef6ffff77c75", memoryItem.getMemoryId());
-                            assertEquals("personal", memoryItem.getMemoryType());
-                            assertEquals("coffee, morning, work", memoryItem.getWhenToUse());
-                            assertEquals(
-                                    "user drinks coffee in the morning while working",
-                                    memoryItem.getContent());
-                            assertEquals(0.048747035796754684, memoryItem.getScore());
-                            assertEquals("2025-12-10 10:30:43", memoryItem.getTimeCreated());
-                            assertEquals("2025-12-10 10:30:43", memoryItem.getTimeModified());
-                            assertEquals("qwen3-30b-a3b-thinking-2507", memoryItem.getAuthor());
-                            assertEquals("user", memoryItem.getTarget());
-                            assertEquals("", memoryItem.getReflectionSubject());
-
-                            // Verify nested metadata
-                            assertNotNull(memoryItem.getMetadata());
-                            assertEquals(
-                                    "coffee, morning, work",
-                                    memoryItem.getMetadata().get("keywords"));
-                            assertEquals("", memoryItem.getMetadata().get("time_info"));
-                            assertEquals(
-                                    "I like to drink coffee while working in the morning",
-                                    memoryItem.getMetadata().get("source_message"));
-                            assertEquals(
-                                    "personal_info_with_time",
-                                    memoryItem.getMetadata().get("observation_type"));
-                            assertEquals("0", memoryItem.getMetadata().get("match_event_flag"));
-                            assertEquals("0", memoryItem.getMetadata().get("match_msg_flag"));
-                        })
+        StepVerifier.create(
+                        memory.record(
+                                List.of(
+                                        Msg.builder()
+                                                .role(MsgRole.USER)
+                                                .content(TextBlock.builder().text("Hello").build())
+                                                .build())))
                 .verifyComplete();
 
-        client.shutdown();
+        RecordedRequest recordedRequest = mockServer.takeRequest();
+        assertTrue(recordedRequest.getBody().readUtf8().contains("\"session_id\":\"legacy-user\""));
+    }
+
+    @Test
+    void testRecordFiltersInvalidMessages() throws Exception {
+        mockServer.enqueue(new MockResponse().setBody("{}").setResponseCode(200));
+
+        ReMeLongTermMemory memory =
+                ReMeLongTermMemory.builder().sessionId("task-session").apiBaseUrl(baseUrl).build();
+
+        List<Msg> messages = new ArrayList<>();
+        messages.add(
+                Msg.builder()
+                        .role(MsgRole.USER)
+                        .content(TextBlock.builder().text("Valid user message").build())
+                        .build());
+        messages.add(
+                Msg.builder()
+                        .role(MsgRole.SYSTEM)
+                        .content(TextBlock.builder().text("System message").build())
+                        .build());
+        messages.add(
+                Msg.builder()
+                        .role(MsgRole.USER)
+                        .content(TextBlock.builder().text("").build())
+                        .build());
+        messages.add(
+                Msg.builder()
+                        .role(MsgRole.ASSISTANT)
+                        .content(TextBlock.builder().text("<compressed_history>ignore").build())
+                        .build());
+        messages.add(
+                Msg.builder()
+                        .role(MsgRole.ASSISTANT)
+                        .content(TextBlock.builder().text("Valid assistant message").build())
+                        .build());
+
+        StepVerifier.create(memory.record(messages)).verifyComplete();
+
+        RecordedRequest recordedRequest = mockServer.takeRequest();
+        String requestBody = recordedRequest.getBody().readUtf8();
+        assertTrue(requestBody.contains("\"content\":\"Valid user message\""));
+        assertTrue(requestBody.contains("\"content\":\"Valid assistant message\""));
+        assertTrue(!requestBody.contains("System message"));
+        assertTrue(!requestBody.contains("<compressed_history>"));
     }
 
     @Test
     void testRecordWithNullMessages() {
         ReMeLongTermMemory memory =
-                ReMeLongTermMemory.builder().userId("task_workspace").apiBaseUrl(baseUrl).build();
+                ReMeLongTermMemory.builder().sessionId("task-session").apiBaseUrl(baseUrl).build();
 
         StepVerifier.create(memory.record(null)).verifyComplete();
+        assertEquals(0, mockServer.getRequestCount());
     }
 
     @Test
     void testRecordWithEmptyMessages() {
         ReMeLongTermMemory memory =
-                ReMeLongTermMemory.builder().userId("task_workspace").apiBaseUrl(baseUrl).build();
+                ReMeLongTermMemory.builder().sessionId("task-session").apiBaseUrl(baseUrl).build();
 
         StepVerifier.create(memory.record(new ArrayList<>())).verifyComplete();
-    }
-
-    @Test
-    void testRecordFiltersNullMessages() {
-        mockServer.enqueue(
-                new MockResponse()
-                        .setBody(
-                                "{\"answer\":\"\",\"success\":true,\"metadata\":{\"memory_list\":[],\"deleted_memory_ids\":[],\"update_result\":{\"deleted_count\":0,\"inserted_count\":1}}}")
-                        .setResponseCode(200));
-
-        ReMeLongTermMemory memory =
-                ReMeLongTermMemory.builder().userId("task_workspace").apiBaseUrl(baseUrl).build();
-
-        List<Msg> messages = new ArrayList<>();
-        messages.add(
-                Msg.builder()
-                        .role(MsgRole.USER)
-                        .content(TextBlock.builder().text("Valid message").build())
-                        .build());
-        messages.add(null);
-        messages.add(
-                Msg.builder()
-                        .role(MsgRole.ASSISTANT)
-                        .content(TextBlock.builder().text("Another valid").build())
-                        .build());
-
-        StepVerifier.create(memory.record(messages)).verifyComplete();
-    }
-
-    @Test
-    void testRecordFiltersEmptyContentMessages() {
-        mockServer.enqueue(
-                new MockResponse()
-                        .setBody(
-                                "{\"answer\":\"\",\"success\":true,\"metadata\":{\"memory_list\":[],\"deleted_memory_ids\":[],\"update_result\":{\"deleted_count\":0,\"inserted_count\":1}}}")
-                        .setResponseCode(200));
-
-        ReMeLongTermMemory memory =
-                ReMeLongTermMemory.builder().userId("task_workspace").apiBaseUrl(baseUrl).build();
-
-        List<Msg> messages = new ArrayList<>();
-        messages.add(
-                Msg.builder()
-                        .role(MsgRole.USER)
-                        .content(TextBlock.builder().text("Valid message").build())
-                        .build());
-        messages.add(
-                Msg.builder()
-                        .role(MsgRole.USER)
-                        .content(TextBlock.builder().text("").build())
-                        .build());
-
-        StepVerifier.create(memory.record(messages)).verifyComplete();
+        assertEquals(0, mockServer.getRequestCount());
     }
 
     @Test
     void testRecordWithOnlyInvalidMessages() {
         ReMeLongTermMemory memory =
-                ReMeLongTermMemory.builder().userId("task_workspace").apiBaseUrl(baseUrl).build();
+                ReMeLongTermMemory.builder().sessionId("task-session").apiBaseUrl(baseUrl).build();
 
         List<Msg> messages = new ArrayList<>();
         messages.add(null);
@@ -332,130 +243,21 @@ class ReMeLongTermMemoryTest {
                         .content(TextBlock.builder().text("").build())
                         .build());
 
-        // Should complete without making HTTP request
         StepVerifier.create(memory.record(messages)).verifyComplete();
-    }
-
-    @Test
-    void testRetrieveWithValidQuery() {
-        // Mock response with complete ReMeSearchResponse structure
-        String responseJson =
-                "{\"answer\":\"user drinks coffee in the morning while working\",\"success\":true,"
-                    + "\"metadata\":{\"memory_list\":[{\"workspace_id\":\"task_workspace\","
-                    + "\"memory_id\":\"688e9ef5904e4c8b8d60ef6ffff77c75\",\"memory_type\":\"personal\",\"when_to_use\":\"coffee,"
-                    + " morning, work\",\"content\":\"user drinks coffee in the morning while"
-                    + " working\",\"score\":0.048747035796754684,\"time_created\":\"2025-12-10"
-                    + " 10:30:43\",\"time_modified\":\"2025-12-10 10:30:43\","
-                    + "\"author\":\"qwen3-30b-a3b-thinking-2507\",\"metadata\":{\"keywords\":\"coffee,"
-                    + " morning, work\",\"time_info\":\"\",\"source_message\":\"I like to drink"
-                    + " coffee while working in the"
-                    + " morning\",\"observation_type\":\"personal_info_with_time\","
-                    + "\"match_event_flag\":\"0\",\"match_msg_flag\":\"0\"},\"target\":\"user\","
-                    + "\"reflection_subject\":\"\"}]}}";
-
-        mockServer.enqueue(new MockResponse().setBody(responseJson).setResponseCode(200));
-
-        ReMeLongTermMemory memory =
-                ReMeLongTermMemory.builder().userId("task_workspace").apiBaseUrl(baseUrl).build();
-
-        Msg query =
-                Msg.builder()
-                        .role(MsgRole.USER)
-                        .content(TextBlock.builder().text("What are my work habits?").build())
-                        .build();
-
-        StepVerifier.create(memory.retrieve(query))
-                .assertNext(
-                        result -> {
-                            assertNotNull(result);
-                            // Should use answer field when available
-                            assertEquals("user drinks coffee in the morning while working", result);
-                        })
-                .verifyComplete();
-
-        // Verify response parsing by directly testing ReMeClient
-        ReMeClient client = new ReMeClient(baseUrl);
-        ReMeSearchRequest searchRequest =
-                ReMeSearchRequest.builder()
-                        .workspaceId("task_workspace")
-                        .query("What are my work habits?")
-                        .topK(5)
-                        .build();
-
-        mockServer.enqueue(new MockResponse().setBody(responseJson).setResponseCode(200));
-
-        StepVerifier.create(client.search(searchRequest))
-                .assertNext(
-                        response -> {
-                            // Verify top-level fields
-                            assertNotNull(response);
-                            assertEquals(
-                                    "user drinks coffee in the morning while working",
-                                    response.getAnswer());
-                            assertEquals(true, response.getSuccess());
-                            assertNotNull(response.getMetadata());
-
-                            // Verify metadata
-                            ReMeSearchResponse.Metadata metadata = response.getMetadata();
-                            assertNotNull(metadata.getMemoryList());
-                            assertEquals(1, metadata.getMemoryList().size());
-
-                            // Verify memory_list item
-                            ReMeSearchResponse.MemoryItem memoryItem =
-                                    metadata.getMemoryList().get(0);
-                            assertEquals("task_workspace", memoryItem.getWorkspaceId());
-                            assertEquals(
-                                    "688e9ef5904e4c8b8d60ef6ffff77c75", memoryItem.getMemoryId());
-                            assertEquals("personal", memoryItem.getMemoryType());
-                            assertEquals("coffee, morning, work", memoryItem.getWhenToUse());
-                            assertEquals(
-                                    "user drinks coffee in the morning while working",
-                                    memoryItem.getContent());
-                            assertEquals(0.048747035796754684, memoryItem.getScore());
-                            assertEquals("2025-12-10 10:30:43", memoryItem.getTimeCreated());
-                            assertEquals("2025-12-10 10:30:43", memoryItem.getTimeModified());
-                            assertEquals("qwen3-30b-a3b-thinking-2507", memoryItem.getAuthor());
-                            assertEquals("user", memoryItem.getTarget());
-                            assertEquals("", memoryItem.getReflectionSubject());
-
-                            // Verify nested metadata
-                            assertNotNull(memoryItem.getMetadata());
-                            assertEquals(
-                                    "coffee, morning, work",
-                                    memoryItem.getMetadata().get("keywords"));
-                            assertEquals("", memoryItem.getMetadata().get("time_info"));
-                            assertEquals(
-                                    "I like to drink coffee while working in the morning",
-                                    memoryItem.getMetadata().get("source_message"));
-                            assertEquals(
-                                    "personal_info_with_time",
-                                    memoryItem.getMetadata().get("observation_type"));
-                            assertEquals("0", memoryItem.getMetadata().get("match_event_flag"));
-                            assertEquals("0", memoryItem.getMetadata().get("match_msg_flag"));
-
-                            // Verify backward compatibility - getMemories() method
-                            List<String> memories = response.getMemories();
-                            assertNotNull(memories);
-                            assertEquals(1, memories.size());
-                            assertEquals(
-                                    "user drinks coffee in the morning while working",
-                                    memories.get(0));
-                        })
-                .verifyComplete();
-
-        client.shutdown();
+        assertEquals(0, mockServer.getRequestCount());
     }
 
     @Test
     void testRetrieveWithAnswerField() {
-        String responseJson =
-                "{\"answer\":\"User prefers coffee in the"
-                        + " morning\",\"success\":true,\"metadata\":{\"memory_list\":[]}}";
-
-        mockServer.enqueue(new MockResponse().setBody(responseJson).setResponseCode(200));
+        mockServer.enqueue(
+                new MockResponse()
+                        .setBody(
+                                "{\"answer\":\"User prefers coffee in the"
+                                        + " morning\",\"success\":true}")
+                        .setResponseCode(200));
 
         ReMeLongTermMemory memory =
-                ReMeLongTermMemory.builder().userId("task_workspace").apiBaseUrl(baseUrl).build();
+                ReMeLongTermMemory.builder().sessionId("task-session").apiBaseUrl(baseUrl).build();
 
         Msg query =
                 Msg.builder()
@@ -469,18 +271,17 @@ class ReMeLongTermMemoryTest {
     }
 
     @Test
-    void testRetrieveWithMemoryList() {
-        // Response with empty answer but memory_list
-        String responseJson =
-                "{\"answer\":\"\",\"success\":true,\"metadata\":{\"memory_list\":[{\"workspace_id\":\"task_workspace\",\"memory_id\":\"mem1\",\"content\":\"User"
-                    + " prefers dark"
-                    + " mode\",\"score\":0.95},{\"workspace_id\":\"task_workspace\",\"memory_id\":\"mem2\",\"content\":\"User"
-                    + " likes coffee\",\"score\":0.85}]}}";
-
-        mockServer.enqueue(new MockResponse().setBody(responseJson).setResponseCode(200));
+    void testRetrieveWithSearchResultsFallback() {
+        mockServer.enqueue(
+                new MockResponse()
+                        .setBody(
+                                "{\"answer\":\"\",\"success\":true,\"metadata\":{\"results\":[{\"id\":\"1\",\"text\":\"User"
+                                    + " prefers dark mode\"},{\"id\":\"2\",\"text\":\"User likes"
+                                    + " coffee\"}]}}")
+                        .setResponseCode(200));
 
         ReMeLongTermMemory memory =
-                ReMeLongTermMemory.builder().userId("task_workspace").apiBaseUrl(baseUrl).build();
+                ReMeLongTermMemory.builder().sessionId("task-session").apiBaseUrl(baseUrl).build();
 
         Msg query =
                 Msg.builder()
@@ -496,13 +297,14 @@ class ReMeLongTermMemoryTest {
 
     @Test
     void testRetrieveWithNoResults() {
-        String responseJson =
-                "{\"answer\":\"\",\"success\":true,\"metadata\":{\"memory_list\":[]}}";
-
-        mockServer.enqueue(new MockResponse().setBody(responseJson).setResponseCode(200));
+        mockServer.enqueue(
+                new MockResponse()
+                        .setBody(
+                                "{\"answer\":\"\",\"success\":true,\"metadata\":{\"results\":[],\"counts\":{\"results\":0}}}")
+                        .setResponseCode(200));
 
         ReMeLongTermMemory memory =
-                ReMeLongTermMemory.builder().userId("task_workspace").apiBaseUrl(baseUrl).build();
+                ReMeLongTermMemory.builder().sessionId("task-session").apiBaseUrl(baseUrl).build();
 
         Msg query =
                 Msg.builder()
@@ -518,7 +320,7 @@ class ReMeLongTermMemoryTest {
     @Test
     void testRetrieveWithNullMessage() {
         ReMeLongTermMemory memory =
-                ReMeLongTermMemory.builder().userId("task_workspace").apiBaseUrl(baseUrl).build();
+                ReMeLongTermMemory.builder().sessionId("task-session").apiBaseUrl(baseUrl).build();
 
         StepVerifier.create(memory.retrieve(null))
                 .assertNext(result -> assertEquals("", result))
@@ -528,7 +330,7 @@ class ReMeLongTermMemoryTest {
     @Test
     void testRetrieveWithEmptyQuery() {
         ReMeLongTermMemory memory =
-                ReMeLongTermMemory.builder().userId("task_workspace").apiBaseUrl(baseUrl).build();
+                ReMeLongTermMemory.builder().sessionId("task-session").apiBaseUrl(baseUrl).build();
 
         Msg query =
                 Msg.builder()
@@ -542,24 +344,12 @@ class ReMeLongTermMemoryTest {
     }
 
     @Test
-    void testRetrieveWithNullQuery() {
-        ReMeLongTermMemory memory =
-                ReMeLongTermMemory.builder().userId("task_workspace").apiBaseUrl(baseUrl).build();
-
-        Msg query = Msg.builder().role(MsgRole.USER).build();
-
-        StepVerifier.create(memory.retrieve(query))
-                .assertNext(result -> assertEquals("", result))
-                .verifyComplete();
-    }
-
-    @Test
     void testRetrieveWithHttpError() {
         mockServer.enqueue(
                 new MockResponse().setBody("{\"error\":\"Not found\"}").setResponseCode(404));
 
         ReMeLongTermMemory memory =
-                ReMeLongTermMemory.builder().userId("task_workspace").apiBaseUrl(baseUrl).build();
+                ReMeLongTermMemory.builder().sessionId("task-session").apiBaseUrl(baseUrl).build();
 
         Msg query =
                 Msg.builder()
@@ -567,132 +357,21 @@ class ReMeLongTermMemoryTest {
                         .content(TextBlock.builder().text("query").build())
                         .build();
 
-        // Should return empty string on error
         StepVerifier.create(memory.retrieve(query))
                 .assertNext(result -> assertEquals("", result))
                 .verifyComplete();
     }
 
     @Test
-    void testRetrieveFiltersNullMemories() {
-        String responseJson =
-                "{\"answer\":\"\",\"success\":true,\"metadata\":{\"memory_list\":[{\"workspace_id\":\"task_workspace\",\"memory_id\":\"mem1\",\"content\":\"Valid"
-                    + " memory\",\"score\":0.95},{\"workspace_id\":\"task_workspace\",\"memory_id\":\"mem2\",\"content\":null,\"score\":0.85},{\"workspace_id\":\"task_workspace\",\"memory_id\":\"mem3\",\"content\":\"Another"
-                    + " valid\",\"score\":0.75}]}}";
-
-        mockServer.enqueue(new MockResponse().setBody(responseJson).setResponseCode(200));
-
-        ReMeLongTermMemory memory =
-                ReMeLongTermMemory.builder().userId("task_workspace").apiBaseUrl(baseUrl).build();
-
-        Msg query =
-                Msg.builder()
-                        .role(MsgRole.USER)
-                        .content(TextBlock.builder().text("query").build())
-                        .build();
-
-        StepVerifier.create(memory.retrieve(query))
-                .assertNext(result -> assertEquals("Valid memory\nAnother valid", result))
-                .verifyComplete();
-    }
-
-    @Test
-    void testRoleMapping() {
+    void testRetrieveRequestContainsNewSearchPayload() throws Exception {
         mockServer.enqueue(
                 new MockResponse()
                         .setBody(
-                                "{\"answer\":\"\",\"success\":true,\"metadata\":{\"memory_list\":[],\"deleted_memory_ids\":[],\"update_result\":{\"deleted_count\":0,\"inserted_count\":1}}}")
+                                "{\"answer\":\"\",\"success\":true,\"metadata\":{\"results\":[{\"id\":\"1\",\"text\":\"Memory\"}]}}")
                         .setResponseCode(200));
 
         ReMeLongTermMemory memory =
-                ReMeLongTermMemory.builder().userId("task_workspace").apiBaseUrl(baseUrl).build();
-
-        // Test USER role -> "user"
-        List<Msg> messages = new ArrayList<>();
-        messages.add(
-                Msg.builder()
-                        .role(MsgRole.USER)
-                        .content(TextBlock.builder().text("User message").build())
-                        .build());
-
-        // Test ASSISTANT role -> "assistant"
-        messages.add(
-                Msg.builder()
-                        .role(MsgRole.ASSISTANT)
-                        .content(TextBlock.builder().text("Assistant message").build())
-                        .build());
-
-        // Test SYSTEM role -> "user"
-        messages.add(
-                Msg.builder()
-                        .role(MsgRole.SYSTEM)
-                        .content(TextBlock.builder().text("System message").build())
-                        .build());
-
-        // Test TOOL role -> "assistant"
-        messages.add(
-                Msg.builder()
-                        .role(MsgRole.TOOL)
-                        .content(TextBlock.builder().text("Tool message").build())
-                        .build());
-
-        StepVerifier.create(memory.record(messages)).verifyComplete();
-
-        // Verify request body contains correct role mappings
-        RecordedRequest recordedRequest;
-        try {
-            recordedRequest = mockServer.takeRequest();
-            String requestBody = recordedRequest.getBody().readUtf8();
-            // Should contain "user" role for USER and SYSTEM
-            assertTrue(requestBody.contains("\"role\":\"user\""));
-            // Should contain "assistant" role for ASSISTANT and TOOL
-            assertTrue(requestBody.contains("\"role\":\"assistant\""));
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-        }
-    }
-
-    @Test
-    void testRecordRequestContainsWorkspaceId() {
-        mockServer.enqueue(
-                new MockResponse()
-                        .setBody(
-                                "{\"answer\":\"\",\"success\":true,\"metadata\":{\"memory_list\":[],\"deleted_memory_ids\":[],\"update_result\":{\"deleted_count\":0,\"inserted_count\":1}}}")
-                        .setResponseCode(200));
-
-        ReMeLongTermMemory memory =
-                ReMeLongTermMemory.builder().userId("test_workspace").apiBaseUrl(baseUrl).build();
-
-        List<Msg> messages = new ArrayList<>();
-        messages.add(
-                Msg.builder()
-                        .role(MsgRole.USER)
-                        .content(TextBlock.builder().text("Test message").build())
-                        .build());
-
-        StepVerifier.create(memory.record(messages)).verifyComplete();
-
-        // Verify request contains workspace_id
-        RecordedRequest recordedRequest;
-        try {
-            recordedRequest = mockServer.takeRequest();
-            String requestBody = recordedRequest.getBody().readUtf8();
-            assertTrue(requestBody.contains("\"workspace_id\":\"test_workspace\""));
-            assertTrue(requestBody.contains("\"trajectories\""));
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-        }
-    }
-
-    @Test
-    void testRetrieveRequestContainsWorkspaceId() {
-        String responseJson =
-                "{\"answer\":\"test answer\",\"success\":true,\"metadata\":{\"memory_list\":[]}}";
-
-        mockServer.enqueue(new MockResponse().setBody(responseJson).setResponseCode(200));
-
-        ReMeLongTermMemory memory =
-                ReMeLongTermMemory.builder().userId("test_workspace").apiBaseUrl(baseUrl).build();
+                ReMeLongTermMemory.builder().sessionId("task-session").apiBaseUrl(baseUrl).build();
 
         Msg query =
                 Msg.builder()
@@ -701,19 +380,14 @@ class ReMeLongTermMemoryTest {
                         .build();
 
         StepVerifier.create(memory.retrieve(query))
-                .assertNext(result -> assertEquals("test answer", result))
+                .assertNext(result -> assertEquals("Memory", result))
                 .verifyComplete();
 
-        // Verify request contains workspace_id and query
-        RecordedRequest recordedRequest;
-        try {
-            recordedRequest = mockServer.takeRequest();
-            String requestBody = recordedRequest.getBody().readUtf8();
-            assertTrue(requestBody.contains("\"workspace_id\":\"test_workspace\""));
-            assertTrue(requestBody.contains("\"query\":\"test query\""));
-            assertTrue(requestBody.contains("\"top_k\":5"));
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-        }
+        RecordedRequest recordedRequest = mockServer.takeRequest();
+        assertEquals("/search", recordedRequest.getPath());
+        String requestBody = recordedRequest.getBody().readUtf8();
+        assertTrue(requestBody.contains("\"query\":\"test query\""));
+        assertTrue(requestBody.contains("\"limit\":5"));
+        assertTrue(!requestBody.contains("workspace_id"));
     }
 }

--- a/docs/v1/en/docs/task/memory.md
+++ b/docs/v1/en/docs/task/memory.md
@@ -232,6 +232,8 @@ mvn exec:java -Dexec.mainClass="io.agentscope.examples.advanced.Mem0Example"
 
 Long-term memory implementation based on [ReMe](https://github.com/agentscope-ai/ReMe).
 
+ReMe `0.4.x` uses `session_id`-based jobs instead of the legacy `workspace_id` personal-memory endpoints.
+
 **Usage Example**:
 
 ```java
@@ -240,7 +242,7 @@ import io.agentscope.core.memory.LongTermMemoryMode;
 import io.agentscope.core.memory.reme.ReMeLongTermMemory;
 
 ReMeLongTermMemory longTermMemory = ReMeLongTermMemory.builder()
-        .userId("example_user")
+        .sessionId("example-session")
         .apiBaseUrl("http://localhost:8002")
         .build();
 
@@ -252,15 +254,11 @@ ReActAgent agent = ReActAgent.builder()
         .build();
 ```
 
-**Complete Example**: `agentscope-examples/documentation/advanced/src/main/java/io/agentscope/examples/advanced/ReMeExample.java`
+`userId(String)` is still accepted for backward compatibility, but it now falls back to `session_id` when `sessionId(String)` is not provided.
 
-**Run Example**:
+ReMe retrieval first uses the server-provided `answer` field when available, otherwise AgentScope-Java joins `metadata.results[].text`.
 
-```bash
-# Requires REME_API_BASE_URL environment variable (optional, defaults to http://localhost:8002)
-cd examples/advanced
-mvn exec:java -Dexec.mainClass="io.agentscope.examples.advanced.ReMeExample"
-```
+There is currently no bundled `ReMeExample.java` example in this repository. Use the snippet above as the reference integration pattern.
 
 ### BailianLongTermMemory
 

--- a/docs/v1/zh/docs/task/memory.md
+++ b/docs/v1/zh/docs/task/memory.md
@@ -232,6 +232,8 @@ mvn exec:java -Dexec.mainClass="io.agentscope.examples.advanced.Mem0Example"
 
 基于 [ReMe](https://github.com/agentscope-ai/ReMe) 的长期记忆实现。
 
+ReMe `0.4.x` 已切换为基于 `session_id` 的 job 接口，不再使用旧版 `workspace_id` personal-memory 端点。
+
 **使用示例**：
 
 ```java
@@ -240,7 +242,7 @@ import io.agentscope.core.memory.LongTermMemoryMode;
 import io.agentscope.core.memory.reme.ReMeLongTermMemory;
 
 ReMeLongTermMemory longTermMemory = ReMeLongTermMemory.builder()
-        .userId("example_user")
+        .sessionId("example-session")
         .apiBaseUrl("http://localhost:8002")
         .build();
 

--- a/docs/v2/en/integration/memory/reme.md
+++ b/docs/v2/en/integration/memory/reme.md
@@ -1,12 +1,12 @@
 # ReMe
 
-`agentscope-extensions-reme` integrates with the self-hosted ReMe memory service. Its distinguishing features are **trajectory-based** memory extraction and **workspace-level** isolation.
+`agentscope-extensions-reme` integrates with the self-hosted ReMe memory service. In ReMe `0.4.x`, AgentScope-Java records filtered conversation messages through the `auto_memory` job and retrieves context through the `search` job.
 
 ## When to use
 
-- You want a lightweight self-hosted memory service that's easy to spin up.
-- You care about summarizing whole conversation trajectories rather than individual messages.
-- You can express logical workspaces by `userId` (one workspace per user).
+- You want a lightweight self-hosted memory service that's easy to run locally.
+- You want ReMe to evolve memory from conversation sessions rather than from single isolated facts.
+- You can manage memory scope with a ReMe `session_id` or with deployment-level isolation.
 
 ## Add the dependency
 
@@ -24,37 +24,31 @@
 import io.agentscope.core.memory.reme.ReMeLongTermMemory;
 
 ReMeLongTermMemory memory = ReMeLongTermMemory.builder()
-    .userId("task_workspace")            // Maps to ReMe's workspace_id
-    .apiBaseUrl("http://localhost:8002") // Your ReMe server
-    .build();
-
-ReActAgent agent = ReActAgent.builder()
-    .name("Assistant")
-    .model(model)
-    .longTermMemory(memory)
-    .longTermMemoryMode(LongTermMemoryMode.BOTH)
+    .sessionId("task-session")
+    .apiBaseUrl("http://localhost:8002")
     .build();
 ```
 
-`userId` is mapped to ReMe's `workspace_id` — the smallest unit of memory partitioning in ReMe.
+`userId(String)` is still accepted for backward compatibility, but in ReMe `0.4.x` it is treated as the `session_id` fallback instead of `workspace_id`.
 
 ## How it works
 
-- **Write (record)**: filtered messages are joined into a single `ReMeTrajectory` and posted to ReMe's `add` endpoint; the server then runs LLM extraction over the trajectory to produce searchable memory snippets.
-- **Retrieve**: the current message is used as the query against ReMe's `search`. The server-aggregated `answer` field is returned when present, otherwise multiple memory snippets are joined.
+- **Write (`record`)**: filtered `USER` and `ASSISTANT` messages are sent to `POST /auto_memory` with `messages` plus `session_id`.
+- **Retrieve (`retrieve`)**: the current message text is sent to `POST /search`. If ReMe returns a non-empty `answer`, AgentScope-Java uses it directly; otherwise it joins `metadata.results[].text`.
 
 Writes use the same filtering as Bailian:
 
 - Only `USER` and `ASSISTANT` messages are kept.
-- Assistant messages containing `ToolUseBlock` (tool-call requests) are skipped.
+- Assistant messages containing `ToolUseBlock` are skipped.
 - Messages containing the `<compressed_history>` marker are skipped.
 
 ## Builder reference
 
 | Method | Required | Default | Notes |
 | --- | --- | --- | --- |
-| `userId(String)` | ✅ | - | Workspace ID (used for both writes and reads) |
-| `apiBaseUrl(String)` | ✅ | - | ReMe service URL, e.g. `http://localhost:8002` |
-| `timeout(Duration)` | ❌ | `60s` | HTTP timeout |
+| `sessionId(String)` | Recommended | - | ReMe `session_id` used for write operations |
+| `userId(String)` | Backward compatible alias | - | Treated as `session_id` when `sessionId` is absent |
+| `apiBaseUrl(String)` | Yes | - | ReMe service URL, e.g. `http://localhost:8002` |
+| `timeout(Duration)` | No | `60s` | HTTP timeout |
 
-> ReMe does not yet expose finer-grained metadata filtering. If you need tag-based segmentation, encode it inside `userId` (e.g. `tenant-a:project-1`).
+> ReMe `0.4.x` no longer exposes the old `workspace_id`-scoped personal-memory API. If you need strict per-user isolation, prefer one ReMe workspace or deployment per logical tenant/user, or encode that boundary into the chosen `session_id`.

--- a/docs/v2/zh/integration/memory/reme.md
+++ b/docs/v2/zh/integration/memory/reme.md
@@ -1,12 +1,12 @@
 # ReMe
 
-`agentscope-extensions-reme` 接入自托管的 ReMe 记忆服务，特点是基于 **trajectory（对话轨迹）** 抽取长期记忆，并按 **workspace** 隔离。
+`agentscope-extensions-reme` 用于接入自托管 ReMe 记忆服务。在 ReMe `0.4.x` 中，AgentScope-Java 通过 `auto_memory` job 写入过滤后的会话消息，通过 `search` job 检索相关上下文。
 
 ## 何时使用
 
-- 想要一个轻量的本地记忆服务，启动门槛低。
-- 关注整段对话轨迹的摘要，而不是单条消息级的存储。
-- 用 `userId` 表达逻辑工作区，每个用户一份独立记忆。
+- 你希望使用一个启动成本较低的自托管记忆服务。
+- 你希望 ReMe 基于整段会话持续演化记忆，而不是只保存单条事实。
+- 你可以通过 ReMe 的 `session_id` 或部署级隔离来管理记忆边界。
 
 ## 添加依赖
 
@@ -18,43 +18,37 @@
 </dependency>
 ```
 
-## 快速上手
+## 快速开始
 
 ```java
 import io.agentscope.core.memory.reme.ReMeLongTermMemory;
 
 ReMeLongTermMemory memory = ReMeLongTermMemory.builder()
-    .userId("task_workspace")            // 映射到 ReMe 的 workspace_id
-    .apiBaseUrl("http://localhost:8002") // 你的 ReMe Server 地址
-    .build();
-
-ReActAgent agent = ReActAgent.builder()
-    .name("Assistant")
-    .model(model)
-    .longTermMemory(memory)
-    .longTermMemoryMode(LongTermMemoryMode.BOTH)
+    .sessionId("task-session")
+    .apiBaseUrl("http://localhost:8002")
     .build();
 ```
 
-`userId` 在 ReMe 里实际作为 `workspace_id`，这是 ReMe 用来切分记忆的最小单位。
+`userId(String)` 仍然保留用于兼容旧代码，但在 ReMe `0.4.x` 下它只会作为 `session_id` 的回退值，不再映射到 `workspace_id`。
 
 ## 工作机制
 
-- **写入（record）**：把过滤后的对话拼成一个 `ReMeTrajectory`，作为整体送给 ReMe 的 `add` 接口；服务端再用 LLM 把轨迹抽取成可检索的记忆片段。
-- **检索（retrieve）**：以当前消息为 query 调用 ReMe 的 `search`，优先返回服务端聚合的 `answer`，没有时退化为多个 memory 片段拼接。
+- **写入（`record`）**：把过滤后的 `USER` / `ASSISTANT` 消息连同 `session_id` 一起发送到 `POST /auto_memory`。
+- **检索（`retrieve`）**：把当前消息文本发送到 `POST /search`。如果 ReMe 返回非空 `answer`，直接使用；否则退化为拼接 `metadata.results[].text`。
 
-写入时遵循与 Bailian 相同的过滤策略：
+写入时沿用与 Bailian 相同的过滤策略：
 
-- 只保留 `USER` 与 `ASSISTANT` 消息。
-- 跳过含 `ToolUseBlock` 的助手消息（工具调用请求不入记忆）。
-- 跳过含 `<compressed_history>` 标记的压缩历史。
+- 只保留 `USER` 和 `ASSISTANT` 消息。
+- 跳过包含 `ToolUseBlock` 的助手消息。
+- 跳过带有 `<compressed_history>` 标记的消息。
 
-## Builder 配置参数
+## Builder 参数
 
-| 方法 | 是否必填 | 默认 | 说明 |
+| 方法 | 是否必填 | 默认值 | 说明 |
 | --- | --- | --- | --- |
-| `userId(String)` | ✅ | - | 工作区 ID（写入和检索都基于它） |
-| `apiBaseUrl(String)` | ✅ | - | ReMe 服务地址，例如 `http://localhost:8002` |
-| `timeout(Duration)` | ❌ | `60s` | HTTP 请求超时 |
+| `sessionId(String)` | 推荐 | - | ReMe `session_id`，用于写入会话消息 |
+| `userId(String)` | 兼容旧代码 | - | 仅在未设置 `sessionId` 时作为 `session_id` 使用 |
+| `apiBaseUrl(String)` | 是 | - | ReMe 服务地址，例如 `http://localhost:8002` |
+| `timeout(Duration)` | 否 | `60s` | HTTP 请求超时 |
 
-> ReMe 暂未提供更细粒度的 metadata 过滤；如果需要按业务标签切分，建议在 `userId` 里编码命名空间（例如 `tenant-a:project-1`）。
+> ReMe `0.4.x` 已不再提供旧版 `workspace_id` 级别的 personal-memory API。如果你的业务需要严格的单用户隔离，建议使用独立的 ReMe workspace / 部署，或在 `session_id` 中显式编码隔离边界。


### PR DESCRIPTION
## Background

Fixes #2005.

`agentscope-extensions-reme` was still modeled around the legacy ReMe personal-memory endpoints:
- `POST /summary_personal_memory`
- `POST /retrieve_personal_memory`

ReMe `0.4.x` has switched to job-based APIs and no longer exposes those endpoints, which causes 404s against current self-hosted deployments.

## What Changed

- migrate `ReMeClient` from legacy personal-memory endpoints to:
  - `POST /auto_memory`
  - `POST /search`
- update ReMe request/response DTOs to match the ReMe `0.4.x` payload and response schema
- update `ReMeLongTermMemory` to:
  - send filtered messages directly instead of building legacy trajectories
  - support `sessionId(String)` for ReMe `0.4.x`
  - keep `userId(String)` as a backward-compatible alias that falls back to `session_id`
  - read retrieval fallback content from `metadata.results[].text`
- rewrite module tests around the new protocol
- update ReMe docs in v1/v2 EN/ZH to reflect the new `session_id`-based behavior and remove stale example references

## Notes

ReMe `0.4.x` no longer provides the old `workspace_id`-scoped personal-memory API.  
For compatibility, this patch keeps the builder surface stable where possible, but `userId` now behaves as a fallback alias for `session_id`.

## Testing

- `mvn -pl agentscope-extensions/agentscope-extensions-mem/agentscope-extensions-reme test`