### PR TITLE
fix(filesystem): resolve leading '/' paths relative to workspace in ROOTED mode

### DIFF
--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/filesystem/local/LocalFilesystem.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/filesystem/local/LocalFilesystem.java
@@ -640,11 +640,14 @@ public class LocalFilesystem implements AbstractFilesystem {
             if (stripped.isEmpty()) {
                 return cwd;
             }
-            // Check for path traversal attacks
-            if (stripped.contains("..") || stripped.startsWith("~")) {
+            if (stripped.startsWith("~")) {
                 throw new SecurityException("Path traversal not allowed: " + effectiveKey);
             }
-            return cwd.resolve(stripped).normalize();
+            Path full = cwd.resolve(stripped).normalize();
+            if (!full.startsWith(cwd)) {
+                throw new SecurityException("Path " + full + " outside root directory: " + cwd);
+            }
+            return full;
         }
 
         Path target = Path.of(effectiveKey);

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/filesystem/local/LocalFilesystem.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/filesystem/local/LocalFilesystem.java
@@ -628,13 +628,20 @@ public class LocalFilesystem implements AbstractFilesystem {
     }
 
     private Path resolveRooted(String effectiveKey) {
-        // In ROOTED mode, paths starting with "/" represent logical workspace-absolute paths
-        // (e.g. "/skills" means "<workspace>/skills"), not host-machine absolute paths.
-        // Strip the leading "/" and resolve relative to cwd, similar to resolveSandboxed().
-        // This is necessary because:
-        // - On Windows: Path.of("/skills").isAbsolute() returns false (no drive letter),
-        //   causing cwd.resolve("/skills") to resolve to <drive>:\skills which doesn't exist.
-        // - On Unix: Path.of("/skills").isAbsolute() returns true, triggering SecurityException.
+        Path target = Path.of(effectiveKey);
+        if (target.isAbsolute()) {
+            Path normalized = target.normalize();
+            if (normalized.startsWith(cwd) || pathPolicy.isAllowed(normalized)) {
+                return normalized;
+            }
+            if (Files.exists(normalized)) {
+                throw rootAccessDenied(normalized);
+            }
+            if (!effectiveKey.startsWith("/")) {
+                throw rootAccessDenied(normalized);
+            }
+        }
+
         if (effectiveKey.startsWith("/")) {
             String stripped = effectiveKey.substring(1);
             if (stripped.isEmpty()) {
@@ -650,22 +657,17 @@ public class LocalFilesystem implements AbstractFilesystem {
             return full;
         }
 
-        Path target = Path.of(effectiveKey);
-        if (target.isAbsolute()) {
-            // True host absolute paths (Windows drive letters, UNC paths)
-            Path normalized = target.normalize();
-            if (normalized.startsWith(cwd) || pathPolicy.isAllowed(normalized)) {
-                return normalized;
-            }
-            throw new SecurityException(
-                    "Absolute path "
-                            + normalized
-                            + " is not within an allowed root. Filesystem root: "
-                            + cwd
-                            + "; additional roots: "
-                            + pathPolicy.roots());
-        }
         return cwd.resolve(target).normalize();
+    }
+
+    private SecurityException rootAccessDenied(Path normalized) {
+        return new SecurityException(
+                "Absolute path "
+                        + normalized
+                        + " is not within an allowed root. Filesystem root: "
+                        + cwd
+                        + "; additional roots: "
+                        + pathPolicy.roots());
     }
 
     private Path resolveUnrestricted(String effectiveKey) {

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/filesystem/local/LocalFilesystem.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/filesystem/local/LocalFilesystem.java
@@ -628,8 +628,28 @@ public class LocalFilesystem implements AbstractFilesystem {
     }
 
     private Path resolveRooted(String effectiveKey) {
+        // In ROOTED mode, paths starting with "/" represent logical workspace-absolute paths
+        // (e.g. "/skills" means "<workspace>/skills"), not host-machine absolute paths.
+        // Strip the leading "/" and resolve relative to cwd, similar to resolveSandboxed().
+        // This is necessary because:
+        // - On Windows: Path.of("/skills").isAbsolute() returns false (no drive letter),
+        //   causing cwd.resolve("/skills") to resolve to <drive>:\skills which doesn't exist.
+        // - On Unix: Path.of("/skills").isAbsolute() returns true, triggering SecurityException.
+        if (effectiveKey.startsWith("/")) {
+            String stripped = effectiveKey.substring(1);
+            if (stripped.isEmpty()) {
+                return cwd;
+            }
+            // Check for path traversal attacks
+            if (stripped.contains("..") || stripped.startsWith("~")) {
+                throw new SecurityException("Path traversal not allowed: " + effectiveKey);
+            }
+            return cwd.resolve(stripped).normalize();
+        }
+
         Path target = Path.of(effectiveKey);
         if (target.isAbsolute()) {
+            // True host absolute paths (Windows drive letters, UNC paths)
             Path normalized = target.normalize();
             if (normalized.startsWith(cwd) || pathPolicy.isAllowed(normalized)) {
                 return normalized;

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/filesystem/LocalFilesystemModeTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/filesystem/LocalFilesystemModeTest.java
@@ -263,6 +263,23 @@ class LocalFilesystemModeTest {
     }
 
     @Test
+    void rooted_leadingSlashAllowsLiteralDotDotInPathName(@TempDir Path workspace)
+            throws IOException {
+        Path dir = workspace.resolve("some..dir");
+        Files.createDirectories(dir);
+        Files.writeString(dir.resolve("note.txt"), "literal name", StandardCharsets.UTF_8);
+
+        LocalFilesystem fs =
+                new LocalFilesystem(workspace, LocalFsMode.ROOTED, PathPolicy.empty(), 10, null);
+
+        ReadResult r = fs.read(RuntimeContext.empty(), "/some..dir/note.txt", 0, 0);
+        assertTrue(
+                r.isSuccess(),
+                () -> "literal '..' inside a path segment should be allowed, got: " + r.error());
+        assertEquals("literal name", r.fileData().content());
+    }
+
+    @Test
     void rooted_leadingSlashPathTraversalRejected(@TempDir Path workspace) {
         LocalFilesystem fs =
                 new LocalFilesystem(workspace, LocalFsMode.ROOTED, PathPolicy.empty(), 10, null);

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/filesystem/LocalFilesystemModeTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/filesystem/LocalFilesystemModeTest.java
@@ -191,4 +191,85 @@ class LocalFilesystemModeTest {
         assertTrue(r.isSuccess(), () -> "relative path should be namespaced, got: " + r.error());
         assertEquals("hello", r.fileData().content());
     }
+
+    // ==================== ROOTED mode with leading "/" paths ====================
+
+    @Test
+    void rooted_leadingSlashResolvesRelativeToWorkspace(@TempDir Path workspace)
+            throws IOException {
+        // Create a "skills" subdirectory in the workspace
+        Path skillsDir = workspace.resolve("skills");
+        Files.createDirectories(skillsDir);
+        Files.writeString(skillsDir.resolve("tool.md"), "skill content", StandardCharsets.UTF_8);
+
+        LocalFilesystem fs =
+                new LocalFilesystem(workspace, LocalFsMode.ROOTED, PathPolicy.empty(), 10, null);
+
+        // "/skills" should resolve to <workspace>/skills, not host absolute path
+        ReadResult r = fs.read(RuntimeContext.empty(), "/skills/tool.md", 0, 0);
+        assertTrue(
+                r.isSuccess(),
+                () -> "leading '/' should resolve relative to workspace, got: " + r.error());
+        assertEquals("skill content", r.fileData().content());
+    }
+
+    @Test
+    void rooted_leadingSlashLsWorks(@TempDir Path workspace) throws IOException {
+        // Create a "skills" subdirectory with files
+        Path skillsDir = workspace.resolve("skills");
+        Files.createDirectories(skillsDir);
+        Files.writeString(skillsDir.resolve("tool1.md"), "content1", StandardCharsets.UTF_8);
+        Files.writeString(skillsDir.resolve("tool2.md"), "content2", StandardCharsets.UTF_8);
+
+        LocalFilesystem fs =
+                new LocalFilesystem(workspace, LocalFsMode.ROOTED, PathPolicy.empty(), 10, null);
+
+        // "/skills" should list files in <workspace>/skills
+        LsResult r = fs.ls(RuntimeContext.empty(), "/skills");
+        assertTrue(r.isSuccess(), () -> "ls with leading '/' should work, got: " + r.error());
+        assertFalse(r.entries().isEmpty(), "ls should find files in the skills directory");
+        assertEquals(2, r.entries().size());
+    }
+
+    @Test
+    void rooted_leadingSlashAloneResolvesToWorkspace(@TempDir Path workspace) throws IOException {
+        Files.writeString(workspace.resolve("root.txt"), "root content", StandardCharsets.UTF_8);
+
+        LocalFilesystem fs =
+                new LocalFilesystem(workspace, LocalFsMode.ROOTED, PathPolicy.empty(), 10, null);
+
+        // "/" should resolve to workspace root
+        ReadResult r = fs.read(RuntimeContext.empty(), "/root.txt", 0, 0);
+        assertTrue(r.isSuccess(), () -> "'/' should resolve to workspace root, got: " + r.error());
+        assertEquals("root content", r.fileData().content());
+    }
+
+    @Test
+    void rooted_leadingSlashWithNamespace(@TempDir Path workspace) throws IOException {
+        // With namespace, "/skills" should still resolve to <workspace>/skills (not namespaced)
+        Path skillsDir = workspace.resolve("skills");
+        Files.createDirectories(skillsDir);
+        Files.writeString(skillsDir.resolve("tool.md"), "global skill", StandardCharsets.UTF_8);
+
+        LocalFilesystem fs =
+                new LocalFilesystem(workspace, LocalFsMode.ROOTED, PathPolicy.empty(), 10, USER_NS);
+        RuntimeContext rc = RuntimeContext.builder().userId("user-1").build();
+
+        // Absolute paths (starting with "/") should NOT be namespace-scoped
+        ReadResult r = fs.read(rc, "/skills/tool.md", 0, 0);
+        assertTrue(
+                r.isSuccess(), () -> "absolute path should not be namespaced, got: " + r.error());
+        assertEquals("global skill", r.fileData().content());
+    }
+
+    @Test
+    void rooted_leadingSlashPathTraversalRejected(@TempDir Path workspace) {
+        LocalFilesystem fs =
+                new LocalFilesystem(workspace, LocalFsMode.ROOTED, PathPolicy.empty(), 10, null);
+
+        // Path traversal with leading "/" should be rejected
+        org.junit.jupiter.api.Assertions.assertThrows(
+                SecurityException.class,
+                () -> fs.read(RuntimeContext.empty(), "/../etc/passwd", 0, 0));
+    }
 }


### PR DESCRIPTION
## AgentScope-Java Version
2.0.0-SNAPSHOT

## Description
Fix #2046

In ROOTED mode, paths starting with "/" represent logical workspace-absolute paths (e.g. "/skills" means "<workspace>/skills"), not host-machine absolute paths. This commit modifies resolveRooted() to strip the leading "/" and resolve relative to cwd, similar to resolveSandboxed().

Root cause:
- On Windows: Path.of("/skills").isAbsolute() returns false (no drive letter), causing cwd.resolve("/skills") to resolve to <drive>:\skills which doesn't exist.
- On Unix: Path.of("/skills").isAbsolute() returns true, triggering SecurityException.

Changes:
- Modified resolveRooted() to handle "/" prefixed paths as workspace-relative
- Added path traversal protection for "/../" patterns
- Added 5 regression tests for the fix

## Checklist

Please check the following items before code is ready to be reviewed.

- [ ]  Code has been formatted with `mvn spotless:apply`
- [ ]  All tests are passing (`mvn test`)
- [ ]  Javadoc comments are complete and follow project conventions
- [ ]  Related documentation has been updated (e.g. links, examples, etc.)
- [ ]  Code is ready for review
