### PR TITLE
fix(harness): avoid empty wait_async_results timeout

### DIFF
--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/HarnessAgent.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/HarnessAgent.java
@@ -2222,8 +2222,15 @@ public class HarnessAgent implements Agent, AutoCloseable {
                         new AsyncToolMiddleware(messageBus, asyncToolTimeout, asyncToolRegistry));
             }
             if (messageBus != null) {
+                TaskRepository waitTaskRepository = null;
+                if (capturedSubagentMw instanceof SubagentsMiddleware subagentsMw) {
+                    waitTaskRepository = subagentsMw.getTaskRepository();
+                } else if (capturedSubagentMw instanceof DynamicSubagentsMiddleware dynMw) {
+                    waitTaskRepository = dynMw.getTaskRepository();
+                }
                 agentToolkit.registerTool(
-                        new io.agentscope.harness.agent.tool.WaitAsyncResultsTool(messageBus));
+                        new io.agentscope.harness.agent.tool.WaitAsyncResultsTool(
+                                messageBus, waitTaskRepository, asyncToolRegistry));
             }
 
             // ---- Toolkit (memory / filesystem / shell tools) ----

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/tool/WaitAsyncResultsTool.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/tool/WaitAsyncResultsTool.java
@@ -18,7 +18,11 @@ package io.agentscope.harness.agent.tool;
 import io.agentscope.core.agent.RuntimeContext;
 import io.agentscope.core.tool.Tool;
 import io.agentscope.core.tool.ToolParam;
+import io.agentscope.harness.agent.bus.AsyncToolRegistry;
 import io.agentscope.harness.agent.bus.MessageBus;
+import io.agentscope.harness.agent.subagent.task.TaskRepository;
+import io.agentscope.harness.agent.subagent.task.TaskStatus;
+import java.time.Duration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -37,9 +41,24 @@ public class WaitAsyncResultsTool {
     private static final long POLL_INTERVAL_MS = 3000;
 
     private final MessageBus messageBus;
+    private final TaskRepository taskRepository;
+    private final AsyncToolRegistry asyncToolRegistry;
 
     public WaitAsyncResultsTool(MessageBus messageBus) {
+        this(messageBus, null, null);
+    }
+
+    public WaitAsyncResultsTool(MessageBus messageBus, TaskRepository taskRepository) {
+        this(messageBus, taskRepository, null);
+    }
+
+    public WaitAsyncResultsTool(
+            MessageBus messageBus,
+            TaskRepository taskRepository,
+            AsyncToolRegistry asyncToolRegistry) {
         this.messageBus = messageBus;
+        this.taskRepository = taskRepository;
+        this.asyncToolRegistry = asyncToolRegistry;
     }
 
     @Tool(
@@ -86,6 +105,11 @@ public class WaitAsyncResultsTool {
                 return "Async results have arrived. Continue reasoning — "
                         + "the results will be injected into your context automatically.";
             }
+            if (!hasRunningTasks(runtimeContext, sessionId)) {
+                log.info("wait_async_results: no running async tasks, session={}", sessionId);
+                return "No async tasks are currently running. Continue reasoning with the available"
+                        + " context.";
+            }
             // Cap sleep to the remaining budget so the tool never overshoots the caller's timeout.
             Thread.sleep(Math.min(POLL_INTERVAL_MS, remainingMs));
         }
@@ -95,5 +119,23 @@ public class WaitAsyncResultsTool {
                 + timeout
                 + "s. No async results yet. "
                 + "You may continue with other work or try waiting again.";
+    }
+
+    private boolean hasRunningTasks(RuntimeContext runtimeContext, String sessionId) {
+        if (taskRepository == null && asyncToolRegistry == null) {
+            return true;
+        }
+        boolean hasSubagentTasks =
+                taskRepository != null
+                        && (!taskRepository
+                                        .listTasks(runtimeContext, sessionId, TaskStatus.PENDING)
+                                        .isEmpty()
+                                || !taskRepository
+                                        .listTasks(runtimeContext, sessionId, TaskStatus.RUNNING)
+                                        .isEmpty());
+        boolean hasAsyncTools =
+                asyncToolRegistry != null
+                        && !asyncToolRegistry.findStale(sessionId, Duration.ZERO).block().isEmpty();
+        return hasSubagentTasks || hasAsyncTools;
     }
 }

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/tool/WaitAsyncResultsToolTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/tool/WaitAsyncResultsToolTest.java
@@ -1,0 +1,191 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.harness.agent.tool;
+
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.agentscope.core.agent.RuntimeContext;
+import io.agentscope.harness.agent.bus.AsyncToolRecord;
+import io.agentscope.harness.agent.bus.AsyncToolRegistry;
+import io.agentscope.harness.agent.bus.BusEntry;
+import io.agentscope.harness.agent.bus.MessageBus;
+import io.agentscope.harness.agent.subagent.task.BackgroundTask;
+import io.agentscope.harness.agent.subagent.task.TaskRepository;
+import io.agentscope.harness.agent.subagent.task.TaskRunSpec;
+import io.agentscope.harness.agent.subagent.task.TaskStatus;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+class WaitAsyncResultsToolTest {
+
+    @Test
+    void noTasksReturnsEarly() throws Exception {
+        WaitAsyncResultsTool tool =
+                new WaitAsyncResultsTool(new EmptyMessageBus(), new EmptyTaskRepository());
+        RuntimeContext context = RuntimeContext.builder().sessionId("session-1").build();
+
+        String result =
+                assertTimeoutPreemptively(
+                        Duration.ofMillis(500), () -> tool.waitForResults(2, context));
+
+        assertTrue(result.contains("No async tasks are currently running"), result);
+    }
+
+    @Test
+    void runningAsyncToolStillWaits() throws Exception {
+        WaitAsyncResultsTool tool =
+                new WaitAsyncResultsTool(
+                        new EmptyMessageBus(),
+                        new EmptyTaskRepository(),
+                        new RunningAsyncToolRegistry());
+        RuntimeContext context = RuntimeContext.builder().sessionId("session-1").build();
+
+        String result =
+                assertTimeoutPreemptively(
+                        Duration.ofMillis(1500), () -> tool.waitForResults(1, context));
+
+        assertTrue(result.contains("Timeout after 1s"), result);
+    }
+
+    private static final class EmptyMessageBus implements MessageBus {
+
+        @Override
+        public Mono<String> queuePush(String key, Map<String, Object> payload) {
+            return Mono.just("id");
+        }
+
+        @Override
+        public Mono<List<BusEntry>> queueDrain(String key, int maxCount) {
+            return Mono.just(List.of());
+        }
+
+        @Override
+        public Mono<Void> queueDelete(String key) {
+            return Mono.empty();
+        }
+
+        @Override
+        public Mono<Boolean> queuePeek(String key) {
+            return Mono.just(false);
+        }
+
+        @Override
+        public Mono<String> logAppend(String key, Map<String, Object> payload, int maxLen) {
+            return Mono.just("id");
+        }
+
+        @Override
+        public Mono<List<BusEntry>> logRead(String key, String since, int maxCount) {
+            return Mono.just(List.of());
+        }
+
+        @Override
+        public Mono<Void> logTrim(String key) {
+            return Mono.empty();
+        }
+
+        @Override
+        public Mono<Void> publish(String key, Map<String, Object> payload) {
+            return Mono.empty();
+        }
+
+        @Override
+        public Flux<Map<String, Object>> subscribe(String key) {
+            return Flux.empty();
+        }
+
+        @Override
+        public void close() {}
+    }
+
+    private static final class EmptyTaskRepository implements TaskRepository {
+
+        @Override
+        public BackgroundTask getTask(RuntimeContext rc, String sessionId, String taskId) {
+            return null;
+        }
+
+        @Override
+        public BackgroundTask putTask(
+                RuntimeContext rc,
+                String taskId,
+                String subAgentId,
+                String sessionId,
+                TaskRunSpec spec) {
+            return null;
+        }
+
+        @Override
+        public void removeTask(RuntimeContext rc, String sessionId, String taskId) {}
+
+        @Override
+        public void clear() {}
+
+        @Override
+        public Collection<BackgroundTask> listTasks(
+                RuntimeContext rc, String sessionId, TaskStatus filter) {
+            return List.of();
+        }
+
+        @Override
+        public boolean cancelTask(RuntimeContext rc, String sessionId, String taskId) {
+            return false;
+        }
+    }
+
+    private static final class RunningAsyncToolRegistry implements AsyncToolRegistry {
+
+        @Override
+        public Mono<Void> register(AsyncToolRecord record) {
+            return Mono.empty();
+        }
+
+        @Override
+        public Mono<Void> complete(String id, String result) {
+            return Mono.empty();
+        }
+
+        @Override
+        public Mono<Void> fail(String id, String error) {
+            return Mono.empty();
+        }
+
+        @Override
+        public Mono<List<AsyncToolRecord>> findStale(String sessionId, Duration ttl) {
+            return Mono.just(
+                    List.of(
+                            new AsyncToolRecord(
+                                    "async-1",
+                                    sessionId,
+                                    "slow_tool",
+                                    "call-1",
+                                    AsyncToolRecord.RUNNING,
+                                    Instant.now().minusSeconds(1))));
+        }
+
+        @Override
+        public Mono<Void> markTimeout(String id) {
+            return Mono.empty();
+        }
+    }
+}


### PR DESCRIPTION
## AgentScope-Java Version

2.0.0-SNAPSHOT

## Description

Fixes #2017 

`wait_async_results` only checked whether the session inbox had messages. After completed subagent results were already drained or injected by middleware, a repeated `wait_async_results` call could see an empty inbox and keep polling until `timeout_seconds`, even when there was no pending async work left.

This PR makes WaitAsyncResultsTool check the existing subagent TaskRepository and AsyncToolRegistry before waiting.

Now it returns early when:

- the inbox is empty
- no subagent task is `PENDING` or `RUNNING`
- no async tool record is still `RUNNING`

If task state is not available, it keeps the previous wait behavior.

## Checklist

Please check the following items before code is ready to be reviewed.

- [x] Code has been formatted with `mvn spotless:apply`
- [x] Related tests are passing (`mvn -pl agentscope-harness -Dtest=WaitAsyncResultsToolTest test`)
- [x] Javadoc comments are complete and follow project conventions
- [x] Related documentation update is not required for this bugfix
- [x] Code is ready for review