### PR TITLE
feat(starters): add Ollama Spring Boot starter

### DIFF
--- a/agentscope-distribution/agentscope-bom/pom.xml
+++ b/agentscope-distribution/agentscope-bom/pom.xml
@@ -462,6 +462,13 @@
                 <version>${project.version}</version>
             </dependency>
 
+            <!-- AgentScope Ollama Spring Boot Starter -->
+            <dependency>
+                <groupId>io.agentscope</groupId>
+                <artifactId>agentscope-ollama-spring-boot-starter</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
             <!-- AgentScope Chat Completions Web Spring Boot Starter -->
             <dependency>
                 <groupId>io.agentscope</groupId>

--- a/agentscope-extensions/agentscope-spring-boot-starters/agentscope-ollama-spring-boot-starter/pom.xml
+++ b/agentscope-extensions/agentscope-spring-boot-starters/agentscope-ollama-spring-boot-starter/pom.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2024-2026 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.agentscope</groupId>
+        <artifactId>agentscope-spring-boot-starters</artifactId>
+        <version>${revision}</version>
+    </parent>
+    <artifactId>agentscope-ollama-spring-boot-starter</artifactId>
+    <name>AgentScope Java Ollama - Spring Boot Starter</name>
+    <description>Spring Boot starter for AgentScope Java Ollama model integration</description>
+    <properties>
+        <maven.deploy.skip>false</maven.deploy.skip>
+    </properties>
+    <dependencies>
+        <dependency>
+            <groupId>io.agentscope</groupId>
+            <artifactId>agentscope-spring-boot-starter</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.agentscope</groupId>
+            <artifactId>agentscope-extensions-model-ollama</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-autoconfigure</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-autoconfigure-processor</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-configuration-processor</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/agentscope-extensions/agentscope-spring-boot-starters/agentscope-ollama-spring-boot-starter/src/main/java/io/agentscope/spring/boot/ollama/OllamaAutoConfiguration.java
+++ b/agentscope-extensions/agentscope-spring-boot-starters/agentscope-ollama-spring-boot-starter/src/main/java/io/agentscope/spring/boot/ollama/OllamaAutoConfiguration.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.spring.boot.ollama;
+
+import io.agentscope.core.model.Model;
+import io.agentscope.extensions.model.ollama.OllamaChatModel;
+import io.agentscope.spring.boot.AgentscopeAutoConfiguration;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+
+/**
+ * Spring Boot auto-configuration for the Ollama model extension.
+ */
+@AutoConfiguration(before = AgentscopeAutoConfiguration.class)
+@EnableConfigurationProperties(OllamaProperties.class)
+@ConditionalOnClass(OllamaChatModel.class)
+public class OllamaAutoConfiguration {
+
+    @Bean
+    @ConditionalOnProperty(prefix = "agentscope.model", name = "provider", havingValue = "ollama")
+    @ConditionalOnProperty(
+            prefix = "agentscope.ollama",
+            name = "enabled",
+            havingValue = "true",
+            matchIfMissing = true)
+    @ConditionalOnMissingBean(Model.class)
+    public OllamaChatModel ollamaChatModel(
+            OllamaProperties properties,
+            ObjectProvider<OllamaChatModelBuilderCustomizer> customizerObjectProvider) {
+        String modelName = trimToNull(properties.getModelName());
+        if (modelName == null) {
+            throw new IllegalStateException(
+                    "agentscope.ollama.model-name must be configured when Ollama provider is"
+                            + " selected");
+        }
+        OllamaChatModel.Builder builder = OllamaChatModel.builder().modelName(modelName);
+        String baseUrl = trimToNull(properties.getBaseUrl());
+        if (baseUrl != null) {
+            builder.baseUrl(baseUrl);
+        }
+        customizerObjectProvider
+                .orderedStream()
+                .forEach(customizer -> customizer.customize(builder));
+        return builder.build();
+    }
+
+    private static String trimToNull(String value) {
+        if (value == null) {
+            return null;
+        }
+        String trimmed = value.trim();
+        return trimmed.isEmpty() ? null : trimmed;
+    }
+}

--- a/agentscope-extensions/agentscope-spring-boot-starters/agentscope-ollama-spring-boot-starter/src/main/java/io/agentscope/spring/boot/ollama/OllamaChatModelBuilderCustomizer.java
+++ b/agentscope-extensions/agentscope-spring-boot-starters/agentscope-ollama-spring-boot-starter/src/main/java/io/agentscope/spring/boot/ollama/OllamaChatModelBuilderCustomizer.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.spring.boot.ollama;
+
+import io.agentscope.extensions.model.ollama.OllamaChatModel;
+import java.util.function.Consumer;
+
+/**
+ * Customizer for {@link OllamaChatModel.Builder}.
+ *
+ * <p>Example usage:
+ *
+ * <pre>{@code
+ *     @Bean
+ *     public OllamaChatModelBuilderCustomizer ollamaChatModelBuilderCustomizer() {
+ *         return builder -> builder.baseUrl("http://ollama.example.com:11434");
+ *     }
+ * }</pre>
+ */
+@FunctionalInterface
+public interface OllamaChatModelBuilderCustomizer extends Consumer<OllamaChatModel.Builder> {
+
+    /**
+     * Customize the {@link OllamaChatModel.Builder}.
+     *
+     * @param builder the builder to customize
+     */
+    void customize(OllamaChatModel.Builder builder);
+
+    /**
+     * Accept and invoke the given builder.
+     *
+     * @param builder the builder to customize
+     */
+    @Override
+    default void accept(OllamaChatModel.Builder builder) {
+        this.customize(builder);
+    }
+}

--- a/agentscope-extensions/agentscope-spring-boot-starters/agentscope-ollama-spring-boot-starter/src/main/java/io/agentscope/spring/boot/ollama/OllamaProperties.java
+++ b/agentscope-extensions/agentscope-spring-boot-starters/agentscope-ollama-spring-boot-starter/src/main/java/io/agentscope/spring/boot/ollama/OllamaProperties.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.spring.boot.ollama;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * Ollama provider specific settings.
+ *
+ * <p>Example configuration:
+ *
+ * <pre>{@code
+ * agentscope:
+ *   model:
+ *     provider: ollama
+ *   ollama:
+ *     enabled: true
+ *     model-name: llama3
+ *     # base-url: http://localhost:11434 # optional
+ * }</pre>
+ */
+@ConfigurationProperties(prefix = "agentscope.ollama")
+public class OllamaProperties {
+
+    /**
+     * Whether Ollama model auto-configuration is enabled.
+     */
+    private boolean enabled = true;
+
+    /**
+     * Ollama model name, for example {@code llama3}.
+     */
+    private String modelName = "llama3";
+
+    /**
+     * Optional base URL for the Ollama server.
+     */
+    private String baseUrl;
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    public String getModelName() {
+        return modelName;
+    }
+
+    public void setModelName(String modelName) {
+        this.modelName = modelName;
+    }
+
+    public String getBaseUrl() {
+        return baseUrl;
+    }
+
+    public void setBaseUrl(String baseUrl) {
+        this.baseUrl = baseUrl;
+    }
+}

--- a/agentscope-extensions/agentscope-spring-boot-starters/agentscope-ollama-spring-boot-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/agentscope-extensions/agentscope-spring-boot-starters/agentscope-ollama-spring-boot-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,16 @@
+#
+# Copyright 2024-2026 the original author or authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+io.agentscope.spring.boot.ollama.OllamaAutoConfiguration

--- a/agentscope-extensions/agentscope-spring-boot-starters/agentscope-ollama-spring-boot-starter/src/test/java/io/agentscope/spring/boot/ollama/OllamaAutoConfigurationTest.java
+++ b/agentscope-extensions/agentscope-spring-boot-starters/agentscope-ollama-spring-boot-starter/src/test/java/io/agentscope/spring/boot/ollama/OllamaAutoConfigurationTest.java
@@ -1,0 +1,195 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.spring.boot.ollama;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.agentscope.core.ReActAgent;
+import io.agentscope.core.message.Msg;
+import io.agentscope.core.model.ChatResponse;
+import io.agentscope.core.model.GenerateOptions;
+import io.agentscope.core.model.Model;
+import io.agentscope.core.model.ToolSchema;
+import io.agentscope.extensions.model.ollama.OllamaChatModel;
+import io.agentscope.spring.boot.AgentscopeAutoConfiguration;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import reactor.core.publisher.Flux;
+
+class OllamaAutoConfigurationTest {
+
+    private final ApplicationContextRunner contextRunner =
+            new ApplicationContextRunner()
+                    .withConfiguration(AutoConfigurations.of(OllamaAutoConfiguration.class));
+
+    @Test
+    void shouldCreateOllamaModelWhenProviderIsOllama() {
+        contextRunner
+                .withPropertyValues(
+                        "agentscope.model.provider=ollama", "agentscope.ollama.model-name=llama3")
+                .run(
+                        context -> {
+                            assertThat(context).hasSingleBean(Model.class);
+                            assertThat(context).hasSingleBean(OllamaChatModel.class);
+                            assertThat(context.getBean(Model.class).getModelName())
+                                    .isEqualTo("llama3");
+                        });
+    }
+
+    @Test
+    void shouldBindSupportedOllamaProperties() {
+        contextRunner
+                .withPropertyValues(
+                        "agentscope.model.provider=ollama",
+                        "agentscope.ollama.model-name=llama3.2",
+                        "agentscope.ollama.base-url=http://ollama.example.com:11434")
+                .run(
+                        context -> {
+                            OllamaChatModel model = context.getBean(OllamaChatModel.class);
+                            assertThat(model.getModelName()).isEqualTo("llama3.2");
+                        });
+    }
+
+    @Test
+    void shouldNotCreateOllamaModelWhenProviderIsDifferent() {
+        contextRunner
+                .withPropertyValues(
+                        "agentscope.model.provider=dashscope",
+                        "agentscope.ollama.model-name=llama3")
+                .run(
+                        context -> {
+                            assertThat(context).doesNotHaveBean(Model.class);
+                            assertThat(context).doesNotHaveBean(OllamaChatModel.class);
+                        });
+    }
+
+    @Test
+    void shouldNotCreateOllamaModelWhenDisabled() {
+        contextRunner
+                .withPropertyValues(
+                        "agentscope.model.provider=ollama",
+                        "agentscope.ollama.enabled=false",
+                        "agentscope.ollama.model-name=llama3")
+                .run(
+                        context -> {
+                            assertThat(context).doesNotHaveBean(Model.class);
+                            assertThat(context).doesNotHaveBean(OllamaChatModel.class);
+                        });
+    }
+
+    @Test
+    void shouldFailClearlyWhenModelNameMissing() {
+        contextRunner
+                .withPropertyValues(
+                        "agentscope.model.provider=ollama", "agentscope.ollama.model-name= ")
+                .run(
+                        context ->
+                                assertThat(context.getStartupFailure())
+                                        .isNotNull()
+                                        .hasMessageContaining(
+                                                "agentscope.ollama.model-name must be configured"));
+    }
+
+    @Test
+    void shouldBackOffWhenUserDefinesModelBean() {
+        contextRunner
+                .withUserConfiguration(CustomModelConfiguration.class)
+                .withPropertyValues("agentscope.model.provider=ollama")
+                .run(
+                        context -> {
+                            assertThat(context).hasSingleBean(Model.class);
+                            assertThat(context).doesNotHaveBean(OllamaChatModel.class);
+                            assertThat(context.getBean(Model.class).getModelName())
+                                    .isEqualTo("custom-model");
+                        });
+    }
+
+    @Test
+    void shouldIntegrateWithGenericAgentscopeAutoConfiguration() {
+        new ApplicationContextRunner()
+                .withConfiguration(
+                        AutoConfigurations.of(
+                                OllamaAutoConfiguration.class, AgentscopeAutoConfiguration.class))
+                .withPropertyValues(
+                        "agentscope.agent.enabled=true",
+                        "agentscope.model.provider=ollama",
+                        "agentscope.ollama.model-name=llama3")
+                .run(
+                        context -> {
+                            assertThat(context).hasSingleBean(Model.class);
+                            assertThat(context).hasSingleBean(OllamaChatModel.class);
+                            assertThat(context).hasSingleBean(ReActAgent.class);
+                        });
+    }
+
+    @Test
+    void shouldApplyOllamaChatModelBuilderCustomizer() {
+        contextRunner
+                .withUserConfiguration(CustomBuilderConfiguration.class)
+                .withPropertyValues(
+                        "agentscope.model.provider=ollama", "agentscope.ollama.model-name=llama3")
+                .run(
+                        context -> {
+                            OllamaChatModel model = context.getBean(OllamaChatModel.class);
+                            assertThat(model.getModelName()).isEqualTo("customized-model-name");
+                        });
+    }
+
+    @Test
+    void shouldDelegateAcceptToCustomizeOnOllamaChatModelBuilderCustomizer() {
+        OllamaChatModel.Builder builder = OllamaChatModel.builder().modelName("original");
+        OllamaChatModelBuilderCustomizer customizer = b -> b.modelName("customized");
+
+        customizer.accept(builder);
+
+        assertThat(builder.build().getModelName()).isEqualTo("customized");
+    }
+
+    @Configuration(proxyBeanMethods = false)
+    static class CustomModelConfiguration {
+
+        @Bean
+        Model customModel() {
+            return new TestModel();
+        }
+    }
+
+    @Configuration(proxyBeanMethods = false)
+    static class CustomBuilderConfiguration {
+
+        @Bean
+        OllamaChatModelBuilderCustomizer testOllamaChatModelBuilderCustomizer() {
+            return builder -> builder.modelName("customized-model-name");
+        }
+    }
+
+    private static final class TestModel implements Model {
+        @Override
+        public Flux<ChatResponse> stream(
+                List<Msg> messages, List<ToolSchema> tools, GenerateOptions options) {
+            return Flux.empty();
+        }
+
+        @Override
+        public String getModelName() {
+            return "custom-model";
+        }
+    }
+}

--- a/agentscope-extensions/agentscope-spring-boot-starters/agentscope-ollama-spring-boot-starter/src/test/java/io/agentscope/spring/boot/ollama/OllamaAutoConfigurationTest.java
+++ b/agentscope-extensions/agentscope-spring-boot-starters/agentscope-ollama-spring-boot-starter/src/test/java/io/agentscope/spring/boot/ollama/OllamaAutoConfigurationTest.java
@@ -62,6 +62,12 @@ class OllamaAutoConfigurationTest {
                         "agentscope.ollama.base-url=http://ollama.example.com:11434")
                 .run(
                         context -> {
+                            OllamaProperties properties = context.getBean(OllamaProperties.class);
+                            assertThat(properties.isEnabled()).isTrue();
+                            assertThat(properties.getModelName()).isEqualTo("llama3.2");
+                            assertThat(properties.getBaseUrl())
+                                    .isEqualTo("http://ollama.example.com:11434");
+
                             OllamaChatModel model = context.getBean(OllamaChatModel.class);
                             assertThat(model.getModelName()).isEqualTo("llama3.2");
                         });
@@ -89,13 +95,15 @@ class OllamaAutoConfigurationTest {
                         "agentscope.ollama.model-name=llama3")
                 .run(
                         context -> {
+                            assertThat(context.getBean(OllamaProperties.class).isEnabled())
+                                    .isFalse();
                             assertThat(context).doesNotHaveBean(Model.class);
                             assertThat(context).doesNotHaveBean(OllamaChatModel.class);
                         });
     }
 
     @Test
-    void shouldFailClearlyWhenModelNameMissing() {
+    void shouldFailClearlyWhenModelNameBlank() {
         contextRunner
                 .withPropertyValues(
                         "agentscope.model.provider=ollama", "agentscope.ollama.model-name= ")

--- a/agentscope-extensions/agentscope-spring-boot-starters/pom.xml
+++ b/agentscope-extensions/agentscope-spring-boot-starters/pom.xml
@@ -42,6 +42,7 @@
         <module>agentscope-dashscope-spring-boot-starter</module>
         <module>agentscope-gemini-spring-boot-starter</module>
         <module>agentscope-anthropic-spring-boot-starter</module>
+        <module>agentscope-ollama-spring-boot-starter</module>
         <module>agentscope-a2a-spring-boot-starter</module>
         <module>agentscope-agui-spring-boot-starter</module>
         <module>agentscope-chat-completions-web-starter</module>

--- a/docs/v2/en/docs/building-blocks/model.md
+++ b/docs/v2/en/docs/building-blocks/model.md
@@ -100,7 +100,7 @@ ReActAgent agent =
 
 ### Spring Boot applications
 
-For Spring Boot, prefer provider-specific starters such as `agentscope-openai-spring-boot-starter`, `agentscope-dashscope-spring-boot-starter`, `agentscope-gemini-spring-boot-starter`, and `agentscope-anthropic-spring-boot-starter`. These starters directly depend on the matching model extension, create Spring-managed `Model` beans, and leave the generic starter focused on common AgentScope infrastructure. They do not create models through the static `ModelRegistry`; advanced users can always provide their own `Model` bean.
+For Spring Boot, prefer provider-specific starters such as `agentscope-openai-spring-boot-starter`, `agentscope-dashscope-spring-boot-starter`, `agentscope-gemini-spring-boot-starter`, `agentscope-anthropic-spring-boot-starter`, and `agentscope-ollama-spring-boot-starter`. These starters directly depend on the matching model extension, create Spring-managed `Model` beans, and leave the generic starter focused on common AgentScope infrastructure. They do not create models through the static `ModelRegistry`; advanced users can always provide their own `Model` bean.
 
 OpenAI example:
 
@@ -127,6 +127,7 @@ default generation options, proxy/client settings, or provider-specific flags.
 | `agentscope-dashscope-spring-boot-starter` | `DashScopeChatModelBuilderCustomizer` |
 | `agentscope-gemini-spring-boot-starter` | `GeminiChatModelBuilderCustomizer` |
 | `agentscope-anthropic-spring-boot-starter` | `AnthropicChatModelBuilderCustomizer` |
+| `agentscope-ollama-spring-boot-starter` | `OllamaChatModelBuilderCustomizer` |
 
 Customizer beans are applied after starter properties are bound and before
 `builder.build()` is called. Multiple customizers are supported and follow Spring's

--- a/docs/v2/en/docs/change-log.md
+++ b/docs/v2/en/docs/change-log.md
@@ -75,8 +75,7 @@ Spring Boot applications should use the provider-specific starters instead of re
 | DashScope | `agentscope-dashscope-spring-boot-starter` |
 | Gemini | `agentscope-gemini-spring-boot-starter` |
 | Anthropic | `agentscope-anthropic-spring-boot-starter` |
-
-Ollama currently has no dedicated Spring Boot starter; use `agentscope-extensions-model-ollama` with `ModelRegistry` or an explicit `OllamaChatModel.builder()`.
+| Ollama | `agentscope-ollama-spring-boot-starter` |
 
 Detail → [Model](building-blocks/model.md), [Model Providers](../integration/overview.md)
 

--- a/docs/v2/en/integration/model/ollama.md
+++ b/docs/v2/en/integration/model/ollama.md
@@ -38,6 +38,26 @@ OllamaChatModel model = OllamaChatModel.builder()
 
 ## Spring Boot
 
-There is currently no dedicated Ollama Spring Boot starter.
+Spring Boot applications can use the Ollama starter:
+
+```xml
+<dependency>
+    <groupId>io.agentscope</groupId>
+    <artifactId>agentscope-ollama-spring-boot-starter</artifactId>
+    <version>${agentscope.version}</version>
+</dependency>
+```
+
+Configure the local Ollama model with `agentscope.model.provider=ollama`. The base URL
+is optional and defaults to `http://localhost:11434`:
+
+```yaml
+agentscope:
+  model:
+    provider: ollama
+  ollama:
+    model-name: llama3
+    # base-url: http://localhost:11434
+```
 
 Full builder options, formatters, credentials, and registry context details are covered in [Model](../../docs/building-blocks/model.md).

--- a/docs/v2/zh/docs/building-blocks/model.md
+++ b/docs/v2/zh/docs/building-blocks/model.md
@@ -100,7 +100,7 @@ ReActAgent agent =
 
 ### Spring Boot 应用
 
-Spring Boot 场景下，优先使用特定模型提供商的 starter，例如 `agentscope-openai-spring-boot-starter`、`agentscope-dashscope-spring-boot-starter`、`agentscope-gemini-spring-boot-starter`、`agentscope-anthropic-spring-boot-starter`。这些 starter 直接依赖对应模型扩展模块，创建 Spring 管理的 `Model` bean，通用的 `agentscope-spring-boot-starter` 继续负责 AgentScope 的公共基础设施。它们不会通过静态 `ModelRegistry` 创建模型；高级用户始终可以自定义 `Model` bean。
+Spring Boot 场景下，优先使用特定模型提供商的 starter，例如 `agentscope-openai-spring-boot-starter`、`agentscope-dashscope-spring-boot-starter`、`agentscope-gemini-spring-boot-starter`、`agentscope-anthropic-spring-boot-starter`、`agentscope-ollama-spring-boot-starter`。这些 starter 直接依赖对应模型扩展模块，创建 Spring 管理的 `Model` bean，通用的 `agentscope-spring-boot-starter` 继续负责 AgentScope 的公共基础设施。它们不会通过静态 `ModelRegistry` 创建模型；高级用户始终可以自定义 `Model` bean。
 
 OpenAI 示例：
 
@@ -126,6 +126,7 @@ formatter、默认生成参数、代理/client 配置，或其他提供商专属
 | `agentscope-dashscope-spring-boot-starter` | `DashScopeChatModelBuilderCustomizer` |
 | `agentscope-gemini-spring-boot-starter` | `GeminiChatModelBuilderCustomizer` |
 | `agentscope-anthropic-spring-boot-starter` | `AnthropicChatModelBuilderCustomizer` |
+| `agentscope-ollama-spring-boot-starter` | `OllamaChatModelBuilderCustomizer` |
 
 这些 customizer 会在 starter 属性绑定之后、调用 `builder.build()` 之前执行。可以注册多个
 customizer，并通过 Spring 的 `@Order` 或 `Ordered` 控制执行顺序。

--- a/docs/v2/zh/docs/change-log.md
+++ b/docs/v2/zh/docs/change-log.md
@@ -75,8 +75,7 @@ Spring Boot 应用应使用对应模型提供商的 starter，而不是依赖 co
 | DashScope | `agentscope-dashscope-spring-boot-starter` |
 | Gemini | `agentscope-gemini-spring-boot-starter` |
 | Anthropic | `agentscope-anthropic-spring-boot-starter` |
-
-Ollama 目前没有专属 Spring Boot starter；请通过 `agentscope-extensions-model-ollama` 配合 `ModelRegistry` 或显式 `OllamaChatModel.builder()` 使用。
+| Ollama | `agentscope-ollama-spring-boot-starter` |
 
 详见 → [模型](building-blocks/model.md)、[模型提供商](../integration/overview.md)
 

--- a/docs/v2/zh/integration/model/ollama.md
+++ b/docs/v2/zh/integration/model/ollama.md
@@ -38,6 +38,26 @@ OllamaChatModel model = OllamaChatModel.builder()
 
 ## Spring Boot
 
-当前没有专属 Ollama Spring Boot starter。
+Spring Boot 应用可以使用 Ollama starter：
+
+```xml
+<dependency>
+    <groupId>io.agentscope</groupId>
+    <artifactId>agentscope-ollama-spring-boot-starter</artifactId>
+    <version>${agentscope.version}</version>
+</dependency>
+```
+
+通过 `agentscope.model.provider=ollama` 配置本地 Ollama 模型。base URL 为可选项，默认是
+`http://localhost:11434`：
+
+```yaml
+agentscope:
+  model:
+    provider: ollama
+  ollama:
+    model-name: llama3
+    # base-url: http://localhost:11434
+```
 
 完整 builder 选项、formatter、credential 和 registry context 细节见 [模型](../../docs/building-blocks/model.md)。


### PR DESCRIPTION
## AgentScope-Java Version

2.0.1-SNAPSHOT

## Description

Adds `agentscope-ollama-spring-boot-starter` for Spring-managed Ollama `Model` auto-configuration, following the same pattern as the existing OpenAI, DashScope, Gemini, and Anthropic model starters.

## Changes

### New module: `agentscope-ollama-spring-boot-starter`

- **`OllamaAutoConfiguration`** — creates an `OllamaChatModel` bean when `agentscope.model.provider=ollama`, with backoff when a user-defined `Model` bean already exists
- **`OllamaProperties`** — binds `agentscope.ollama.*` (`enabled`, `model-name`, `base-url`)
- **`OllamaChatModelBuilderCustomizer`** — hook for advanced builder customization
- **`OllamaAutoConfigurationTest`** — 9 unit tests covering provider selection, property binding, disable flag, missing model name, bean backoff, generic `AgentscopeAutoConfiguration` integration, and customizer behavior
- **Spring registration** — `META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports`

### Reactor & distribution

- Registered module in `agentscope-spring-boot-starters/pom.xml`
- Added to `agentscope-bom/pom.xml`

### Documentation (EN + ZH)

- Updated Ollama integration guides with Spring Boot starter usage
- Added `agentscope-ollama-spring-boot-starter` to model building-blocks and change-log tables
- Removed all claims that an Ollama Spring Boot starter is unavailable

## Example configuration

```yaml
agentscope:
  model:
    provider: ollama
  ollama:
    enabled: true
    model-name: llama3
    # base-url: http://localhost:11434  # optional
```

## Validation

| Check | Result |
|-------|--------|
| `mvn spotless:apply` on Ollama starter | Pass |
| `mvn spotless:check` on Ollama starter | Pass |
| `mvn test` on Ollama starter (9 tests) | Pass — 9 run, 0 failures, 0 errors |
| JaCoCo coverage report (Ollama starter) | Pass — 3 classes analyzed |
| `.github/scripts/check-shade-and-bom-sync.sh` | Pass — module synced to BOM |
| `git diff --check` | Pass — no whitespace/conflict issues |
| Stale "no Ollama starter" doc scan | Pass — no remaining claims |

**Test command used:**

```bash
mvn -pl agentscope-extensions/agentscope-spring-boot-starters/agentscope-ollama-spring-boot-starter test
```

## Checklist

- [x] Code has been formatted with `mvn spotless:apply`
- [x] All tests are passing (`mvn test` on Ollama starter module)
- [x] Javadoc comments are complete and follow project conventions
- [x] Related documentation has been updated
- [x] Code is ready for review

## Closes
#2172 