### PR TITLE
fix(harness): restore remote snapshot state deserialization

### DIFF
--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/sandbox/SandboxClient.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/sandbox/SandboxClient.java
@@ -41,4 +41,8 @@ public interface SandboxClient<O extends SandboxClientOptions> {
     String serializeState(SandboxState state);
 
     SandboxState deserializeState(String json);
+
+    default SandboxState deserializeState(String json, SandboxSnapshotSpec snapshotSpec) {
+        return deserializeState(json);
+    }
 }

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/sandbox/SandboxManager.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/sandbox/SandboxManager.java
@@ -102,7 +102,9 @@ public class SandboxManager {
                         log.debug(
                                 "[sandbox] Priority 3: resuming from persisted state (scope={})",
                                 scopeKey.get());
-                        SandboxState state = client.deserializeState(stateJson.get());
+                        SandboxState state =
+                                client.deserializeState(
+                                        stateJson.get(), sandboxContext.getSnapshotSpec());
                         Sandbox sandbox = client.resume(state);
                         return SandboxAcquireResult.selfManaged(sandbox, lease);
                     }

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/sandbox/impl/docker/DockerSandboxClient.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/sandbox/impl/docker/DockerSandboxClient.java
@@ -22,6 +22,9 @@ import io.agentscope.harness.agent.sandbox.SandboxException;
 import io.agentscope.harness.agent.sandbox.SandboxState;
 import io.agentscope.harness.agent.sandbox.WorkspaceSpec;
 import io.agentscope.harness.agent.sandbox.json.HarnessSandboxJacksonModule;
+import io.agentscope.harness.agent.sandbox.snapshot.RemoteSandboxSnapshot;
+import io.agentscope.harness.agent.sandbox.snapshot.RemoteSnapshotSpec;
+import io.agentscope.harness.agent.sandbox.snapshot.SandboxSnapshot;
 import io.agentscope.harness.agent.sandbox.snapshot.SandboxSnapshotSpec;
 import java.util.UUID;
 import org.slf4j.Logger;
@@ -129,5 +132,29 @@ public class DockerSandboxClient implements SandboxClient<DockerSandboxClientOpt
             throw new SandboxException.SandboxConfigurationException(
                     "Failed to deserialize Docker sandbox state", e);
         }
+    }
+
+    @Override
+    public SandboxState deserializeState(String json, SandboxSnapshotSpec snapshotSpec) {
+        try {
+            SandboxState state = objectMapper.readValue(json, SandboxState.class);
+            rebindRemoteSnapshot(state, snapshotSpec);
+            return state;
+        } catch (Exception e) {
+            throw new SandboxException.SandboxConfigurationException(
+                    "Failed to deserialize Docker sandbox state", e);
+        }
+    }
+
+    private static void rebindRemoteSnapshot(SandboxState state, SandboxSnapshotSpec snapshotSpec) {
+        if (!(snapshotSpec instanceof RemoteSnapshotSpec remoteSnapshotSpec)) {
+            return;
+        }
+        SandboxSnapshot snapshot = state.getSnapshot();
+        if (!(snapshot instanceof RemoteSandboxSnapshot)) {
+            return;
+        }
+        state.setSnapshot(
+                new RemoteSandboxSnapshot(remoteSnapshotSpec.getClient(), snapshot.getId()));
     }
 }

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/sandbox/snapshot/NoopSandboxSnapshot.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/sandbox/snapshot/NoopSandboxSnapshot.java
@@ -15,6 +15,7 @@
  */
 package io.agentscope.harness.agent.sandbox.snapshot;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import java.io.InputStream;
 import java.io.OutputStream;
 
@@ -25,6 +26,7 @@ import java.io.OutputStream;
  * session stops. Each time a session is started fresh, the full manifest is applied
  * (Branch D of the start logic). Use this when workspace durability is not required.
  */
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class NoopSandboxSnapshot implements SandboxSnapshot {
 
     private static final String ID = "noop";

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/sandbox/snapshot/RemoteSandboxSnapshot.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/sandbox/snapshot/RemoteSandboxSnapshot.java
@@ -15,6 +15,10 @@
  */
 package io.agentscope.harness.agent.sandbox.snapshot;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import io.agentscope.harness.agent.sandbox.SandboxException;
 import java.io.InputStream;
 
@@ -28,10 +32,16 @@ import java.io.InputStream;
  * {@link RemoteSnapshotClient} cannot be serialized. When persisting session state,
  * only the {@code id} is needed — the client is re-injected from the builder at resume time.
  */
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class RemoteSandboxSnapshot implements SandboxSnapshot {
 
-    private final RemoteSnapshotClient client;
+    @JsonIgnore private final RemoteSnapshotClient client;
     private final String id;
+
+    @JsonCreator
+    public RemoteSandboxSnapshot(@JsonProperty("id") String id) {
+        this(null, id);
+    }
 
     /**
      * Creates a remote snapshot.
@@ -52,7 +62,7 @@ public class RemoteSandboxSnapshot implements SandboxSnapshot {
     @Override
     public void persist(InputStream workspaceArchive) throws Exception {
         try {
-            client.upload(id, workspaceArchive);
+            requireClient().upload(id, workspaceArchive);
         } catch (Exception e) {
             throw new SandboxException.SnapshotException(id, "Remote upload failed", e);
         }
@@ -66,7 +76,7 @@ public class RemoteSandboxSnapshot implements SandboxSnapshot {
     @Override
     public InputStream restore() throws Exception {
         try {
-            return client.download(id);
+            return requireClient().download(id);
         } catch (Exception e) {
             throw new SandboxException.SnapshotException(id, "Remote download failed", e);
         }
@@ -80,7 +90,7 @@ public class RemoteSandboxSnapshot implements SandboxSnapshot {
     @Override
     public boolean isRestorable() throws Exception {
         try {
-            return client.exists(id);
+            return requireClient().exists(id);
         } catch (Exception e) {
             throw new SandboxException.SnapshotException(id, "Remote exists check failed", e);
         }
@@ -94,5 +104,13 @@ public class RemoteSandboxSnapshot implements SandboxSnapshot {
     @Override
     public String getType() {
         return "remote";
+    }
+
+    private RemoteSnapshotClient requireClient() {
+        if (client == null) {
+            throw new IllegalStateException(
+                    "RemoteSnapshotClient is not bound to snapshot id: " + id);
+        }
+        return client;
     }
 }

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/sandbox/snapshot/RemoteSnapshotSpec.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/sandbox/snapshot/RemoteSnapshotSpec.java
@@ -36,6 +36,10 @@ public class RemoteSnapshotSpec implements SandboxSnapshotSpec {
         this.client = client;
     }
 
+    public RemoteSnapshotClient getClient() {
+        return client;
+    }
+
     /**
      * {@inheritDoc}
      *

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/sandbox/snapshot/SandboxSnapshot.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/sandbox/snapshot/SandboxSnapshot.java
@@ -15,6 +15,7 @@
  */
 package io.agentscope.harness.agent.sandbox.snapshot;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import java.io.InputStream;
@@ -58,6 +59,7 @@ public interface SandboxSnapshot {
      * @return true if {@link #restore()} would succeed
      * @throws Exception if checking restorability fails
      */
+    @JsonIgnore
     boolean isRestorable() throws Exception;
 
     /**
@@ -72,6 +74,7 @@ public interface SandboxSnapshot {
      *
      * @return type string (e.g. "noop", "local", "remote")
      */
+    @JsonIgnore
     String getType();
 
     /**
@@ -82,6 +85,7 @@ public interface SandboxSnapshot {
      *
      * @return false only for no-op implementations that discard all archive data
      */
+    @JsonIgnore
     default boolean isPersistenceEnabled() {
         return true;
     }

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/sandbox/SandboxManagerIsolationTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/sandbox/SandboxManagerIsolationTest.java
@@ -91,7 +91,7 @@ class SandboxManagerIsolationTest {
     @Test
     void priority3_stateStoreHit_resumesSession() throws Exception {
         when(stateStore.load(any())).thenReturn(Optional.of(STATE_JSON));
-        when(client.deserializeState(STATE_JSON)).thenReturn(resumedState);
+        when(client.deserializeState(STATE_JSON, null)).thenReturn(resumedState);
         when(client.resume(resumedState)).thenReturn(resumedSandbox);
 
         RuntimeContext rtx = RuntimeContext.builder().sessionId("sess-1").build();
@@ -145,7 +145,7 @@ class SandboxManagerIsolationTest {
     @Test
     void userScope_withUserId_loadsFromStore() throws Exception {
         when(stateStore.load(any())).thenReturn(Optional.of(STATE_JSON));
-        when(client.deserializeState(STATE_JSON)).thenReturn(resumedState);
+        when(client.deserializeState(STATE_JSON, null)).thenReturn(resumedState);
         when(client.resume(resumedState)).thenReturn(resumedSandbox);
 
         RuntimeContext rtx = RuntimeContext.builder().userId("user-42").build();
@@ -154,6 +154,25 @@ class SandboxManagerIsolationTest {
         SandboxAcquireResult result = manager.acquire(sCtx, rtx);
 
         assertSame(resumedSandbox, result.getSandbox());
+    }
+
+    @Test
+    void priority3_stateStoreHit_passesSnapshotSpecToDeserialize() throws Exception {
+        when(stateStore.load(any())).thenReturn(Optional.of(STATE_JSON));
+        when(client.deserializeState(STATE_JSON, snapshotSpec)).thenReturn(resumedState);
+        when(client.resume(resumedState)).thenReturn(resumedSandbox);
+
+        RuntimeContext rtx = RuntimeContext.builder().sessionId("sess-1").build();
+        SandboxContext sCtx =
+                SandboxContext.builder()
+                        .isolationScope(IsolationScope.SESSION)
+                        .snapshotSpec(snapshotSpec)
+                        .build();
+
+        SandboxAcquireResult result = manager.acquire(sCtx, rtx);
+
+        assertSame(resumedSandbox, result.getSandbox());
+        verify(client).deserializeState(STATE_JSON, snapshotSpec);
     }
 
     @Test

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/sandbox/json/HarnessSandboxJacksonModuleTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/sandbox/json/HarnessSandboxJacksonModuleTest.java
@@ -18,13 +18,20 @@ package io.agentscope.harness.agent.sandbox.json;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.agentscope.harness.agent.sandbox.SandboxState;
+import io.agentscope.harness.agent.sandbox.impl.docker.DockerSandboxClient;
 import io.agentscope.harness.agent.sandbox.impl.docker.DockerSandboxState;
 import io.agentscope.harness.agent.sandbox.snapshot.LocalSandboxSnapshot;
+import io.agentscope.harness.agent.sandbox.snapshot.RemoteSandboxSnapshot;
+import io.agentscope.harness.agent.sandbox.snapshot.RemoteSnapshotClient;
+import io.agentscope.harness.agent.sandbox.snapshot.RemoteSnapshotSpec;
 import io.agentscope.harness.agent.sandbox.snapshot.SandboxSnapshot;
+import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import org.junit.jupiter.api.Test;
@@ -78,5 +85,121 @@ class HarnessSandboxJacksonModuleTest {
         assertEquals(sessionId, snapshot.getId());
         assertEquals("local", snapshot.getType());
         assertTrue(snapshot.isRestorable());
+    }
+
+    @Test
+    void serializesRemoteSnapshotWithoutDerivedProperties() throws Exception {
+        ObjectMapper mapper =
+                new ObjectMapper()
+                        .findAndRegisterModules()
+                        .registerModule(new HarnessSandboxJacksonModule());
+
+        DockerSandboxState original = new DockerSandboxState();
+        original.setSessionId("remote-session-1");
+        original.setSnapshot(new RemoteSandboxSnapshot(new FakeRemoteSnapshotClient(), "snap-1"));
+
+        JsonNode snapshotNode =
+                mapper.readTree(mapper.writeValueAsString(original)).get("snapshot");
+
+        assertNotNull(snapshotNode);
+        assertEquals("remote", snapshotNode.get("type").asText());
+        assertEquals("snap-1", snapshotNode.get("id").asText());
+        assertNull(snapshotNode.get("restorable"));
+        assertNull(snapshotNode.get("persistenceEnabled"));
+    }
+
+    @Test
+    void deserializesDockerSandboxStateWithRemoteSnapshotViaMapper() throws Exception {
+        ObjectMapper mapper =
+                new ObjectMapper()
+                        .findAndRegisterModules()
+                        .registerModule(new HarnessSandboxJacksonModule());
+
+        DockerSandboxState original = new DockerSandboxState();
+        original.setSessionId("remote-session-2");
+        original.setSnapshot(new RemoteSandboxSnapshot(new FakeRemoteSnapshotClient(), "snap-2"));
+
+        SandboxState parsed =
+                mapper.readValue(mapper.writeValueAsString(original), SandboxState.class);
+
+        assertInstanceOf(DockerSandboxState.class, parsed);
+        SandboxSnapshot snapshot = parsed.getSnapshot();
+        assertNotNull(snapshot);
+        assertInstanceOf(RemoteSandboxSnapshot.class, snapshot);
+        assertEquals("snap-2", snapshot.getId());
+        assertEquals("remote", snapshot.getType());
+    }
+
+    @Test
+    void deserializesLegacyRemoteSnapshotJsonWithUnknownDerivedProperties() throws Exception {
+        ObjectMapper mapper =
+                new ObjectMapper()
+                        .findAndRegisterModules()
+                        .registerModule(new HarnessSandboxJacksonModule());
+
+        String json =
+                """
+                {
+                  "type":"docker",
+                  "sessionId":"remote-session-legacy",
+                  "snapshot":{
+                    "type":"remote",
+                    "id":"snap-legacy",
+                    "restorable":true,
+                    "persistenceEnabled":true
+                  }
+                }
+                """;
+
+        SandboxState parsed = mapper.readValue(json, SandboxState.class);
+
+        assertInstanceOf(DockerSandboxState.class, parsed);
+        SandboxSnapshot snapshot = parsed.getSnapshot();
+        assertNotNull(snapshot);
+        assertInstanceOf(RemoteSandboxSnapshot.class, snapshot);
+        assertEquals("snap-legacy", snapshot.getId());
+        assertEquals("remote", snapshot.getType());
+    }
+
+    @Test
+    void roundTripsDockerSandboxStateWithRemoteSnapshotViaDockerClient() throws Exception {
+        ObjectMapper mapper =
+                new ObjectMapper()
+                        .findAndRegisterModules()
+                        .registerModule(new HarnessSandboxJacksonModule());
+        DockerSandboxClient client = new DockerSandboxClient(mapper);
+
+        DockerSandboxState original = new DockerSandboxState();
+        original.setSessionId("remote-session-3");
+        original.setSnapshot(new RemoteSandboxSnapshot(new FakeRemoteSnapshotClient(), "snap-3"));
+
+        String json = mapper.writeValueAsString(original);
+        SandboxState parsed =
+                client.deserializeState(
+                        json, new RemoteSnapshotSpec(new FakeRemoteSnapshotClient()));
+
+        assertInstanceOf(DockerSandboxState.class, parsed);
+        SandboxSnapshot snapshot = parsed.getSnapshot();
+        assertNotNull(snapshot);
+        assertInstanceOf(RemoteSandboxSnapshot.class, snapshot);
+        assertEquals("snap-3", snapshot.getId());
+        assertEquals("remote", snapshot.getType());
+        assertTrue(snapshot.isRestorable());
+    }
+
+    private static final class FakeRemoteSnapshotClient implements RemoteSnapshotClient {
+
+        @Override
+        public void upload(String id, InputStream in) {}
+
+        @Override
+        public InputStream download(String id) {
+            return InputStream.nullInputStream();
+        }
+
+        @Override
+        public boolean exists(String id) {
+            return true;
+        }
     }
 }


### PR DESCRIPTION
## Summary

Fix remote sandbox snapshot state restore for `agentscope-harness`.

`RemoteSandboxSnapshot` could be serialized but not deserialized correctly, which caused persisted Docker sandbox state restore to fail whenever a remote snapshot store was configured. In practice, `SandboxManager.acquire()` would fall back to creating a fresh sandbox, silently losing the previous workspace state.

## Root Cause

There were two issues in the snapshot serialization flow:

1. `RemoteSandboxSnapshot` did not expose a Jackson-usable creator for deserialization.
2. Snapshot JSON included derived properties such as `type`, `restorable`, and `persistenceEnabled`, which polluted the payload and could collide with the polymorphic discriminator.

A second runtime problem also existed after deserialization:
`RemoteSnapshotClient` is a runtime dependency and should not be serialized, but it must be rebound when persisted state is restored.

## What Changed

- Added a Jackson-friendly deserialize path for `RemoteSandboxSnapshot` using `id` only.
- Excluded runtime-only / derived snapshot properties from JSON output.
- Added a `SandboxClient` overload that accepts `SandboxSnapshotSpec` during state deserialization.
- Updated `SandboxManager` to pass the current snapshot spec when restoring persisted sandbox state.
- Rebound `RemoteSnapshotClient` inside `DockerSandboxClient` when deserializing remote snapshots.
- Added regression tests for:
  - remote snapshot JSON shape
  - mapper deserialization
  - legacy JSON with extra derived fields
  - Docker client rebind behavior
  - `SandboxManager` snapshotSpec passthrough

## Impact

This restores the expected behavior for remote snapshot backed sandboxes:
persisted state can now be read back, and remote snapshot recovery no longer silently degrades to a fresh workspace because of snapshot deserialization failure.

## Validation

- `mvn -pl agentscope-harness -DskipTests spotless:check`

Note:
targeted test execution was blocked by pre-existing compile errors on current `upstream/main` in unrelated `agentscope-harness` / `agentscope-core` integration points, so validation here was limited to formatting and local change inspection.