### PR TITLE
fix(harness): persist evicted tool results remotely

### DIFF
--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/filesystem/spec/RemoteFilesystemSpec.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/filesystem/spec/RemoteFilesystemSpec.java
@@ -222,6 +222,12 @@ public class RemoteFilesystemSpec {
                 overlayRoute(workspace.resolve("knowledge"), "knowledge", effectiveAgentId));
         routes.put("plans/", overlayRoute(workspace.resolve("plans"), "plans", effectiveAgentId));
         routes.put(
+                "large_tool_results/",
+                overlayRoute(
+                        workspace.resolve("large_tool_results"),
+                        "large_tool_results",
+                        effectiveAgentId));
+        routes.put(
                 "agents/" + effectiveAgentId + "/sessions/",
                 overlayRoute(
                         workspace.resolve("agents").resolve(effectiveAgentId).resolve("sessions"),

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/memory/compaction/ToolResultEvictionConfig.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/memory/compaction/ToolResultEvictionConfig.java
@@ -49,7 +49,7 @@ public class ToolResultEvictionConfig {
     public static final int DEFAULT_PREVIEW_CHARS = 2_000;
 
     /** Root path prefix under which evicted results are stored. */
-    public static final String DEFAULT_EVICTION_PATH = "/large_tool_results";
+    public static final String DEFAULT_EVICTION_PATH = "large_tool_results";
 
     /**
      * Tools excluded from eviction by default.

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/middleware/ToolResultEvictionMiddleware.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/middleware/ToolResultEvictionMiddleware.java
@@ -29,7 +29,9 @@ import io.agentscope.harness.agent.filesystem.AbstractFilesystem;
 import io.agentscope.harness.agent.filesystem.model.WriteResult;
 import io.agentscope.harness.agent.memory.compaction.ToolResultEvictionConfig;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.function.Function;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -74,15 +76,23 @@ public class ToolResultEvictionMiddleware implements HarnessRuntimeMiddleware {
             ReasoningInput input,
             Function<ReasoningInput, Flux<AgentEvent>> next) {
         final RuntimeContext rc = ctx != null ? ctx : RuntimeContext.empty();
-        evictOversizedToolResults(agent, rc);
-        return next.apply(input);
+        Map<String, ToolResultBlock> replacements = evictOversizedToolResults(agent, rc);
+        if (replacements.isEmpty()) {
+            return next.apply(input);
+        }
+        List<Msg> boundedInput =
+                input.messages().stream()
+                        .map(message -> replaceEvictedResults(message, replacements))
+                        .toList();
+        return next.apply(new ReasoningInput(boundedInput, input.tools(), input.options()));
     }
 
-    private void evictOversizedToolResults(Agent agent, RuntimeContext rc) {
+    private Map<String, ToolResultBlock> evictOversizedToolResults(Agent agent, RuntimeContext rc) {
         AgentState state = RuntimeContext.resolveAgentState(rc, agent);
         if (state == null) {
-            return;
+            return Map.of();
         }
+        Map<String, ToolResultBlock> replacements = new HashMap<>();
         List<Msg> ctx = state.contextMutable();
         String agentName = agent.getName();
         for (int i = 0; i < ctx.size(); i++) {
@@ -90,14 +100,19 @@ public class ToolResultEvictionMiddleware implements HarnessRuntimeMiddleware {
             if (msg == null || msg.getRole() != MsgRole.TOOL) {
                 continue;
             }
-            Msg rebuilt = evictMessage(msg, agentName, rc);
+            Msg rebuilt = evictMessage(msg, agentName, rc, replacements);
             if (rebuilt != msg) {
                 ctx.set(i, rebuilt);
             }
         }
+        return replacements;
     }
 
-    private Msg evictMessage(Msg msg, String agentName, RuntimeContext rc) {
+    private Msg evictMessage(
+            Msg msg,
+            String agentName,
+            RuntimeContext rc,
+            Map<String, ToolResultBlock> replacements) {
         List<ContentBlock> contentBlocks = msg.getContent();
         if (contentBlocks == null || contentBlocks.isEmpty()) {
             return msg;
@@ -109,7 +124,39 @@ public class ToolResultEvictionMiddleware implements HarnessRuntimeMiddleware {
                 ToolResultBlock maybeEvicted = maybeEvict(tr, agentName, rc);
                 if (maybeEvicted != tr) {
                     changed = true;
+                    replacements.put(tr.getId(), maybeEvicted);
                     rebuilt.add(maybeEvicted);
+                    continue;
+                }
+            }
+            rebuilt.add(block);
+        }
+        if (!changed) {
+            return msg;
+        }
+        return Msg.builder()
+                .id(msg.getId())
+                .name(msg.getName())
+                .role(msg.getRole())
+                .content(rebuilt)
+                .metadata(msg.getMetadata())
+                .timestamp(msg.getTimestamp())
+                .build();
+    }
+
+    private Msg replaceEvictedResults(Msg msg, Map<String, ToolResultBlock> replacements) {
+        if (msg == null || msg.getRole() != MsgRole.TOOL) {
+            return msg;
+        }
+        List<ContentBlock> contentBlocks = msg.getContent();
+        boolean changed = false;
+        List<ContentBlock> rebuilt = new ArrayList<>(contentBlocks.size());
+        for (ContentBlock block : contentBlocks) {
+            if (block instanceof ToolResultBlock result) {
+                ToolResultBlock replacement = replacements.get(result.getId());
+                if (replacement != null) {
+                    changed = true;
+                    rebuilt.add(replacement);
                     continue;
                 }
             }
@@ -189,9 +236,12 @@ public class ToolResultEvictionMiddleware implements HarnessRuntimeMiddleware {
     }
 
     private String buildEvictionPath(String agentName, String toolCallId) {
-        String base = config.getEvictionPath();
-        if (!base.startsWith("/")) {
-            base = "/" + base;
+        String base = config.getEvictionPath().replace('\\', '/');
+        while (base.startsWith("/")) {
+            base = base.substring(1);
+        }
+        while (base.endsWith("/")) {
+            base = base.substring(0, base.length() - 1);
         }
         String safeAgent = agentName.replaceAll("[^a-zA-Z0-9_-]", "_");
         String safeId = toolCallId.replaceAll("[^a-zA-Z0-9_-]", "_");

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/middleware/ToolResultEvictionMiddlewareTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/middleware/ToolResultEvictionMiddlewareTest.java
@@ -1,0 +1,273 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.harness.agent.middleware;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.AdditionalAnswers.delegatesTo;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.agentscope.core.agent.Agent;
+import io.agentscope.core.agent.RuntimeContext;
+import io.agentscope.core.message.ContentBlock;
+import io.agentscope.core.message.Msg;
+import io.agentscope.core.message.MsgRole;
+import io.agentscope.core.message.TextBlock;
+import io.agentscope.core.message.ToolResultBlock;
+import io.agentscope.core.message.ToolUseBlock;
+import io.agentscope.core.middleware.ReasoningInput;
+import io.agentscope.core.model.ChatResponse;
+import io.agentscope.core.model.GenerateOptions;
+import io.agentscope.core.model.Model;
+import io.agentscope.core.model.ToolSchema;
+import io.agentscope.core.state.AgentState;
+import io.agentscope.core.state.InMemoryAgentStateStore;
+import io.agentscope.core.tool.ToolBase;
+import io.agentscope.core.tool.ToolCallParam;
+import io.agentscope.core.tool.Toolkit;
+import io.agentscope.harness.agent.HarnessAgent;
+import io.agentscope.harness.agent.IsolationScope;
+import io.agentscope.harness.agent.filesystem.AbstractFilesystem;
+import io.agentscope.harness.agent.filesystem.remote.store.InMemoryStore;
+import io.agentscope.harness.agent.filesystem.spec.RemoteFilesystemSpec;
+import io.agentscope.harness.agent.memory.compaction.ToolResultEvictionConfig;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+class ToolResultEvictionMiddlewareTest {
+
+    @TempDir Path workspace;
+
+    @Test
+    void remoteFilesystemWritesArtifactAndReplacesCallScopedState() {
+        InMemoryStore store = new InMemoryStore();
+        AbstractFilesystem filesystem =
+                new RemoteFilesystemSpec(store)
+                        .isolationScope(IsolationScope.SESSION)
+                        .toFilesystem(workspace, "eviction-agent", rc -> List.of("session-1"));
+        ToolResultEvictionMiddleware middleware =
+                new ToolResultEvictionMiddleware(
+                        filesystem,
+                        ToolResultEvictionConfig.builder()
+                                .maxResultChars(32)
+                                .previewChars(8)
+                                .build());
+        String fullOutput = "large-output-" + "x".repeat(128);
+        ToolResultBlock result =
+                ToolResultBlock.text(fullOutput).withIdAndName("call-1", "execute");
+        Msg toolMessage = Msg.builder().role(MsgRole.TOOL).content(result).build();
+        AgentState state = AgentState.builder().sessionId("session-1").build();
+        state.contextMutable().add(toolMessage);
+        RuntimeContext context =
+                RuntimeContext.builder().sessionId("session-1").agentState(state).build();
+        Agent agent = mock(Agent.class);
+        when(agent.getName()).thenReturn("eviction-agent");
+        assertSame(state, context.getAgentState());
+
+        middleware
+                .onReasoning(
+                        agent,
+                        context,
+                        new ReasoningInput(List.of(toolMessage), List.of(), null),
+                        ignored -> Flux.empty())
+                .collectList()
+                .block();
+        assertSame(state, context.getAgentState());
+        assertNotSame(toolMessage, state.contextMutable().get(0));
+
+        String persisted =
+                filesystem
+                        .read(context, "/large_tool_results/eviction-agent/call-1", 0, 0)
+                        .fileData()
+                        .content();
+        assertEquals(fullOutput, persisted);
+        String bounded =
+                state
+                        .contextMutable()
+                        .get(0)
+                        .getContentBlocks(ToolResultBlock.class)
+                        .get(0)
+                        .getOutput()
+                        .stream()
+                        .filter(TextBlock.class::isInstance)
+                        .map(TextBlock.class::cast)
+                        .map(TextBlock::getText)
+                        .findFirst()
+                        .orElseThrow();
+        assertTrue(bounded.contains("Tool output was too large"), bounded);
+        assertFalse(bounded.contains("x".repeat(32)));
+    }
+
+    @Test
+    void harnessTurnEvictsBeforeNextModelCallAndPersistentSave() {
+        InMemoryStore fileStore = new InMemoryStore();
+        InMemoryAgentStateStore backingStateStore = new InMemoryAgentStateStore();
+        io.agentscope.core.state.AgentStateStore stateStore =
+                mock(
+                        io.agentscope.core.state.AgentStateStore.class,
+                        delegatesTo(backingStateStore));
+        String fullOutput = "large-output-" + "x".repeat(128);
+        AtomicReference<String> secondModelInput = new AtomicReference<>();
+        Toolkit toolkit = new Toolkit();
+        toolkit.registerAgentTool(new LargeOutputTool(fullOutput));
+        RuntimeContext context =
+                RuntimeContext.builder().userId("user-1").sessionId("session-1").build();
+
+        try (HarnessAgent agent =
+                HarnessAgent.builder()
+                        .name("eviction-agent")
+                        .workspace(workspace)
+                        .model(new EvictionModel(secondModelInput))
+                        .toolkit(toolkit)
+                        .stateStore(stateStore)
+                        .filesystem(
+                                new RemoteFilesystemSpec(fileStore)
+                                        .isolationScope(IsolationScope.SESSION))
+                        .toolResultEviction(
+                                ToolResultEvictionConfig.builder()
+                                        .maxResultChars(32)
+                                        .previewChars(8)
+                                        .build())
+                        .build()) {
+            Msg reply =
+                    agent.call(
+                                    List.of(
+                                            Msg.builder()
+                                                    .role(MsgRole.USER)
+                                                    .content(
+                                                            TextBlock.builder()
+                                                                    .text("run tool")
+                                                                    .build())
+                                                    .build()),
+                                    context)
+                            .block();
+            assertEquals("done", reply.getTextContent());
+
+            String modelInput = secondModelInput.get();
+            assertTrue(modelInput.contains("Tool output was too large"));
+            assertFalse(modelInput.contains("x".repeat(32)));
+            assertEquals(
+                    fullOutput,
+                    agent.getWorkspaceManager()
+                            .readManagedWorkspaceFileUtf8(
+                                    context,
+                                    "large_tool_results/eviction-agent/large-output-call"));
+            AgentState persisted =
+                    stateStore
+                            .get("user-1", "session-1", "agent_state", AgentState.class)
+                            .orElseThrow();
+            String persistedText = toolResultText(persisted);
+            assertTrue(persistedText.contains("Tool output was too large"));
+            assertFalse(persistedText.contains("x".repeat(32)));
+        }
+    }
+
+    private static String toolResultText(AgentState state) {
+        return state.getContext().stream()
+                .flatMap(message -> message.getContentBlocks(ToolResultBlock.class).stream())
+                .flatMap(result -> result.getOutput().stream())
+                .filter(TextBlock.class::isInstance)
+                .map(TextBlock.class::cast)
+                .map(TextBlock::getText)
+                .reduce("", String::concat);
+    }
+
+    private static final class LargeOutputTool extends ToolBase {
+        private final String output;
+
+        private LargeOutputTool(String output) {
+            super(
+                    "large_output_probe",
+                    "Returns a deterministic oversized output.",
+                    Map.of("type", "object", "properties", Map.of()),
+                    false,
+                    true,
+                    false,
+                    null,
+                    false,
+                    false);
+            this.output = output;
+        }
+
+        @Override
+        public Mono<ToolResultBlock> callAsync(ToolCallParam param) {
+            return Mono.just(ToolResultBlock.text(output));
+        }
+    }
+
+    private static final class EvictionModel implements Model {
+        private final AtomicReference<String> secondInput;
+
+        private EvictionModel(AtomicReference<String> secondInput) {
+            this.secondInput = secondInput;
+        }
+
+        @Override
+        public Flux<ChatResponse> stream(
+                List<Msg> messages, List<ToolSchema> tools, GenerateOptions options) {
+            boolean hasToolResult =
+                    messages.stream()
+                            .flatMap(message -> message.getContent().stream())
+                            .anyMatch(ToolResultBlock.class::isInstance);
+            if (hasToolResult) {
+                secondInput.set(
+                        messages.stream()
+                                .flatMap(message -> message.getContent().stream())
+                                .filter(ToolResultBlock.class::isInstance)
+                                .map(ToolResultBlock.class::cast)
+                                .flatMap(result -> result.getOutput().stream())
+                                .filter(TextBlock.class::isInstance)
+                                .map(TextBlock.class::cast)
+                                .map(TextBlock::getText)
+                                .reduce("", String::concat));
+                return Flux.just(
+                        new ChatResponse(
+                                "final",
+                                List.<ContentBlock>of(TextBlock.builder().text("done").build()),
+                                null,
+                                Map.of(),
+                                "stop"));
+            }
+            return Flux.just(
+                    new ChatResponse(
+                            "tool-request",
+                            List.<ContentBlock>of(
+                                    ToolUseBlock.builder()
+                                            .id("large-output-call")
+                                            .name("large_output_probe")
+                                            .input(Map.of())
+                                            .build()),
+                            null,
+                            Map.of(),
+                            "tool_calls"));
+        }
+
+        @Override
+        public String getModelName() {
+            return "tool-result-eviction-test";
+        }
+    }
+}


### PR DESCRIPTION
Summary:
- keep tool-result eviction paths workspace-relative and route large_tool_results through RemoteFilesystemSpec
- apply the same bounded replacements to call-scoped AgentState and the already-built current ReasoningInput
- cover direct remote filesystem behavior and the full model-tool-next-model-persistent-state lifecycle

Fixes #2145

Verification: 37 focused Harness/RemoteFilesystem/eviction tests passed; real Redis strict writer and fresh reader each passed in JCode; Spotless and git diff check passed.