### PR TITLE
fix(shell): escape spaces in skill paths returned by ShellPathPolicy

### DIFF
--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/skill/runtime/ShellPathPolicy.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/skill/runtime/ShellPathPolicy.java
@@ -112,9 +112,14 @@ public final class ShellPathPolicy {
 
     private String joinSkills(String skillName) {
         return switch (mode) {
-            case SANDBOX -> sandboxPrefix + "/skills/" + skillName;
+            case SANDBOX -> escapeSpaces(sandboxPrefix + "/skills/" + skillName);
             case LOCAL_WITH_SHELL ->
-                    workspaceRoot.resolve("skills").resolve(skillName).toAbsolutePath().toString();
+                    escapeSpaces(
+                            workspaceRoot
+                                    .resolve("skills")
+                                    .resolve(skillName)
+                                    .toAbsolutePath()
+                                    .toString());
             case NO_SHELL -> null;
         };
     }
@@ -122,21 +127,31 @@ public final class ShellPathPolicy {
     private String joinCache(String sourceNs, String skillName) {
         return switch (mode) {
             case SANDBOX ->
-                    sandboxPrefix
-                            + "/"
-                            + MarketplaceStager.CACHE_DIR
-                            + "/"
-                            + sourceNs
-                            + "/"
-                            + skillName;
+                    escapeSpaces(
+                            sandboxPrefix
+                                    + "/"
+                                    + MarketplaceStager.CACHE_DIR
+                                    + "/"
+                                    + sourceNs
+                                    + "/"
+                                    + skillName);
             case LOCAL_WITH_SHELL ->
-                    workspaceRoot
-                            .resolve(MarketplaceStager.CACHE_DIR)
-                            .resolve(sourceNs)
-                            .resolve(skillName)
-                            .toAbsolutePath()
-                            .toString();
+                    escapeSpaces(
+                            workspaceRoot
+                                    .resolve(MarketplaceStager.CACHE_DIR)
+                                    .resolve(sourceNs)
+                                    .resolve(skillName)
+                                    .toAbsolutePath()
+                                    .toString());
             case NO_SHELL -> null;
         };
+    }
+
+    /**
+     * Escapes space characters with backslash so the path can be safely used in shell commands
+     * by the LLM.
+     */
+    static String escapeSpaces(String value) {
+        return value.indexOf(' ') >= 0 ? value.replace(" ", "\\ ") : value;
     }
 }

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/skill/runtime/ShellPathPolicy.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/skill/runtime/ShellPathPolicy.java
@@ -148,8 +148,10 @@ public final class ShellPathPolicy {
     }
 
     /**
-     * Escapes space characters with backslash so the path can be safely used in shell commands
-     * by the LLM.
+     * Escapes spaces with backslash (e.g. {@code "a b" -> "a\ b"}) so the value can be embedded
+     * unquoted in POSIX shell commands without word-splitting.
+     *
+     * <p>This is not a general-purpose shell escaping routine.
      */
     static String escapeSpaces(String value) {
         return value.indexOf(' ') >= 0 ? value.replace(" ", "\\ ") : value;

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/skill/runtime/SkillRuntimeTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/skill/runtime/SkillRuntimeTest.java
@@ -30,6 +30,8 @@ import io.agentscope.core.skill.SkillFilter;
 import io.agentscope.core.tool.ToolCallParam;
 import io.agentscope.core.tool.Toolkit;
 import io.agentscope.harness.agent.skill.SkillResources;
+import io.agentscope.harness.agent.skill.runtime.MarketplaceStager.StageResult;
+import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -75,6 +77,59 @@ class SkillRuntimeTest {
     }
 
     // =========================================================================
+    //  ShellPathPolicy
+    // =========================================================================
+
+    @Nested
+    class ShellPathPolicyTests {
+
+        @Test
+        void escapeSpacesReplacesWithBackslashSpace() {
+            assertEquals("hello", ShellPathPolicy.escapeSpaces("hello"));
+            assertEquals("hello\\ world", ShellPathPolicy.escapeSpaces("hello world"));
+            assertEquals("V2Ray\\ 代理配置助手", ShellPathPolicy.escapeSpaces("V2Ray 代理配置助手"));
+            assertEquals("a\\ b\\ c", ShellPathPolicy.escapeSpaces("a b c"));
+        }
+
+        @Test
+        void sandboxResolveEscapesSpacesInSkillName() {
+            ShellPathPolicy policy = ShellPathPolicy.sandbox();
+            String result = policy.resolve("V2Ray 代理配置助手", new StageResult.WorkspaceNative());
+            assertEquals("/workspace/skills/V2Ray\\ 代理配置助手", result);
+        }
+
+        @Test
+        void sandboxResolveEscapesSpacesInCachedSkill() {
+            ShellPathPolicy policy = ShellPathPolicy.sandbox();
+            String result = policy.resolve("ignored", new StageResult.Cached("ns", "my skill"));
+            assertEquals("/workspace/.skills-cache/ns/my\\ skill", result);
+        }
+
+        @Test
+        void localWithShellResolveEscapesSpaces() {
+            ShellPathPolicy policy = ShellPathPolicy.localWithShell(Paths.get("/tmp/my workspace"));
+            String result = policy.resolve("my skill", new StageResult.WorkspaceNative());
+            assertEquals("/tmp/my\\ workspace/skills/my\\ skill", result);
+        }
+
+        @Test
+        void noShellAlwaysReturnsNull() {
+            ShellPathPolicy policy = ShellPathPolicy.noShell();
+            assertNull(policy.resolve("any name", new StageResult.WorkspaceNative()));
+            assertNull(policy.resolve("any name", new StageResult.Cached("ns", "name")));
+            assertNull(policy.resolve("any name", StageResult.NONE));
+            assertNull(policy.resolve("any name", null));
+        }
+
+        @Test
+        void nullStageOrNoneReturnsNull() {
+            ShellPathPolicy policy = ShellPathPolicy.sandbox();
+            assertNull(policy.resolve("alpha", null));
+            assertNull(policy.resolve("alpha", StageResult.NONE));
+        }
+    }
+
+    // =========================================================================
     //  SkillPromptBuilder
     // =========================================================================
 
@@ -107,6 +162,17 @@ class SkillRuntimeTest {
             assertTrue(out.contains("<files-root>/workspace/skills/alpha</files-root>"));
             assertTrue(out.contains("## Code Execution"));
             assertTrue(out.contains("<files-root>"));
+        }
+
+        @Test
+        void rendersEscapedFilesRootWhenPathContainsSpaces() {
+            HarnessSkillEntry e =
+                    new HarnessSkillEntry(
+                            skill("V2Ray 代理配置助手", "wkspace"),
+                            null,
+                            "/workspace/skills/V2Ray\\ 代理配置助手");
+            String out = new SkillPromptBuilder().render(SkillCatalog.of(List.of(e)));
+            assertTrue(out.contains("<files-root>/workspace/skills/V2Ray\\ 代理配置助手</files-root>"));
         }
 
         @Test


### PR DESCRIPTION
## AgentScope-Java Version

2.0.0

**Description:**

Closes #1893

When a skill name contains spaces (e.g., `V2Ray 代理配置助手`), the `<files-root>` path emitted in `<available_skills>` and the `"Files root: "` line in `load_skill_through_path` responses are both consumed by the LLM to construct shell commands. Without escaping, the space makes the path ambiguous and causes shell execution failures.

`filesRoot` propagates from `ShellPathPolicy` to the LLM prompt through two call sites:

1. **`SkillPromptBuilder`** — renders `<files-root>` inside `<available_skills>`
2. **`SkillLoadTool`** — renders `"Files root: "` in skill/resource load responses

**Changes:**

- **`ShellPathPolicy`**: Added `escapeSpaces()` to replace spaces with `\ ` in both `joinSkills()` and `joinCache()`, covering all three modes (`SANDBOX`, `LOCAL_WITH_SHELL`, `NO_SHELL`).
- **`SkillRuntimeTest`**: Added `ShellPathPolicyTests` with tests for paths with/without spaces, multiple spaces, Chinese characters, sandbox/localWithShell/noShell modes, and null/`NONE` stage inputs. Added a `SkillPromptBuilder` test case for XML rendering with escaped spaces.

## Checklist

Please check the following items before code is ready to be reviewed.

- [x]  Code has been formatted with `mvn spotless:apply`
- [x]  All tests are passing (`mvn test`)
- [x]  Javadoc comments are complete and follow project conventions
- [x]  Related documentation has been updated (e.g. links, examples, etc.)
- [x]  Code is ready for review
