### PR TITLE
feat(starters): add builder customizers for OpenAI, DashScope and Anthropic models

### DIFF
--- a/agentscope-extensions/agentscope-spring-boot-starters/agentscope-anthropic-spring-boot-starter/src/main/java/io/agentscope/spring/boot/anthropic/AnthropicAutoConfiguration.java
+++ b/agentscope-extensions/agentscope-spring-boot-starters/agentscope-anthropic-spring-boot-starter/src/main/java/io/agentscope/spring/boot/anthropic/AnthropicAutoConfiguration.java
@@ -18,6 +18,7 @@ package io.agentscope.spring.boot.anthropic;
 import io.agentscope.core.model.Model;
 import io.agentscope.extensions.model.anthropic.AnthropicChatModel;
 import io.agentscope.spring.boot.AgentscopeAutoConfiguration;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
@@ -44,7 +45,9 @@ public class AnthropicAutoConfiguration {
             havingValue = "true",
             matchIfMissing = true)
     @ConditionalOnMissingBean(Model.class)
-    public AnthropicChatModel anthropicChatModel(AnthropicProperties properties) {
+    public AnthropicChatModel anthropicChatModel(
+            AnthropicProperties properties,
+            ObjectProvider<AnthropicChatModelBuilderCustomizer> customizerObjectProvider) {
         String modelName = trimToNull(properties.getModelName());
         if (modelName == null) {
             throw new IllegalStateException(
@@ -61,6 +64,10 @@ public class AnthropicAutoConfiguration {
         if (baseUrl != null) {
             builder.baseUrl(baseUrl);
         }
+
+        customizerObjectProvider
+                .orderedStream()
+                .forEach(customizer -> customizer.customize(builder));
 
         return builder.build();
     }

--- a/agentscope-extensions/agentscope-spring-boot-starters/agentscope-anthropic-spring-boot-starter/src/main/java/io/agentscope/spring/boot/anthropic/AnthropicChatModelBuilderCustomizer.java
+++ b/agentscope-extensions/agentscope-spring-boot-starters/agentscope-anthropic-spring-boot-starter/src/main/java/io/agentscope/spring/boot/anthropic/AnthropicChatModelBuilderCustomizer.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.spring.boot.anthropic;
+
+import io.agentscope.extensions.model.anthropic.AnthropicChatModel;
+import java.util.function.Consumer;
+
+/**
+ * Customizer for {@link AnthropicChatModel.Builder}.
+ *
+ * <p>Example usage:
+ *
+ * <pre>{@code
+ *     @Bean
+ *     public AnthropicChatModelBuilderCustomizer anthropicChatModelBuilderCustomizer() {
+ *         return builder -> builder.baseUrl("https://custom.example.com/v1");
+ *     }
+ * }</pre>
+ */
+@FunctionalInterface
+public interface AnthropicChatModelBuilderCustomizer extends Consumer<AnthropicChatModel.Builder> {
+
+    /**
+     * Customize the {@link AnthropicChatModel.Builder}.
+     *
+     * @param builder the builder to customize
+     */
+    void customize(AnthropicChatModel.Builder builder);
+
+    /**
+     * Accept and invoke the given builder.
+     *
+     * @param builder the builder to customize
+     */
+    @Override
+    default void accept(AnthropicChatModel.Builder builder) {
+        this.customize(builder);
+    }
+}

--- a/agentscope-extensions/agentscope-spring-boot-starters/agentscope-anthropic-spring-boot-starter/src/test/java/io/agentscope/spring/boot/anthropic/AnthropicAutoConfigurationTest.java
+++ b/agentscope-extensions/agentscope-spring-boot-starters/agentscope-anthropic-spring-boot-starter/src/test/java/io/agentscope/spring/boot/anthropic/AnthropicAutoConfigurationTest.java
@@ -149,12 +149,36 @@ class AnthropicAutoConfigurationTest {
                         });
     }
 
+    @Test
+    void shouldApplyAnthropicChatModelBuilderCustomizer() {
+        contextRunner
+                .withUserConfiguration(CustomBuilderConfiguration.class)
+                .withPropertyValues(
+                        "agentscope.model.provider=anthropic",
+                        "agentscope.anthropic.api-key=test-anthropic-key",
+                        "agentscope.anthropic.model-name=claude-sonnet-4.5")
+                .run(
+                        context -> {
+                            AnthropicChatModel model = context.getBean(AnthropicChatModel.class);
+                            assertThat(model.getModelName()).isEqualTo("customized-claude");
+                        });
+    }
+
     @Configuration(proxyBeanMethods = false)
     static class CustomModelConfiguration {
 
         @Bean
         Model customModel() {
             return new TestModel();
+        }
+    }
+
+    @Configuration(proxyBeanMethods = false)
+    static class CustomBuilderConfiguration {
+
+        @Bean
+        AnthropicChatModelBuilderCustomizer testAnthropicChatModelBuilderCustomizer() {
+            return builder -> builder.modelName("customized-claude");
         }
     }
 

--- a/agentscope-extensions/agentscope-spring-boot-starters/agentscope-dashscope-spring-boot-starter/src/main/java/io/agentscope/spring/boot/dashscope/DashScopeAutoConfiguration.java
+++ b/agentscope-extensions/agentscope-spring-boot-starters/agentscope-dashscope-spring-boot-starter/src/main/java/io/agentscope/spring/boot/dashscope/DashScopeAutoConfiguration.java
@@ -18,6 +18,7 @@ package io.agentscope.spring.boot.dashscope;
 import io.agentscope.core.model.Model;
 import io.agentscope.extensions.model.dashscope.DashScopeChatModel;
 import io.agentscope.spring.boot.AgentscopeAutoConfiguration;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
@@ -41,7 +42,9 @@ public class DashScopeAutoConfiguration {
             havingValue = "true",
             matchIfMissing = true)
     @ConditionalOnMissingBean(Model.class)
-    public DashScopeChatModel dashScopeChatModel(DashScopeProperties properties) {
+    public DashScopeChatModel dashScopeChatModel(
+            DashScopeProperties properties,
+            ObjectProvider<DashScopeChatModelBuilderCustomizer> customizerObjectProvider) {
         String apiKey = trimToNull(properties.getApiKey());
         if (apiKey == null) {
             throw new IllegalStateException(
@@ -68,6 +71,10 @@ public class DashScopeAutoConfiguration {
         if (properties.getEnableThinking() != null) {
             builder.enableThinking(properties.getEnableThinking());
         }
+
+        customizerObjectProvider
+                .orderedStream()
+                .forEach(customizer -> customizer.customize(builder));
 
         return builder.build();
     }

--- a/agentscope-extensions/agentscope-spring-boot-starters/agentscope-dashscope-spring-boot-starter/src/main/java/io/agentscope/spring/boot/dashscope/DashScopeChatModelBuilderCustomizer.java
+++ b/agentscope-extensions/agentscope-spring-boot-starters/agentscope-dashscope-spring-boot-starter/src/main/java/io/agentscope/spring/boot/dashscope/DashScopeChatModelBuilderCustomizer.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.spring.boot.dashscope;
+
+import io.agentscope.extensions.model.dashscope.DashScopeChatModel;
+import java.util.function.Consumer;
+
+/**
+ * Customizer for {@link DashScopeChatModel.Builder}.
+ *
+ * <p>Example usage:
+ *
+ * <pre>{@code
+ *     @Bean
+ *     public DashScopeChatModelBuilderCustomizer dashScopeChatModelBuilderCustomizer() {
+ *         return builder -> builder.baseUrl("https://custom.example.com/v1");
+ *     }
+ * }</pre>
+ */
+@FunctionalInterface
+public interface DashScopeChatModelBuilderCustomizer extends Consumer<DashScopeChatModel.Builder> {
+
+    /**
+     * Customize the {@link DashScopeChatModel.Builder}.
+     *
+     * @param builder the builder to customize
+     */
+    void customize(DashScopeChatModel.Builder builder);
+
+    /**
+     * Accept and invoke the given builder.
+     *
+     * @param builder the builder to customize
+     */
+    @Override
+    default void accept(DashScopeChatModel.Builder builder) {
+        this.customize(builder);
+    }
+}

--- a/agentscope-extensions/agentscope-spring-boot-starters/agentscope-dashscope-spring-boot-starter/src/test/java/io/agentscope/spring/boot/dashscope/DashScopeAutoConfigurationTest.java
+++ b/agentscope-extensions/agentscope-spring-boot-starters/agentscope-dashscope-spring-boot-starter/src/test/java/io/agentscope/spring/boot/dashscope/DashScopeAutoConfigurationTest.java
@@ -162,12 +162,36 @@ class DashScopeAutoConfigurationTest {
                         });
     }
 
+    @Test
+    void shouldApplyDashScopeChatModelBuilderCustomizer() {
+        contextRunner
+                .withUserConfiguration(CustomBuilderConfiguration.class)
+                .withPropertyValues(
+                        "agentscope.model.provider=dashscope",
+                        "agentscope.dashscope.api-key=test-dashscope-key",
+                        "agentscope.dashscope.model-name=qwen-max")
+                .run(
+                        context -> {
+                            DashScopeChatModel model = context.getBean(DashScopeChatModel.class);
+                            assertThat(model.getModelName()).isEqualTo("customized-qwen");
+                        });
+    }
+
     @Configuration(proxyBeanMethods = false)
     static class CustomModelConfiguration {
 
         @Bean
         Model customModel() {
             return new TestModel();
+        }
+    }
+
+    @Configuration(proxyBeanMethods = false)
+    static class CustomBuilderConfiguration {
+
+        @Bean
+        DashScopeChatModelBuilderCustomizer testDashScopeChatModelBuilderCustomizer() {
+            return builder -> builder.modelName("customized-qwen");
         }
     }
 

--- a/agentscope-extensions/agentscope-spring-boot-starters/agentscope-openai-spring-boot-starter/src/main/java/io/agentscope/spring/boot/openai/OpenAIAutoConfiguration.java
+++ b/agentscope-extensions/agentscope-spring-boot-starters/agentscope-openai-spring-boot-starter/src/main/java/io/agentscope/spring/boot/openai/OpenAIAutoConfiguration.java
@@ -18,6 +18,7 @@ package io.agentscope.spring.boot.openai;
 import io.agentscope.core.model.Model;
 import io.agentscope.extensions.model.openai.OpenAIChatModel;
 import io.agentscope.spring.boot.AgentscopeAutoConfiguration;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
@@ -41,7 +42,9 @@ public class OpenAIAutoConfiguration {
             havingValue = "true",
             matchIfMissing = true)
     @ConditionalOnMissingBean(Model.class)
-    public OpenAIChatModel openAIChatModel(OpenAIProperties properties) {
+    public OpenAIChatModel openAIChatModel(
+            OpenAIProperties properties,
+            ObjectProvider<OpenAIChatModelBuilderCustomizer> customizerObjectProvider) {
         String apiKey = trimToNull(properties.getApiKey());
         if (apiKey == null) {
             throw new IllegalStateException(
@@ -69,6 +72,10 @@ public class OpenAIAutoConfiguration {
         if (endpointPath != null) {
             builder.endpointPath(endpointPath);
         }
+
+        customizerObjectProvider
+                .orderedStream()
+                .forEach(customizer -> customizer.customize(builder));
 
         return builder.build();
     }

--- a/agentscope-extensions/agentscope-spring-boot-starters/agentscope-openai-spring-boot-starter/src/main/java/io/agentscope/spring/boot/openai/OpenAIChatModelBuilderCustomizer.java
+++ b/agentscope-extensions/agentscope-spring-boot-starters/agentscope-openai-spring-boot-starter/src/main/java/io/agentscope/spring/boot/openai/OpenAIChatModelBuilderCustomizer.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.spring.boot.openai;
+
+import io.agentscope.extensions.model.openai.OpenAIChatModel;
+import java.util.function.Consumer;
+
+/**
+ * Customizer for {@link OpenAIChatModel.Builder}.
+ *
+ * <p>Example usage:
+ *
+ * <pre>{@code
+ *     @Bean
+ *     public OpenAIChatModelBuilderCustomizer openAIChatModelBuilderCustomizer() {
+ *         return builder -> builder.baseUrl("https://custom.example.com/v1");
+ *     }
+ * }</pre>
+ */
+@FunctionalInterface
+public interface OpenAIChatModelBuilderCustomizer extends Consumer<OpenAIChatModel.Builder> {
+
+    /**
+     * Customize the {@link OpenAIChatModel.Builder}.
+     *
+     * @param builder the builder to customize
+     */
+    void customize(OpenAIChatModel.Builder builder);
+
+    /**
+     * Accept and invoke the given builder.
+     *
+     * @param builder the builder to customize
+     */
+    @Override
+    default void accept(OpenAIChatModel.Builder builder) {
+        this.customize(builder);
+    }
+}

--- a/agentscope-extensions/agentscope-spring-boot-starters/agentscope-openai-spring-boot-starter/src/test/java/io/agentscope/spring/boot/openai/OpenAIAutoConfigurationTest.java
+++ b/agentscope-extensions/agentscope-spring-boot-starters/agentscope-openai-spring-boot-starter/src/test/java/io/agentscope/spring/boot/openai/OpenAIAutoConfigurationTest.java
@@ -146,12 +146,36 @@ class OpenAIAutoConfigurationTest {
                         });
     }
 
+    @Test
+    void shouldApplyOpenAIChatModelBuilderCustomizer() {
+        contextRunner
+                .withUserConfiguration(CustomBuilderConfiguration.class)
+                .withPropertyValues(
+                        "agentscope.model.provider=openai",
+                        "agentscope.openai.api-key=test-openai-key",
+                        "agentscope.openai.model-name=gpt-4.1-mini")
+                .run(
+                        context -> {
+                            OpenAIChatModel model = context.getBean(OpenAIChatModel.class);
+                            assertThat(model.getModelName()).isEqualTo("customized-model-name");
+                        });
+    }
+
     @Configuration(proxyBeanMethods = false)
     static class CustomModelConfiguration {
 
         @Bean
         Model customModel() {
             return new TestModel();
+        }
+    }
+
+    @Configuration(proxyBeanMethods = false)
+    static class CustomBuilderConfiguration {
+
+        @Bean
+        OpenAIChatModelBuilderCustomizer testOpenAIChatModelBuilderCustomizer() {
+            return builder -> builder.modelName("customized-model-name");
         }
     }
 


### PR DESCRIPTION
 This PR introduces ordered Spring Bean customizers for the model builders in the OpenAI, DashScope and Anthropic Spring Boot starters, allowing users to programmatically customize the
  *ChatModel.Builder instances created by auto-configuration.

  Changes

  - Added OpenAIChatModelBuilderCustomizer in agentscope-openai-spring-boot-starter.
  - Added DashScopeChatModelBuilderCustomizer in agentscope-dashscope-spring-boot-starter.
  - Added AnthropicChatModelBuilderCustomizer in agentscope-anthropic-spring-boot-starter.
  - Updated OpenAIAutoConfiguration, DashScopeAutoConfiguration and AnthropicAutoConfiguration to inject ObjectProvider<*BuilderCustomizer> and apply all discovered customizers via orderedStream()
  before calling builder.build().
  - Added unit tests in each starter's *AutoConfigurationTest to verify that customizer beans are applied.

  Usage Example

  @Bean
  public OpenAIChatModelBuilderCustomizer openAIChatModelBuilderCustomizer() {
      return builder -> builder.modelName("customized-model-name");
  }

  Multiple customizers are supported and applied in order respecting Spring's @Order or Ordered interface.