### PR TITLE
fix(mcp): preserve client lifecycle across toolkit copies

### DIFF
--- a/agentscope-core/src/main/java/io/agentscope/core/ReActAgent.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/ReActAgent.java
@@ -3820,8 +3820,7 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
 
     @Override
     public void close() {
-        // No-op for the core ReActAgent. Subclasses / wrappers (HarnessAgent) may release
-        // additional resources here.
+        toolkit.close();
     }
 
     // ==================== Builder ====================
@@ -4589,51 +4588,54 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
         public ReActAgent build() {
             // Deep copy toolkit to avoid state interference between agents
             Toolkit agentToolkit = this.toolkit.copy();
-
-            // Rebind externally-constructed middleware that holds a reference to the
-            // original (pre-copy) toolkit so it uses the agent's actual instance.
-            for (MiddlewareBase mw : middlewares) {
-                if (mw instanceof io.agentscope.core.tool.ToolkitAware aware) {
-                    aware.rebindToolkit(agentToolkit);
+            try {
+                // Rebind externally-constructed middleware that holds a reference to the
+                // original (pre-copy) toolkit so it uses the agent's actual instance.
+                for (MiddlewareBase mw : middlewares) {
+                    if (mw instanceof io.agentscope.core.tool.ToolkitAware aware) {
+                        aware.rebindToolkit(agentToolkit);
+                    }
                 }
-            }
 
-            registerToolsFromHooks(agentToolkit);
+                registerToolsFromHooks(agentToolkit);
 
-            if (enableMetaTool) {
-                agentToolkit.registerMetaTool();
-            }
+                if (enableMetaTool) {
+                    agentToolkit.registerMetaTool();
+                }
 
-            // 1.x legacy compat: shared selfRef gives the long-term-memory hook (constructed
-            // pre-agent) a way to resolve AgentState.context lazily once the agent exists.
-            AtomicReference<ReActAgent> selfRef = new AtomicReference<>();
+                // 1.x legacy compat: shared selfRef gives the long-term-memory hook (constructed
+                // pre-agent) a way to resolve AgentState.context lazily once the agent exists.
+                AtomicReference<ReActAgent> selfRef = new AtomicReference<>();
 
-            if (longTermMemory != null) {
-                configureLongTermMemory(agentToolkit, selfRef);
-            }
-            if (!knowledgeBases.isEmpty()) {
-                configureRAG(agentToolkit);
-            }
-            if (taskListEnabled) {
-                configureTodoTools(agentToolkit);
-            }
-            if (skillBox != null) {
-                configureSkillBox(agentToolkit);
-            }
-            if (!skillRepositories.isEmpty() && dynamicSkillsEnabled) {
-                middlewares.add(
-                        new DynamicSkillMiddleware(
-                                List.copyOf(skillRepositories),
-                                agentToolkit,
-                                skillFilter != null ? skillFilter : SkillFilter.all(),
-                                skillCodeExecutionEnabled,
-                                skillWorkDir));
-            }
+                if (longTermMemory != null) {
+                    configureLongTermMemory(agentToolkit, selfRef);
+                }
+                if (!knowledgeBases.isEmpty()) {
+                    configureRAG(agentToolkit);
+                }
+                if (taskListEnabled) {
+                    configureTodoTools(agentToolkit);
+                }
+                if (skillBox != null) {
+                    configureSkillBox(agentToolkit);
+                }
+                if (!skillRepositories.isEmpty() && dynamicSkillsEnabled) {
+                    middlewares.add(
+                            new DynamicSkillMiddleware(
+                                    List.copyOf(skillRepositories),
+                                    agentToolkit,
+                                    skillFilter != null ? skillFilter : SkillFilter.all(),
+                                    skillCodeExecutionEnabled,
+                                    skillWorkDir));
+                }
 
-            ReActAgent agent = new ReActAgent(this, agentToolkit);
-            selfRef.set(agent);
-
-            return agent;
+                ReActAgent agent = new ReActAgent(this, agentToolkit);
+                selfRef.set(agent);
+                return agent;
+            } catch (RuntimeException | Error e) {
+                agentToolkit.close();
+                throw e;
+            }
         }
 
         /**

--- a/agentscope-core/src/main/java/io/agentscope/core/tool/McpClientLifecycleOwner.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/tool/McpClientLifecycleOwner.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.core.tool;
+
+import io.agentscope.core.tool.mcp.McpClientWrapper;
+import java.util.HashMap;
+import java.util.Map;
+
+/** Shared, reference-counted ownership of MCP client transports across toolkit copies. */
+final class McpClientLifecycleOwner {
+
+    private final Map<String, Entry> entries = new HashMap<>();
+
+    synchronized void register(String name, McpClientWrapper wrapper) {
+        if (entries.containsKey(name)) {
+            throw new IllegalStateException("MCP client already registered: " + name);
+        }
+        entries.put(name, new Entry(wrapper, 1));
+    }
+
+    synchronized McpClientWrapper acquire(String name) {
+        Entry entry = entries.get(name);
+        if (entry == null) {
+            throw new IllegalStateException("MCP client lifecycle owner not found: " + name);
+        }
+        entry.references++;
+        return entry.wrapper;
+    }
+
+    McpClientWrapper release(String name) {
+        McpClientWrapper toClose = null;
+        synchronized (this) {
+            Entry entry = entries.get(name);
+            if (entry == null) {
+                return null;
+            }
+            entry.references--;
+            if (entry.references == 0) {
+                entries.remove(name);
+                toClose = entry.wrapper;
+            }
+        }
+        if (toClose != null) {
+            toClose.close();
+        }
+        return toClose;
+    }
+
+    synchronized McpClientWrapper get(String name) {
+        Entry entry = entries.get(name);
+        return entry != null ? entry.wrapper : null;
+    }
+
+    private static final class Entry {
+        private final McpClientWrapper wrapper;
+        private int references;
+
+        private Entry(McpClientWrapper wrapper, int references) {
+            this.wrapper = wrapper;
+            this.references = references;
+        }
+    }
+}

--- a/agentscope-core/src/main/java/io/agentscope/core/tool/McpClientManager.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/tool/McpClientManager.java
@@ -37,7 +37,8 @@ class McpClientManager {
 
     private static final Logger logger = LoggerFactory.getLogger(McpClientManager.class);
 
-    private final Map<String, McpClientWrapper> mcpClients = new ConcurrentHashMap<>();
+    private final Set<String> ownedClients = ConcurrentHashMap.newKeySet();
+    private final McpClientLifecycleOwner lifecycleOwner;
     private final ToolRegistry toolRegistry;
     private final ToolGroupManager groupManager;
     private final ToolRegistrationCallback registrationCallback;
@@ -57,10 +58,19 @@ class McpClientManager {
     McpClientManager(
             ToolRegistry toolRegistry,
             ToolGroupManager groupManager,
-            ToolRegistrationCallback registrationCallback) {
+            ToolRegistrationCallback registrationCallback,
+            McpClientLifecycleOwner lifecycleOwner) {
         this.toolRegistry = toolRegistry;
         this.groupManager = groupManager;
         this.registrationCallback = registrationCallback;
+        this.lifecycleOwner = lifecycleOwner;
+    }
+
+    McpClientManager(
+            ToolRegistry toolRegistry,
+            ToolGroupManager groupManager,
+            ToolRegistrationCallback registrationCallback) {
+        this(toolRegistry, groupManager, registrationCallback, new McpClientLifecycleOwner());
     }
 
     /**
@@ -204,17 +214,26 @@ class McpClientManager {
                 .then()
                 .doOnSuccess(
                         v -> {
-                            mcpClients.put(mcpClientWrapper.getName(), mcpClientWrapper);
+                            lifecycleOwner.register(mcpClientWrapper.getName(), mcpClientWrapper);
+                            ownedClients.add(mcpClientWrapper.getName());
                             logger.info(
                                     "MCP client '{}' registered successfully",
                                     mcpClientWrapper.getName());
                         })
-                .doOnError(
-                        e ->
-                                logger.error(
-                                        "Failed to register MCP client: {}",
-                                        mcpClientWrapper.getName(),
-                                        e));
+                .onErrorResume(
+                        e -> {
+                            removeClientTools(mcpClientWrapper.getName());
+                            if (ownedClients.remove(mcpClientWrapper.getName())) {
+                                lifecycleOwner.release(mcpClientWrapper.getName());
+                            } else {
+                                mcpClientWrapper.close();
+                            }
+                            logger.error(
+                                    "Failed to register MCP client: {}",
+                                    mcpClientWrapper.getName(),
+                                    e);
+                            return Mono.error(e);
+                        });
     }
 
     /**
@@ -224,8 +243,7 @@ class McpClientManager {
      * @return Mono that completes when removal is finished
      */
     Mono<Void> removeMcpClient(String mcpClientName) {
-        McpClientWrapper wrapper = mcpClients.remove(mcpClientName);
-        if (wrapper == null) {
+        if (!ownedClients.remove(mcpClientName)) {
             logger.warn("MCP client not found: {}", mcpClientName);
             return Mono.empty();
         }
@@ -233,6 +251,15 @@ class McpClientManager {
         logger.info("Removing MCP client: {}", mcpClientName);
 
         // Remove all tools from this MCP client
+        removeClientTools(mcpClientName);
+
+        return Mono.fromRunnable(() -> lifecycleOwner.release(mcpClientName))
+                .then()
+                .doOnSuccess(
+                        v -> logger.info("MCP client '{}' removed successfully", mcpClientName));
+    }
+
+    private void removeClientTools(String mcpClientName) {
         List<String> toolsToRemove =
                 toolRegistry.getAllRegisteredTools().values().stream()
                         .filter(reg -> mcpClientName.equals(reg.getMcpClientName()))
@@ -244,11 +271,24 @@ class McpClientManager {
                     toolRegistry.removeTool(toolName);
                     logger.debug("Removed MCP tool: {}", toolName);
                 });
+    }
 
-        return Mono.fromRunnable(wrapper::close)
-                .then()
-                .doOnSuccess(
-                        v -> logger.info("MCP client '{}' removed successfully", mcpClientName));
+    void copyOwnershipTo(McpClientManager target) {
+        for (String name : ownedClients) {
+            lifecycleOwner.acquire(name);
+            if (!target.ownedClients.add(name)) {
+                lifecycleOwner.release(name);
+            }
+        }
+    }
+
+    void closeAll() {
+        for (String name : new HashSet<>(ownedClients)) {
+            if (ownedClients.remove(name)) {
+                removeClientTools(name);
+                lifecycleOwner.release(name);
+            }
+        }
     }
 
     /**
@@ -257,7 +297,7 @@ class McpClientManager {
      * @return set of MCP client names, never null but may be empty
      */
     Set<String> getMcpClientNames() {
-        return new HashSet<>(mcpClients.keySet());
+        return new HashSet<>(ownedClients);
     }
 
     /**
@@ -267,7 +307,7 @@ class McpClientManager {
      * @return the MCP client wrapper, or null if not found
      */
     McpClientWrapper getMcpClient(String name) {
-        return mcpClients.get(name);
+        return ownedClients.contains(name) ? lifecycleOwner.get(name) : null;
     }
 
     /**

--- a/agentscope-core/src/main/java/io/agentscope/core/tool/Toolkit.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/tool/Toolkit.java
@@ -63,7 +63,7 @@ import reactor.core.publisher.Mono;
  *   <li>MCP (Model Context Protocol) client support for external tool providers</li>
  * </ul>
  */
-public class Toolkit {
+public class Toolkit implements AutoCloseable {
 
     private static final Logger logger = LoggerFactory.getLogger(Toolkit.class);
 
@@ -72,6 +72,7 @@ public class Toolkit {
     private final ToolSchemaProvider schemaProvider;
     private final MetaToolFactory metaToolFactory;
     private final McpClientManager mcpClientManager;
+    private final McpClientLifecycleOwner mcpLifecycleOwner;
     private final ToolSchemaGenerator schemaGenerator = new ToolSchemaGenerator();
     private final ToolMethodInvoker methodInvoker;
     private final ToolkitConfig config;
@@ -90,7 +91,12 @@ public class Toolkit {
      * @param config Toolkit configuration (if null, uses defaultConfig())
      */
     public Toolkit(ToolkitConfig config) {
+        this(config, new McpClientLifecycleOwner());
+    }
+
+    private Toolkit(ToolkitConfig config, McpClientLifecycleOwner mcpLifecycleOwner) {
         this.config = config != null ? config : ToolkitConfig.defaultConfig();
+        this.mcpLifecycleOwner = mcpLifecycleOwner;
         this.methodInvoker = new ToolMethodInvoker(new DefaultToolResultConverter());
         this.schemaProvider = new ToolSchemaProvider(toolRegistry, groupManager);
         this.metaToolFactory = new MetaToolFactory(groupManager, toolRegistry);
@@ -100,7 +106,8 @@ public class Toolkit {
                         groupManager,
                         (tool, groupName, mcpClientName, presetParameters) ->
                                 registerAgentTool(
-                                        tool, groupName, null, mcpClientName, presetParameters));
+                                        tool, groupName, null, mcpClientName, presetParameters),
+                        mcpLifecycleOwner);
 
         // Create executor based on configuration
         if (config != null && config.hasCustomExecutor()) {
@@ -549,6 +556,17 @@ public class Toolkit {
         return mcpClientManager.removeMcpClient(mcpClientName);
     }
 
+    /** Returns a snapshot of MCP client names owned by this toolkit. */
+    public Set<String> getMcpClientNames() {
+        return mcpClientManager.getMcpClientNames();
+    }
+
+    /** Releases all MCP clients owned by this toolkit. Idempotent. */
+    @Override
+    public void close() {
+        mcpClientManager.closeAll();
+    }
+
     // ==================== Tool Group Management (Delegated) ====================
 
     /**
@@ -781,18 +799,23 @@ public class Toolkit {
      * @return A new Toolkit instance with copied state
      */
     public Toolkit copy() {
-        Toolkit copy = new Toolkit(this.config);
+        Toolkit copy = new Toolkit(this.config, this.mcpLifecycleOwner);
+        try {
+            // Copy all registered tools
+            this.toolRegistry.copyTo(copy.toolRegistry);
 
-        // Copy all registered tools
-        this.toolRegistry.copyTo(copy.toolRegistry);
+            // Copy all tool groups and their states
+            this.groupManager.copyTo(copy.groupManager);
 
-        // Copy all tool groups and their states
-        this.groupManager.copyTo(copy.groupManager);
+            // Preserve user-defined chunk callbacks across toolkit copies (Issue #870)
+            copy.executor.setChunkCallback(this.executor.getChunkCallback());
 
-        // Preserve user-defined chunk callbacks across toolkit copies (Issue #870)
-        copy.executor.setChunkCallback(this.executor.getChunkCallback());
-
-        return copy;
+            this.mcpClientManager.copyOwnershipTo(copy.mcpClientManager);
+            return copy;
+        } catch (RuntimeException | Error e) {
+            copy.close();
+            throw e;
+        }
     }
 
     /**

--- a/agentscope-core/src/test/java/io/agentscope/core/tool/McpClientManagerTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/tool/McpClientManagerTest.java
@@ -19,8 +19,11 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -34,6 +37,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import reactor.core.publisher.Mono;
@@ -412,5 +416,58 @@ class McpClientManagerTest {
         assertEquals("mcp-group", registeredGroupName[0]);
         assertEquals("test-client", registeredClientName[0]);
         assertEquals(toolPresetParams, registeredPresetParams[0]);
+    }
+
+    @Test
+    void toolkitCopiesShareMcpTransportUntilLastOwnerCloses() {
+        McpClientWrapper wrapper = mock(McpClientWrapper.class);
+        when(wrapper.getName()).thenReturn("shared-client");
+        when(wrapper.initialize()).thenReturn(Mono.empty());
+        when(wrapper.listTools()).thenReturn(Mono.just(List.of()));
+
+        Toolkit source = new Toolkit();
+        source.registerMcpClient(wrapper).block();
+        Toolkit copy = source.copy();
+
+        source.close();
+        verify(wrapper, never()).close();
+        assertEquals(Set.of("shared-client"), copy.getMcpClientNames());
+
+        copy.close();
+        copy.close();
+        verify(wrapper, times(1)).close();
+    }
+
+    @Test
+    void removeMcpClientReleasesOnlyCurrentToolkitOwnership() {
+        McpClientWrapper wrapper = mock(McpClientWrapper.class);
+        when(wrapper.getName()).thenReturn("removable-client");
+        when(wrapper.initialize()).thenReturn(Mono.empty());
+        when(wrapper.listTools()).thenReturn(Mono.just(List.of()));
+
+        Toolkit source = new Toolkit();
+        source.registerMcpClient(wrapper).block();
+        Toolkit copy = source.copy();
+
+        copy.removeMcpClient("removable-client").block();
+        verify(wrapper, never()).close();
+        assertTrue(copy.getMcpClientNames().isEmpty());
+        assertEquals(Set.of("removable-client"), source.getMcpClientNames());
+
+        source.close();
+        verify(wrapper, times(1)).close();
+    }
+
+    @Test
+    void failedRegistrationClosesTransportAndLeavesNoOwnership() {
+        McpClientWrapper wrapper = mock(McpClientWrapper.class);
+        when(wrapper.getName()).thenReturn("failed-client");
+        when(wrapper.initialize()).thenReturn(Mono.error(new IllegalStateException("boom")));
+
+        Toolkit toolkit = new Toolkit();
+        assertThrows(IllegalStateException.class, () -> toolkit.registerMcpClient(wrapper).block());
+
+        assertTrue(toolkit.getMcpClientNames().isEmpty());
+        verify(wrapper, times(1)).close();
     }
 }

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/HarnessAgent.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/HarnessAgent.java
@@ -2473,7 +2473,13 @@ public class HarnessAgent implements Agent, AutoCloseable {
 
             // ---- Build inner ReActAgent ----
             inner.toolkit(agentToolkit);
-            ReActAgent delegate = inner.build();
+            ReActAgent delegate;
+            try {
+                delegate = inner.build();
+            } finally {
+                // ReActAgent owns its copied toolkit. Release this build-only MCP reference.
+                agentToolkit.close();
+            }
             selfRef.set(delegate);
 
             return new HarnessAgent(


### PR DESCRIPTION
Closes #2139.

## Summary
- share reference-counted MCP transport ownership across Toolkit copies
- expose Toolkit MCP client inventory and idempotent close
- close final ReActAgent/Harness toolkit resources and roll back failed registration/build
- verify last-owner close, per-copy removal, and failed initialization cleanup

## Verification
- mvn -pl agentscope-core -Dtest=McpClientManagerTest test (15/15)
- mvn -pl agentscope-core,agentscope-harness -am -Dtest=ToolkitTest,McpClientManagerTest,ReActAgentTest,HarnessAgentTest,HarnessAgentToolsConfigTest test -Dsurefire.failIfNoSpecifiedTests=false (37/37)
- JCode real stdio MCP lifecycle acceptance (12/12): final Toolkit remove and Harness close terminate the fixture process