### PR TITLE
refactor(harness): remove unnecessary ReActAgent type restriction in MemoryFlushMiddleware

### DIFF
--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/middleware/MemoryFlushMiddleware.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/middleware/MemoryFlushMiddleware.java
@@ -15,7 +15,6 @@
  */
 package io.agentscope.harness.agent.middleware;
 
-import io.agentscope.core.ReActAgent;
 import io.agentscope.core.agent.Agent;
 import io.agentscope.core.agent.RuntimeContext;
 import io.agentscope.core.event.AgentEvent;
@@ -156,10 +155,7 @@ public class MemoryFlushMiddleware implements HarnessRuntimeMiddleware {
     }
 
     private Mono<Void> doFlush(Agent agent, RuntimeContext rc) {
-        if (!(agent instanceof ReActAgent reActAgent)) {
-            return Mono.empty();
-        }
-        AgentState state = RuntimeContext.resolveAgentState(rc, reActAgent);
+        AgentState state = RuntimeContext.resolveAgentState(rc, agent);
         if (state == null) {
             return Mono.empty();
         }
@@ -216,7 +212,7 @@ public class MemoryFlushMiddleware implements HarnessRuntimeMiddleware {
      * namespace (see {@link #timerKeyFor(RuntimeContext)}).
      *
      * <p>Package-private for unit testing of the trigger gate without standing up a full
-     * {@code ReActAgent}.
+     * {@code Agent}.
      */
     boolean shouldFlushNow(RuntimeContext rc) {
         switch (flushTrigger.mode()) {


### PR DESCRIPTION
## Summary

- `MemoryFlushMiddleware.doFlush()` guarded on `instanceof ReActAgent`, but all downstream code (`RuntimeContext.resolveAgentState`, `MemoryFlushManager`) only requires the `Agent` interface
- The guard is currently a no-op since the middleware is registered on the inner `ReActAgent`, but it would silently skip flush if the middleware were ever used with a different `Agent` implementation
- Remove the restriction so the code works with any `Agent` type

## Test plan

- [x] `mvn compile -pl agentscope-harness -am` passes
- [ ] Existing memory flush tests still pass