### PR TITLE
fix(harness): allow SkillLoadTool in Plan Mode by promoting isReadOnly to AgentTool interface

### DIFF
--- a/agentscope-core/src/main/java/io/agentscope/core/tool/AgentTool.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/tool/AgentTool.java
@@ -101,6 +101,18 @@ public interface AgentTool {
     }
 
     /**
+     * Returns whether this tool performs only read operations and never mutates state.
+     *
+     * <p>Read-only tools are automatically permitted in restricted execution modes such as
+     * Plan Mode, where write operations require explicit approval.
+     *
+     * @return {@code true} if the tool is read-only; {@code false} by default
+     */
+    default boolean isReadOnly() {
+        return false;
+    }
+
+    /**
      * Execute the tool with the given parameters (asynchronous).
      *
      * <p>This method accepts a {@link ToolCallParam} object containing all necessary context for

--- a/agentscope-core/src/main/java/io/agentscope/core/tool/ToolBase.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/tool/ToolBase.java
@@ -143,6 +143,7 @@ public abstract class ToolBase implements AgentTool {
         return concurrencySafe;
     }
 
+    @Override
     public final boolean isReadOnly() {
         return readOnly;
     }

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/HarnessAgent.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/HarnessAgent.java
@@ -39,7 +39,6 @@ import io.agentscope.core.state.AgentStateStore;
 import io.agentscope.core.state.InMemoryAgentStateStore;
 import io.agentscope.core.state.JsonFileAgentStateStore;
 import io.agentscope.core.tool.AgentTool;
-import io.agentscope.core.tool.ToolBase;
 import io.agentscope.core.tool.ToolExecutionContext;
 import io.agentscope.core.tool.Toolkit;
 import io.agentscope.harness.agent.filesystem.AbstractFilesystem;
@@ -2276,7 +2275,7 @@ public class HarnessAgent implements Agent, AutoCloseable {
                                 planModeManager,
                                 toolName -> {
                                     AgentTool t = roToolkit.getTool(toolName);
-                                    return t instanceof ToolBase tb && tb.isReadOnly();
+                                    return t != null && t.isReadOnly();
                                 },
                                 planExtraAllowed));
             }

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/skill/runtime/SkillLoadTool.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/skill/runtime/SkillLoadTool.java
@@ -68,6 +68,11 @@ public final class SkillLoadTool implements AgentTool {
     }
 
     @Override
+    public boolean isReadOnly() {
+        return true;
+    }
+
+    @Override
     public String getName() {
         return TOOL_NAME;
     }

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/middleware/PlanModeMiddlewareTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/middleware/PlanModeMiddlewareTest.java
@@ -28,8 +28,11 @@ import io.agentscope.core.message.Msg;
 import io.agentscope.core.message.ToolUseBlock;
 import io.agentscope.core.middleware.ActingInput;
 import io.agentscope.core.state.AgentState;
+import io.agentscope.core.tool.AgentTool;
+import io.agentscope.core.tool.Toolkit;
 import io.agentscope.harness.agent.filesystem.AbstractFilesystem;
 import io.agentscope.harness.agent.filesystem.spec.LocalFilesystemSpec;
+import io.agentscope.harness.agent.skill.runtime.SkillLoadTool;
 import io.agentscope.harness.agent.workspace.WorkspaceManager;
 import io.agentscope.harness.agent.workspace.plan.PlanModeManager;
 import java.nio.file.Path;
@@ -221,6 +224,53 @@ class PlanModeMiddlewareTest {
                 List.of("agent_spawn", "agent_send", "agent_list", "task_output", "task_list"),
                 forwardedNames);
         assertTrue(events.isEmpty(), "no denied events expected");
+    }
+
+    @Test
+    void skillLoadToolIsReadOnlyAndPermittedInPlanMode(
+            @TempDir Path project, @TempDir Path workspace) {
+        // SkillLoadTool implements AgentTool (not ToolBase) — verify isReadOnly() is true.
+        SkillLoadTool loadTool = new SkillLoadTool(new AtomicReference<>(null));
+        assertTrue(loadTool.isReadOnly(), "SkillLoadTool must be read-only");
+
+        // Build a toolkit containing the SkillLoadTool and wire a resolver matching
+        // the pattern used in HarnessAgent.Builder.build().
+        Toolkit toolkit = new Toolkit();
+        toolkit.registerTool(loadTool);
+        Predicate<String> resolver =
+                toolName -> {
+                    AgentTool t = toolkit.getTool(toolName);
+                    return t != null && t.isReadOnly();
+                };
+
+        PlanModeManager manager = manager(project, workspace);
+        AgentState state = AgentState.builder().build();
+        manager.enter(state);
+        StubAgent agent = new StubAgent("tester", state);
+
+        PlanModeMiddleware mw = new PlanModeMiddleware(manager, resolver);
+
+        List<ToolUseBlock> calls =
+                List.of(call("1", SkillLoadTool.TOOL_NAME), call("2", "write_file"));
+
+        AtomicReference<ActingInput> forwarded = new AtomicReference<>();
+        List<AgentEvent> events =
+                mw.onActing(
+                                agent,
+                                null,
+                                new ActingInput(calls),
+                                ai -> {
+                                    forwarded.set(ai);
+                                    return Flux.empty();
+                                })
+                        .collectList()
+                        .block();
+
+        // load_skill_through_path should pass; write_file should be denied.
+        List<String> forwardedNames =
+                forwarded.get().toolCalls().stream().map(ToolUseBlock::getName).toList();
+        assertEquals(List.of(SkillLoadTool.TOOL_NAME), forwardedNames);
+        assertEquals(3, events.size(), "denied write_file should produce start+delta+end events");
     }
 
     /** Minimal Agent stub exposing only name + state. */


### PR DESCRIPTION
## Summary

- `SkillLoadTool` implements `AgentTool` directly (not `ToolBase`), so `PlanModeMiddleware`'s `readOnlyResolver` — which checked `instanceof ToolBase` — never recognized it as read-only, blocking `load_skill_through_path` calls in Plan Mode.
- Adds `default boolean isReadOnly()` to the `AgentTool` interface (returns `false` by default), overrides it in `SkillLoadTool` to return `true`, and updates `HarnessAgent`'s resolver to use the interface method instead of downcasting to `ToolBase`.

## Changes

- `AgentTool.java`: add `default boolean isReadOnly()` returning `false`
- `ToolBase.java`: add `@Override` to existing `isReadOnly()` 
- `SkillLoadTool.java`: override `isReadOnly()` to return `true`
- `HarnessAgent.java`: change resolver from `t instanceof ToolBase tb && tb.isReadOnly()` to `t != null && t.isReadOnly()`; remove unused `ToolBase` import
- `PlanModeMiddlewareTest.java`: add test verifying `SkillLoadTool` is permitted in Plan Mode via the toolkit-based resolver

## Test plan

- [x] Existing `PlanModeMiddlewareTest` tests pass (7/7)
- [x] `SkillLoadToolFrontmatterViewTest` passes
- [x] New `skillLoadToolIsReadOnlyAndPermittedInPlanMode` test validates end-to-end: `SkillLoadTool.isReadOnly() == true`, toolkit resolver permits it, `write_file` is still denied
- [x] `mvn spotless:check` clean

Closes #2056