### PR TITLE
fix(coding-agent): use resolved workingDir for Docker workspaceRoot

### DIFF
--- a/agentscope-examples/agents/agentscope-codingagent/src/main/java/io/agentscope/harness/coding/agent/CodingAgentFactory.java
+++ b/agentscope-examples/agents/agentscope-codingagent/src/main/java/io/agentscope/harness/coding/agent/CodingAgentFactory.java
@@ -81,7 +81,7 @@ public final class CodingAgentFactory {
             String image = resolveSandboxImage();
             DockerFilesystemSpec sandboxSpec = new DockerFilesystemSpec();
             sandboxSpec.image(image);
-            sandboxSpec.workspaceRoot("/home/agentscope/workspace");
+            sandboxSpec.workspaceRoot(workingDir);
             sandboxSpec.isolationScope(IsolationScope.SESSION);
             builder.filesystem(sandboxSpec);
         }


### PR DESCRIPTION
## AgentScope-Java Version
0.1.0-SNAPSHOT (current main)

## Description

Closes #2030

In `CodingAgentFactory.create()`, the system prompt uses `resolveSandboxWorkingDir()` (which reads the `SANDBOX_WORK_DIR` env var) to tell the agent its working directory. However, the Docker filesystem spec hardcodes `workspaceRoot` to `/home/agentscope/workspace`, ignoring the env var.

When `SANDBOX_WORK_DIR` is set to a different path (e.g. `/workspace`), the prompt and the actual Docker mount point diverge — the agent thinks it's working in one directory while Docker manages files in another.

The fix replaces the hardcoded string with the already-resolved `workingDir` variable, consistent with how `CodingBootstrap.configureSandbox()` does it.

## Checklist
- [x] Code has been formatted with `mvn spotless:apply`
- [x] All tests are passing
- [x] Javadoc comments are complete
- [x] Documentation updated
- [x] Code is ready for review