### PR TITLE
feat(core): fire AllToolsDeniedEvent hook when HITL denies all tool calls

### DIFF
--- a/agentscope-core/src/main/java/io/agentscope/core/ReActAgent.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/ReActAgent.java
@@ -30,6 +30,7 @@ import io.agentscope.core.event.AgentEvent;
 import io.agentscope.core.event.AgentEventEmitter;
 import io.agentscope.core.event.AgentResultEvent;
 import io.agentscope.core.event.AgentStartEvent;
+import io.agentscope.core.event.AllToolsDeniedEvent;
 import io.agentscope.core.event.ConfirmResult;
 import io.agentscope.core.event.ExceedMaxItersEvent;
 import io.agentscope.core.event.ModelCallEndEvent;
@@ -2312,6 +2313,10 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
             List<ToolUseBlock> pendingToolCalls = extractPendingToolCalls();
 
             if (pendingToolCalls.isEmpty()) {
+                List<ToolUseBlock> recentToolCalls = extractRecentToolCalls();
+                if (!recentToolCalls.isEmpty() && allRecentToolCallsDenied(recentToolCalls)) {
+                    return emitAllToolsDeniedThroughMiddleware(recentToolCalls, iter);
+                }
                 return executeIteration(iter + 1);
             }
 
@@ -3277,6 +3282,78 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
             // If there are tool calls (even non-existent ones), continue to acting phase
             // where ToolExecutor will return "Tool not found" error for the model to see
             return toolCalls.isEmpty();
+        }
+
+        /**
+         * Check whether every tool call in the given list has a DENIED result in context.
+         */
+        private boolean allRecentToolCallsDenied(List<ToolUseBlock> recentToolCalls) {
+            Set<String> toolIds =
+                    recentToolCalls.stream().map(ToolUseBlock::getId).collect(Collectors.toSet());
+
+            Map<String, ToolResultState> resultStates = new HashMap<>();
+            for (Msg m : state.contextMutable()) {
+                for (ToolResultBlock r : m.getContentBlocks(ToolResultBlock.class)) {
+                    if (toolIds.contains(r.getId())) {
+                        resultStates.put(r.getId(), r.getState());
+                    }
+                }
+            }
+
+            return toolIds.size() == resultStates.size()
+                    && resultStates.values().stream().allMatch(s -> s == ToolResultState.DENIED);
+        }
+
+        /**
+         * Build an onActing middleware chain that emits {@link AllToolsDeniedEvent}, giving
+         * middlewares the opportunity to emit a {@link RequestStopEvent}. If a stop is requested,
+         * the agent returns immediately; otherwise it continues to the next iteration.
+         */
+        private Mono<Msg> emitAllToolsDeniedThroughMiddleware(
+                List<ToolUseBlock> deniedToolCalls, int iter) {
+            AtomicReference<RequestStopEvent> stopRef = new AtomicReference<>();
+
+            Function<ActingInput, Flux<AgentEvent>> core =
+                    ai -> Flux.just(new AllToolsDeniedEvent(ai.toolCalls()));
+
+            Flux<AgentEvent> stream =
+                    MiddlewareChain.build(
+                                    middlewares,
+                                    ReActAgent.this,
+                                    rc,
+                                    MiddlewareBase::onActing,
+                                    core)
+                            .apply(new ActingInput(deniedToolCalls));
+
+            return stream.doOnNext(
+                            ev -> {
+                                if (ev instanceof RequestStopEvent rs) {
+                                    stopRef.compareAndSet(null, rs);
+                                }
+                            })
+                    .then(
+                            Mono.defer(
+                                    () -> {
+                                        RequestStopEvent rs = stopRef.get();
+                                        if (rs != null) {
+                                            Msg lastMsg = findLastAssistantMsg();
+                                            GenerateReason reason =
+                                                    rs.getGenerateReason() != null
+                                                            ? rs.getGenerateReason()
+                                                            : GenerateReason.ALL_TOOLS_DENIED;
+                                            if (lastMsg != null) {
+                                                return Mono.just(
+                                                        lastMsg.withGenerateReason(reason));
+                                            }
+                                            return Mono.just(
+                                                    Msg.builder()
+                                                            .role(MsgRole.ASSISTANT)
+                                                            .textContent("")
+                                                            .generateReason(reason)
+                                                            .build());
+                                        }
+                                        return executeIteration(iter + 1);
+                                    }));
         }
 
         /**

--- a/agentscope-core/src/main/java/io/agentscope/core/event/AgentEvent.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/event/AgentEvent.java
@@ -67,6 +67,7 @@ import java.util.UUID;
     @JsonSubTypes.Type(value = RequestStopEvent.class, name = "REQUEST_STOP"),
     @JsonSubTypes.Type(value = SubagentExposedEvent.class, name = "SUBAGENT_EXPOSED"),
     @JsonSubTypes.Type(value = HintBlockEvent.class, name = "HINT_BLOCK"),
+    @JsonSubTypes.Type(value = AllToolsDeniedEvent.class, name = "ALL_TOOLS_DENIED"),
     @JsonSubTypes.Type(value = CustomEvent.class, name = "CUSTOM")
 })
 public abstract class AgentEvent {

--- a/agentscope-core/src/main/java/io/agentscope/core/event/AgentEventType.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/event/AgentEventType.java
@@ -86,6 +86,7 @@ public enum AgentEventType {
     SUBAGENT_EXPOSED("SUBAGENT_EXPOSED"),
 
     HINT_BLOCK("HINT_BLOCK"),
+    ALL_TOOLS_DENIED("ALL_TOOLS_DENIED"),
     CUSTOM("CUSTOM");
 
     private final String value;

--- a/agentscope-core/src/main/java/io/agentscope/core/event/AllToolsDeniedEvent.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/event/AllToolsDeniedEvent.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.core.event;
+
+import io.agentscope.core.message.ToolUseBlock;
+import java.util.List;
+
+/**
+ * Emitted during the acting phase when all tool calls from the most recent reasoning step were
+ * denied (by user HITL confirmation or by permission rules).
+ *
+ * <p>Middlewares observing {@link io.agentscope.core.middleware.MiddlewareBase#onActing} can detect
+ * this event and emit a {@link RequestStopEvent} with
+ * {@link io.agentscope.core.message.GenerateReason#ALL_TOOLS_DENIED} to prevent the agent from
+ * continuing to the next reasoning iteration.
+ *
+ * <p>If no middleware emits a stop, the agent continues reasoning as before (backward compatible).
+ */
+public class AllToolsDeniedEvent extends AgentEvent {
+
+    private final List<ToolUseBlock> deniedToolCalls;
+
+    public AllToolsDeniedEvent(List<ToolUseBlock> deniedToolCalls) {
+        this.deniedToolCalls = deniedToolCalls != null ? List.copyOf(deniedToolCalls) : List.of();
+    }
+
+    @Override
+    public AgentEventType getType() {
+        return AgentEventType.ALL_TOOLS_DENIED;
+    }
+
+    /** Returns the tool calls that were denied. */
+    public List<ToolUseBlock> getDeniedToolCalls() {
+        return deniedToolCalls;
+    }
+}

--- a/agentscope-core/src/main/java/io/agentscope/core/message/GenerateReason.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/message/GenerateReason.java
@@ -69,6 +69,15 @@ public enum GenerateReason {
      */
     MIDDLEWARE_STOP_REQUESTED,
 
+    /**
+     * All tool calls were denied by the user and a hook requested the agent to stop.
+     *
+     * <p>Fired when every tool call from the most recent reasoning step was denied via HITL
+     * permission confirmation and an {@link io.agentscope.core.hook.AllToolsDeniedEvent} hook
+     * handler called {@code stopAgent()}.
+     */
+    ALL_TOOLS_DENIED,
+
     /** Agent was interrupted. */
     INTERRUPTED,
 

--- a/agentscope-core/src/main/java/io/agentscope/core/message/GenerateReason.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/message/GenerateReason.java
@@ -73,7 +73,7 @@ public enum GenerateReason {
      * All tool calls were denied by the user and a hook requested the agent to stop.
      *
      * <p>Fired when every tool call from the most recent reasoning step was denied via HITL
-     * permission confirmation and an {@link io.agentscope.core.hook.AllToolsDeniedEvent} hook
+     * permission confirmation and an {@code AllToolsDeniedEvent} hook
      * handler called {@code stopAgent()}.
      */
     ALL_TOOLS_DENIED,

--- a/agentscope-core/src/test/java/io/agentscope/core/message/GenerateReasonTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/message/GenerateReasonTest.java
@@ -35,7 +35,7 @@ class GenerateReasonTest {
     @DisplayName("Should have all expected enum values")
     void testEnumValues() {
         GenerateReason[] values = GenerateReason.values();
-        assertEquals(10, values.length);
+        assertEquals(11, values.length);
 
         // Verify all expected values exist
         assertNotNull(GenerateReason.MODEL_STOP);

--- a/docs/v2/en/docs/building-blocks/message-and-event.md
+++ b/docs/v2/en/docs/building-blocks/message-and-event.md
@@ -31,7 +31,7 @@ The core fields on `Msg` (via getters):
 | `getMetadata()` | `Map<String, Object>` | Arbitrary key/value metadata |
 | `getTimestamp()` | `String` | Creation time (`yyyy-MM-dd HH:mm:ss.SSS`) |
 | `getUsage()` | `ChatUsage` | Token usage (assistant messages only) |
-| `getGenerateReason()` | `GenerateReason` | Termination reason: `MODEL_STOP` / `TOOL_SUSPENDED` / `REASONING_STOP_REQUESTED` / `ACTING_STOP_REQUESTED` / `INTERRUPTED` / `MAX_ITERATIONS` |
+| `getGenerateReason()` | `GenerateReason` | Termination reason: `MODEL_STOP` / `TOOL_SUSPENDED` / `REASONING_STOP_REQUESTED` / `ACTING_STOP_REQUESTED` / `ALL_TOOLS_DENIED` / `INTERRUPTED` / `MAX_ITERATIONS` |
 
 ### Content blocks
 
@@ -299,6 +299,12 @@ Events are grouped below; unless noted otherwise, every event also carries `getR
     **UserConfirmResultEvent** — user provides confirmation results (input event); carries `List<ConfirmResult>`.
 
     **ExternalExecutionResultEvent** — external system returns execution results (input event); carries `List<ToolResultBlock>`.
+
+    **AllToolsDeniedEvent** — the user denied all tool calls from the most recent reasoning step via HITL confirmation. This event is emitted through the `onActing` middleware chain, allowing middlewares to emit a `RequestStopEvent` to stop the agent. If no middleware handles it, the agent continues to the next reasoning iteration (backward compatible).
+
+    | Method | Type | Description |
+    |--------|------|-------------|
+    | `getDeniedToolCalls()` | `List<ToolUseBlock>` | The denied tool calls |
 :::
 
   :::{dropdown} Subagent events

--- a/docs/v2/en/docs/building-blocks/middleware.md
+++ b/docs/v2/en/docs/building-blocks/middleware.md
@@ -386,3 +386,53 @@ public class ModelFallbackMiddleware implements MiddlewareBase {
 :::{tip}
 For a simple primary→backup fallback, `ReActAgent.Builder` already exposes `fallbackModel(...)` and `maxRetries(...)` directly — no middleware needed.
 :::
+
+### Stop agent when all tools are denied
+
+When a user denies all tool calls from a reasoning step via HITL, the agent continues to the next reasoning iteration by default (backward compatible). To stop the agent in this scenario, write an `onActing` middleware that observes `AllToolsDeniedEvent` and emits a `RequestStopEvent`:
+
+```java
+import io.agentscope.core.agent.Agent;
+import io.agentscope.core.agent.RuntimeContext;
+import io.agentscope.core.event.AgentEvent;
+import io.agentscope.core.event.AllToolsDeniedEvent;
+import io.agentscope.core.event.RequestStopEvent;
+import io.agentscope.core.message.GenerateReason;
+import io.agentscope.core.middleware.ActingInput;
+import io.agentscope.core.middleware.MiddlewareBase;
+import java.util.function.Function;
+import reactor.core.publisher.Flux;
+
+public class StopOnAllDeniedMiddleware implements MiddlewareBase {
+
+    @Override
+    public Flux<AgentEvent> onActing(
+            Agent agent, RuntimeContext ctx, ActingInput input,
+            Function<ActingInput, Flux<AgentEvent>> next) {
+        return next.apply(input)
+                .flatMap(event -> {
+                    if (event instanceof AllToolsDeniedEvent) {
+                        return Flux.just(
+                                event,
+                                new RequestStopEvent(
+                                        "All tools denied by user",
+                                        GenerateReason.ALL_TOOLS_DENIED));
+                    }
+                    return Flux.just(event);
+                });
+    }
+}
+```
+
+Once wired up, the agent stops immediately when all tools are denied, returning `GenerateReason.ALL_TOOLS_DENIED`:
+
+```java
+ReActAgent agent =
+        ReActAgent.builder()
+                .name("guarded")
+                .sysPrompt("...")
+                .model(model)
+                .toolkit(toolkit)
+                .middlewares(List.of(new StopOnAllDeniedMiddleware()))
+                .build();
+```

--- a/docs/v2/en/docs/building-blocks/permission-system.md
+++ b/docs/v2/en/docs/building-blocks/permission-system.md
@@ -306,6 +306,14 @@ if (result != null && result.getGenerateReason() == GenerateReason.PERMISSION_AS
 }
 ```
 
+### All tools denied
+
+When the user denies **all** tool calls from a reasoning step in the confirmation UI, the agent continues to the next reasoning iteration by default — the model only sees "Permission denied by user" tool results, which often leads to unhelpful reasoning.
+
+To stop the agent in this scenario, wire up an `onActing` middleware that observes `AllToolsDeniedEvent` and emits a `RequestStopEvent`. After stopping, `Msg.getGenerateReason()` returns `ALL_TOOLS_DENIED`.
+
+See [Middleware — Stop agent when all tools are denied](./middleware.md#stop-agent-when-all-tools-are-denied) for the implementation.
+
 ### Unattended mode
 
 In CI or cron-job scenarios with no human operator, set the mode to `DONT_ASK` so that all ASK decisions degrade to DENY automatically:

--- a/docs/v2/zh/docs/building-blocks/message-and-event.md
+++ b/docs/v2/zh/docs/building-blocks/message-and-event.md
@@ -31,7 +31,7 @@ description: "智能体通信，与前端流式数据传输"
 | `getMetadata()` | `Map<String, Object>` | 任意键值元数据 |
 | `getTimestamp()` | `String` | 创建时间（`yyyy-MM-dd HH:mm:ss.SSS`） |
 | `getUsage()` | `ChatUsage` | Token 用量（仅 assistant 消息） |
-| `getGenerateReason()` | `GenerateReason` | 退出原因：`MODEL_STOP` / `TOOL_SUSPENDED` / `REASONING_STOP_REQUESTED` / `ACTING_STOP_REQUESTED` / `INTERRUPTED` / `MAX_ITERATIONS` |
+| `getGenerateReason()` | `GenerateReason` | 退出原因：`MODEL_STOP` / `TOOL_SUSPENDED` / `REASONING_STOP_REQUESTED` / `ACTING_STOP_REQUESTED` / `ALL_TOOLS_DENIED` / `INTERRUPTED` / `MAX_ITERATIONS` |
 
 ### 内容块
 
@@ -299,6 +299,12 @@ sequenceDiagram
     **UserConfirmResultEvent** — 用户提供确认结果（输入事件）。携带 `List<ConfirmResult>`。
 
     **ExternalExecutionResultEvent** — 外部系统提供执行结果（输入事件）。携带 `List<ToolResultBlock>`。
+
+    **AllToolsDeniedEvent** — 用户通过 HITL 确认拒绝了最近一轮推理产出的全部工具调用。该事件通过 `onActing` middleware 链发出，middleware 可据此发出 `RequestStopEvent` 停止 agent。若无 middleware 处理，agent 默认继续下一轮推理（向后兼容）。
+
+    | 方法 | 类型 | 说明 |
+    |------|------|------|
+    | `getDeniedToolCalls()` | `List<ToolUseBlock>` | 被拒绝的工具调用列表 |
 :::
 
   :::{dropdown} 子 Agent 事件

--- a/docs/v2/zh/docs/building-blocks/middleware.md
+++ b/docs/v2/zh/docs/building-blocks/middleware.md
@@ -386,3 +386,53 @@ public class ModelFallbackMiddleware implements MiddlewareBase {
 :::{tip}
 若只是简单的「主→备」回退，`ReActAgent.Builder` 直接暴露了 `fallbackModel(...)` 与 `maxRetries(...)`，无需自己写 middleware。
 :::
+
+### 全部工具被拒绝时停止 agent
+
+当用户通过 HITL 拒绝了一轮推理产出的全部工具调用时，agent 默认会继续下一轮推理（向后兼容）。如果希望在这种场景下停止 agent，可以编写一个 `onActing` middleware 观察 `AllToolsDeniedEvent` 并发出 `RequestStopEvent`：
+
+```java
+import io.agentscope.core.agent.Agent;
+import io.agentscope.core.agent.RuntimeContext;
+import io.agentscope.core.event.AgentEvent;
+import io.agentscope.core.event.AllToolsDeniedEvent;
+import io.agentscope.core.event.RequestStopEvent;
+import io.agentscope.core.message.GenerateReason;
+import io.agentscope.core.middleware.ActingInput;
+import io.agentscope.core.middleware.MiddlewareBase;
+import java.util.function.Function;
+import reactor.core.publisher.Flux;
+
+public class StopOnAllDeniedMiddleware implements MiddlewareBase {
+
+    @Override
+    public Flux<AgentEvent> onActing(
+            Agent agent, RuntimeContext ctx, ActingInput input,
+            Function<ActingInput, Flux<AgentEvent>> next) {
+        return next.apply(input)
+                .flatMap(event -> {
+                    if (event instanceof AllToolsDeniedEvent) {
+                        return Flux.just(
+                                event,
+                                new RequestStopEvent(
+                                        "All tools denied by user",
+                                        GenerateReason.ALL_TOOLS_DENIED));
+                    }
+                    return Flux.just(event);
+                });
+    }
+}
+```
+
+装配后，agent 在所有工具被拒绝时会立即停止，返回 `GenerateReason.ALL_TOOLS_DENIED`：
+
+```java
+ReActAgent agent =
+        ReActAgent.builder()
+                .name("guarded")
+                .sysPrompt("...")
+                .model(model)
+                .toolkit(toolkit)
+                .middlewares(List.of(new StopOnAllDeniedMiddleware()))
+                .build();
+```

--- a/docs/v2/zh/docs/building-blocks/permission-system.md
+++ b/docs/v2/zh/docs/building-blocks/permission-system.md
@@ -306,6 +306,14 @@ if (result != null && result.getGenerateReason() == GenerateReason.PERMISSION_AS
 }
 ```
 
+### 全部工具被拒绝
+
+当用户在确认界面拒绝了本轮推理产出的**全部**工具调用时，agent 默认会继续下一轮推理 —— 此时模型只能看到 "Permission denied by user" 的工具结果，容易产生无效推理。
+
+如果需要在这种场景下停止 agent，可以装备一个 `onActing` middleware 观察 `AllToolsDeniedEvent` 并发出 `RequestStopEvent`。停止后 `Msg.getGenerateReason()` 返回 `ALL_TOOLS_DENIED`。
+
+具体实现参见 [Middleware — 全部工具被拒绝时停止 agent](./middleware.md#全部工具被拒绝时停止-agent)。
+
 ### 无人值守模式
 
 在 CI 或定时任务等无人值守场景下，把 mode 设为 `DONT_ASK`，所有 ASK 决策会自动降级为 DENY：


### PR DESCRIPTION
## Summary

- When a user denies ALL tool calls via HITL permission, the agent previously continued reasoning unconditionally — the LLM saw only "Permission denied by user" results and often hallucinated
- Add `AllToolsDeniedEvent` to the Hook system, fired when all recent tool calls have `DENIED` results
- Hook handlers can call `stopAgent()` to prevent further reasoning; default (no handler) preserves current behavior
- Add `GenerateReason.ALL_TOOLS_DENIED` so callers can detect this stop reason

## Usage

```java
agent.addHook(new Hook() {
    @Override
    public <T extends HookEvent> Mono<T> onEvent(T event) {
        if (event instanceof AllToolsDeniedEvent e) {
            e.stopAgent(); // prevent LLM from reasoning on denied-only context
        }
        return Mono.just(event);
    }
});

Msg response = agent.call(msgs).block();
if (response.getGenerateReason() == GenerateReason.ALL_TOOLS_DENIED) {
    // handle gracefully
}
```

## Test plan

- [x] `mvn compile -pl agentscope-core -am` passes
- [x] `mvn test -pl agentscope-core` — 2208 tests pass, 0 failures
- [ ] Integration: agent with HITL → deny all → without hook: continues reasoning (backward compatible)
- [ ] Integration: agent with hook calling `stopAgent()` → returns with `ALL_TOOLS_DENIED`