### PR TITLE
fix(models): terminate OpenAI stream on [DONE] sentinel

### DIFF
--- a/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-openai/src/main/java/io/agentscope/extensions/model/openai/OpenAIClient.java
+++ b/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-openai/src/main/java/io/agentscope/extensions/model/openai/OpenAIClient.java
@@ -65,6 +65,9 @@ public class OpenAIClient {
 
     private static final Logger log = LoggerFactory.getLogger(OpenAIClient.class);
 
+    /** SSE sentinel emitted by the OpenAI streaming API to signal end of stream. */
+    private static final String SSE_DONE_MARKER = "[DONE]";
+
     /** Default base URL for OpenAI API. */
     public static final String DEFAULT_BASE_URL = "https://api.openai.com";
 
@@ -402,7 +405,7 @@ public class OpenAIClient {
                     // rather than merely filtering it out, otherwise completion is deferred until
                     // the underlying connection closes (keep-alive gateways may stall this for the
                     // full idle timeout even though the model has finished responding).
-                    .takeWhile(data -> !data.equals("[DONE]"))
+                    .takeWhile(data -> !SSE_DONE_MARKER.equals(data))
                     .<OpenAIResponse>handle(
                             (data, sink) -> {
                                 OpenAIResponse response = parseStreamData(data);

--- a/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-openai/src/main/java/io/agentscope/extensions/model/openai/OpenAIClient.java
+++ b/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-openai/src/main/java/io/agentscope/extensions/model/openai/OpenAIClient.java
@@ -398,7 +398,11 @@ public class OpenAIClient {
                             .build();
 
             return transport.stream(httpRequest)
-                    .filter(data -> !data.equals("[DONE]"))
+                    // The SSE `[DONE]` sentinel terminates the stream: complete the Flux here
+                    // rather than merely filtering it out, otherwise completion is deferred until
+                    // the underlying connection closes (keep-alive gateways may stall this for the
+                    // full idle timeout even though the model has finished responding).
+                    .takeWhile(data -> !data.equals("[DONE]"))
                     .<OpenAIResponse>handle(
                             (data, sink) -> {
                                 OpenAIResponse response = parseStreamData(data);

--- a/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-openai/src/test/java/io/agentscope/extensions/model/openai/OpenAIStreamTerminationTest.java
+++ b/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-openai/src/test/java/io/agentscope/extensions/model/openai/OpenAIStreamTerminationTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.extensions.model.openai;
+
+import io.agentscope.core.model.GenerateOptions;
+import io.agentscope.core.model.transport.HttpRequest;
+import io.agentscope.core.model.transport.HttpResponse;
+import io.agentscope.core.model.transport.HttpTransport;
+import io.agentscope.extensions.model.openai.dto.OpenAIMessage;
+import io.agentscope.extensions.model.openai.dto.OpenAIRequest;
+import java.time.Duration;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Flux;
+import reactor.test.StepVerifier;
+
+/**
+ * Tests that the OpenAI streaming response is terminated deterministically by the SSE
+ * {@code [DONE]} sentinel, independent of the underlying HTTP connection lifecycle.
+ *
+ * <p>Regression test for the case where {@code [DONE]} was merely filtered out instead of
+ * completing the {@link Flux}. Against an OpenAI-compatible gateway that keeps the connection
+ * open (HTTP keep-alive) after emitting {@code [DONE]}, the stream would only complete when the
+ * socket was eventually closed by an idle timeout, stalling the ReAct turn for up to a minute.
+ */
+@Tag("unit")
+@DisplayName("OpenAI Stream Termination Tests")
+class OpenAIStreamTerminationTest {
+
+    private static final String CHUNK_CONTENT =
+            "{\"id\":\"1\",\"choices\":[{\"delta\":{\"content\":\"hello\"},\"index\":0}]}";
+    private static final String CHUNK_FINISH =
+            "{\"id\":\"1\",\"choices\":[{\"delta\":{},\"finish_reason\":\"stop\",\"index\":0}]}";
+
+    /**
+     * A transport that emits two content chunks and the {@code [DONE]} sentinel, then never
+     * completes ({@link Flux#never()}) — simulating a gateway that holds the connection open
+     * after {@code [DONE]}.
+     */
+    private static HttpTransport keepAliveTransportAfterDone() {
+        return new HttpTransport() {
+            @Override
+            public HttpResponse execute(HttpRequest request) {
+                throw new UnsupportedOperationException("not used in this test");
+            }
+
+            @Override
+            public Flux<String> stream(HttpRequest request) {
+                return Flux.just(CHUNK_CONTENT, CHUNK_FINISH, "[DONE]").concatWith(Flux.never());
+            }
+
+            @Override
+            public void close() {}
+        };
+    }
+
+    private static OpenAIRequest sampleRequest() {
+        return OpenAIRequest.builder()
+                .model("gpt-4o-mini")
+                .messages(List.of(OpenAIMessage.builder().role("user").content("hi").build()))
+                .build();
+    }
+
+    @Test
+    @DisplayName("Stream should complete on [DONE] even if the connection stays open")
+    void streamCompletesOnDoneSentinelWithoutWaitingForConnectionClose() {
+        OpenAIClient client = new OpenAIClient(keepAliveTransportAfterDone());
+
+        StepVerifier.create(
+                        client.stream(
+                                "test-key",
+                                "http://localhost",
+                                sampleRequest(),
+                                GenerateOptions.builder().build()))
+                .expectNextCount(2)
+                .expectComplete()
+                .verify(Duration.ofSeconds(5));
+    }
+}


### PR DESCRIPTION
## AgentScope-Java Version

2.0.1-SNAPSHOT (main)

## Description

**Background.** `OpenAIClient#stream` treats the SSE `[DONE]` sentinel as a data line to be *discarded* (`.filter(data -> !data.equals("[DONE]"))`) rather than as the stream-termination signal. Nothing completes the `Flux` when `[DONE]` arrives, so it only completes when the underlying HTTP response body reaches EOF — i.e. when the server actually closes the connection.

**Impact.** Many OpenAI-compatible gateways (LiteLLM-style proxies, corporate model gateways, nginx-fronted vLLM, …) send `data: [DONE]` and then keep the connection open (HTTP keep-alive) until an idle timeout (~60s). As a result all tokens arrive in real time, but the model call's reactive completion is delayed by up to a minute: the ReAct turn does not advance, `AgentResultEvent` is not emitted, and `agent.streamEvents(...)`'s `onComplete` fires ~60s after the last token — a finished agent looks "still running". Direct `api.openai.com` connections mask this because the server closes promptly.

**Change.** Replace `filter` with `takeWhile` so `[DONE]` completes the stream deterministically, regardless of connection lifecycle. This matches the OpenAI Python/JS SDKs, which both treat `[DONE]` as the terminator. One-line logic change in `OpenAIClient#stream`.

**How to test.** Added `OpenAIStreamTerminationTest`: a fake `HttpTransport` emits two content chunks + `[DONE]`, then `Flux.never()` (simulating a gateway that never closes the connection). `StepVerifier` asserts the stream completes within 5s.
- Before the fix: the stream never completes → the test times out (~5.4s, `VerifySubscriber timed out`).
- After the fix: it completes in ~0.4s.

Full module suite: `Tests run: 379, Failures: 0, Errors: 0, Skipped: 10`.

Closes #2073

## Checklist

- [x] Code has been formatted with `mvn spotless:apply`
- [x] All tests are passing (`mvn test`)
- [x] Javadoc comments are complete and follow project conventions
- [x] Related documentation has been updated (e.g. links, examples, etc.) — N/A (behavioral bug fix, no doc surface)
- [x] Code is ready for review