### PR TITLE
fix PostgreSQL upsert SQL syntax error (#2166)

### DIFF
--- a/agentscope-extensions/agentscope-extensions-postgresql/src/main/java/io/agentscope/extensions/postgresql/store/PostgresBaseStore.java
+++ b/agentscope-extensions/agentscope-extensions-postgresql/src/main/java/io/agentscope/extensions/postgresql/store/PostgresBaseStore.java
@@ -107,7 +107,7 @@ public class PostgresBaseStore implements BaseStore {
             VALUES (?, ?, ?, 1, ?)
             ON CONFLICT (namespace_path, item_key) DO UPDATE SET
                 value_json = EXCLUDED.value_json,
-                version    = %1$s.version + 1,,
+                version    = %1$s.version + 1,
                 updated_at = EXCLUDED.updated_at
             """;
 


### PR DESCRIPTION
Fixes #2166.
Removed an extra comma in `PostgresBaseStore.UPSERT_SQL` that caused a PostgreSQL syntax error on the `ON CONFLICT ... DO UPDATE` branch.