### PR TITLE
fix(shell-execute): optimize working_directory parameter and tool usage hints

### DIFF
--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/tool/ShellExecuteTool.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/tool/ShellExecuteTool.java
@@ -51,7 +51,8 @@ public class ShellExecuteTool {
             @ToolParam(
                             name = "working_directory",
                             description =
-                                    "Working directory (relative to workspace root, optional)",
+                                    "Optional relative path from workspace root. Must not start"
+                                            + " with /, ~, or ..(e.g., ., src).",
                             required = false)
                     String workingDirectory,
             @ToolParam(name = "timeout", description = "Timeout in seconds (default: 30)")

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/tool/ShellExecuteTool.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/tool/ShellExecuteTool.java
@@ -44,7 +44,9 @@ public class ShellExecuteTool {
     @Tool(
             description =
                     "Execute a shell command. Use for git, npm, build, test, and other terminal"
-                            + " operations. Returns combined output and exit code.")
+                        + " operations. Returns combined output and exit code. If a dedicated tool"
+                        + " exists (e.g., read_file, write_file), you MUST use it instead of shell"
+                        + " commands.")
     public String execute(
             RuntimeContext runtimeContext,
             @ToolParam(name = "command", description = "Shell command to execute") String command,

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/tool/ShellExecuteTool.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/tool/ShellExecuteTool.java
@@ -26,7 +26,9 @@ import io.agentscope.harness.agent.filesystem.sandbox.AbstractSandboxFilesystem;
  */
 public class ShellExecuteTool {
 
-    /** Registered tool name (derived from the {@link #execute} method name). */
+    /**
+     * Registered tool name (derived from the {@link #execute} method name).
+     */
     public static final String NAME = "execute";
 
     private final AbstractSandboxFilesystem sandbox;
@@ -37,7 +39,7 @@ public class ShellExecuteTool {
 
     /**
      * @param runtimeContext per-call agent runtime injected by the framework (not an LLM argument);
-     *     may be {@code null} when no merged context is available
+     *                       may be {@code null} when no merged context is available
      */
     @Tool(
             description =
@@ -49,7 +51,8 @@ public class ShellExecuteTool {
             @ToolParam(
                             name = "working_directory",
                             description =
-                                    "Working directory (relative to workspace root, optional)")
+                                    "Working directory (relative to workspace root, optional)",
+                            required = false)
                     String workingDirectory,
             @ToolParam(name = "timeout", description = "Timeout in seconds (default: 30)")
                     int timeout) {


### PR DESCRIPTION
## AgentScope-Java Version

Based on upstream/main

## Description

Three optimizations for ShellExecuteTool:

1. **refactor(tool):** Mark `working_directory` parameter as non-required (`required = false`)
2. **fix(agent):** Improve `workingDirectory` parameter description
3. **docs(shell-execute):** Add prompt suggesting llm prefer special tools (read_file, write_file, etc.) over shell commands when applicable

### How to Test

- Verify `working_directory` parameter is non-required
- Verify parameter descriptions are clear
- Verify shell tool prompt message is correct

## Checklist

- [x] Code has been formatted with `mvn spotless:apply`
- [x] All tests are passing (`mvn test`)
- [x] Javadoc comments are complete and follow project conventions
- [x] Related documentation has been updated (e.g. links, examples, etc.)
- [x] Code is ready for review