### PR TITLE
fix(harness): allow MemoryFlushMiddleware to flush for all Agent types

### DIFF
--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/middleware/MemoryFlushMiddleware.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/middleware/MemoryFlushMiddleware.java
@@ -15,7 +15,6 @@
  */
 package io.agentscope.harness.agent.middleware;
 
-import io.agentscope.core.ReActAgent;
 import io.agentscope.core.agent.Agent;
 import io.agentscope.core.agent.RuntimeContext;
 import io.agentscope.core.event.AgentEvent;
@@ -156,10 +155,7 @@ public class MemoryFlushMiddleware implements HarnessRuntimeMiddleware {
     }
 
     private Mono<Void> doFlush(Agent agent, RuntimeContext rc) {
-        if (!(agent instanceof ReActAgent reActAgent)) {
-            return Mono.empty();
-        }
-        AgentState state = RuntimeContext.resolveAgentState(rc, reActAgent);
+        AgentState state = RuntimeContext.resolveAgentState(rc, agent);
         if (state == null) {
             return Mono.empty();
         }
@@ -216,7 +212,7 @@ public class MemoryFlushMiddleware implements HarnessRuntimeMiddleware {
      * namespace (see {@link #timerKeyFor(RuntimeContext)}).
      *
      * <p>Package-private for unit testing of the trigger gate without standing up a full
-     * {@code ReActAgent}.
+     * {@code Agent}.
      */
     boolean shouldFlushNow(RuntimeContext rc) {
         switch (flushTrigger.mode()) {


### PR DESCRIPTION
## Summary

- `MemoryFlushMiddleware.doFlush()` had an `instanceof ReActAgent` guard that silently skipped `HarnessAgent` (which implements `Agent` directly, not via `ReActAgent`)
- This caused daily memory journals (`memory/YYYY-MM-DD.md`, MEMORY type) and consolidated `MEMORY.md` (CONTEXT type) to never be written for HarnessAgent-based agents
- Removed the type guard since `RuntimeContext.resolveAgentState()` accepts any `Agent`, and `HarnessAgent` provides `getAgentState()` via its delegate

Closes #2030

## Test plan

- [ ] Verify `mvn compile -pl agentscope-harness -am` passes
- [ ] Deploy with a HarnessAgent-based agent and confirm `tmg_sc_agent_memory` table receives new `memory_type=MEMORY` and `CONTEXT` records