### PR TITLE
fix(core): include ASKING ToolUseBlocks in PERMISSION_ASKING result message

### DIFF
--- a/agentscope-core/src/main/java/io/agentscope/core/ReActAgent.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/ReActAgent.java
@@ -2349,6 +2349,15 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
                                 // collected.
                                 RequestStopEvent rs = actingStopRequested.get();
                                 if (rs != null) {
+                                    if (rs.getGenerateReason()
+                                            == GenerateReason.PERMISSION_ASKING) {
+                                        Msg lastAssistant = findLastAssistantMsg();
+                                        if (lastAssistant != null) {
+                                            return Mono.just(
+                                                    lastAssistant.withGenerateReason(
+                                                            GenerateReason.PERMISSION_ASKING));
+                                        }
+                                    }
                                     Msg stopMsg = buildStopMsg(results, rs.getGenerateReason());
                                     return Mono.just(stopMsg);
                                 }

--- a/agentscope-core/src/test/java/io/agentscope/core/agent/ReActAgentHitlTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/agent/ReActAgentHitlTest.java
@@ -226,7 +226,15 @@ class ReActAgentHitlTest {
         assertNotNull(firstResult);
         assertEquals(GenerateReason.PERMISSION_ASKING, firstResult.getGenerateReason());
 
-        // Verify state has been persisted: ToolUseBlock should be in ASKING state
+        // The returned Msg must contain the ASKING ToolUseBlocks so blocking-API
+        // callers can extract them to build ConfirmResult (issue #2066).
+        List<ToolUseBlock> returnedBlocks = firstResult.getContentBlocks(ToolUseBlock.class);
+        assertEquals(
+                1, returnedBlocks.size(), "returned Msg must contain the pending ToolUseBlock");
+        assertEquals(ToolCallState.ASKING, returnedBlocks.get(0).getState());
+        assertEquals("tc1", returnedBlocks.get(0).getId());
+
+        // Also verify state has been persisted consistently
         Msg lastAssistant = null;
         for (int i = agent.getAgentState().getContext().size() - 1; i >= 0; i--) {
             Msg m = agent.getAgentState().getContext().get(i);
@@ -333,6 +341,38 @@ class ReActAgentHitlTest {
                                                         .build()))
                                 .block(),
                 "expected explicit failure when no ConfirmResult is supplied");
+    }
+
+    @Test
+    void blockingApiCanExtractToolCallsFromReturnedMsgAndResume() {
+        ChatModelBase model =
+                new ScriptedModel(
+                        List.of(
+                                () -> Flux.just(toolUseResponse("tc1", "ask", "data")),
+                                () -> Flux.just(textResponse("completed"))));
+        ReActAgent agent = buildAgent(model, toolkitWith(new AskingTool("ask")));
+
+        // First call returns PERMISSION_ASKING with ToolUseBlocks in content
+        Msg result = agent.call(List.of()).block();
+        assertNotNull(result);
+        assertEquals(GenerateReason.PERMISSION_ASKING, result.getGenerateReason());
+
+        // Extract ToolUseBlocks directly from the returned Msg — no state access
+        List<ToolUseBlock> pending =
+                result.getContent().stream()
+                        .filter(b -> b instanceof ToolUseBlock)
+                        .map(ToolUseBlock.class::cast)
+                        .filter(t -> t.getState() == ToolCallState.ASKING)
+                        .toList();
+        assertEquals(1, pending.size(), "must find exactly one ASKING tool in returned Msg");
+
+        // Build ConfirmResult from the extracted ToolUseBlock and resume
+        Msg resumed = agent.call(List.of(confirmMsg(true, pending.get(0)))).block();
+        assertNotNull(resumed);
+        assertTrue(
+                resumed.getGenerateReason() == GenerateReason.MODEL_STOP
+                        || resumed.getGenerateReason() == GenerateReason.TOOL_CALLS,
+                "expected normal completion after confirm, got " + resumed.getGenerateReason());
     }
 
     @Test

--- a/agentscope-examples/documentation/src/main/java/io/agentscope/examples/documentation2/hitl/PermissionHITLExample.java
+++ b/agentscope-examples/documentation/src/main/java/io/agentscope/examples/documentation2/hitl/PermissionHITLExample.java
@@ -16,8 +16,12 @@
 package io.agentscope.examples.documentation2.hitl;
 
 import io.agentscope.core.ReActAgent;
+import io.agentscope.core.event.ConfirmResult;
 import io.agentscope.core.message.GenerateReason;
 import io.agentscope.core.message.Msg;
+import io.agentscope.core.message.MsgRole;
+import io.agentscope.core.message.ToolCallState;
+import io.agentscope.core.message.ToolUseBlock;
 import io.agentscope.core.message.UserMessage;
 import io.agentscope.core.permission.PermissionBehavior;
 import io.agentscope.core.permission.PermissionContextState;
@@ -28,6 +32,9 @@ import io.agentscope.core.tool.ToolParam;
 import io.agentscope.core.tool.Toolkit;
 import io.agentscope.extensions.model.dashscope.DashScopeChatModel;
 import io.agentscope.extensions.model.dashscope.formatter.DashScopeChatFormatter;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.Scanner;
 
 /**
@@ -154,18 +161,36 @@ public class PermissionHITLExample {
                 System.out.println(
                         "\n[HITL] The agent wants to execute a tool that requires your approval.");
                 System.out.println("[HITL] Pending operations:");
-                result.getContent().forEach(block -> System.out.println("  - " + block));
-                System.out.print("[HITL] Allow? (yes/no): ");
 
+                // Extract ASKING ToolUseBlocks from the returned Msg
+                List<ToolUseBlock> askingTools =
+                        result.getContent().stream()
+                                .filter(b -> b instanceof ToolUseBlock)
+                                .map(ToolUseBlock.class::cast)
+                                .filter(t -> t.getState() == ToolCallState.ASKING)
+                                .toList();
+                askingTools.forEach(
+                        t -> System.out.println("  - " + t.getName() + " " + t.getInput()));
+
+                System.out.print("[HITL] Allow? (yes/no): ");
                 String decision = scanner.hasNextLine() ? scanner.nextLine().trim() : "no";
                 boolean approved =
                         "yes".equalsIgnoreCase(decision) || "y".equalsIgnoreCase(decision);
 
-                // Resume the agent with the user's decision
-                String resumeText =
-                        approved ? "yes, proceed with the operation" : "no, cancel the operation";
-                Msg resumeMsg = new UserMessage("user", resumeText);
-                Msg finalResult = agent.call(java.util.List.of(resumeMsg)).block();
+                // Build ConfirmResult from the extracted ToolUseBlocks and resume
+                List<ConfirmResult> confirmResults =
+                        askingTools.stream().map(t -> new ConfirmResult(approved, t)).toList();
+                Map<String, Object> meta = new HashMap<>();
+                meta.put(Msg.METADATA_CONFIRM_RESULTS, confirmResults);
+                Msg resumeMsg =
+                        Msg.builder()
+                                .name("user")
+                                .role(MsgRole.USER)
+                                .textContent(approved ? "approved" : "denied")
+                                .metadata(meta)
+                                .build();
+
+                Msg finalResult = agent.call(List.of(resumeMsg)).block();
                 System.out.println(
                         "\nAgent: "
                                 + (finalResult != null ? finalResult.getTextContent() : "(null)"));

--- a/docs/v2/en/docs/building-blocks/permission-system.md
+++ b/docs/v2/en/docs/building-blocks/permission-system.md
@@ -250,23 +250,30 @@ The `ToolBase` dangerous-path list is maintained in `ToolDangerousPathConstants`
 
 ## HITL integration
 
-When the permission engine returns an ASK decision for a tool call, the agent pauses instead of executing and returns a response with `GenerateReason.PERMISSION_ASKING`. The caller inspects this, presents the pending operation to the user, and resumes the agent after collecting a decision.
+When the permission engine returns an ASK decision for a tool call, the agent pauses instead of executing and returns a response with `GenerateReason.PERMISSION_ASKING`. The returned `Msg` contains the `ToolUseBlock`s in `ASKING` state. The caller extracts them, presents the pending operation to the user, and resumes the agent with `ConfirmResult` objects.
 
 ### Interaction flow
 
 1. Configure ASK rules for tools that require human confirmation
 2. Agent pauses on ASK tools, returning `PERMISSION_ASKING`
-3. Caller checks `getGenerateReason()` and shows the pending tool calls to the user
-4. After user confirms, send a new message to resume the agent
+3. Extract `ToolUseBlock`s (with `ASKING` state) from the returned `Msg` and show them to the user
+4. Build `ConfirmResult` objects and attach them to the resume message via metadata
 
 ```java
+import io.agentscope.core.event.ConfirmResult;
 import io.agentscope.core.message.GenerateReason;
 import io.agentscope.core.message.Msg;
+import io.agentscope.core.message.MsgRole;
+import io.agentscope.core.message.ToolCallState;
+import io.agentscope.core.message.ToolUseBlock;
 import io.agentscope.core.message.UserMessage;
 import io.agentscope.core.permission.PermissionBehavior;
 import io.agentscope.core.permission.PermissionContextState;
 import io.agentscope.core.permission.PermissionMode;
 import io.agentscope.core.permission.PermissionRule;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 // 1. Configure permissions: safe_read auto-allowed, dangerous_delete requires confirmation
 PermissionContextState permCtx =
@@ -296,15 +303,91 @@ Msg result = agent.call(new UserMessage("Delete /tmp/important.txt")).block();
 
 // 3. Check whether user confirmation is needed
 if (result != null && result.getGenerateReason() == GenerateReason.PERMISSION_ASKING) {
-    // Show the pending tool calls to the user
-    result.getContent().forEach(block -> System.out.println("Pending: " + block));
+    // Extract the ASKING ToolUseBlocks from the returned Msg
+    List<ToolUseBlock> askingTools =
+            result.getContent().stream()
+                    .filter(b -> b instanceof ToolUseBlock)
+                    .map(ToolUseBlock.class::cast)
+                    .filter(t -> t.getState() == ToolCallState.ASKING)
+                    .toList();
 
-    // 4. Collect the user's decision and resume the agent
+    // Show pending operations to the user
+    askingTools.forEach(t -> System.out.println("Pending: " + t.getName() + " " + t.getInput()));
+
+    // 4. Collect the user's decision, build ConfirmResult, and resume
     boolean approved = askUser();
-    String resumeText = approved ? "yes, proceed" : "no, cancel";
-    Msg finalResult = agent.call(new UserMessage(resumeText)).block();
+    List<ConfirmResult> confirmResults =
+            askingTools.stream()
+                    .map(t -> new ConfirmResult(approved, t))
+                    .toList();
+
+    Map<String, Object> meta = new HashMap<>();
+    meta.put(Msg.METADATA_CONFIRM_RESULTS, confirmResults);
+    Msg resumeMsg =
+            Msg.builder()
+                    .name("user")
+                    .role(MsgRole.USER)
+                    .textContent(approved ? "approved" : "denied")
+                    .metadata(meta)
+                    .build();
+
+    Msg finalResult = agent.call(List.of(resumeMsg)).block();
 }
 ```
+
+### Streaming mode
+
+When using `streamEvents()`, you don't need to extract `ToolUseBlock`s from the returned `Msg` — the event stream delivers a `RequireUserConfirmEvent` that carries the pending tool calls directly:
+
+```java
+import io.agentscope.core.event.AgentEvent;
+import io.agentscope.core.event.ConfirmResult;
+import io.agentscope.core.event.RequireUserConfirmEvent;
+import io.agentscope.core.message.Msg;
+import io.agentscope.core.message.MsgRole;
+import io.agentscope.core.message.ToolUseBlock;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+// Subscribe to the event stream
+agent.streamEvents(List.of(new UserMessage("Delete /tmp/important.txt")))
+        .doOnNext(event -> {
+            if (event instanceof RequireUserConfirmEvent confirmEvent) {
+                // Get pending ToolUseBlocks directly from the event
+                List<ToolUseBlock> pending = confirmEvent.getToolCalls();
+                pending.forEach(t ->
+                        System.out.println("Pending: " + t.getName() + " " + t.getInput()));
+
+                // Collect user decision, store pending list for the resume call
+            }
+        })
+        .blockLast();
+
+// Resume is the same as with the blocking API: build ConfirmResult in metadata
+List<ConfirmResult> confirmResults =
+        pendingTools.stream()
+                .map(t -> new ConfirmResult(true, t))
+                .toList();
+Map<String, Object> meta = new HashMap<>();
+meta.put(Msg.METADATA_CONFIRM_RESULTS, confirmResults);
+Msg resumeMsg =
+        Msg.builder()
+                .name("user")
+                .role(MsgRole.USER)
+                .textContent("approved")
+                .metadata(meta)
+                .build();
+agent.call(List.of(resumeMsg)).block();
+```
+
+Comparison of the two modes:
+
+| | Blocking `call()` | Streaming `streamEvents()` |
+|---|---|---|
+| Getting pending tools | Filter `ToolUseBlock`s (state `ASKING`) from `Msg.getContent()` | Get directly from `RequireUserConfirmEvent.getToolCalls()` |
+| Resuming | Same: build `ConfirmResult` in metadata and issue a new `call()` | Same |
+| Use case | REST APIs, simple synchronous services | WebSocket, SSE, real-time UIs |
 
 ### Unattended mode
 

--- a/docs/v2/zh/docs/building-blocks/permission-system.md
+++ b/docs/v2/zh/docs/building-blocks/permission-system.md
@@ -250,23 +250,30 @@ public class MyTool extends ToolBase {
 
 ## 结合 HITL
 
-当权限引擎对某个工具调用返回 ASK 决策时，agent 不会直接执行，而是暂停并返回一个 `GenerateReason.PERMISSION_ASKING` 的响应。调用方据此向用户展示待确认的操作，收集决策后恢复 agent。
+当权限引擎对某个工具调用返回 ASK 决策时，agent 不会直接执行，而是暂停并返回一个 `GenerateReason.PERMISSION_ASKING` 的响应。返回的 `Msg` 中包含处于 `ASKING` 状态的 `ToolUseBlock`，调用方据此向用户展示待确认的操作，收集决策后通过 `ConfirmResult` 恢复 agent。
 
 ### 交互流程
 
 1. 配置 ASK 规则，标记需要人工确认的工具
 2. Agent 遇到 ASK 工具时暂停，返回 `PERMISSION_ASKING`
-3. 调用方检查 `getGenerateReason()`，向用户展示待执行的工具调用
-4. 用户确认后，发送新消息恢复 agent 继续执行
+3. 从返回的 `Msg` 中提取 `ToolUseBlock`（状态为 `ASKING`），向用户展示
+4. 构建 `ConfirmResult`，附在新消息的 metadata 中恢复 agent
 
 ```java
+import io.agentscope.core.event.ConfirmResult;
 import io.agentscope.core.message.GenerateReason;
 import io.agentscope.core.message.Msg;
+import io.agentscope.core.message.MsgRole;
+import io.agentscope.core.message.ToolCallState;
+import io.agentscope.core.message.ToolUseBlock;
 import io.agentscope.core.message.UserMessage;
 import io.agentscope.core.permission.PermissionBehavior;
 import io.agentscope.core.permission.PermissionContextState;
 import io.agentscope.core.permission.PermissionMode;
 import io.agentscope.core.permission.PermissionRule;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 // 1. 配置权限：safe_read 自动放行，dangerous_delete 需要确认
 PermissionContextState permCtx =
@@ -296,15 +303,92 @@ Msg result = agent.call(new UserMessage("Delete /tmp/important.txt")).block();
 
 // 3. 检查是否需要用户确认
 if (result != null && result.getGenerateReason() == GenerateReason.PERMISSION_ASKING) {
-    // 向用户展示待确认的工具调用
-    result.getContent().forEach(block -> System.out.println("Pending: " + block));
+    // 从返回的 Msg 中提取待确认的 ToolUseBlock
+    List<ToolUseBlock> askingTools =
+            result.getContent().stream()
+                    .filter(b -> b instanceof ToolUseBlock)
+                    .map(ToolUseBlock.class::cast)
+                    .filter(t -> t.getState() == ToolCallState.ASKING)
+                    .toList();
 
-    // 4. 收集用户决策后恢复 agent
+    // 向用户展示
+    askingTools.forEach(t -> System.out.println("Pending: " + t.getName() + " " + t.getInput()));
+
+    // 4. 收集用户决策，构建 ConfirmResult 恢复 agent
     boolean approved = askUser();
-    String resumeText = approved ? "yes, proceed" : "no, cancel";
-    Msg finalResult = agent.call(new UserMessage(resumeText)).block();
+    List<ConfirmResult> confirmResults =
+            askingTools.stream()
+                    .map(t -> new ConfirmResult(approved, t))
+                    .toList();
+
+    Map<String, Object> meta = new HashMap<>();
+    meta.put(Msg.METADATA_CONFIRM_RESULTS, confirmResults);
+    Msg resumeMsg =
+            Msg.builder()
+                    .name("user")
+                    .role(MsgRole.USER)
+                    .textContent(approved ? "approved" : "denied")
+                    .metadata(meta)
+                    .build();
+
+    Msg finalResult = agent.call(List.of(resumeMsg)).block();
 }
 ```
+
+### Streaming 模式
+
+使用 `streamEvents()` 时，不需要从返回的 `Msg` 提取 `ToolUseBlock` —— 通过事件流直接获得 `RequireUserConfirmEvent`，它携带了待确认的工具调用列表：
+
+```java
+import io.agentscope.core.event.AgentEvent;
+import io.agentscope.core.event.ConfirmResult;
+import io.agentscope.core.event.RequireUserConfirmEvent;
+import io.agentscope.core.message.Msg;
+import io.agentscope.core.message.MsgRole;
+import io.agentscope.core.message.ToolUseBlock;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+// 订阅事件流
+agent.streamEvents(List.of(new UserMessage("Delete /tmp/important.txt")))
+        .doOnNext(event -> {
+            if (event instanceof RequireUserConfirmEvent confirmEvent) {
+                // 直接从事件中获取待确认的 ToolUseBlocks
+                List<ToolUseBlock> pending = confirmEvent.getToolCalls();
+                pending.forEach(t ->
+                        System.out.println("Pending: " + t.getName() + " " + t.getInput()));
+
+                // 收集用户决策后，在下一次 call 时恢复
+                // （存储 pending 列表，在后续 call 时使用）
+            }
+        })
+        .blockLast();
+
+// 恢复方式与 blocking API 相同：构建 ConfirmResult 附在 metadata 中
+List<ConfirmResult> confirmResults =
+        pendingTools.stream()
+                .map(t -> new ConfirmResult(true, t))
+                .toList();
+Map<String, Object> meta = new HashMap<>();
+meta.put(Msg.METADATA_CONFIRM_RESULTS, confirmResults);
+Msg resumeMsg =
+        Msg.builder()
+                .name("user")
+                .role(MsgRole.USER)
+                .textContent("approved")
+                .metadata(meta)
+                .build();
+agent.call(List.of(resumeMsg)).block();
+```
+
+两种模式的区别：
+
+| | Blocking `call()` | Streaming `streamEvents()` |
+|---|---|---|
+| 获取待确认工具 | 从返回的 `Msg.getContent()` 中筛选 `ToolUseBlock`（状态为 `ASKING`） | 从 `RequireUserConfirmEvent.getToolCalls()` 直接获取 |
+| 恢复方式 | 相同：构建 `ConfirmResult` 附在 metadata 中发起新的 `call()` | 相同 |
+| 适用场景 | REST API、简单同步服务 | WebSocket、SSE、实时 UI |
 
 ### 无人值守模式
 


### PR DESCRIPTION
Closes #2066

## Summary

- When the blocking `call()` API triggers `PERMISSION_ASKING`, the returned `Msg` had **empty content** because `buildStopMsg()` received an empty result list. Users could not extract `ToolUseBlock`s to construct `ConfirmResult` objects for the resume call.
- Fixed by returning the last assistant message from context (which already contains `ToolUseBlock`s with `ASKING` state) instead of building an empty stop message. This follows the same pattern used by `buildSuspendedMsg()`.
- Added assertions to the existing HITL test and a new end-to-end test that exercises the full blocking API flow: extract `ToolUseBlock`s from the returned `Msg`, build `ConfirmResult`, and resume.

## Test plan

- [x] `ReActAgentHitlTest.askingToolPausesFirstCallAndExecutesOnConfirmedSecondCall` — now also asserts returned Msg content
- [x] `ReActAgentHitlTest.blockingApiCanExtractToolCallsFromReturnedMsgAndResume` — new end-to-end test
- [x] Full core test suite passes (2209 tests, 0 failures)
- [x] `spotless:check` passes