### PR TITLE
feat(kubernetes): add security context options to sandbox

### DIFF
--- a/agentscope-extensions/agentscope-extensions-sandbox/agentscope-extensions-sandbox-kubernetes/src/main/java/io/agentscope/extensions/sandbox/kubernetes/Fabric8KubernetesPodRuntime.java
+++ b/agentscope-extensions/agentscope-extensions-sandbox/agentscope-extensions-sandbox-kubernetes/src/main/java/io/agentscope/extensions/sandbox/kubernetes/Fabric8KubernetesPodRuntime.java
@@ -243,6 +243,9 @@ public class Fabric8KubernetesPodRuntime {
                         .withImage(state.getImage())
                         .withCommand("sh", "-c")
                         .withArgs("while true; do sleep 3600; done");
+        if (templateOptions.getContainerSecurityContext() != null) {
+            cb.withSecurityContext(templateOptions.getContainerSecurityContext());
+        }
 
         if (templateOptions.getCpuRequest() != null || templateOptions.getMemoryRequest() != null) {
             ResourceRequirementsBuilder rb = new ResourceRequirementsBuilder();
@@ -310,6 +313,9 @@ public class Fabric8KubernetesPodRuntime {
         }
 
         PodSpecBuilder specBuilder = new PodSpecBuilder().withRestartPolicy("Always");
+        if (templateOptions.getPodSecurityContext() != null) {
+            specBuilder.withSecurityContext(templateOptions.getPodSecurityContext());
+        }
         for (Volume v : bindVolumes) {
             specBuilder.addToVolumes(v);
         }

--- a/agentscope-extensions/agentscope-extensions-sandbox/agentscope-extensions-sandbox-kubernetes/src/main/java/io/agentscope/extensions/sandbox/kubernetes/KubernetesSandboxClient.java
+++ b/agentscope-extensions/agentscope-extensions-sandbox/agentscope-extensions-sandbox-kubernetes/src/main/java/io/agentscope/extensions/sandbox/kubernetes/KubernetesSandboxClient.java
@@ -159,6 +159,12 @@ public class KubernetesSandboxClient implements SandboxClient<KubernetesSandboxC
         if (callOptions.getServiceAccount() != null) {
             o.setServiceAccount(callOptions.getServiceAccount());
         }
+        if (callOptions.getContainerSecurityContext() != null) {
+            o.setContainerSecurityContext(callOptions.getContainerSecurityContext());
+        }
+        if (callOptions.getPodSecurityContext() != null) {
+            o.setPodSecurityContext(callOptions.getPodSecurityContext());
+        }
         if (callOptions.getNodeSelector() != null && !callOptions.getNodeSelector().isEmpty()) {
             o.setNodeSelector(callOptions.getNodeSelector());
         }
@@ -183,6 +189,8 @@ public class KubernetesSandboxClient implements SandboxClient<KubernetesSandboxC
         o.setContainerName(src.getContainerName());
         o.setWorkspaceRoot(src.getWorkspaceRoot());
         o.setServiceAccount(src.getServiceAccount());
+        o.setContainerSecurityContext(src.getContainerSecurityContext());
+        o.setPodSecurityContext(src.getPodSecurityContext());
         o.setNodeSelector(src.getNodeSelector());
         o.setPodLabels(src.getPodLabels());
         o.setCpuRequest(src.getCpuRequest());

--- a/agentscope-extensions/agentscope-extensions-sandbox/agentscope-extensions-sandbox-kubernetes/src/main/java/io/agentscope/extensions/sandbox/kubernetes/KubernetesSandboxClientOptions.java
+++ b/agentscope-extensions/agentscope-extensions-sandbox/agentscope-extensions-sandbox-kubernetes/src/main/java/io/agentscope/extensions/sandbox/kubernetes/KubernetesSandboxClientOptions.java
@@ -17,6 +17,8 @@ package io.agentscope.extensions.sandbox.kubernetes;
 
 import io.agentscope.harness.agent.sandbox.SandboxClient;
 import io.agentscope.harness.agent.sandbox.SandboxClientOptions;
+import io.fabric8.kubernetes.api.model.PodSecurityContext;
+import io.fabric8.kubernetes.api.model.SecurityContext;
 import io.fabric8.kubernetes.client.Config;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import java.util.HashMap;
@@ -32,6 +34,8 @@ public class KubernetesSandboxClientOptions extends SandboxClientOptions {
     private String containerName = "workspace";
     private String workspaceRoot = "/workspace";
     private String serviceAccount;
+    private SecurityContext containerSecurityContext;
+    private PodSecurityContext podSecurityContext;
     private Map<String, String> nodeSelector = new HashMap<>();
     private Map<String, String> podLabels = new HashMap<>();
     private String cpuRequest;
@@ -105,6 +109,22 @@ public class KubernetesSandboxClientOptions extends SandboxClientOptions {
 
     public void setServiceAccount(String serviceAccount) {
         this.serviceAccount = serviceAccount;
+    }
+
+    public SecurityContext getContainerSecurityContext() {
+        return containerSecurityContext;
+    }
+
+    public void setContainerSecurityContext(SecurityContext containerSecurityContext) {
+        this.containerSecurityContext = containerSecurityContext;
+    }
+
+    public PodSecurityContext getPodSecurityContext() {
+        return podSecurityContext;
+    }
+
+    public void setPodSecurityContext(PodSecurityContext podSecurityContext) {
+        this.podSecurityContext = podSecurityContext;
     }
 
     public Map<String, String> getNodeSelector() {

--- a/agentscope-extensions/agentscope-extensions-sandbox/agentscope-extensions-sandbox-kubernetes/src/test/java/io/agentscope/extensions/sandbox/kubernetes/Fabric8KubernetesPodRuntimeTest.java
+++ b/agentscope-extensions/agentscope-extensions-sandbox/agentscope-extensions-sandbox-kubernetes/src/test/java/io/agentscope/extensions/sandbox/kubernetes/Fabric8KubernetesPodRuntimeTest.java
@@ -16,6 +16,7 @@
 package io.agentscope.extensions.sandbox.kubernetes;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -23,11 +24,14 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 
+import io.agentscope.harness.agent.sandbox.Sandbox;
 import io.agentscope.harness.agent.sandbox.SandboxException;
 import io.agentscope.harness.agent.sandbox.WorkspaceSpec;
 import io.fabric8.kubernetes.api.model.EnvVar;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.PodList;
+import io.fabric8.kubernetes.api.model.PodSecurityContextBuilder;
+import io.fabric8.kubernetes.api.model.SecurityContextBuilder;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.dsl.ContainerResource;
 import io.fabric8.kubernetes.client.dsl.ExecWatch;
@@ -129,6 +133,97 @@ class Fabric8KubernetesPodRuntimeTest {
         Pod created = podCaptor.getValue();
         List<EnvVar> envVars = created.getSpec().getContainers().get(0).getEnv();
         assertTrue(envVars == null || envVars.isEmpty());
+    }
+
+    @Test
+    void ensurePodReady_appliesSecurityContextsFromOptions() throws Exception {
+        opts.setContainerSecurityContext(
+                new SecurityContextBuilder()
+                        .withRunAsNonRoot(true)
+                        .withAllowPrivilegeEscalation(false)
+                        .build());
+        opts.setPodSecurityContext(
+                new PodSecurityContextBuilder().withRunAsUser(1001L).withFsGroup(1001L).build());
+
+        KubernetesSandboxState state = new KubernetesSandboxState();
+        state.setSessionId("test-session-id-secctx");
+        state.setNamespace("default");
+        state.setContainerName("workspace");
+        state.setImage("ubuntu:22.04");
+        state.setWorkspaceRoot("/workspace");
+
+        ArgumentCaptor<Pod> podCaptor = ArgumentCaptor.forClass(Pod.class);
+        doReturn(podResource).when(inNamespace).resource(podCaptor.capture());
+
+        runtime.ensurePodReady(state);
+
+        Pod created = podCaptor.getValue();
+        assertEquals(1001L, created.getSpec().getSecurityContext().getRunAsUser());
+        assertEquals(1001L, created.getSpec().getSecurityContext().getFsGroup());
+        assertTrue(created.getSpec().getContainers().get(0).getSecurityContext().getRunAsNonRoot());
+        assertEquals(
+                false,
+                created.getSpec()
+                        .getContainers()
+                        .get(0)
+                        .getSecurityContext()
+                        .getAllowPrivilegeEscalation());
+    }
+
+    @Test
+    void clientCreate_mergesSecurityContextsIntoRuntimeOptions() throws Exception {
+        KubernetesSandboxClientOptions callOptions = new KubernetesSandboxClientOptions();
+        callOptions.setKubernetesClient(kc);
+        callOptions.setContainerSecurityContext(
+                new SecurityContextBuilder().withRunAsNonRoot(true).build());
+        callOptions.setPodSecurityContext(
+                new PodSecurityContextBuilder().withRunAsUser(1001L).build());
+
+        ArgumentCaptor<Pod> podCaptor = ArgumentCaptor.forClass(Pod.class);
+        doReturn(podResource).when(inNamespace).resource(podCaptor.capture());
+        ContainerResource container = mock(ContainerResource.class);
+        ExecWatch execWatch = mock(ExecWatch.class);
+        ContainerResource writingOut = mock(ContainerResource.class);
+        ContainerResource writingErr = mock(ContainerResource.class);
+        doReturn(container).when(podResource).inContainer(anyString());
+        doReturn(writingOut).when(container).writingOutput(any(ByteArrayOutputStream.class));
+        doReturn(writingErr).when(writingOut).writingError(any(ByteArrayOutputStream.class));
+        doReturn(execWatch).when(writingErr).exec(anyString(), anyString(), anyString());
+        doReturn(CompletableFuture.completedFuture(0)).when(execWatch).exitCode();
+
+        Sandbox sandbox =
+                new KubernetesSandboxClient().create(new WorkspaceSpec(), null, callOptions);
+        sandbox.start();
+
+        Pod created = podCaptor.getValue();
+        assertEquals(1001L, created.getSpec().getSecurityContext().getRunAsUser());
+        assertTrue(created.getSpec().getContainers().get(0).getSecurityContext().getRunAsNonRoot());
+    }
+
+    @Test
+    void clientCreate_withoutSecurityContextsLeavesPodSecurityContextsUnset() throws Exception {
+        KubernetesSandboxClientOptions callOptions = new KubernetesSandboxClientOptions();
+        callOptions.setKubernetesClient(kc);
+
+        ArgumentCaptor<Pod> podCaptor = ArgumentCaptor.forClass(Pod.class);
+        doReturn(podResource).when(inNamespace).resource(podCaptor.capture());
+        ContainerResource container = mock(ContainerResource.class);
+        ExecWatch execWatch = mock(ExecWatch.class);
+        ContainerResource writingOut = mock(ContainerResource.class);
+        ContainerResource writingErr = mock(ContainerResource.class);
+        doReturn(container).when(podResource).inContainer(anyString());
+        doReturn(writingOut).when(container).writingOutput(any(ByteArrayOutputStream.class));
+        doReturn(writingErr).when(writingOut).writingError(any(ByteArrayOutputStream.class));
+        doReturn(execWatch).when(writingErr).exec(anyString(), anyString(), anyString());
+        doReturn(CompletableFuture.completedFuture(0)).when(execWatch).exitCode();
+
+        Sandbox sandbox =
+                new KubernetesSandboxClient().create(new WorkspaceSpec(), null, callOptions);
+        sandbox.start();
+
+        Pod created = podCaptor.getValue();
+        assertNull(created.getSpec().getSecurityContext());
+        assertNull(created.getSpec().getContainers().get(0).getSecurityContext());
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Add typed `containerSecurityContext` and `podSecurityContext` options to the Kubernetes sandbox client options.
- Apply those options to generated Fabric8 container and pod specs when set.
- Preserve existing default behavior because both options are `null` by default.
- Cover both direct runtime options and `KubernetesSandboxClient#create` merge/copy paths.

## Tests
- `mvn -f pom.xml -pl agentscope-extensions/agentscope-extensions-sandbox/agentscope-extensions-sandbox-kubernetes -am -Dtest=Fabric8KubernetesPodRuntimeTest test`