### PR TITLE
fix(model): preserve executionConfig in OllamaOptions fromOptions/toBuilder

### DIFF
--- a/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-ollama/src/main/java/io/agentscope/extensions/model/ollama/options/OllamaOptions.java
+++ b/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-ollama/src/main/java/io/agentscope/extensions/model/ollama/options/OllamaOptions.java
@@ -344,6 +344,7 @@ public class OllamaOptions {
                 .mirostatEta(fromOptions.getMirostatEta())
                 .penalizeNewline(fromOptions.getPenalizeNewline())
                 .stop(fromOptions.getStop())
+                .executionConfig(fromOptions.getExecutionConfig())
                 .build();
     }
 
@@ -1015,7 +1016,8 @@ public class OllamaOptions {
                 .mirostatTau(this.mirostatTau)
                 .mirostatEta(this.mirostatEta)
                 .penalizeNewline(this.penalizeNewline)
-                .stop(this.stop);
+                .stop(this.stop)
+                .executionConfig(this.executionConfig);
     }
 
     // @formatter:on

--- a/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-ollama/src/test/java/io/agentscope/extensions/model/ollama/options/OllamaOptionsTest.java
+++ b/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-ollama/src/test/java/io/agentscope/extensions/model/ollama/options/OllamaOptionsTest.java
@@ -282,4 +282,25 @@ class OllamaOptionsTest {
         assertNotNull(options.getThinkOption());
         assertEquals(ThinkOption.ThinkBoolean.ENABLED, options.getThinkOption());
     }
+
+    @Test
+    @DisplayName("Should preserve executionConfig via fromOptions, toBuilder and copy")
+    void testExecutionConfigPreservedOnCopy() {
+        ExecutionConfig executionConfig =
+                ExecutionConfig.builder().timeout(Duration.ofSeconds(30)).maxAttempts(3).build();
+        OllamaOptions original =
+                OllamaOptions.builder().temperature(0.7).executionConfig(executionConfig).build();
+
+        // copy() delegates to fromOptions(OllamaOptions)
+        OllamaOptions copy = original.copy();
+        assertEquals(executionConfig, copy.getExecutionConfig());
+
+        // fromOptions(OllamaOptions) directly
+        OllamaOptions fromOptions = OllamaOptions.fromOptions(original);
+        assertEquals(executionConfig, fromOptions.getExecutionConfig());
+
+        // toBuilder().build() round-trip
+        OllamaOptions rebuilt = original.toBuilder().build();
+        assertEquals(executionConfig, rebuilt.getExecutionConfig());
+    }
 }


### PR DESCRIPTION
### Summary

`OllamaOptions.fromOptions(OllamaOptions)` and `toBuilder()` do not copy the
`executionConfig` field, so any instance produced via `copy()`, `fromOptions()`
or `toBuilder()` silently loses the timeout/retry configuration carried by
`executionConfig`.

`merge(OllamaOptions)` and `toGenerateOptions()` already propagate
`executionConfig`, so the two copy paths were simply missing it. This aligns
them with the rest of the class.

### Test

Added `OllamaOptionsTest#testExecutionConfigPreservedOnCopy`, which verifies that
`executionConfig` survives `copy()`, `fromOptions()` and `toBuilder()`. Note that
`equals()`/`hashCode()` intentionally ignore `executionConfig`, so the test
asserts `getExecutionConfig()` directly.

Closes #1957
