### PR TITLE
fix(harness): stream Docker exec commands through stdin

### DIFF
--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/sandbox/impl/docker/DockerSandbox.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/sandbox/impl/docker/DockerSandbox.java
@@ -57,7 +57,8 @@ import org.slf4j.LoggerFactory;
  *
  * <h2>Workspace Operations</h2>
  * <ul>
- *   <li>Exec: {@code docker exec -w <root> <containerId> sh -c <command>}</li>
+ *   <li>Exec: {@code docker exec -i -w <root> <containerId> sh -s}, with the command sent via
+ *       stdin</li>
  *   <li>PersistWorkspace: {@code docker exec <containerId> tar -cf - -C <root> .}</li>
  *   <li>HydrateWorkspace: {@code docker exec -i <containerId> tar -xf - -C <root>}</li>
  * </ul>
@@ -138,17 +139,7 @@ public class DockerSandbox extends AbstractBaseSandbox {
         String containerId = dockerState.getContainerId();
         String workspaceRoot = dockerState.getWorkspaceRoot();
 
-        List<String> cmd = new ArrayList<>();
-        cmd.add("docker");
-        cmd.add("exec");
-        cmd.add("-w");
-        cmd.add(workspaceRoot);
-        cmd.add(containerId);
-        cmd.add("sh");
-        cmd.add("-c");
-        cmd.add(command);
-
-        ProcessBuilder pb = new ProcessBuilder(cmd);
+        ProcessBuilder pb = new ProcessBuilder(buildExecCommand(containerId, workspaceRoot));
         Process process = pb.start();
 
         ExecutorService drainer =
@@ -169,6 +160,14 @@ public class DockerSandbox extends AbstractBaseSandbox {
                 drainer.submit(() -> readStream(process.getErrorStream(), OUTPUT_TRUNCATE_BYTES));
         drainer.shutdown();
 
+        try (OutputStream stdin = process.getOutputStream()) {
+            writeShellProgram(stdin, command);
+        } catch (IOException e) {
+            process.destroyForcibly();
+            drainer.shutdownNow();
+            throw e;
+        }
+
         boolean exited = process.waitFor(timeoutSeconds, TimeUnit.SECONDS);
         if (!exited) {
             process.destroyForcibly();
@@ -188,6 +187,14 @@ public class DockerSandbox extends AbstractBaseSandbox {
             throw new SandboxException.ExecException(exitCode, stdout, stderr);
         }
         return result;
+    }
+
+    static List<String> buildExecCommand(String containerId, String workspaceRoot) {
+        return List.of("docker", "exec", "-i", "-w", workspaceRoot, containerId, "sh", "-s");
+    }
+
+    static void writeShellProgram(OutputStream stdin, String command) throws IOException {
+        stdin.write(command.getBytes(StandardCharsets.UTF_8));
     }
 
     @Override

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/sandbox/impl/docker/DockerSandboxCommandTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/sandbox/impl/docker/DockerSandboxCommandTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.harness.agent.sandbox.impl.docker;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import io.agentscope.core.agent.RuntimeContext;
+import io.agentscope.harness.agent.sandbox.ExecResult;
+import io.agentscope.harness.agent.sandbox.Sandbox;
+import io.agentscope.harness.agent.sandbox.WorkspaceSpec;
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+
+class DockerSandboxCommandTest {
+
+    @Test
+    void execUsesStdinInsteadOfEmbeddingComplexShellProgramInHostArguments() throws Exception {
+        String script =
+                "mkdir -p \"$(dirname '/workspace/a b/result.txt')\" && "
+                        + "printf '%s' \"nested 'quotes' and $HOME\" > '/workspace/a b/result.txt'";
+
+        List<String> command = DockerSandbox.buildExecCommand("container-id", "/workspace");
+        ByteArrayOutputStream stdin = new ByteArrayOutputStream();
+        DockerSandbox.writeShellProgram(stdin, script);
+
+        assertEquals(
+                List.of("docker", "exec", "-i", "-w", "/workspace", "container-id", "sh", "-s"),
+                command);
+        assertFalse(command.contains(script));
+        assertEquals(script, stdin.toString(StandardCharsets.UTF_8));
+    }
+
+    @Test
+    void execHostArgumentsStayBoundedForLargeShellPrograms() throws Exception {
+        String script = "printf 'x%.0s' $(seq 1 100000)\n#" + "x".repeat(100_000);
+
+        List<String> command = DockerSandbox.buildExecCommand("container-id", "/workspace");
+        ByteArrayOutputStream stdin = new ByteArrayOutputStream();
+        DockerSandbox.writeShellProgram(stdin, script);
+
+        assertEquals(8, command.size());
+        assertFalse(command.stream().anyMatch(argument -> argument.length() > 100));
+        assertEquals(script.getBytes(StandardCharsets.UTF_8).length, stdin.size());
+    }
+
+    @Test
+    @EnabledIfEnvironmentVariable(named = "AGENTSCOPE_DOCKER_INTEGRATION", matches = "true")
+    void realDockerExecPreservesComplexAndLargeShellPrograms() throws Exception {
+        DockerSandboxClient client = new DockerSandboxClient();
+        DockerSandboxClientOptions options =
+                new DockerSandboxClientOptions().image("ubuntu:24.04").workspaceRoot("/workspace");
+        try (Sandbox sandbox = client.create(new WorkspaceSpec(), null, options)) {
+            sandbox.start();
+
+            String complex =
+                    "mkdir -p \"$(dirname '/workspace/a b/result.txt')\" && printf '%s' 'nested"
+                            + " \"quotes\" and $HOME' > '/workspace/a b/result.txt' && cat"
+                            + " '/workspace/a b/result.txt'";
+            ExecResult complexResult = sandbox.exec(RuntimeContext.empty(), complex, 30);
+            assertEquals("nested \"quotes\" and $HOME", complexResult.stdout());
+
+            String large =
+                    "#"
+                            + "x".repeat(100_000)
+                            + "\n"
+                            + "printf '%s' 'large-script-ok' > /workspace/large.txt && cat"
+                            + " /workspace/large.txt";
+            ExecResult largeResult = sandbox.exec(RuntimeContext.empty(), large, 30);
+            assertEquals("large-script-ok", largeResult.stdout());
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- run Docker sandbox shell programs through `docker exec -i ... sh -s`
- keep shell text out of the host process argument list
- preserve UTF-8 complex commands and avoid Windows command-line length limits
- add unit contracts plus an opt-in real Docker regression test

## Why

`docker exec ... sh -c <command>` puts the complete shell program in the Windows `CreateProcess` argument list. Complex nested quoting can be corrupted, and large filesystem scripts can exceed the host command-line limit.

The public Sandbox API and command semantics remain unchanged; only the Docker CLI transport changes.

## Tests

- `mvn -pl agentscope-harness spotless:check test -Dtest=DockerSandboxCommandTest,BaseSandboxFilesystemTest,HarnessAgentDistributedSandboxTest -Dsurefire.failIfNoSpecifiedTests=false`
  - 16 tests, 12 passed, 4 environment-gated skipped
- `AGENTSCOPE_DOCKER_INTEGRATION=true mvn -pl agentscope-harness test -Dtest=DockerSandboxCommandTest`
  - 3/3 passed on Windows with Docker Desktop
  - covers nested quotes, `$(dirname ...)`, paths with spaces, and a 100KB shell program
- downstream JCode acceptance against the patched `2.0.1-SNAPSHOT`
  - real Docker provider lifecycle 1/1
  - Redis + Docker fresh-JVM writer 1/1
  - Redis + Docker fresh-JVM reader 1/1

Closes #2135.
Addresses #1560.