### PR TITLE
fix(harness): interrupt orphan sub-agent when AgentSpawnTool parent subscription cancels (#2062)

### DIFF
--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/tool/AgentSpawnTool.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/tool/AgentSpawnTool.java
@@ -55,7 +55,9 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import reactor.core.Disposable;
 import reactor.core.publisher.Mono;
+import reactor.core.publisher.SignalType;
 
 /**
  * Simple subagent tool for agent-internal use. Much lighter than {@code SessionsTool}:
@@ -720,16 +722,40 @@ public class AgentSpawnTool {
                                 sink -> {
                                     CompletableFuture<Msg> bridge = new CompletableFuture<>();
 
-                                    execLocalSync(
-                                                    agent,
-                                                    sessionId,
-                                                    userId,
-                                                    task,
-                                                    spawned,
-                                                    runtimeContext)
-                                            .contextWrite(
-                                                    c -> reactor.util.context.Context.of(parentCtx))
-                                            .subscribe(
+                                    Mono<Msg> inner =
+                                            execLocalSync(
+                                                            agent,
+                                                            sessionId,
+                                                            userId,
+                                                            task,
+                                                            spawned,
+                                                            runtimeContext)
+                                                    .contextWrite(
+                                                            c ->
+                                                                    reactor.util.context.Context.of(
+                                                                            parentCtx))
+                                                    .doFinally(
+                                                            signal -> {
+                                                                // Parent subscription was
+                                                                // cancelled (outer Mono.timeout,
+                                                                // user stop, or upstream Reactor
+                                                                // cancel). The fire-and-forget
+                                                                // subscribe below detaches the
+                                                                // inner execution from the parent
+                                                                // lifecycle, so without this
+                                                                // doFinally the sub-agent would
+                                                                // keep running as an orphan and
+                                                                // the eventual sink.success(...)
+                                                                // would be a no-op on the
+                                                                // already-cancelled sink.
+                                                                if (signal == SignalType.CANCEL) {
+                                                                    interruptAgent(
+                                                                            agent, runtimeContext);
+                                                                }
+                                                            });
+
+                                    Disposable innerSub =
+                                            inner.subscribe(
                                                     bridge::complete,
                                                     bridge::completeExceptionally,
                                                     () -> {
@@ -762,7 +788,33 @@ public class AgentSpawnTool {
                                                                     + textOf(msg));
                                                 }
                                             });
+
+                                    // Propagate parent cancellation to the inner fire-and-forget
+                                    // subscription. Without this, doFinally(CANCEL) above never
+                                    // fires because the inner is subscribed independently of the
+                                    // parent Mono.create sink.
+                                    sink.onCancel(innerSub);
                                 }));
+    }
+
+    /**
+     * Interrupts the sub-agent's reasoning loop when its parent tool-call subscription is
+     * cancelled. Mirrors the fix in core {@code SubAgentTool.interruptAgent} (commit
+     * {@code 029cc55e}, issue #1783) — see issue #2062 for the harness-side equivalent.
+     *
+     * <p>Only {@link ReActAgent} exposes {@code interrupt(RuntimeContext)}. Other {@link Agent}
+     * implementations are no-ops here; their inner execution will still be disposed by the caller's
+     * {@code sink.onCancel(innerSub::dispose)}, which is enough for non-looping agents.
+     */
+    private void interruptAgent(Agent agent, RuntimeContext ctx) {
+        if (agent instanceof ReActAgent ra) {
+            ra.interrupt(ctx);
+            log.warn(
+                    "Sub-agent '{}' (id={}) was interrupted because its parent tool call"
+                            + " subscription was cancelled.",
+                    ra.getName(),
+                    ra.getAgentId());
+        }
     }
 
     /**

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/tool/AgentSpawnToolOrphanCancelTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/tool/AgentSpawnToolOrphanCancelTest.java
@@ -1,0 +1,320 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.harness.agent.tool;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.verify;
+
+import io.agentscope.core.ReActAgent;
+import io.agentscope.core.agent.RuntimeContext;
+import io.agentscope.core.agent.test.MockModel;
+import io.agentscope.core.message.TextBlock;
+import io.agentscope.core.message.ToolResultBlock;
+import io.agentscope.core.tool.AgentTool;
+import io.agentscope.core.tool.ToolCallParam;
+import io.agentscope.core.tool.Toolkit;
+import io.agentscope.harness.agent.middleware.SubagentEntry;
+import io.agentscope.harness.agent.subagent.DefaultAgentManager;
+import io.agentscope.harness.agent.subagent.SubagentFactory;
+import io.agentscope.harness.agent.subagent.task.BackgroundTask;
+import io.agentscope.harness.agent.subagent.task.TaskRepository;
+import io.agentscope.harness.agent.subagent.task.TaskRunSpec;
+import io.agentscope.harness.agent.subagent.task.TaskStatus;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.time.Duration;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.mockito.Mockito;
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
+
+/**
+ * Reproduction / regression test for orphan sub-agent leak in {@code AgentSpawnTool}.
+ *
+ * <p><b>Scenario</b>: a parent agent invokes {@code agent_spawn} and the parent's subscription to
+ * the returned {@link Mono} is cancelled before completion (e.g. by an outer
+ * {@code Mono.timeout()}, a user-initiated stop, or upstream Reactor cancel). The inner execution
+ * Mono from {@code execLocalSync} is fire-and-forget subscribed via plain {@code .subscribe(...)}
+ * inside {@code execWithTimeoutPromotion} — the resulting {@code Disposable} is never captured and
+ * never disposed on parent cancel, so the sub-agent keeps running as an orphan.
+ *
+ * <p>This test mirrors the structure of {@code SubAgentToolTimeoutRetryIntegrationTest} (which
+ * covered the equivalent bug in the core {@code SubAgentTool}, fixed in {@code 029cc55e}) but
+ * adapted to the harness-side {@code AgentSpawnTool} API:
+ *
+ * <ul>
+ *   <li>{@link DefaultAgentManager} + {@link SubagentEntry} instead of {@code SubAgentProvider}
+ *   <li>Direct {@code tool.agentSpawn(...)} call instead of {@code tool.callAsync(param)}
+ *   <li>Outer {@code Mono.timeout(2s)} instead of {@code .timeout(3s).retryWhen(1)}
+ * </ul>
+ *
+ * <p>Assertions are written for the <em>fixed</em> state. On current (unfixed) code, the
+ * assertions fail and the failure message carries concrete measurements (file lines and model call
+ * counts at timeout vs after a wait window) — those numbers form the proof in the GitHub issue.
+ */
+@DisplayName("AgentSpawnTool parent-cancel: orphan sub-agent must be interrupted")
+class AgentSpawnToolOrphanCancelTest {
+
+    private Path tmpFile;
+
+    @AfterEach
+    void cleanup() throws Exception {
+        if (tmpFile != null) {
+            try {
+                Files.deleteIfExists(tmpFile);
+            } catch (Exception ignored) {
+                // best-effort cleanup
+            }
+        }
+    }
+
+    @Test
+    @DisplayName("Sub-agent loop stops after parent timeout cancels the tool subscription")
+    @Timeout(30)
+    void orphanAgentInterruptedOnParentCancel() throws Exception {
+        tmpFile = Files.createTempFile("agentspawn_orphan_", ".log");
+        // Start from an empty file so line counts are deterministic.
+        Files.writeString(tmpFile, "");
+
+        // ---- slow_tool: writes one line per call. A short sleep per call slows the loop enough
+        //      that the outer 2s timeout fires while the agent is still mid-flight (not already
+        //      exited via summarizing/max-iters), and the orphan window (post-timeout) shows
+        //      measurable progression. ----
+        AtomicInteger toolCallCount = new AtomicInteger(0);
+        AgentTool slowTool =
+                new AgentTool() {
+                    @Override
+                    public String getName() {
+                        return "slow_tool";
+                    }
+
+                    @Override
+                    public String getDescription() {
+                        return "Appends one line to a temp file, then returns ok.";
+                    }
+
+                    @Override
+                    public Map<String, Object> getParameters() {
+                        return Map.of("type", "object", "properties", Map.of());
+                    }
+
+                    @Override
+                    public Mono<ToolResultBlock> callAsync(ToolCallParam p) {
+                        return Mono.fromRunnable(
+                                        () -> {
+                                            toolCallCount.incrementAndGet();
+                                            try {
+                                                Thread.sleep(150);
+                                                Files.writeString(
+                                                        tmpFile,
+                                                        "line\n",
+                                                        StandardOpenOption.APPEND);
+                                            } catch (Exception ignored) {
+                                                // best-effort write; test asserts on counts, not
+                                                // file contents
+                                            }
+                                        })
+                                .subscribeOn(Schedulers.boundedElastic())
+                                .then(
+                                        Mono.just(
+                                                ToolResultBlock.of(
+                                                        TextBlock.builder().text("ok").build())));
+                    }
+                };
+
+        Toolkit slowTk = new Toolkit();
+        slowTk.registerTool(slowTool);
+
+        // ---- MockModel that emits a UNIQUE tool_call_id on every invocation ----
+        // The stock MockModel.withToolCall(...) returns the same id each call, which the
+        // ReActAgent dedupes — only the first call executes, then the loop short-circuits to
+        // summarizing. Using a generator with a fresh UUID forces every iteration to actually
+        // execute slow_tool, so the orphan (pre-fix) keeps writing new lines until interrupted.
+        java.util.function.Function<
+                        List<io.agentscope.core.message.Msg>,
+                        List<io.agentscope.core.model.ChatResponse>>
+                gen =
+                        messages -> {
+                            java.util.Map<String, Object> args = new java.util.HashMap<>();
+                            String callId = "call_" + java.util.UUID.randomUUID();
+                            io.agentscope.core.model.ChatResponse resp =
+                                    io.agentscope.core.model.ChatResponse.builder()
+                                            .id("msg_" + java.util.UUID.randomUUID())
+                                            .content(
+                                                    java.util.List.of(
+                                                            io.agentscope.core.message.ToolUseBlock
+                                                                    .builder()
+                                                                    .name("slow_tool")
+                                                                    .id(callId)
+                                                                    .input(args)
+                                                                    .content(
+                                                                            io.agentscope.core.util
+                                                                                    .JsonUtils
+                                                                                    .getJsonCodec()
+                                                                                    .toJson(args))
+                                                                    .build()))
+                                            .usage(
+                                                    new io.agentscope.core.model.ChatUsage(
+                                                            8, 15, 23))
+                                            .build();
+                            return java.util.List.of(resp);
+                        };
+        MockModel slowModel = new MockModel(gen);
+
+        ReActAgent slowSpy =
+                Mockito.spy(
+                        ReActAgent.builder()
+                                .name("slow_sub")
+                                .sysPrompt("slow sub")
+                                .model(slowModel)
+                                .toolkit(slowTk)
+                                .maxIters(50)
+                                .build());
+
+        // ---- DefaultAgentManager + AgentSpawnTool ----
+        SubagentFactory factory = rc -> slowSpy;
+        DefaultAgentManager manager =
+                new DefaultAgentManager(
+                        List.of(new SubagentEntry("slow_agent", "Test slow agent", factory)), null);
+
+        TaskRepository stubRepo = new NoopTaskRepository();
+        AgentSpawnTool tool = new AgentSpawnTool(manager, stubRepo, 0);
+
+        RuntimeContext ctx = RuntimeContext.builder().sessionId("s1").userId("u1").build();
+
+        // ---- Trigger parent cancel via outer .timeout(2s) ----
+        // The agent has a 30s internal timeout so its inner race.orTimeout will not fire first.
+        // The outer Mono.timeout(2s) cancels the Mono<String> returned by agentSpawn — that is
+        // exactly the parent-cancel scenario we want to exercise.
+        long t0 = System.currentTimeMillis();
+        try {
+            tool.agentSpawn(ctx, null, "slow_agent", "go", null, 30, null)
+                    .timeout(Duration.ofSeconds(2))
+                    .block();
+        } catch (Exception expected) {
+            // Expected: outer timeout fires TimeoutException (may be wrapped by .block()).
+            // The exact exception type is not asserted — what matters is that the parent
+            // subscription has been cancelled by the time we reach the assertions below.
+            System.out.println(
+                    "[AgentSpawnToolOrphanCancelTest] outer timeout fired at t="
+                            + (System.currentTimeMillis() - t0)
+                            + "ms, exception class="
+                            + expected.getClass().getSimpleName());
+        }
+
+        long linesAtTimeout = Files.readAllLines(tmpFile).size();
+        long callsAtTimeout = slowModel.getCallCount();
+        System.out.println(
+                "[AgentSpawnToolOrphanCancelTest] at timeout: lines="
+                        + linesAtTimeout
+                        + ", modelCalls="
+                        + callsAtTimeout
+                        + ", toolCalls="
+                        + toolCallCount.get());
+
+        // ---- Wait long enough to see if the orphan kept running ----
+        Thread.sleep(4_000);
+
+        long linesAfter = Files.readAllLines(tmpFile).size();
+        long callsAfter = slowModel.getCallCount();
+        long deltaLines = linesAfter - linesAtTimeout;
+        long deltaCalls = callsAfter - callsAtTimeout;
+        System.out.println(
+                "[AgentSpawnToolOrphanCancelTest] after 4s wait: lines="
+                        + linesAfter
+                        + " (delta="
+                        + deltaLines
+                        + "), modelCalls="
+                        + callsAfter
+                        + " (delta="
+                        + deltaCalls
+                        + "), toolCalls="
+                        + toolCallCount.get());
+
+        // ===== Proof #1: interrupt() was called on the slow agent after parent cancel =====
+        // Pre-fix: this fails — interrupt is never called because the inner subscription is never
+        // disposed.
+        verify(slowSpy, atLeastOnce()).interrupt(any(RuntimeContext.class));
+
+        // ===== Proof #2: file did not keep growing after parent cancel =====
+        // Pre-fix: this fails — orphan loop writes many more lines during the 4s window.
+        //   We allow a slack of 1 to tolerate a single in-flight tool call that completes before
+        //   the interrupt flag is observed.
+        assertTrue(
+                deltaLines <= 1,
+                "Orphan kept writing lines after parent cancel. linesAtTimeout="
+                        + linesAtTimeout
+                        + ", linesAfter="
+                        + linesAfter
+                        + ", delta="
+                        + deltaLines);
+
+        // ===== Proof #3: model was not called many more times after parent cancel =====
+        assertTrue(
+                deltaCalls <= 1,
+                "Orphan kept invoking the model after parent cancel. callsAtTimeout="
+                        + callsAtTimeout
+                        + ", callsAfter="
+                        + callsAfter
+                        + ", delta="
+                        + deltaCalls);
+    }
+
+    /** Minimal no-op TaskRepository — the bug scenario never reaches promotion, so stubs suffice. */
+    private static final class NoopTaskRepository implements TaskRepository {
+        @Override
+        public BackgroundTask getTask(RuntimeContext rc, String sessionId, String taskId) {
+            return null;
+        }
+
+        @Override
+        public BackgroundTask putTask(
+                RuntimeContext rc,
+                String taskId,
+                String subAgentId,
+                String sessionId,
+                TaskRunSpec spec) {
+            return null;
+        }
+
+        @Override
+        public void removeTask(RuntimeContext rc, String sessionId, String taskId) {}
+
+        @Override
+        public void clear() {}
+
+        @Override
+        public Collection<BackgroundTask> listTasks(
+                RuntimeContext rc, String sessionId, TaskStatus filter) {
+            return List.of();
+        }
+
+        @Override
+        public boolean cancelTask(RuntimeContext rc, String sessionId, String taskId) {
+            return false;
+        }
+    }
+}

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/tool/AgentSpawnToolPromotionTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/tool/AgentSpawnToolPromotionTest.java
@@ -1,0 +1,267 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.harness.agent.tool;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import io.agentscope.core.ReActAgent;
+import io.agentscope.core.agent.RuntimeContext;
+import io.agentscope.core.agent.test.MockModel;
+import io.agentscope.core.message.TextBlock;
+import io.agentscope.core.message.ToolResultBlock;
+import io.agentscope.core.message.ToolUseBlock;
+import io.agentscope.core.model.ChatResponse;
+import io.agentscope.core.model.ChatUsage;
+import io.agentscope.core.tool.AgentTool;
+import io.agentscope.core.tool.ToolCallParam;
+import io.agentscope.core.tool.Toolkit;
+import io.agentscope.harness.agent.middleware.SubagentEntry;
+import io.agentscope.harness.agent.subagent.DefaultAgentManager;
+import io.agentscope.harness.agent.subagent.SubagentFactory;
+import io.agentscope.harness.agent.subagent.task.BackgroundTask;
+import io.agentscope.harness.agent.subagent.task.TaskRepository;
+import io.agentscope.harness.agent.subagent.task.TaskRunSpec;
+import io.agentscope.harness.agent.subagent.task.TaskStatus;
+import java.time.Duration;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Function;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.mockito.Mockito;
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
+
+/**
+ * Regression test for the <b>timeout-promotion</b> path of {@code
+ * AgentSpawnTool.execWithTimeoutPromotion}.
+ *
+ * <p>The sibling test {@code AgentSpawnToolOrphanCancelTest} covers the orphan-cancel fix; this
+ * test pins down the sibling guarantee: when the internal {@code race.orTimeout} fires (because
+ * the agent legitimately exceeds {@code timeout_seconds}), the in-flight execution is wrapped as
+ * an {@link TaskRunSpec.AdoptedTaskRunSpec} and submitted to the {@link TaskRepository}, so the
+ * user can still retrieve the eventual result via {@code task_output}.
+ *
+ * <p>The orphan-cancel fix adds a {@code doFinally(CANCEL) → interrupt} handler and a
+ * {@code sink.onCancel(innerSub::dispose)} hook on the inner Mono. Neither of those should fire on
+ * the promotion path (it terminates via {@code sink.success(...)} after a CompletableFuture
+ * timeout, not via Reactor cancel). This test asserts both halves of that contract:
+ *
+ * <ol>
+ *   <li>The agent is NOT interrupted — it keeps running and eventually produces a reply.
+ *   <li>The {@link TaskRunSpec.AdoptedTaskRunSpec#future()} completes with that reply.
+ * </ol>
+ *
+ * <p>If a future refactor accidentally disposes the inner subscription in the timeout branch (the
+ * most plausible regression), this test fails on both halves.
+ */
+@DisplayName(
+        "AgentSpawnTool timeout-promotion: AdoptedTaskRunSpec still works after orphan-cancel fix")
+class AgentSpawnToolPromotionTest {
+
+    @Test
+    @DisplayName(
+            "Inner timeout wraps in-flight execution as AdoptedTaskRunSpec; future completes with"
+                    + " reply")
+    @Timeout(30)
+    void innerTimeoutPromotesToAdoptedTaskRunSpec() throws Exception {
+        // ---- slow_tool: sleeps 2s before returning. Forces the 1s inner timeout to fire first.
+        // ----
+        AgentTool slowTool =
+                new AgentTool() {
+                    @Override
+                    public String getName() {
+                        return "slow_tool";
+                    }
+
+                    @Override
+                    public String getDescription() {
+                        return "Sleeps 2s, then returns ok.";
+                    }
+
+                    @Override
+                    public Map<String, Object> getParameters() {
+                        return Map.of("type", "object", "properties", Map.of());
+                    }
+
+                    @Override
+                    public Mono<ToolResultBlock> callAsync(ToolCallParam p) {
+                        return Mono.fromRunnable(
+                                        () -> {
+                                            try {
+                                                Thread.sleep(2_000);
+                                            } catch (InterruptedException e) {
+                                                Thread.currentThread().interrupt();
+                                            }
+                                        })
+                                .subscribeOn(Schedulers.boundedElastic())
+                                .then(
+                                        Mono.just(
+                                                ToolResultBlock.of(
+                                                        TextBlock.builder().text("ok").build())));
+                    }
+                };
+
+        Toolkit tk = new Toolkit();
+        tk.registerTool(slowTool);
+
+        // ---- Stateful MockModel: 1st call returns tool_call, 2nd+ returns final text "task done".
+        // ----
+        AtomicInteger modelCall = new AtomicInteger(0);
+        Function<List<io.agentscope.core.message.Msg>, List<ChatResponse>> gen =
+                messages -> {
+                    if (modelCall.incrementAndGet() == 1) {
+                        Map<String, Object> args = new HashMap<>();
+                        return List.of(
+                                ChatResponse.builder()
+                                        .id("msg_" + java.util.UUID.randomUUID())
+                                        .content(
+                                                List.of(
+                                                        ToolUseBlock.builder()
+                                                                .name("slow_tool")
+                                                                .id("call_1")
+                                                                .input(args)
+                                                                .content("{}")
+                                                                .build()))
+                                        .usage(new ChatUsage(8, 15, 23))
+                                        .build());
+                    }
+                    return List.of(
+                            ChatResponse.builder()
+                                    .id("msg_" + java.util.UUID.randomUUID())
+                                    .content(List.of(TextBlock.builder().text("task done").build()))
+                                    .usage(new ChatUsage(10, 20, 30))
+                                    .build());
+                };
+        MockModel model = new MockModel(gen);
+
+        ReActAgent agentSpy =
+                Mockito.spy(
+                        ReActAgent.builder()
+                                .name("slow_sub")
+                                .sysPrompt("slow sub")
+                                .model(model)
+                                .toolkit(tk)
+                                .build());
+
+        // ---- DefaultAgentManager + AgentSpawnTool with a capturing TaskRepository ----
+        SubagentFactory factory = rc -> agentSpy;
+        DefaultAgentManager manager =
+                new DefaultAgentManager(
+                        List.of(new SubagentEntry("slow_agent", "Test slow agent", factory)), null);
+
+        AtomicReference<TaskRunSpec> capturedSpec = new AtomicReference<>();
+        AtomicReference<String> capturedTaskId = new AtomicReference<>();
+        TaskRepository captureRepo = new CapturingTaskRepository(capturedSpec, capturedTaskId);
+
+        AgentSpawnTool tool = new AgentSpawnTool(manager, captureRepo, 0);
+        RuntimeContext ctx = RuntimeContext.builder().sessionId("s1").userId("u1").build();
+
+        // ---- Call agentSpawn with 1s timeout — agent takes ~2s+ to finish naturally ----
+        String result =
+                tool.agentSpawn(ctx, null, "slow_agent", "go", null, 1, null)
+                        .block(Duration.ofSeconds(10));
+
+        // ===== Proof #1: tool returned the promotion message, not an error =====
+        assertNotNull(result, "agentSpawn returned null");
+        assertTrue(
+                result.contains("status: timeout_promoted"),
+                "Expected 'status: timeout_promoted' in result, got: " + result);
+        assertNotNull(capturedTaskId.get(), "TaskRepository.putTask was never called");
+        assertTrue(
+                result.contains("task_id: " + capturedTaskId.get()),
+                "Result should include the captured task_id. result=" + result);
+
+        // ===== Proof #2: the captured spec is AdoptedTaskRunSpec (not Local/Remote) =====
+        TaskRunSpec spec = capturedSpec.get();
+        assertNotNull(spec, "Captured TaskRunSpec was null");
+        assertTrue(
+                spec instanceof TaskRunSpec.AdoptedTaskRunSpec,
+                "Expected AdoptedTaskRunSpec but got " + spec.getClass().getSimpleName());
+
+        // ===== Proof #3: the adopted future eventually completes with the agent's reply =====
+        // This is the critical assertion: the orphan-cancel fix must NOT dispose the inner
+        // subscription when the timeout fires via race.orTimeout (CompletableFuture), otherwise
+        // the agent would be killed and this future would never complete.
+        CompletableFuture<String> adoptedFuture = ((TaskRunSpec.AdoptedTaskRunSpec) spec).future();
+        String finalReply = adoptedFuture.get(15, TimeUnit.SECONDS);
+        assertNotNull(finalReply, "Adopted future completed with null");
+        assertTrue(
+                finalReply.contains("task done"),
+                "Adopted future should complete with agent's reply. Got: " + finalReply);
+
+        // ===== Proof #4: interrupt() was never called on the agent =====
+        // Promotion is supposed to keep the agent running, not kill it. If the orphan-cancel
+        // fix accidentally fires on the promotion path, interrupt() would be invoked here.
+        verify(agentSpy, never()).interrupt(any(RuntimeContext.class));
+    }
+
+    /** Captures the {@link TaskRunSpec} submitted to {@code putTask} so the test can inspect it. */
+    private static final class CapturingTaskRepository implements TaskRepository {
+        private final AtomicReference<TaskRunSpec> capturedSpec;
+        private final AtomicReference<String> capturedTaskId;
+
+        CapturingTaskRepository(AtomicReference<TaskRunSpec> spec, AtomicReference<String> id) {
+            this.capturedSpec = spec;
+            this.capturedTaskId = id;
+        }
+
+        @Override
+        public BackgroundTask putTask(
+                RuntimeContext rc,
+                String taskId,
+                String subAgentId,
+                String sessionId,
+                TaskRunSpec spec) {
+            capturedSpec.set(spec);
+            capturedTaskId.set(taskId);
+            return null;
+        }
+
+        @Override
+        public BackgroundTask getTask(RuntimeContext rc, String sessionId, String taskId) {
+            return null;
+        }
+
+        @Override
+        public void removeTask(RuntimeContext rc, String sessionId, String taskId) {}
+
+        @Override
+        public void clear() {}
+
+        @Override
+        public Collection<BackgroundTask> listTasks(
+                RuntimeContext rc, String sessionId, TaskStatus filter) {
+            return List.of();
+        }
+
+        @Override
+        public boolean cancelTask(RuntimeContext rc, String sessionId, String taskId) {
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
  ## Summary

  Fix an orphan sub-agent leak in `AgentSpawnTool.execWithTimeoutPromotion`: when the parent's subscription to the
  `agentSpawn` Mono is cancelled (outer `Mono.timeout()`, user stop, or upstream Reactor cancel), the inner execution
  Mono — subscribed via fire-and-forget `.subscribe(...)` — was never disposed, so the spawned `ReActAgent` kept running
   indefinitely.

  Closes #2062.

  ## Root cause

  `execWithTimeoutPromotion` builds the result `Mono<String>` by wrapping an inner `Mono<Msg>` in a `MonoSink` +
  `CompletableFuture` bridge, then does plain `.subscribe(...)` on the inner Mono:

  ```java
  Disposable innerSub = inner.subscribe(
      bridge::complete,
      bridge::completeExceptionally,
      () -> { if (!bridge.isDone()) bridge.complete(null); });

  3. The returned Disposable is captured but never wired to the outer subscription, so Reactor cancel on the outer Mono
  never propagates into the inner one. Same shape as the core SubAgentTool bug fixed in 029cc55e.

  Fix

  3. Two-part, mirroring 029cc55e but adapted for AgentSpawnTool's bridge wrapper:

    - inner.doFinally(CANCEL -> interruptAgent(...)) — when the inner Mono is disposed, call ReActAgent.interrupt(ctx)
  to break the ReAct loop.
    - sink.onCancel(innerSub) — propagate outer Reactor cancel into the inner subscription so doFinally(CANCEL) actually
   fires.

  What this does NOT change

    - Timeout promotion (race.orTimeout → AdoptedTaskRunSpec) — terminates via sink.success(...), not Reactor cancel, so
   doFinally(CANCEL) doesn't fire and the agent continues. Pinned by AgentSpawnToolPromotionTest.
    - Async cooperation (timeout_seconds == 0 → taskRepository.putTask) — separate code path, untouched.

  Test plan

  Two new regression tests in agentscope-harness:

  | Test                           | Scenario                                            | Assertion
                                                                                                |
  |--------------------------------|-----------------------------------------------------|------------------------------
  ----------------------------------------------------------------------------------------------|
  | AgentSpawnToolOrphanCancelTest | outer Mono.timeout(2s) cancels mid-flight           | interrupt() called on
  sub-agent; file lines + model calls stop growing within 4s window (delta ≤ 1). Pre-fix delta was 25. |
  | AgentSpawnToolPromotionTest    | internal race.orTimeout fires before agent finishes | captured spec is
  AdoptedTaskRunSpec; its future() completes with the agent's reply; interrupt() is never called.           |

  Full harness suite: 608 tests pass, 0 failures, 3 pre-existing skips.

    - mvn -pl agentscope-harness test -Dtest=AgentSpawnToolOrphanCancelTest
    - mvn -pl agentscope-harness test -Dtest=AgentSpawnToolPromotionTest
    - mvn -pl agentscope-harness test (full suite)
    - mvn -pl agentscope-harness spotless:check