### PR TITLE
fix(openai): make api-key optional for OpenAI

### DIFF
--- a/agentscope-extensions/agentscope-spring-boot-starters/agentscope-openai-spring-boot-starter/src/main/java/io/agentscope/spring/boot/openai/OpenAIAutoConfiguration.java
+++ b/agentscope-extensions/agentscope-spring-boot-starters/agentscope-openai-spring-boot-starter/src/main/java/io/agentscope/spring/boot/openai/OpenAIAutoConfiguration.java
@@ -46,11 +46,6 @@ public class OpenAIAutoConfiguration {
             OpenAIProperties properties,
             ObjectProvider<OpenAIChatModelBuilderCustomizer> customizerObjectProvider) {
         String apiKey = trimToNull(properties.getApiKey());
-        if (apiKey == null) {
-            throw new IllegalStateException(
-                    "agentscope.openai.api-key must be configured when OpenAI provider is"
-                            + " selected");
-        }
 
         String modelName = trimToNull(properties.getModelName());
         if (modelName == null) {

--- a/agentscope-extensions/agentscope-spring-boot-starters/agentscope-openai-spring-boot-starter/src/main/java/io/agentscope/spring/boot/openai/OpenAIProperties.java
+++ b/agentscope-extensions/agentscope-spring-boot-starters/agentscope-openai-spring-boot-starter/src/main/java/io/agentscope/spring/boot/openai/OpenAIProperties.java
@@ -45,6 +45,9 @@ public class OpenAIProperties {
 
     /**
      * OpenAI API key.
+     *
+     * <p>Optional: some OpenAI-compatible providers (for example free model endpoints)
+     * do not require an API key. Leave unset for those providers.
      */
     private String apiKey;
 

--- a/agentscope-extensions/agentscope-spring-boot-starters/agentscope-openai-spring-boot-starter/src/test/java/io/agentscope/spring/boot/openai/OpenAIAutoConfigurationTest.java
+++ b/agentscope-extensions/agentscope-spring-boot-starters/agentscope-openai-spring-boot-starter/src/test/java/io/agentscope/spring/boot/openai/OpenAIAutoConfigurationTest.java
@@ -100,15 +100,30 @@ class OpenAIAutoConfigurationTest {
     }
 
     @Test
-    void shouldFailClearlyWhenApiKeyMissing() {
+    void shouldCreateOpenAIModelWhenApiKeyMissing() {
         contextRunner
-                .withPropertyValues("agentscope.model.provider=openai")
+                .withPropertyValues(
+                        "agentscope.model.provider=openai",
+                        "agentscope.openai.model-name=gpt-4.1-mini")
                 .run(
-                        context ->
-                                assertThat(context.getStartupFailure())
-                                        .isNotNull()
-                                        .hasMessageContaining(
-                                                "agentscope.openai.api-key must be configured"));
+                        context -> {
+                            assertThat(context).hasSingleBean(Model.class);
+                            assertThat(context).hasSingleBean(OpenAIChatModel.class);
+                        });
+    }
+
+    @Test
+    void shouldCreateOpenAIModelForApiKeyFreeProvider() {
+        contextRunner
+                .withPropertyValues(
+                        "agentscope.model.provider=openai",
+                        "agentscope.openai.model-name=opencode-free-model",
+                        "agentscope.openai.base-url=https://api.opencode.example.com/v1")
+                .run(
+                        context -> {
+                            assertThat(context).hasSingleBean(Model.class);
+                            assertThat(context).hasSingleBean(OpenAIChatModel.class);
+                        });
     }
 
     @Test


### PR DESCRIPTION
Some OpenAI-compatible providers (e.g., free model endpoints such as opencode) do not require an API key. The current OpenAIAutoConfiguration throws an IllegalStateException at startup when
  agentscope.openai.api-key is missing, which prevents these providers from being used.

  This change removes the mandatory API key check from the auto-configuration. The underlying OpenAIClient already handles a missing key gracefully by omitting the Authorization header, so runtime
  behavior remains correct for providers that do require authentication.

  Changes:
  - OpenAIAutoConfiguration: removed the apiKey == null startup validation.
  - OpenAIProperties: updated Javadoc to clarify that api-key is optional for API-key-free providers.
  - OpenAIAutoConfigurationTest: replaced the "must fail when API key missing" test with tests that verify the model is created successfully without an API key, including a free-provider scenario with
  a custom base-url.