### PR TITLE
feat(extensions-postgresql): add PostgresDistributedStore for HarnessAgent

### DIFF
--- a/agentscope-distribution/agentscope-all/pom.xml
+++ b/agentscope-distribution/agentscope-all/pom.xml
@@ -229,6 +229,13 @@
 
         <dependency>
             <groupId>io.agentscope</groupId>
+            <artifactId>agentscope-extensions-postgresql</artifactId>
+            <scope>compile</scope>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
+            <groupId>io.agentscope</groupId>
             <artifactId>agentscope-extensions-redis</artifactId>
             <scope>compile</scope>
             <optional>true</optional>

--- a/agentscope-distribution/agentscope-bom/pom.xml
+++ b/agentscope-distribution/agentscope-bom/pom.xml
@@ -239,6 +239,13 @@
                 <version>${project.version}</version>
             </dependency>
 
+            <!-- AgentScope Extensions PostgreSql (AgentStateStore + BaseStore) -->
+            <dependency>
+                <groupId>io.agentscope</groupId>
+                <artifactId>agentscope-extensions-postgresql</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
             <!-- AgentScope Extensions Sandbox -->
             <dependency>
                 <groupId>io.agentscope</groupId>

--- a/agentscope-extensions/agentscope-extensions-postgresql/pom.xml
+++ b/agentscope-extensions/agentscope-extensions-postgresql/pom.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2024-2026 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.agentscope</groupId>
+        <artifactId>agentscope-extensions</artifactId>
+        <version>${revision}</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <name>AgentScope Java - Extensions - PostgreSQL</name>
+    <description>PostgreSQL-backed distributed implementations for AgentStateStore and BaseStore.</description>
+    <artifactId>agentscope-extensions-postgresql</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.agentscope</groupId>
+            <artifactId>agentscope-harness</artifactId>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/agentscope-extensions/agentscope-extensions-postgresql/src/main/java/io/agentscope/extensions/postgresql/PostgresDistributedStore.java
+++ b/agentscope-extensions/agentscope-extensions-postgresql/src/main/java/io/agentscope/extensions/postgresql/PostgresDistributedStore.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.extensions.postgresql;
+
+import io.agentscope.core.state.AgentStateStore;
+import io.agentscope.extensions.postgresql.sandbox.PostgresSandboxExecutionGuard;
+import io.agentscope.extensions.postgresql.snapshot.PostgresSnapshotSpec;
+import io.agentscope.extensions.postgresql.state.PostgresAgentStateStore;
+import io.agentscope.extensions.postgresql.store.PostgresBaseStore;
+import io.agentscope.harness.agent.DistributedStore;
+import io.agentscope.harness.agent.filesystem.remote.store.BaseStore;
+import io.agentscope.harness.agent.sandbox.SandboxExecutionGuard;
+import io.agentscope.harness.agent.sandbox.snapshot.SandboxSnapshotSpec;
+import java.util.Objects;
+import javax.sql.DataSource;
+
+/**
+ * PostgreSQL-backed {@link DistributedStore}.
+ *
+ * <p>Usage:
+ * <pre>{@code
+ * DataSource dataSource = ... // HikariCP, Druid, etc.
+ *
+ * HarnessAgent agent = HarnessAgent.builder()
+ *     .name("my-agent")
+ *     .model("dashscope:qwen-plus")
+ *     .distributedStore(PostgresDistributedStore.create(dataSource))
+ *     .filesystem(new DockerFilesystemSpec()
+ *             .image("ubuntu:24.04"))
+ *     .build();
+ * }</pre>
+ *
+ * <p>This configures:
+ * <ul>
+ *   <li>{@link PostgresAgentStateStore} — agent session state in PostgreSQL</li>
+ *   <li>{@link PostgresBaseStore} — workspace filesystem KV in PostgreSQL</li>
+ *   <li>{@link PostgresSnapshotSpec} — sandbox snapshots as BYTEAs in PostgreSQL</li>
+ *   <li>{@link PostgresSandboxExecutionGuard} — distributed lock via PostgreSQL advisory locks</li>
+ * </ul>
+ *
+ * <p>The target database must already exist; schema and tables are created automatically by
+ * default.
+ */
+public class PostgresDistributedStore implements DistributedStore {
+
+    private final DataSource dataSource;
+
+    private PostgresDistributedStore(DataSource dataSource) {
+        this.dataSource = Objects.requireNonNull(dataSource, "dataSource");
+    }
+
+    /**
+     * Creates a PostgreSQL distributed store.
+     *
+     * @param dataSource JDBC data source for PostgreSQL
+     * @return a new PostgreSQL distributed store
+     */
+    public static PostgresDistributedStore create(DataSource dataSource) {
+        return new PostgresDistributedStore(dataSource);
+    }
+
+    @Override
+    public AgentStateStore agentStateStore() {
+        return new PostgresAgentStateStore(dataSource, true);
+    }
+
+    @Override
+    public BaseStore baseStore() {
+        return PostgresBaseStore.builder(dataSource).initializeSchema(true).build();
+    }
+
+    @Override
+    public SandboxSnapshotSpec sandboxSnapshotSpec() {
+        return new PostgresSnapshotSpec(dataSource);
+    }
+
+    @Override
+    public SandboxExecutionGuard sandboxExecutionGuard() {
+        return PostgresSandboxExecutionGuard.builder(dataSource).build();
+    }
+}

--- a/agentscope-extensions/agentscope-extensions-postgresql/src/main/java/io/agentscope/extensions/postgresql/sandbox/PostgresSandboxExecutionGuard.java
+++ b/agentscope-extensions/agentscope-extensions-postgresql/src/main/java/io/agentscope/extensions/postgresql/sandbox/PostgresSandboxExecutionGuard.java
@@ -1,0 +1,200 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.extensions.postgresql.sandbox;
+
+import io.agentscope.harness.agent.sandbox.SandboxExecutionGuard;
+import io.agentscope.harness.agent.sandbox.SandboxIsolationKey;
+import io.agentscope.harness.agent.sandbox.SandboxLease;
+import java.nio.charset.StandardCharsets;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.time.Duration;
+import java.util.Objects;
+import javax.sql.DataSource;
+import org.apache.commons.codec.digest.MurmurHash3;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * PostgreSQL advisory-lock-based {@link SandboxExecutionGuard}.
+ *
+ * <p>Each lock is identified by a 64-bit key derived from the {@link SandboxIsolationKey}'s scope
+ * and value via MurmurHash3. The lock is acquired with {@code pg_advisory_lock(key)} and released
+ * with {@code pg_advisory_unlock(key)}.
+ *
+ * <p>The lock is tied to the database connection — when the connection closes, the lock is
+ * automatically released. The returned {@link SandboxLease#close()} calls
+ * {@code pg_advisory_unlock(key)} and closes the underlying connection.
+ *
+ * <p>A configurable timeout is supported by polling {@code pg_try_advisory_lock(key)} until the
+ * lock is acquired or the timeout expires, matching the semantics of MySQL's
+ * {@code GET_LOCK(name, timeout)}.
+ */
+public final class PostgresSandboxExecutionGuard implements SandboxExecutionGuard {
+
+    private static final Logger log = LoggerFactory.getLogger(PostgresSandboxExecutionGuard.class);
+
+    private static final String DEFAULT_KEY_PREFIX = "agentscope:sandbox:lock:";
+
+    private final DataSource dataSource;
+    private final String keyPrefix;
+    private final int lockTimeoutSeconds;
+
+    private PostgresSandboxExecutionGuard(Builder builder) {
+        this.dataSource = builder.dataSource;
+        this.keyPrefix = builder.keyPrefix;
+        this.lockTimeoutSeconds = builder.lockTimeoutSeconds;
+    }
+
+    public static Builder builder(DataSource dataSource) {
+        return new Builder(dataSource);
+    }
+
+    @Override
+    public SandboxLease tryEnter(SandboxIsolationKey key) throws InterruptedException {
+        long lockName = composeLockKey(key);
+        log.debug("[sandbox-guard] Acquiring PostgreSQL advisory lock: {}", lockName);
+
+        long deadline = System.nanoTime() + Duration.ofSeconds(lockTimeoutSeconds).toNanos();
+        try {
+            Connection conn = dataSource.getConnection();
+            try {
+                while (true) {
+                    try (PreparedStatement ps =
+                            conn.prepareStatement("SELECT pg_try_advisory_lock(?)")) {
+                        ps.setLong(1, lockName);
+                        try (ResultSet rs = ps.executeQuery()) {
+                            if (rs.next() && rs.getBoolean(1)) {
+                                log.debug(
+                                        "[sandbox-guard] Acquired PostgreSQL advisory lock: {}",
+                                        lockName);
+                                return new PostgresLease(conn, lockName);
+                            }
+                        }
+                    }
+
+                    if (System.nanoTime() >= deadline) {
+                        conn.close();
+                        throw new InterruptedException(
+                                "Timed out waiting for PostgreSQL advisory lock: "
+                                        + lockName
+                                        + " (timeout="
+                                        + lockTimeoutSeconds
+                                        + "s)");
+                    }
+
+                    Thread.sleep(100L);
+                }
+            } catch (InterruptedException e) {
+                try {
+                    conn.close();
+                } catch (SQLException closeEx) {
+                    log.warn(
+                            "[sandbox-guard] Failed to close lock connection after interrupt: {}",
+                            closeEx.getMessage());
+                }
+                throw e;
+            } catch (SQLException e) {
+                try {
+                    conn.close();
+                } catch (SQLException closeEx) {
+                    log.warn(
+                            "[sandbox-guard] Failed to close lock connection: {}",
+                            closeEx.getMessage());
+                }
+                throw new RuntimeException(
+                        "Failed to acquire PostgreSQL advisory lock: " + lockName, e);
+            }
+        } catch (SQLException e) {
+            throw new RuntimeException(
+                    "Failed to acquire PostgreSQL advisory lock: " + lockName, e);
+        }
+    }
+
+    private long composeLockKey(SandboxIsolationKey key) {
+        String raw = keyPrefix + key.getScope().name().toLowerCase() + ":" + key.getValue();
+        long[] hash = MurmurHash3.hash128(raw.getBytes(StandardCharsets.UTF_8));
+        return hash[0];
+    }
+
+    private static final class PostgresLease implements SandboxLease {
+
+        private final Connection conn;
+        private final long lockName;
+
+        PostgresLease(Connection conn, long lockName) {
+            this.conn = conn;
+            this.lockName = lockName;
+        }
+
+        @Override
+        public void close() {
+            try (PreparedStatement ps = conn.prepareStatement("SELECT pg_advisory_unlock(?)")) {
+                ps.setLong(1, lockName);
+                ps.executeQuery();
+                log.debug("[sandbox-guard] Released PostgreSQL advisory lock: {}", lockName);
+            } catch (Exception e) {
+                log.warn(
+                        "[sandbox-guard] Failed to release PostgreSQL advisory lock {}: {}",
+                        lockName,
+                        e.getMessage(),
+                        e);
+            } finally {
+                try {
+                    conn.close();
+                } catch (SQLException e) {
+                    log.warn("[sandbox-guard] Failed to close lock connection: {}", e.getMessage());
+                }
+            }
+        }
+    }
+
+    public static final class Builder {
+
+        private static final int DEFAULT_LOCK_TIMEOUT_SECONDS = 1800; // 30 minutes
+
+        private final DataSource dataSource;
+        private String keyPrefix = DEFAULT_KEY_PREFIX;
+        private int lockTimeoutSeconds = DEFAULT_LOCK_TIMEOUT_SECONDS;
+
+        private Builder(DataSource dataSource) {
+            this.dataSource = Objects.requireNonNull(dataSource, "dataSource");
+        }
+
+        public Builder keyPrefix(String keyPrefix) {
+            if (keyPrefix == null || keyPrefix.isBlank()) {
+                throw new IllegalArgumentException("keyPrefix must not be blank");
+            }
+            this.keyPrefix = keyPrefix.endsWith(":") ? keyPrefix : keyPrefix + ":";
+            return this;
+        }
+
+        public Builder lockTimeout(Duration timeout) {
+            Objects.requireNonNull(timeout, "timeout");
+            if (timeout.isNegative() || timeout.isZero()) {
+                throw new IllegalArgumentException("timeout must be positive");
+            }
+            this.lockTimeoutSeconds = (int) timeout.toSeconds();
+            return this;
+        }
+
+        public PostgresSandboxExecutionGuard build() {
+            return new PostgresSandboxExecutionGuard(this);
+        }
+    }
+}

--- a/agentscope-extensions/agentscope-extensions-postgresql/src/main/java/io/agentscope/extensions/postgresql/snapshot/PostgresRemoteSnapshotClient.java
+++ b/agentscope-extensions/agentscope-extensions-postgresql/src/main/java/io/agentscope/extensions/postgresql/snapshot/PostgresRemoteSnapshotClient.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.extensions.postgresql.snapshot;
+
+import io.agentscope.harness.agent.sandbox.snapshot.RemoteSnapshotClient;
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.Objects;
+import javax.sql.DataSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * {@link RemoteSnapshotClient} backed by a PostgreSQL {@code BYTEA} column.
+ *
+ * <p>Stores sandbox workspace tar archives in a database table with columns
+ * {@code (snapshot_id VARCHAR PK, data BYTEA, created_at TIMESTAMP)}.
+ *
+ * <p>The table is auto-created if it does not exist when {@code initializeSchema} is true.
+ */
+public class PostgresRemoteSnapshotClient implements RemoteSnapshotClient {
+
+    private static final Logger log = LoggerFactory.getLogger(PostgresRemoteSnapshotClient.class);
+
+    private static final String DEFAULT_TABLE = "agentscope_snapshots";
+
+    private final DataSource dataSource;
+    private final String tableName;
+
+    public PostgresRemoteSnapshotClient(DataSource dataSource, boolean initializeSchema) {
+        this(dataSource, DEFAULT_TABLE, initializeSchema);
+    }
+
+    public PostgresRemoteSnapshotClient(
+            DataSource dataSource, String tableName, boolean initializeSchema) {
+        this.dataSource = Objects.requireNonNull(dataSource, "dataSource");
+        this.tableName = tableName != null ? tableName : DEFAULT_TABLE;
+        if (initializeSchema) {
+            initSchema();
+        }
+    }
+
+    private void initSchema() {
+        String ddl =
+                String.format(
+                        """
+                            CREATE TABLE IF NOT EXISTS %s (
+                            snapshot_id VARCHAR(512) NOT NULL PRIMARY KEY,
+                            data        BYTEA        NOT NULL,
+                            created_at  TIMESTAMP    DEFAULT CURRENT_TIMESTAMP
+                        )
+                        """,
+                        tableName);
+        try (Connection conn = dataSource.getConnection();
+                Statement stmt = conn.createStatement()) {
+            stmt.execute(ddl);
+        } catch (SQLException e) {
+            log.warn("Failed to initialize snapshot table '{}': {}", tableName, e.getMessage());
+        }
+    }
+
+    @Override
+    public void upload(String snapshotId, InputStream data) throws Exception {
+        Objects.requireNonNull(snapshotId, "snapshotId");
+        Objects.requireNonNull(data, "data");
+        byte[] bytes = data.readAllBytes();
+        String sql =
+                """
+                INSERT INTO %s (snapshot_id, data) VALUES (?, ?)
+                ON CONFLICT (snapshot_id) DO UPDATE SET
+                    data = EXCLUDED.data,
+                    created_at = CURRENT_TIMESTAMP
+                """
+                        .formatted(tableName);
+        try (Connection conn = dataSource.getConnection();
+                PreparedStatement ps = conn.prepareStatement(sql)) {
+            ps.setString(1, snapshotId);
+            ps.setBytes(2, bytes);
+            ps.executeUpdate();
+        }
+    }
+
+    @Override
+    public InputStream download(String snapshotId) throws Exception {
+        Objects.requireNonNull(snapshotId, "snapshotId");
+        String sql = "SELECT data FROM " + tableName + " WHERE snapshot_id = ?";
+        try (Connection conn = dataSource.getConnection();
+                PreparedStatement ps = conn.prepareStatement(sql)) {
+            ps.setString(1, snapshotId);
+            try (ResultSet rs = ps.executeQuery()) {
+                if (!rs.next()) {
+                    throw new java.io.FileNotFoundException(
+                            "Snapshot not found in database: " + snapshotId);
+                }
+                return new ByteArrayInputStream(rs.getBytes("data"));
+            }
+        }
+    }
+
+    @Override
+    public boolean exists(String snapshotId) throws Exception {
+        Objects.requireNonNull(snapshotId, "snapshotId");
+        String sql = "SELECT 1 FROM " + tableName + " WHERE snapshot_id = ?";
+        try (Connection conn = dataSource.getConnection();
+                PreparedStatement ps = conn.prepareStatement(sql)) {
+            ps.setString(1, snapshotId);
+            try (ResultSet rs = ps.executeQuery()) {
+                return rs.next();
+            }
+        }
+    }
+}

--- a/agentscope-extensions/agentscope-extensions-postgresql/src/main/java/io/agentscope/extensions/postgresql/snapshot/PostgresSnapshotSpec.java
+++ b/agentscope-extensions/agentscope-extensions-postgresql/src/main/java/io/agentscope/extensions/postgresql/snapshot/PostgresSnapshotSpec.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.extensions.postgresql.snapshot;
+
+import io.agentscope.harness.agent.sandbox.snapshot.RemoteSnapshotSpec;
+import javax.sql.DataSource;
+
+/**
+ * Convenience {@link io.agentscope.harness.agent.sandbox.snapshot.SandboxSnapshotSpec}
+ * for PostgreSQL-backed snapshot storage.
+ *
+ * <p>Stores sandbox workspace tar archives as BYTEAs in a database table.
+ */
+public class PostgresSnapshotSpec extends RemoteSnapshotSpec {
+
+    public PostgresSnapshotSpec(DataSource dataSource) {
+        super(new PostgresRemoteSnapshotClient(dataSource, true));
+    }
+
+    public PostgresSnapshotSpec(DataSource dataSource, String tableName) {
+        super(new PostgresRemoteSnapshotClient(dataSource, tableName, true));
+    }
+}

--- a/agentscope-extensions/agentscope-extensions-postgresql/src/main/java/io/agentscope/extensions/postgresql/state/PostgresAgentStateStore.java
+++ b/agentscope-extensions/agentscope-extensions-postgresql/src/main/java/io/agentscope/extensions/postgresql/state/PostgresAgentStateStore.java
@@ -1,0 +1,667 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.extensions.postgresql.state;
+
+import io.agentscope.core.state.AgentStateStore;
+import io.agentscope.core.state.ListHashUtil;
+import io.agentscope.core.state.State;
+import io.agentscope.core.util.JsonUtils;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.regex.Pattern;
+import javax.sql.DataSource;
+
+/**
+ * PostgreSQL database-based {@link AgentStateStore} implementation.
+ *
+ * <p>Stores session state in PostgreSQL tables with the following structure:
+ *
+ * <pre>
+ * CREATE TABLE IF NOT EXISTS "agentscope"."agentscope_sessions" (
+ *     session_id VARCHAR(255) NOT NULL,
+ *     state_key  VARCHAR(255) NOT NULL,
+ *     item_index INT          NOT NULL DEFAULT 0,
+ *     state_data TEXT         NOT NULL,
+ *     created_at TIMESTAMP    DEFAULT CURRENT_TIMESTAMP,
+ *     updated_at TIMESTAMP    DEFAULT CURRENT_TIMESTAMP,
+ *     PRIMARY KEY (session_id, state_key, item_index)
+ * );
+ * </pre>
+ *
+ * <ul>
+ *   <li>Single state: stored as JSON with item_index = 0</li>
+ *   <li>List state: each item stored in a separate row with item_index = 0, 1, 2, ...</li>
+ * </ul>
+ */
+public class PostgresAgentStateStore implements AgentStateStore {
+
+    private static final String DEFAULT_SCHEMA_NAME = "agentscope";
+    private static final String DEFAULT_TABLE_NAME = "agentscope_sessions";
+
+    /**
+     * Suffix for hash storage keys.
+     */
+    private static final String HASH_KEY_SUFFIX = ":_hash";
+
+    /**
+     * item_index value for single state values.
+     */
+    private static final int SINGLE_STATE_INDEX = 0;
+
+    private static final Pattern IDENTIFIER_PATTERN = Pattern.compile("^[a-zA-Z_][a-zA-Z0-9_]*$");
+    private static final int MAX_IDENTIFIER_LENGTH = 63;
+
+    private final DataSource dataSource;
+    private final String schemaName;
+    private final String tableName;
+
+    @FunctionalInterface
+    private interface SqlOperation {
+        void execute() throws Exception;
+    }
+
+    /**
+     * Creates a PostgresAgentStateStore with default settings.
+     *
+     * <p>Uses default schema ({@code agentscope}) and table ({@code agentscope_sessions}) and does
+     * NOT auto-create the schema or table.
+     */
+    public PostgresAgentStateStore(DataSource dataSource) {
+        this(dataSource, DEFAULT_SCHEMA_NAME, DEFAULT_TABLE_NAME, false);
+    }
+
+    /**
+     * Creates a PostgresAgentStateStore with optional auto-creation.
+     *
+     * <p>Uses default schema and table. If {@code createIfNotExist} is true, the schema and table
+     * are created automatically if they don't exist.
+     */
+    public PostgresAgentStateStore(DataSource dataSource, boolean createIfNotExist) {
+        this(dataSource, DEFAULT_SCHEMA_NAME, DEFAULT_TABLE_NAME, createIfNotExist);
+    }
+
+    /**
+     * Creates a PostgresAgentStateStore with custom schema/table and optional auto-creation.
+     */
+    public PostgresAgentStateStore(
+            DataSource dataSource, String schemaName, String tableName, boolean createIfNotExist) {
+        if (dataSource == null) {
+            throw new IllegalArgumentException("DataSource cannot be null");
+        }
+
+        this.dataSource = dataSource;
+        this.schemaName =
+                (schemaName == null || schemaName.trim().isEmpty())
+                        ? DEFAULT_SCHEMA_NAME
+                        : schemaName.trim();
+        this.tableName =
+                (tableName == null || tableName.trim().isEmpty())
+                        ? DEFAULT_TABLE_NAME
+                        : tableName.trim();
+
+        validateIdentifier(this.schemaName, "Schema name");
+        validateIdentifier(this.tableName, "Table name");
+
+        if (createIfNotExist) {
+            createSchemaIfNotExist();
+            createTableIfNotExist();
+        } else {
+            verifySchemaExists();
+            verifyTableExists();
+        }
+    }
+
+    private void createSchemaIfNotExist() {
+        String sql = "CREATE SCHEMA IF NOT EXISTS \"" + schemaName + "\"";
+        try (Connection conn = dataSource.getConnection();
+                PreparedStatement stmt = conn.prepareStatement(sql)) {
+            stmt.execute();
+        } catch (SQLException e) {
+            throw new RuntimeException("Failed to create schema: " + schemaName, e);
+        }
+    }
+
+    private void createTableIfNotExist() {
+        String createTableSql =
+                """
+                CREATE TABLE IF NOT EXISTS %s (
+                    session_id VARCHAR(255) NOT NULL,
+                    state_key  VARCHAR(255) NOT NULL,
+                    item_index INT          NOT NULL DEFAULT 0,
+                    state_data TEXT         NOT NULL,
+                    created_at TIMESTAMP    DEFAULT CURRENT_TIMESTAMP,
+                    updated_at TIMESTAMP    DEFAULT CURRENT_TIMESTAMP,
+                    PRIMARY KEY (session_id, state_key, item_index)
+                )
+                """
+                        .formatted(getFullTableName());
+        try (Connection conn = dataSource.getConnection();
+                PreparedStatement stmt = conn.prepareStatement(createTableSql)) {
+            stmt.execute();
+        } catch (SQLException e) {
+            throw new RuntimeException("Failed to create session table: " + tableName, e);
+        }
+    }
+
+    private void verifySchemaExists() {
+        String sql = "SELECT SCHEMA_NAME FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = ?";
+        try (Connection conn = dataSource.getConnection();
+                PreparedStatement stmt = conn.prepareStatement(sql)) {
+            stmt.setString(1, schemaName);
+            try (ResultSet rs = stmt.executeQuery()) {
+                if (!rs.next()) {
+                    throw new IllegalStateException(
+                            "Schema does not exist: "
+                                    + schemaName
+                                    + ". Use PostgresAgentStateStore(dataSource, true) or"
+                                    + " builder(dataSource).createIfNotExist(true).build() to"
+                                    + " auto-create.");
+                }
+            }
+        } catch (SQLException e) {
+            throw new RuntimeException("Failed to check schema existence: " + schemaName, e);
+        }
+    }
+
+    private void verifyTableExists() {
+        String sql =
+                """
+                SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES
+                WHERE TABLE_SCHEMA = ? AND TABLE_NAME = ?
+                """;
+        try (Connection conn = dataSource.getConnection();
+                PreparedStatement stmt = conn.prepareStatement(sql)) {
+            stmt.setString(1, schemaName);
+            stmt.setString(2, tableName);
+            try (ResultSet rs = stmt.executeQuery()) {
+                if (!rs.next()) {
+                    throw new IllegalStateException(
+                            "Table does not exist: "
+                                    + schemaName
+                                    + "."
+                                    + tableName
+                                    + ". Use PostgresAgentStateStore(dataSource, true) or"
+                                    + " builder(dataSource).createIfNotExist(true).build() to"
+                                    + " auto-create.");
+                }
+            }
+        } catch (SQLException e) {
+            throw new RuntimeException("Failed to check table existence: " + tableName, e);
+        }
+    }
+
+    private String getFullTableName() {
+        return "\"" + schemaName + "\".\"" + tableName + "\"";
+    }
+
+    private void executeInWriteTransaction(Connection conn, SqlOperation operation)
+            throws Exception {
+        boolean originalAutoCommit = conn.getAutoCommit();
+        if (originalAutoCommit) {
+            conn.setAutoCommit(false);
+        }
+        try {
+            operation.execute();
+            conn.commit();
+        } catch (Exception e) {
+            try {
+                conn.rollback();
+            } catch (SQLException rollbackException) {
+                e.addSuppressed(rollbackException);
+            }
+            throw e;
+        } finally {
+            if (conn.getAutoCommit() != originalAutoCommit) {
+                conn.setAutoCommit(originalAutoCommit);
+            }
+        }
+    }
+
+    @Override
+    public void save(String userId, String sessionId, String key, State value) {
+        String slotId = slotId(userId, sessionId);
+        validateSessionId(slotId);
+        validateStateKey(key);
+
+        String upsertSql =
+                """
+                INSERT INTO %s (session_id, state_key, item_index, state_data, updated_at)
+                VALUES (?, ?, ?, ?, ?)
+                ON CONFLICT (session_id, state_key, item_index) DO UPDATE SET
+                    state_data = EXCLUDED.state_data,
+                    updated_at = EXCLUDED.updated_at
+                """
+                        .formatted(getFullTableName());
+        Timestamp now = new Timestamp(System.currentTimeMillis());
+
+        try (Connection conn = dataSource.getConnection()) {
+            executeInWriteTransaction(
+                    conn,
+                    () -> {
+                        try (PreparedStatement stmt = conn.prepareStatement(upsertSql)) {
+                            String json = JsonUtils.getJsonCodec().toJson(value);
+                            stmt.setString(1, slotId);
+                            stmt.setString(2, key);
+                            stmt.setInt(3, SINGLE_STATE_INDEX);
+                            stmt.setString(4, json);
+                            stmt.setTimestamp(5, now);
+                            stmt.executeUpdate();
+                        }
+                    });
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to save state: " + key, e);
+        }
+    }
+
+    @Override
+    public void save(String userId, String sessionId, String key, List<? extends State> values) {
+        String slotId = slotId(userId, sessionId);
+        validateSessionId(slotId);
+        validateStateKey(key);
+
+        if (values.isEmpty()) {
+            return;
+        }
+
+        String hashKey = key + HASH_KEY_SUFFIX;
+
+        try (Connection conn = dataSource.getConnection()) {
+            executeInWriteTransaction(
+                    conn,
+                    () -> {
+                        String currentHash = ListHashUtil.computeHash(values);
+                        String storedHash = getStoredHash(conn, slotId, hashKey);
+                        int existingCount = getListCount(conn, slotId, key);
+                        boolean needsFullRewrite =
+                                ListHashUtil.needsFullRewrite(values, storedHash, existingCount);
+
+                        if (needsFullRewrite) {
+                            deleteListItems(conn, slotId, key);
+                            insertAllItems(conn, slotId, key, values);
+                            saveHash(conn, slotId, hashKey, currentHash);
+                        } else if (values.size() > existingCount) {
+                            List<? extends State> newItems =
+                                    values.subList(existingCount, values.size());
+                            insertItems(conn, slotId, key, newItems, existingCount);
+                            saveHash(conn, slotId, hashKey, currentHash);
+                        }
+                    });
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to save list: " + key, e);
+        }
+    }
+
+    private String getStoredHash(Connection conn, String sessionId, String hashKey)
+            throws SQLException {
+        String sql =
+                "SELECT state_data FROM "
+                        + getFullTableName()
+                        + " WHERE session_id = ? AND state_key = ? AND item_index = ?";
+        try (PreparedStatement stmt = conn.prepareStatement(sql)) {
+            stmt.setString(1, sessionId);
+            stmt.setString(2, hashKey);
+            stmt.setInt(3, SINGLE_STATE_INDEX);
+            try (ResultSet rs = stmt.executeQuery()) {
+                if (rs.next()) {
+                    return rs.getString("state_data");
+                }
+                return null;
+            }
+        }
+    }
+
+    private void saveHash(Connection conn, String sessionId, String hashKey, String hash)
+            throws SQLException {
+        String upsertSql =
+                """
+                INSERT INTO %s (session_id, state_key, item_index, state_data, updated_at)
+                VALUES (?, ?, ?, ?, ?)
+                ON CONFLICT (session_id, state_key, item_index) DO UPDATE SET
+                    state_data = EXCLUDED.state_data,
+                    updated_at = EXCLUDED.updated_at
+                """
+                        .formatted(getFullTableName());
+        Timestamp now = new Timestamp(System.currentTimeMillis());
+        try (PreparedStatement stmt = conn.prepareStatement(upsertSql)) {
+            stmt.setString(1, sessionId);
+            stmt.setString(2, hashKey);
+            stmt.setInt(3, SINGLE_STATE_INDEX);
+            stmt.setString(4, hash);
+            stmt.setTimestamp(5, now);
+            stmt.executeUpdate();
+        }
+    }
+
+    private void deleteListItems(Connection conn, String sessionId, String key)
+            throws SQLException {
+        String sql =
+                "DELETE FROM " + getFullTableName() + " WHERE session_id = ? AND state_key = ?";
+        try (PreparedStatement stmt = conn.prepareStatement(sql)) {
+            stmt.setString(1, sessionId);
+            stmt.setString(2, key);
+            stmt.executeUpdate();
+        }
+    }
+
+    private void insertAllItems(
+            Connection conn, String sessionId, String key, List<? extends State> values)
+            throws Exception {
+        insertItems(conn, sessionId, key, values, 0);
+    }
+
+    private void insertItems(
+            Connection conn,
+            String sessionId,
+            String key,
+            List<? extends State> items,
+            int startIndex)
+            throws Exception {
+        String sql =
+                "INSERT INTO "
+                        + getFullTableName()
+                        + " (session_id, state_key, item_index, state_data) VALUES (?, ?, ?, ?)";
+        try (PreparedStatement stmt = conn.prepareStatement(sql)) {
+            int index = startIndex;
+            for (State item : items) {
+                String json = JsonUtils.getJsonCodec().toJson(item);
+                stmt.setString(1, sessionId);
+                stmt.setString(2, key);
+                stmt.setInt(3, index);
+                stmt.setString(4, json);
+                stmt.addBatch();
+                index++;
+            }
+            stmt.executeBatch();
+        }
+    }
+
+    private int getListCount(Connection conn, String sessionId, String key) throws SQLException {
+        String sql =
+                "SELECT MAX(item_index) as max_index FROM "
+                        + getFullTableName()
+                        + " WHERE session_id = ? AND state_key = ?";
+        try (PreparedStatement stmt = conn.prepareStatement(sql)) {
+            stmt.setString(1, sessionId);
+            stmt.setString(2, key);
+            try (ResultSet rs = stmt.executeQuery()) {
+                if (rs.next()) {
+                    int maxIndex = rs.getInt("max_index");
+                    if (rs.wasNull()) {
+                        return 0;
+                    }
+                    return maxIndex + 1;
+                }
+                return 0;
+            }
+        }
+    }
+
+    @Override
+    public <T extends State> Optional<T> get(
+            String userId, String sessionId, String key, Class<T> type) {
+        String slotId = slotId(userId, sessionId);
+        validateSessionId(slotId);
+        validateStateKey(key);
+
+        String sql =
+                "SELECT state_data FROM "
+                        + getFullTableName()
+                        + " WHERE session_id = ? AND state_key = ? AND item_index = ?";
+        try (Connection conn = dataSource.getConnection();
+                PreparedStatement stmt = conn.prepareStatement(sql)) {
+            stmt.setString(1, slotId);
+            stmt.setString(2, key);
+            stmt.setInt(3, SINGLE_STATE_INDEX);
+            try (ResultSet rs = stmt.executeQuery()) {
+                if (rs.next()) {
+                    String json = rs.getString("state_data");
+                    return Optional.of(JsonUtils.getJsonCodec().fromJson(json, type));
+                }
+                return Optional.empty();
+            }
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to get state: " + key, e);
+        }
+    }
+
+    @Override
+    public <T extends State> List<T> getList(
+            String userId, String sessionId, String key, Class<T> itemType) {
+        String slotId = slotId(userId, sessionId);
+        validateSessionId(slotId);
+        validateStateKey(key);
+
+        String sql =
+                "SELECT state_data FROM "
+                        + getFullTableName()
+                        + " WHERE session_id = ? AND state_key = ? ORDER BY item_index";
+        try (Connection conn = dataSource.getConnection();
+                PreparedStatement stmt = conn.prepareStatement(sql)) {
+            stmt.setString(1, slotId);
+            stmt.setString(2, key);
+            try (ResultSet rs = stmt.executeQuery()) {
+                List<T> result = new ArrayList<>();
+                while (rs.next()) {
+                    String json = rs.getString("state_data");
+                    result.add(JsonUtils.getJsonCodec().fromJson(json, itemType));
+                }
+                return result;
+            }
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to get list: " + key, e);
+        }
+    }
+
+    @Override
+    public boolean exists(String userId, String sessionId) {
+        String slotId = slotId(userId, sessionId);
+        validateSessionId(slotId);
+
+        String sql = "SELECT 1 FROM " + getFullTableName() + " WHERE session_id = ? LIMIT 1";
+        try (Connection conn = dataSource.getConnection();
+                PreparedStatement stmt = conn.prepareStatement(sql)) {
+            stmt.setString(1, slotId);
+            try (ResultSet rs = stmt.executeQuery()) {
+                return rs.next();
+            }
+        } catch (SQLException e) {
+            throw new RuntimeException("Failed to check session existence: " + slotId, e);
+        }
+    }
+
+    @Override
+    public void delete(String userId, String sessionId) {
+        String slotId = slotId(userId, sessionId);
+        validateSessionId(slotId);
+
+        String sql = "DELETE FROM " + getFullTableName() + " WHERE session_id = ?";
+        try (Connection conn = dataSource.getConnection()) {
+            executeInWriteTransaction(
+                    conn,
+                    () -> {
+                        try (PreparedStatement stmt = conn.prepareStatement(sql)) {
+                            stmt.setString(1, slotId);
+                            stmt.executeUpdate();
+                        }
+                    });
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to delete session: " + slotId, e);
+        }
+    }
+
+    @Override
+    public Set<String> listSessionIds(String userId) {
+        String userSegment = normalizeUser(userId);
+        String prefix = userSegment + ":";
+        String sql =
+                "SELECT DISTINCT session_id FROM "
+                        + getFullTableName()
+                        + " WHERE session_id LIKE ? ORDER BY session_id";
+        try (Connection conn = dataSource.getConnection();
+                PreparedStatement stmt = conn.prepareStatement(sql)) {
+            stmt.setString(1, prefix + "%");
+            try (ResultSet rs = stmt.executeQuery()) {
+                Set<String> sessionIds = new HashSet<>();
+                while (rs.next()) {
+                    String slot = rs.getString("session_id");
+                    sessionIds.add(slot.substring(prefix.length()));
+                }
+                return sessionIds;
+            }
+        } catch (SQLException e) {
+            throw new RuntimeException("Failed to list sessions", e);
+        }
+    }
+
+    private static final String ANON_USER = "__anon__";
+
+    private static String normalizeUser(String userId) {
+        return userId == null || userId.isBlank() ? ANON_USER : userId;
+    }
+
+    private static String slotId(String userId, String sessionId) {
+        if (sessionId == null || sessionId.isBlank()) {
+            throw new IllegalArgumentException("sessionId must not be blank");
+        }
+        return normalizeUser(userId) + ":" + sessionId;
+    }
+
+    @Override
+    public void close() {
+        // DataSource is managed externally, so we don't close it here
+    }
+
+    /**
+     * Truncate session table from the database (for testing or cleanup).
+     *
+     * <p>This method clears all session records by executing a {@code TRUNCATE TABLE} statement on
+     * the sessions table. TRUNCATE is faster than DELETE as it resets the table without logging
+     * individual row deletions and reclaims storage space immediately.
+     *
+     * <p><strong>Note:</strong> In PostgreSQL, {@code TRUNCATE TABLE} is DDL and triggers an
+     * implicit commit. For that reason, this method executes the statement directly instead of
+     * routing it through {@link #executeInWriteTransaction(Connection, SqlOperation)}.
+     *
+     * @return typically 0 if successful
+     */
+    public int truncateAllSessions() {
+        String clearSql = "TRUNCATE TABLE " + getFullTableName();
+
+        try (Connection conn = dataSource.getConnection();
+                PreparedStatement stmt = conn.prepareStatement(clearSql)) {
+            return stmt.executeUpdate();
+        } catch (SQLException e) {
+            throw new RuntimeException("Failed to truncate sessions", e);
+        }
+    }
+
+    public String getSchemaName() {
+        return schemaName;
+    }
+
+    public String getTableName() {
+        return tableName;
+    }
+
+    public DataSource getDataSource() {
+        return dataSource;
+    }
+
+    protected void validateSessionId(String sessionId) {
+        if (sessionId == null || sessionId.trim().isEmpty()) {
+            throw new IllegalArgumentException("AgentStateStore ID cannot be null or empty");
+        }
+        if (sessionId.contains("/") || sessionId.contains("\\")) {
+            throw new IllegalArgumentException("AgentStateStore ID cannot contain path separators");
+        }
+        if (sessionId.length() > 255) {
+            throw new IllegalArgumentException("AgentStateStore ID cannot exceed 255 characters");
+        }
+    }
+
+    private void validateStateKey(String key) {
+        if (key == null || key.trim().isEmpty()) {
+            throw new IllegalArgumentException("State key cannot be null or empty");
+        }
+        if (key.length() > 255) {
+            throw new IllegalArgumentException("State key cannot exceed 255 characters");
+        }
+    }
+
+    private void validateIdentifier(String identifier, String identifierType) {
+        if (identifier.length() > MAX_IDENTIFIER_LENGTH) {
+            throw new IllegalArgumentException(
+                    identifierType + " cannot exceed " + MAX_IDENTIFIER_LENGTH + " characters");
+        }
+        if (!IDENTIFIER_PATTERN.matcher(identifier).matches()) {
+            throw new IllegalArgumentException(
+                    identifierType
+                            + " contains invalid characters. Only alphanumeric characters and"
+                            + " underscores are allowed, and it must start with a letter or"
+                            + " underscore. Invalid value: "
+                            + identifier);
+        }
+    }
+
+    /**
+     * Builder for {@link PostgresAgentStateStore}.
+     */
+    public static final class Builder {
+
+        private final DataSource dataSource;
+        private String schemaName = DEFAULT_SCHEMA_NAME;
+        private String tableName = DEFAULT_TABLE_NAME;
+        private boolean createIfNotExist = true;
+
+        private Builder(DataSource dataSource) {
+            if (dataSource == null) {
+                throw new IllegalArgumentException("DataSource cannot be null");
+            }
+            this.dataSource = dataSource;
+        }
+
+        public Builder schemaName(String schemaName) {
+            this.schemaName = schemaName;
+            return this;
+        }
+
+        public Builder tableName(String tableName) {
+            this.tableName = tableName;
+            return this;
+        }
+
+        public Builder createIfNotExist(boolean createIfNotExist) {
+            this.createIfNotExist = createIfNotExist;
+            return this;
+        }
+
+        public PostgresAgentStateStore build() {
+            return new PostgresAgentStateStore(dataSource, schemaName, tableName, createIfNotExist);
+        }
+    }
+
+    public static Builder builder(DataSource dataSource) {
+        return new Builder(dataSource);
+    }
+}

--- a/agentscope-extensions/agentscope-extensions-postgresql/src/main/java/io/agentscope/extensions/postgresql/store/PostgresBaseStore.java
+++ b/agentscope-extensions/agentscope-extensions-postgresql/src/main/java/io/agentscope/extensions/postgresql/store/PostgresBaseStore.java
@@ -1,0 +1,416 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.extensions.postgresql.store;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.agentscope.harness.agent.filesystem.remote.store.BaseStore;
+import io.agentscope.harness.agent.filesystem.remote.store.InMemoryStore;
+import io.agentscope.harness.agent.filesystem.remote.store.StoreItem;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.SQLIntegrityConstraintViolationException;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.regex.Pattern;
+import javax.sql.DataSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * PostgreSQL-backed {@link BaseStore}.
+ *
+ * <h2>Schema</h2>
+ *
+ * <pre>{@code
+ * CREATE TABLE agentscope_store (
+ *   namespace_path  VARCHAR(2048) NOT NULL,
+ *   item_key        VARCHAR(255)  NOT NULL,
+ *   value_json      TEXT          NOT NULL,
+ *   version         BIGINT        NOT NULL,
+ *   updated_at      BIGINT        NOT NULL,
+ *   PRIMARY KEY (namespace_path, item_key)
+ * )
+ * }</pre>
+ *
+ * <p>The optional {@code Builder#initializeSchema(true)} flag runs
+ * {@code CREATE TABLE IF NOT EXISTS} on construction.
+ *
+ * <h2>Namespace encoding</h2>
+ *
+ * <p>To preserve the prefix-search behaviour of {@link InMemoryStore},
+ * the namespace components are joined with the ASCII unit-separator {@code 0x1F} and stored with a
+ * trailing separator. Searching by namespace {@code [a, b]} translates into
+ * {@code WHERE namespace_path LIKE 'ab%' ESCAPE '!'}, which matches both that exact
+ * namespace and any deeper sub-namespace. Namespace segments that contain {@code 0x1F} are
+ * rejected.
+ *
+ * <h2>CAS</h2>
+ *
+ * <p>{@link #putIfVersion} uses a single-statement conditional {@code UPDATE} keyed on
+ * {@code version}. The {@code expectedVersion == 0} case issues an {@code INSERT} and treats a
+ * primary-key conflict as a failed CAS. Both paths are atomic without additional locking, so the
+ * store is safe to share among multiple JVMs writing to the same database.
+ */
+public class PostgresBaseStore implements BaseStore {
+
+    private static final Logger LOG = LoggerFactory.getLogger(PostgresBaseStore.class);
+
+    /**
+     * ASCII unit separator (U+001F) used between namespace segments inside {@code namespace_path}.
+     * Picked because it does not collide with printable identifiers and is rare in JSON / user
+     * input. Namespace segments containing it are rejected.
+     */
+    private static final String NS_SEPARATOR = "";
+
+    /** Default table name used when the builder is not customised. */
+    public static final String DEFAULT_TABLE_NAME = "agentscope_store";
+
+    private static final Pattern VALID_TABLE_NAME = Pattern.compile("[A-Za-z_][A-Za-z0-9_]*");
+
+    private static final String CREATE_TABLE_SQL =
+            """
+            CREATE TABLE IF NOT EXISTS %s (
+                namespace_path VARCHAR(2048) NOT NULL,
+                item_key       VARCHAR(255)  NOT NULL,
+                value_json     TEXT          NOT NULL,
+                version        BIGINT        NOT NULL,
+                updated_at     BIGINT        NOT NULL,
+                PRIMARY KEY (namespace_path, item_key)
+            )
+            """;
+
+    private static final String SELECT_SQL =
+            "SELECT value_json, version FROM %s WHERE namespace_path = ? AND item_key = ?";
+
+    private static final String UPSERT_SQL =
+            """
+            INSERT INTO %s (namespace_path, item_key, value_json, version, updated_at)
+            VALUES (?, ?, ?, 1, ?)
+            ON CONFLICT (namespace_path, item_key) DO UPDATE SET
+                value_json = EXCLUDED.value_json,
+                version    = %1$s.version + 1,,
+                updated_at = EXCLUDED.updated_at
+            """;
+
+    private static final String INSERT_SQL =
+            """
+            INSERT INTO %s (namespace_path, item_key, value_json, version, updated_at)
+            VALUES (?, ?, ?, 1, ?)
+            """;
+
+    private static final String CAS_UPDATE_SQL =
+            """
+            UPDATE %s SET
+                value_json = ?,
+                version    = version + 1,
+                updated_at = ?
+            WHERE namespace_path = ? AND item_key = ? AND version = ?
+            """;
+
+    private static final String DELETE_SQL =
+            "DELETE FROM %s WHERE namespace_path = ? AND item_key = ?";
+
+    private static final String SEARCH_SQL =
+            """
+            SELECT item_key, value_json, version FROM %s
+            WHERE namespace_path LIKE ? ESCAPE '!'
+            ORDER BY item_key
+            LIMIT ? OFFSET ?
+            """;
+
+    private final DataSource dataSource;
+    private final ObjectMapper objectMapper;
+    private final String tableName;
+
+    private final String selectSql;
+    private final String upsertSql;
+    private final String insertSql;
+    private final String casUpdateSql;
+    private final String deleteSql;
+    private final String searchSql;
+
+    private PostgresBaseStore(Builder b) {
+        this.dataSource = b.dataSource;
+        this.objectMapper = b.objectMapper != null ? b.objectMapper : new ObjectMapper();
+        this.tableName = b.tableName;
+        this.selectSql = String.format(SELECT_SQL, tableName);
+        this.upsertSql = String.format(UPSERT_SQL, tableName);
+        this.insertSql = String.format(INSERT_SQL, tableName);
+        this.casUpdateSql = String.format(CAS_UPDATE_SQL, tableName);
+        this.deleteSql = String.format(DELETE_SQL, tableName);
+        this.searchSql = String.format(SEARCH_SQL, tableName);
+        if (b.initializeSchema) {
+            initializeSchema();
+        }
+    }
+
+    /** Creates a builder for {@link PostgresBaseStore}. */
+    public static Builder builder(DataSource dataSource) {
+        return new Builder(dataSource);
+    }
+
+    private void initializeSchema() {
+        String ddl = String.format(CREATE_TABLE_SQL, tableName);
+        try (Connection c = dataSource.getConnection();
+                Statement st = c.createStatement()) {
+            st.executeUpdate(ddl);
+        } catch (SQLException e) {
+            throw new IllegalStateException(
+                    "Failed to initialize PostgresBaseStore schema for table " + tableName, e);
+        }
+    }
+
+    @Override
+    public StoreItem get(List<String> namespace, String key) {
+        validateKey(key);
+        String nsPath = namespacePath(namespace);
+        try (Connection c = dataSource.getConnection();
+                PreparedStatement ps = c.prepareStatement(selectSql)) {
+            ps.setString(1, nsPath);
+            ps.setString(2, key);
+            try (ResultSet rs = ps.executeQuery()) {
+                if (!rs.next()) {
+                    return null;
+                }
+                String json = rs.getString(1);
+                long version = rs.getLong(2);
+                return new StoreItem(key, deserialize(json), version);
+            }
+        } catch (SQLException e) {
+            throw new IllegalStateException("PostgresBaseStore get failed", e);
+        }
+    }
+
+    @Override
+    public void put(List<String> namespace, String key, Map<String, Object> value) {
+        validateKey(key);
+        String nsPath = namespacePath(namespace);
+        String json = serialize(value);
+        try (Connection c = dataSource.getConnection();
+                PreparedStatement ps = c.prepareStatement(upsertSql)) {
+            ps.setString(1, nsPath);
+            ps.setString(2, key);
+            ps.setString(3, json);
+            ps.setLong(4, System.currentTimeMillis());
+            ps.executeUpdate();
+        } catch (SQLException e) {
+            throw new IllegalStateException("PostgresBaseStore put failed", e);
+        }
+    }
+
+    @Override
+    public boolean putIfVersion(
+            List<String> namespace, String key, Map<String, Object> value, long expectedVersion) {
+        validateKey(key);
+        if (expectedVersion < 0) {
+            throw new IllegalArgumentException("expectedVersion must be non-negative");
+        }
+        String nsPath = namespacePath(namespace);
+        String json = serialize(value);
+        long now = System.currentTimeMillis();
+
+        if (expectedVersion == 0L) {
+            try (Connection c = dataSource.getConnection();
+                    PreparedStatement ps = c.prepareStatement(insertSql)) {
+                ps.setString(1, nsPath);
+                ps.setString(2, key);
+                ps.setString(3, json);
+                ps.setLong(4, now);
+                ps.executeUpdate();
+                return true;
+            } catch (SQLException e) {
+                if (isDuplicateKey(e)) {
+                    return false;
+                }
+                throw new IllegalStateException(
+                        "PostgresBaseStore putIfVersion (insert) failed", e);
+            }
+        }
+
+        try (Connection c = dataSource.getConnection();
+                PreparedStatement ps = c.prepareStatement(casUpdateSql)) {
+            ps.setString(1, json);
+            ps.setLong(2, now);
+            ps.setString(3, nsPath);
+            ps.setString(4, key);
+            ps.setLong(5, expectedVersion);
+            return ps.executeUpdate() == 1;
+        } catch (SQLException e) {
+            throw new IllegalStateException("PostgresBaseStore putIfVersion (update) failed", e);
+        }
+    }
+
+    @Override
+    public List<StoreItem> search(List<String> namespace, int limit, int offset) {
+        if (limit <= 0) {
+            return List.of();
+        }
+        int safeOffset = Math.max(offset, 0);
+        String pattern = likePrefixPattern(namespace);
+        List<StoreItem> result = new ArrayList<>();
+        try (Connection c = dataSource.getConnection();
+                PreparedStatement ps = c.prepareStatement(searchSql)) {
+            ps.setString(1, pattern);
+            ps.setInt(2, limit);
+            ps.setInt(3, safeOffset);
+            try (ResultSet rs = ps.executeQuery()) {
+                while (rs.next()) {
+                    String itemKey = rs.getString(1);
+                    String json = rs.getString(2);
+                    long version = rs.getLong(3);
+                    result.add(new StoreItem(itemKey, deserialize(json), version));
+                }
+            }
+        } catch (SQLException e) {
+            throw new IllegalStateException("PostgresBaseStore search failed", e);
+        }
+        return result;
+    }
+
+    @Override
+    public void delete(List<String> namespace, String key) {
+        validateKey(key);
+        String nsPath = namespacePath(namespace);
+        try (Connection c = dataSource.getConnection();
+                PreparedStatement ps = c.prepareStatement(deleteSql)) {
+            ps.setString(1, nsPath);
+            ps.setString(2, key);
+            ps.executeUpdate();
+        } catch (SQLException e) {
+            throw new IllegalStateException("PostgresBaseStore delete failed", e);
+        }
+    }
+
+    private String serialize(Map<String, Object> value) {
+        try {
+            return objectMapper.writeValueAsString(value == null ? Map.of() : value);
+        } catch (Exception e) {
+            throw new IllegalArgumentException("Failed to JSON-encode store value", e);
+        }
+    }
+
+    private Map<String, Object> deserialize(String json) {
+        if (json == null || json.isEmpty()) {
+            return Map.of();
+        }
+        try {
+            return objectMapper.readValue(json, new TypeReference<Map<String, Object>>() {});
+        } catch (Exception e) {
+            throw new IllegalStateException("Failed to JSON-decode store value", e);
+        }
+    }
+
+    private static String namespacePath(List<String> namespace) {
+        Objects.requireNonNull(namespace, "namespace must not be null");
+        StringBuilder sb = new StringBuilder();
+        for (String segment : namespace) {
+            if (segment == null) {
+                throw new IllegalArgumentException("namespace segment must not be null");
+            }
+            if (segment.indexOf(NS_SEPARATOR.charAt(0)) >= 0) {
+                throw new IllegalArgumentException(
+                        "namespace segment must not contain the unit separator (0x1F)");
+            }
+            sb.append(segment).append(NS_SEPARATOR);
+        }
+        return sb.toString();
+    }
+
+    private String likePrefixPattern(List<String> namespace) {
+        char esc = '!';
+        StringBuilder sb = new StringBuilder();
+        for (char ch : namespacePath(namespace).toCharArray()) {
+            if (ch == esc || ch == '%' || ch == '_') {
+                sb.append(esc);
+            }
+            sb.append(ch);
+        }
+        sb.append('%');
+        return sb.toString();
+    }
+
+    private static void validateKey(String key) {
+        if (key == null || key.isEmpty()) {
+            throw new IllegalArgumentException("key must not be null or empty");
+        }
+    }
+
+    private static boolean isDuplicateKey(SQLException e) {
+        if (e instanceof SQLIntegrityConstraintViolationException) {
+            return true;
+        }
+        String state = e.getSQLState();
+        return state != null && state.startsWith("23");
+    }
+
+    /** Builder for {@link PostgresBaseStore}. */
+    public static final class Builder {
+
+        private final DataSource dataSource;
+        private ObjectMapper objectMapper;
+        private String tableName = DEFAULT_TABLE_NAME;
+        private boolean initializeSchema;
+
+        private Builder(DataSource dataSource) {
+            this.dataSource = Objects.requireNonNull(dataSource, "dataSource must not be null");
+        }
+
+        /** Sets a custom Jackson {@link ObjectMapper} for value serialisation. */
+        public Builder objectMapper(ObjectMapper objectMapper) {
+            this.objectMapper = objectMapper;
+            return this;
+        }
+
+        /**
+         * Overrides the table name. Must match the regex {@code [A-Za-z_][A-Za-z0-9_]*}; this is
+         * the only place a table identifier ever flows into the SQL string verbatim, so the
+         * validation here is the SQL-injection guard.
+         */
+        public Builder tableName(String tableName) {
+            if (tableName == null
+                    || tableName.isBlank()
+                    || !VALID_TABLE_NAME.matcher(tableName).matches()) {
+                throw new IllegalArgumentException(
+                        "tableName must match [A-Za-z_][A-Za-z0-9_]*, got: " + tableName);
+            }
+            this.tableName = tableName;
+            return this;
+        }
+
+        /**
+         * When {@code true}, runs {@code CREATE TABLE IF NOT EXISTS} during construction.
+         * Defaults to {@code false} — production deployments usually own their schema via
+         * migration tooling.
+         */
+        public Builder initializeSchema(boolean initializeSchema) {
+            this.initializeSchema = initializeSchema;
+            return this;
+        }
+
+        /** Builds the {@link PostgresBaseStore}. */
+        public PostgresBaseStore build() {
+            PostgresBaseStore store = new PostgresBaseStore(this);
+            LOG.debug("PostgresBaseStore built: table={}", store.tableName);
+            return store;
+        }
+    }
+}

--- a/agentscope-extensions/agentscope-extensions-postgresql/src/test/java/io/agentscope/extensions/postgresql/PostgresDistributedStoreTest.java
+++ b/agentscope-extensions/agentscope-extensions-postgresql/src/test/java/io/agentscope/extensions/postgresql/PostgresDistributedStoreTest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.extensions.postgresql;
+
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.when;
+
+import io.agentscope.extensions.postgresql.sandbox.PostgresSandboxExecutionGuard;
+import io.agentscope.extensions.postgresql.snapshot.PostgresSnapshotSpec;
+import io.agentscope.extensions.postgresql.state.PostgresAgentStateStore;
+import io.agentscope.extensions.postgresql.store.PostgresBaseStore;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import javax.sql.DataSource;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+class PostgresDistributedStoreTest {
+
+    @Mock private DataSource dataSource;
+    @Mock private Connection connection;
+    @Mock private Statement statement;
+    @Mock private PreparedStatement preparedStatement;
+    @Mock private ResultSet resultSet;
+
+    private AutoCloseable mocks;
+
+    @BeforeEach
+    void setUp() throws SQLException {
+        mocks = MockitoAnnotations.openMocks(this);
+        when(dataSource.getConnection()).thenReturn(connection);
+        when(connection.createStatement()).thenReturn(statement);
+        when(connection.prepareStatement(org.mockito.ArgumentMatchers.anyString()))
+                .thenReturn(preparedStatement);
+        when(preparedStatement.executeQuery()).thenReturn(resultSet);
+        when(preparedStatement.execute()).thenReturn(true);
+        when(resultSet.next()).thenReturn(true, true);
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        if (mocks != null) {
+            mocks.close();
+        }
+    }
+
+    @Test
+    void createRejectsNullDataSource() {
+        assertThrows(NullPointerException.class, () -> PostgresDistributedStore.create(null));
+    }
+
+    @Test
+    void createReturnsStore() {
+        assertNotNull(PostgresDistributedStore.create(dataSource));
+    }
+
+    @Test
+    void agentStateStoreReturnsPostgresAgentStateStore() {
+        PostgresDistributedStore store = PostgresDistributedStore.create(dataSource);
+        assertInstanceOf(PostgresAgentStateStore.class, store.agentStateStore());
+    }
+
+    @Test
+    void baseStoreReturnsPostgresBaseStore() {
+        PostgresDistributedStore store = PostgresDistributedStore.create(dataSource);
+        assertInstanceOf(PostgresBaseStore.class, store.baseStore());
+    }
+
+    @Test
+    void sandboxSnapshotSpecReturnsPostgresSnapshotSpec() {
+        PostgresDistributedStore store = PostgresDistributedStore.create(dataSource);
+        assertInstanceOf(PostgresSnapshotSpec.class, store.sandboxSnapshotSpec());
+    }
+
+    @Test
+    void sandboxExecutionGuardReturnsPostgresSandboxExecutionGuard() {
+        PostgresDistributedStore store = PostgresDistributedStore.create(dataSource);
+        assertInstanceOf(PostgresSandboxExecutionGuard.class, store.sandboxExecutionGuard());
+    }
+}

--- a/agentscope-extensions/agentscope-extensions-postgresql/src/test/java/io/agentscope/extensions/postgresql/sandbox/PostgresSandboxExecutionGuardTest.java
+++ b/agentscope-extensions/agentscope-extensions-postgresql/src/test/java/io/agentscope/extensions/postgresql/sandbox/PostgresSandboxExecutionGuardTest.java
@@ -1,0 +1,317 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.extensions.postgresql.sandbox;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.agentscope.harness.agent.IsolationScope;
+import io.agentscope.harness.agent.sandbox.SandboxIsolationKey;
+import io.agentscope.harness.agent.sandbox.SandboxLease;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.time.Duration;
+import javax.sql.DataSource;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+class PostgresSandboxExecutionGuardTest {
+
+    @Mock private DataSource dataSource;
+    @Mock private Connection connection;
+    @Mock private PreparedStatement preparedStatement;
+    @Mock private ResultSet resultSet;
+
+    private AutoCloseable mocks;
+
+    @BeforeEach
+    void setUp() throws SQLException {
+        mocks = MockitoAnnotations.openMocks(this);
+        when(dataSource.getConnection()).thenReturn(connection);
+        when(connection.prepareStatement(anyString())).thenReturn(preparedStatement);
+        when(preparedStatement.executeQuery()).thenReturn(resultSet);
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        reset(dataSource, connection, preparedStatement, resultSet);
+        if (mocks != null) {
+            mocks.close();
+        }
+    }
+
+    private SandboxIsolationKey key() {
+        return SandboxIsolationKey.resolve(
+                        IsolationScope.SESSION,
+                        new io.agentscope.core.agent.RuntimeContext.Builder()
+                                .sessionId("session-1")
+                                .build(),
+                        "agent")
+                .orElseThrow();
+    }
+
+    @Test
+    void builderRejectsNullDataSource() {
+        assertThrows(NullPointerException.class, () -> PostgresSandboxExecutionGuard.builder(null));
+    }
+
+    @Test
+    void builderWithDefaultsCreatesGuard() {
+        PostgresSandboxExecutionGuard guard =
+                PostgresSandboxExecutionGuard.builder(dataSource).build();
+        assertNotNull(guard);
+    }
+
+    @Test
+    void builderWithCustomKeyPrefix() {
+        PostgresSandboxExecutionGuard guard =
+                PostgresSandboxExecutionGuard.builder(dataSource)
+                        .keyPrefix("custom:prefix")
+                        .build();
+        assertNotNull(guard);
+    }
+
+    @Test
+    void builderWithKeyPrefixAlreadyEndingWithColon() {
+        PostgresSandboxExecutionGuard guard =
+                PostgresSandboxExecutionGuard.builder(dataSource)
+                        .keyPrefix("custom:prefix:")
+                        .build();
+        assertNotNull(guard);
+    }
+
+    @Test
+    void builderWithCustomTimeout() {
+        PostgresSandboxExecutionGuard guard =
+                PostgresSandboxExecutionGuard.builder(dataSource)
+                        .lockTimeout(Duration.ofSeconds(5))
+                        .build();
+        assertNotNull(guard);
+    }
+
+    @Test
+    void builderRejectsBlankKeyPrefix() {
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> PostgresSandboxExecutionGuard.builder(dataSource).keyPrefix("").build());
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> PostgresSandboxExecutionGuard.builder(dataSource).keyPrefix("  ").build());
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> PostgresSandboxExecutionGuard.builder(dataSource).keyPrefix(null).build());
+    }
+
+    @Test
+    void builderRejectsNonPositiveTimeout() {
+        assertThrows(
+                IllegalArgumentException.class,
+                () ->
+                        PostgresSandboxExecutionGuard.builder(dataSource)
+                                .lockTimeout(Duration.ZERO)
+                                .build());
+        assertThrows(
+                IllegalArgumentException.class,
+                () ->
+                        PostgresSandboxExecutionGuard.builder(dataSource)
+                                .lockTimeout(Duration.ofSeconds(-1))
+                                .build());
+    }
+
+    @Test
+    void tryEnterAcquiresLockAndReturnsLease() throws Exception {
+        PostgresSandboxExecutionGuard guard =
+                PostgresSandboxExecutionGuard.builder(dataSource).build();
+        when(resultSet.next()).thenReturn(true);
+        when(resultSet.getBoolean(1)).thenReturn(true);
+
+        SandboxLease lease = guard.tryEnter(key());
+
+        assertNotNull(lease);
+        verify(preparedStatement).setLong(eq(1), anyLong());
+    }
+
+    @Test
+    void tryEnterPollsUntilLockAcquired() throws Exception {
+        PostgresSandboxExecutionGuard guard =
+                PostgresSandboxExecutionGuard.builder(dataSource)
+                        .lockTimeout(Duration.ofSeconds(10))
+                        .build();
+        when(resultSet.next()).thenReturn(true, true, true);
+        when(resultSet.getBoolean(1)).thenReturn(false, false, true);
+
+        SandboxLease lease = guard.tryEnter(key());
+
+        assertNotNull(lease);
+    }
+
+    @Test
+    void tryEnterPollsWhenResultSetEmptyThenAcquires() throws Exception {
+        PostgresSandboxExecutionGuard guard =
+                PostgresSandboxExecutionGuard.builder(dataSource)
+                        .lockTimeout(Duration.ofSeconds(10))
+                        .build();
+        when(resultSet.next()).thenReturn(false, true);
+        when(resultSet.getBoolean(1)).thenReturn(true);
+
+        SandboxLease lease = guard.tryEnter(key());
+
+        assertNotNull(lease);
+    }
+
+    @Test
+    void tryEnterPropagatesResultSetCloseFailure() throws Exception {
+        PostgresSandboxExecutionGuard guard =
+                PostgresSandboxExecutionGuard.builder(dataSource)
+                        .lockTimeout(Duration.ofSeconds(10))
+                        .build();
+        when(resultSet.next()).thenReturn(false, true);
+        when(resultSet.getBoolean(1)).thenReturn(true);
+        doThrow(new SQLException("close failed")).when(resultSet).close();
+
+        assertThrows(RuntimeException.class, () -> guard.tryEnter(key()));
+    }
+
+    @Test
+    void tryEnterTimesOutWhenLockNeverAcquired() throws Exception {
+        PostgresSandboxExecutionGuard guard =
+                PostgresSandboxExecutionGuard.builder(dataSource)
+                        .lockTimeout(Duration.ofMillis(50))
+                        .build();
+        when(resultSet.next()).thenReturn(true);
+        when(resultSet.getBoolean(1)).thenReturn(false);
+
+        assertThrows(InterruptedException.class, () -> guard.tryEnter(key()));
+    }
+
+    @Test
+    void tryEnterWrapsSqlException() throws Exception {
+        PostgresSandboxExecutionGuard guard =
+                PostgresSandboxExecutionGuard.builder(dataSource).build();
+        when(dataSource.getConnection()).thenThrow(new SQLException("boom"));
+
+        assertThrows(RuntimeException.class, () -> guard.tryEnter(key()));
+    }
+
+    @Test
+    void leaseCloseReleasesLockAndClosesConnection() throws Exception {
+        PostgresSandboxExecutionGuard guard =
+                PostgresSandboxExecutionGuard.builder(dataSource).build();
+        when(resultSet.next()).thenReturn(true);
+        when(resultSet.getBoolean(1)).thenReturn(true);
+
+        SandboxLease lease = guard.tryEnter(key());
+        lease.close();
+
+        verify(preparedStatement, org.mockito.Mockito.atLeast(2)).setLong(eq(1), anyLong());
+        verify(connection).close();
+    }
+
+    @Test
+    void leaseCloseHandlesReleaseFailure() throws Exception {
+        PostgresSandboxExecutionGuard guard =
+                PostgresSandboxExecutionGuard.builder(dataSource).build();
+        when(resultSet.next()).thenReturn(true);
+        when(resultSet.getBoolean(1)).thenReturn(true);
+
+        SandboxLease lease = guard.tryEnter(key());
+        doThrow(new SQLException("release failed")).when(preparedStatement).executeQuery();
+        lease.close();
+
+        verify(connection).close();
+    }
+
+    @Test
+    void leaseCloseHandlesConnectionCloseFailure() throws Exception {
+        PostgresSandboxExecutionGuard guard =
+                PostgresSandboxExecutionGuard.builder(dataSource).build();
+        when(resultSet.next()).thenReturn(true);
+        when(resultSet.getBoolean(1)).thenReturn(true);
+
+        SandboxLease lease = guard.tryEnter(key());
+        doThrow(new SQLException("close failed")).when(connection).close();
+
+        lease.close();
+
+        verify(connection).close();
+    }
+
+    @Test
+    void tryEnterHandlesInnerSQLException() throws Exception {
+        PostgresSandboxExecutionGuard guard =
+                PostgresSandboxExecutionGuard.builder(dataSource).build();
+        when(connection.prepareStatement(anyString())).thenThrow(new SQLException("boom"));
+
+        assertThrows(RuntimeException.class, () -> guard.tryEnter(key()));
+    }
+
+    @Test
+    void tryEnterHandlesInnerInterruptedException() throws Exception {
+        PostgresSandboxExecutionGuard guard =
+                PostgresSandboxExecutionGuard.builder(dataSource)
+                        .lockTimeout(Duration.ofSeconds(10))
+                        .build();
+        when(resultSet.next()).thenReturn(true);
+        when(resultSet.getBoolean(1)).thenReturn(false);
+
+        Thread.currentThread().interrupt();
+        try {
+            assertThrows(InterruptedException.class, () -> guard.tryEnter(key()));
+        } finally {
+            Thread.interrupted();
+        }
+    }
+
+    @Test
+    void tryEnterHandlesInnerSQLExceptionAndCloseFailure() throws Exception {
+        PostgresSandboxExecutionGuard guard =
+                PostgresSandboxExecutionGuard.builder(dataSource).build();
+        when(connection.prepareStatement(anyString())).thenThrow(new SQLException("boom"));
+        doThrow(new SQLException("close failed")).when(connection).close();
+
+        assertThrows(RuntimeException.class, () -> guard.tryEnter(key()));
+    }
+
+    @Test
+    void tryEnterHandlesInnerInterruptedExceptionAndCloseFailure() throws Exception {
+        PostgresSandboxExecutionGuard guard =
+                PostgresSandboxExecutionGuard.builder(dataSource)
+                        .lockTimeout(Duration.ofSeconds(10))
+                        .build();
+        when(resultSet.next()).thenReturn(true);
+        when(resultSet.getBoolean(1)).thenReturn(false);
+        doThrow(new SQLException("close failed")).when(connection).close();
+
+        Thread.currentThread().interrupt();
+        try {
+            assertThrows(InterruptedException.class, () -> guard.tryEnter(key()));
+        } finally {
+            Thread.interrupted();
+        }
+    }
+}

--- a/agentscope-extensions/agentscope-extensions-postgresql/src/test/java/io/agentscope/extensions/postgresql/snapshot/PostgresRemoteSnapshotClientTest.java
+++ b/agentscope-extensions/agentscope-extensions-postgresql/src/test/java/io/agentscope/extensions/postgresql/snapshot/PostgresRemoteSnapshotClientTest.java
@@ -1,0 +1,201 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.extensions.postgresql.snapshot;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.agentscope.harness.agent.sandbox.snapshot.RemoteSnapshotSpec;
+import java.io.ByteArrayInputStream;
+import java.io.FileNotFoundException;
+import java.io.InputStream;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import javax.sql.DataSource;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+class PostgresRemoteSnapshotClientTest {
+
+    @Mock private DataSource dataSource;
+    @Mock private Connection connection;
+    @Mock private Statement statement;
+    @Mock private PreparedStatement preparedStatement;
+    @Mock private ResultSet resultSet;
+
+    private AutoCloseable mocks;
+
+    @BeforeEach
+    void setUp() throws SQLException {
+        mocks = MockitoAnnotations.openMocks(this);
+        when(dataSource.getConnection()).thenReturn(connection);
+        when(connection.createStatement()).thenReturn(statement);
+        when(connection.prepareStatement(anyString())).thenReturn(preparedStatement);
+        when(preparedStatement.executeQuery()).thenReturn(resultSet);
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        if (mocks != null) {
+            mocks.close();
+        }
+    }
+
+    @Test
+    void constructorWithDefaultTableInitializesSchema() throws SQLException {
+        new PostgresRemoteSnapshotClient(dataSource, true);
+        verify(statement).execute(anyString());
+    }
+
+    @Test
+    void constructorWithCustomTableInitializesSchema() throws SQLException {
+        new PostgresRemoteSnapshotClient(dataSource, "custom_snapshots", true);
+        verify(statement).execute(anyString());
+    }
+
+    @Test
+    void constructorDoesNotInitializeSchemaWhenFalse() throws SQLException {
+        new PostgresRemoteSnapshotClient(dataSource, false);
+        verify(statement, never()).execute(anyString());
+    }
+
+    @Test
+    void constructorWithNullTableNameUsesDefault() throws SQLException {
+        PostgresRemoteSnapshotClient client =
+                new PostgresRemoteSnapshotClient(dataSource, null, false);
+        assertNotNull(client);
+    }
+
+    @Test
+    void constructorRejectsNullDataSource() {
+        assertThrows(
+                NullPointerException.class, () -> new PostgresRemoteSnapshotClient(null, true));
+    }
+
+    @Test
+    void uploadReadsStreamAndExecutesUpsert() throws Exception {
+        PostgresRemoteSnapshotClient client = new PostgresRemoteSnapshotClient(dataSource, false);
+        when(preparedStatement.executeUpdate()).thenReturn(1);
+
+        byte[] data = "snapshot-data".getBytes();
+        client.upload("snap-1", new ByteArrayInputStream(data));
+
+        verify(preparedStatement).setString(1, "snap-1");
+        verify(preparedStatement).setBytes(2, data);
+        verify(preparedStatement).executeUpdate();
+    }
+
+    @Test
+    void uploadRejectsNullSnapshotId() {
+        PostgresRemoteSnapshotClient client = new PostgresRemoteSnapshotClient(dataSource, false);
+        assertThrows(
+                NullPointerException.class,
+                () -> client.upload(null, new ByteArrayInputStream(new byte[0])));
+    }
+
+    @Test
+    void uploadRejectsNullData() {
+        PostgresRemoteSnapshotClient client = new PostgresRemoteSnapshotClient(dataSource, false);
+        assertThrows(NullPointerException.class, () -> client.upload("snap-1", null));
+    }
+
+    @Test
+    void downloadReturnsByteArrayInputStream() throws Exception {
+        PostgresRemoteSnapshotClient client = new PostgresRemoteSnapshotClient(dataSource, false);
+        byte[] data = "downloaded".getBytes();
+        when(resultSet.next()).thenReturn(true);
+        when(resultSet.getBytes("data")).thenReturn(data);
+
+        InputStream is = client.download("snap-1");
+        assertArrayEquals(data, is.readAllBytes());
+    }
+
+    @Test
+    void downloadThrowsWhenSnapshotMissing() throws Exception {
+        PostgresRemoteSnapshotClient client = new PostgresRemoteSnapshotClient(dataSource, false);
+        when(resultSet.next()).thenReturn(false);
+
+        assertThrows(FileNotFoundException.class, () -> client.download("snap-1"));
+    }
+
+    @Test
+    void existsReturnsTrue() throws Exception {
+        PostgresRemoteSnapshotClient client = new PostgresRemoteSnapshotClient(dataSource, false);
+        when(resultSet.next()).thenReturn(true);
+        assertTrue(client.exists("snap-1"));
+    }
+
+    @Test
+    void existsReturnsFalse() throws Exception {
+        PostgresRemoteSnapshotClient client = new PostgresRemoteSnapshotClient(dataSource, false);
+        when(resultSet.next()).thenReturn(false);
+        assertFalse(client.exists("snap-1"));
+    }
+
+    @Test
+    void existsRejectsNullSnapshotId() {
+        PostgresRemoteSnapshotClient client = new PostgresRemoteSnapshotClient(dataSource, false);
+        assertThrows(NullPointerException.class, () -> client.exists(null));
+    }
+
+    @Test
+    void initSchemaFailureIsLogged() throws SQLException {
+        when(connection.createStatement()).thenThrow(new SQLException("boom"));
+        assertNotNull(new PostgresRemoteSnapshotClient(dataSource, true));
+    }
+
+    @Test
+    void snapshotSpecWithCustomTableName() throws SQLException {
+        RemoteSnapshotSpec spec = new PostgresSnapshotSpec(dataSource, "custom_snapshots");
+        assertNotNull(spec);
+    }
+
+    @Test
+    void uploadThrowsWhenSqlFails() throws SQLException {
+        PostgresRemoteSnapshotClient client = new PostgresRemoteSnapshotClient(dataSource, false);
+        when(dataSource.getConnection()).thenThrow(new SQLException("boom"));
+        assertThrows(
+                SQLException.class,
+                () -> client.upload("snap-1", new ByteArrayInputStream(new byte[0])));
+    }
+
+    @Test
+    void downloadThrowsWhenSqlFails() throws SQLException {
+        PostgresRemoteSnapshotClient client = new PostgresRemoteSnapshotClient(dataSource, false);
+        when(dataSource.getConnection()).thenThrow(new SQLException("boom"));
+        assertThrows(SQLException.class, () -> client.download("snap-1"));
+    }
+
+    @Test
+    void existsThrowsWhenSqlFails() throws SQLException {
+        PostgresRemoteSnapshotClient client = new PostgresRemoteSnapshotClient(dataSource, false);
+        when(dataSource.getConnection()).thenThrow(new SQLException("boom"));
+        assertThrows(SQLException.class, () -> client.exists("snap-1"));
+    }
+}

--- a/agentscope-extensions/agentscope-extensions-postgresql/src/test/java/io/agentscope/extensions/postgresql/state/PostgresAgentStateStoreTest.java
+++ b/agentscope-extensions/agentscope-extensions-postgresql/src/test/java/io/agentscope/extensions/postgresql/state/PostgresAgentStateStoreTest.java
@@ -1,0 +1,707 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.extensions.postgresql.state;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.agentscope.core.state.State;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import javax.sql.DataSource;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+class PostgresAgentStateStoreTest {
+
+    record TestState(String value) implements State {}
+
+    @Mock private DataSource dataSource;
+    @Mock private Connection connection;
+    @Mock private Statement statement;
+    @Mock private PreparedStatement preparedStatement;
+    @Mock private ResultSet resultSet;
+
+    private AutoCloseable mocks;
+
+    @BeforeEach
+    void setUp() throws SQLException {
+        mocks = MockitoAnnotations.openMocks(this);
+        when(dataSource.getConnection()).thenReturn(connection);
+        when(connection.createStatement()).thenReturn(statement);
+        when(connection.prepareStatement(anyString())).thenReturn(preparedStatement);
+        when(connection.prepareStatement(anyString(), anyInt())).thenReturn(preparedStatement);
+        when(preparedStatement.executeQuery()).thenReturn(resultSet);
+        when(preparedStatement.execute()).thenReturn(true);
+        when(preparedStatement.executeUpdate()).thenReturn(1);
+        when(resultSet.next()).thenReturn(true, true);
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        reset(dataSource, connection, statement, preparedStatement, resultSet);
+        if (mocks != null) {
+            mocks.close();
+        }
+    }
+
+    @Test
+    void builderRejectsNullDataSource() {
+        assertThrows(IllegalArgumentException.class, () -> PostgresAgentStateStore.builder(null));
+    }
+
+    @Test
+    void builderWithDefaultsCreatesStore() {
+        PostgresAgentStateStore store = PostgresAgentStateStore.builder(dataSource).build();
+        assertNotNull(store);
+        assertEquals("agentscope", store.getSchemaName());
+        assertEquals("agentscope_sessions", store.getTableName());
+        assertEquals(dataSource, store.getDataSource());
+    }
+
+    @Test
+    void builderWithCustomNames() {
+        PostgresAgentStateStore store =
+                PostgresAgentStateStore.builder(dataSource)
+                        .schemaName("custom_schema")
+                        .tableName("custom_sessions")
+                        .createIfNotExist(false)
+                        .build();
+        assertEquals("custom_schema", store.getSchemaName());
+        assertEquals("custom_sessions", store.getTableName());
+    }
+
+    @Test
+    void builderNullNamesFallbackToDefaults() {
+        PostgresAgentStateStore store =
+                PostgresAgentStateStore.builder(dataSource)
+                        .schemaName(null)
+                        .tableName(null)
+                        .build();
+        assertEquals("agentscope", store.getSchemaName());
+        assertEquals("agentscope_sessions", store.getTableName());
+    }
+
+    @Test
+    void builderBlankNamesFallbackToDefaults() {
+        PostgresAgentStateStore store =
+                PostgresAgentStateStore.builder(dataSource).schemaName("  ").tableName("").build();
+        assertEquals("agentscope", store.getSchemaName());
+        assertEquals("agentscope_sessions", store.getTableName());
+    }
+
+    @Test
+    void constructorDefaultsDoNotAutoCreate() throws SQLException {
+        PostgresAgentStateStore store = new PostgresAgentStateStore(dataSource);
+        assertNotNull(store);
+        verify(connection, never()).createStatement();
+    }
+
+    @Test
+    void constructorWithAutoCreate() throws SQLException {
+        PostgresAgentStateStore store = new PostgresAgentStateStore(dataSource, true);
+        assertNotNull(store);
+        verify(preparedStatement, atLeastOnce()).execute();
+    }
+
+    @Test
+    void rejectsNullDataSourceInConstructor() {
+        assertThrows(IllegalArgumentException.class, () -> new PostgresAgentStateStore(null, true));
+    }
+
+    @Test
+    void rejectsInvalidSchemaName() {
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> PostgresAgentStateStore.builder(dataSource).schemaName("bad-schema").build());
+    }
+
+    @Test
+    void rejectsTooLongIdentifier() {
+        String longName = "a".repeat(64);
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> PostgresAgentStateStore.builder(dataSource).schemaName(longName).build());
+    }
+
+    @Test
+    void rejectsInvalidTableName() {
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> PostgresAgentStateStore.builder(dataSource).tableName("bad;table").build());
+    }
+
+    @Test
+    void createSchemaFailureThrows() throws SQLException {
+        when(connection.prepareStatement(anyString())).thenReturn(preparedStatement);
+        doThrow(new SQLException("boom")).when(preparedStatement).execute();
+        assertThrows(
+                RuntimeException.class,
+                () -> PostgresAgentStateStore.builder(dataSource).createIfNotExist(true).build());
+    }
+
+    @Test
+    void createTableFailureThrows() throws SQLException {
+        when(connection.prepareStatement(anyString()))
+                .thenReturn(preparedStatement)
+                .thenThrow(new SQLException("boom"));
+        assertThrows(
+                RuntimeException.class,
+                () -> PostgresAgentStateStore.builder(dataSource).createIfNotExist(true).build());
+    }
+
+    @Test
+    void verifySchemaMissingThrows() throws SQLException {
+        when(resultSet.next()).thenReturn(false);
+        assertThrows(
+                IllegalStateException.class,
+                () -> PostgresAgentStateStore.builder(dataSource).createIfNotExist(false).build());
+    }
+
+    @Test
+    void verifyTableMissingThrows() throws SQLException {
+        when(resultSet.next()).thenReturn(true, false);
+        assertThrows(
+                IllegalStateException.class,
+                () -> PostgresAgentStateStore.builder(dataSource).createIfNotExist(false).build());
+    }
+
+    @Test
+    void verifySchemaSqlExceptionThrows() throws SQLException {
+        when(preparedStatement.executeQuery()).thenThrow(new SQLException("boom"));
+        assertThrows(
+                RuntimeException.class,
+                () -> PostgresAgentStateStore.builder(dataSource).createIfNotExist(false).build());
+    }
+
+    @Test
+    void saveSingleState() throws SQLException {
+        PostgresAgentStateStore store =
+                PostgresAgentStateStore.builder(dataSource).createIfNotExist(false).build();
+        when(preparedStatement.executeUpdate()).thenReturn(1);
+
+        store.save("user", "session", "key", new TestState("value"));
+
+        verify(preparedStatement).setString(1, "user:session");
+        verify(preparedStatement).setString(2, "key");
+        verify(preparedStatement).setInt(3, 0);
+        verify(preparedStatement).setString(4, "{\"value\":\"value\"}");
+    }
+
+    @Test
+    void saveSingleStateThrowsWhenSqlFails() throws SQLException {
+        PostgresAgentStateStore store =
+                PostgresAgentStateStore.builder(dataSource).createIfNotExist(false).build();
+        when(dataSource.getConnection()).thenThrow(new SQLException("boom"));
+        assertThrows(
+                RuntimeException.class,
+                () -> store.save("user", "session", "key", new TestState("value")));
+    }
+
+    @Test
+    void saveListAppendsNewItems() throws SQLException {
+        PostgresAgentStateStore store =
+                PostgresAgentStateStore.builder(dataSource).createIfNotExist(false).build();
+        when(preparedStatement.executeUpdate()).thenReturn(1);
+        when(preparedStatement.executeBatch()).thenReturn(new int[] {1});
+        when(resultSet.next())
+                .thenReturn(true, false, true, false); // hash exists, count, then hash save
+        when(resultSet.getString("state_data")).thenReturn(null);
+        when(resultSet.getInt("max_index")).thenReturn(-1);
+
+        store.save("user", "session", "list", List.of(new TestState("a"), new TestState("b")));
+
+        verify(preparedStatement, atLeastOnce()).executeBatch();
+    }
+
+    @Test
+    void saveListEmptyDoesNothing() throws SQLException {
+        PostgresAgentStateStore store =
+                PostgresAgentStateStore.builder(dataSource).createIfNotExist(false).build();
+        store.save("user", "session", "list", List.of());
+        verify(preparedStatement, never()).executeBatch();
+    }
+
+    @Test
+    void getSingleState() throws Exception {
+        PostgresAgentStateStore store =
+                PostgresAgentStateStore.builder(dataSource).createIfNotExist(false).build();
+        when(resultSet.next()).thenReturn(true);
+        when(resultSet.getString("state_data")).thenReturn("{\"value\":\"found\"}");
+
+        Optional<TestState> result = store.get("user", "session", "key", TestState.class);
+
+        assertTrue(result.isPresent());
+        assertEquals("found", result.get().value());
+    }
+
+    @Test
+    void getSingleStateReturnsEmptyWhenMissing() throws Exception {
+        PostgresAgentStateStore store =
+                PostgresAgentStateStore.builder(dataSource).createIfNotExist(false).build();
+        when(resultSet.next()).thenReturn(false);
+
+        Optional<TestState> result = store.get("user", "session", "key", TestState.class);
+
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void getList() throws Exception {
+        PostgresAgentStateStore store =
+                PostgresAgentStateStore.builder(dataSource).createIfNotExist(false).build();
+        when(resultSet.next()).thenReturn(true, true, false);
+        when(resultSet.getString("state_data"))
+                .thenReturn("{\"value\":\"a\"}", "{\"value\":\"b\"}");
+
+        List<TestState> result = store.getList("user", "session", "list", TestState.class);
+
+        assertEquals(2, result.size());
+        assertEquals("a", result.get(0).value());
+        assertEquals("b", result.get(1).value());
+    }
+
+    @Test
+    void existsTrue() throws SQLException {
+        PostgresAgentStateStore store =
+                PostgresAgentStateStore.builder(dataSource).createIfNotExist(false).build();
+        when(resultSet.next()).thenReturn(true);
+        assertTrue(store.exists("user", "session"));
+    }
+
+    @Test
+    void existsFalse() throws SQLException {
+        PostgresAgentStateStore store =
+                PostgresAgentStateStore.builder(dataSource).createIfNotExist(false).build();
+        when(resultSet.next()).thenReturn(false);
+        assertFalse(store.exists("user", "session"));
+    }
+
+    @Test
+    void deleteSession() throws SQLException {
+        PostgresAgentStateStore store =
+                PostgresAgentStateStore.builder(dataSource).createIfNotExist(false).build();
+        when(preparedStatement.executeUpdate()).thenReturn(1);
+
+        store.delete("user", "session");
+
+        verify(preparedStatement).setString(1, "user:session");
+    }
+
+    @Test
+    void listSessionIds() throws SQLException {
+        PostgresAgentStateStore store =
+                PostgresAgentStateStore.builder(dataSource).createIfNotExist(false).build();
+        when(resultSet.next()).thenReturn(true, true, false);
+        when(resultSet.getString("session_id")).thenReturn("user:s1", "user:s2");
+
+        Set<String> ids = store.listSessionIds("user");
+
+        assertEquals(Set.of("s1", "s2"), ids);
+    }
+
+    @Test
+    void listSessionIdsForAnonymousUser() throws SQLException {
+        PostgresAgentStateStore store =
+                PostgresAgentStateStore.builder(dataSource).createIfNotExist(false).build();
+        when(resultSet.next()).thenReturn(true, false);
+        when(resultSet.getString("session_id")).thenReturn("__anon__:s1");
+
+        Set<String> ids = store.listSessionIds(null);
+
+        assertEquals(Set.of("s1"), ids);
+    }
+
+    @Test
+    void listSessionIdsForBlankUser() throws SQLException {
+        PostgresAgentStateStore store =
+                PostgresAgentStateStore.builder(dataSource).createIfNotExist(false).build();
+        when(resultSet.next()).thenReturn(true, false);
+        when(resultSet.getString("session_id")).thenReturn("__anon__:s1");
+
+        Set<String> ids = store.listSessionIds("  ");
+
+        assertEquals(Set.of("s1"), ids);
+    }
+
+    @Test
+    void rejectsNullSessionId() {
+        PostgresAgentStateStore store =
+                PostgresAgentStateStore.builder(dataSource).createIfNotExist(false).build();
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> store.save("user", null, "key", new TestState("v")));
+    }
+
+    @Test
+    void rejectsBlankSessionId() {
+        PostgresAgentStateStore store =
+                PostgresAgentStateStore.builder(dataSource).createIfNotExist(false).build();
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> store.save("user", "  ", "key", new TestState("v")));
+    }
+
+    @Test
+    void validateSessionIdRejectsNullOrEmpty() {
+        PostgresAgentStateStore store =
+                PostgresAgentStateStore.builder(dataSource).createIfNotExist(false).build();
+        assertThrows(IllegalArgumentException.class, () -> store.validateSessionId(null));
+        assertThrows(IllegalArgumentException.class, () -> store.validateSessionId("  "));
+    }
+
+    @Test
+    void rejectsSessionIdWithPathSeparators() {
+        PostgresAgentStateStore store =
+                PostgresAgentStateStore.builder(dataSource).createIfNotExist(false).build();
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> store.save("user", "a/b", "key", new TestState("v")));
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> store.save("user", "a\\b", "key", new TestState("v")));
+    }
+
+    @Test
+    void rejectsTooLongSessionId() {
+        PostgresAgentStateStore store =
+                PostgresAgentStateStore.builder(dataSource).createIfNotExist(false).build();
+        String longId = "a".repeat(256);
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> store.save("user", longId, "key", new TestState("v")));
+    }
+
+    @Test
+    void rejectsNullStateKey() {
+        PostgresAgentStateStore store =
+                PostgresAgentStateStore.builder(dataSource).createIfNotExist(false).build();
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> store.save("user", "session", null, new TestState("v")));
+    }
+
+    @Test
+    void closeIsNoOp() {
+        PostgresAgentStateStore store =
+                PostgresAgentStateStore.builder(dataSource).createIfNotExist(false).build();
+        store.close();
+    }
+
+    @Test
+    void executeInWriteTransactionRollsBackOnException() throws SQLException {
+        PostgresAgentStateStore store =
+                PostgresAgentStateStore.builder(dataSource).createIfNotExist(false).build();
+        when(connection.getAutoCommit()).thenReturn(true, false);
+        when(preparedStatement.executeUpdate()).thenThrow(new SQLException("boom"));
+
+        assertThrows(RuntimeException.class, () -> store.delete("user", "session"));
+        verify(connection).rollback();
+        verify(connection).setAutoCommit(true);
+    }
+
+    @Test
+    void verifyTableExistenceSqlExceptionThrows() throws SQLException {
+        when(preparedStatement.executeQuery())
+                .thenReturn(resultSet)
+                .thenThrow(new SQLException("boom"));
+        assertThrows(
+                RuntimeException.class,
+                () -> PostgresAgentStateStore.builder(dataSource).createIfNotExist(false).build());
+    }
+
+    @Test
+    void rollbackFailureIsAddedAsSuppressed() throws SQLException {
+        PostgresAgentStateStore store =
+                PostgresAgentStateStore.builder(dataSource).createIfNotExist(false).build();
+        when(connection.getAutoCommit()).thenReturn(true, false);
+        SQLException rollbackException = new SQLException("rollback failed");
+        when(preparedStatement.executeUpdate()).thenThrow(new SQLException("boom"));
+        doThrow(rollbackException).when(connection).rollback();
+
+        RuntimeException exception =
+                assertThrows(RuntimeException.class, () -> store.delete("user", "session"));
+        assertTrue(
+                java.util.Arrays.stream(exception.getCause().getSuppressed())
+                        .anyMatch(t -> t == rollbackException));
+    }
+
+    @Test
+    void saveListThrowsWhenSqlFails() throws SQLException {
+        PostgresAgentStateStore store =
+                PostgresAgentStateStore.builder(dataSource).createIfNotExist(false).build();
+        when(dataSource.getConnection()).thenThrow(new SQLException("boom"));
+        assertThrows(
+                RuntimeException.class,
+                () -> store.save("user", "session", "list", List.of(new TestState("a"))));
+    }
+
+    @Test
+    void saveListFullRewriteWhenHashChanged() throws SQLException {
+        PostgresAgentStateStore store =
+                PostgresAgentStateStore.builder(dataSource).createIfNotExist(false).build();
+        when(preparedStatement.executeUpdate()).thenReturn(1);
+        when(preparedStatement.executeBatch()).thenReturn(new int[] {1, 1});
+        when(resultSet.next()).thenReturn(true, true, false);
+        when(resultSet.getString("state_data")).thenReturn("different_hash");
+        when(resultSet.getInt("max_index")).thenReturn(1);
+
+        store.save("user", "session", "list", List.of(new TestState("a"), new TestState("b")));
+
+        verify(preparedStatement, atLeastOnce()).executeBatch();
+    }
+
+    @Test
+    void saveListHashNotFound() throws SQLException {
+        PostgresAgentStateStore store =
+                PostgresAgentStateStore.builder(dataSource).createIfNotExist(false).build();
+        when(preparedStatement.executeUpdate()).thenReturn(1);
+        when(preparedStatement.executeBatch()).thenReturn(new int[] {1});
+        when(resultSet.next()).thenReturn(false, true);
+        when(resultSet.getInt("max_index")).thenReturn(2);
+
+        store.save(
+                "user",
+                "session",
+                "list",
+                List.of(new TestState("a"), new TestState("b"), new TestState("c")));
+
+        verify(preparedStatement, atLeastOnce()).executeBatch();
+    }
+
+    @Test
+    void saveListSkipsWhenHashMatchesAndSizeUnchanged() throws SQLException {
+        PostgresAgentStateStore store =
+                PostgresAgentStateStore.builder(dataSource).createIfNotExist(false).build();
+        when(preparedStatement.executeUpdate()).thenReturn(1);
+        when(resultSet.next()).thenReturn(true, true);
+        when(resultSet.getString("state_data"))
+                .thenReturn(
+                        io.agentscope.core.state.ListHashUtil.computeHash(
+                                List.of(new TestState("a"), new TestState("b"))));
+        when(resultSet.getInt("max_index")).thenReturn(1);
+
+        store.save("user", "session", "list", List.of(new TestState("a"), new TestState("b")));
+
+        verify(preparedStatement, never()).executeBatch();
+    }
+
+    @Test
+    void getListCountReturnsZeroWhenNoRows() throws SQLException {
+        PostgresAgentStateStore store =
+                PostgresAgentStateStore.builder(dataSource).createIfNotExist(false).build();
+        when(preparedStatement.executeUpdate()).thenReturn(1);
+        when(preparedStatement.executeBatch()).thenReturn(new int[] {1, 1});
+        when(resultSet.next()).thenReturn(false, false);
+
+        store.save("user", "session", "list", List.of(new TestState("a"), new TestState("b")));
+
+        verify(preparedStatement, atLeastOnce()).executeBatch();
+    }
+
+    @Test
+    void executeInWriteTransactionKeepsAutoCommitWhenAlreadyDisabled() throws SQLException {
+        PostgresAgentStateStore store =
+                PostgresAgentStateStore.builder(dataSource).createIfNotExist(false).build();
+        when(connection.getAutoCommit()).thenReturn(false);
+        when(preparedStatement.executeUpdate()).thenReturn(1);
+
+        store.delete("user", "session");
+
+        verify(connection, never()).setAutoCommit(false);
+        verify(connection).commit();
+    }
+
+    @Test
+    void getListCountReturnsZeroWhenMaxIndexNull() throws SQLException {
+        PostgresAgentStateStore store =
+                PostgresAgentStateStore.builder(dataSource).createIfNotExist(false).build();
+        when(preparedStatement.executeUpdate()).thenReturn(1);
+        when(preparedStatement.executeBatch()).thenReturn(new int[] {1});
+        when(resultSet.next()).thenReturn(false, true);
+        when(resultSet.getInt("max_index")).thenReturn(0);
+        when(resultSet.wasNull()).thenReturn(true);
+
+        store.save("user", "session", "list", List.of(new TestState("a")));
+
+        verify(preparedStatement, atLeastOnce()).executeBatch();
+    }
+
+    @Test
+    void getThrowsWhenSqlFails() throws SQLException {
+        PostgresAgentStateStore store =
+                PostgresAgentStateStore.builder(dataSource).createIfNotExist(false).build();
+        when(dataSource.getConnection()).thenThrow(new SQLException("boom"));
+        assertThrows(
+                RuntimeException.class, () -> store.get("user", "session", "key", TestState.class));
+    }
+
+    @Test
+    void getThrowsWhenJsonInvalid() throws SQLException {
+        PostgresAgentStateStore store =
+                PostgresAgentStateStore.builder(dataSource).createIfNotExist(false).build();
+        when(resultSet.next()).thenReturn(true);
+        when(resultSet.getString("state_data")).thenReturn("not-json");
+
+        assertThrows(
+                RuntimeException.class, () -> store.get("user", "session", "key", TestState.class));
+    }
+
+    @Test
+    void getThrowsWhenQueryFails() throws SQLException {
+        PostgresAgentStateStore store =
+                PostgresAgentStateStore.builder(dataSource).createIfNotExist(false).build();
+        when(preparedStatement.executeQuery()).thenThrow(new SQLException("boom"));
+
+        assertThrows(
+                RuntimeException.class, () -> store.get("user", "session", "key", TestState.class));
+    }
+
+    @Test
+    void getThrowsWhenResultSetReadFails() throws SQLException {
+        PostgresAgentStateStore store =
+                PostgresAgentStateStore.builder(dataSource).createIfNotExist(false).build();
+        when(resultSet.next()).thenReturn(true);
+        when(resultSet.getString("state_data")).thenThrow(new SQLException("read failed"));
+
+        assertThrows(
+                RuntimeException.class, () -> store.get("user", "session", "key", TestState.class));
+    }
+
+    @Test
+    void getPropagatesResultSetCloseFailure() throws SQLException {
+        PostgresAgentStateStore store =
+                PostgresAgentStateStore.builder(dataSource).createIfNotExist(false).build();
+        when(resultSet.next()).thenReturn(false);
+        doThrow(new SQLException("close failed")).when(resultSet).close();
+
+        assertThrows(
+                RuntimeException.class, () -> store.get("user", "session", "key", TestState.class));
+    }
+
+    @Test
+    void saveListPropagatesResultSetCloseFailure() throws SQLException {
+        PostgresAgentStateStore store =
+                PostgresAgentStateStore.builder(dataSource).createIfNotExist(false).build();
+        when(resultSet.next()).thenReturn(false);
+        doThrow(new SQLException("close failed")).when(resultSet).close();
+
+        assertThrows(
+                RuntimeException.class,
+                () -> store.save("user", "session", "list", List.of(new TestState("a"))));
+    }
+
+    @Test
+    void getListCountUsesMaxIndexWhenPresent() throws SQLException {
+        PostgresAgentStateStore store =
+                PostgresAgentStateStore.builder(dataSource).createIfNotExist(false).build();
+        when(preparedStatement.executeUpdate()).thenReturn(1);
+        when(preparedStatement.executeBatch()).thenReturn(new int[] {1});
+        when(resultSet.next()).thenReturn(true, true);
+        when(resultSet.getString("state_data")).thenReturn("stale_hash");
+        when(resultSet.getInt("max_index")).thenReturn(0);
+        when(resultSet.wasNull()).thenReturn(false);
+
+        store.save("user", "session", "list", List.of(new TestState("only")));
+
+        verify(preparedStatement, atLeastOnce()).executeBatch();
+    }
+
+    @Test
+    void getListThrowsWhenSqlFails() throws SQLException {
+        PostgresAgentStateStore store =
+                PostgresAgentStateStore.builder(dataSource).createIfNotExist(false).build();
+        when(dataSource.getConnection()).thenThrow(new SQLException("boom"));
+        assertThrows(
+                RuntimeException.class,
+                () -> store.getList("user", "session", "list", TestState.class));
+    }
+
+    @Test
+    void existsThrowsWhenSqlFails() throws SQLException {
+        PostgresAgentStateStore store =
+                PostgresAgentStateStore.builder(dataSource).createIfNotExist(false).build();
+        when(dataSource.getConnection()).thenThrow(new SQLException("boom"));
+        assertThrows(RuntimeException.class, () -> store.exists("user", "session"));
+    }
+
+    @Test
+    void listSessionIdsThrowsWhenSqlFails() throws SQLException {
+        PostgresAgentStateStore store =
+                PostgresAgentStateStore.builder(dataSource).createIfNotExist(false).build();
+        when(dataSource.getConnection()).thenThrow(new SQLException("boom"));
+        assertThrows(RuntimeException.class, () -> store.listSessionIds("user"));
+    }
+
+    @Test
+    void rejectsEmptyStateKey() {
+        PostgresAgentStateStore store =
+                PostgresAgentStateStore.builder(dataSource).createIfNotExist(false).build();
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> store.save("user", "session", "  ", new TestState("v")));
+    }
+
+    @Test
+    void rejectsTooLongStateKey() {
+        PostgresAgentStateStore store =
+                PostgresAgentStateStore.builder(dataSource).createIfNotExist(false).build();
+        String longKey = "a".repeat(256);
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> store.save("user", "session", longKey, new TestState("v")));
+    }
+
+    @Test
+    void truncateAllSessionsTruncatesTable() throws SQLException {
+        PostgresAgentStateStore store =
+                PostgresAgentStateStore.builder(dataSource).createIfNotExist(false).build();
+        when(preparedStatement.executeUpdate()).thenReturn(0);
+
+        int result = store.truncateAllSessions();
+
+        assertEquals(0, result);
+        verify(preparedStatement).executeUpdate();
+    }
+
+    @Test
+    void truncateAllSessionsThrowsWhenSqlFails() throws SQLException {
+        PostgresAgentStateStore store =
+                PostgresAgentStateStore.builder(dataSource).createIfNotExist(false).build();
+        when(dataSource.getConnection()).thenThrow(new SQLException("boom"));
+        assertThrows(RuntimeException.class, () -> store.truncateAllSessions());
+    }
+}

--- a/agentscope-extensions/agentscope-extensions-postgresql/src/test/java/io/agentscope/extensions/postgresql/store/PostgresBaseStoreTest.java
+++ b/agentscope-extensions/agentscope-extensions-postgresql/src/test/java/io/agentscope/extensions/postgresql/store/PostgresBaseStoreTest.java
@@ -1,0 +1,431 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.extensions.postgresql.store;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.agentscope.harness.agent.filesystem.remote.store.StoreItem;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.SQLIntegrityConstraintViolationException;
+import java.sql.Statement;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import javax.sql.DataSource;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+class PostgresBaseStoreTest {
+
+    @Mock private DataSource dataSource;
+    @Mock private Connection connection;
+    @Mock private Statement statement;
+    @Mock private PreparedStatement preparedStatement;
+    @Mock private ResultSet resultSet;
+
+    private AutoCloseable mocks;
+
+    @BeforeEach
+    void setUp() throws SQLException {
+        mocks = MockitoAnnotations.openMocks(this);
+        when(dataSource.getConnection()).thenReturn(connection);
+        when(connection.createStatement()).thenReturn(statement);
+        when(connection.prepareStatement(anyString())).thenReturn(preparedStatement);
+        when(connection.prepareStatement(anyString(), anyInt())).thenReturn(preparedStatement);
+        when(preparedStatement.executeQuery()).thenReturn(resultSet);
+        when(preparedStatement.getConnection()).thenReturn(connection);
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        reset(dataSource, connection, statement, preparedStatement, resultSet);
+        if (mocks != null) {
+            mocks.close();
+        }
+    }
+
+    @Test
+    void builderRejectsNullDataSource() {
+        assertThrows(NullPointerException.class, () -> PostgresBaseStore.builder(null));
+    }
+
+    @Test
+    void builderWithDefaultsCreatesStore() {
+        PostgresBaseStore store = PostgresBaseStore.builder(dataSource).build();
+        assertNotNull(store);
+    }
+
+    @Test
+    void builderWithCustomTableName() {
+        PostgresBaseStore store =
+                PostgresBaseStore.builder(dataSource).tableName("custom_store").build();
+        assertNotNull(store);
+    }
+
+    @Test
+    void builderRejectsInvalidTableName() {
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> PostgresBaseStore.builder(dataSource).tableName("store;drop").build());
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> PostgresBaseStore.builder(dataSource).tableName("").build());
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> PostgresBaseStore.builder(dataSource).tableName(null).build());
+    }
+
+    @Test
+    void initializeSchemaDefaultDoesNotCreateTable() throws SQLException {
+        PostgresBaseStore store = PostgresBaseStore.builder(dataSource).build();
+        assertNotNull(store);
+        verify(connection, org.mockito.Mockito.never()).createStatement();
+    }
+
+    @Test
+    void initializeSchemaTrueCreatesTable() throws SQLException {
+        PostgresBaseStore store =
+                PostgresBaseStore.builder(dataSource).initializeSchema(true).build();
+        assertNotNull(store);
+        verify(connection).createStatement();
+    }
+
+    @Test
+    void initializeSchemaFailureThrows() throws SQLException {
+        when(connection.createStatement()).thenThrow(new SQLException("boom"));
+        assertThrows(
+                IllegalStateException.class,
+                () -> PostgresBaseStore.builder(dataSource).initializeSchema(true).build());
+    }
+
+    @Test
+    void getReturnsItem() throws SQLException {
+        when(resultSet.next()).thenReturn(true);
+        when(resultSet.getString(1)).thenReturn("{\"k\":\"v\"}");
+        when(resultSet.getLong(2)).thenReturn(5L);
+
+        PostgresBaseStore store = PostgresBaseStore.builder(dataSource).build();
+        StoreItem item = store.get(List.of("a", "b"), "key");
+
+        assertNotNull(item);
+        assertEquals("key", item.key());
+        assertEquals("v", item.value().get("k"));
+        assertEquals(5L, item.version());
+    }
+
+    @Test
+    void getReturnsNullWhenNotFound() throws SQLException {
+        when(resultSet.next()).thenReturn(false);
+
+        PostgresBaseStore store = PostgresBaseStore.builder(dataSource).build();
+        assertNull(store.get(List.of("a"), "key"));
+    }
+
+    @Test
+    void getThrowsWhenSqlFails() throws SQLException {
+        PostgresBaseStore store = PostgresBaseStore.builder(dataSource).build();
+        when(dataSource.getConnection()).thenThrow(new SQLException("boom"));
+        assertThrows(IllegalStateException.class, () -> store.get(List.of("a"), "key"));
+    }
+
+    @Test
+    void getThrowsWhenQueryFails() throws SQLException {
+        PostgresBaseStore store = PostgresBaseStore.builder(dataSource).build();
+        when(preparedStatement.executeQuery()).thenThrow(new SQLException("boom"));
+        assertThrows(IllegalStateException.class, () -> store.get(List.of("a"), "key"));
+    }
+
+    @Test
+    void getPropagatesResultSetCloseFailure() throws SQLException {
+        when(resultSet.next()).thenReturn(false);
+        doThrow(new SQLException("close failed")).when(resultSet).close();
+
+        PostgresBaseStore store = PostgresBaseStore.builder(dataSource).build();
+        assertThrows(IllegalStateException.class, () -> store.get(List.of("a"), "key"));
+    }
+
+    @Test
+    void putWritesItem() throws SQLException {
+        when(preparedStatement.executeUpdate()).thenReturn(1);
+
+        PostgresBaseStore store = PostgresBaseStore.builder(dataSource).build();
+        store.put(List.of("a"), "key", Map.of("k", "v"));
+
+        verify(preparedStatement).setString(1, "a");
+        verify(preparedStatement).setString(2, "key");
+        verify(preparedStatement).setString(3, "{\"k\":\"v\"}");
+        verify(preparedStatement).setLong(eq(4), anyLong());
+        verify(preparedStatement).executeUpdate();
+    }
+
+    @Test
+    void putThrowsWhenSqlFails() throws SQLException {
+        PostgresBaseStore store = PostgresBaseStore.builder(dataSource).build();
+        when(dataSource.getConnection()).thenThrow(new SQLException("boom"));
+        assertThrows(IllegalStateException.class, () -> store.put(List.of("a"), "key", Map.of()));
+    }
+
+    @Test
+    void putIfVersionRejectsNegativeExpectedVersion() {
+        PostgresBaseStore store = PostgresBaseStore.builder(dataSource).build();
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> store.putIfVersion(List.of("a"), "key", Map.of(), -1L));
+    }
+
+    @Test
+    void putIfVersionInsertSucceeds() throws SQLException {
+        when(preparedStatement.executeUpdate()).thenReturn(1);
+
+        PostgresBaseStore store = PostgresBaseStore.builder(dataSource).build();
+        assertTrue(store.putIfVersion(List.of("a"), "key", Map.of("k", "v"), 0L));
+    }
+
+    @Test
+    void putIfVersionInsertDuplicateReturnsFalse() throws SQLException {
+        when(preparedStatement.executeUpdate())
+                .thenThrow(new SQLIntegrityConstraintViolationException("dup"));
+
+        PostgresBaseStore store = PostgresBaseStore.builder(dataSource).build();
+        assertFalse(store.putIfVersion(List.of("a"), "key", Map.of(), 0L));
+    }
+
+    @Test
+    void putIfVersionInsertDuplicateBySqlStateReturnsFalse() throws SQLException {
+        when(preparedStatement.executeUpdate()).thenThrow(new SQLException("dup", "23505"));
+
+        PostgresBaseStore store = PostgresBaseStore.builder(dataSource).build();
+        assertFalse(store.putIfVersion(List.of("a"), "key", Map.of(), 0L));
+    }
+
+    @Test
+    void putIfVersionInsertDuplicateByNullSqlStateThrows() throws SQLException {
+        when(preparedStatement.executeUpdate()).thenThrow(new SQLException("dup"));
+
+        PostgresBaseStore store = PostgresBaseStore.builder(dataSource).build();
+        assertThrows(
+                IllegalStateException.class,
+                () -> store.putIfVersion(List.of("a"), "key", Map.of(), 0L));
+    }
+
+    @Test
+    void putIfVersionInsertOtherSqlExceptionThrows() throws SQLException {
+        when(preparedStatement.executeUpdate()).thenThrow(new SQLException("boom", "42000"));
+
+        PostgresBaseStore store = PostgresBaseStore.builder(dataSource).build();
+        assertThrows(
+                IllegalStateException.class,
+                () -> store.putIfVersion(List.of("a"), "key", Map.of(), 0L));
+    }
+
+    @Test
+    void putIfVersionUpdateSucceeds() throws SQLException {
+        when(preparedStatement.executeUpdate()).thenReturn(1);
+
+        PostgresBaseStore store = PostgresBaseStore.builder(dataSource).build();
+        assertTrue(store.putIfVersion(List.of("a"), "key", Map.of("k", "v"), 5L));
+    }
+
+    @Test
+    void putIfVersionUpdateMismatchReturnsFalse() throws SQLException {
+        when(preparedStatement.executeUpdate()).thenReturn(0);
+
+        PostgresBaseStore store = PostgresBaseStore.builder(dataSource).build();
+        assertFalse(store.putIfVersion(List.of("a"), "key", Map.of(), 5L));
+    }
+
+    @Test
+    void putIfVersionUpdateThrowsWhenSqlFails() throws SQLException {
+        PostgresBaseStore store = PostgresBaseStore.builder(dataSource).build();
+        when(dataSource.getConnection()).thenThrow(new SQLException("boom"));
+        assertThrows(
+                IllegalStateException.class,
+                () -> store.putIfVersion(List.of("a"), "key", Map.of(), 5L));
+    }
+
+    @Test
+    void searchReturnsItems() throws SQLException {
+        when(resultSet.next()).thenReturn(true, true, false);
+        when(resultSet.getString(1)).thenReturn("key1", "key2");
+        when(resultSet.getString(2)).thenReturn("{\"a\":1}", "{\"b\":2}");
+        when(resultSet.getLong(3)).thenReturn(1L, 2L);
+
+        PostgresBaseStore store = PostgresBaseStore.builder(dataSource).build();
+        List<StoreItem> items = store.search(List.of("ns"), 10, 0);
+
+        assertEquals(2, items.size());
+        assertEquals("key1", items.get(0).key());
+        assertEquals("key2", items.get(1).key());
+    }
+
+    @Test
+    void searchEscapesLikeSpecialCharacters() throws SQLException {
+        when(resultSet.next()).thenReturn(false);
+
+        PostgresBaseStore store = PostgresBaseStore.builder(dataSource).build();
+        store.search(List.of("n%s", "_under", "!bang"), 10, 0);
+
+        verify(preparedStatement).setString(eq(1), org.mockito.ArgumentMatchers.contains("n!%s"));
+        verify(preparedStatement)
+                .setString(eq(1), org.mockito.ArgumentMatchers.contains("!_under"));
+        verify(preparedStatement).setString(eq(1), org.mockito.ArgumentMatchers.contains("!!bang"));
+    }
+
+    @Test
+    void searchReturnsEmptyForNonPositiveLimit() {
+        PostgresBaseStore store = PostgresBaseStore.builder(dataSource).build();
+        assertTrue(store.search(List.of("ns"), 0, 0).isEmpty());
+        assertTrue(store.search(List.of("ns"), -1, 0).isEmpty());
+    }
+
+    @Test
+    void searchThrowsWhenSqlFails() throws SQLException {
+        PostgresBaseStore store = PostgresBaseStore.builder(dataSource).build();
+        when(dataSource.getConnection()).thenThrow(new SQLException("boom"));
+        assertThrows(IllegalStateException.class, () -> store.search(List.of("ns"), 10, 0));
+    }
+
+    @Test
+    void deleteRemovesItem() throws SQLException {
+        when(preparedStatement.executeUpdate()).thenReturn(1);
+
+        PostgresBaseStore store = PostgresBaseStore.builder(dataSource).build();
+        store.delete(List.of("a"), "key");
+
+        verify(preparedStatement).setString(1, "a");
+        verify(preparedStatement).setString(2, "key");
+        verify(preparedStatement).executeUpdate();
+    }
+
+    @Test
+    void deleteThrowsWhenSqlFails() throws SQLException {
+        PostgresBaseStore store = PostgresBaseStore.builder(dataSource).build();
+        when(dataSource.getConnection()).thenThrow(new SQLException("boom"));
+        assertThrows(IllegalStateException.class, () -> store.delete(List.of("a"), "key"));
+    }
+
+    @Test
+    void deserializeHandlesNullAndEmpty() throws SQLException {
+        when(resultSet.next()).thenReturn(true);
+        when(resultSet.getString(1)).thenReturn(null);
+        when(resultSet.getLong(2)).thenReturn(1L);
+
+        PostgresBaseStore store = PostgresBaseStore.builder(dataSource).build();
+        StoreItem item = store.get(List.of("a"), "key");
+
+        assertNotNull(item);
+        assertTrue(item.value().isEmpty());
+
+        when(resultSet.getString(1)).thenReturn("");
+        item = store.get(List.of("a"), "key");
+        assertTrue(item.value().isEmpty());
+    }
+
+    @Test
+    void namespaceSegmentCannotBeNull() {
+        PostgresBaseStore store = PostgresBaseStore.builder(dataSource).build();
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> store.put(Arrays.asList("a", null), "key", Map.of()));
+    }
+
+    @Test
+    void namespaceSegmentCannotContainSeparator() {
+        PostgresBaseStore store = PostgresBaseStore.builder(dataSource).build();
+        assertThrows(
+                IllegalArgumentException.class, () -> store.put(List.of("a"), "key", Map.of()));
+    }
+
+    @Test
+    void keyCannotBeNullOrEmpty() {
+        PostgresBaseStore store = PostgresBaseStore.builder(dataSource).build();
+        assertThrows(IllegalArgumentException.class, () -> store.put(List.of("a"), null, Map.of()));
+        assertThrows(IllegalArgumentException.class, () -> store.put(List.of("a"), "", Map.of()));
+    }
+
+    @Test
+    void serializeNullValueAsEmptyMap() throws SQLException {
+        when(preparedStatement.executeUpdate()).thenReturn(1);
+
+        PostgresBaseStore store = PostgresBaseStore.builder(dataSource).build();
+        store.put(List.of("a"), "key", null);
+
+        verify(preparedStatement).setString(3, "{}");
+    }
+
+    @Test
+    void customObjectMapperRoundTrip() throws SQLException {
+        ObjectMapper mapper = new ObjectMapper();
+        when(preparedStatement.executeUpdate()).thenReturn(1);
+        when(resultSet.next()).thenReturn(true);
+        when(resultSet.getString(1)).thenReturn("{\"custom\":true}");
+        when(resultSet.getLong(2)).thenReturn(7L);
+
+        PostgresBaseStore store =
+                PostgresBaseStore.builder(dataSource).objectMapper(mapper).build();
+        store.put(List.of("a"), "key", Map.of("custom", true));
+        StoreItem item = store.get(List.of("a"), "key");
+
+        assertEquals(Boolean.TRUE, item.value().get("custom"));
+    }
+
+    @Test
+    void deserializeInvalidJsonThrows() throws SQLException {
+        when(resultSet.next()).thenReturn(true);
+        when(resultSet.getString(1)).thenReturn("not-json");
+        when(resultSet.getLong(2)).thenReturn(1L);
+
+        PostgresBaseStore store = PostgresBaseStore.builder(dataSource).build();
+        assertThrows(IllegalStateException.class, () -> store.get(List.of("a"), "key"));
+    }
+
+    @Test
+    void serializeFailureThrows() {
+        ObjectMapper failingMapper =
+                new ObjectMapper() {
+                    @Override
+                    public String writeValueAsString(Object value)
+                            throws com.fasterxml.jackson.core.JsonProcessingException {
+                        throw new com.fasterxml.jackson.core.JsonProcessingException("fail") {};
+                    }
+                };
+        PostgresBaseStore store =
+                PostgresBaseStore.builder(dataSource).objectMapper(failingMapper).build();
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> store.put(List.of("a"), "key", Map.of("x", "y")));
+    }
+}

--- a/agentscope-extensions/pom.xml
+++ b/agentscope-extensions/pom.xml
@@ -38,6 +38,7 @@
         <module>agentscope-extensions-cos</module>
         <module>agentscope-extensions-redis</module>
         <module>agentscope-extensions-mysql</module>
+        <module>agentscope-extensions-postgresql</module>
         <module>agentscope-extensions-rag</module>
         <module>agentscope-extensions-model</module>
         <module>agentscope-extensions-higress</module>


### PR DESCRIPTION
## AgentScope-Java Version

2.0.0-SNAPSHOT

### Background

`agentscope-extensions-mysql` already provides a JDBC-backed `DistributedStore` for MySQL. This PR adds a dedicated PostgreSQL extension module so users running PostgreSQL can configure distributed agent state, workspace KV storage, sandbox snapshots, and execution locking with a one-line setup, mirroring the MySQL module's API.

### Changes

- Add new Maven module `agentscope-extensions-postgresql` and register it in `agentscope-extensions/pom.xml`.
- Introduce `PostgresDistributedStore` implementing `DistributedStore` with `PostgresDistributedStore.create(DataSource)`.
- Implement PostgreSQL-specific components (aligned with the MySQL module's responsibilities):
  - **`PostgresAgentStateStore`** — agent session state persistence (schema `agentscope`, table `agentscope_sessions`)
  - **`PostgresBaseStore`** — workspace filesystem KV store with CAS updates (`INSERT ... ON CONFLICT`)
  - **`PostgresSnapshotSpec` / `PostgresRemoteSnapshotClient`** — sandbox snapshots stored as `BYTEA`
  - **`PostgresSandboxExecutionGuard`** — distributed locking via PostgreSQL advisory locks (`pg_advisory_lock` / `pg_try_advisory_lock`)
- Add Mockito-based unit tests for all public classes; no real PostgreSQL instance required.

### PostgreSQL-specific design notes

- **Database must exist beforehand** — the module does not auto-create databases (unlike MySQL's optional database creation).
- **Schema/tables are auto-created by default** — controlled via `createIfNotExist` / `initializeSchema` builder flags.
- Uses PostgreSQL-native SQL (`ON CONFLICT`, `BYTEA`, advisory locks) instead of the MySQL module's JDBC dialect abstraction.

### Usage

```java
DataSource dataSource = ... // HikariCP, Druid, etc.

HarnessAgent agent = HarnessAgent.builder()
    .name("my-agent")
    .model("dashscope:qwen-plus")
    .distributedStore(PostgresDistributedStore.create(dataSource))
    .filesystem(new DockerFilesystemSpec()
            .image("ubuntu:24.04"))
    .build();