### PR TITLE
fix(model): map thinkingBudget to OpenAI-compatible API request

### DIFF
--- a/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-openai/src/main/java/io/agentscope/extensions/model/openai/dto/OpenAIRequest.java
+++ b/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-openai/src/main/java/io/agentscope/extensions/model/openai/dto/OpenAIRequest.java
@@ -129,6 +129,13 @@ public class OpenAIRequest {
     private String reasoningEffort;
 
     /**
+     * Maximum number of tokens the model may spend on thinking/reasoning content.
+     * Used by reasoning models (e.g. Qwen3, DeepSeek-R1) to cap internal chain-of-thought.
+     */
+    @JsonProperty("thinking_budget")
+    private Integer thinkingBudget;
+
+    /**
      * Controls whether to allow parallel tool calls.
      * Set to false to disable parallel tool calling.
      */
@@ -345,6 +352,14 @@ public class OpenAIRequest {
         this.reasoningEffort = reasoningEffort;
     }
 
+    public Integer getThinkingBudget() {
+        return thinkingBudget;
+    }
+
+    public void setThinkingBudget(Integer thinkingBudget) {
+        this.thinkingBudget = thinkingBudget;
+    }
+
     public Boolean getParallelToolCalls() {
         return parallelToolCalls;
     }
@@ -551,6 +566,11 @@ public class OpenAIRequest {
 
         public Builder reasoningEffort(String reasoningEffort) {
             request.setReasoningEffort(reasoningEffort);
+            return this;
+        }
+
+        public Builder thinkingBudget(Integer thinkingBudget) {
+            request.setThinkingBudget(thinkingBudget);
             return this;
         }
 

--- a/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-openai/src/main/java/io/agentscope/extensions/model/openai/formatter/OpenAIChatFormatter.java
+++ b/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-openai/src/main/java/io/agentscope/extensions/model/openai/formatter/OpenAIChatFormatter.java
@@ -258,6 +258,11 @@ public class OpenAIChatFormatter extends OpenAIBaseFormatter {
                             request.setIncludeReasoning((Boolean) value);
                         }
                         break;
+                    case "thinking_budget":
+                        if (value instanceof Number number) {
+                            request.setThinkingBudget(number.intValue());
+                        }
+                        break;
                     case "stop":
                         if (value instanceof List) {
                             @SuppressWarnings("unchecked")

--- a/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-openai/src/main/java/io/agentscope/extensions/model/openai/formatter/OpenAIChatFormatter.java
+++ b/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-openai/src/main/java/io/agentscope/extensions/model/openai/formatter/OpenAIChatFormatter.java
@@ -80,6 +80,12 @@ public class OpenAIChatFormatter extends OpenAIBaseFormatter {
         if (reasoningEffort != null) {
             request.setReasoningEffort(reasoningEffort);
         }
+        // Apply thinking budget
+        Integer thinkingBudget =
+                getOptionOrDefault(options, defaultOptions, GenerateOptions::getThinkingBudget);
+        if (thinkingBudget != null) {
+            request.setThinkingBudget(thinkingBudget);
+        }
 
         // Apply top_p
         Double topP = getOptionOrDefault(options, defaultOptions, GenerateOptions::getTopP);

--- a/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-openai/src/test/java/io/agentscope/extensions/model/openai/formatter/OpenAIChatFormatterTest.java
+++ b/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-openai/src/test/java/io/agentscope/extensions/model/openai/formatter/OpenAIChatFormatterTest.java
@@ -439,6 +439,59 @@ class OpenAIChatFormatterTest {
         }
 
         @Test
+        @DisplayName("Should apply thinkingBudget from GenerateOptions")
+        void testApplyThinkingBudget() {
+            OpenAIRequest request =
+                    OpenAIRequest.builder().model("qwen3").messages(List.of()).build();
+
+            GenerateOptions options = GenerateOptions.builder().thinkingBudget(4096).build();
+
+            formatter.applyOptions(request, options, null);
+
+            assertEquals(4096, request.getThinkingBudget());
+        }
+
+        @Test
+        @DisplayName("Should apply thinkingBudget from default when options is null")
+        void testApplyThinkingBudgetFromDefault() {
+            OpenAIRequest request =
+                    OpenAIRequest.builder().model("qwen3").messages(List.of()).build();
+
+            GenerateOptions defaultOptions = GenerateOptions.builder().thinkingBudget(2048).build();
+
+            formatter.applyOptions(request, null, defaultOptions);
+
+            assertEquals(2048, request.getThinkingBudget());
+        }
+
+        @Test
+        @DisplayName("Should override thinkingBudget from default with options value")
+        void testApplyThinkingBudgetOverride() {
+            OpenAIRequest request =
+                    OpenAIRequest.builder().model("qwen3").messages(List.of()).build();
+
+            GenerateOptions defaultOptions = GenerateOptions.builder().thinkingBudget(2048).build();
+            GenerateOptions options = GenerateOptions.builder().thinkingBudget(4096).build();
+
+            formatter.applyOptions(request, options, defaultOptions);
+
+            assertEquals(4096, request.getThinkingBudget());
+        }
+
+        @Test
+        @DisplayName("Should not set thinkingBudget when absent from both options and defaults")
+        void testThinkingBudgetAbsent() {
+            OpenAIRequest request =
+                    OpenAIRequest.builder().model("qwen3").messages(List.of()).build();
+
+            GenerateOptions options = GenerateOptions.builder().temperature(0.7).build();
+
+            formatter.applyOptions(request, options, null);
+
+            assertNull(request.getThinkingBudget());
+        }
+
+        @Test
         @DisplayName("Should apply include_reasoning parameter")
         void testApplyIncludeReasoning() {
             OpenAIRequest request =

--- a/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-openai/src/test/java/io/agentscope/extensions/model/openai/formatter/OpenAIChatFormatterTest.java
+++ b/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-openai/src/test/java/io/agentscope/extensions/model/openai/formatter/OpenAIChatFormatterTest.java
@@ -492,6 +492,26 @@ class OpenAIChatFormatterTest {
         }
 
         @Test
+        @DisplayName(
+                "Should let additionalBodyParams override thinkingBudget without duplicate extra"
+                        + " param")
+        void testThinkingBudgetAdditionalBodyParamOverride() {
+            OpenAIRequest request =
+                    OpenAIRequest.builder().model("qwen3").messages(List.of()).build();
+
+            GenerateOptions defaultOptions = GenerateOptions.builder().thinkingBudget(2048).build();
+            GenerateOptions options =
+                    GenerateOptions.builder().additionalBodyParam("thinking_budget", 4096).build();
+
+            formatter.applyOptions(request, options, defaultOptions);
+
+            assertEquals(4096, request.getThinkingBudget());
+            assertTrue(
+                    request.getExtraParams() == null
+                            || !request.getExtraParams().containsKey("thinking_budget"));
+        }
+
+        @Test
         @DisplayName("Should apply include_reasoning parameter")
         void testApplyIncludeReasoning() {
             OpenAIRequest request =


### PR DESCRIPTION
## Summary
- `GenerateOptions.thinkingBudget` was stored but never mapped to `OpenAIRequest`, causing the `thinking_budget` parameter to be silently dropped from all OpenAI-compatible API calls
- This breaks reasoning models (Qwen3, DeepSeek-R1) that need `thinking_budget` to cap internal chain-of-thought — without it, the model exhausts all `max_completion_tokens` on reasoning and returns empty `content`

## Related Issue
Fixes #1697
Supersedes #1727 (which targets pre-migration file paths in `agentscope-core`)

## Changes
- **`OpenAIRequest.java`**: Add `@JsonProperty("thinking_budget")` field with getter/setter and Builder method
- **`OpenAIChatFormatter.java`**: Map `GenerateOptions.thinkingBudget` in `applyOptions()`
- **`OpenAIChatFormatterTest.java`**: Add 4 unit tests covering direct, default, override, and absent cases

## Validation
```
mvn -pl agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-openai -Dtest=OpenAIChatFormatterTest test
```