### PR TITLE
fix(harness): cancel spawned agent on parent dispose

### DIFF
--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/tool/AgentSpawnTool.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/tool/AgentSpawnTool.java
@@ -53,9 +53,13 @@ import java.util.concurrent.CompletionException;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import reactor.core.Disposable;
+import reactor.core.Disposables;
 import reactor.core.publisher.Mono;
+import reactor.core.publisher.SignalType;
 
 /**
  * Simple subagent tool for agent-internal use. Much lighter than {@code SessionsTool}:
@@ -719,24 +723,44 @@ public class AgentSpawnTool {
                         Mono.<String>create(
                                 sink -> {
                                     CompletableFuture<Msg> bridge = new CompletableFuture<>();
+                                    AtomicBoolean outerCancelled = new AtomicBoolean(false);
+                                    Disposable.Swap innerSubscription = Disposables.swap();
 
-                                    execLocalSync(
-                                                    agent,
-                                                    sessionId,
-                                                    userId,
-                                                    task,
-                                                    spawned,
-                                                    runtimeContext)
-                                            .contextWrite(
-                                                    c -> reactor.util.context.Context.of(parentCtx))
-                                            .subscribe(
-                                                    bridge::complete,
-                                                    bridge::completeExceptionally,
-                                                    () -> {
-                                                        if (!bridge.isDone()) {
-                                                            bridge.complete(null);
-                                                        }
-                                                    });
+                                    sink.onCancel(
+                                            () -> {
+                                                outerCancelled.set(true);
+                                                innerSubscription.dispose();
+                                                bridge.cancel(false);
+                                            });
+
+                                    Disposable inner =
+                                            execLocalSync(
+                                                            agent,
+                                                            sessionId,
+                                                            userId,
+                                                            task,
+                                                            spawned,
+                                                            runtimeContext)
+                                                    .contextWrite(
+                                                            c ->
+                                                                    reactor.util.context.Context.of(
+                                                                            parentCtx))
+                                                    .doFinally(
+                                                            signal -> {
+                                                                if (signal == SignalType.CANCEL) {
+                                                                    interruptAgent(
+                                                                            agent, runtimeContext);
+                                                                }
+                                                            })
+                                                    .subscribe(
+                                                            bridge::complete,
+                                                            bridge::completeExceptionally,
+                                                            () -> {
+                                                                if (!bridge.isDone()) {
+                                                                    bridge.complete(null);
+                                                                }
+                                                            });
+                                    innerSubscription.update(inner);
 
                                     // Race against timeout without cancelling the bridge.
                                     // thenApply(m -> m) creates a dependent future so orTimeout
@@ -746,6 +770,9 @@ public class AgentSpawnTool {
 
                                     race.whenComplete(
                                             (msg, err) -> {
+                                                if (outerCancelled.get()) {
+                                                    return;
+                                                }
                                                 if (err != null) {
                                                     handleExecError(
                                                             err,
@@ -763,6 +790,17 @@ public class AgentSpawnTool {
                                                 }
                                             });
                                 }));
+    }
+
+    /** Interrupts a local subagent when its parent subscription is cancelled. */
+    private static void interruptAgent(Agent agent, RuntimeContext ctx) {
+        if (agent instanceof ReActAgent ra) {
+            ra.interrupt(ctx);
+            log.warn(
+                    "Sub-agent '{}' (id={}) was interrupted because agent_spawn was cancelled.",
+                    ra.getName(),
+                    ra.getAgentId());
+        }
     }
 
     /**

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/tool/AgentSpawnToolCancellationTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/tool/AgentSpawnToolCancellationTest.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.harness.agent.tool;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.atLeastOnce;
+
+import io.agentscope.core.ReActAgent;
+import io.agentscope.core.agent.RuntimeContext;
+import io.agentscope.core.message.Msg;
+import io.agentscope.harness.agent.middleware.SubagentEntry;
+import io.agentscope.harness.agent.subagent.DefaultAgentManager;
+import io.agentscope.harness.agent.subagent.task.TaskRepository;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.mockito.Mockito;
+import reactor.core.publisher.Mono;
+
+/** Verifies that cancelling {@code agent_spawn} stops the in-flight local subagent. */
+class AgentSpawnToolCancellationTest {
+
+    @Test
+    @Timeout(value = 15, unit = TimeUnit.SECONDS)
+    void cancelingAgentSpawnCancelsAndInterruptsLocalSubagent() throws Exception {
+        ReActAgent realAgent =
+                ReActAgent.builder()
+                        .name("slow_subagent")
+                        .sysPrompt("You are a slow test subagent.")
+                        .maxIters(1)
+                        .build();
+        ReActAgent slowAgent = Mockito.spy(realAgent);
+
+        CountDownLatch enteredCall = new CountDownLatch(1);
+        AtomicBoolean childSubscribed = new AtomicBoolean(false);
+        AtomicBoolean childCancelled = new AtomicBoolean(false);
+
+        Mockito.doAnswer(
+                        invocation -> {
+                            enteredCall.countDown();
+                            return Mono.<Msg>never()
+                                    .doOnSubscribe(subscription -> childSubscribed.set(true))
+                                    .doOnCancel(() -> childCancelled.set(true));
+                        })
+                .when(slowAgent)
+                .call(anyList(), any(RuntimeContext.class));
+
+        DefaultAgentManager manager =
+                new DefaultAgentManager(
+                        List.of(new SubagentEntry("slow", "Slow subagent", rc -> slowAgent)), null);
+        AgentSpawnTool tool = new AgentSpawnTool(manager, Mockito.mock(TaskRepository.class), 0);
+        RuntimeContext ctx =
+                RuntimeContext.builder().sessionId("parent-session").userId("user-1").build();
+
+        var subscription =
+                tool.agentSpawn(ctx, null, "slow", "run slowly", null, 30, null).subscribe();
+
+        assertTrue(enteredCall.await(5, TimeUnit.SECONDS), "subagent call should start");
+        assertTrue(childSubscribed.get(), "subagent Mono should be subscribed");
+
+        subscription.dispose();
+
+        assertEventuallyTrue(childCancelled, "subagent Mono should be cancelled");
+        assertEventuallyInterrupted(slowAgent);
+    }
+
+    private static void assertEventuallyTrue(AtomicBoolean condition, String message)
+            throws InterruptedException {
+        long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(5);
+        while (System.nanoTime() < deadline) {
+            if (condition.get()) {
+                return;
+            }
+            Thread.sleep(50);
+        }
+        assertTrue(condition.get(), message);
+    }
+
+    private static void assertEventuallyInterrupted(ReActAgent agent) throws InterruptedException {
+        long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(5);
+        while (System.nanoTime() < deadline) {
+            try {
+                Mockito.verify(agent, atLeastOnce()).interrupt(any(RuntimeContext.class));
+                return;
+            } catch (org.mockito.exceptions.base.MockitoAssertionError ignored) {
+                Thread.sleep(50);
+            }
+        }
+        Mockito.verify(agent, atLeastOnce()).interrupt(any(RuntimeContext.class));
+    }
+}


### PR DESCRIPTION
## AgentScope-Java Version

2.0.0-RC5

## Description

This PR fixes #2062.

`AgentSpawnTool.execWithTimeoutPromotion()` starts local sub-agent execution with an inner Reactor subscription. Previously, when the parent `agent_spawn` subscription was cancelled, the inner subscription was not disposed. As a result, the spawned local sub-agent could continue running after the parent no longer observed the result.

This change propagates parent cancellation to the in-flight local sub-agent execution by:

- capturing the inner `Disposable`
- disposing it from `sink.onCancel(...)`
- interrupting local `ReActAgent` instances when the inner execution receives `SignalType.CANCEL`
- avoiding post-cancel bridge callbacks from writing back to an already-cancelled sink

This only affects parent subscription cancellation. It does not change the normal async/background task path (`timeout_seconds=0`) or timeout promotion behavior where a `task_id` is returned.

Tests added:

- `AgentSpawnToolCancellationTest`
  - verifies that cancelling `agent_spawn` cancels the in-flight local sub-agent `Mono`
  - verifies that `ReActAgent.interrupt(RuntimeContext)` is called

Tested with:

```bash
mvn -pl agentscope-harness test -Dtest=AgentSpawnToolCancellationTest -DfailIfNoTests=false
mvn -pl agentscope-harness test