### PR TITLE
fix(openai): allow disabling native structured output

### DIFF
--- a/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-openai/src/main/java/io/agentscope/extensions/model/openai/OpenAIChatModel.java
+++ b/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-openai/src/main/java/io/agentscope/extensions/model/openai/OpenAIChatModel.java
@@ -72,6 +72,7 @@ public class OpenAIChatModel extends ChatModelBase {
     private final OpenAIClient client;
     private final Formatter<OpenAIMessage, OpenAIResponse, OpenAIRequest> formatter;
     private final GenerateOptions configuredOptions;
+    private Boolean nativeStructuredOutput;
 
     /**
      * Creates a new OpenAI chat model instance with pre-configured options.
@@ -200,7 +201,7 @@ public class OpenAIChatModel extends ChatModelBase {
 
     @Override
     public boolean supportsNativeStructuredOutput() {
-        return true;
+        return nativeStructuredOutput != null ? nativeStructuredOutput : true;
     }
 
     /**
@@ -229,6 +230,7 @@ public class OpenAIChatModel extends ChatModelBase {
         private HttpTransport httpTransport;
         private ProxyConfig proxyConfig;
         private int contextWindowSize = -1;
+        private Boolean nativeStructuredOutput;
         private Boolean nativeStructuredOutputWithTools;
 
         /**
@@ -382,6 +384,23 @@ public class OpenAIChatModel extends ChatModelBase {
         }
 
         /**
+         * Sets whether this model supports native structured output via
+         * {@code response_format}.
+         *
+         * <p>Defaults to {@code true}, which is correct for OpenAI's own models. Set to
+         * {@code false} for OpenAI-compatible providers that do not reliably return schema
+         * constrained JSON through {@code response_format}; the agent will use the
+         * {@code generate_response} fallback path instead.
+         *
+         * @param nativeStructuredOutput false to use fallback structured output
+         * @return this builder instance
+         */
+        public Builder nativeStructuredOutput(boolean nativeStructuredOutput) {
+            this.nativeStructuredOutput = nativeStructuredOutput;
+            return this;
+        }
+
+        /**
          * Sets whether this model correctly handles native structured output
          * ({@code response_format}) alongside tool calling.
          *
@@ -443,6 +462,7 @@ public class OpenAIChatModel extends ChatModelBase {
             if (nativeStructuredOutputWithTools != null) {
                 model.setNativeStructuredOutputWithTools(nativeStructuredOutputWithTools);
             }
+            model.nativeStructuredOutput = nativeStructuredOutput;
             return model;
         }
 

--- a/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-openai/src/main/java/io/agentscope/extensions/model/openai/OpenAIModelProvider.java
+++ b/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-openai/src/main/java/io/agentscope/extensions/model/openai/OpenAIModelProvider.java
@@ -33,6 +33,7 @@ public final class OpenAIModelProvider implements ModelProvider {
     private static final String PREFIX = "openai:";
     private static final Pattern MODEL_ID = Pattern.compile("openai:.+");
     private static final String OPTION_CONTEXT_WINDOW_SIZE = "contextWindowSize";
+    private static final String OPTION_NATIVE_STRUCTURED_OUTPUT = "nativeStructuredOutput";
     private static final String OPTION_NATIVE_STRUCTURED_OUTPUT_WITH_TOOLS =
             "nativeStructuredOutputWithTools";
 
@@ -102,6 +103,10 @@ public final class OpenAIModelProvider implements ModelProvider {
         Integer contextWindowSize = intOption(context, OPTION_CONTEXT_WINDOW_SIZE);
         if (contextWindowSize != null) {
             builder.contextWindowSize(contextWindowSize);
+        }
+        Boolean nativeStructuredOutput = booleanOption(context, OPTION_NATIVE_STRUCTURED_OUTPUT);
+        if (nativeStructuredOutput != null) {
+            builder.nativeStructuredOutput(nativeStructuredOutput);
         }
         Boolean nativeStructuredOutputWithTools =
                 booleanOption(context, OPTION_NATIVE_STRUCTURED_OUTPUT_WITH_TOOLS);

--- a/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-openai/src/test/java/io/agentscope/extensions/model/openai/OpenAIChatModelTest.java
+++ b/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-openai/src/test/java/io/agentscope/extensions/model/openai/OpenAIChatModelTest.java
@@ -95,6 +95,22 @@ class OpenAIChatModelTest {
     }
 
     @Test
+    @DisplayName("Should allow native structured output capability override")
+    void testNativeStructuredOutputCapabilityOverride() {
+        OpenAIChatModel defaultModel =
+                OpenAIChatModel.builder().apiKey("test-api-key").modelName("gpt-4").build();
+        OpenAIChatModel fallbackModel =
+                OpenAIChatModel.builder()
+                        .apiKey("test-api-key")
+                        .modelName("gpt-4")
+                        .nativeStructuredOutput(false)
+                        .build();
+
+        assertTrue(defaultModel.supportsNativeStructuredOutput());
+        assertFalse(fallbackModel.supportsNativeStructuredOutput());
+    }
+
+    @Test
     @DisplayName("Should make non-streaming call successfully")
     void testNonStreamingCall() throws Exception {
         String responseJson =

--- a/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-openai/src/test/java/io/agentscope/extensions/model/openai/OpenAIModelProviderTest.java
+++ b/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-openai/src/test/java/io/agentscope/extensions/model/openai/OpenAIModelProviderTest.java
@@ -64,6 +64,7 @@ class OpenAIModelProviderTest {
                         .component(GenerateOptions.class, GenerateOptions.builder().build())
                         .component(ProxyConfig.class, ProxyConfig.http("localhost", 8080))
                         .option("contextWindowSize", 128000)
+                        .option("nativeStructuredOutput", false)
                         .option("nativeStructuredOutputWithTools", true)
                         .build();
 
@@ -72,6 +73,8 @@ class OpenAIModelProviderTest {
         assertTrue(model instanceof OpenAIChatModel);
         assertTrue(model.getModelName().equals("gpt-4o-mini"));
         assertEquals(128000, model.getContextWindowSize());
+        assertFalse(model.supportsNativeStructuredOutput());
+        assertTrue(model.supportsNativeStructuredOutputWithTools());
     }
 
     @Test


### PR DESCRIPTION
## AgentScope-Java Version

latest

## Description

Fixes #2025 

This PR makes OpenAI native structured-output capability configurable.

`OpenAIChatModel` previously returned `true` from `supportsNativeStructuredOutput()` unconditionally. That works for native OpenAI-compatible models that fully support `response_format`, but it breaks compatible gateways where native structured output is unavailable or unreliable.

This change adds a `nativeStructuredOutput` builder/provider option. By default, behavior remains unchanged. Users can explicitly set it to `false` to let `ReActAgent` use the fallback structured-output flow instead.

