### PR TITLE
fix(core): make seedSystemMsg reactive to avoid block() on NIO threads

### DIFF
--- a/agentscope-core/src/main/java/io/agentscope/core/ReActAgent.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/ReActAgent.java
@@ -540,18 +540,18 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
     }
 
     @Override
-    protected Msg seedSystemMsg(Object callExectution) {
+    protected Mono<Msg> seedSystemMsg(Object callExectution) {
         RuntimeContext rc =
                 callExectution instanceof CallExecution ce ? ce.rc : getRuntimeContext();
         String base = sysPrompt != null ? sysPrompt.trim() : "";
-        String prompt = applySystemPromptMiddlewares(base, rc);
-        if (prompt == null || prompt.isEmpty()) {
-            return null;
-        }
-        return SystemMessage.builder()
-                .name("system")
-                .content(TextBlock.builder().text(prompt).build())
-                .build();
+        return applySystemPromptMiddlewares(base, rc)
+                .filter(prompt -> !prompt.isEmpty())
+                .map(
+                        prompt ->
+                                SystemMessage.builder()
+                                        .name("system")
+                                        .content(TextBlock.builder().text(prompt).build())
+                                        .build());
     }
 
     @Override
@@ -559,13 +559,10 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
         return callScope instanceof CallExecution ce ? ce.state : getAgentState();
     }
 
-    private String applySystemPromptMiddlewares(String prompt, RuntimeContext ctx) {
+    private Mono<String> applySystemPromptMiddlewares(String prompt, RuntimeContext ctx) {
         if (middlewares.isEmpty()) {
-            return prompt;
+            return Mono.just(prompt);
         }
-        // Only build a reactive chain if at least one middleware overrides onSystemPrompt
-        // (the default implementation is identity). This avoids an unnecessary block() call
-        // which would fail on non-blocking schedulers (e.g. Reactor parallel scheduler).
         boolean hasOverride = false;
         for (MiddlewareBase mw : middlewares) {
             try {
@@ -586,13 +583,13 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
             }
         }
         if (!hasOverride) {
-            return prompt;
+            return Mono.just(prompt);
         }
         Mono<String> result = Mono.just(prompt);
         for (MiddlewareBase mw : middlewares) {
             result = result.flatMap(p -> mw.onSystemPrompt(this, ctx, p));
         }
-        return result.block();
+        return result;
     }
 
     @Override

--- a/agentscope-core/src/main/java/io/agentscope/core/agent/AgentBase.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/agent/AgentBase.java
@@ -687,10 +687,10 @@ public abstract class AgentBase implements Agent {
      * @param callScope the per-call scope captured at call entry (may be {@code null}); lets
      *     subclasses resolve the call's {@link RuntimeContext} for system-prompt middlewares without
      *     reading a shared instance field
-     * @return the seed system message, or {@code null} if none
+     * @return the seed system message; empty Mono if none
      */
-    protected Msg seedSystemMsg(Object callScope) {
-        return null;
+    protected Mono<Msg> seedSystemMsg(Object callScope) {
+        return Mono.empty();
     }
 
     /**
@@ -752,9 +752,9 @@ public abstract class AgentBase implements Agent {
         }
 
         PreCallEvent event = new PreCallEvent(this, fullInput);
-        event.setSystemMessage(seedSystemMsg(callScope));
 
-        Mono<PreCallEvent> result = Mono.just(event);
+        Mono<PreCallEvent> result =
+                seedSystemMsg(callScope).doOnNext(event::setSystemMessage).thenReturn(event);
         for (Hook hook : getSortedHooks()) {
             result = result.flatMap(hook::onEvent);
         }


### PR DESCRIPTION
Change seedSystemMsg signature from Msg to Mono<Msg> so the middleware chain stays fully reactive. This eliminates the IllegalStateException thrown when the agent lifecycle runs on Reactor NIO threads (e.g. WebFlux with R2DBC).

Closes #2080

## AgentScope-Java Version

2.0.0-RC5

## Description

`ReActAgent.applySystemPromptMiddlewares()` calls `Mono.block()` to synchronously resolve the middleware `onSystemPrompt` chain. When the agent lifecycle is subscribed on a Reactor NIO thread (e.g. `reactor-tcp-nio-*` from WebFlux/R2DBC), Reactor throws `IllegalStateException` because `block()` is forbidden on `NonBlocking`-marked threads.

**Changes:**
- `AgentBase.seedSystemMsg` signature: `Msg` → `Mono<Msg>`
- `AgentBase.notifyPreCall`: wire via `doOnNext` + `thenReturn`
- `ReActAgent.applySystemPromptMiddlewares` return type: `String` → `Mono<String>`, removing `block()`

**Test:** `mvn -pl agentscope-core test` — all existing tests pass.

## Checklist

- [x] Code has been formatted with `mvn spotless:apply`
- [x] All tests are passing (`mvn test`)
- [x] Javadoc comments are complete and follow project conventions
- [x] Related documentation has been updated (e.g. links, examples, etc.)
- [x] Code is ready for review