### PR TITLE
refactor(core): remove redundant null check in TextBlock.Builder.build()

### DIFF
--- a/agentscope-core/src/main/java/io/agentscope/core/message/TextBlock.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/message/TextBlock.java
@@ -89,7 +89,7 @@ public final class TextBlock extends ContentBlock {
          * @return A new TextBlock instance (null text will be converted to empty string)
          */
         public TextBlock build() {
-            return new TextBlock(text != null ? text : "");
+            return new TextBlock(this.text);
         }
     }
 }


### PR DESCRIPTION
## AgentScope-Java Version

2.0.0-RC5

## Description

**Background & Purpose**
While reviewing the codebase, I noticed a redundant null check in the `TextBlock.Builder` class. The `build()` method was performing a `text != null ? text : ""` check before passing the string to the constructor. However, the private constructor `TextBlock(String text)` (which is also annotated with `@JsonCreator` for deserialization) already performs this exact same null safety validation internally. 

**Changes made**
Removed the redundant `text != null ? text : ""` check in `TextBlock.Builder.build()` and replaced it with a direct pass of `this.text`. This adheres to the DRY (Don't Repeat Yourself) principle and makes the code slightly cleaner, as the Builder can fully trust the constructor to handle null safety.

**How to test**
This is a pure internal refactoring without behavior changes. The existing unit tests for `MsgTest.java` naturally cover `TextBlock` creation and ensure it still handles null correctly. Run `mvn test -pl agentscope-core` (which passes successfully).