### PR TITLE
fix(core): createSkillToolGroup appends _skill_tools suffix internally

### DIFF
--- a/agentscope-core/src/main/java/io/agentscope/core/tool/ToolGroupManager.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/tool/ToolGroupManager.java
@@ -33,6 +33,9 @@ class ToolGroupManager {
 
     private static final Logger logger = LoggerFactory.getLogger(ToolGroupManager.class);
 
+    /** Suffix appended to skill-bound tool group names for internal lookup. */
+    public static final String SKILL_TOOL_GROUP_SUFFIX = "_skill_tools";
+
     private final Map<String, ToolGroup> toolGroups = new ConcurrentHashMap<>(); // group -> tools
     private final Map<String, Set<String>> tools = new ConcurrentHashMap<>(); // tool -> groups
     private volatile List<String> activeGroups = new CopyOnWriteArrayList<>();
@@ -120,7 +123,13 @@ class ToolGroupManager {
     /**
      * Create a {@link SkillToolGroup} bound to a specific skill.
      *
-     * @param groupName Name of the tool group
+     * <p>The provided {@code groupName} is automatically suffixed with
+     * {@value #SKILL_TOOL_GROUP_SUFFIX} so that it matches the name produced by
+     * {@code RegisteredSkill.getToolsGroupName()}. Callers should pass the bare
+     * skill-related name (e.g. {@code "data-analysis"}) without appending the
+     * suffix themselves.
+     *
+     * @param groupName Name of the tool group (without the {@code _skill_tools} suffix)
      * @param description Description of the tool group
      * @param active Whether the tool group is active by default
      * @param activateOnSkill The skill name that this group is bound to
@@ -128,9 +137,13 @@ class ToolGroupManager {
      */
     public void createSkillToolGroup(
             String groupName, String description, boolean active, String activateOnSkill) {
+        String internalName =
+                groupName.endsWith(SKILL_TOOL_GROUP_SUFFIX)
+                        ? groupName
+                        : groupName + SKILL_TOOL_GROUP_SUFFIX;
         SkillToolGroup group =
                 SkillToolGroup.skillBuilder()
-                        .name(groupName)
+                        .name(internalName)
                         .description(description)
                         .active(active)
                         .activateOnSkill(activateOnSkill)

--- a/agentscope-core/src/test/java/io/agentscope/core/tool/MetaToolFactoryTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/tool/MetaToolFactoryTest.java
@@ -552,7 +552,7 @@ class MetaToolFactoryTest {
         AgentTool metaTool = metaToolFactory.createResetEquippedToolsAgentTool();
 
         Map<String, Object> input = new HashMap<>();
-        input.put("to_activate", List.of("code_tools"));
+        input.put("to_activate", List.of("code_tools_skill_tools"));
 
         // Act
         ToolResultBlock result = callTool(metaTool, input);

--- a/agentscope-core/src/test/java/io/agentscope/core/tool/SkillToolGroupTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/tool/SkillToolGroupTest.java
@@ -155,11 +155,22 @@ class SkillToolGroupTest {
         ToolGroupManager manager = new ToolGroupManager();
         manager.createSkillToolGroup("code_tools", "Code execution tools", false, "coding");
 
-        ToolGroup retrieved = manager.getToolGroup("code_tools");
+        ToolGroup retrieved = manager.getToolGroup("code_tools_skill_tools");
         assertNotNull(retrieved);
         assertInstanceOf(SkillToolGroup.class, retrieved);
         assertEquals("coding", ((SkillToolGroup) retrieved).getActivateOnSkill());
         assertFalse(retrieved.isActive());
+    }
+
+    @Test
+    void testCreateSkillToolGroupIdempotentSuffix() {
+        ToolGroupManager manager = new ToolGroupManager();
+        manager.createSkillToolGroup(
+                "code_tools_skill_tools", "Code execution tools", false, "coding");
+
+        ToolGroup retrieved = manager.getToolGroup("code_tools_skill_tools");
+        assertNotNull(retrieved);
+        assertEquals("coding", ((SkillToolGroup) retrieved).getActivateOnSkill());
     }
 
     @Test
@@ -170,7 +181,7 @@ class SkillToolGroupTest {
         ToolGroupManager target = new ToolGroupManager();
         source.copyTo(target);
 
-        ToolGroup copied = target.getToolGroup("code_tools");
+        ToolGroup copied = target.getToolGroup("code_tools_skill_tools");
         assertNotNull(copied);
         assertInstanceOf(SkillToolGroup.class, copied);
         assertEquals("coding", ((SkillToolGroup) copied).getActivateOnSkill());
@@ -182,7 +193,7 @@ class SkillToolGroupTest {
         ToolGroupManager manager = new ToolGroupManager();
         manager.createSkillToolGroup("skill_tools", "desc", false, "my_skill");
 
-        assertTrue(manager.getMetaGroupNames().contains("skill_tools"));
+        assertTrue(manager.getMetaGroupNames().contains("skill_tools_skill_tools"));
     }
 
     private static int countOccurrences(String text, String substring) {

--- a/agentscope-examples/documentation/src/main/java/io/agentscope/examples/documentation2/skill/SkillWithToolGroupExample.java
+++ b/agentscope-examples/documentation/src/main/java/io/agentscope/examples/documentation2/skill/SkillWithToolGroupExample.java
@@ -43,9 +43,9 @@ import java.nio.file.Paths;
  *
  * <p><b>Pattern:</b>
  * <pre>
- *   toolkit.createSkillToolGroup("analysis-tools", "Data analysis tools", false, "data-analysis");
- *   toolkit.registration().tool(new AnalysisTools()).group("analysis-tools").apply();
- *   // Agent loads the "data-analysis" SKILL.md → "analysis-tools" group becomes active
+ *   toolkit.createSkillToolGroup("data-analysis", "Data analysis tools", false, "data-analysis");
+ *   toolkit.registration().tool(new AnalysisTools()).group("data-analysis_skill_tools").apply();
+ *   // Agent loads the "data-analysis" SKILL.md → "data-analysis_skill_tools" group becomes active
  * </pre>
  *
  * <p><b>Skill file structure (SKILLS_DIR/data-analysis/SKILL.md):</b>
@@ -81,8 +81,9 @@ public class SkillWithToolGroupExample {
 
     /**
      * Name of the tool group bound to the skill.
+     * Must match the skill name so that automatic activation works.
      */
-    private static final String TOOL_GROUP = "skill-tools";
+    private static final String TOOL_GROUP = "data-analysis";
 
     /**
      * Runs the skill-with-tool-group example.
@@ -129,7 +130,9 @@ public class SkillWithToolGroupExample {
                 ACTIVATING_SKILL);
 
         // ── 2. Register tools into the skill-bound group ──────────────────────────────
-        toolkit.registration().tool(new DataTools()).group(TOOL_GROUP).apply();
+        // createSkillToolGroup appends "_skill_tools" internally, so the registered
+        // internal group name is "data-analysis_skill_tools" rather than "data-analysis".
+        toolkit.registration().tool(new DataTools()).group(TOOL_GROUP + "_skill_tools").apply();
 
         // ── 3. Register a plain tool (always active, no group) ────────────────────────
         toolkit.registerTool(new InfoTool());


### PR DESCRIPTION
## Description

Fixes #2034.

`ToolGroupManager.createSkillToolGroup()` now automatically appends the `_skill_tools` suffix to the provided group name. This aligns the registered group name with the name produced by `RegisteredSkill.getToolsGroupName()`, so skill-bound tool groups are correctly activated when the associated skill is loaded.

### Changes

- `ToolGroupManager#createSkillToolGroup`: computes an internal name by appending `_skill_tools` (idempotent — no double suffix if the caller already includes it).
- Added a `SKILL_TOOL_GROUP_SUFFIX` constant in `ToolGroupManager`.
- Updated affected unit tests to look up groups by their suffixed names.
- Added `testCreateSkillToolGroupIdempotentSuffix` to verify backward compatibility for callers that already pass the suffixed name.
- Fixed `SkillWithToolGroupExample` so the tool group name matches the activating skill (`data-analysis`), making the automatic activation path work as documented.

### Verification

- `mvn test -pl agentscope-core -Dtest=SkillToolGroupTest,MetaToolFactoryTest` passes (36 tests).
- `mvn spotless:apply` was run on affected modules.

## Checklist

- [x] Code follows the project style guidelines (spotless applied)
- [x] Tests added/updated and passing
- [x] Example updated to reflect the fix