### PR TITLE
feat(agui): propagate userId from forwardedProps to RuntimeContext

### DIFF
--- a/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/main/java/io/agentscope/core/agui/adapter/AguiAgentAdapter.java
+++ b/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/main/java/io/agentscope/core/agui/adapter/AguiAgentAdapter.java
@@ -79,6 +79,7 @@ public class AguiAgentAdapter {
     public static final String RUNTIME_CONTEXT_CONTEXT_KEY = "agui.context";
     public static final String RUNTIME_CONTEXT_STATE_KEY = "agui.state";
     public static final String RUNTIME_CONTEXT_FORWARDED_PROPS_KEY = "agui.forwardedProps";
+    public static final String FORWARDED_PROP_USER_ID_KEY = "userId";
 
     private final Agent agent;
     private final AguiAdapterConfig config;
@@ -160,17 +161,27 @@ public class AguiAgentAdapter {
     }
 
     private RuntimeContext buildRuntimeContext(RunAgentInput input) {
-        return RuntimeContext.builder()
-                .sessionId(input.getThreadId())
-                .put(RunAgentInput.class, input)
-                .put(RUNTIME_CONTEXT_THREAD_ID_KEY, input.getThreadId())
-                .put(RUNTIME_CONTEXT_RUN_ID_KEY, input.getRunId())
-                .put(RUNTIME_CONTEXT_MESSAGES_KEY, input.getMessages())
-                .put(RUNTIME_CONTEXT_TOOLS_KEY, input.getTools())
-                .put(RUNTIME_CONTEXT_CONTEXT_KEY, input.getContext())
-                .put(RUNTIME_CONTEXT_STATE_KEY, input.getState())
-                .put(RUNTIME_CONTEXT_FORWARDED_PROPS_KEY, input.getForwardedProps())
-                .build();
+        RuntimeContext.Builder builder =
+                RuntimeContext.builder()
+                        .sessionId(input.getThreadId())
+                        .put(RunAgentInput.class, input)
+                        .put(RUNTIME_CONTEXT_THREAD_ID_KEY, input.getThreadId())
+                        .put(RUNTIME_CONTEXT_RUN_ID_KEY, input.getRunId())
+                        .put(RUNTIME_CONTEXT_MESSAGES_KEY, input.getMessages())
+                        .put(RUNTIME_CONTEXT_TOOLS_KEY, input.getTools())
+                        .put(RUNTIME_CONTEXT_CONTEXT_KEY, input.getContext())
+                        .put(RUNTIME_CONTEXT_STATE_KEY, input.getState())
+                        .put(RUNTIME_CONTEXT_FORWARDED_PROPS_KEY, input.getForwardedProps());
+
+        Object userId = input.getForwardedProp(FORWARDED_PROP_USER_ID_KEY);
+        if (userId != null) {
+            String userIdValue = userId.toString().trim();
+            if (!userIdValue.isEmpty()) {
+                builder.userId(userIdValue);
+            }
+        }
+
+        return builder.build();
     }
 
     private ToolInjection injectFrontendTools(RunAgentInput input) {

--- a/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/test/java/io/agentscope/core/agui/adapter/AguiAgentAdapterTest.java
+++ b/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/test/java/io/agentscope/core/agui/adapter/AguiAgentAdapterTest.java
@@ -103,6 +103,51 @@ class AguiAgentAdapterTest {
     }
 
     @Test
+    void testRunSetsUserIdFromForwardedPropsIntoRuntimeContext() {
+        ArgumentCaptor<RuntimeContext> contextCaptor =
+                ArgumentCaptor.forClass(RuntimeContext.class);
+        when(mockAgent.stream(anyList(), any(StreamOptions.class), contextCaptor.capture()))
+                .thenReturn(Flux.empty());
+
+        RunAgentInput input =
+                RunAgentInput.builder()
+                        .threadId("thread-user")
+                        .runId("run-user")
+                        .messages(List.of(AguiMessage.userMessage("msg-1", "Hello")))
+                        .forwardedProps(Map.of("userId", "user-123"))
+                        .build();
+
+        adapter.run(input).collectList().block();
+
+        RuntimeContext context = contextCaptor.getValue();
+        assertEquals("user-123", context.getUserId());
+        assertSame(
+                input.getForwardedProps(),
+                context.get(AguiAgentAdapter.RUNTIME_CONTEXT_FORWARDED_PROPS_KEY));
+    }
+
+    @Test
+    void testRunIgnoresEmptyUserIdFromForwardedProps() {
+        ArgumentCaptor<RuntimeContext> contextCaptor =
+                ArgumentCaptor.forClass(RuntimeContext.class);
+        when(mockAgent.stream(anyList(), any(StreamOptions.class), contextCaptor.capture()))
+                .thenReturn(Flux.empty());
+
+        RunAgentInput input =
+                RunAgentInput.builder()
+                        .threadId("thread-no-user")
+                        .runId("run-no-user")
+                        .messages(List.of(AguiMessage.userMessage("msg-1", "Hello")))
+                        .forwardedProps(Map.of("userId", "  "))
+                        .build();
+
+        adapter.run(input).collectList().block();
+
+        RuntimeContext context = contextCaptor.getValue();
+        assertNull(context.getUserId());
+    }
+
+    @Test
     void testRunRegistersFrontendToolsForRunAndCleansUp() {
         Toolkit toolkit = new Toolkit();
         when(mockAgent.getToolkit()).thenReturn(toolkit);


### PR DESCRIPTION
When an AG-UI client sends a userId inside RunAgentInput.forwardedProps, AguiAgentAdapter now copies it into the built RuntimeContext so that downstream agents, tools, and hooks can access it via
  RuntimeContext.getUserId().

  Changes

  - Added FORWARDED_PROP_USER_ID_KEY = "userId" constant in AguiAgentAdapter.
  - Updated AguiAgentAdapter.buildRuntimeContext(RunAgentInput) to read userId from input.getForwardedProps() and set it on RuntimeContext.Builder.userId(...).
  - Empty or blank userId values are ignored.
  - Existing behavior of storing the full forwardedProps map under agui.forwardedProps is preserved.
  - Added unit tests:
    - testRunSetsUserIdFromForwardedPropsIntoRuntimeContext
    - testRunIgnoresEmptyUserIdFromForwardedProps

  Example

  An AG-UI client can now forward the user identity like this:

  {
    "threadId": "thread-1",
    "runId": "run-1",
    "forwardedProps": {
      "userId": "user-123"
    }
  }

  Inside the agent run, RuntimeContext.getUserId() will return "user-123".

  Checklist

  - [x] Change is localized to AguiAgentAdapter.
  - [x] Existing RuntimeContext behavior is preserved.
  - [x] Unit tests added and passing.
  - [x] Spotless formatting applied.