### PR TITLE
Fix Optional Timeout Parameter in ShellExecuteTool

### DIFF
--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/tool/ShellExecuteTool.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/tool/ShellExecuteTool.java
@@ -57,8 +57,11 @@ public class ShellExecuteTool {
                                             + " with /, ~, or ..(e.g., ., src).",
                             required = false)
                     String workingDirectory,
-            @ToolParam(name = "timeout", description = "Timeout in seconds (default: 30)")
-                    int timeout) {
+            @ToolParam(
+                            name = "timeout",
+                            description = "Timeout in seconds (default: 30)",
+                            required = false)
+                    Integer timeout) {
         String effectiveCommand = command;
         if (workingDirectory != null && !workingDirectory.isBlank()) {
             String wd = workingDirectory.strip();
@@ -69,8 +72,9 @@ public class ShellExecuteTool {
             effectiveCommand = "cd '" + wd.replace("'", "'\\''") + "' && " + command;
         }
 
+        int effectiveTimeout = timeout != null && timeout > 0 ? timeout : 30;
         ExecuteResponse result =
-                sandbox.execute(runtimeContext, effectiveCommand, timeout > 0 ? timeout : 30);
+                sandbox.execute(runtimeContext, effectiveCommand, effectiveTimeout);
 
         StringBuilder sb = new StringBuilder();
         sb.append("Exit code: ").append(result.exitCode()).append("\n");

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/tool/ShellExecuteToolTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/tool/ShellExecuteToolTest.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.harness.agent.tool;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.agentscope.core.agent.RuntimeContext;
+import io.agentscope.core.message.ToolUseBlock;
+import io.agentscope.core.tool.AgentTool;
+import io.agentscope.core.tool.ToolCallParam;
+import io.agentscope.core.tool.Toolkit;
+import io.agentscope.harness.agent.filesystem.model.ExecuteResponse;
+import io.agentscope.harness.agent.filesystem.sandbox.AbstractSandboxFilesystem;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/** Unit tests for {@link ShellExecuteTool}. */
+class ShellExecuteToolTest {
+
+    private static final RuntimeContext RT = RuntimeContext.empty();
+
+    private AbstractSandboxFilesystem sandbox;
+    private ShellExecuteTool tool;
+
+    @BeforeEach
+    void setUp() {
+        sandbox = mock(AbstractSandboxFilesystem.class);
+        tool = new ShellExecuteTool(sandbox);
+    }
+
+    @Test
+    void schema_onlyRequiresCommand() {
+        Toolkit toolkit = new Toolkit();
+        toolkit.registerTool(tool);
+
+        AgentTool registeredTool = toolkit.getTool(ShellExecuteTool.NAME);
+
+        assertEquals(List.of("command"), registeredTool.getParameters().get("required"));
+    }
+
+    @Test
+    void execute_omittedOptionalParameters_defaultsTimeoutToThirtySeconds() {
+        when(sandbox.execute(RT, "pwd", 30)).thenReturn(new ExecuteResponse("", 0, false));
+        Toolkit toolkit = new Toolkit();
+        toolkit.registerTool(tool);
+        Map<String, Object> input = Map.of("command", "pwd");
+        ToolUseBlock toolUse =
+                ToolUseBlock.builder()
+                        .id("call-execute")
+                        .name(ShellExecuteTool.NAME)
+                        .input(input)
+                        .content("{\"command\":\"pwd\"}")
+                        .build();
+
+        toolkit.callTool(
+                        ToolCallParam.builder()
+                                .toolUseBlock(toolUse)
+                                .input(input)
+                                .runtimeContext(RT)
+                                .build())
+                .block(Duration.ofSeconds(3));
+
+        verify(sandbox).execute(RT, "pwd", 30);
+    }
+
+    @Test
+    void execute_explicitTimeout_passesTimeoutToSandbox() {
+        when(sandbox.execute(RT, "pwd", 10)).thenReturn(new ExecuteResponse("", 0, false));
+
+        tool.execute(RT, "pwd", null, 10);
+
+        verify(sandbox).execute(RT, "pwd", 10);
+    }
+
+    @Test
+    void execute_nonPositiveTimeout_defaultsTimeoutToThirtySeconds() {
+        when(sandbox.execute(RT, "pwd", 30)).thenReturn(new ExecuteResponse("", 0, false));
+
+        tool.execute(RT, "pwd", null, 0);
+
+        verify(sandbox).execute(RT, "pwd", 30);
+    }
+}


### PR DESCRIPTION
## 问题

-  `working_directory` 和 `timeout` 这两个参数在描述和实际代码中，都是有默认值的，但是实际注册schema的时候没有传入 @ToolParam(required=false)`，导致实际上这两个参数会被当成必填项进行校验，造成Agent调用频繁出错，造成效率损失。
-  `timeout` 参数是`int`类型，如果大模型没有返回这个值，那么反射处理参数的地方会传入null，传给primitive `int`会直接报错。

## Summary

- mark `working_directory` and `timeout` as optional in the generated schema
- accept a nullable `timeout` and default it to 30 seconds when omitted or non-positive
- add regression coverage for the schema, command-only reflective invocation, and explicit timeouts


## Root cause

`@ToolParam.required()` defaults to `true`, but `ShellExecuteTool` did not override it for its optional parameters. In addition, the primitive `int` timeout could not receive the `null` produced for an omitted argument.


## Testing

```text
mvn -pl agentscope-harness -am "-Dtest=ShellExecuteToolTest" "-Dsurefire.failIfNoSpecifiedTests=false" "-Dspotless.check.skip=true" test
```

Result: 3 tests passed, 0 failures.

## 更新（2026-07-18）

### 更新原因

本 PR rebase 到最新 `main` 后，提交 [`0e67ac1be`](https://github.com/agentscope-ai/agentscope-java/commit/0e67ac1be094ecc3095f642f6229516922af28aa) 已将 `working_directory` 标记为可选，并优化了 shell 工具的使用提示。为避免重复修改，本 PR 保留该提交的语义，调整为只补充 `timeout` 的可选参数支持。

### 当前调整

- `timeout` 仍可由调用方显式修改，正数值会原样传递给 sandbox。
- 省略 `timeout` 时允许反射调用器传入 `null`，并默认使用 30 秒。
- `timeout` 为非正数时同样回退到 30 秒。
- 生成的 Schema 只要求 `command`。

### 最新验证

`ShellExecuteToolTest` 共 4 个测试全部通过，覆盖 Schema、仅传 `command`、显式 timeout 和非正数 timeout 的行为；timeout 新增判断的分支覆盖为 4/4。
