### PR TITLE
feat(agui): support custom RuntimeContext in AguiAgentAdapter

### DIFF
--- a/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/main/java/io/agentscope/core/agui/adapter/AguiAgentAdapter.java
+++ b/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/main/java/io/agentscope/core/agui/adapter/AguiAgentAdapter.java
@@ -108,6 +108,21 @@ public class AguiAgentAdapter {
      * @return A Flux of AG-UI events
      */
     public Flux<AguiEvent> run(RunAgentInput input) {
+        return run(input, null);
+    }
+
+    /**
+     * Run the agent with AG-UI protocol input and a custom runtime context.
+     *
+     * <p>If {@code runtimeContext} is {@code null}, a default context is built from the
+     * input via {@link #buildRuntimeContext(RunAgentInput)}. Otherwise the supplied
+     * context is passed directly to the agent.
+     *
+     * @param input The AG-UI run input
+     * @param runtimeContext The runtime context to use, or {@code null} to use the default
+     * @return A Flux of AG-UI events
+     */
+    public Flux<AguiEvent> run(RunAgentInput input, RuntimeContext runtimeContext) {
         return Flux.defer(
                 () -> {
                     String threadId = input.getThreadId();
@@ -125,12 +140,13 @@ public class AguiAgentAdapter {
 
                     // Track state for event conversion
                     EventConversionState state = new EventConversionState(threadId, runId);
-                    RuntimeContext runtimeContext = buildRuntimeContext(input);
+                    RuntimeContext effectiveRuntimeContext =
+                            runtimeContext != null ? runtimeContext : buildRuntimeContext(input);
                     ToolInjection toolInjection = ToolInjection.empty();
                     Flux<Event> agentEvents;
                     try {
                         toolInjection = injectFrontendTools(input);
-                        agentEvents = agent.stream(msgs, options, runtimeContext);
+                        agentEvents = agent.stream(msgs, options, effectiveRuntimeContext);
                         if (agentEvents == null) {
                             agentEvents = agent.stream(msgs, options);
                         }
@@ -159,7 +175,17 @@ public class AguiAgentAdapter {
                 });
     }
 
-    private RuntimeContext buildRuntimeContext(RunAgentInput input) {
+    /**
+     * Build the default runtime context for an AG-UI run.
+     *
+     * <p>Subclasses may override this method to customize the context that is passed to
+     * the agent when no explicit context is supplied to {@link #run(RunAgentInput,
+     * RuntimeContext)}.
+     *
+     * @param input The AG-UI run input
+     * @return The runtime context for the agent run
+     */
+    protected RuntimeContext buildRuntimeContext(RunAgentInput input) {
         return RuntimeContext.builder()
                 .sessionId(input.getThreadId())
                 .put(RunAgentInput.class, input)

--- a/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/main/java/io/agentscope/core/agui/processor/AguiRequestProcessor.java
+++ b/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/main/java/io/agentscope/core/agui/processor/AguiRequestProcessor.java
@@ -16,6 +16,7 @@
 package io.agentscope.core.agui.processor;
 
 import io.agentscope.core.agent.Agent;
+import io.agentscope.core.agent.RuntimeContext;
 import io.agentscope.core.agui.adapter.AguiAdapterConfig;
 import io.agentscope.core.agui.adapter.AguiAgentAdapter;
 import io.agentscope.core.agui.event.AguiEvent;
@@ -85,6 +86,26 @@ public class AguiRequestProcessor {
      * @return A ProcessResult containing the agent and event stream
      */
     public ProcessResult process(RunAgentInput input, String headerAgentId, String pathAgentId) {
+        return process(input, headerAgentId, pathAgentId, null);
+    }
+
+    /**
+     * Process an AG-UI request with a custom runtime context.
+     *
+     * <p>If {@code runtimeContext} is {@code null}, a default context is built from the input
+     * by the adapter.
+     *
+     * @param input The run agent input
+     * @param headerAgentId The agent ID from HTTP header (may be null)
+     * @param pathAgentId The agent ID from URL path variable (may be null)
+     * @param runtimeContext The runtime context to use, or {@code null} to use the default
+     * @return A ProcessResult containing the agent and event stream
+     */
+    public ProcessResult process(
+            RunAgentInput input,
+            String headerAgentId,
+            String pathAgentId,
+            RuntimeContext runtimeContext) {
         String threadId = input.getThreadId();
 
         // Resolve agent ID
@@ -104,7 +125,7 @@ public class AguiRequestProcessor {
 
         // Create adapter and run
         AguiAgentAdapter adapter = new AguiAgentAdapter(agent, config);
-        Flux<AguiEvent> events = adapter.run(effectiveInput);
+        Flux<AguiEvent> events = adapter.run(effectiveInput, runtimeContext);
 
         return new ProcessResult(agent, events);
     }

--- a/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/test/java/io/agentscope/core/agui/adapter/AguiAgentAdapterTest.java
+++ b/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/test/java/io/agentscope/core/agui/adapter/AguiAgentAdapterTest.java
@@ -103,6 +103,78 @@ class AguiAgentAdapterTest {
     }
 
     @Test
+    void testRunWithCustomRuntimeContext() {
+        ArgumentCaptor<RuntimeContext> contextCaptor =
+                ArgumentCaptor.forClass(RuntimeContext.class);
+        when(mockAgent.stream(anyList(), any(StreamOptions.class), contextCaptor.capture()))
+                .thenReturn(Flux.empty());
+
+        RuntimeContext customContext = RuntimeContext.builder().sessionId("custom-session").build();
+        RunAgentInput input =
+                RunAgentInput.builder()
+                        .threadId("thread-1")
+                        .runId("run-1")
+                        .messages(List.of(AguiMessage.userMessage("msg-1", "Hello")))
+                        .build();
+
+        adapter.run(input, customContext).collectList().block();
+
+        RuntimeContext captured = contextCaptor.getValue();
+        assertSame(customContext, captured);
+        assertEquals("custom-session", captured.getSessionId());
+    }
+
+    @Test
+    void testRunWithNullRuntimeContextFallsBackToBuiltContext() {
+        ArgumentCaptor<RuntimeContext> contextCaptor =
+                ArgumentCaptor.forClass(RuntimeContext.class);
+        when(mockAgent.stream(anyList(), any(StreamOptions.class), contextCaptor.capture()))
+                .thenReturn(Flux.empty());
+
+        RunAgentInput input =
+                RunAgentInput.builder()
+                        .threadId("thread-null-ctx")
+                        .runId("run-null-ctx")
+                        .messages(List.of(AguiMessage.userMessage("msg-1", "Hello")))
+                        .build();
+
+        adapter.run(input, null).collectList().block();
+
+        RuntimeContext context = contextCaptor.getValue();
+        assertEquals("thread-null-ctx", context.getSessionId());
+        assertSame(input, context.get(RunAgentInput.class));
+    }
+
+    @Test
+    void testBuildRuntimeContextCanBeOverriddenBySubclass() {
+        RuntimeContext customContext =
+                RuntimeContext.builder().sessionId("subclass-session").build();
+        AguiAgentAdapter subclassAdapter =
+                new AguiAgentAdapter(mockAgent, AguiAdapterConfig.defaultConfig()) {
+                    @Override
+                    protected RuntimeContext buildRuntimeContext(RunAgentInput input) {
+                        return customContext;
+                    }
+                };
+
+        ArgumentCaptor<RuntimeContext> contextCaptor =
+                ArgumentCaptor.forClass(RuntimeContext.class);
+        when(mockAgent.stream(anyList(), any(StreamOptions.class), contextCaptor.capture()))
+                .thenReturn(Flux.empty());
+
+        RunAgentInput input =
+                RunAgentInput.builder()
+                        .threadId("thread-1")
+                        .runId("run-1")
+                        .messages(List.of(AguiMessage.userMessage("msg-1", "Hello")))
+                        .build();
+
+        subclassAdapter.run(input).collectList().block();
+
+        assertSame(customContext, contextCaptor.getValue());
+    }
+
+    @Test
     void testRunRegistersFrontendToolsForRunAndCleansUp() {
         Toolkit toolkit = new Toolkit();
         when(mockAgent.getToolkit()).thenReturn(toolkit);

--- a/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/test/java/io/agentscope/core/agui/processor/AguiRequestProcessorTest.java
+++ b/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/test/java/io/agentscope/core/agui/processor/AguiRequestProcessorTest.java
@@ -16,13 +16,22 @@
 package io.agentscope.core.agui.processor;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
+import io.agentscope.core.agent.Agent;
+import io.agentscope.core.agent.RuntimeContext;
+import io.agentscope.core.agent.StreamOptions;
 import io.agentscope.core.agui.model.AguiMessage;
 import io.agentscope.core.agui.model.RunAgentInput;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import reactor.core.publisher.Flux;
 
 /** Unit tests for AguiRequestProcessor. */
 class AguiRequestProcessorTest {
@@ -51,5 +60,64 @@ class AguiRequestProcessorTest {
         assertEquals(List.of(lastUser), extracted.getMessages());
         assertEquals(input.getState(), extracted.getState());
         assertEquals(input.getForwardedProps(), extracted.getForwardedProps());
+    }
+
+    @Test
+    void processForwardsCustomRuntimeContextToAgent() {
+        Agent mockAgent = mock(Agent.class);
+        AgentResolver agentResolver = mock(AgentResolver.class);
+        when(agentResolver.resolveAgent("agent-a", "thread-1")).thenReturn(mockAgent);
+        when(agentResolver.hasMemory("thread-1")).thenReturn(false);
+
+        ArgumentCaptor<RuntimeContext> contextCaptor =
+                ArgumentCaptor.forClass(RuntimeContext.class);
+        when(mockAgent.stream(anyList(), any(StreamOptions.class), contextCaptor.capture()))
+                .thenReturn(Flux.empty());
+
+        AguiRequestProcessor processor =
+                AguiRequestProcessor.builder().agentResolver(agentResolver).build();
+
+        RuntimeContext customContext = RuntimeContext.builder().sessionId("custom-session").build();
+        RunAgentInput input =
+                RunAgentInput.builder()
+                        .threadId("thread-1")
+                        .runId("run-1")
+                        .messages(List.of(AguiMessage.userMessage("msg-1", "Hello")))
+                        .forwardedProps(Map.of("agentId", "agent-a"))
+                        .build();
+
+        processor.process(input, null, null, customContext).events().collectList().block();
+
+        assertSame(customContext, contextCaptor.getValue());
+    }
+
+    @Test
+    void processWithNullRuntimeContextFallsBackToBuiltContext() {
+        Agent mockAgent = mock(Agent.class);
+        AgentResolver agentResolver = mock(AgentResolver.class);
+        when(agentResolver.resolveAgent("agent-a", "thread-1")).thenReturn(mockAgent);
+        when(agentResolver.hasMemory("thread-1")).thenReturn(false);
+
+        ArgumentCaptor<RuntimeContext> contextCaptor =
+                ArgumentCaptor.forClass(RuntimeContext.class);
+        when(mockAgent.stream(anyList(), any(StreamOptions.class), contextCaptor.capture()))
+                .thenReturn(Flux.empty());
+
+        AguiRequestProcessor processor =
+                AguiRequestProcessor.builder().agentResolver(agentResolver).build();
+
+        RunAgentInput input =
+                RunAgentInput.builder()
+                        .threadId("thread-1")
+                        .runId("run-1")
+                        .messages(List.of(AguiMessage.userMessage("msg-1", "Hello")))
+                        .forwardedProps(Map.of("agentId", "agent-a"))
+                        .build();
+
+        processor.process(input, null, null).events().collectList().block();
+
+        RuntimeContext context = contextCaptor.getValue();
+        assertEquals("thread-1", context.getSessionId());
+        assertSame(input, context.get(RunAgentInput.class));
     }
 }


### PR DESCRIPTION
## Summary

  Allow callers to provide a custom `RuntimeContext` when running an agent through `AguiAgentAdapter` and `AguiRequestProcessor`, and let subclasses override the default context construction.

  ## Problem

  `AguiAgentAdapter.run(RunAgentInput)` always built the `RuntimeContext` internally, so callers could not:

  - Pass an existing runtime context that already carries request-scoped metadata.
  - Customize the default context via subclassing, because `buildRuntimeContext` was `private`.

  More importantly, because the adapter owned the context instance, any custom data written by downstream middleware or tools during the run was invisible to the upstream caller. The caller had no way
  to read that data back or use it to customize post-run processing.

  `AguiRequestProcessor` had the same limitation: it only exposed `process(RunAgentInput, String, String)`, so AG-UI request handlers could not inject a pre-built context either.

  ## Changes

  - Added `AguiAgentAdapter.run(RunAgentInput input, RuntimeContext runtimeContext)`.
    - Uses the supplied context when non-null; otherwise falls back to `buildRuntimeContext(input)`.
    - The caller keeps the same context reference, so values written by middleware/tools are observable after the run.
  - Changed `AguiAgentAdapter.buildRuntimeContext` from `private` to `protected` for subclass overrides.
  - Added `AguiRequestProcessor.process(RunAgentInput, String, String, RuntimeContext)`.
    - Forwards the context to the adapter; passing `null` preserves the original behavior.
  - Kept the original `run(RunAgentInput)` and `process(RunAgentInput, String, String)` methods unchanged for backward compatibility.