### PR TITLE
fix(openai): make nativeStructuredOutput configurable

### DIFF
--- a/agentscope-core/src/main/java/io/agentscope/core/model/ChatModelBase.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/model/ChatModelBase.java
@@ -30,6 +30,8 @@ public abstract class ChatModelBase implements Model {
 
     private int contextWindowSize;
 
+    private Boolean nativeStructuredOutput;
+
     private Boolean nativeStructuredOutputWithTools;
 
     @Override
@@ -39,6 +41,15 @@ public abstract class ChatModelBase implements Model {
 
     protected void setContextWindowSize(int contextWindowSize) {
         this.contextWindowSize = contextWindowSize;
+    }
+
+    @Override
+    public boolean supportsNativeStructuredOutput() {
+        return nativeStructuredOutput != null ? nativeStructuredOutput : false;
+    }
+
+    protected void setNativeStructuredOutput(boolean nativeStructuredOutput) {
+        this.nativeStructuredOutput = nativeStructuredOutput;
     }
 
     @Override

--- a/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-dashscope/src/main/java/io/agentscope/extensions/model/dashscope/DashScopeChatModel.java
+++ b/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-dashscope/src/main/java/io/agentscope/extensions/model/dashscope/DashScopeChatModel.java
@@ -69,7 +69,6 @@ public class DashScopeChatModel extends ChatModelBase {
     private final boolean stream;
     private final Boolean enableThinking; // nullable
     private final Boolean enableSearch; // nullable
-    private Boolean nativeStructuredOutput; // nullable, set by Builder
     private final EndpointType endpointType;
     private final GenerateOptions defaultOptions;
     private final Formatter<DashScopeMessage, DashScopeResponse, DashScopeRequest> formatter;
@@ -161,7 +160,6 @@ public class DashScopeChatModel extends ChatModelBase {
         this.stream = enableThinking != null && enableThinking ? true : stream;
         this.enableThinking = enableThinking;
         this.enableSearch = enableSearch;
-        this.nativeStructuredOutput = null;
         this.endpointType = endpointType != null ? endpointType : EndpointType.AUTO;
         this.defaultOptions =
                 defaultOptions != null ? defaultOptions : GenerateOptions.builder().build();
@@ -397,10 +395,7 @@ public class DashScopeChatModel extends ChatModelBase {
         if (Boolean.TRUE.equals(enableThinking)) {
             return false;
         }
-        if (nativeStructuredOutput != null) {
-            return nativeStructuredOutput;
-        }
-        return false;
+        return super.supportsNativeStructuredOutput();
     }
 
     public static class Builder {
@@ -737,7 +732,7 @@ public class DashScopeChatModel extends ChatModelBase {
                             ? contextWindowSize
                             : ModelContextWindows.lookup(modelName, ModelContextWindows.DASHSCOPE));
             if (nativeStructuredOutput != null) {
-                model.nativeStructuredOutput = nativeStructuredOutput;
+                model.setNativeStructuredOutput(nativeStructuredOutput);
             }
             if (nativeStructuredOutputWithTools != null) {
                 model.setNativeStructuredOutputWithTools(nativeStructuredOutputWithTools);

--- a/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-dashscope/src/main/java/io/agentscope/extensions/model/dashscope/DashScopeModelProvider.java
+++ b/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-dashscope/src/main/java/io/agentscope/extensions/model/dashscope/DashScopeModelProvider.java
@@ -37,6 +37,7 @@ public final class DashScopeModelProvider implements ModelProvider {
     private static final String OPTION_ENABLE_ENCRYPT = "enableEncrypt";
     private static final String OPTION_ENABLE_SEARCH = "enableSearch";
     private static final String OPTION_ENDPOINT_TYPE = "endpointType";
+    private static final String OPTION_NATIVE_STRUCTURED_OUTPUT = "nativeStructuredOutput";
     private static final String OPTION_NATIVE_STRUCTURED_OUTPUT_WITH_TOOLS =
             "nativeStructuredOutputWithTools";
 
@@ -120,6 +121,10 @@ public final class DashScopeModelProvider implements ModelProvider {
         Integer contextWindowSize = intOption(context, OPTION_CONTEXT_WINDOW_SIZE);
         if (contextWindowSize != null) {
             builder.contextWindowSize(contextWindowSize);
+        }
+        Boolean nativeStructuredOutput = booleanOption(context, OPTION_NATIVE_STRUCTURED_OUTPUT);
+        if (nativeStructuredOutput != null) {
+            builder.nativeStructuredOutput(nativeStructuredOutput);
         }
         Boolean nativeStructuredOutputWithTools =
                 booleanOption(context, OPTION_NATIVE_STRUCTURED_OUTPUT_WITH_TOOLS);

--- a/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-openai/src/main/java/io/agentscope/extensions/model/openai/OpenAIChatModel.java
+++ b/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-openai/src/main/java/io/agentscope/extensions/model/openai/OpenAIChatModel.java
@@ -198,11 +198,6 @@ public class OpenAIChatModel extends ChatModelBase {
         return configuredOptions != null ? configuredOptions.getModelName() : null;
     }
 
-    @Override
-    public boolean supportsNativeStructuredOutput() {
-        return true;
-    }
-
     /**
      * Creates a new builder for OpenAIChatModel.
      *
@@ -229,6 +224,7 @@ public class OpenAIChatModel extends ChatModelBase {
         private HttpTransport httpTransport;
         private ProxyConfig proxyConfig;
         private int contextWindowSize = -1;
+        private Boolean nativeStructuredOutput;
         private Boolean nativeStructuredOutputWithTools;
 
         /**
@@ -382,6 +378,23 @@ public class OpenAIChatModel extends ChatModelBase {
         }
 
         /**
+         * Sets whether this model supports native structured output via
+         * {@code response_format}.
+         *
+         * <p>Defaults to {@code true}, which is correct for OpenAI's own models. Set to
+         * {@code false} for OpenAI-compatible providers that do not reliably return
+         * schema-constrained JSON through {@code response_format}; the agent will use
+         * the {@code generate_response} fallback tool instead.
+         *
+         * @param nativeStructuredOutput false to disable native structured output
+         * @return this builder instance
+         */
+        public Builder nativeStructuredOutput(boolean nativeStructuredOutput) {
+            this.nativeStructuredOutput = nativeStructuredOutput;
+            return this;
+        }
+
+        /**
          * Sets whether this model correctly handles native structured output
          * ({@code response_format}) alongside tool calling.
          *
@@ -440,6 +453,8 @@ public class OpenAIChatModel extends ChatModelBase {
                     contextWindowSize >= 0
                             ? contextWindowSize
                             : ModelContextWindows.lookup(modelName, ModelContextWindows.OPENAI));
+            model.setNativeStructuredOutput(
+                    nativeStructuredOutput != null ? nativeStructuredOutput : true);
             if (nativeStructuredOutputWithTools != null) {
                 model.setNativeStructuredOutputWithTools(nativeStructuredOutputWithTools);
             }

--- a/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-openai/src/main/java/io/agentscope/extensions/model/openai/OpenAIModelProvider.java
+++ b/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-openai/src/main/java/io/agentscope/extensions/model/openai/OpenAIModelProvider.java
@@ -33,6 +33,7 @@ public final class OpenAIModelProvider implements ModelProvider {
     private static final String PREFIX = "openai:";
     private static final Pattern MODEL_ID = Pattern.compile("openai:.+");
     private static final String OPTION_CONTEXT_WINDOW_SIZE = "contextWindowSize";
+    private static final String OPTION_NATIVE_STRUCTURED_OUTPUT = "nativeStructuredOutput";
     private static final String OPTION_NATIVE_STRUCTURED_OUTPUT_WITH_TOOLS =
             "nativeStructuredOutputWithTools";
 
@@ -102,6 +103,10 @@ public final class OpenAIModelProvider implements ModelProvider {
         Integer contextWindowSize = intOption(context, OPTION_CONTEXT_WINDOW_SIZE);
         if (contextWindowSize != null) {
             builder.contextWindowSize(contextWindowSize);
+        }
+        Boolean nativeStructuredOutput = booleanOption(context, OPTION_NATIVE_STRUCTURED_OUTPUT);
+        if (nativeStructuredOutput != null) {
+            builder.nativeStructuredOutput(nativeStructuredOutput);
         }
         Boolean nativeStructuredOutputWithTools =
                 booleanOption(context, OPTION_NATIVE_STRUCTURED_OUTPUT_WITH_TOOLS);

--- a/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-openai/src/test/java/io/agentscope/extensions/model/openai/OpenAIChatModelTest.java
+++ b/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-openai/src/test/java/io/agentscope/extensions/model/openai/OpenAIChatModelTest.java
@@ -95,6 +95,25 @@ class OpenAIChatModelTest {
     }
 
     @Test
+    @DisplayName("Default builder enables native structured output")
+    void testNativeStructuredOutputDefaultTrue() {
+        OpenAIChatModel m = OpenAIChatModel.builder().apiKey("k").modelName("gpt-4").build();
+        assertTrue(m.supportsNativeStructuredOutput());
+    }
+
+    @Test
+    @DisplayName("Builder can disable native structured output for compatible gateways")
+    void testNativeStructuredOutputDisabled() {
+        OpenAIChatModel m =
+                OpenAIChatModel.builder()
+                        .apiKey("k")
+                        .modelName("gpt-4")
+                        .nativeStructuredOutput(false)
+                        .build();
+        assertFalse(m.supportsNativeStructuredOutput());
+    }
+
+    @Test
     @DisplayName("Should make non-streaming call successfully")
     void testNonStreamingCall() throws Exception {
         String responseJson =

--- a/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-openai/src/test/java/io/agentscope/extensions/model/openai/OpenAIModelProviderTest.java
+++ b/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-openai/src/test/java/io/agentscope/extensions/model/openai/OpenAIModelProviderTest.java
@@ -64,6 +64,7 @@ class OpenAIModelProviderTest {
                         .component(GenerateOptions.class, GenerateOptions.builder().build())
                         .component(ProxyConfig.class, ProxyConfig.http("localhost", 8080))
                         .option("contextWindowSize", 128000)
+                        .option("nativeStructuredOutput", false)
                         .option("nativeStructuredOutputWithTools", true)
                         .build();
 
@@ -72,6 +73,7 @@ class OpenAIModelProviderTest {
         assertTrue(model instanceof OpenAIChatModel);
         assertTrue(model.getModelName().equals("gpt-4o-mini"));
         assertEquals(128000, model.getContextWindowSize());
+        assertFalse(model.supportsNativeStructuredOutput());
     }
 
     @Test

--- a/docs/v1/en/docs/task/model.md
+++ b/docs/v1/en/docs/task/model.md
@@ -130,6 +130,8 @@ DashScopeChatModel model = DashScopeChatModel.builder()
 | `endpointType` | API endpoint type (default `AUTO` auto-detect), options: `TEXT` (force text API) or `MULTIMODAL` (force multimodal API) |
 | `defaultOptions` | Default generation options (temperature, maxTokens, etc.) |
 | `formatter` | Message formatter (default `DashScopeChatFormatter`) |
+| `nativeStructuredOutput` | Enable native `response_format` structured output, default `false` |
+| `nativeStructuredOutputWithTools` | Enable native structured output when tools are present, defaults to `nativeStructuredOutput` |
 
 ### Endpoint Type (endpointType)
 
@@ -191,13 +193,16 @@ OpenAIChatModel model = OpenAIChatModel.builder()
 
 ### Compatible APIs
 
-For DeepSeek, vLLM, and other compatible providers:
+For DeepSeek, vLLM, and other compatible providers. Note that you need to configure the appropriate Formatter and structured output capabilities:
 
 ```java
 OpenAIChatModel model = OpenAIChatModel.builder()
         .apiKey("your-api-key")
         .modelName("deepseek-chat")
         .baseUrl("https://api.deepseek.com")
+        .formatter(new DeepSeekFormatter())
+        .nativeStructuredOutput(false)
+        .nativeStructuredOutputWithTools(false)
         .build();
 ```
 
@@ -208,8 +213,14 @@ OpenAIChatModel model = OpenAIChatModel.builder()
 | `apiKey` | API key |
 | `modelName` | Model name, e.g., `gpt-4o`, `gpt-4o-mini` |
 | `baseUrl` | Custom API endpoint (optional) |
+| `endpointPath` | Custom request path (optional), e.g., `/v4/chat/completions` |
 | `stream` | Enable streaming, default `true` |
 | `generateOptions` | Default generation options (note: OpenAI uses `.generateOptions()` instead of `.defaultOptions()`) |
+| `formatter` | Message formatter (default `OpenAIChatFormatter`). Compatible providers need their own Formatter (e.g., `DeepSeekFormatter`, `GLMFormatter`) |
+| `nativeStructuredOutput` | Enable native `response_format` structured output, default `true`. Unsupported providers (DeepSeek, vLLM, etc.) should set to `false` |
+| `nativeStructuredOutputWithTools` | Enable native structured output when tools are present, default `true`. Some providers prioritize `response_format` over tool calls, should set to `false` |
+| `contextWindowSize` | Override context window size (optional, auto-inferred from model name by default) |
+| `proxy` | Proxy configuration (optional), e.g., `ProxyConfig.http("localhost", 8080)` |
 
 ## Anthropic
 

--- a/docs/v1/zh/docs/task/model.md
+++ b/docs/v1/zh/docs/task/model.md
@@ -130,6 +130,8 @@ DashScopeChatModel model = DashScopeChatModel.builder()
 | `endpointType` | API 端点类型（默认 `AUTO` 自动识别），可选 `TEXT`（强制文本 API）或 `MULTIMODAL`（强制多模态 API） |
 | `defaultOptions` | 默认生成选项（temperature、maxTokens 等） |
 | `formatter` | 消息格式化器（默认 `DashScopeChatFormatter`） |
+| `nativeStructuredOutput` | 是否启用原生 `response_format` 结构化输出，默认 `false` |
+| `nativeStructuredOutputWithTools` | 与工具同时使用时是否启用原生结构化输出，默认跟随 `nativeStructuredOutput` |
 
 ### 端点类型（endpointType）
 
@@ -189,13 +191,16 @@ OpenAIChatModel model = OpenAIChatModel.builder()
 
 ### 兼容 API
 
-适用于 DeepSeek、vLLM 等兼容提供商：
+适用于 DeepSeek、vLLM 等兼容提供商。注意需要配置对应的 Formatter 和结构化输出能力：
 
 ```java
 OpenAIChatModel model = OpenAIChatModel.builder()
         .apiKey("your-api-key")
         .modelName("deepseek-chat")
         .baseUrl("https://api.deepseek.com")
+        .formatter(new DeepSeekFormatter())
+        .nativeStructuredOutput(false)
+        .nativeStructuredOutputWithTools(false)
         .build();
 ```
 
@@ -206,8 +211,14 @@ OpenAIChatModel model = OpenAIChatModel.builder()
 | `apiKey` | API 密钥 |
 | `modelName` | 模型名称，如 `gpt-4o`、`gpt-4o-mini` |
 | `baseUrl` | 自定义 API 端点（可选） |
+| `endpointPath` | 自定义请求路径（可选），如 `/v4/chat/completions` |
 | `stream` | 是否启用流式输出，默认 `true` |
 | `generateOptions` | 默认生成选项（注意：OpenAI 使用 `.generateOptions()` 而非 `.defaultOptions()`） |
+| `formatter` | 消息格式化器（默认 `OpenAIChatFormatter`），兼容提供商需使用对应 Formatter（如 `DeepSeekFormatter`、`GLMFormatter`） |
+| `nativeStructuredOutput` | 是否启用原生 `response_format` 结构化输出，默认 `true`。不支持的提供商（DeepSeek、vLLM 等）需设为 `false` |
+| `nativeStructuredOutputWithTools` | 与工具同时使用时是否启用原生结构化输出，默认 `true`。部分提供商会优先 `response_format` 而跳过工具调用，需设为 `false` |
+| `contextWindowSize` | 覆盖上下文窗口大小（可选，默认按模型名称自动推断） |
+| `proxy` | 代理配置（可选），如 `ProxyConfig.http("localhost", 8080)` |
 
 ## Anthropic
 


### PR DESCRIPTION
## Summary

- Add configurable `nativeStructuredOutput` capability flag to `ChatModelBase`, reusing the same nullable-Boolean pattern established by `nativeStructuredOutputWithTools`
- Remove hardcoded `supportsNativeStructuredOutput() { return true; }` from `OpenAIChatModel`; default to `true` in Builder so existing users are unaffected
- Wire `nativeStructuredOutput` option through `OpenAIModelProvider` so it can be set via `ModelCreationContext`

This allows users on OpenAI-compatible gateways (vLLM, Ollama, etc.) that don't support `response_format` with `json_schema` to set `nativeStructuredOutput=false` and fall back to the `generate_response` tool approach.

## Test plan

- [x] `OpenAIChatModelTest.testNativeStructuredOutputDefaultTrue` — builder default is `true`
- [x] `OpenAIChatModelTest.testNativeStructuredOutputDisabled` — explicit `false` propagates
- [x] `OpenAIModelProviderTest.createUsesModelCreationContext` — option read from context
- [x] `ReActAgentStructuredOutputWithToolsTest` — no regression

Closes #2025