### PR TITLE
fix(anthropic): split parallel tool calls into alternating messages

### DIFF
--- a/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-anthropic/src/main/java/io/agentscope/extensions/model/anthropic/formatter/AnthropicMessageConverter.java
+++ b/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-anthropic/src/main/java/io/agentscope/extensions/model/anthropic/formatter/AnthropicMessageConverter.java
@@ -34,6 +34,7 @@ import io.agentscope.core.message.ThinkingBlock;
 import io.agentscope.core.message.ToolResultBlock;
 import io.agentscope.core.message.ToolUseBlock;
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
@@ -79,6 +80,13 @@ public class AnthropicMessageConverter {
         for (int i = 0; i < messages.size(); i++) {
             Msg msg = messages.get(i);
             boolean isFirstMessage = (i == 0);
+            SplitToolResultSequence splitResults = collectSplitToolResults(messages, i + 1);
+
+            if (shouldSplitParallelToolCalls(msg, splitResults)) {
+                result.addAll(convertParallelToolCalls(msg, splitResults));
+                i += splitResults.consumedMessages();
+                continue;
+            }
 
             // Special handling for tool results - they create separate user messages
             if (msg.hasContentBlocks(ToolResultBlock.class)) {
@@ -116,6 +124,117 @@ public class AnthropicMessageConverter {
 
         return result;
     }
+
+    /**
+     * Decide whether the current assistant message should be expanded into Anthropic's required
+     * tool-use/tool-result alternation.
+     *
+     * <p>Splitting is enabled only when all of the following are true:
+     *
+     * <ul>
+     *   <li>The current message role is {@link MsgRole#ASSISTANT}.
+     *   <li>At least one following pure tool-result message was discovered.
+     *   <li>The current message contains two or more {@link ToolUseBlock}s.
+     *   <li>Every tool-use id is present and non-blank.
+     *   <li>The number of collected tool results equals the number of tool uses, and every
+     *       tool-use id has a corresponding result.
+     * </ul>
+     */
+    private boolean shouldSplitParallelToolCalls(Msg msg, SplitToolResultSequence splitResults) {
+        if (msg.getRole() != MsgRole.ASSISTANT || splitResults.consumedMessages() == 0) {
+            return false;
+        }
+
+        List<ToolUseBlock> toolUses = msg.getContentBlocks(ToolUseBlock.class);
+        if (toolUses.size() <= 1) {
+            return false;
+        }
+
+        List<String> toolUseIds = toolUses.stream().map(ToolUseBlock::getId).toList();
+        if (toolUseIds.stream().anyMatch(id -> id == null || id.isBlank())) {
+            return false;
+        }
+
+        return splitResults.resultsById().size() == toolUseIds.size()
+                && toolUseIds.stream().allMatch(id -> splitResults.resultsById().containsKey(id));
+    }
+
+    /**
+     * Collect the consecutive pure tool-result messages that immediately follow an assistant
+     * message.
+     *
+     * <p>Scanning starts at {@code startIndex}, which is normally the message right after the
+     * assistant message being inspected. The scan continues only across messages whose content is
+     * made entirely of {@link ToolResultBlock}s. It stops as soon as a message has no tool results
+     * or contains any non-tool-result content, because such a message must be preserved in its
+     * original position rather than consumed into the split sequence.
+     */
+    private SplitToolResultSequence collectSplitToolResults(List<Msg> messages, int startIndex) {
+        Map<String, ToolResultBlock> byId = new LinkedHashMap<>();
+        int consumed = 0;
+
+        for (int i = startIndex; i < messages.size(); i++) {
+            Msg msg = messages.get(i);
+            List<ToolResultBlock> toolResults = msg.getContentBlocks(ToolResultBlock.class);
+            if (toolResults.isEmpty() || hasNonToolResultContent(msg)) {
+                break;
+            }
+
+            consumed++;
+            for (ToolResultBlock toolResult : toolResults) {
+                if (toolResult.getId() != null) {
+                    byId.putIfAbsent(toolResult.getId(), toolResult);
+                }
+            }
+        }
+
+        return new SplitToolResultSequence(byId, consumed);
+    }
+
+    private boolean hasNonToolResultContent(Msg msg) {
+        return msg.getContent().stream().anyMatch(block -> !(block instanceof ToolResultBlock));
+    }
+
+    /**
+     * Expand one assistant message with parallel tool uses into alternating Anthropic messages.
+     *
+     * <p>Each {@link ToolUseBlock} from the original assistant message is wrapped in its own
+     * assistant message and immediately followed by the matching user tool-result message. Any
+     * leading assistant content, such as explanatory text before the tool calls, is attached only
+     * to the first split assistant message so it is not duplicated across the generated sequence.
+     */
+    private List<MessageParam> convertParallelToolCalls(
+            Msg assistantMsg, SplitToolResultSequence splitResults) {
+        List<MessageParam> converted = new ArrayList<>();
+        List<ContentBlock> leadingBlocks =
+                assistantMsg.getContent().stream()
+                        .filter(block -> !(block instanceof ToolUseBlock))
+                        .toList();
+        List<ToolUseBlock> toolUses = assistantMsg.getContentBlocks(ToolUseBlock.class);
+
+        for (int i = 0; i < toolUses.size(); i++) {
+            ToolUseBlock toolUse = toolUses.get(i);
+            List<ContentBlock> assistantBlocks = new ArrayList<>();
+            if (i == 0) {
+                assistantBlocks.addAll(leadingBlocks);
+            }
+            assistantBlocks.add(toolUse);
+
+            MessageParam assistantParam =
+                    convertMessageContent(assistantMsg, assistantBlocks, false);
+            if (assistantParam != null) {
+                converted.add(assistantParam);
+            }
+
+            ToolResultBlock toolResult = splitResults.resultsById().get(toolUse.getId());
+            converted.add(convertToolResult(toolResult));
+        }
+
+        return converted;
+    }
+
+    private record SplitToolResultSequence(
+            Map<String, ToolResultBlock> resultsById, int consumedMessages) {}
 
     /**
      * Convert message content to MessageParam.

--- a/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-anthropic/src/main/java/io/agentscope/extensions/model/anthropic/formatter/AnthropicMessageConverter.java
+++ b/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-anthropic/src/main/java/io/agentscope/extensions/model/anthropic/formatter/AnthropicMessageConverter.java
@@ -80,12 +80,15 @@ public class AnthropicMessageConverter {
         for (int i = 0; i < messages.size(); i++) {
             Msg msg = messages.get(i);
             boolean isFirstMessage = (i == 0);
-            SplitToolResultSequence splitResults = collectSplitToolResults(messages, i + 1);
 
-            if (shouldSplitParallelToolCalls(msg, splitResults)) {
-                result.addAll(convertParallelToolCalls(msg, splitResults));
-                i += splitResults.consumedMessages();
-                continue;
+            if (msg.getRole() == MsgRole.ASSISTANT
+                    && msg.getContentBlocks(ToolUseBlock.class).size() > 1) {
+                SplitToolResultSequence splitResults = collectSplitToolResults(messages, i + 1);
+                if (shouldSplitParallelToolCalls(msg, splitResults)) {
+                    result.addAll(convertParallelToolCalls(msg, splitResults));
+                    i += splitResults.consumedMessages();
+                    continue;
+                }
             }
 
             // Special handling for tool results - they create separate user messages

--- a/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-anthropic/src/test/java/io/agentscope/extensions/model/anthropic/formatter/AnthropicMessageConverterTest.java
+++ b/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-anthropic/src/test/java/io/agentscope/extensions/model/anthropic/formatter/AnthropicMessageConverterTest.java
@@ -323,6 +323,100 @@ class AnthropicMessageConverterTest extends AnthropicFormatterTestBase {
     }
 
     @Test
+    void testConvertParallelToolCallsToAlternatingMessages() {
+        Msg userMsg =
+                Msg.builder()
+                        .name("User")
+                        .role(MsgRole.USER)
+                        .content(
+                                TextBlock.builder()
+                                        .text("Check Beijing and Hangzhou weather in parallel.")
+                                        .build())
+                        .build();
+        Msg assistantMsg =
+                Msg.builder()
+                        .name("Assistant")
+                        .role(MsgRole.ASSISTANT)
+                        .content(
+                                List.of(
+                                        TextBlock.builder()
+                                                .text("I will check both cities at the same time.")
+                                                .build(),
+                                        ToolUseBlock.builder()
+                                                .id("call_1")
+                                                .name("get_weather")
+                                                .input(Map.of("city", "Beijing"))
+                                                .build(),
+                                        ToolUseBlock.builder()
+                                                .id("call_2")
+                                                .name("get_weather")
+                                                .input(Map.of("city", "Hangzhou"))
+                                                .build()))
+                        .build();
+        Msg toolResultsMsg1 =
+                Msg.builder()
+                        .name("Tool")
+                        .role(MsgRole.TOOL)
+                        .content(
+                                List.of(
+                                        ToolResultBlock.builder()
+                                                .id("call_1")
+                                                .name("get_weather")
+                                                .output(
+                                                        TextBlock.builder()
+                                                                .text("Beijing: sunny, 28 C")
+                                                                .build())
+                                                .build()))
+                        .build();
+        Msg toolResultsMsg2 =
+                Msg.builder()
+                        .name("Tool")
+                        .role(MsgRole.TOOL)
+                        .content(
+                                List.of(
+                                        ToolResultBlock.builder()
+                                                .id("call_2")
+                                                .name("get_weather")
+                                                .output(
+                                                        TextBlock.builder()
+                                                                .text("Hangzhou: cloudy, 30 C")
+                                                                .build())
+                                                .build()))
+                        .build();
+
+        List<MessageParam> result =
+                converter.convert(List.of(userMsg, assistantMsg, toolResultsMsg1, toolResultsMsg2));
+
+        assertEquals(5, result.size());
+        assertEquals(MessageParam.Role.USER, result.get(0).role());
+        assertEquals(
+                "Check Beijing and Hangzhou weather in parallel.",
+                result.get(0).content().asBlockParams().get(0).asText().text());
+        assertEquals(MessageParam.Role.ASSISTANT, result.get(1).role());
+        assertEquals(2, result.get(1).content().asBlockParams().size());
+        assertTrue(result.get(1).content().asBlockParams().get(0).isText());
+        assertEquals(
+                "I will check both cities at the same time.",
+                result.get(1).content().asBlockParams().get(0).asText().text());
+        assertTrue(result.get(1).content().asBlockParams().get(1).isToolUse());
+        assertEquals("call_1", result.get(1).content().asBlockParams().get(1).asToolUse().id());
+        assertEquals(MessageParam.Role.USER, result.get(2).role());
+        assertTrue(result.get(2).content().asBlockParams().get(0).isToolResult());
+        assertEquals(
+                "call_1",
+                result.get(2).content().asBlockParams().get(0).asToolResult().toolUseId());
+        assertEquals(MessageParam.Role.ASSISTANT, result.get(3).role());
+        assertEquals(1, result.get(3).content().asBlockParams().size());
+        assertTrue(result.get(3).content().asBlockParams().get(0).isToolUse());
+        assertEquals("call_2", result.get(3).content().asBlockParams().get(0).asToolUse().id());
+        assertEquals(MessageParam.Role.USER, result.get(4).role());
+        assertTrue(result.get(4).content().asBlockParams().get(0).isToolResult());
+        assertEquals(
+                "call_2",
+                result.get(4).content().asBlockParams().get(0).asToolResult().toolUseId());
+    }
+
+    @Test
     void testConvertToolResultBlockNullOutput() {
         // Builder without output() call will have null output, which becomes empty list
         Msg msg =


### PR DESCRIPTION
## Description

Close #2077 

## Summary

Fixes Anthropic message formatting for parallel tool calls.

When a single assistant message contains multiple `ToolUseBlock`s and the following messages contain the corresponding `ToolResultBlock`s, Anthropic requires the request payload to alternate as:

assistant(tool_use_1) -> user(tool_result_1) -> assistant(tool_use_2) -> user(tool_result_2)

This PR updates `AnthropicMessageConverter` to detect completed parallel tool-call batches and expand them into Anthropic-compatible alternating messages before sending the request.

## Checklist

Please check the following items before code is ready to be reviewed.

- [ ]  Code has been formatted with `mvn spotless:apply`
- [ ]  All tests are passing (`mvn test`)
- [ ]  Javadoc comments are complete and follow project conventions
- [ ]  Related documentation has been updated (e.g. links, examples, etc.)
- [ ]  Code is ready for review
