### PR TITLE
fix(tool): external tool execution now correctly produces suspended result

### DIFF
--- a/agentscope-core/src/main/java/io/agentscope/core/tool/ReflectiveFunctionTool.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/tool/ReflectiveFunctionTool.java
@@ -159,7 +159,8 @@ final class ReflectiveFunctionTool extends ToolBase {
     @Override
     public Mono<ToolResultBlock> callAsync(ToolCallParam param) {
         if (isExternalTool()) {
-            return Mono.error(new ToolSuspendException());
+            return Mono.just(
+                    ToolResultBlock.suspended(param.getToolUseBlock(), new ToolSuspendException()));
         }
         return methodInvoker.invokeAsync(toolObject, method, param, customConverter);
     }

--- a/agentscope-core/src/main/java/io/agentscope/core/tool/ToolExecutor.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/tool/ToolExecutor.java
@@ -193,7 +193,7 @@ class ToolExecutor {
         // validation, preset injection, or scheduling. SchemaOnlyTool and any
         // @Tool(externalTool=true) method end up here.
         if (tool instanceof ToolBase tb && tb.isExternalTool()) {
-            return Mono.error(new ToolSuspendException());
+            return Mono.just(ToolResultBlock.suspended(toolCall, new ToolSuspendException()));
         }
 
         // Check tool activation

--- a/agentscope-core/src/test/java/io/agentscope/core/tool/ExternalToolSupportTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/tool/ExternalToolSupportTest.java
@@ -22,6 +22,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.agentscope.core.message.ToolResultBlock;
+import io.agentscope.core.message.ToolUseBlock;
 import io.agentscope.core.model.ToolSchema;
 import java.util.List;
 import java.util.Map;
@@ -233,6 +234,76 @@ class ExternalToolSupportTest {
         // Verify schemas include both
         List<ToolSchema> schemas = toolkit.getToolSchemas();
         assertEquals(2, schemas.size());
+    }
+
+    @Test
+    @DisplayName("Should produce suspended result when executing SchemaOnlyTool via Toolkit")
+    void testSchemaOnlyToolExecutionReturnsSuspended() {
+        ToolSchema schema =
+                ToolSchema.builder()
+                        .name("db_query")
+                        .description("Query database")
+                        .parameters(
+                                Map.of(
+                                        "type",
+                                        "object",
+                                        "properties",
+                                        Map.of("sql", Map.of("type", "string")),
+                                        "required",
+                                        List.of("sql")))
+                        .build();
+        toolkit.registerSchema(schema);
+
+        Map<String, Object> input = Map.of("sql", "SELECT 1");
+        ToolUseBlock toolCall =
+                ToolUseBlock.builder()
+                        .id("call-ext-1")
+                        .name("db_query")
+                        .input(input)
+                        .content(io.agentscope.core.util.JsonUtils.getJsonCodec().toJson(input))
+                        .build();
+
+        List<ToolResultBlock> results =
+                toolkit.callTools(List.of(toolCall), null, null, null)
+                        .block(java.time.Duration.ofSeconds(3));
+
+        assertNotNull(results);
+        assertEquals(1, results.size());
+        assertTrue(results.get(0).isSuspended(), "External tool result should be suspended");
+        assertEquals("call-ext-1", results.get(0).getId());
+        assertEquals("db_query", results.get(0).getName());
+    }
+
+    @Test
+    @DisplayName(
+            "Should produce suspended result when executing @Tool(externalTool=true) via Toolkit")
+    void testAnnotationExternalToolExecutionReturnsSuspended() {
+        toolkit.registerTool(new AnnotationExternalToolExample());
+
+        Map<String, Object> input = Map.of("endpoint", "/api/test");
+        ToolUseBlock toolCall =
+                ToolUseBlock.builder()
+                        .id("call-ext-2")
+                        .name("call_api")
+                        .input(input)
+                        .content(io.agentscope.core.util.JsonUtils.getJsonCodec().toJson(input))
+                        .build();
+
+        List<ToolResultBlock> results =
+                toolkit.callTools(List.of(toolCall), null, null, null)
+                        .block(java.time.Duration.ofSeconds(3));
+
+        assertNotNull(results);
+        assertEquals(1, results.size());
+        assertTrue(results.get(0).isSuspended(), "External tool result should be suspended");
+        assertEquals("call-ext-2", results.get(0).getId());
+    }
+
+    static class AnnotationExternalToolExample {
+        @Tool(name = "call_api", description = "Call external API", externalTool = true)
+        public String callApi(@ToolParam(name = "endpoint") String endpoint) {
+            throw new AssertionError("External tool body should never be invoked");
+        }
     }
 
     /** Sample internal tool for testing. */


### PR DESCRIPTION
## Summary

- `ToolExecutor.executeCore` and `ReflectiveFunctionTool.callAsync` used `Mono.error(ToolSuspendException)` for external tools (`@Tool(externalTool=true)` and `SchemaOnlyTool`), but the downstream `onErrorResume(ToolSuspendException.class)` handler in `executeWithInfrastructure` never received the error because `executeCore` short-circuits before reaching that path
- Changed both sites to return `Mono.just(ToolResultBlock.suspended(...))` so the suspended result propagates correctly through the reactive chain
- Added two tests covering both `SchemaOnlyTool` and `@Tool(externalTool=true)` execution paths

## Test plan

- [x] `ExternalToolSupportTest#testSchemaOnlyToolExecutionReturnsSuspended` — verifies `SchemaOnlyTool` produces `isSuspended() == true`
- [x] `ExternalToolSupportTest#testAnnotationExternalToolExecutionReturnsSuspended` — verifies `@Tool(externalTool=true)` produces `isSuspended() == true`
- [x] Existing `ExternalToolSupportTest` tests continue to pass