### PR TITLE
fix(core): prevent pending recovery from consuming HITL approvals

### DIFF
--- a/agentscope-core/src/main/java/io/agentscope/core/ReActAgent.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/ReActAgent.java
@@ -1518,9 +1518,20 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
                 msgs = List.of();
             }
 
+            List<ConfirmResult> confirmResults = extractConfirmResults(msgs);
+            boolean hasConfirmResultInput =
+                    msgs != null
+                            && msgs.stream()
+                                    .anyMatch(
+                                            msg ->
+                                                    msg.getMetadata()
+                                                            .containsKey(
+                                                                    Msg.METADATA_CONFIRM_RESULTS));
+
             // Pending-tool-call recovery: auto-patch orphaned pending tool calls with synthetic
-            // error results so the agent can continue instead of crashing.
-            if (enablePendingToolRecovery) {
+            // error results so the agent can continue instead of crashing. Confirmation input
+            // must be handled by the permission HITL flow below instead of recovery.
+            if (enablePendingToolRecovery && !hasConfirmResultInput) {
                 maybePatchPendingToolCalls(msgs);
             }
 
@@ -1536,7 +1547,6 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
             // ConfirmResults (via Msg.METADATA_CONFIRM_RESULTS) before we can proceed.
             List<ToolUseBlock> asking = askingToolCalls();
             if (!asking.isEmpty()) {
-                List<ConfirmResult> confirmResults = extractConfirmResults(msgs);
                 if (confirmResults.isEmpty()) {
                     String pendingSummary =
                             asking.stream()
@@ -1719,10 +1729,6 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
             if (userProvidedResults) {
                 return;
             }
-            log.warn(
-                    "Pending tool calls detected without results, auto-generating error results."
-                            + " Pending IDs: {}",
-                    pendingIds);
             Msg lastAssistant = findLastAssistantMsg();
             if (lastAssistant == null) {
                 return;
@@ -1730,7 +1736,15 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
             List<ToolUseBlock> pendingToolCalls =
                     lastAssistant.getContentBlocks(ToolUseBlock.class).stream()
                             .filter(toolUse -> pendingIds.contains(toolUse.getId()))
+                            .filter(toolUse -> toolUse.getState() != ToolCallState.ASKING)
                             .toList();
+            if (pendingToolCalls.isEmpty()) {
+                return;
+            }
+            log.warn(
+                    "Pending tool calls detected without results, auto-generating error results."
+                            + " Pending IDs: {}",
+                    pendingToolCalls.stream().map(ToolUseBlock::getId).toList());
             for (ToolUseBlock toolCall : pendingToolCalls) {
                 ToolResultBlock errorResult =
                         buildErrorToolResult(

--- a/agentscope-core/src/main/java/io/agentscope/core/ReActAgent.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/ReActAgent.java
@@ -1522,11 +1522,12 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
             boolean hasConfirmResultInput =
                     msgs != null
                             && msgs.stream()
+                                    .map(Msg::getMetadata)
+                                    .filter(Objects::nonNull)
                                     .anyMatch(
-                                            msg ->
-                                                    msg.getMetadata()
-                                                            .containsKey(
-                                                                    Msg.METADATA_CONFIRM_RESULTS));
+                                            metadata ->
+                                                    metadata.containsKey(
+                                                            Msg.METADATA_CONFIRM_RESULTS));
 
             // Pending-tool-call recovery: auto-patch orphaned pending tool calls with synthetic
             // error results so the agent can continue instead of crashing. Confirmation input

--- a/agentscope-core/src/main/java/io/agentscope/core/ReActAgent.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/ReActAgent.java
@@ -1520,24 +1520,6 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
                 msgs = List.of();
             }
 
-            List<ConfirmResult> confirmResults = extractConfirmResults(msgs);
-            boolean hasConfirmResultInput =
-                    msgs != null
-                            && msgs.stream()
-                                    .map(Msg::getMetadata)
-                                    .filter(Objects::nonNull)
-                                    .anyMatch(
-                                            metadata ->
-                                                    metadata.containsKey(
-                                                            Msg.METADATA_CONFIRM_RESULTS));
-
-            // Pending-tool-call recovery: auto-patch orphaned pending tool calls with synthetic
-            // error results so the agent can continue instead of crashing. Confirmation input
-            // must be handled by the permission HITL flow below instead of recovery.
-            if (enablePendingToolRecovery && !hasConfirmResultInput) {
-                maybePatchPendingToolCalls(msgs);
-            }
-
             Set<String> pendingIds = getPendingToolUseIds();
 
             // No pending tools -> normal processing
@@ -1557,6 +1539,18 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
                 applyConfirmResults(confirmResults);
                 clearPendingConfirmRequest();
                 return resumeAgent();
+            }
+
+            // Pending-tool-call recovery: auto-patch orphaned pending tool calls with synthetic
+            // error results so the agent can continue instead of crashing. This must happen after
+            // the permission HITL flow so ASKING tool calls are handled by confirmation first.
+            if (enablePendingToolRecovery) {
+                maybePatchPendingToolCalls(msgs, pendingIds);
+                pendingIds = getPendingToolUseIds();
+                if (pendingIds.isEmpty()) {
+                    addToContext(msgs);
+                    return coreAgent();
+                }
             }
 
             // Has pending tools but no input -> resume (execute pending tools directly)
@@ -1832,8 +1826,7 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
             }
         }
 
-        private void maybePatchPendingToolCalls(List<Msg> msgs) {
-            Set<String> pendingIds = getPendingToolUseIds();
+        private void maybePatchPendingToolCalls(List<Msg> msgs, Set<String> pendingIds) {
             if (pendingIds.isEmpty()) {
                 return;
             }

--- a/agentscope-core/src/test/java/io/agentscope/core/agent/ReActAgentHitlTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/agent/ReActAgentHitlTest.java
@@ -180,6 +180,16 @@ class ReActAgentHitlTest {
         return ReActAgent.builder().name("asst").model(model).toolkit(toolkit).build();
     }
 
+    private static ReActAgent buildAgentWithPendingToolRecovery(
+            ChatModelBase model, Toolkit toolkit) {
+        return ReActAgent.builder()
+                .name("asst")
+                .model(model)
+                .toolkit(toolkit)
+                .enablePendingToolRecovery(true)
+                .build();
+    }
+
     private static int indexOf(List<AgentEvent> events, Class<?> type) {
         for (int i = 0; i < events.size(); i++) {
             if (type.isInstance(events.get(i))) {
@@ -318,6 +328,80 @@ class ReActAgentHitlTest {
                                         "tc1".equals(tr.getId())
                                                 && tr.getState() == ToolResultState.DENIED);
         assertTrue(foundDenied, "expected a DENIED ToolResultBlock for the rejected tool");
+    }
+
+    @Test
+    void pendingToolRecoveryDoesNotConsumeConfirmedAskingTool() {
+        ChatModelBase model =
+                new ScriptedModel(
+                        List.of(
+                                () -> Flux.just(toolUseResponse("tc1", "ask", "ping")),
+                                () -> Flux.just(textResponse("done"))));
+        ReActAgent agent =
+                buildAgentWithPendingToolRecovery(model, toolkitWith(new AskingTool("ask")));
+
+        Msg first = agent.call(List.of()).block();
+        ToolUseBlock asking = first.getContentBlocks(ToolUseBlock.class).get(0);
+
+        agent.call(List.of(confirmMsg(true, asking))).block();
+
+        boolean foundExecutedResult =
+                agent.getAgentState().getContext().stream()
+                        .flatMap(m -> m.getContentBlocks(ToolResultBlock.class).stream())
+                        .filter(tr -> "tc1".equals(tr.getId()))
+                        .flatMap(tr -> tr.getOutput().stream())
+                        .filter(TextBlock.class::isInstance)
+                        .map(TextBlock.class::cast)
+                        .anyMatch(text -> "executed:ping".equals(text.getText()));
+        assertTrue(foundExecutedResult, "confirmed ASKING tool should execute normally");
+    }
+
+    @Test
+    void pendingToolRecoveryDoesNotConsumeDeniedAskingTool() {
+        ChatModelBase model =
+                new ScriptedModel(
+                        List.of(
+                                () -> Flux.just(toolUseResponse("tc1", "ask", "ping")),
+                                () -> Flux.just(textResponse("done"))));
+        ReActAgent agent =
+                buildAgentWithPendingToolRecovery(model, toolkitWith(new AskingTool("ask")));
+
+        Msg first = agent.call(List.of()).block();
+        ToolUseBlock asking = first.getContentBlocks(ToolUseBlock.class).get(0);
+
+        agent.call(List.of(confirmMsg(false, asking))).block();
+
+        boolean foundDenied =
+                agent.getAgentState().getContext().stream()
+                        .flatMap(m -> m.getContentBlocks(ToolResultBlock.class).stream())
+                        .anyMatch(
+                                tr ->
+                                        "tc1".equals(tr.getId())
+                                                && tr.getState() == ToolResultState.DENIED);
+        assertTrue(foundDenied, "denied ASKING tool should produce a DENIED result");
+    }
+
+    @Test
+    void pendingToolRecoveryDoesNotSilentlySkipAskingToolForRegularPrompt() {
+        ChatModelBase model =
+                new ScriptedModel(List.of(() -> Flux.just(toolUseResponse("tc1", "ask", "ping"))));
+        ReActAgent agent =
+                buildAgentWithPendingToolRecovery(model, toolkitWith(new AskingTool("ask")));
+
+        agent.call(List.of()).block();
+
+        assertThrows(
+                Throwable.class,
+                () ->
+                        agent.call(
+                                        List.of(
+                                                Msg.builder()
+                                                        .name("user")
+                                                        .role(MsgRole.USER)
+                                                        .textContent("new prompt")
+                                                        .build()))
+                                .block(),
+                "regular input must not bypass an ASKING tool call");
     }
 
     @Test

--- a/agentscope-core/src/test/java/io/agentscope/core/agent/ReActAgentHitlTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/agent/ReActAgentHitlTest.java
@@ -210,10 +210,12 @@ class ReActAgentHitlTest {
     }
 
     private static Msg confirmMsg(boolean confirmed, ToolUseBlock toolCall) {
+        return confirmMsg(List.of(new ConfirmResult(confirmed, toolCall, null)));
+    }
+
+    private static Msg confirmMsg(List<ConfirmResult> confirmResults) {
         Map<String, Object> meta = new HashMap<>();
-        meta.put(
-                Msg.METADATA_CONFIRM_RESULTS,
-                List.of(new ConfirmResult(confirmed, toolCall, null)));
+        meta.put(Msg.METADATA_CONFIRM_RESULTS, confirmResults);
         return Msg.builder()
                 .name("user")
                 .role(MsgRole.USER)
@@ -379,6 +381,103 @@ class ReActAgentHitlTest {
                                         "tc1".equals(tr.getId())
                                                 && tr.getState() == ToolResultState.DENIED);
         assertTrue(foundDenied, "denied ASKING tool should produce a DENIED result");
+    }
+
+    @Test
+    void pendingToolRecoveryPreservesModifiedArgumentsFromConfirmation() {
+        ChatModelBase model =
+                new ScriptedModel(
+                        List.of(
+                                () -> Flux.just(toolUseResponse("tc1", "ask", "original")),
+                                () -> Flux.just(textResponse("done"))));
+        ReActAgent agent =
+                buildAgentWithPendingToolRecovery(model, toolkitWith(new AskingTool("ask")));
+
+        Msg first = agent.call(List.of()).block();
+        ToolUseBlock asking = first.getContentBlocks(ToolUseBlock.class).get(0);
+        ToolUseBlock modified =
+                ToolUseBlock.builder()
+                        .id(asking.getId())
+                        .name(asking.getName())
+                        .input(Map.of("query", "modified"))
+                        .content(asking.getContent())
+                        .metadata(asking.getMetadata())
+                        .state(asking.getState())
+                        .build();
+
+        agent.call(List.of(confirmMsg(true, modified))).block();
+
+        boolean foundModifiedResult =
+                agent.getAgentState().getContext().stream()
+                        .flatMap(m -> m.getContentBlocks(ToolResultBlock.class).stream())
+                        .filter(tr -> "tc1".equals(tr.getId()))
+                        .flatMap(tr -> tr.getOutput().stream())
+                        .filter(TextBlock.class::isInstance)
+                        .map(TextBlock.class::cast)
+                        .anyMatch(text -> "executed:modified".equals(text.getText()));
+        assertTrue(foundModifiedResult, "confirmed tool should execute with modified arguments");
+    }
+
+    @Test
+    void pendingToolRecoveryReasksForUnconfirmedAskingTools() {
+        ChatModelBase model =
+                new ScriptedModel(
+                        List.of(
+                                () ->
+                                        Flux.just(
+                                                ChatResponse.builder()
+                                                        .content(
+                                                                List.<ContentBlock>of(
+                                                                        ToolUseBlock.builder()
+                                                                                .id("tc1")
+                                                                                .name("ask")
+                                                                                .input(
+                                                                                        Map.of(
+                                                                                                "query",
+                                                                                                "first"))
+                                                                                .build(),
+                                                                        ToolUseBlock.builder()
+                                                                                .id("tc2")
+                                                                                .name("ask")
+                                                                                .input(
+                                                                                        Map.of(
+                                                                                                "query",
+                                                                                                "second"))
+                                                                                .build()))
+                                                        .build())));
+        ReActAgent agent =
+                buildAgentWithPendingToolRecovery(model, toolkitWith(new AskingTool("ask")));
+
+        Msg first = agent.call(List.of()).block();
+        List<ToolUseBlock> asking =
+                first.getContentBlocks(ToolUseBlock.class).stream()
+                        .filter(t -> t.getState() == ToolCallState.ASKING)
+                        .toList();
+        assertEquals(2, asking.size());
+
+        Msg resumed =
+                agent.call(
+                                List.of(
+                                        confirmMsg(
+                                                List.of(
+                                                        new ConfirmResult(
+                                                                true, asking.get(0), null)))))
+                        .block();
+
+        assertEquals(GenerateReason.PERMISSION_ASKING, resumed.getGenerateReason());
+        List<ToolUseBlock> remaining =
+                resumed.getContentBlocks(ToolUseBlock.class).stream()
+                        .filter(t -> t.getState() == ToolCallState.ASKING)
+                        .toList();
+        assertEquals(1, remaining.size());
+        assertEquals("tc2", remaining.get(0).getId());
+
+        long remainingResults =
+                agent.getAgentState().getContext().stream()
+                        .flatMap(m -> m.getContentBlocks(ToolResultBlock.class).stream())
+                        .filter(tr -> "tc2".equals(tr.getId()))
+                        .count();
+        assertEquals(0, remainingResults, "unconfirmed ASKING tool must not be auto-patched");
     }
 
     @Test


### PR DESCRIPTION
## AgentScope-Java Version

2.0.1-SNAPSHOT

## Description

### Problem

When `enablePendingToolRecovery` is enabled, a permission-gated tool call in the `ASKING` state is treated as an ordinary dangling tool call before the incoming `ConfirmResult` is read. Recovery writes a synthetic failure result first, clears the pending ID, and routes the approval message through normal user-message processing.

As a result:

- approving the tool does not execute it;
- denying the tool does not produce a `DENIED` result;
- modified arguments and accepted permission rules are ignored; and
- regular user input can silently bypass a pending confirmation instead of reporting that approval is still required.

### Background

Pending tool recovery was introduced in #956 as an explicit opt-in mechanism for repairing orphaned tool calls. During that PR, maintainers called out that automatic result patching must not hide incorrect HITL usage or create unintended resume paths. The merged implementation therefore skipped recovery when callers supplied manual `ToolResultBlock`s and kept the feature disabled by default.

Permission HITL now resumes through `ConfirmResult` objects stored under `Msg.METADATA_CONFIRM_RESULTS`, while pending recovery still recognizes only `ToolResultBlock` input. With `enablePendingToolRecovery=true`, an `ASKING` tool call is consequently patched as a failed orphan before its `ConfirmResult` can be applied. Approval, denial, modified arguments, and accepted permission rules are then ignored.

Relevant #956 discussions:

- HITL concerns around automatic result patching: https://github.com/agentscope-ai/agentscope-java/pull/956#issuecomment-4141506834
- Proposed separation between HITL pauses and orphan recovery: https://github.com/agentscope-ai/agentscope-java/pull/956#issuecomment-4142790083
- Decision to keep pending recovery explicitly opt-in: https://github.com/agentscope-ai/agentscope-java/pull/956#discussion_r3013173779

### Changes

- Detect confirmation metadata before running pending tool recovery, so approval input reaches the existing Permission HITL flow.
- Exclude `ToolCallState.ASKING` calls from orphan recovery as a state-level safeguard.
- Add regression coverage for approval, denial, and regular user input while recovery is enabled.

This does not change the recovery default, introduce a new policy, or alter recovery for ordinary orphaned tool calls.

### Validation

Result: all tests passed, including the existing pending recovery scenarios.

## Checklist

Please check the following items before code is ready to be reviewed.

- [x] Code has been formatted with `mvn spotless:apply`
- [x] All tests are passing (`mvn test`) — focused HITL and pending recovery tests pass; the full repository suite was not run
- [x] Javadoc comments are complete and follow project conventions (no public API changes)
- [x] Related documentation has been updated (not needed for this internal bug fix)
- [x] Code is ready for review (draft)
