### PR TITLE
fix toolResult Prefix Check

### DIFF
--- a/agentscope-core/src/main/java/io/agentscope/core/ReActAgent.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/ReActAgent.java
@@ -2793,7 +2793,9 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
                                     b ->
                                             b instanceof TextBlock tb
                                                     && tb.getText() != null
-                                                    && tb.getText().startsWith("[ERROR]"))) {
+                                                    && (tb.getText().startsWith("[ERROR]")
+                                                            || tb.getText()
+                                                                    .startsWith("Error:")))) {
                 return ToolResultState.ERROR;
             }
             return ToolResultState.SUCCESS;

--- a/agentscope-core/src/main/java/io/agentscope/core/ReActAgent.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/ReActAgent.java
@@ -1751,6 +1751,7 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
             return ToolResultBlock.builder()
                     .id(toolId)
                     .output(List.of(TextBlock.builder().text("[ERROR] " + errorMessage).build()))
+                    .state(ToolResultState.ERROR)
                     .build();
         }
 
@@ -2793,9 +2794,7 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
                                     b ->
                                             b instanceof TextBlock tb
                                                     && tb.getText() != null
-                                                    && (tb.getText().startsWith("[ERROR]")
-                                                            || tb.getText()
-                                                                    .startsWith("Error:")))) {
+                                                    && tb.getText().startsWith("[ERROR]"))) {
                 return ToolResultState.ERROR;
             }
             return ToolResultState.SUCCESS;

--- a/agentscope-core/src/main/java/io/agentscope/core/message/ToolResultBlock.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/message/ToolResultBlock.java
@@ -207,7 +207,8 @@ public final class ToolResultBlock extends ContentBlock {
                 null,
                 null,
                 List.of(TextBlock.builder().text("Error: " + errorMessage).build()),
-                null);
+                null,
+                ToolResultState.ERROR);
     }
 
     /**

--- a/agentscope-core/src/test/java/io/agentscope/core/agent/ReActAgentNewLoopE2ETest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/agent/ReActAgentNewLoopE2ETest.java
@@ -134,6 +134,32 @@ class ReActAgentNewLoopE2ETest {
         }
     }
 
+    private static final class ReturningErrorTool extends ToolBase {
+        ReturningErrorTool(String name) {
+            super(
+                    name,
+                    "returns structured error",
+                    AlwaysAllowTool.schema(),
+                    true,
+                    true,
+                    false,
+                    null,
+                    false,
+                    false);
+        }
+
+        @Override
+        public Mono<PermissionDecision> checkPermissions(
+                Map<String, Object> input, PermissionContextState ctx) {
+            return Mono.just(PermissionDecision.allow("ok"));
+        }
+
+        @Override
+        public Mono<ToolResultBlock> callAsync(ToolCallParam param) {
+            return Mono.just(ToolResultBlock.error("probe failed"));
+        }
+    }
+
     private static final class RecordingMiddleware implements MiddlewareBase {
         final List<String> trace = new ArrayList<>();
 
@@ -227,5 +253,43 @@ class ReActAgentNewLoopE2ETest {
                         .flatMap(m -> m.getContentBlocks(TextBlock.class).stream())
                         .anyMatch(tb -> tb.getText().equals("done-final"));
         assertTrue(hasFinalText, "final assistant text 'done-final' must be in state.context");
+    }
+
+    @Test
+    void toolReturningErrorBlockEmitsErrorResultEndState() {
+        ScriptedModel model =
+                new ScriptedModel(
+                        List.of(
+                                () -> Flux.just(toolUseResponse("c1", "failing", "probe")),
+                                () -> Flux.just(textResponse("handled"))));
+        Toolkit tk = new Toolkit();
+        tk.registerAgentTool(new ReturningErrorTool("failing"));
+
+        ReActAgent agent =
+                ReActAgent.builder()
+                        .name("asst")
+                        .sysPrompt("you are helpful")
+                        .model(model)
+                        .toolkit(tk)
+                        .build();
+
+        List<AgentEvent> events =
+                agent.streamEvents(
+                                List.of(
+                                        Msg.builder()
+                                                .role(MsgRole.USER)
+                                                .textContent("run the failing tool")
+                                                .build()))
+                        .collectList()
+                        .block();
+        assertNotNull(events);
+
+        ToolResultEndEvent end =
+                events.stream()
+                        .filter(ToolResultEndEvent.class::isInstance)
+                        .map(ToolResultEndEvent.class::cast)
+                        .findFirst()
+                        .orElseThrow();
+        assertEquals(ToolResultState.ERROR, end.getState());
     }
 }

--- a/agentscope-core/src/test/java/io/agentscope/core/message/ToolResultBlockTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/message/ToolResultBlockTest.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.core.message;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+
+import org.junit.jupiter.api.Test;
+
+class ToolResultBlockTest {
+
+    @Test
+    void errorFactoryCreatesStructuredErrorState() {
+        ToolResultBlock result = ToolResultBlock.error("probe failed");
+
+        assertEquals(ToolResultState.ERROR, result.getState());
+        TextBlock output = assertInstanceOf(TextBlock.class, result.getOutput().get(0));
+        assertEquals("Error: probe failed", output.getText());
+    }
+}


### PR DESCRIPTION
## 关联 issue
- Fixes :
- #2157
- #2111

## AgentScope-Java Version

v2.0.0

## Description

### Background

MCP 工具执行超时后，`ToolExecutor` 重试 2 次均失败，最终错误结果被标记为 `state=SUCCESS` 而非 `state=ERROR`，导致 Agent 推理循环无法感知工具失败，继续基于错误数据进行推理。

### Root Cause

错误处理存在两条路径，使用了不同的错误前缀：

- **路径 A**：`ReActAgent.buildErrorToolResult()` 使用 `"[ERROR] "` 前缀 — 能被 `determineToolResultState()` 识别
- **路径 B**：`ToolExecutor.executeWithInfrastructure()` 通过 `ToolResultBlock.error()` 产生 `"Error: "` 前缀 —— 不能被 `determineToolResultState()` 识别

`determineToolResultState()` 仅检查 `startsWith("[ERROR]")`，当 `state` 字段为 null 时作为 fallback 文本检测。由于 `ToolResultBlock.error()` 返回的 `state=null`（默认为 `RUNNING`）且前缀为 `"Error: "`，导致该方法始终返回 `SUCCESS`。

## Changes

- Set `ToolResultBlock.error(...)` to explicitly use `ToolResultState.ERROR`.
- Set ReActAgent internally built error tool results to `ToolResultState.ERROR`.
- Added regression coverage for:
  - `ToolResultBlock.error(...)` carrying structured `ERROR`.
  - ReAct event emission reporting `ToolResultEndEvent.state = ERROR` for tools returning `ToolResultBlock.error(...)`.

## Checklist

- [x] Code has been formatted with `mvn spotless:apply`
- [x] All tests are passing (`mvn test`)
- [x] Javadoc comments are complete and follow project conventions
- [ ] Related documentation has been updated (e.g. links, examples, etc.)
- [x] Code is ready for revieww