### PR TITLE
fix(core): activate SkillToolGroup via activateOnSkill field

### DIFF
--- a/agentscope-core/src/main/java/io/agentscope/core/skill/SkillBox.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/skill/SkillBox.java
@@ -168,14 +168,28 @@ public class SkillBox {
 
         // Dynamically update active/inactive tool groups based on skills' states
         for (RegisteredSkill registeredSkill : skillRegistry.getAllRegisteredSkills().values()) {
-            if (toolkit.getToolGroup(registeredSkill.getToolsGroupName()) == null) {
-                continue; // Skip uncreated skill tools
+            // Name-convention path: skillId + "_skill_tools"
+            if (toolkit.getToolGroup(registeredSkill.getToolsGroupName()) != null) {
+                if (!registeredSkill.isActive()) {
+                    inactiveSkillToolGroups.add(registeredSkill.getToolsGroupName());
+                } else {
+                    activeSkillToolGroups.add(registeredSkill.getToolsGroupName());
+                }
             }
-            if (!registeredSkill.isActive()) {
-                inactiveSkillToolGroups.add(registeredSkill.getToolsGroupName());
-                continue; // Skip inactive skill's tools, its tools won't be included
+
+            // activateOnSkill path: scan SkillToolGroups bound to this skill's name
+            AgentSkill agentSkill = skillRegistry.getSkill(registeredSkill.getSkillId());
+            if (agentSkill != null) {
+                List<String> boundGroups =
+                        toolkit.findSkillToolGroupsByActivateOnSkill(agentSkill.getName());
+                for (String group : boundGroups) {
+                    if (!registeredSkill.isActive()) {
+                        inactiveSkillToolGroups.add(group);
+                    } else {
+                        activeSkillToolGroups.add(group);
+                    }
+                }
             }
-            activeSkillToolGroups.add(registeredSkill.getToolsGroupName());
         }
         toolkit.updateToolGroups(inactiveSkillToolGroups, false);
         toolkit.updateToolGroups(activeSkillToolGroups, true);
@@ -322,12 +336,22 @@ public class SkillBox {
 
         skillRegistry.setSkillActive(skillId, active);
 
-        // sync ToolGroup state
+        // sync ToolGroup state — name-convention path
         RegisteredSkill registeredSkill = skillRegistry.getRegisteredSkill(skillId);
         if (registeredSkill != null) {
             String toolGroupName = registeredSkill.getToolsGroupName();
             if (this.toolkit.getToolGroup(toolGroupName) != null) {
                 this.toolkit.updateToolGroups(List.of(toolGroupName), active);
+            }
+        }
+
+        // sync ToolGroup state — activateOnSkill path
+        AgentSkill agentSkill = skillRegistry.getSkill(skillId);
+        if (agentSkill != null && this.toolkit != null) {
+            List<String> boundGroups =
+                    this.toolkit.findSkillToolGroupsByActivateOnSkill(agentSkill.getName());
+            if (!boundGroups.isEmpty()) {
+                this.toolkit.updateToolGroups(boundGroups, active);
             }
         }
 

--- a/agentscope-core/src/main/java/io/agentscope/core/skill/SkillToolFactory.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/skill/SkillToolFactory.java
@@ -379,5 +379,23 @@ class SkillToolFactory {
                     toolsGroupName,
                     toolkit.getToolGroup(toolsGroupName).getTools());
         }
+
+        // Also activate any SkillToolGroup bound to this skill via activateOnSkill
+        AgentSkill agentSkill = skillRegistry.getSkill(skillId);
+        if (agentSkill != null) {
+            List<String> boundGroups =
+                    toolkit.findSkillToolGroupsByActivateOnSkill(agentSkill.getName());
+            for (String group : boundGroups) {
+                if (!group.equals(toolsGroupName)
+                        && toolkit.getToolGroup(group) != null
+                        && !toolkit.getToolGroup(group).isActive()) {
+                    toolkit.updateToolGroups(List.of(group), true);
+                    logger.info(
+                            "Activated skill-bound tool group: {} for skill: {}",
+                            group,
+                            agentSkill.getName());
+                }
+            }
+        }
     }
 }

--- a/agentscope-core/src/main/java/io/agentscope/core/tool/ToolGroupManager.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/tool/ToolGroupManager.java
@@ -139,6 +139,26 @@ class ToolGroupManager {
     }
 
     /**
+     * Find all {@link SkillToolGroup} instances whose {@code activateOnSkill} matches the given
+     * skill name.
+     *
+     * @param skillName The skill name to match against
+     * @return List of matching group names (never null, may be empty)
+     */
+    public List<String> findSkillToolGroupsByActivateOnSkill(String skillName) {
+        if (skillName == null) {
+            return List.of();
+        }
+        return toolGroups.values().stream()
+                .filter(
+                        g ->
+                                g instanceof SkillToolGroup stg
+                                        && skillName.equals(stg.getActivateOnSkill()))
+                .map(ToolGroup::getName)
+                .toList();
+    }
+
+    /**
      * Update the active status of tool groups.
      *
      * @param groupNames List of tool group names to update

--- a/agentscope-core/src/main/java/io/agentscope/core/tool/Toolkit.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/tool/Toolkit.java
@@ -608,6 +608,17 @@ public class Toolkit {
     }
 
     /**
+     * Find all {@link SkillToolGroup} instances whose {@code activateOnSkill} matches the given
+     * skill name.
+     *
+     * @param skillName The skill name to match against
+     * @return List of matching group names (never null, may be empty)
+     */
+    public List<String> findSkillToolGroupsByActivateOnSkill(String skillName) {
+        return groupManager.findSkillToolGroupsByActivateOnSkill(skillName);
+    }
+
+    /**
      * Register a pre-built {@link ToolGroup} instance (including subclasses).
      *
      * <p>Use this method when you need full control over the ToolGroup construction,

--- a/agentscope-core/src/test/java/io/agentscope/core/tool/SkillToolGroupTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/tool/SkillToolGroupTest.java
@@ -185,6 +185,46 @@ class SkillToolGroupTest {
         assertTrue(manager.getMetaGroupNames().contains("skill_tools"));
     }
 
+    @Test
+    void testFindSkillToolGroupsByActivateOnSkill() {
+        ToolGroupManager manager = new ToolGroupManager();
+        manager.createSkillToolGroup("analysis-tools", "Analysis tools", false, "data-analysis");
+        manager.createSkillToolGroup("viz-tools", "Visualization tools", false, "data-analysis");
+        manager.createSkillToolGroup("code-tools", "Code tools", false, "coding");
+
+        var matched = manager.findSkillToolGroupsByActivateOnSkill("data-analysis");
+        assertEquals(2, matched.size());
+        assertTrue(matched.contains("analysis-tools"));
+        assertTrue(matched.contains("viz-tools"));
+
+        var codingMatched = manager.findSkillToolGroupsByActivateOnSkill("coding");
+        assertEquals(1, codingMatched.size());
+        assertTrue(codingMatched.contains("code-tools"));
+
+        var noMatch = manager.findSkillToolGroupsByActivateOnSkill("unknown-skill");
+        assertTrue(noMatch.isEmpty());
+    }
+
+    @Test
+    void testFindSkillToolGroupsByActivateOnSkillIgnoresRegularGroups() {
+        ToolGroupManager manager = new ToolGroupManager();
+        manager.createToolGroup("regular-group", "A regular group", true);
+        manager.createSkillToolGroup("skill-group", "Skill group", false, "my-skill");
+
+        var matched = manager.findSkillToolGroupsByActivateOnSkill("my-skill");
+        assertEquals(1, matched.size());
+        assertEquals("skill-group", matched.get(0));
+    }
+
+    @Test
+    void testFindSkillToolGroupsByActivateOnSkillNullSafe() {
+        ToolGroupManager manager = new ToolGroupManager();
+        manager.createSkillToolGroup("group", "desc", false, "skill");
+
+        var result = manager.findSkillToolGroupsByActivateOnSkill(null);
+        assertTrue(result.isEmpty());
+    }
+
     private static int countOccurrences(String text, String substring) {
         int count = 0;
         int idx = 0;

--- a/agentscope-examples/documentation/src/main/java/io/agentscope/examples/documentation2/skill/SkillWithToolGroupExample.java
+++ b/agentscope-examples/documentation/src/main/java/io/agentscope/examples/documentation2/skill/SkillWithToolGroupExample.java
@@ -45,7 +45,7 @@ import java.nio.file.Paths;
  * <pre>
  *   toolkit.createSkillToolGroup("analysis-tools", "Data analysis tools", false, "data-analysis");
  *   toolkit.registration().tool(new AnalysisTools()).group("analysis-tools").apply();
- *   // Agent loads the "data-analysis" SKILL.md → "analysis-tools" group becomes active
+ *   // Agent loads "data-analysis" SKILL.md → "analysis-tools" group becomes active via activateOnSkill
  * </pre>
  *
  * <p><b>Skill file structure (SKILLS_DIR/data-analysis/SKILL.md):</b>
@@ -80,9 +80,10 @@ public class SkillWithToolGroupExample {
     private static final String ACTIVATING_SKILL = "data-analysis";
 
     /**
-     * Name of the tool group bound to the skill.
+     * Name of the tool group bound to the skill. Can be any name — the group is activated
+     * automatically when the skill matching {@code activateOnSkill} is loaded.
      */
-    private static final String TOOL_GROUP = "skill-tools";
+    private static final String TOOL_GROUP = "data-analysis-tools";
 
     /**
      * Runs the skill-with-tool-group example.


### PR DESCRIPTION
## Summary

Fixes #2034.

- `SkillToolGroup.activateOnSkill` was stored but never queried — skill-bound tool groups created via `createSkillToolGroup()` were never auto-activated when the associated skill was loaded.
- Added `findSkillToolGroupsByActivateOnSkill()` to `ToolGroupManager`/`Toolkit` to scan groups by their `activateOnSkill` field.
- Updated all activation sites (`SkillToolFactory.activateSkill()`, `SkillBox.syncToolGroupStates()`, `SkillBox.setSkillActive()`) to also activate groups matched by `activateOnSkill`, in addition to the existing `skillId + "_skill_tools"` name-convention path.
- The existing internal path (SkillBox line 579) continues to work unchanged — this is purely additive.

## Test plan

- [x] `mvn test -pl agentscope-core -Dtest=SkillToolGroupTest,MetaToolFactoryTest` passes
- [x] New tests: `testFindSkillToolGroupsByActivateOnSkill`, `testFindSkillToolGroupsByActivateOnSkillIgnoresRegularGroups`, `testFindSkillToolGroupsByActivateOnSkillNullSafe`
- [x] `mvn compile -pl agentscope-examples/documentation -am` compiles cleanly
- [ ] Verify end-to-end: create a `SkillToolGroup` with an arbitrary name, load the matching skill, confirm the group becomes active