### PR TITLE
fix(mysql): remove path-separator check from MysqlAgentStateStore session id validation 

### DIFF
--- a/agentscope-extensions/agentscope-extensions-mysql/src/main/java/io/agentscope/extensions/mysql/state/MysqlAgentStateStore.java
+++ b/agentscope-extensions/agentscope-extensions-mysql/src/main/java/io/agentscope/extensions/mysql/state/MysqlAgentStateStore.java
@@ -812,9 +812,6 @@ public class MysqlAgentStateStore implements AgentStateStore {
         if (sessionId == null || sessionId.trim().isEmpty()) {
             throw new IllegalArgumentException("AgentStateStore ID cannot be null or empty");
         }
-        if (sessionId.contains("/") || sessionId.contains("\\")) {
-            throw new IllegalArgumentException("AgentStateStore ID cannot contain path separators");
-        }
         if (sessionId.length() > 255) {
             throw new IllegalArgumentException("AgentStateStore ID cannot exceed 255 characters");
         }


### PR DESCRIPTION
…ore session id validation
2.0.0-SNAPSHOT

[The version of AgentScope-Java you are working on, e.g. 1.0.12, check your pom.xml dependency version or run `mvn dependency:tree | grep agentscope-parent:pom`(only mac/linux)]
## Summary                                                                                                                                                                                                                                                                                                                                                   
  MysqlAgentStateStore.validateSessionId() rejects any session id containing / or \, which makes it incompatible with legitimate callers such as SessionSandboxStateStore. This 
  PR removes that check because it is a filesystem-oriented constraint that has no meaning for a relational store and violates the AgentStateStore interface contract that other
   implementations (e.g. JsonFileAgentStateStore) already honor.                                                                                                                
## Problem                                                                                                                                                                                                                                                                                                                                       
  SessionSandboxStateStore.slotSessionId(SandboxIsolationKey) composes a session id from the isolation scope, e.g.:                                                             
                                                                                                                                                                                
  - sandbox/session/<value>                                                                                                                                                     
  - sandbox/user/<agentId>/<value>                                                                                                                                              
  - sandbox/agent/<agentId>                                                                                                                                                     
  - sandbox/global                                                                                                                                                              
                                                                                                                                                                                
  Every one of these contains / as a namespace delimiter. When the underlying AgentStateStore is MysqlAgentStateStore, every load/save/delete call goes through                 
  validateSessionId(String) at MysqlAgentStateStore.java:811, which throws:                                                                                                     
                                                                                                                                                                                
  IllegalArgumentException: AgentStateStore ID cannot contain path separators  
  Result: sandbox lifecycle state cannot be persisted or resumed at all when MySQL is used as the state backend, so distributed sandbox resume — the very feature the           
  class-level Javadoc of SessionSandboxStateStore advertises — is broken for MySQL users.                                                                                                                                                                                               

  ## Root Cause                                                                                                                                                                    
                                                                                                                                                                                
  The rejected characters (/, \) are path separators, not database characters. The error message itself gives away that this check was copied from a filesystem-oriented store. 

- [ ok]  Code has been formatted with `mvn spotless:apply`
- [ok ]  All tests are passing (`mvn test`)
- [ ok]  Javadoc comments are complete and follow project conventions
- [ ok]  Related documentation has been updated (e.g. links, examples, etc.)
- [ok ]  Code is ready for review
