### PR TITLE
fix:ChannelRouter.buildOutboundAddress 构造 to 字符串时丢失了 kind：

### DIFF
--- a/agentscope-examples/agents/agentscope-paw/src/test/java/io/agentscope/claw2/runtime/channel/ChannelRouterGroupTest.java
+++ b/agentscope-examples/agents/agentscope-paw/src/test/java/io/agentscope/claw2/runtime/channel/ChannelRouterGroupTest.java
@@ -62,7 +62,7 @@ class ChannelRouterGroupTest {
         assertEquals("peer", route.matchedBy());
         // Outbound address must encode the kind so e.g. WeComOutboundClient routes to
         // /cgi-bin/appchat/send instead of /cgi-bin/message/send.
-        assertEquals("wecom-prod:gid_123", route.outboundAddress().to());
+        assertEquals("wecom-prod:GROUP:gid_123", route.outboundAddress().to());
         assertEquals("corp-1", route.outboundAddress().accountId());
         assertNull(route.outboundAddress().threadId());
     }
@@ -79,7 +79,7 @@ class ChannelRouterGroupTest {
 
         assertEquals("main", route.agentId());
         assertEquals("channel-default", route.matchedBy());
-        assertEquals("wecom-prod:u9", route.outboundAddress().to());
+        assertEquals("wecom-prod:DIRECT:u9", route.outboundAddress().to());
     }
 
     @Test

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/gateway/channel/ChannelRouter.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/gateway/channel/ChannelRouter.java
@@ -215,7 +215,7 @@ public final class ChannelRouter {
     // -----------------------------------------------------------------
 
     private OutboundAddress buildOutboundAddress(InboundMessage msg) {
-        String to = msg.channelId() + ":" + msg.peer().kind()+":" + msg.peer().id();
+        String to = msg.channelId() + ":" + msg.peer().kind() + ":" + msg.peer().id();
         String threadId = msg.peer().kind().isThread() ? msg.peer().id() : null;
         return new OutboundAddress(msg.channelId(), msg.accountId(), to, threadId);
     }

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/gateway/channel/ChannelRouter.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/gateway/channel/ChannelRouter.java
@@ -215,7 +215,7 @@ public final class ChannelRouter {
     // -----------------------------------------------------------------
 
     private OutboundAddress buildOutboundAddress(InboundMessage msg) {
-        String to = msg.channelId() + ":" + msg.peer().id();
+        String to = msg.channelId() + ":" + msg.peer().kind()+":" + msg.peer().id();
         String threadId = msg.peer().kind().isThread() ? msg.peer().id() : null;
         return new OutboundAddress(msg.channelId(), msg.accountId(), to, threadId);
     }


### PR DESCRIPTION
## 问题复现
钉钉群 中通过机器人调用HarnessAgent，回复消息报错DingTalk channel 'dingtalk' dispatch failed: 400 Bad Request from POST https://api.dingtalk.com/v1.0/robot/oToMessages/batchSend

## 修改内容
1. ChannelRouter.buildOutboundAddress 构造 to 字符串时丢失了 kind。补充丢失的kind

## 自测验证
在钉钉群通过机器人调用HarnessAgent可以正常回复消息

## 关联
BUG#2039