### PR TITLE
fix(skill): fallback to simple key-value extraction when YAML parsing fails

### DIFF
--- a/agentscope-core/src/main/java/io/agentscope/core/skill/util/MarkdownSkillParser.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/skill/util/MarkdownSkillParser.java
@@ -78,6 +78,9 @@ public class MarkdownSkillParser {
             Pattern.compile(
                     "^---\\s*[\\r\\n]+(.*?)[\\r\\n]*---(?:\\s*[\\r\\n]+)?(.*)", Pattern.DOTALL);
 
+    private static final Pattern SIMPLE_KV_PATTERN =
+            Pattern.compile("^([A-Za-z][A-Za-z0-9_-]*)\\s*:\\s*(.*)$");
+
     private static final LoaderOptions LOADER_OPTIONS = createLoaderOptions();
 
     private static final DumperOptions DUMPER_OPTIONS = createDumperOptions();
@@ -158,8 +161,8 @@ public class MarkdownSkillParser {
         try {
             loaded = createParserYaml().load(yamlContent);
         } catch (RuntimeException e) {
-            logger.debug("Failed to parse YAML frontmatter, returning empty metadata", e);
-            return Map.of();
+            logger.debug("Full YAML parse failed, falling back to simple key-value extraction", e);
+            return fallbackParseSimpleKeyValues(yamlContent);
         }
 
         if (loaded == null) {
@@ -205,6 +208,74 @@ public class MarkdownSkillParser {
 
     private static Yaml createParserYaml() {
         return new Yaml(new SafeConstructor(LOADER_OPTIONS));
+    }
+
+    /**
+     * Fallback line-by-line parser that extracts simple {@code key: value} pairs from YAML content
+     * when the full SnakeYAML parser fails. Gracefully skips lines it cannot handle (lists, nested
+     * objects, block scalars) while still extracting scalar key-value pairs like {@code name} and
+     * {@code description}.
+     */
+    private static Map<String, Object> fallbackParseSimpleKeyValues(String yamlContent) {
+        LinkedHashMap<String, Object> result = new LinkedHashMap<>();
+        String[] lines = yamlContent.split("\\r?\\n");
+
+        for (String line : lines) {
+            if (line.isBlank()) {
+                continue;
+            }
+
+            // Indented lines belong to a previous block scalar or complex structure — skip them
+            if (line.startsWith(" ") || line.startsWith("\t")) {
+                continue;
+            }
+
+            // Skip list items at the top level
+            if (line.trim().startsWith("-")) {
+                continue;
+            }
+
+            Matcher matcher = SIMPLE_KV_PATTERN.matcher(line);
+            if (!matcher.matches()) {
+                logger.debug("Fallback parser skipping unsupported line: {}", line);
+                continue;
+            }
+
+            String key = matcher.group(1);
+            String rawValue = matcher.group(2).trim();
+
+            // Skip block scalar modifiers — their content spans subsequent indented lines
+            if (rawValue.startsWith("|") || rawValue.startsWith(">")) {
+                logger.debug("Fallback parser skipping block scalar key: {}", key);
+                continue;
+            }
+
+            // Skip keys whose value is empty (likely followed by nested content)
+            if (rawValue.isEmpty()) {
+                continue;
+            }
+
+            result.put(key, unquote(rawValue));
+        }
+
+        if (result.isEmpty()) {
+            logger.debug("Fallback parser extracted no metadata");
+        } else {
+            logger.debug(
+                    "Fallback parser extracted {} entries: {}", result.size(), result.keySet());
+        }
+        return result;
+    }
+
+    private static String unquote(String value) {
+        if (value.length() >= 2) {
+            char first = value.charAt(0);
+            char last = value.charAt(value.length() - 1);
+            if ((first == '"' && last == '"') || (first == '\'' && last == '\'')) {
+                return value.substring(1, value.length() - 1);
+            }
+        }
+        return value;
     }
 
     private static Yaml createDumperYaml() {

--- a/agentscope-core/src/test/java/io/agentscope/core/skill/util/MarkdownSkillParserTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/skill/util/MarkdownSkillParserTest.java
@@ -285,26 +285,87 @@ class MarkdownSkillParserTest {
     class ErrorHandlingTests {
 
         @Test
-        @DisplayName("Should return empty metadata for invalid YAML frontmatter")
+        @DisplayName("Should fallback and extract valid key-value pairs from invalid YAML")
         void testInvalidYaml() {
             String markdown = "---\nname: test\nthis is not a valid line\n---\nContent";
 
             MarkdownSkillParser.ParsedMarkdown parsed = MarkdownSkillParser.parse(markdown);
             Map<String, Object> metadata = parsed.getMetadata();
 
-            assertTrue(metadata.isEmpty());
+            assertEquals("test", metadata.get("name"));
             assertEquals("Content", parsed.getContent());
         }
 
         @Test
-        @DisplayName("Should return empty metadata for invalid list-style frontmatter")
+        @DisplayName("Should fallback and extract scalars when mixed with list items")
         void testListFormat() {
             String markdown = "---\nname: test_skill\n- item1\n- item2\n---\nContent";
 
             MarkdownSkillParser.ParsedMarkdown parsed = MarkdownSkillParser.parse(markdown);
             Map<String, Object> metadata = parsed.getMetadata();
 
-            assertTrue(metadata.isEmpty());
+            assertEquals("test_skill", metadata.get("name"));
+        }
+
+        @Test
+        @DisplayName("Fallback parser should extract name and description from complex SKILL.md")
+        void testFallbackExtractsFromComplexSkillMd() {
+            // Simulates the user scenario from Issue #1999: SKILL.md with mixed valid/invalid YAML
+            String markdown =
+                    """
+                    ---
+                    name: minimax-docx
+                    description: Document processing with minimax API
+                    version: 1.0
+                    deps:
+                      - requests>=2.0
+                      - minimax-sdk
+                    config: |
+                      api_key: ${MINIMAX_KEY}
+                    invalid: [unclosed bracket
+                    ---
+                    # Usage
+                    Process documents with minimax.\
+                    """;
+
+            MarkdownSkillParser.ParsedMarkdown parsed = MarkdownSkillParser.parse(markdown);
+            Map<String, Object> metadata = parsed.getMetadata();
+
+            assertEquals("minimax-docx", metadata.get("name"));
+            assertEquals("Document processing with minimax API", metadata.get("description"));
+            assertEquals("1.0", metadata.get("version"));
+            assertTrue(parsed.getContent().contains("# Usage"));
+        }
+
+        @Test
+        @DisplayName("Fallback parser should handle quoted values")
+        void testFallbackWithQuotedValues() {
+            // Trigger SnakeYAML failure with truly broken YAML + quoted values
+            String markdown =
+                    "---\nname: \"my skill\"\ndescription: 'A cool skill'\n"
+                            + "broken: [}\n---\nContent";
+
+            MarkdownSkillParser.ParsedMarkdown parsed = MarkdownSkillParser.parse(markdown);
+            Map<String, Object> metadata = parsed.getMetadata();
+
+            assertEquals("my skill", metadata.get("name"));
+            assertEquals("A cool skill", metadata.get("description"));
+        }
+
+        @Test
+        @DisplayName("Fallback parser should skip block scalar keys")
+        void testFallbackSkipsBlockScalars() {
+            // SnakeYAML fails due to tab character in YAML (not allowed per spec)
+            String markdown =
+                    "---\nname: test_skill\ndescription: |\n"
+                            + "  multi-line\n\tbroken-tab-char\nversion: 2.0\n---\nContent";
+
+            MarkdownSkillParser.ParsedMarkdown parsed = MarkdownSkillParser.parse(markdown);
+            Map<String, Object> metadata = parsed.getMetadata();
+
+            assertEquals("test_skill", metadata.get("name"));
+            assertNull(metadata.get("description"));
+            assertEquals("2.0", metadata.get("version"));
         }
 
         @Test


### PR DESCRIPTION
## Summary
- When SnakeYAML fails to parse malformed YAML frontmatter in SKILL.md, fall back to a line-by-line `key: value` extractor instead of returning empty metadata
- This restores the tolerant parsing behavior from 1.x (commit `66885593`), allowing skills with partially invalid YAML to still have `name` and `description` extracted
- Prevents `IllegalArgumentException` in `SkillUtil.createFrom` which caused entire skill directories to be silently skipped

## Related Issue
Closes #1999

## Changes
- `MarkdownSkillParser.parseYamlMetadata()`: on SnakeYAML `RuntimeException`, delegate to new `fallbackParseSimpleKeyValues()` instead of returning `Map.of()`
- `fallbackParseSimpleKeyValues()`: line-by-line parser that extracts scalar `key: value` pairs, gracefully skipping lists, block scalars, indented content, and unrecognized lines
- Updated existing tests to reflect new fallback behavior (previously expected empty metadata, now expects partial extraction)
- Added regression tests covering the Issue #1999 scenario (complex SKILL.md with mixed valid/invalid YAML)

## Validation
```
mvn -pl agentscope-core -Dtest=MarkdownSkillParserTest,SkillUtilTest test
```