### PR TITLE
fix(core): return asking tool calls on HITL permission pause

### DIFF
--- a/agentscope-core/src/main/java/io/agentscope/core/ReActAgent.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/ReActAgent.java
@@ -2349,7 +2349,11 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
                                 // collected.
                                 RequestStopEvent rs = actingStopRequested.get();
                                 if (rs != null) {
-                                    Msg stopMsg = buildStopMsg(results, rs.getGenerateReason());
+                                    Msg stopMsg =
+                                            rs.getGenerateReason()
+                                                            == GenerateReason.PERMISSION_ASKING
+                                                    ? buildPermissionAskingStopMsg(results)
+                                                    : buildStopMsg(results, rs.getGenerateReason());
                                     return Mono.just(stopMsg);
                                 }
                                 List<Map.Entry<ToolUseBlock, ToolResultBlock>> successPairs =
@@ -2827,6 +2831,38 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
                     .name(getName())
                     .content(content)
                     .generateReason(reason)
+                    .build();
+        }
+
+        /**
+         * Build the user-facing stop message for permission HITL. Unlike a generic acting stop,
+         * the caller must receive the ASKING ToolUseBlocks so they can construct ConfirmResults.
+         */
+        private Msg buildPermissionAskingStopMsg(
+                List<Map.Entry<ToolUseBlock, ToolResultBlock>> results) {
+            List<ContentBlock> content = new ArrayList<>();
+            Set<String> includedToolIds = new HashSet<>();
+            if (results != null) {
+                for (Map.Entry<ToolUseBlock, ToolResultBlock> pair : results) {
+                    ToolUseBlock toolUse = pair.getKey();
+                    if (toolUse != null) {
+                        content.add(toolUse);
+                        includedToolIds.add(toolUse.getId());
+                    }
+                    if (pair.getValue() != null) {
+                        content.add(pair.getValue());
+                    }
+                }
+            }
+            for (ToolUseBlock asking : askingToolCalls()) {
+                if (asking.getId() == null || includedToolIds.add(asking.getId())) {
+                    content.add(asking);
+                }
+            }
+            return AssistantMessage.builder()
+                    .name(getName())
+                    .content(content)
+                    .generateReason(GenerateReason.PERMISSION_ASKING)
                     .build();
         }
 

--- a/agentscope-core/src/test/java/io/agentscope/core/agent/ReActAgentHitlTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/agent/ReActAgentHitlTest.java
@@ -225,6 +225,10 @@ class ReActAgentHitlTest {
         Msg firstResult = agent.call(List.of()).block();
         assertNotNull(firstResult);
         assertEquals(GenerateReason.PERMISSION_ASKING, firstResult.getGenerateReason());
+        List<ToolUseBlock> returnedBlocks = firstResult.getContentBlocks(ToolUseBlock.class);
+        assertEquals(1, returnedBlocks.size());
+        assertEquals("tc1", returnedBlocks.get(0).getId());
+        assertEquals(ToolCallState.ASKING, returnedBlocks.get(0).getState());
 
         // Verify state has been persisted: ToolUseBlock should be in ASKING state
         Msg lastAssistant = null;
@@ -238,10 +242,11 @@ class ReActAgentHitlTest {
         assertNotNull(lastAssistant);
         List<ToolUseBlock> blocks = lastAssistant.getContentBlocks(ToolUseBlock.class);
         assertEquals(1, blocks.size());
+        assertEquals(returnedBlocks.get(0).getId(), blocks.get(0).getId());
         assertEquals(ToolCallState.ASKING, blocks.get(0).getState());
 
-        // Second call: resume with a confirmed ConfirmResult
-        Msg secondResult = agent.call(List.of(confirmMsg(true, blocks.get(0)))).block();
+        // Second call: resume with the ToolUseBlock returned to the caller.
+        Msg secondResult = agent.call(List.of(confirmMsg(true, returnedBlocks.get(0)))).block();
         assertNotNull(secondResult);
         // Should have proceeded normally to the next reasoning round
         assertTrue(


### PR DESCRIPTION
## Summary

Close #2066 

Issue showed that `HarnessAgent.call(...)` paused for HITL confirmation, but the returned `Msg.content` could be empty. Code following the documented pattern of extracting `ToolUseBlock`s from the returned message then produced an empty confirmation list, causing resume to fail with “This call supplied no confirmation”.

- Return `ASKING` `ToolUseBlock`s in the `PERMISSION_ASKING` response message so callers can build `ConfirmResult`s from `result.getContent()`.
- Keep the generic acting stop behavior unchanged and add permission-specific stop message handling.
- Add regression coverage proving resume works when the confirmation uses the `ToolUseBlock` returned by the first paused call.

## Checklist

Please check the following items before code is ready to be reviewed.

- [ ]  Code has been formatted with `mvn spotless:apply`
- [ ]  All tests are passing (`mvn test`)
- [ ]  Javadoc comments are complete and follow project conventions
- [ ]  Related documentation has been updated (e.g. links, examples, etc.)
- [ ]  Code is ready for review
