### PR TITLE
docs(event): clarify stream event blockId semantics

### DIFF
--- a/docs/v2/en/docs/building-blocks/message-and-event.md
+++ b/docs/v2/en/docs/building-blocks/message-and-event.md
@@ -128,7 +128,7 @@ Events are the streaming counterpart of messages. While the agent runs, it emits
 
 ### Event lifecycle
 
-Every event carries `getReplyId()`, tying it to the message being assembled. Within a reply, `getBlockId()` or `getToolCallId()` identifies the content block the event belongs to. Events follow a **start → delta → end** pattern:
+Every event carries `getReplyId()`, tying it to the message being assembled. Within a reply, `getBlockId()` or `getToolCallId()` acts as a correlation key for events that belong to the same content-block lifecycle. Events follow a **start → delta → end** pattern:
 
 ```{mermaid}
 sequenceDiagram
@@ -175,7 +175,7 @@ sequenceDiagram
     Agent->>Client: AgentEndEvent
 ```
 
-All events in one reply share the same `replyId`. Within a reply, `blockId` ties text/thinking/data block events together; `toolCallId` ties tool calls and tool results.
+All events in one reply share the same `replyId`. Within a reply, `blockId` ties text/thinking/data block events together; `toolCallId` ties tool calls and tool results. A `blockId` is scoped to its `replyId` and does not have to be a globally unique generated ID. When a block type can have at most one lifecycle within a reply, an implementation may use a stable type key, such as a fixed key for the text block.
 
 ### Event types
 
@@ -221,14 +221,14 @@ Events are grouped below; unless noted otherwise, every event also carries `getR
     | Method | Type | Description |
     |--------|------|-------------|
     | `getReplyId()` | `String` | Reply message ID |
-    | `getBlockId()` | `String` | Unique text block ID |
+    | `getBlockId()` | `String` | Text-block correlation key within the current reply |
 
     **TextBlockDeltaEvent** — incremental text content arrives.
 
     | Method | Type | Description |
     |--------|------|-------------|
     | `getReplyId()` | `String` | Reply message ID |
-    | `getBlockId()` | `String` | Unique text block ID |
+    | `getBlockId()` | `String` | Text-block correlation key within the current reply |
     | `getDelta()` | `String` | Incremental text content |
 
     **TextBlockEndEvent** — text block completes.
@@ -236,11 +236,11 @@ Events are grouped below; unless noted otherwise, every event also carries `getR
     | Method | Type | Description |
     |--------|------|-------------|
     | `getReplyId()` | `String` | Reply message ID |
-    | `getBlockId()` | `String` | Unique text block ID |
+    | `getBlockId()` | `String` | Text-block correlation key within the current reply |
 :::
 
   :::{dropdown} Thinking streaming events
-**ThinkingBlockStartEvent / ThinkingBlockDeltaEvent / ThinkingBlockEndEvent** — same shape as the text streaming events; specific to the model's chain of thought.
+**ThinkingBlockStartEvent / ThinkingBlockDeltaEvent / ThinkingBlockEndEvent** — same shape as the text streaming events; specific to the model's chain of thought. Its `blockId` has the same reply-scoped correlation-key semantics.
 :::
 
   :::{dropdown} Data streaming events

--- a/docs/v2/zh/docs/building-blocks/message-and-event.md
+++ b/docs/v2/zh/docs/building-blocks/message-and-event.md
@@ -128,7 +128,7 @@ if (msg.hasContentBlocks(ToolResultBlock.class)) {
 
 ### 事件生命周期
 
-每个事件都携带 `getReplyId()`，将其关联到正在构建的消息。在一次回复中，`getBlockId()` 或 `getToolCallId()` 标识事件所属的内容块。事件遵循 **start → delta → end** 模式：
+每个事件都携带 `getReplyId()`，将其关联到正在构建的消息。在一次回复中，`getBlockId()` 或 `getToolCallId()` 用作事件关联键，表示事件属于同一个内容块生命周期。事件遵循 **start → delta → end** 模式：
 
 ```{mermaid}
 sequenceDiagram
@@ -175,7 +175,7 @@ sequenceDiagram
     Agent->>Client: AgentEndEvent
 ```
 
-同一次回复中的所有事件共享相同的 `replyId`。在回复内部，用 `blockId` 关联文本/思考/数据块事件，用 `toolCallId` 关联工具调用和工具结果事件。
+同一次回复中的所有事件共享相同的 `replyId`。在回复内部，用 `blockId` 关联文本/思考/数据块事件，用 `toolCallId` 关联工具调用和工具结果事件。`blockId` 是 `replyId` 作用域内的关联键，不要求是全局唯一的随机 ID；当某类内容块在一次回复中最多出现一个生命周期时，实现可以使用稳定的类型标识（如文本块的固定标识）作为 `blockId`。
 
 ### 事件类型
 
@@ -221,14 +221,14 @@ sequenceDiagram
     | 方法 | 类型 | 说明 |
     |------|------|------|
     | `getReplyId()` | `String` | 回复消息 ID |
-    | `getBlockId()` | `String` | 文本块唯一标识符 |
+    | `getBlockId()` | `String` | 文本块在当前回复中的关联键 |
 
     **TextBlockDeltaEvent** — 增量文本内容到达。
 
     | 方法 | 类型 | 说明 |
     |------|------|------|
     | `getReplyId()` | `String` | 回复消息 ID |
-    | `getBlockId()` | `String` | 文本块唯一标识符 |
+    | `getBlockId()` | `String` | 文本块在当前回复中的关联键 |
     | `getDelta()` | `String` | 增量文本内容 |
 
     **TextBlockEndEvent** — 文本块完成。
@@ -236,11 +236,11 @@ sequenceDiagram
     | 方法 | 类型 | 说明 |
     |------|------|------|
     | `getReplyId()` | `String` | 回复消息 ID |
-    | `getBlockId()` | `String` | 文本块唯一标识符 |
+    | `getBlockId()` | `String` | 文本块在当前回复中的关联键 |
 :::
 
   :::{dropdown} 思考流式事件
-**ThinkingBlockStartEvent / ThinkingBlockDeltaEvent / ThinkingBlockEndEvent** —— 与文本流式事件结构对应，仅用于模型的思维链内容。
+**ThinkingBlockStartEvent / ThinkingBlockDeltaEvent / ThinkingBlockEndEvent** —— 与文本流式事件结构对应，仅用于模型的思维链内容；`blockId` 同样表示当前回复中的关联键。
 :::
 
   :::{dropdown} 数据流式事件


### PR DESCRIPTION
## Summary
Close https://github.com/agentscope-ai/agentscope-java/issues/1899

Clarify the documented semantics of `blockId` in stream events.

`blockId` is a correlation key scoped to a `replyId`, not necessarily a globally unique generated ID. The docs now explain that implementations may use a stable type key when a block type has at most one lifecycle within a reply.

## Changes

- Update English and Chinese event lifecycle docs.
- Replace “unique text block ID” wording with reply-scoped correlation key terminology.
- Clarify message reconstruction should use `replyId`, `blockId` / `toolCallId`, and event type together.

## Checklist

Please check the following items before code is ready to be reviewed.

- [ ]  Code has been formatted with `mvn spotless:apply`
- [ ]  All tests are passing (`mvn test`)
- [ ]  Javadoc comments are complete and follow project conventions
- [ ]  Related documentation has been updated (e.g. links, examples, etc.)
- [ ]  Code is ready for review
