### PR TITLE
fix(harness): drain session mirrors on close

### DIFF
--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/HarnessAgent.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/HarnessAgent.java
@@ -59,6 +59,7 @@ import io.agentscope.harness.agent.memory.MemoryFlushManager;
 import io.agentscope.harness.agent.memory.compaction.CompactionConfig;
 import io.agentscope.harness.agent.memory.compaction.ConversationCompactor;
 import io.agentscope.harness.agent.memory.compaction.ToolResultEvictionConfig;
+import io.agentscope.harness.agent.memory.session.SessionTree;
 import io.agentscope.harness.agent.middleware.AgentTraceMiddleware;
 import io.agentscope.harness.agent.middleware.AsyncToolMiddleware;
 import io.agentscope.harness.agent.middleware.AtPathExpansionMiddleware;
@@ -378,11 +379,15 @@ public class HarnessAgent implements Agent, AutoCloseable {
             shutdownTaskRepository();
         } finally {
             try {
-                if (ownedWorkspaceIndex != null) {
-                    ownedWorkspaceIndex.close();
-                }
+                SessionTree.awaitPendingMirrors();
             } finally {
-                delegate.close();
+                try {
+                    if (ownedWorkspaceIndex != null) {
+                        ownedWorkspaceIndex.close();
+                    }
+                } finally {
+                    delegate.close();
+                }
             }
         }
     }

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/memory/session/SessionTree.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/memory/session/SessionTree.java
@@ -34,7 +34,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.ExecutionException;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.stream.Collectors;
@@ -101,12 +101,12 @@ public class SessionTree {
         try {
             while (true) {
                 try {
-                    MIRROR_EXECUTOR.submit(() -> {}).get();
+                    CountDownLatch barrier = new CountDownLatch(1);
+                    MIRROR_EXECUTOR.execute(barrier::countDown);
+                    barrier.await();
                     return;
                 } catch (InterruptedException e) {
                     interrupted = true;
-                } catch (ExecutionException e) {
-                    throw new IllegalStateException("Failed to await session tree mirrors", e);
                 }
             }
         } finally {

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/memory/session/SessionTree.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/memory/session/SessionTree.java
@@ -34,6 +34,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.stream.Collectors;
@@ -87,6 +88,33 @@ public class SessionTree {
                         t.setDaemon(true);
                         return t;
                     });
+
+    /**
+     * Waits until all remote mirror work submitted before this call has completed.
+     *
+     * <p>Harness lifecycle owners should call this before closing filesystem or index resources.
+     * The wait is deliberately uninterruptible so that resource shutdown cannot race an in-flight
+     * upload; the interrupted status is restored before returning.
+     */
+    public static void awaitPendingMirrors() {
+        boolean interrupted = false;
+        try {
+            while (true) {
+                try {
+                    MIRROR_EXECUTOR.submit(() -> {}).get();
+                    return;
+                } catch (InterruptedException e) {
+                    interrupted = true;
+                } catch (ExecutionException e) {
+                    throw new IllegalStateException("Failed to await session tree mirrors", e);
+                }
+            }
+        } finally {
+            if (interrupted) {
+                Thread.currentThread().interrupt();
+            }
+        }
+    }
 
     private final Path contextFile;
     private final Path logFile;

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/memory/session/SessionTreeMirrorTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/memory/session/SessionTreeMirrorTest.java
@@ -16,7 +16,11 @@
 package io.agentscope.harness.agent.memory.session;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
 
 import io.agentscope.core.agent.RuntimeContext;
 import io.agentscope.harness.agent.filesystem.AbstractFilesystem;
@@ -26,6 +30,10 @@ import io.agentscope.harness.agent.filesystem.spec.RemoteFilesystemSpec;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -200,11 +208,43 @@ class SessionTreeMirrorTest {
                 "local log file must exist immediately after flush()");
     }
 
+    @Test
+    void awaitPendingMirrors_blocksUntilInFlightUploadCompletes() throws Exception {
+        AbstractFilesystem fs = mock(AbstractFilesystem.class);
+        CountDownLatch uploadStarted = new CountDownLatch(1);
+        CountDownLatch releaseUpload = new CountDownLatch(1);
+        doAnswer(
+                        invocation -> {
+                            uploadStarted.countDown();
+                            releaseUpload.await();
+                            return null;
+                        })
+                .when(fs)
+                .uploadFiles(any(), any());
+        Path context = workspace.resolve("agents/agent-a/sessions/blocking.jsonl");
+        SessionTree tree = new SessionTree(context, workspace, fs);
+        tree.append(new SessionEntry.MessageEntry(null, null, null, "USER", "hi", null));
+        tree.flush();
+        assertTrue(uploadStarted.await(5, TimeUnit.SECONDS));
+
+        ExecutorService closer = Executors.newSingleThreadExecutor();
+        try {
+            Future<?> barrier = closer.submit(SessionTree::awaitPendingMirrors);
+            assertFalse(barrier.isDone(), "barrier must wait for the in-flight upload");
+
+            releaseUpload.countDown();
+            barrier.get(5, TimeUnit.SECONDS);
+        } finally {
+            releaseUpload.countDown();
+            closer.shutdownNow();
+        }
+    }
+
     // -----------------------------------------------------------------------
     //  Helper
     // -----------------------------------------------------------------------
 
-    private static void awaitMirror() throws InterruptedException {
-        TimeUnit.MILLISECONDS.sleep(300);
+    private static void awaitMirror() {
+        SessionTree.awaitPendingMirrors();
     }
 }

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/memory/session/SessionTreeMirrorTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/memory/session/SessionTreeMirrorTest.java
@@ -35,6 +35,8 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -238,6 +240,52 @@ class SessionTreeMirrorTest {
             releaseUpload.countDown();
             closer.shutdownNow();
         }
+    }
+
+    @Test
+    void awaitPendingMirrors_restoresInterruptAfterInFlightUploadCompletes() throws Exception {
+        AbstractFilesystem fs = mock(AbstractFilesystem.class);
+        CountDownLatch uploadStarted = new CountDownLatch(1);
+        CountDownLatch releaseUpload = new CountDownLatch(1);
+        doAnswer(
+                        invocation -> {
+                            uploadStarted.countDown();
+                            releaseUpload.await();
+                            return null;
+                        })
+                .when(fs)
+                .uploadFiles(any(), any());
+        Path context = workspace.resolve("agents/agent-a/sessions/interrupted.jsonl");
+        SessionTree tree = new SessionTree(context, workspace, fs);
+        tree.append(new SessionEntry.MessageEntry(null, null, null, "USER", "hi", null));
+        tree.flush();
+        assertTrue(uploadStarted.await(5, TimeUnit.SECONDS));
+
+        ExecutorService closer = Executors.newSingleThreadExecutor();
+        AtomicReference<Thread> worker = new AtomicReference<>();
+        AtomicBoolean interruptedOnReturn = new AtomicBoolean();
+        CountDownLatch returned = new CountDownLatch(1);
+        try {
+            Future<?> barrier =
+                    closer.submit(
+                            () -> {
+                                worker.set(Thread.currentThread());
+                                SessionTree.awaitPendingMirrors();
+                                interruptedOnReturn.set(Thread.currentThread().isInterrupted());
+                                returned.countDown();
+                            });
+            while (worker.get() == null) {
+                Thread.yield();
+            }
+            worker.get().interrupt();
+            releaseUpload.countDown();
+            assertTrue(returned.await(5, TimeUnit.SECONDS));
+            barrier.get(5, TimeUnit.SECONDS);
+        } finally {
+            releaseUpload.countDown();
+            closer.shutdownNow();
+        }
+        assertTrue(interruptedOnReturn.get(), "await must restore the interrupt status");
     }
 
     // -----------------------------------------------------------------------


### PR DESCRIPTION
Summary:
- add a deterministic FIFO barrier for SessionTree mirror work submitted before shutdown
- drain pending mirrors before HarnessAgent closes its workspace index and delegate
- replace timing-based mirror waits and cover an in-flight blocking upload

Fixes #2147

Verification: 41 focused Harness/session/memory tests passed; Spotless and git diff check passed.