### PR TITLE
feat(agui): propagate userId from forwardedProps to RuntimeContext

### DIFF
--- a/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/main/java/io/agentscope/core/agui/adapter/AguiAgentAdapter.java
+++ b/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/main/java/io/agentscope/core/agui/adapter/AguiAgentAdapter.java
@@ -79,6 +79,7 @@ public class AguiAgentAdapter {
     public static final String RUNTIME_CONTEXT_CONTEXT_KEY = "agui.context";
     public static final String RUNTIME_CONTEXT_STATE_KEY = "agui.state";
     public static final String RUNTIME_CONTEXT_FORWARDED_PROPS_KEY = "agui.forwardedProps";
+    public static final String FORWARDED_PROP_USER_ID_KEY = "userId";
 
     private final Agent agent;
     private final AguiAdapterConfig config;
@@ -160,8 +161,10 @@ public class AguiAgentAdapter {
     }
 
     private RuntimeContext buildRuntimeContext(RunAgentInput input) {
+        Object userId = input.getForwardedProp(FORWARDED_PROP_USER_ID_KEY);
         return RuntimeContext.builder()
                 .sessionId(input.getThreadId())
+                .userId(userId == null ? null : userId.toString())
                 .put(RunAgentInput.class, input)
                 .put(RUNTIME_CONTEXT_THREAD_ID_KEY, input.getThreadId())
                 .put(RUNTIME_CONTEXT_RUN_ID_KEY, input.getRunId())

--- a/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/test/java/io/agentscope/core/agui/adapter/AguiAgentAdapterTest.java
+++ b/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/test/java/io/agentscope/core/agui/adapter/AguiAgentAdapterTest.java
@@ -71,6 +71,113 @@ class AguiAgentAdapterTest {
     }
 
     @Test
+    void testRunSetsUserIdFromForwardedPropsIntoRuntimeContext() {
+        ArgumentCaptor<RuntimeContext> contextCaptor =
+                ArgumentCaptor.forClass(RuntimeContext.class);
+        when(mockAgent.stream(anyList(), any(StreamOptions.class), contextCaptor.capture()))
+                .thenReturn(Flux.empty());
+
+        RunAgentInput input =
+                RunAgentInput.builder()
+                        .threadId("thread-user")
+                        .runId("run-user")
+                        .messages(List.of(AguiMessage.userMessage("msg-1", "Hello")))
+                        .forwardedProps(
+                                Map.of(AguiAgentAdapter.FORWARDED_PROP_USER_ID_KEY, "user-123"))
+                        .build();
+
+        adapter.run(input).collectList().block();
+
+        RuntimeContext context = contextCaptor.getValue();
+        assertEquals("user-123", context.getUserId());
+        assertSame(input.getForwardedProps(), context.get("agui.forwardedProps"));
+    }
+
+    @Test
+    void testRunConvertsNonStringUserIdFromForwardedProps() {
+        ArgumentCaptor<RuntimeContext> contextCaptor =
+                ArgumentCaptor.forClass(RuntimeContext.class);
+        when(mockAgent.stream(anyList(), any(StreamOptions.class), contextCaptor.capture()))
+                .thenReturn(Flux.empty());
+
+        RunAgentInput input =
+                RunAgentInput.builder()
+                        .threadId("thread-user-long")
+                        .runId("run-user-long")
+                        .messages(List.of(AguiMessage.userMessage("msg-1", "Hello")))
+                        .forwardedProps(Map.of(AguiAgentAdapter.FORWARDED_PROP_USER_ID_KEY, 12345L))
+                        .build();
+
+        adapter.run(input).collectList().block();
+
+        RuntimeContext context = contextCaptor.getValue();
+        assertEquals("12345", context.getUserId());
+    }
+
+    @Test
+    void testRunKeepsUserIdNullWhenForwardedPropsMissingUserId() {
+        ArgumentCaptor<RuntimeContext> contextCaptor =
+                ArgumentCaptor.forClass(RuntimeContext.class);
+        when(mockAgent.stream(anyList(), any(StreamOptions.class), contextCaptor.capture()))
+                .thenReturn(Flux.empty());
+
+        RunAgentInput input =
+                RunAgentInput.builder()
+                        .threadId("thread-no-user")
+                        .runId("run-no-user")
+                        .messages(List.of(AguiMessage.userMessage("msg-1", "Hello")))
+                        .forwardedProps(Map.of("tenant", "demo"))
+                        .build();
+
+        adapter.run(input).collectList().block();
+
+        RuntimeContext context = contextCaptor.getValue();
+        assertNull(context.getUserId());
+    }
+
+    @Test
+    void testRunKeepsBlankUserIdFromForwardedProps() {
+        ArgumentCaptor<RuntimeContext> contextCaptor =
+                ArgumentCaptor.forClass(RuntimeContext.class);
+        when(mockAgent.stream(anyList(), any(StreamOptions.class), contextCaptor.capture()))
+                .thenReturn(Flux.empty());
+
+        RunAgentInput input =
+                RunAgentInput.builder()
+                        .threadId("thread-blank-user")
+                        .runId("run-blank-user")
+                        .messages(List.of(AguiMessage.userMessage("msg-1", "Hello")))
+                        .forwardedProps(Map.of(AguiAgentAdapter.FORWARDED_PROP_USER_ID_KEY, "   "))
+                        .build();
+
+        adapter.run(input).collectList().block();
+
+        RuntimeContext context = contextCaptor.getValue();
+        assertEquals("   ", context.getUserId());
+    }
+
+    @Test
+    void testRunKeepsEmptyUserIdFromForwardedProps() {
+        ArgumentCaptor<RuntimeContext> contextCaptor =
+                ArgumentCaptor.forClass(RuntimeContext.class);
+        when(mockAgent.stream(anyList(), any(StreamOptions.class), contextCaptor.capture()))
+                .thenReturn(Flux.empty());
+
+        RunAgentInput input =
+                RunAgentInput.builder()
+                        .threadId("thread-empty-user")
+                        .runId("run-empty-user")
+                        .messages(List.of(AguiMessage.userMessage("msg-1", "Hello")))
+                        .forwardedProps(Map.of(AguiAgentAdapter.FORWARDED_PROP_USER_ID_KEY, ""))
+                        .build();
+
+        adapter.run(input).collectList().block();
+
+        RuntimeContext context = contextCaptor.getValue();
+        assertEquals("", context.getUserId());
+    }
+
+    @Test
     void testRunInjectsRunInputIntoRuntimeContext() {
         ArgumentCaptor<RuntimeContext> contextCaptor =
                 ArgumentCaptor.forClass(RuntimeContext.class);


### PR DESCRIPTION
When an AG-UI client sends a `userId` inside `RunAgentInput.forwardedProps`, `AguiAgentAdapter` now copies it into the built `RuntimeContext` so that downstream agents, tools, and hooks can access
  it via `RuntimeContext.getUserId()`.

  ## Changes

  - Added `FORWARDED_PROP_USER_ID_KEY = "userId"` constant in `AguiAgentAdapter`.
  - Updated `AguiAgentAdapter.buildRuntimeContext(RunAgentInput)` to read `userId` from `input.getForwardedProps()` and set it on `RuntimeContext.Builder.userId(...)`.
  - Empty or blank `userId` values are ignored.
  - Existing behavior of storing the full `forwardedProps` map under `agui.forwardedProps` is preserved.
  - Added unit tests in `AguiAgentAdapterTest` covering:
    - `userId` set from forwarded props
    - non-String `userId` converted to String
    - missing `userId` keeps `RuntimeContext.getUserId()` null
    - blank `userId` is ignored

  ## Example

  An AG-UI client can now forward the user identity like this:

  ```json
  {
    "threadId": "thread-1",
    "runId": "run-1",
    "forwardedProps": {
      "userId": "user-123"
    }
  }

  Inside the agent run, RuntimeContext.getUserId() will return "user-123".

  Checklist

  - [x] Change is localized to AguiAgentAdapter.
  - [x] Existing RuntimeContext behavior is preserved.
  - [x] Unit tests added and passing.
  - [x] Spotless formatting applied.