### PR TITLE
fix(agent): restore structured-output self-healing retry in fallback path

### DIFF
--- a/agentscope-core/src/main/java/io/agentscope/core/ReActAgent.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/ReActAgent.java
@@ -93,6 +93,8 @@ import io.agentscope.core.model.ExecutionConfig;
 import io.agentscope.core.model.GenerateOptions;
 import io.agentscope.core.model.Model;
 import io.agentscope.core.model.ModelRegistry;
+import io.agentscope.core.model.StructuredOutputReminder;
+import io.agentscope.core.model.ToolChoice;
 import io.agentscope.core.model.ToolSchema;
 import io.agentscope.core.permission.PermissionBehavior;
 import io.agentscope.core.permission.PermissionContextState;
@@ -220,6 +222,9 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
 
     /** Tool name used for the per-call structured-output {@code generate_response} tool. */
     public static final String STRUCTURED_OUTPUT_TOOL_NAME = "generate_response";
+
+    /** Maximum retries when the model ignores the fallback structured-output tool. */
+    private static final int STRUCTURED_OUTPUT_MAX_RETRIES = 3;
 
     /**
      * @deprecated Permission HITL no longer uses a Reactor Sink. Confirm results are now
@@ -1349,16 +1354,21 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
                     scope.soTool = createStructuredOutputTool(jsonSchema);
 
                     return scope.doCallInner(msgs)
-                            .onErrorResume(error -> saveStateAfterCallFailure(scope, error))
+                            .doOnCancel(() -> cleanupFallbackStructuredOutputContext(scope))
+                            .onErrorResume(
+                                    error -> {
+                                        cleanupFallbackStructuredOutputContext(scope);
+                                        return saveStateAfterCallFailure(scope, error);
+                                    })
                             .flatMap(
                                     result -> {
                                         Msg out = result;
                                         if (scope.soCompleted && scope.soResultMsg != null) {
                                             ChatUsage aggregatedUsage =
-                                                    collectAggregatedUsage(scope.state);
+                                                    collectAggregatedUsage(scope);
                                             ThinkingBlock aggregatedThinking =
                                                     collectLastThinking(scope.state);
-                                            compressStructuredOutputContext(scope.state);
+                                            cleanupFallbackStructuredOutputContext(scope);
                                             Msg extracted =
                                                     extractStructuredResult(scope.soResultMsg);
                                             if (extracted != null) {
@@ -1369,6 +1379,8 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
                                                                 aggregatedThinking);
                                             }
                                             scope.state.contextMutable().add(out);
+                                        } else {
+                                            cleanupFallbackStructuredOutputContext(scope);
                                         }
                                         return saveStateToSession(scope).thenReturn(out);
                                     });
@@ -1417,6 +1429,11 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
         }
     }
 
+    private void cleanupFallbackStructuredOutputContext(CallExecution scope) {
+        compressStructuredOutputContext(scope.state);
+        scope.removeStructuredOutputRetryArtifacts();
+    }
+
     private boolean isStructuredOutputRelated(Msg msg) {
         Map<String, Object> metadata = msg.getMetadata();
         if (metadata != null
@@ -1434,14 +1451,15 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
                         .allMatch(tr -> STRUCTURED_OUTPUT_TOOL_NAME.equals(tr.getName()));
     }
 
-    private ChatUsage collectAggregatedUsage(AgentState agentState) {
+    private ChatUsage collectAggregatedUsage(CallExecution scope) {
         int totalInput = 0;
         int totalOutput = 0;
         int totalCached = 0;
         double totalTime = 0;
         boolean hasUsage = false;
-        for (Msg msg : agentState.getContext()) {
-            if (isStructuredOutputRelated(msg) && msg.getRole() == MsgRole.ASSISTANT) {
+        for (Msg msg : scope.state.getContext()) {
+            if ((isStructuredOutputRelated(msg) || scope.isStructuredOutputRetryAttempt(msg))
+                    && msg.getRole() == MsgRole.ASSISTANT) {
                 ChatUsage usage = msg.getChatUsage();
                 if (usage != null) {
                     hasUsage = true;
@@ -1691,6 +1709,12 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
 
         /** The tool result message from the successful {@code generate_response} call. */
         Msg soResultMsg;
+
+        /** Number of retries after the model returned a tool-free structured-output response. */
+        int soRetryCount;
+
+        /** Intermediate model responses removed after structured-output retry completes. */
+        final List<Msg> soRetryAttemptMsgs = new ArrayList<>();
 
         /** Native structured-output format set on the per-call scope for native-path calls. */
         ResponseFormat nativeResponseFormat;
@@ -2315,6 +2339,17 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
                                                             .build(),
                                                     options);
                                 }
+                                if (soTool != null
+                                        && isToolChoiceReminder(event.getInputMessages())) {
+                                    options =
+                                            GenerateOptions.mergeOptions(
+                                                    GenerateOptions.builder()
+                                                            .toolChoice(
+                                                                    new ToolChoice.Specific(
+                                                                            STRUCTURED_OUTPUT_TOOL_NAME))
+                                                            .build(),
+                                                    options);
+                                }
                                 List<Msg> modelInput =
                                         prependSystemMsg(
                                                 event.getInputMessages(), event.getSystemMessage());
@@ -2452,6 +2487,24 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
 
                                 // Check finish conditions
                                 if (isFinished(eventMsg)) {
+                                    if (eventMsg != null
+                                            && soTool != null
+                                            && !soCompleted
+                                            && soRetryCount < STRUCTURED_OUTPUT_MAX_RETRIES) {
+                                        soRetryCount++;
+                                        log.debug(
+                                                "Model didn't call {}, requesting retry ({}/{})",
+                                                STRUCTURED_OUTPUT_TOOL_NAME,
+                                                soRetryCount,
+                                                STRUCTURED_OUTPUT_MAX_RETRIES);
+                                        soRetryAttemptMsgs.add(eventMsg);
+                                        state.contextMutable()
+                                                .add(createStructuredOutputReminder());
+                                        return reasoning(iter + 1, true);
+                                    }
+                                    if (soTool != null && !soCompleted) {
+                                        removeStructuredOutputRetryArtifacts();
+                                    }
                                     return Mono.justOrEmpty(eventMsg);
                                 }
 
@@ -3796,6 +3849,62 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
                                     Msg.METADATA_REMINDER_KIND,
                                     "empty_response"))
                     .build();
+        }
+
+        /** Build the reminder used to force the fallback structured-output tool on retry. */
+        private static Msg createStructuredOutputReminder() {
+            return Msg.builder()
+                    .name("system")
+                    .role(MsgRole.USER)
+                    .content(
+                            TextBlock.builder()
+                                    .text(
+                                            "Please call the '"
+                                                    + STRUCTURED_OUTPUT_TOOL_NAME
+                                                    + "' function to provide your response.")
+                                    .build())
+                    .metadata(
+                            Map.of(
+                                    MessageMetadataKeys.STRUCTURED_OUTPUT_REMINDER,
+                                    true,
+                                    MessageMetadataKeys.STRUCTURED_OUTPUT_REMINDER_TYPE,
+                                    StructuredOutputReminder.TOOL_CHOICE.toString()))
+                    .build();
+        }
+
+        /** Return whether the latest input asks the model to call the structured-output tool. */
+        private static boolean isToolChoiceReminder(List<Msg> msgs) {
+            if (msgs == null || msgs.isEmpty()) {
+                return false;
+            }
+            Msg last = msgs.get(msgs.size() - 1);
+            Map<String, Object> metadata = last != null ? last.getMetadata() : null;
+            return metadata != null
+                    && Boolean.TRUE.equals(
+                            metadata.get(MessageMetadataKeys.STRUCTURED_OUTPUT_REMINDER))
+                    && StructuredOutputReminder.TOOL_CHOICE
+                            .toString()
+                            .equals(
+                                    metadata.get(
+                                            MessageMetadataKeys.STRUCTURED_OUTPUT_REMINDER_TYPE));
+        }
+
+        /** Remove internal reminder messages and intermediate retry responses from context. */
+        private void removeStructuredOutputRetryArtifacts() {
+            state.contextMutable().removeIf(this::isStructuredOutputRetryArtifact);
+        }
+
+        private boolean isStructuredOutputRetryArtifact(Msg msg) {
+            Map<String, Object> metadata = msg.getMetadata();
+            boolean isReminder =
+                    metadata != null
+                            && Boolean.TRUE.equals(
+                                    metadata.get(MessageMetadataKeys.STRUCTURED_OUTPUT_REMINDER));
+            return isReminder || isStructuredOutputRetryAttempt(msg);
+        }
+
+        private boolean isStructuredOutputRetryAttempt(Msg msg) {
+            return soRetryAttemptMsgs.stream().anyMatch(attempt -> attempt == msg);
         }
 
         /**

--- a/agentscope-core/src/test/java/io/agentscope/core/agent/ReActAgentStructuredOutputRetryTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/agent/ReActAgentStructuredOutputRetryTest.java
@@ -1,0 +1,403 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.agentscope.core.agent;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.agentscope.core.ReActAgent;
+import io.agentscope.core.agent.test.MockModel;
+import io.agentscope.core.agent.test.TestConstants;
+import io.agentscope.core.message.MessageMetadataKeys;
+import io.agentscope.core.message.Msg;
+import io.agentscope.core.message.MsgRole;
+import io.agentscope.core.message.TextBlock;
+import io.agentscope.core.message.ToolUseBlock;
+import io.agentscope.core.model.ChatResponse;
+import io.agentscope.core.model.ChatUsage;
+import io.agentscope.core.model.GenerateOptions;
+import io.agentscope.core.model.Model;
+import io.agentscope.core.model.ToolChoice;
+import io.agentscope.core.model.ToolSchema;
+import io.agentscope.core.tool.Toolkit;
+import io.agentscope.core.util.JsonUtils;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import reactor.core.Disposable;
+import reactor.core.publisher.Flux;
+
+/**
+ * Tests for the structured-output fallback self-healing loop: when the model answers with plain
+ * text instead of calling the synthetic {@code generate_response} tool, the agent injects a
+ * reminder message and retries the reasoning step with {@code tool_choice} forced to the
+ * structured-output tool (parity with the 1.x {@code StructuredOutputHook}).
+ */
+class ReActAgentStructuredOutputRetryTest {
+
+    private Toolkit toolkit;
+
+    static class WeatherResponse {
+        public String location;
+        public String temperature;
+        public String condition;
+    }
+
+    @BeforeEach
+    void setUp() {
+        toolkit = new Toolkit();
+    }
+
+    private static boolean isReminder(Msg msg) {
+        Map<String, Object> metadata = msg.getMetadata();
+        return metadata != null
+                && Boolean.TRUE.equals(
+                        metadata.get(MessageMetadataKeys.STRUCTURED_OUTPUT_REMINDER));
+    }
+
+    private static ChatResponse textResponse(String id, String text) {
+        return ChatResponse.builder()
+                .id(id)
+                .content(List.of(TextBlock.builder().text(text).build()))
+                .usage(new ChatUsage(10, 20, 30))
+                .build();
+    }
+
+    private static ChatResponse generateResponseToolCall(String id, Map<String, Object> toolInput) {
+        return ChatResponse.builder()
+                .id(id)
+                .content(
+                        List.of(
+                                ToolUseBlock.builder()
+                                        .id("call_retry")
+                                        .name(ReActAgent.STRUCTURED_OUTPUT_TOOL_NAME)
+                                        .input(toolInput)
+                                        .content(JsonUtils.getJsonCodec().toJson(toolInput))
+                                        .build()))
+                .usage(new ChatUsage(10, 20, 30))
+                .build();
+    }
+
+    private static Msg userMsg(String text) {
+        return Msg.builder()
+                .name("user")
+                .role(MsgRole.USER)
+                .content(TextBlock.builder().text(text).build())
+                .build();
+    }
+
+    @Test
+    @DisplayName("Plain-text answer triggers reminder + forced tool_choice retry, then succeeds")
+    void retriesWhenModelReturnsPlainTextInsteadOfCallingGenerateResponse() {
+        Map<String, Object> toolInput =
+                Map.of(
+                        "response",
+                        Map.of(
+                                "location",
+                                "San Francisco",
+                                "temperature",
+                                "72°F",
+                                "condition",
+                                "Sunny"));
+
+        // Round 1 (no reminder yet): plain text, no tool call — the buggy behaviour we heal.
+        // Round 2 (reminder present): the model complies and calls generate_response.
+        MockModel mockModel =
+                new MockModel(
+                        msgs -> {
+                            boolean reminded =
+                                    msgs.stream()
+                                            .anyMatch(
+                                                    ReActAgentStructuredOutputRetryTest
+                                                            ::isReminder);
+                            if (!reminded) {
+                                return List.of(
+                                        textResponse(
+                                                "msg_text",
+                                                "The weather in San Francisco is 72°F and"
+                                                        + " sunny."));
+                            }
+                            boolean hasToolResults =
+                                    msgs.stream().anyMatch(m -> m.getRole() == MsgRole.TOOL);
+                            if (!hasToolResults) {
+                                return List.of(generateResponseToolCall("msg_tool", toolInput));
+                            }
+                            return List.of(textResponse("msg_done", "Done"));
+                        });
+
+        ReActAgent agent =
+                ReActAgent.builder()
+                        .name("weather-agent")
+                        .sysPrompt("You are a weather assistant")
+                        .model(mockModel)
+                        .toolkit(toolkit)
+                        .build();
+
+        Msg responseMsg =
+                agent.call(userMsg("What's the weather in San Francisco?"), WeatherResponse.class)
+                        .block(Duration.ofMillis(TestConstants.DEFAULT_TEST_TIMEOUT_MS));
+
+        assertNotNull(responseMsg);
+        assertTrue(
+                responseMsg.hasStructuredData(),
+                "Structured data should be present after the self-healing retry");
+        WeatherResponse result = responseMsg.getStructuredData(WeatherResponse.class);
+        assertNotNull(result);
+        assertEquals("San Francisco", result.location);
+        assertEquals("72°F", result.temperature);
+        assertEquals("Sunny", result.condition);
+
+        ChatUsage usage = responseMsg.getChatUsage();
+        assertNotNull(usage, "Structured result should include usage from every model attempt");
+        assertEquals(20, usage.getInputTokens());
+        assertEquals(40, usage.getOutputTokens());
+        assertEquals(60, usage.getTime());
+
+        // The retry round must force tool_choice to the structured-output tool.
+        assertNotNull(mockModel.getLastOptions(), "Retry round should carry GenerateOptions");
+        assertEquals(
+                new ToolChoice.Specific(ReActAgent.STRUCTURED_OUTPUT_TOOL_NAME),
+                mockModel.getLastOptions().getToolChoice(),
+                "Retry round should force tool_choice to generate_response");
+
+        // Successful retries must not leak their reminder or intermediate plain-text answer into
+        // the next turn's model input.
+        Msg followUp =
+                agent.call(userMsg("Just say hi"))
+                        .block(Duration.ofMillis(TestConstants.DEFAULT_TEST_TIMEOUT_MS));
+        assertNotNull(followUp);
+        assertFalse(
+                mockModel.getLastMessages().stream()
+                        .anyMatch(ReActAgentStructuredOutputRetryTest::isReminder),
+                "Successful retry should strip reminder messages from persisted context");
+        assertFalse(
+                mockModel.getLastMessages().stream()
+                        .anyMatch(
+                                m ->
+                                        "The weather in San Francisco is 72°F and sunny."
+                                                .equals(m.getTextContent())),
+                "Successful retry should strip the intermediate plain-text answer");
+    }
+
+    @Test
+    @DisplayName("Gives up after max retries and returns the plain-text message")
+    void givesUpAfterMaxRetriesAndReturnsPlainTextResult() {
+        // The model never calls generate_response, no matter how often it is reminded.
+        MockModel mockModel =
+                new MockModel(
+                        msgs ->
+                                List.of(
+                                        textResponse(
+                                                "msg_stubborn",
+                                                "I refuse to call tools and just chat.")));
+
+        ReActAgent agent =
+                ReActAgent.builder()
+                        .name("weather-agent")
+                        .sysPrompt("You are a weather assistant")
+                        .model(mockModel)
+                        .toolkit(toolkit)
+                        .build();
+
+        Msg responseMsg =
+                agent.call(userMsg("What's the weather in San Francisco?"), WeatherResponse.class)
+                        .block(Duration.ofMillis(TestConstants.DEFAULT_TEST_TIMEOUT_MS));
+
+        assertNotNull(responseMsg);
+        assertFalse(
+                responseMsg.hasStructuredData(),
+                "No structured data when the model never calls generate_response");
+        // Initial round + 3 reminder retries (parity with 1.x StructuredOutputHook MAX_RETRIES).
+        assertEquals(
+                4,
+                mockModel.getCallCount(),
+                "Should attempt the initial round plus exactly 3 retries");
+
+        // The injected reminders are internal artifacts: a follow-up turn on the same agent
+        // must not see them in its model input.
+        Msg followUp =
+                agent.call(userMsg("Just say hi"))
+                        .block(Duration.ofMillis(TestConstants.DEFAULT_TEST_TIMEOUT_MS));
+        assertNotNull(followUp);
+        assertFalse(
+                mockModel.getLastMessages().stream()
+                        .anyMatch(ReActAgentStructuredOutputRetryTest::isReminder),
+                "Give-up path should strip reminder messages from the persisted context");
+        assertEquals(
+                1,
+                mockModel.getLastMessages().stream()
+                        .filter(m -> m.getRole() == MsgRole.ASSISTANT)
+                        .filter(
+                                m ->
+                                        "I refuse to call tools and just chat."
+                                                .equals(m.getTextContent()))
+                        .count(),
+                "Give-up path should retain only the final plain-text assistant result");
+    }
+
+    @Test
+    @DisplayName("Retry failure removes internal structured-output retry artifacts")
+    void cleansRetryArtifactsWhenRetryFails() {
+        AtomicInteger responseCount = new AtomicInteger();
+        MockModel mockModel =
+                new MockModel(
+                        msgs -> {
+                            if (responseCount.getAndIncrement() == 0) {
+                                return List.of(
+                                        textResponse(
+                                                "msg_text",
+                                                "Intermediate answer that should be removed."));
+                            }
+                            throw new RuntimeException("retry failed");
+                        });
+
+        ReActAgent agent =
+                ReActAgent.builder()
+                        .name("weather-agent")
+                        .sysPrompt("You are a weather assistant")
+                        .model(mockModel)
+                        .toolkit(toolkit)
+                        .build();
+
+        assertThrows(
+                RuntimeException.class,
+                () ->
+                        agent.call(
+                                        userMsg("What's the weather in San Francisco?"),
+                                        WeatherResponse.class)
+                                .block(Duration.ofMillis(TestConstants.DEFAULT_TEST_TIMEOUT_MS)));
+
+        assertFalse(
+                agent.getAgentState().getContext().stream()
+                        .anyMatch(ReActAgentStructuredOutputRetryTest::isReminder),
+                "Failed retry should strip reminder messages from persisted context");
+        assertFalse(
+                agent.getAgentState().getContext().stream()
+                        .anyMatch(
+                                m ->
+                                        "Intermediate answer that should be removed."
+                                                .equals(m.getTextContent())),
+                "Failed retry should strip the discarded intermediate answer");
+    }
+
+    @Test
+    @DisplayName("Cancelling an in-flight retry removes internal retry artifacts")
+    void cleansRetryArtifactsWhenRetryIsCancelled() throws InterruptedException {
+        AtomicInteger callCount = new AtomicInteger();
+        CountDownLatch retryStarted = new CountDownLatch(1);
+        Model model =
+                new Model() {
+                    @Override
+                    public Flux<ChatResponse> stream(
+                            List<Msg> messages, List<ToolSchema> tools, GenerateOptions options) {
+                        if (callCount.incrementAndGet() == 1) {
+                            return Flux.just(
+                                    textResponse(
+                                            "msg_text",
+                                            "Cancelled intermediate answer that should be"
+                                                    + " removed."));
+                        }
+                        return Flux.<ChatResponse>never()
+                                .doOnSubscribe(ignored -> retryStarted.countDown());
+                    }
+
+                    @Override
+                    public String getModelName() {
+                        return "cancellable-structured-output-retry";
+                    }
+                };
+
+        ReActAgent agent =
+                ReActAgent.builder()
+                        .name("weather-agent")
+                        .sysPrompt("You are a weather assistant")
+                        .model(model)
+                        .toolkit(toolkit)
+                        .build();
+
+        Disposable subscription =
+                agent.call(userMsg("What's the weather?"), WeatherResponse.class).subscribe();
+        assertTrue(retryStarted.await(2, TimeUnit.SECONDS), "Retry model call should start");
+        subscription.dispose();
+
+        assertFalse(
+                agent.getAgentState().getContext().stream()
+                        .anyMatch(ReActAgentStructuredOutputRetryTest::isReminder),
+                "Cancelled retry should strip reminder messages from cached context");
+        assertFalse(
+                agent.getAgentState().getContext().stream()
+                        .anyMatch(
+                                m ->
+                                        ("Cancelled intermediate answer that should be"
+                                                        + " removed.")
+                                                .equals(m.getTextContent())),
+                "Cancelled retry should strip the discarded intermediate answer");
+    }
+
+    @Test
+    @DisplayName("Voluntary generate_response call on the first round needs no retry")
+    void noRetryWhenModelCallsGenerateResponseVoluntarily() {
+        Map<String, Object> toolInput =
+                Map.of(
+                        "response",
+                        Map.of(
+                                "location",
+                                "San Francisco",
+                                "temperature",
+                                "72°F",
+                                "condition",
+                                "Sunny"));
+
+        MockModel mockModel =
+                new MockModel(
+                        msgs -> {
+                            boolean hasToolResults =
+                                    msgs.stream().anyMatch(m -> m.getRole() == MsgRole.TOOL);
+                            if (!hasToolResults) {
+                                return List.of(generateResponseToolCall("msg_tool", toolInput));
+                            }
+                            return List.of(textResponse("msg_done", "Done"));
+                        });
+
+        ReActAgent agent =
+                ReActAgent.builder()
+                        .name("weather-agent")
+                        .sysPrompt("You are a weather assistant")
+                        .model(mockModel)
+                        .toolkit(toolkit)
+                        .build();
+
+        Msg responseMsg =
+                agent.call(userMsg("What's the weather in San Francisco?"), WeatherResponse.class)
+                        .block(Duration.ofMillis(TestConstants.DEFAULT_TEST_TIMEOUT_MS));
+
+        assertNotNull(responseMsg);
+        WeatherResponse result = responseMsg.getStructuredData(WeatherResponse.class);
+        assertNotNull(result);
+        assertEquals("San Francisco", result.location);
+        assertEquals(1, mockModel.getCallCount(), "No retry needed — single model call");
+    }
+}


### PR DESCRIPTION
## Problem

On the tool-based fallback structured-output path, `ReActAgent` relies on the model voluntarily calling the synthetic `generate_response` tool. If the model instead returns a normal text answer, the call ends without structured data and `getStructuredData()` fails.

This regresses the 1.x self-healing behavior, which reminded the model and retried with `tool_choice` forced to `generate_response`.

Fixes #641  
Refs #1103

## Fix

- Retry a finished, tool-free fallback structured-output response up to 3 times.
- Tag each retry with the existing structured-output reminder metadata and force `ToolChoice.Specific("generate_response")` only on those retry rounds.
- Leave ordinary calls, native `response_format`, and ReAct rounds containing business tool calls unchanged.
- Remove internal reminders and intermediate retry answers from persisted context on both success and give-up; the final structured result or final plain-text answer remains.

## Tests

Added `ReActAgentStructuredOutputRetryTest` covering:

- plain text -> forced `generate_response` retry -> structured result;
- refusal through the retry limit -> exactly 1 initial call + 3 retries, then plain text;
- voluntary first-round `generate_response` -> no retry;
- no reminder or intermediate-answer leakage into a follow-up turn;
- retry errors and Reactor cancellation also clean internal retry artifacts;
- returned usage includes every model attempt, including discarded retry answers.

TDD checks confirmed the retry, usage accounting, error cleanup, and cancellation cleanup regressions fail before their corresponding implementation changes.

Local verification on the rebuilt branch:

- `mvn -pl agentscope-core -Dtest=ReActAgentStructuredOutputRetryTest test`
- `mvn -pl agentscope-core test` — 2311 tests, 0 failures, 0 errors, 9 skipped
- `mvn spotless:check`
- `mvn -pl agentscope-core -am verify`
