### PR TITLE
fix(channel): include PeerKind in OutboundAddress to fix group message routing

### DIFF
--- a/agentscope-examples/agents/agentscope-paw/src/test/java/io/agentscope/claw2/runtime/channel/ChannelRouterGroupTest.java
+++ b/agentscope-examples/agents/agentscope-paw/src/test/java/io/agentscope/claw2/runtime/channel/ChannelRouterGroupTest.java
@@ -62,7 +62,7 @@ class ChannelRouterGroupTest {
         assertEquals("peer", route.matchedBy());
         // Outbound address must encode the kind so e.g. WeComOutboundClient routes to
         // /cgi-bin/appchat/send instead of /cgi-bin/message/send.
-        assertEquals("wecom-prod:gid_123", route.outboundAddress().to());
+        assertEquals("wecom-prod:GROUP:gid_123", route.outboundAddress().to());
         assertEquals("corp-1", route.outboundAddress().accountId());
         assertNull(route.outboundAddress().threadId());
     }
@@ -79,7 +79,7 @@ class ChannelRouterGroupTest {
 
         assertEquals("main", route.agentId());
         assertEquals("channel-default", route.matchedBy());
-        assertEquals("wecom-prod:u9", route.outboundAddress().to());
+        assertEquals("wecom-prod:DIRECT:u9", route.outboundAddress().to());
     }
 
     @Test

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/gateway/channel/ChannelRouter.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/gateway/channel/ChannelRouter.java
@@ -215,7 +215,7 @@ public final class ChannelRouter {
     // -----------------------------------------------------------------
 
     private OutboundAddress buildOutboundAddress(InboundMessage msg) {
-        String to = msg.channelId() + ":" + msg.peer().id();
+        String to = msg.channelId() + ":" + msg.peer().kind().name() + ":" + msg.peer().id();
         String threadId = msg.peer().kind().isThread() ? msg.peer().id() : null;
         return new OutboundAddress(msg.channelId(), msg.accountId(), to, threadId);
     }

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/gateway/channel/OutboundAddress.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/gateway/channel/OutboundAddress.java
@@ -24,7 +24,7 @@ import java.util.Objects;
  *
  * @param channelId the channel adapter to deliver through (e.g. {@code "chatui"}, {@code "slack"})
  * @param accountId optional multi-account identifier (nullable for single-account channels)
- * @param to delivery address in {@code "channel:peerId"} format (e.g. {@code "telegram:12345"})
+ * @param to delivery address in {@code "channelId:peerKind:peerId"} format (e.g. {@code "dingtalk:GROUP:cidXXX"})
  * @param threadId optional thread context for threaded replies (nullable)
  */
 public record OutboundAddress(String channelId, String accountId, String to, String threadId) {

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/gateway/channel/ChannelRouterOutboundAddressTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/gateway/channel/ChannelRouterOutboundAddressTest.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.harness.agent.gateway.channel;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.agentscope.core.message.Msg;
+import io.agentscope.core.message.UserMessage;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class ChannelRouterOutboundAddressTest {
+
+    private final ChannelRouter router = new ChannelRouter("default-agent");
+
+    @Test
+    void directPeerProducesThreeSegmentAddress() {
+        Peer peer = new Peer(PeerKind.DIRECT, "user123");
+        InboundMessage msg = InboundMessage.builder("dingtalk", peer, msgs()).build();
+
+        RouteResult result = router.resolveRoute(defaultConfig(), msg);
+
+        assertEquals("dingtalk:DIRECT:user123", result.outboundAddress().to());
+        assertNull(result.outboundAddress().threadId());
+    }
+
+    @Test
+    void groupPeerProducesThreeSegmentAddress() {
+        Peer peer = new Peer(PeerKind.GROUP, "cidAbcDef123");
+        InboundMessage msg = InboundMessage.builder("dingtalk", peer, msgs()).build();
+
+        RouteResult result = router.resolveRoute(defaultConfig(), msg);
+
+        assertEquals("dingtalk:GROUP:cidAbcDef123", result.outboundAddress().to());
+        assertNull(result.outboundAddress().threadId());
+    }
+
+    @Test
+    void channelPeerProducesThreeSegmentAddress() {
+        Peer peer = new Peer(PeerKind.CHANNEL, "C0123456");
+        InboundMessage msg = InboundMessage.builder("slack", peer, msgs()).build();
+
+        RouteResult result = router.resolveRoute(defaultConfig(), msg);
+
+        assertEquals("slack:CHANNEL:C0123456", result.outboundAddress().to());
+        assertNull(result.outboundAddress().threadId());
+    }
+
+    @Test
+    void threadPeerIncludesThreadId() {
+        Peer peer = new Peer(PeerKind.THREAD, "thread-99");
+        Peer parent = new Peer(PeerKind.CHANNEL, "C0123456");
+        InboundMessage msg =
+                InboundMessage.builder("slack", peer, msgs()).parentPeer(parent).build();
+
+        RouteResult result = router.resolveRoute(defaultConfig(), msg);
+
+        assertEquals("slack:THREAD:thread-99", result.outboundAddress().to());
+        assertEquals("thread-99", result.outboundAddress().threadId());
+    }
+
+    @Test
+    void groupAddressCanBeParsedByDingTalkPattern() {
+        Peer peer = new Peer(PeerKind.GROUP, "cidXYZ");
+        InboundMessage msg = InboundMessage.builder("dingtalk", peer, msgs()).build();
+
+        RouteResult result = router.resolveRoute(defaultConfig(), msg);
+        String to = result.outboundAddress().to();
+
+        // Simulate DingTalkOutboundClient.parseAddress logic
+        int sep = to.indexOf(':');
+        assertTrue(sep > 0);
+        String rest = to.substring(sep + 1);
+        int sep2 = rest.indexOf(':');
+        assertTrue(sep2 > 0, "should have 3 segments with kind in the middle");
+        String kindRaw = rest.substring(0, sep2);
+        String id = rest.substring(sep2 + 1);
+        assertEquals("GROUP", kindRaw);
+        assertEquals("cidXYZ", id);
+    }
+
+    private static ChannelConfig defaultConfig() {
+        return ChannelConfig.of("test-channel", "default-agent");
+    }
+
+    private static List<Msg> msgs() {
+        return List.of(new UserMessage("hello"));
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #2039

- `ChannelRouter.buildOutboundAddress()` was producing a 2-segment `to` field (`"channelId:peerId"`), causing outbound clients (DingTalk, WeCom) to default to `DIRECT` peer kind when parsing the address
- Group messages were sent to the wrong API endpoint (e.g. DingTalk's `oToMessages/batchSend` instead of `groupMessages/send`), resulting in 400 Bad Request
- Changed the `to` format to 3 segments: `"channelId:KIND:peerId"` (e.g. `"dingtalk:GROUP:cidXXX"`)

## Root Cause

`buildOutboundAddress()` omitted the `PeerKind` segment. All outbound clients that distinguish DIRECT from GROUP (DingTalk, WeCom) use a `parseAddress()` that expects 3 segments — with only 2 segments, they default to `DIRECT`.

## Impact

- **DingTalk**: fixes the reported 400 error on group replies
- **WeCom**: fixes the same latent bug (group replies would use wrong endpoint)
- **Feishu**: no functional change (uses same API for both kinds)
- **GitHub/GitLab**: no functional change (their parsers already handle both 2- and 3-segment formats by skipping the middle segment)

## Test Plan

- [x] Added `ChannelRouterOutboundAddressTest` with 5 test cases covering DIRECT, GROUP, CHANNEL, THREAD, and DingTalk-style parsing
- [x] All existing `agentscope-harness` tests pass