### PR TITLE
fix(core): activate SkillToolGroups by activateOnSkill field during skill load

### DIFF
--- a/agentscope-core/src/main/java/io/agentscope/core/skill/SkillToolFactory.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/skill/SkillToolFactory.java
@@ -374,6 +374,7 @@ class SkillToolFactory {
         skillRegistry.setSkillActive(skillId, true);
         logger.info("Activated skill: {}", skillId);
 
+        // Convention-based activation (SkillBox.SkillRegistration creates plain ToolGroups)
         String toolsGroupName = skillRegistry.getRegisteredSkill(skillId).getToolsGroupName();
         if (toolkit.getToolGroup(toolsGroupName) != null) {
             toolkit.updateToolGroups(List.of(toolsGroupName), true);
@@ -381,6 +382,13 @@ class SkillToolFactory {
                     "Activated skill tool group: {} and its tools: {}",
                     toolsGroupName,
                     toolkit.getToolGroup(toolsGroupName).getTools());
+        }
+
+        // Field-based activation (SkillToolGroups created via createSkillToolGroup)
+        List<String> boundGroups = toolkit.findSkillToolGroupNames(skillId);
+        if (!boundGroups.isEmpty()) {
+            toolkit.updateToolGroups(boundGroups, true);
+            logger.info("Activated bound skill tool groups: {}", boundGroups);
         }
     }
 }

--- a/agentscope-core/src/main/java/io/agentscope/core/tool/ToolGroupManager.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/tool/ToolGroupManager.java
@@ -496,6 +496,25 @@ class ToolGroupManager {
     }
 
     /**
+     * Find all {@link SkillToolGroup} names whose {@code activateOnSkill} matches the given skill.
+     *
+     * @param skillId The skill identifier to match against
+     * @return List of matching group names (empty if none found)
+     */
+    public List<String> findSkillToolGroupNames(String skillId) {
+        if (skillId == null) {
+            return List.of();
+        }
+        List<String> result = new ArrayList<>();
+        for (ToolGroup group : toolGroups.values()) {
+            if (group instanceof SkillToolGroup stg && skillId.equals(stg.getActivateOnSkill())) {
+                result.add(group.getName());
+            }
+        }
+        return result;
+    }
+
+    /**
      * Copy all tool groups from this manager to another manager.
      *
      * @param target The target manager to copy tool groups to

--- a/agentscope-core/src/main/java/io/agentscope/core/tool/Toolkit.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/tool/Toolkit.java
@@ -721,6 +721,16 @@ public class Toolkit {
         return groupManager.getToolGroup(groupName);
     }
 
+    /**
+     * Find all {@link SkillToolGroup} names whose {@code activateOnSkill} matches the given skill.
+     *
+     * @param skillId The skill identifier to match against
+     * @return List of matching group names (never null, may be empty)
+     */
+    public List<String> findSkillToolGroupNames(String skillId) {
+        return groupManager.findSkillToolGroupNames(skillId);
+    }
+
     // ==================== Meta Tool Registration ====================
 
     /**


### PR DESCRIPTION
## AgentScope-Java Version

2.0.0-SNAPSHOT

## Description

Fixes #2034

`SkillToolGroup.activateOnSkill` field was never used during automatic skill activation. When a skill was loaded via `load_skill_through_path`, the activation logic in `SkillToolFactory` only looked up tool groups by the naming convention (`skillId + "_skill_tools"`), ignoring any `SkillToolGroup` whose `activateOnSkill` field matched the loaded skill.

This meant `Toolkit.createSkillToolGroup(groupName, desc, active, activateOnSkill)` silently failed to auto-activate the group when the bound skill was loaded, unless the caller manually named the group `skillId + "_skill_tools"` (leaking an internal convention).

**Changes:**
- Added `ToolGroupManager.findSkillToolGroupNames(skillId)` to find all `SkillToolGroup` instances whose `activateOnSkill` matches a given skill ID
- Exposed the method on `Toolkit` as a public API
- Extended `SkillToolFactory.activateSkill()` to also activate groups matched by the `activateOnSkill` field (in addition to the existing convention-based lookup for backward compatibility)

**Result:** `createSkillToolGroup()` now delivers on its API contract — groups are automatically activated when the bound skill is loaded, regardless of group name.

## Checklist

- [x] Code has been formatted with `mvn spotless:apply`
- [x] All tests are passing (`mvn test`)
- [x] Javadoc comments are complete and follow project conventions
- [x] Related documentation has been updated (e.g. links, examples, etc.)
- [x] Code is ready for review