### PR TITLE
fix(openai): handle DataBlock in OpenAIMessageConverter

### DIFF
--- a/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-openai/src/main/java/io/agentscope/extensions/model/openai/formatter/OpenAIMessageConverter.java
+++ b/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-openai/src/main/java/io/agentscope/extensions/model/openai/formatter/OpenAIMessageConverter.java
@@ -15,9 +15,11 @@
  */
 package io.agentscope.extensions.model.openai.formatter;
 
+import io.agentscope.core.formatter.MediaUtils;
 import io.agentscope.core.message.AudioBlock;
 import io.agentscope.core.message.Base64Source;
 import io.agentscope.core.message.ContentBlock;
+import io.agentscope.core.message.DataBlock;
 import io.agentscope.core.message.HintBlock;
 import io.agentscope.core.message.ImageBlock;
 import io.agentscope.core.message.MessageMetadataKeys;
@@ -249,6 +251,8 @@ public class OpenAIMessageConverter {
                             OpenAIContentPart.text(
                                     "[Video - processing failed: " + errorMsg + "]"));
                 }
+            } else if (block instanceof DataBlock db) {
+                convertDataBlock(db, contentParts);
             } else if (block instanceof ToolUseBlock) {
                 log.warn("ToolUseBlock is not supported in user messages");
             } else if (block instanceof ToolResultBlock) {
@@ -432,11 +436,78 @@ public class OpenAIMessageConverter {
         for (ContentBlock block : blocks) {
             if (block instanceof ImageBlock
                     || block instanceof AudioBlock
-                    || block instanceof VideoBlock) {
+                    || block instanceof VideoBlock
+                    || block instanceof DataBlock) {
                 return true;
             }
         }
         return false;
+    }
+
+    private void convertDataBlock(DataBlock db, List<OpenAIContentPart> contentParts) {
+        Source source = db.getSource();
+        if (source == null) {
+            log.warn("DataBlock has null source, skipping");
+            return;
+        }
+
+        String mimeType;
+        if (source instanceof Base64Source b64) {
+            mimeType = b64.getMediaType();
+        } else if (source instanceof URLSource u) {
+            mimeType = MediaUtils.determineMediaType(u.getUrl());
+        } else {
+            log.warn("DataBlock has unknown source type: {}", source.getClass().getSimpleName());
+            return;
+        }
+
+        if (mimeType == null || mimeType.equals("application/octet-stream")) {
+            log.warn("DataBlock has unrecognized MIME type '{}', skipping", mimeType);
+            contentParts.add(
+                    OpenAIContentPart.text("[Data - unrecognized type: " + mimeType + "]"));
+            return;
+        }
+
+        try {
+            if (mimeType.startsWith("image/")) {
+                String imageUrl = convertImageSourceToUrl(source);
+                contentParts.add(OpenAIContentPart.imageUrl(imageUrl));
+            } else if (mimeType.startsWith("audio/")) {
+                if (source instanceof Base64Source b64) {
+                    String audioData = b64.getData();
+                    if (audioData == null || audioData.isEmpty()) {
+                        contentParts.add(OpenAIContentPart.text("[Audio - data missing]"));
+                        return;
+                    }
+                    String format = detectAudioFormat(mimeType);
+                    if (format == null) {
+                        format = "wav";
+                    }
+                    contentParts.add(OpenAIContentPart.inputAudio(audioData, format));
+                } else if (source instanceof URLSource u) {
+                    String url = u.getUrl();
+                    if (url == null || url.isEmpty()) {
+                        contentParts.add(OpenAIContentPart.text("[Audio URL - missing]"));
+                        return;
+                    }
+                    log.warn("URL-based audio not directly supported, using text reference");
+                    contentParts.add(OpenAIContentPart.text("[Audio URL: " + url + "]"));
+                }
+            } else if (mimeType.startsWith("video/")) {
+                String videoUrl = convertVideoSourceToUrl(source);
+                contentParts.add(OpenAIContentPart.videoUrl(videoUrl));
+            } else {
+                log.warn("DataBlock has unrecognized MIME type '{}', skipping", mimeType);
+                contentParts.add(
+                        OpenAIContentPart.text("[Data - unrecognized type: " + mimeType + "]"));
+            }
+        } catch (Exception e) {
+            String errorMsg =
+                    e.getMessage() != null ? e.getMessage() : e.getClass().getSimpleName();
+            log.warn("Failed to process DataBlock: {}", errorMsg);
+            contentParts.add(
+                    OpenAIContentPart.text("[Data - processing failed: " + errorMsg + "]"));
+        }
     }
 
     /**

--- a/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-openai/src/test/java/io/agentscope/extensions/model/openai/formatter/OpenAIDataBlockConverterTest.java
+++ b/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-openai/src/test/java/io/agentscope/extensions/model/openai/formatter/OpenAIDataBlockConverterTest.java
@@ -1,0 +1,242 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.extensions.model.openai.formatter;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.agentscope.core.message.Base64Source;
+import io.agentscope.core.message.DataBlock;
+import io.agentscope.core.message.Msg;
+import io.agentscope.core.message.TextBlock;
+import io.agentscope.core.message.URLSource;
+import io.agentscope.core.message.UserMessage;
+import io.agentscope.extensions.model.openai.dto.OpenAIContentPart;
+import io.agentscope.extensions.model.openai.dto.OpenAIMessage;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class OpenAIDataBlockConverterTest {
+
+    @Test
+    void testDataBlockImageUrlNotDropped() {
+        var formatter = new OpenAIChatFormatter();
+
+        Msg msg =
+                new UserMessage(
+                        List.of(
+                                TextBlock.builder().text("analyze this").build(),
+                                DataBlock.builder()
+                                        .source(
+                                                URLSource.builder()
+                                                        .url("https://example.com/photo.png")
+                                                        .build())
+                                        .build()));
+
+        List<OpenAIMessage> result = formatter.format(List.of(msg));
+        assertEquals(1, result.size());
+
+        Object content = result.get(0).getContent();
+        assertTrue(content instanceof List<?>);
+
+        @SuppressWarnings("unchecked")
+        List<OpenAIContentPart> parts = (List<OpenAIContentPart>) content;
+
+        boolean hasText =
+                parts.stream()
+                        .anyMatch(
+                                p ->
+                                        "text".equals(p.getType())
+                                                && "analyze this".equals(p.getText()));
+        boolean hasImage =
+                parts.stream()
+                        .anyMatch(
+                                p ->
+                                        "image_url".equals(p.getType())
+                                                && p.getImageUrl() != null
+                                                && "https://example.com/photo.png"
+                                                        .equals(p.getImageUrl().getUrl()));
+
+        assertTrue(hasText, "text block should be present");
+        assertTrue(hasImage, "image_url from DataBlock should be present");
+    }
+
+    @Test
+    void testDataBlockBase64Image() {
+        var formatter = new OpenAIChatFormatter();
+
+        Msg msg =
+                new UserMessage(
+                        List.of(
+                                DataBlock.builder()
+                                        .source(new Base64Source("image/png", "iVBORw0KGgo="))
+                                        .build()));
+
+        List<OpenAIMessage> result = formatter.format(List.of(msg));
+        assertEquals(1, result.size());
+
+        Object content = result.get(0).getContent();
+        assertTrue(content instanceof List<?>);
+
+        @SuppressWarnings("unchecked")
+        List<OpenAIContentPart> parts = (List<OpenAIContentPart>) content;
+
+        boolean hasImage =
+                parts.stream()
+                        .anyMatch(
+                                p ->
+                                        "image_url".equals(p.getType())
+                                                && p.getImageUrl() != null
+                                                && p.getImageUrl()
+                                                        .getUrl()
+                                                        .startsWith("data:image/png;base64"));
+
+        assertTrue(hasImage, "base64 image from DataBlock should be present");
+    }
+
+    @Test
+    void testDataBlockVideoUrl() {
+        var formatter = new OpenAIChatFormatter();
+
+        Msg msg =
+                new UserMessage(
+                        List.of(
+                                DataBlock.builder()
+                                        .source(
+                                                URLSource.builder()
+                                                        .url("https://example.com/movie.mp4")
+                                                        .build())
+                                        .build()));
+
+        List<OpenAIMessage> result = formatter.format(List.of(msg));
+        assertEquals(1, result.size());
+
+        Object content = result.get(0).getContent();
+        assertTrue(content instanceof List<?>);
+
+        @SuppressWarnings("unchecked")
+        List<OpenAIContentPart> parts = (List<OpenAIContentPart>) content;
+
+        boolean hasVideo =
+                parts.stream()
+                        .anyMatch(
+                                p ->
+                                        "video_url".equals(p.getType())
+                                                && p.getVideoUrl() != null
+                                                && "https://example.com/movie.mp4"
+                                                        .equals(p.getVideoUrl().getUrl()));
+        assertTrue(hasVideo, "video_url from DataBlock should be present");
+    }
+
+    @Test
+    void testDataBlockAudioUrlFallback() {
+        var formatter = new OpenAIChatFormatter();
+
+        Msg msg =
+                new UserMessage(
+                        List.of(
+                                DataBlock.builder()
+                                        .source(
+                                                URLSource.builder()
+                                                        .url("https://example.com/song.mp3")
+                                                        .build())
+                                        .build()));
+
+        List<OpenAIMessage> result = formatter.format(List.of(msg));
+        assertEquals(1, result.size());
+
+        Object content = result.get(0).getContent();
+        assertTrue(content instanceof List<?>);
+
+        @SuppressWarnings("unchecked")
+        List<OpenAIContentPart> parts = (List<OpenAIContentPart>) content;
+
+        boolean hasAudioText =
+                parts.stream()
+                        .anyMatch(
+                                p ->
+                                        "text".equals(p.getType())
+                                                && p.getText() != null
+                                                && p.getText()
+                                                        .contains("https://example.com/song.mp3"));
+        assertTrue(hasAudioText, "URL-based audio should produce a text placeholder");
+    }
+
+    @Test
+    void testDataBlockBase64Audio() {
+        var formatter = new OpenAIChatFormatter();
+
+        Msg msg =
+                new UserMessage(
+                        List.of(
+                                DataBlock.builder()
+                                        .source(new Base64Source("audio/wav", "base64audiodata"))
+                                        .build()));
+
+        List<OpenAIMessage> result = formatter.format(List.of(msg));
+        assertEquals(1, result.size());
+
+        Object content = result.get(0).getContent();
+        assertTrue(content instanceof List<?>);
+
+        @SuppressWarnings("unchecked")
+        List<OpenAIContentPart> parts = (List<OpenAIContentPart>) content;
+
+        boolean hasAudio =
+                parts.stream()
+                        .anyMatch(
+                                p ->
+                                        "input_audio".equals(p.getType())
+                                                && p.getInputAudio() != null
+                                                && "base64audiodata"
+                                                        .equals(p.getInputAudio().getData()));
+        assertTrue(hasAudio, "Base64 audio from DataBlock should produce input_audio part");
+    }
+
+    @Test
+    void testDataBlockUnknownMimeType() {
+        var formatter = new OpenAIChatFormatter();
+
+        Msg msg =
+                new UserMessage(
+                        List.of(
+                                DataBlock.builder()
+                                        .source(
+                                                URLSource.builder()
+                                                        .url("https://example.com/file.unknown")
+                                                        .build())
+                                        .build()));
+
+        List<OpenAIMessage> result = formatter.format(List.of(msg));
+        assertEquals(1, result.size());
+
+        Object content = result.get(0).getContent();
+        assertTrue(content instanceof List<?>);
+
+        @SuppressWarnings("unchecked")
+        List<OpenAIContentPart> parts = (List<OpenAIContentPart>) content;
+
+        boolean hasFallback =
+                parts.stream()
+                        .anyMatch(
+                                p ->
+                                        "text".equals(p.getType())
+                                                && p.getText() != null
+                                                && p.getText()
+                                                        .startsWith("[Data - unrecognized type:"));
+        assertTrue(hasFallback, "unknown MIME should produce a text placeholder");
+    }
+}


### PR DESCRIPTION
## Summary

- Add `DataBlock` handling in `OpenAIMessageConverter.convertContentBlocks()` — routes to image/audio/video content parts based on MIME type (from `Base64Source.getMediaType()` or URL extension via `MediaUtils.determineMediaType()`)
- Update `hasMediaContent()` to recognize `DataBlock` so multimodal formatting is triggered correctly
- Add 6 unit tests covering image URL, base64 image, video URL, audio URL fallback, base64 audio, and unknown MIME type scenarios

Previously, `DataBlock` instances were silently dropped during message conversion, causing multimodal content to be lost when using the unified `DataBlock` API (introduced in 2.0 as the forward-looking replacement for legacy `ImageBlock`/`AudioBlock`/`VideoBlock`).

Closes #1744

## Test plan

- [x] `OpenAIDataBlockConverterTest` — 6 tests all passing
- [x] Compile clean, spotless pass