### PR TITLE
feat(harness): resume permission-suspended subagent tasks

### DIFF
--- a/agentscope-core/src/main/java/io/agentscope/core/ReActAgent.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/ReActAgent.java
@@ -3675,10 +3675,29 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
     public void setPermissionMode(String userId, String sessionId, PermissionMode mode) {
         Objects.requireNonNull(mode, "mode must not be null");
         String sid = (sessionId == null || sessionId.isBlank()) ? defaultSessionId : sessionId;
-        String slot = slotKey(userId, sid);
         AgentState s = getAgentState(userId, sid);
-        s.setPermissionContext(s.getPermissionContext().withMode(mode));
-        permissionEngineCache.put(slot, new PermissionEngine(s.getPermissionContext()));
+        replacePermissionContext(userId, sid, s.getPermissionContext().withMode(mode));
+    }
+
+    /**
+     * Replaces the permission context for one {@code (userId, sessionId)} slot, rebuilds that
+     * slot's permission engine and persists the updated state.
+     *
+     * <p>An in-flight call keeps the call-scoped engine it started with. The replacement applies
+     * to subsequent calls on this slot and does not affect any other user or session.
+     *
+     * @param userId user identity for the slot (may be {@code null})
+     * @param sessionId session identity (falls back to the default session id when {@code null})
+     * @param permissionContext complete replacement context
+     */
+    public void replacePermissionContext(
+            String userId, String sessionId, PermissionContextState permissionContext) {
+        Objects.requireNonNull(permissionContext, "permissionContext must not be null");
+        String sid = (sessionId == null || sessionId.isBlank()) ? defaultSessionId : sessionId;
+        String slot = slotKey(userId, sid);
+        AgentState state = getAgentState(userId, sid);
+        state.setPermissionContext(permissionContext);
+        permissionEngineCache.put(slot, new PermissionEngine(permissionContext));
         saveAgentState(userId, sid);
     }
 

--- a/agentscope-core/src/main/java/io/agentscope/core/permission/PermissionContextState.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/permission/PermissionContextState.java
@@ -17,6 +17,7 @@ package io.agentscope.core.permission;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import java.util.ArrayList;
@@ -34,7 +35,17 @@ import java.util.Objects;
  * that tool. The engine evaluates {@code denyRules} first, then {@code askRules}, then tool
  * self-check, then {@code allowRules}; see the {@code PermissionEngine} javadoc for full ordering.
  */
-@JsonPropertyOrder({"mode", "working_directories", "allow_rules", "deny_rules", "ask_rules"})
+@JsonPropertyOrder({
+    "mode",
+    "working_directories",
+    "allow_rules",
+    "deny_rules",
+    "ask_rules",
+    "inherited_working_directories",
+    "inherited_allow_rules",
+    "inherited_deny_rules",
+    "inherited_ask_rules"
+})
 public final class PermissionContextState {
 
     private final PermissionMode mode;
@@ -42,6 +53,10 @@ public final class PermissionContextState {
     private final Map<String, List<PermissionRule>> allowRules;
     private final Map<String, List<PermissionRule>> denyRules;
     private final Map<String, List<PermissionRule>> askRules;
+    private final Map<String, AdditionalWorkingDirectory> inheritedWorkingDirectories;
+    private final Map<String, List<PermissionRule>> inheritedAllowRules;
+    private final Map<String, List<PermissionRule>> inheritedDenyRules;
+    private final Map<String, List<PermissionRule>> inheritedAskRules;
 
     private PermissionContextState(Builder builder) {
         this.mode = builder.mode == null ? PermissionMode.DEFAULT : builder.mode;
@@ -50,6 +65,12 @@ public final class PermissionContextState {
         this.allowRules = freeze(builder.allowRules);
         this.denyRules = freeze(builder.denyRules);
         this.askRules = freeze(builder.askRules);
+        this.inheritedWorkingDirectories =
+                Collections.unmodifiableMap(
+                        new LinkedHashMap<>(builder.inheritedWorkingDirectories));
+        this.inheritedAllowRules = freeze(builder.inheritedAllowRules);
+        this.inheritedDenyRules = freeze(builder.inheritedDenyRules);
+        this.inheritedAskRules = freeze(builder.inheritedAskRules);
     }
 
     @JsonCreator
@@ -59,7 +80,15 @@ public final class PermissionContextState {
                     Map<String, AdditionalWorkingDirectory> workingDirectories,
             @JsonProperty("allow_rules") Map<String, List<PermissionRule>> allowRules,
             @JsonProperty("deny_rules") Map<String, List<PermissionRule>> denyRules,
-            @JsonProperty("ask_rules") Map<String, List<PermissionRule>> askRules) {
+            @JsonProperty("ask_rules") Map<String, List<PermissionRule>> askRules,
+            @JsonProperty("inherited_working_directories")
+                    Map<String, AdditionalWorkingDirectory> inheritedWorkingDirectories,
+            @JsonProperty("inherited_allow_rules")
+                    Map<String, List<PermissionRule>> inheritedAllowRules,
+            @JsonProperty("inherited_deny_rules")
+                    Map<String, List<PermissionRule>> inheritedDenyRules,
+            @JsonProperty("inherited_ask_rules")
+                    Map<String, List<PermissionRule>> inheritedAskRules) {
         Builder b = builder();
         if (mode != null) {
             b.mode(mode);
@@ -70,6 +99,12 @@ public final class PermissionContextState {
         copyInto(allowRules, b::addAllowRule);
         copyInto(denyRules, b::addDenyRule);
         copyInto(askRules, b::addAskRule);
+        if (inheritedWorkingDirectories != null) {
+            inheritedWorkingDirectories.forEach(b::markInheritedWorkingDirectory);
+        }
+        copyInto(inheritedAllowRules, b::markInheritedAllowRule);
+        copyInto(inheritedDenyRules, b::markInheritedDenyRule);
+        copyInto(inheritedAskRules, b::markInheritedAskRule);
         return b.build();
     }
 
@@ -133,6 +168,30 @@ public final class PermissionContextState {
         return askRules;
     }
 
+    @JsonProperty("inherited_working_directories")
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public Map<String, AdditionalWorkingDirectory> getInheritedWorkingDirectories() {
+        return inheritedWorkingDirectories;
+    }
+
+    @JsonProperty("inherited_allow_rules")
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public Map<String, List<PermissionRule>> getInheritedAllowRules() {
+        return inheritedAllowRules;
+    }
+
+    @JsonProperty("inherited_deny_rules")
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public Map<String, List<PermissionRule>> getInheritedDenyRules() {
+        return inheritedDenyRules;
+    }
+
+    @JsonProperty("inherited_ask_rules")
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public Map<String, List<PermissionRule>> getInheritedAskRules() {
+        return inheritedAskRules;
+    }
+
     public static Builder builder() {
         return new Builder();
     }
@@ -156,6 +215,10 @@ public final class PermissionContextState {
         copyInto(allowRules, b::addAllowRule);
         copyInto(denyRules, b::addDenyRule);
         copyInto(askRules, b::addAskRule);
+        inheritedWorkingDirectories.forEach(b::markInheritedWorkingDirectory);
+        copyInto(inheritedAllowRules, b::markInheritedAllowRule);
+        copyInto(inheritedDenyRules, b::markInheritedDenyRule);
+        copyInto(inheritedAskRules, b::markInheritedAskRule);
         return b.build();
     }
 
@@ -175,27 +238,73 @@ public final class PermissionContextState {
     public PermissionContextState inheritFrom(PermissionContextState parent) {
         Objects.requireNonNull(parent, "parent must not be null");
         Builder b = builder().mode(mode);
-        workingDirectories.forEach(b::addWorkingDirectory);
+        Map<String, AdditionalWorkingDirectory> localWorkingDirectories =
+                withoutInheritedWorkingDirectories();
+        localWorkingDirectories.forEach(b::addWorkingDirectory);
         parent.workingDirectories.forEach(
                 (key, directory) -> {
-                    if (!workingDirectories.containsKey(key)) {
+                    if (!localWorkingDirectories.containsKey(key)) {
                         b.addWorkingDirectory(key, directory);
+                        b.markInheritedWorkingDirectory(key, directory);
                     }
                 });
-        copyMergedRules(allowRules, parent.allowRules, b::addAllowRule);
-        copyMergedRules(denyRules, parent.denyRules, b::addDenyRule);
-        copyMergedRules(askRules, parent.askRules, b::addAskRule);
+        copyRebasedRules(
+                allowRules,
+                inheritedAllowRules,
+                parent.allowRules,
+                b::addAllowRule,
+                b::markInheritedAllowRule);
+        copyRebasedRules(
+                denyRules,
+                inheritedDenyRules,
+                parent.denyRules,
+                b::addDenyRule,
+                b::markInheritedDenyRule);
+        copyRebasedRules(
+                askRules,
+                inheritedAskRules,
+                parent.askRules,
+                b::addAskRule,
+                b::markInheritedAskRule);
         return b.build();
     }
 
-    private static void copyMergedRules(
-            Map<String, List<PermissionRule>> child,
+    private Map<String, AdditionalWorkingDirectory> withoutInheritedWorkingDirectories() {
+        Map<String, AdditionalWorkingDirectory> local = new LinkedHashMap<>(workingDirectories);
+        inheritedWorkingDirectories.forEach((key, directory) -> local.remove(key, directory));
+        return local;
+    }
+
+    private static void copyRebasedRules(
+            Map<String, List<PermissionRule>> effectiveChild,
+            Map<String, List<PermissionRule>> inheritedChild,
             Map<String, List<PermissionRule>> parent,
-            RuleAdder adder) {
-        Map<String, LinkedHashSet<PermissionRule>> merged = new LinkedHashMap<>();
-        collectDistinctRules(merged, child);
-        collectDistinctRules(merged, parent);
-        merged.forEach((tool, rules) -> rules.forEach(rule -> adder.add(tool, rule)));
+            RuleAdder effectiveAdder,
+            RuleAdder inheritedAdder) {
+        Map<String, LinkedHashSet<PermissionRule>> local = new LinkedHashMap<>();
+        collectDistinctRules(local, effectiveChild);
+        inheritedChild.forEach(
+                (tool, rules) -> {
+                    LinkedHashSet<PermissionRule> localRules = local.get(tool);
+                    if (localRules != null) {
+                        localRules.removeAll(rules);
+                        if (localRules.isEmpty()) {
+                            local.remove(tool);
+                        }
+                    }
+                });
+        local.forEach((tool, rules) -> rules.forEach(rule -> effectiveAdder.add(tool, rule)));
+        parent.forEach(
+                (tool, rules) -> {
+                    LinkedHashSet<PermissionRule> mergedRules =
+                            local.computeIfAbsent(tool, ignored -> new LinkedHashSet<>());
+                    for (PermissionRule rule : rules) {
+                        if (mergedRules.add(rule)) {
+                            effectiveAdder.add(tool, rule);
+                            inheritedAdder.add(tool, rule);
+                        }
+                    }
+                });
     }
 
     private static void collectDistinctRules(
@@ -219,12 +328,25 @@ public final class PermissionContextState {
                 && Objects.equals(workingDirectories, other.workingDirectories)
                 && Objects.equals(allowRules, other.allowRules)
                 && Objects.equals(denyRules, other.denyRules)
-                && Objects.equals(askRules, other.askRules);
+                && Objects.equals(askRules, other.askRules)
+                && Objects.equals(inheritedWorkingDirectories, other.inheritedWorkingDirectories)
+                && Objects.equals(inheritedAllowRules, other.inheritedAllowRules)
+                && Objects.equals(inheritedDenyRules, other.inheritedDenyRules)
+                && Objects.equals(inheritedAskRules, other.inheritedAskRules);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(mode, workingDirectories, allowRules, denyRules, askRules);
+        return Objects.hash(
+                mode,
+                workingDirectories,
+                allowRules,
+                denyRules,
+                askRules,
+                inheritedWorkingDirectories,
+                inheritedAllowRules,
+                inheritedDenyRules,
+                inheritedAskRules);
     }
 
     @Override
@@ -254,6 +376,11 @@ public final class PermissionContextState {
         private final Map<String, List<PermissionRule>> allowRules = new LinkedHashMap<>();
         private final Map<String, List<PermissionRule>> denyRules = new LinkedHashMap<>();
         private final Map<String, List<PermissionRule>> askRules = new LinkedHashMap<>();
+        private final Map<String, AdditionalWorkingDirectory> inheritedWorkingDirectories =
+                new LinkedHashMap<>();
+        private final Map<String, List<PermissionRule>> inheritedAllowRules = new LinkedHashMap<>();
+        private final Map<String, List<PermissionRule>> inheritedDenyRules = new LinkedHashMap<>();
+        private final Map<String, List<PermissionRule>> inheritedAskRules = new LinkedHashMap<>();
 
         private Builder() {}
 
@@ -282,6 +409,23 @@ public final class PermissionContextState {
         public Builder addAskRule(String toolName, PermissionRule rule) {
             appendRule(askRules, toolName, rule);
             return this;
+        }
+
+        private void markInheritedWorkingDirectory(
+                String key, AdditionalWorkingDirectory directory) {
+            inheritedWorkingDirectories.put(key, directory);
+        }
+
+        private void markInheritedAllowRule(String toolName, PermissionRule rule) {
+            appendRule(inheritedAllowRules, toolName, rule);
+        }
+
+        private void markInheritedDenyRule(String toolName, PermissionRule rule) {
+            appendRule(inheritedDenyRules, toolName, rule);
+        }
+
+        private void markInheritedAskRule(String toolName, PermissionRule rule) {
+            appendRule(inheritedAskRules, toolName, rule);
         }
 
         private static void appendRule(

--- a/agentscope-core/src/main/java/io/agentscope/core/permission/PermissionContextState.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/permission/PermissionContextState.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -156,6 +157,54 @@ public final class PermissionContextState {
         copyInto(denyRules, b::addDenyRule);
         copyInto(askRules, b::addAskRule);
         return b.build();
+    }
+
+    /**
+     * Returns an immutable child permission context that also carries the supplied parent scope
+     * and rules.
+     *
+     * <p>The child mode and child entries take precedence. Parent working directories are added
+     * only when the child does not already define the same key. Rule tables retain child-first
+     * insertion order and de-duplicate equal rules before appending parent rules. Permission
+     * evaluation still applies the engine's deny/ask/tool-check/allow ordering, so inherited deny
+     * and ask rules cannot be bypassed by an inherited allow rule.
+     *
+     * @param parent the parent context to inherit
+     * @return a new merged context; neither source context is mutated
+     */
+    public PermissionContextState inheritFrom(PermissionContextState parent) {
+        Objects.requireNonNull(parent, "parent must not be null");
+        Builder b = builder().mode(mode);
+        workingDirectories.forEach(b::addWorkingDirectory);
+        parent.workingDirectories.forEach(
+                (key, directory) -> {
+                    if (!workingDirectories.containsKey(key)) {
+                        b.addWorkingDirectory(key, directory);
+                    }
+                });
+        copyMergedRules(allowRules, parent.allowRules, b::addAllowRule);
+        copyMergedRules(denyRules, parent.denyRules, b::addDenyRule);
+        copyMergedRules(askRules, parent.askRules, b::addAskRule);
+        return b.build();
+    }
+
+    private static void copyMergedRules(
+            Map<String, List<PermissionRule>> child,
+            Map<String, List<PermissionRule>> parent,
+            RuleAdder adder) {
+        Map<String, LinkedHashSet<PermissionRule>> merged = new LinkedHashMap<>();
+        collectDistinctRules(merged, child);
+        collectDistinctRules(merged, parent);
+        merged.forEach((tool, rules) -> rules.forEach(rule -> adder.add(tool, rule)));
+    }
+
+    private static void collectDistinctRules(
+            Map<String, LinkedHashSet<PermissionRule>> target,
+            Map<String, List<PermissionRule>> source) {
+        source.forEach(
+                (tool, rules) ->
+                        target.computeIfAbsent(tool, ignored -> new LinkedHashSet<>())
+                                .addAll(rules));
     }
 
     @Override

--- a/agentscope-core/src/test/java/io/agentscope/core/agent/ReActAgentHitlTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/agent/ReActAgentHitlTest.java
@@ -39,9 +39,12 @@ import io.agentscope.core.model.ChatModelBase;
 import io.agentscope.core.model.ChatResponse;
 import io.agentscope.core.model.GenerateOptions;
 import io.agentscope.core.model.ToolSchema;
+import io.agentscope.core.permission.PermissionBehavior;
 import io.agentscope.core.permission.PermissionContextState;
 import io.agentscope.core.permission.PermissionDecision;
+import io.agentscope.core.permission.PermissionRule;
 import io.agentscope.core.state.AgentState;
+import io.agentscope.core.state.InMemoryAgentStateStore;
 import io.agentscope.core.tool.ToolBase;
 import io.agentscope.core.tool.ToolCallParam;
 import io.agentscope.core.tool.Toolkit;
@@ -396,5 +399,49 @@ class ReActAgentHitlTest {
         ToolResultEndEvent end =
                 (ToolResultEndEvent) events.get(indexOf(events, ToolResultEndEvent.class));
         assertEquals(ToolResultState.SUCCESS, end.getState());
+    }
+
+    @Test
+    void replacePermissionContextUpdatesPersistedStateAndNextCallEngine() {
+        InMemoryAgentStateStore stateStore = new InMemoryAgentStateStore();
+        ChatModelBase model =
+                new ScriptedModel(List.of(() -> Flux.just(toolUseResponse("tc1", "allow", "x"))));
+        ReActAgent agent =
+                ReActAgent.builder()
+                        .name("asst")
+                        .model(model)
+                        .toolkit(toolkitWith(new AllowingTool("allow")))
+                        .stateStore(stateStore)
+                        .build();
+        agent.getAgentState("user-a", "slot-a");
+        AgentState otherUserState = agent.getAgentState("user-b", "slot-a");
+        PermissionContextState replacement =
+                PermissionContextState.builder()
+                        .addAskRule(
+                                "allow",
+                                new PermissionRule("allow", null, PermissionBehavior.ASK, "parent"))
+                        .build();
+
+        agent.replacePermissionContext("user-a", "slot-a", replacement);
+
+        AgentState persisted =
+                stateStore.get("user-a", "slot-a", "agent_state", AgentState.class).orElseThrow();
+        assertEquals(replacement, persisted.getPermissionContext());
+        List<AgentEvent> events =
+                agent.streamEvents(
+                                List.of(),
+                                RuntimeContext.builder()
+                                        .userId("user-a")
+                                        .sessionId("slot-a")
+                                        .build())
+                        .collectList()
+                        .block();
+        assertNotNull(events);
+        assertTrue(indexOf(events, RequireUserConfirmEvent.class) >= 0);
+        assertTrue(indexOf(events, RequestStopEvent.class) >= 0);
+        assertTrue(otherUserState.getPermissionContext().isTrivial());
+        assertThrows(
+                NullPointerException.class,
+                () -> agent.replacePermissionContext("user-a", "slot-a", null));
     }
 }

--- a/agentscope-core/src/test/java/io/agentscope/core/permission/PermissionContextStateTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/permission/PermissionContextStateTest.java
@@ -118,6 +118,7 @@ class PermissionContextStateTest {
         String json = mapper.writeValueAsString(original);
         PermissionContextState decoded = mapper.readValue(json, PermissionContextState.class);
         assertEquals(original, decoded);
+        assertTrue(!json.contains("inherited_"));
     }
 
     @Test
@@ -168,5 +169,57 @@ class PermissionContextStateTest {
         PermissionContextState child = PermissionContextState.builder().build();
 
         assertThrows(NullPointerException.class, () -> child.inheritFrom(null));
+    }
+
+    @Test
+    void reinheritFromReplacesOnlyPreviouslyInheritedEntries() throws Exception {
+        PermissionRule childRule =
+                new PermissionRule("Read", "child/**", PermissionBehavior.ALLOW, "child");
+        PermissionRule duplicateChildRule =
+                new PermissionRule("Bash", "git status", PermissionBehavior.ALLOW, "shared");
+        PermissionRule parentV1Rule =
+                new PermissionRule("Read", "parent-v1/**", PermissionBehavior.ALLOW, "parent-v1");
+        PermissionRule parentV2Rule =
+                new PermissionRule("Read", "parent-v2/**", PermissionBehavior.ALLOW, "parent-v2");
+        PermissionContextState child =
+                PermissionContextState.builder()
+                        .addWorkingDirectory(
+                                "child", new AdditionalWorkingDirectory("/child", "child"))
+                        .addAllowRule("Read", childRule)
+                        .addAllowRule("Bash", duplicateChildRule)
+                        .build();
+        PermissionContextState parentV1 =
+                PermissionContextState.builder()
+                        .addWorkingDirectory(
+                                "parent-v1",
+                                new AdditionalWorkingDirectory("/parent-v1", "parent-v1"))
+                        .addAllowRule("Read", parentV1Rule)
+                        .addAllowRule("Bash", duplicateChildRule)
+                        .build();
+        PermissionContextState persisted =
+                mapper.readValue(
+                        mapper.writeValueAsString(child.inheritFrom(parentV1)),
+                        PermissionContextState.class);
+        PermissionContextState parentV2 =
+                PermissionContextState.builder()
+                        .addWorkingDirectory(
+                                "parent-v2",
+                                new AdditionalWorkingDirectory("/parent-v2", "parent-v2"))
+                        .addAllowRule("Read", parentV2Rule)
+                        .build();
+
+        PermissionContextState reinherited = persisted.inheritFrom(parentV2);
+
+        assertEquals(
+                java.util.List.of(childRule, parentV2Rule),
+                reinherited.getAllowRules().get("Read"));
+        assertEquals(
+                java.util.List.of(duplicateChildRule), reinherited.getAllowRules().get("Bash"));
+        assertTrue(reinherited.getWorkingDirectories().containsKey("child"));
+        assertTrue(reinherited.getWorkingDirectories().containsKey("parent-v2"));
+        assertTrue(!reinherited.getWorkingDirectories().containsKey("parent-v1"));
+        assertEquals(
+                java.util.List.of(parentV2Rule), reinherited.getInheritedAllowRules().get("Read"));
+        assertTrue(!reinherited.getInheritedAllowRules().containsKey("Bash"));
     }
 }

--- a/agentscope-core/src/test/java/io/agentscope/core/permission/PermissionContextStateTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/permission/PermissionContextStateTest.java
@@ -16,6 +16,7 @@
 package io.agentscope.core.permission;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -117,5 +118,55 @@ class PermissionContextStateTest {
         String json = mapper.writeValueAsString(original);
         PermissionContextState decoded = mapper.readValue(json, PermissionContextState.class);
         assertEquals(original, decoded);
+    }
+
+    @Test
+    void inheritFromMergesParentScopeAndRulesWithoutMutatingEitherContext() {
+        AdditionalWorkingDirectory childShared =
+                new AdditionalWorkingDirectory("/child/shared", "child");
+        AdditionalWorkingDirectory parentShared =
+                new AdditionalWorkingDirectory("/parent/shared", "parent");
+        AdditionalWorkingDirectory parentOnly =
+                new AdditionalWorkingDirectory("/parent/only", "parent");
+        PermissionRule duplicateAllow =
+                new PermissionRule("Bash", "git status", PermissionBehavior.ALLOW, "shared");
+        PermissionRule parentDeny =
+                new PermissionRule("Bash", "rm -rf", PermissionBehavior.DENY, "parent");
+        PermissionRule parentAsk =
+                new PermissionRule("Write", "/etc/**", PermissionBehavior.ASK, "parent");
+        PermissionContextState child =
+                PermissionContextState.builder()
+                        .mode(PermissionMode.ACCEPT_EDITS)
+                        .addWorkingDirectory("shared", childShared)
+                        .addAllowRule("Bash", duplicateAllow)
+                        .build();
+        PermissionContextState parent =
+                PermissionContextState.builder()
+                        .mode(PermissionMode.DONT_ASK)
+                        .addWorkingDirectory("shared", parentShared)
+                        .addWorkingDirectory("parent-only", parentOnly)
+                        .addAllowRule("Bash", duplicateAllow)
+                        .addDenyRule("Bash", parentDeny)
+                        .addAskRule("Write", parentAsk)
+                        .build();
+
+        PermissionContextState inherited = child.inheritFrom(parent);
+
+        assertNotSame(child, inherited);
+        assertEquals(PermissionMode.ACCEPT_EDITS, inherited.getMode());
+        assertEquals(childShared, inherited.getWorkingDirectories().get("shared"));
+        assertEquals(parentOnly, inherited.getWorkingDirectories().get("parent-only"));
+        assertEquals(java.util.List.of(duplicateAllow), inherited.getAllowRules().get("Bash"));
+        assertEquals(java.util.List.of(parentDeny), inherited.getDenyRules().get("Bash"));
+        assertEquals(java.util.List.of(parentAsk), inherited.getAskRules().get("Write"));
+        assertEquals(1, child.getWorkingDirectories().size());
+        assertEquals(2, parent.getWorkingDirectories().size());
+    }
+
+    @Test
+    void inheritFromRejectsNullParent() {
+        PermissionContextState child = PermissionContextState.builder().build();
+
+        assertThrows(NullPointerException.class, () -> child.inheritFrom(null));
     }
 }

--- a/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agent-protocol/src/main/java/io/agentscope/extensions/agentprotocol/AgentProtocolTaskStore.java
+++ b/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agent-protocol/src/main/java/io/agentscope/extensions/agentprotocol/AgentProtocolTaskStore.java
@@ -297,9 +297,11 @@ public final class AgentProtocolTaskStore {
         return switch (s) {
             case PENDING -> "pending";
             case RUNNING -> "running";
+            case WAITING_FOR_APPROVAL -> "pending";
             case COMPLETED -> "success";
             case FAILED -> "error";
             case CANCELLED -> "cancelled";
+            case DENIED -> "error";
         };
     }
 }

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/HarnessAgent.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/HarnessAgent.java
@@ -449,6 +449,16 @@ public class HarnessAgent implements Agent, AutoCloseable {
         return null;
     }
 
+    /** Installs a customization applied after each native child materialization. */
+    public void setSubagentMaterializationCustomizer(
+            java.util.function.Consumer<Agent> customizer) {
+        io.agentscope.harness.agent.subagent.DefaultAgentManager manager =
+                getSubagentAgentManager();
+        if (manager != null) {
+            manager.setMaterializationCustomizer(customizer);
+        }
+    }
+
     /**
      * Resumes a background subagent task suspended for permission approval through the native
      * Harness task lifecycle.

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/HarnessAgent.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/HarnessAgent.java
@@ -556,8 +556,10 @@ public class HarnessAgent implements Agent, AutoCloseable {
         gw.bindMainAgent(this);
 
         SubagentGatewayBridge bridge =
-                (agentId, sessionId, agent, replyTo) -> {
-                    String subagentId = gw.exposeSubagent(agentId, sessionId, agent, replyTo);
+                (agentId, sessionId, agent, replyTo, userId, parentSessionId) -> {
+                    String subagentId =
+                            gw.exposeSubagent(
+                                    agentId, sessionId, agent, replyTo, userId, parentSessionId);
                     return new SubagentGatewayBridge.ExposeResult(subagentId);
                 };
         io.agentscope.harness.agent.subagent.DefaultAgentManager agentManager = null;

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/HarnessAgent.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/HarnessAgent.java
@@ -24,6 +24,7 @@ import io.agentscope.core.agent.StreamOptions;
 import io.agentscope.core.agent.config.ModelConfig;
 import io.agentscope.core.agent.config.ReactConfig;
 import io.agentscope.core.event.AgentEvent;
+import io.agentscope.core.event.ConfirmResult;
 import io.agentscope.core.hook.Hook;
 import io.agentscope.core.message.Msg;
 import io.agentscope.core.message.UserMessage;
@@ -445,6 +446,30 @@ public class HarnessAgent implements Agent, AutoCloseable {
             return dm.getAgentManager();
         }
         return null;
+    }
+
+    /**
+     * Resumes a background subagent task suspended for permission approval through the native
+     * Harness task lifecycle.
+     */
+    public boolean resumeSubagentTask(
+            RuntimeContext parentContext,
+            String taskId,
+            String replyId,
+            List<ConfirmResult> confirmResults) {
+        if (parentContext == null) {
+            return false;
+        }
+        AgentState parentState = delegate.getAgentState(parentContext);
+        if (subagentMiddleware instanceof SubagentsMiddleware sm) {
+            return sm.resumeSubagentTask(
+                    parentContext, parentState, taskId, replyId, confirmResults);
+        }
+        if (subagentMiddleware instanceof DynamicSubagentsMiddleware dm) {
+            return dm.resumeSubagentTask(
+                    parentContext, parentState, taskId, replyId, confirmResults);
+        }
+        return false;
     }
 
     /** @see ReActAgent#getDefaultSessionId() */

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/HarnessAgent.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/HarnessAgent.java
@@ -115,6 +115,7 @@ import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiFunction;
@@ -470,6 +471,38 @@ public class HarnessAgent implements Agent, AutoCloseable {
                     parentContext, parentState, taskId, replyId, confirmResults);
         }
         return false;
+    }
+
+    /**
+     * Resolves and resumes a waiting subagent task from the child-session approval context.
+     * Repository lookup remains user-scoped and owns the task-to-parent lineage.
+     */
+    public boolean resumeSubagentTask(
+            RuntimeContext childContext,
+            String childSessionId,
+            List<ConfirmResult> confirmResults) {
+        if (childContext == null || childSessionId == null || childSessionId.isBlank()) {
+            return false;
+        }
+        TaskRepository repository = null;
+        if (subagentMiddleware instanceof SubagentsMiddleware sm) {
+            repository = sm.getTaskRepository();
+        } else if (subagentMiddleware instanceof DynamicSubagentsMiddleware dm) {
+            repository = dm.getTaskRepository();
+        }
+        if (repository == null) {
+            return false;
+        }
+        Optional<TaskRepository.SuspendedTaskRef> suspended =
+                repository.findSuspendedTaskByChildSession(childContext, childSessionId);
+        if (suspended.isEmpty()) {
+            return false;
+        }
+        TaskRepository.SuspendedTaskRef ref = suspended.get();
+        RuntimeContext parentContext =
+                RuntimeContext.builder(childContext).sessionId(ref.parentSessionId()).build();
+        return resumeSubagentTask(
+                parentContext, ref.taskId(), ref.suspension().replyId(), confirmResults);
     }
 
     /** @see ReActAgent#getDefaultSessionId() */
@@ -2214,7 +2247,7 @@ public class HarnessAgent implements Agent, AutoCloseable {
                 if (filesystem != null && !disableDynamicSubagents) {
                     DynamicSubagentsMiddleware dynMw =
                             HarnessAgentBuilderSupport.buildDynamicSubagentsMiddleware(
-                                    this, wsManager, resolvedWorkspace, capturedSandboxFs);
+                                    this, wsManager, resolvedWorkspace, filesystem);
                     if (dynMw != null) {
                         if (messageBus != null) {
                             wireTaskRepositoryMessageBus(
@@ -2229,7 +2262,7 @@ public class HarnessAgent implements Agent, AutoCloseable {
                 } else {
                     SubagentsMiddleware subagentsMw =
                             HarnessAgentBuilderSupport.buildSubagentsMiddleware(
-                                    this, wsManager, resolvedWorkspace, capturedSandboxFs);
+                                    this, wsManager, resolvedWorkspace, filesystem);
                     if (subagentsMw != null) {
                         if (messageBus != null) {
                             subagentsMw.wireMessageBus(messageBus, agentId);

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/HarnessAgent.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/HarnessAgent.java
@@ -494,17 +494,8 @@ public class HarnessAgent implements Agent, AutoCloseable {
         if (childContext == null || childSessionId == null || childSessionId.isBlank()) {
             return false;
         }
-        TaskRepository repository = null;
-        if (subagentMiddleware instanceof SubagentsMiddleware sm) {
-            repository = sm.getTaskRepository();
-        } else if (subagentMiddleware instanceof DynamicSubagentsMiddleware dm) {
-            repository = dm.getTaskRepository();
-        }
-        if (repository == null) {
-            return false;
-        }
         Optional<TaskRepository.SuspendedTaskRef> suspended =
-                repository.findSuspendedTaskByChildSession(childContext, childSessionId);
+                findSuspendedSubagentTask(childContext, childSessionId);
         if (suspended.isEmpty()) {
             return false;
         }
@@ -513,6 +504,24 @@ public class HarnessAgent implements Agent, AutoCloseable {
                 RuntimeContext.builder(childContext).sessionId(ref.parentSessionId()).build();
         return resumeSubagentTask(
                 parentContext, ref.taskId(), ref.suspension().replyId(), confirmResults);
+    }
+
+    /** Finds one waiting task by exact user and child-session lineage. */
+    public Optional<TaskRepository.SuspendedTaskRef> findSuspendedSubagentTask(
+            RuntimeContext childContext, String childSessionId) {
+        if (childContext == null || childSessionId == null || childSessionId.isBlank()) {
+            return Optional.empty();
+        }
+        TaskRepository repository = null;
+        if (subagentMiddleware instanceof SubagentsMiddleware sm) {
+            repository = sm.getTaskRepository();
+        } else if (subagentMiddleware instanceof DynamicSubagentsMiddleware dm) {
+            repository = dm.getTaskRepository();
+        }
+        if (repository == null) {
+            return Optional.empty();
+        }
+        return repository.findSuspendedTaskByChildSession(childContext, childSessionId);
     }
 
     /** @see ReActAgent#getDefaultSessionId() */

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/HarnessAgentBuilderSupport.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/HarnessAgentBuilderSupport.java
@@ -32,7 +32,6 @@ import io.agentscope.core.skill.repository.FileSystemSkillRepository;
 import io.agentscope.core.tool.Toolkit;
 import io.agentscope.harness.agent.filesystem.AbstractFilesystem;
 import io.agentscope.harness.agent.filesystem.remote.store.NamespaceFactory;
-import io.agentscope.harness.agent.filesystem.sandbox.SandboxBackedFilesystem;
 import io.agentscope.harness.agent.filesystem.spec.LocalFilesystemSpec;
 import io.agentscope.harness.agent.memory.compaction.CompactionConfig;
 import io.agentscope.harness.agent.memory.compaction.ToolResultEvictionConfig;
@@ -186,7 +185,7 @@ final class HarnessAgentBuilderSupport {
      * {@code workspace/subagents/*.md}, and custom factories.
      */
     static List<SubagentEntry> buildSubagentEntries(
-            HarnessAgent.Builder b, Path resolvedWorkspace, SandboxBackedFilesystem sandboxFs) {
+            HarnessAgent.Builder b, Path resolvedWorkspace, AbstractFilesystem sharedFilesystem) {
         List<SubagentDeclaration> allDeclarations = new ArrayList<>(b.subagentDeclarations);
 
         Path subagentsDir = resolvedWorkspace.resolve("subagents");
@@ -202,7 +201,7 @@ final class HarnessAgentBuilderSupport {
                         "general-purpose",
                         "General-purpose subagent with same capabilities as the main agent."
                                 + " Use for any isolated task that can be fully delegated.",
-                        buildGeneralPurposeFactory(b, resolvedWorkspace, sandboxFs),
+                        buildGeneralPurposeFactory(b, resolvedWorkspace, sharedFilesystem),
                         null));
 
         for (SubagentDeclaration decl : allDeclarations) {
@@ -210,7 +209,7 @@ final class HarnessAgentBuilderSupport {
                     new SubagentEntry(
                             decl.getName(),
                             decl.getDescription(),
-                            buildDeclaredFactory(b, decl, resolvedWorkspace, sandboxFs),
+                            buildDeclaredFactory(b, decl, resolvedWorkspace, sharedFilesystem),
                             decl));
         }
 
@@ -231,13 +230,13 @@ final class HarnessAgentBuilderSupport {
     }
 
     /**
-     * Like {@link #buildSubagentEntries(HarnessAgent.Builder, Path, SandboxBackedFilesystem)} but
+     * Like {@link #buildSubagentEntries(HarnessAgent.Builder, Path, AbstractFilesystem)} but
      * omits the local-disk {@code subagents/} scan. The {@code DynamicSubagentsMiddleware} performs that
      * scan itself on every reasoning step (Layer 2), so feeding the same entries in here would
      * register them twice.
      */
     static List<SubagentEntry> buildStaticSubagentEntries(
-            HarnessAgent.Builder b, Path resolvedWorkspace, SandboxBackedFilesystem sandboxFs) {
+            HarnessAgent.Builder b, Path resolvedWorkspace, AbstractFilesystem sharedFilesystem) {
         List<SubagentEntry> entries = new ArrayList<>();
 
         entries.add(
@@ -245,7 +244,7 @@ final class HarnessAgentBuilderSupport {
                         "general-purpose",
                         "General-purpose subagent with same capabilities as the main agent."
                                 + " Use for any isolated task that can be fully delegated.",
-                        buildGeneralPurposeFactory(b, resolvedWorkspace, sandboxFs),
+                        buildGeneralPurposeFactory(b, resolvedWorkspace, sharedFilesystem),
                         null));
 
         for (SubagentDeclaration decl : b.subagentDeclarations) {
@@ -253,7 +252,7 @@ final class HarnessAgentBuilderSupport {
                     new SubagentEntry(
                             decl.getName(),
                             decl.getDescription(),
-                            buildDeclaredFactory(b, decl, resolvedWorkspace, sandboxFs),
+                            buildDeclaredFactory(b, decl, resolvedWorkspace, sharedFilesystem),
                             decl));
         }
 
@@ -277,11 +276,11 @@ final class HarnessAgentBuilderSupport {
      * Builds a factory for the built-in general-purpose subagent.
      */
     static SubagentFactory buildGeneralPurposeFactory(
-            HarnessAgent.Builder b, Path workspace, SandboxBackedFilesystem sandboxFs) {
+            HarnessAgent.Builder b, Path workspace, AbstractFilesystem sharedFilesystem) {
         final Model capturedModel = b.model;
         final Toolkit capturedParentToolkit = b.toolkit != null ? b.toolkit.copy() : new Toolkit();
         final AbstractFilesystem capturedBackend =
-                sandboxFs != null ? sandboxFs : b.abstractFilesystem;
+                sharedFilesystem != null ? sharedFilesystem : b.abstractFilesystem;
         final int capturedMaxIters = b.maxIters;
         final ExecutionConfig capturedModelExec = b.modelExecutionConfig;
         final ExecutionConfig capturedToolExec = b.toolExecutionConfig;
@@ -374,13 +373,13 @@ final class HarnessAgentBuilderSupport {
             HarnessAgent.Builder b,
             SubagentDeclaration decl,
             Path mainWorkspace,
-            SandboxBackedFilesystem sandboxFs) {
+            AbstractFilesystem sharedFilesystem) {
         final Model capturedModel = b.model;
         final Toolkit capturedParentToolkit = b.toolkit != null ? b.toolkit.copy() : new Toolkit();
         final Function<String, Model> capturedResolver = b.modelResolver;
         final List<MiddlewareBase> capturedMiddlewares = List.copyOf(b.middlewares);
         final AbstractFilesystem capturedSharedBackend =
-                sandboxFs != null ? sandboxFs : b.abstractFilesystem;
+                sharedFilesystem != null ? sharedFilesystem : b.abstractFilesystem;
         final boolean capturedUseLegacyXmlWorkspaceContext = b.useLegacyXmlWorkspaceContext;
         final boolean capturedDisableFilesystemTools = b.disableFilesystemTools;
         final boolean capturedDisableShellTool = b.disableShellTool;
@@ -658,8 +657,8 @@ final class HarnessAgentBuilderSupport {
             HarnessAgent.Builder b,
             WorkspaceManager wsManager,
             Path workspace,
-            SandboxBackedFilesystem sandboxFs) {
-        List<SubagentEntry> entries = buildSubagentEntries(b, workspace, sandboxFs);
+            AbstractFilesystem sharedFilesystem) {
+        List<SubagentEntry> entries = buildSubagentEntries(b, workspace, sharedFilesystem);
         TaskRepository repo = resolveTaskRepository(b, wsManager);
 
         if (b.externalSubagentTool != null) {
@@ -668,7 +667,7 @@ final class HarnessAgentBuilderSupport {
 
         AbstractFilesystem fs = wsManager.getFilesystem();
         Function<SubagentDeclaration, SubagentFactory> factoryFn =
-                decl -> buildDeclaredFactory(b, decl, workspace, sandboxFs);
+                decl -> buildDeclaredFactory(b, decl, workspace, sharedFilesystem);
         return new SubagentsMiddleware(entries, repo, wsManager, fs, workspace, factoryFn);
     }
 
@@ -676,13 +675,14 @@ final class HarnessAgentBuilderSupport {
             HarnessAgent.Builder b,
             WorkspaceManager wsManager,
             Path workspace,
-            SandboxBackedFilesystem sandboxFs) {
-        List<SubagentEntry> staticEntries = buildStaticSubagentEntries(b, workspace, sandboxFs);
+            AbstractFilesystem sharedFilesystem) {
+        List<SubagentEntry> staticEntries =
+                buildStaticSubagentEntries(b, workspace, sharedFilesystem);
         TaskRepository repo = resolveTaskRepository(b, wsManager);
 
         AbstractFilesystem fs = wsManager.getFilesystem();
         Function<SubagentDeclaration, SubagentFactory> factoryFn =
-                decl -> buildDeclaredFactory(b, decl, workspace, sandboxFs);
+                decl -> buildDeclaredFactory(b, decl, workspace, sharedFilesystem);
         DefaultAgentManager manager = new DefaultAgentManager(staticEntries, wsManager);
         return new DynamicSubagentsMiddleware(
                 staticEntries, fs, workspace, factoryFn, manager, b.externalSubagentTool, repo);

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/gateway/GatewayBootstrap.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/gateway/GatewayBootstrap.java
@@ -131,8 +131,10 @@ public final class GatewayBootstrap {
      * the {@code expose_to_user} parameter on {@code agent_spawn}.
      */
     public SubagentGatewayBridge gatewayBridge() {
-        return (agentId, sessionId, agent, replyTo) -> {
-            String subagentId = gateway.exposeSubagent(agentId, sessionId, agent, replyTo);
+        return (agentId, sessionId, agent, replyTo, userId, parentSessionId) -> {
+            String subagentId =
+                    gateway.exposeSubagent(
+                            agentId, sessionId, agent, replyTo, userId, parentSessionId);
             return new SubagentGatewayBridge.ExposeResult(subagentId);
         };
     }

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/gateway/HarnessGateway.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/gateway/HarnessGateway.java
@@ -247,6 +247,8 @@ public final class HarnessGateway implements Gateway, WakeupDispatcher.WakeupTar
             String subagentId,
             String agentId,
             String sessionId,
+            String userId,
+            String parentSessionId,
             Agent agent,
             OutboundAddress replyTo) {}
 
@@ -262,14 +264,34 @@ public final class HarnessGateway implements Gateway, WakeupDispatcher.WakeupTar
      */
     public String exposeSubagent(
             String agentId, String sessionId, Agent agent, OutboundAddress replyTo) {
+        return exposeSubagent(agentId, sessionId, agent, replyTo, null, null);
+    }
+
+    /** Exposes a subagent while preserving its complete runtime lineage. */
+    public String exposeSubagent(
+            String agentId,
+            String sessionId,
+            Agent agent,
+            OutboundAddress replyTo,
+            String userId,
+            String parentSessionId) {
         Objects.requireNonNull(agent, "agent");
         String subagentId = "sub-" + UUID.randomUUID().toString().substring(0, 8);
         exposedSessions.put(
-                subagentId, new ExposedSession(subagentId, agentId, sessionId, agent, replyTo));
+                subagentId,
+                new ExposedSession(
+                        subagentId, agentId, sessionId, userId, parentSessionId, agent, replyTo));
         try {
             subagentRegistry.register(
                     new SubagentRecord(
-                            subagentId, agentId, sessionId, null, null, Instant.now(), null));
+                            subagentId,
+                            agentId,
+                            sessionId,
+                            userId,
+                            parentSessionId,
+                            replyTo,
+                            Instant.now(),
+                            null));
         } catch (RuntimeException e) {
             log.warn(
                     "Failed to persist exposed-subagent record {}: {}", subagentId, e.getMessage());
@@ -312,6 +334,12 @@ public final class HarnessGateway implements Gateway, WakeupDispatcher.WakeupTar
         this.subagentMaterializer = materializer;
     }
 
+    /** Resolves a child only when user, parent and child session lineage all match. */
+    public Optional<SubagentRecord> findExposedSubagent(
+            String userId, String parentSessionId, String childSessionId) {
+        return subagentRegistry.findByLineage(userId, parentSessionId, childSessionId);
+    }
+
     /**
      * Resolves an exposed subagent to a runnable session: returns the cached live session when
      * present, otherwise rebuilds it from the durable registry via the configured
@@ -332,10 +360,7 @@ public final class HarnessGateway implements Gateway, WakeupDispatcher.WakeupTar
             return null;
         }
         SubagentRecord record = recordOpt.get();
-        RuntimeContext.Builder rcb = RuntimeContext.builder().sessionId(record.sessionId());
-        if (record.userId() != null && !record.userId().isBlank()) {
-            rcb.userId(record.userId());
-        }
+        RuntimeContext.Builder rcb = runtimeContextBuilder(record);
         Optional<Agent> agentOpt = materializer.materialize(record.agentId(), rcb.build());
         if (agentOpt.isEmpty()) {
             log.warn(
@@ -349,8 +374,10 @@ public final class HarnessGateway implements Gateway, WakeupDispatcher.WakeupTar
                         record.subagentId(),
                         record.agentId(),
                         record.sessionId(),
+                        record.userId(),
+                        record.parentSessionId(),
                         agentOpt.get(),
-                        null);
+                        record.replyTo());
         exposedSessions.putIfAbsent(subagentId, rebuilt);
         return exposedSessions.get(subagentId);
     }
@@ -362,7 +389,7 @@ public final class HarnessGateway implements Gateway, WakeupDispatcher.WakeupTar
             return Mono.error(new IllegalArgumentException("Unknown subagentId: " + subagentId));
         }
 
-        RuntimeContext rtc = RuntimeContext.builder().sessionId(session.sessionId()).build();
+        RuntimeContext rtc = runtimeContext(session);
         String gateKey = "subagent:" + subagentId;
 
         return withGatedTurn(gateKey, () -> invokeExposedAgent(session.agent(), messages, rtc))
@@ -417,7 +444,7 @@ public final class HarnessGateway implements Gateway, WakeupDispatcher.WakeupTar
             return Flux.error(new IllegalArgumentException("Unknown subagentId: " + subagentId));
         }
 
-        RuntimeContext rtc = RuntimeContext.builder().sessionId(session.sessionId()).build();
+        RuntimeContext rtc = runtimeContext(session);
         String gateKey = "subagent:" + subagentId;
 
         return withGatedStream(gateKey, () -> streamExposedAgent(session.agent(), messages, rtc));
@@ -436,6 +463,28 @@ public final class HarnessGateway implements Gateway, WakeupDispatcher.WakeupTar
                         "Agent type "
                                 + agent.getClass().getName()
                                 + " does not support streaming"));
+    }
+
+    private static RuntimeContext runtimeContext(ExposedSession session) {
+        return runtimeContextBuilder(
+                        session.sessionId(), session.userId(), session.parentSessionId())
+                .build();
+    }
+
+    private static RuntimeContext.Builder runtimeContextBuilder(SubagentRecord record) {
+        return runtimeContextBuilder(record.sessionId(), record.userId(), record.parentSessionId());
+    }
+
+    private static RuntimeContext.Builder runtimeContextBuilder(
+            String sessionId, String userId, String parentSessionId) {
+        RuntimeContext.Builder builder = RuntimeContext.builder().sessionId(sessionId);
+        if (userId != null && !userId.isBlank()) {
+            builder.userId(userId);
+        }
+        if (parentSessionId != null && !parentSessionId.isBlank()) {
+            builder.put(SubagentRecord.RUNTIME_PARENT_SESSION_ID, parentSessionId);
+        }
+        return builder;
     }
 
     // ------------------------------------------------------------------

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/gateway/InMemorySubagentRegistry.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/gateway/InMemorySubagentRegistry.java
@@ -16,6 +16,8 @@
 package io.agentscope.harness.agent.gateway;
 
 import java.time.Instant;
+import java.util.Comparator;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -52,6 +54,24 @@ public final class InMemorySubagentRegistry implements SubagentRegistry {
     }
 
     @Override
+    public Optional<SubagentRecord> findByLineage(
+            String userId, String parentSessionId, String childSessionId) {
+        if (isBlank(userId) || isBlank(parentSessionId) || isBlank(childSessionId)) {
+            return Optional.empty();
+        }
+        Instant now = Instant.now();
+        records.values().removeIf(record -> record.isExpired(now));
+        return records.values().stream()
+                .filter(record -> Objects.equals(userId, record.userId()))
+                .filter(record -> Objects.equals(parentSessionId, record.parentSessionId()))
+                .filter(record -> Objects.equals(childSessionId, record.sessionId()))
+                .max(
+                        Comparator.comparing(
+                                SubagentRecord::createdAt,
+                                Comparator.nullsFirst(Instant::compareTo)));
+    }
+
+    @Override
     public void revoke(String subagentId) {
         if (subagentId != null) {
             records.remove(subagentId);
@@ -64,5 +84,9 @@ public final class InMemorySubagentRegistry implements SubagentRegistry {
             return;
         }
         records.values().removeIf(r -> parentSessionId.equals(r.parentSessionId()));
+    }
+
+    private static boolean isBlank(String value) {
+        return value == null || value.isBlank();
     }
 }

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/gateway/StoreBackedSubagentRegistry.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/gateway/StoreBackedSubagentRegistry.java
@@ -18,6 +18,7 @@ package io.agentscope.harness.agent.gateway;
 import io.agentscope.harness.agent.filesystem.remote.store.BaseStore;
 import io.agentscope.harness.agent.filesystem.remote.store.StoreItem;
 import java.time.Instant;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -94,6 +95,46 @@ public final class StoreBackedSubagentRegistry implements SubagentRegistry {
     }
 
     @Override
+    public Optional<SubagentRecord> findByLineage(
+            String userId, String parentSessionId, String childSessionId) {
+        if (isBlank(userId) || isBlank(parentSessionId) || isBlank(childSessionId)) {
+            return Optional.empty();
+        }
+        try {
+            int offset = 0;
+            SubagentRecord latest = null;
+            while (true) {
+                List<StoreItem> items = store.search(NAMESPACE, SCAN_PAGE_SIZE, offset);
+                if (items == null || items.isEmpty()) {
+                    break;
+                }
+                for (StoreItem item : items) {
+                    SubagentRecord record = SubagentRecord.fromMap(item.value());
+                    if (record != null
+                            && !record.isExpired(Instant.now())
+                            && Objects.equals(userId, record.userId())
+                            && Objects.equals(parentSessionId, record.parentSessionId())
+                            && Objects.equals(childSessionId, record.sessionId())
+                            && (latest == null
+                                    || Comparator.nullsFirst(Instant::compareTo)
+                                                    .compare(record.createdAt(), latest.createdAt())
+                                            > 0)) {
+                        latest = record;
+                    }
+                }
+                if (items.size() < SCAN_PAGE_SIZE) {
+                    break;
+                }
+                offset += items.size();
+            }
+            return Optional.ofNullable(latest);
+        } catch (RuntimeException e) {
+            log.warn("Failed to resolve exposed-subagent lineage: {}", e.getMessage());
+            return Optional.empty();
+        }
+    }
+
+    @Override
     public void revoke(String subagentId) {
         if (subagentId == null) {
             return;
@@ -111,15 +152,26 @@ public final class StoreBackedSubagentRegistry implements SubagentRegistry {
             return;
         }
         try {
-            List<StoreItem> items = store.search(NAMESPACE, SCAN_PAGE_SIZE, 0);
-            if (items == null) {
-                return;
-            }
-            for (StoreItem item : items) {
-                SubagentRecord r = SubagentRecord.fromMap(item.value());
-                if (r != null && parentSessionId.equals(r.parentSessionId())) {
-                    revoke(r.subagentId());
+            int offset = 0;
+            List<String> matches = new java.util.ArrayList<>();
+            while (true) {
+                List<StoreItem> items = store.search(NAMESPACE, SCAN_PAGE_SIZE, offset);
+                if (items == null || items.isEmpty()) {
+                    break;
                 }
+                for (StoreItem item : items) {
+                    SubagentRecord record = SubagentRecord.fromMap(item.value());
+                    if (record != null && parentSessionId.equals(record.parentSessionId())) {
+                        matches.add(record.subagentId());
+                    }
+                }
+                if (items.size() < SCAN_PAGE_SIZE) {
+                    break;
+                }
+                offset += items.size();
+            }
+            for (String subagentId : matches) {
+                revoke(subagentId);
             }
         } catch (RuntimeException e) {
             log.warn(
@@ -127,5 +179,9 @@ public final class StoreBackedSubagentRegistry implements SubagentRegistry {
                     parentSessionId,
                     e.getMessage());
         }
+    }
+
+    private static boolean isBlank(String value) {
+        return value == null || value.isBlank();
     }
 }

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/gateway/SubagentGatewayBridge.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/gateway/SubagentGatewayBridge.java
@@ -44,7 +44,15 @@ public interface SubagentGatewayBridge {
      * @param agent the agent instance
      * @param replyTo the outbound address for delivering replies back to the user's channel;
      *     may be null if no outbound channel context is available
+     * @param userId the owning user namespace
+     * @param parentSessionId the parent runtime session that spawned the child
      * @return the expose result containing the subagentId handle
      */
-    ExposeResult expose(String agentId, String sessionId, Agent agent, OutboundAddress replyTo);
+    ExposeResult expose(
+            String agentId,
+            String sessionId,
+            Agent agent,
+            OutboundAddress replyTo,
+            String userId,
+            String parentSessionId);
 }

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/gateway/SubagentRecord.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/gateway/SubagentRecord.java
@@ -15,6 +15,7 @@
  */
 package io.agentscope.harness.agent.gateway;
 
+import io.agentscope.harness.agent.gateway.channel.OutboundAddress;
 import java.time.Instant;
 import java.util.HashMap;
 import java.util.Map;
@@ -35,6 +36,7 @@ import java.util.Map;
  * @param sessionId the subagent's own session id (used to load its conversational state)
  * @param userId the originating user id, or {@code null} when unknown
  * @param parentSessionId the parent session that exposed this subagent, or {@code null}
+ * @param replyTo the durable outbound delivery address, or {@code null}
  * @param createdAt when the subagent was exposed
  * @param expiresAt optional expiry instant; {@code null} means no TTL
  */
@@ -44,8 +46,22 @@ public record SubagentRecord(
         String sessionId,
         String userId,
         String parentSessionId,
+        OutboundAddress replyTo,
         Instant createdAt,
         Instant expiresAt) {
+
+    public static final String RUNTIME_PARENT_SESSION_ID = "agentscope.subagent.parent_session_id";
+
+    public SubagentRecord(
+            String subagentId,
+            String agentId,
+            String sessionId,
+            String userId,
+            String parentSessionId,
+            Instant createdAt,
+            Instant expiresAt) {
+        this(subagentId, agentId, sessionId, userId, parentSessionId, null, createdAt, expiresAt);
+    }
 
     /** Whether this record has a TTL that has already elapsed relative to {@code now}. */
     public boolean isExpired(Instant now) {
@@ -63,6 +79,16 @@ public record SubagentRecord(
         }
         if (parentSessionId != null) {
             m.put("parentSessionId", parentSessionId);
+        }
+        if (replyTo != null) {
+            m.put("replyChannelId", replyTo.channelId());
+            m.put("replyTo", replyTo.to());
+            if (replyTo.accountId() != null) {
+                m.put("replyAccountId", replyTo.accountId());
+            }
+            if (replyTo.threadId() != null) {
+                m.put("replyThreadId", replyTo.threadId());
+            }
         }
         if (createdAt != null) {
             m.put("createdAt", createdAt.toEpochMilli());
@@ -84,8 +110,19 @@ public record SubagentRecord(
                 asString(m.get("sessionId")),
                 asString(m.get("userId")),
                 asString(m.get("parentSessionId")),
+                asOutboundAddress(m),
                 asInstant(m.get("createdAt")),
                 asInstant(m.get("expiresAt")));
+    }
+
+    private static OutboundAddress asOutboundAddress(Map<String, Object> m) {
+        String channelId = asString(m.get("replyChannelId"));
+        String to = asString(m.get("replyTo"));
+        if (channelId == null || to == null) {
+            return null;
+        }
+        return new OutboundAddress(
+                channelId, asString(m.get("replyAccountId")), to, asString(m.get("replyThreadId")));
     }
 
     private static String asString(Object v) {

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/gateway/SubagentRegistry.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/gateway/SubagentRegistry.java
@@ -56,6 +56,10 @@ public interface SubagentRegistry {
      */
     Optional<SubagentRecord> find(String subagentId);
 
+    /** Resolves an exposed child only when the complete owning lineage matches. */
+    Optional<SubagentRecord> findByLineage(
+            String userId, String parentSessionId, String childSessionId);
+
     /** Removes a single exposure record. No-op when the id is unknown. */
     void revoke(String subagentId);
 

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/middleware/DynamicSubagentsMiddleware.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/middleware/DynamicSubagentsMiddleware.java
@@ -18,8 +18,10 @@ package io.agentscope.harness.agent.middleware;
 import io.agentscope.core.agent.Agent;
 import io.agentscope.core.agent.RuntimeContext;
 import io.agentscope.core.event.AgentEvent;
+import io.agentscope.core.event.ConfirmResult;
 import io.agentscope.core.message.Msg;
 import io.agentscope.core.middleware.ReasoningInput;
+import io.agentscope.core.state.AgentState;
 import io.agentscope.harness.agent.filesystem.AbstractFilesystem;
 import io.agentscope.harness.agent.filesystem.model.FileInfo;
 import io.agentscope.harness.agent.filesystem.model.GlobResult;
@@ -142,6 +144,18 @@ public class DynamicSubagentsMiddleware implements HarnessRuntimeMiddleware {
 
     public TaskRepository getTaskRepository() {
         return taskRepository;
+    }
+
+    /** Resume a native {@link AgentSpawnTool} task suspended for permission approval. */
+    public boolean resumeSubagentTask(
+            RuntimeContext parentContext,
+            AgentState parentState,
+            String taskId,
+            String replyId,
+            List<ConfirmResult> confirmResults) {
+        return subagentTool instanceof AgentSpawnTool spawnTool
+                && spawnTool.resumeSuspendedTask(
+                        parentContext, parentState, taskId, replyId, confirmResults);
     }
 
     @Override

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/middleware/SubagentsMiddleware.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/middleware/SubagentsMiddleware.java
@@ -508,6 +508,12 @@ public class SubagentsMiddleware implements HarnessRuntimeMiddleware {
                     sb.append("\n</task_error>\n");
                 }
                 case CANCELLED -> sb.append("Task was cancelled before producing a result.\n");
+                case DENIED -> {
+                    sb.append("<task_denied>\n");
+                    sb.append(
+                            d.result() != null ? d.result() : "User denied the pending operation.");
+                    sb.append("\n</task_denied>\n");
+                }
                 default ->
                         sb.append("Task ended in non-terminal state ")
                                 .append(d.status())

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/middleware/SubagentsMiddleware.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/middleware/SubagentsMiddleware.java
@@ -19,11 +19,13 @@ import io.agentscope.core.ReActAgent;
 import io.agentscope.core.agent.Agent;
 import io.agentscope.core.agent.RuntimeContext;
 import io.agentscope.core.event.AgentEvent;
+import io.agentscope.core.event.ConfirmResult;
 import io.agentscope.core.message.Msg;
 import io.agentscope.core.message.MsgRole;
 import io.agentscope.core.message.TextBlock;
 import io.agentscope.core.middleware.AgentInput;
 import io.agentscope.core.middleware.ReasoningInput;
+import io.agentscope.core.state.AgentState;
 import io.agentscope.harness.agent.filesystem.AbstractFilesystem;
 import io.agentscope.harness.agent.subagent.AgentSpecLoader;
 import io.agentscope.harness.agent.subagent.DefaultAgentManager;
@@ -262,6 +264,18 @@ public class SubagentsMiddleware implements HarnessRuntimeMiddleware {
     /** Returns the {@link TaskRepository} used by this middleware. */
     public TaskRepository getTaskRepository() {
         return taskRepository;
+    }
+
+    /** Resume a native {@link AgentSpawnTool} task suspended for permission approval. */
+    public boolean resumeSubagentTask(
+            RuntimeContext parentContext,
+            AgentState parentState,
+            String taskId,
+            String replyId,
+            List<ConfirmResult> confirmResults) {
+        return subagentTool instanceof AgentSpawnTool spawnTool
+                && spawnTool.resumeSuspendedTask(
+                        parentContext, parentState, taskId, replyId, confirmResults);
     }
 
     /**

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/subagent/DefaultAgentManager.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/subagent/DefaultAgentManager.java
@@ -38,6 +38,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.function.Consumer;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
@@ -55,6 +56,7 @@ public final class DefaultAgentManager {
     private volatile Map<String, SubagentFactory> agentFactories;
     private volatile Map<String, SubagentDeclaration> declarations;
     private final WorkspaceManager workspaceManager;
+    private volatile Consumer<Agent> materializationCustomizer = ignored -> {};
 
     /**
      * Builds a manager from subagent entries (factories plus optional {@link SubagentDeclaration}
@@ -127,7 +129,7 @@ public final class DefaultAgentManager {
         if (decl != null && decl.getMode() == SubagentDeclaration.Mode.PRIMARY) {
             return Optional.empty();
         }
-        return Optional.of(factory.create(parentRc != null ? parentRc : RuntimeContext.empty()));
+        return Optional.of(customize(factory.create(effectiveContext(parentRc))));
     }
 
     /**
@@ -167,7 +169,21 @@ public final class DefaultAgentManager {
         if (factory == null) {
             throw new IllegalArgumentException("Unknown agent_id: " + agentId);
         }
-        return factory.create(parentRc != null ? parentRc : RuntimeContext.empty());
+        return customize(factory.create(effectiveContext(parentRc)));
+    }
+
+    /** Applies a host customization after every native child materialization. */
+    public void setMaterializationCustomizer(Consumer<Agent> customizer) {
+        materializationCustomizer = customizer != null ? customizer : ignored -> {};
+    }
+
+    private Agent customize(Agent agent) {
+        materializationCustomizer.accept(agent);
+        return agent;
+    }
+
+    private static RuntimeContext effectiveContext(RuntimeContext context) {
+        return context != null ? context : RuntimeContext.empty();
     }
 
     /**

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/subagent/DefaultAgentManager.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/subagent/DefaultAgentManager.java
@@ -21,15 +21,22 @@ import io.agentscope.core.agent.Event;
 import io.agentscope.core.agent.EventSource;
 import io.agentscope.core.agent.RuntimeContext;
 import io.agentscope.core.agent.StreamOptions;
+import io.agentscope.core.event.AgentEvent;
+import io.agentscope.core.event.AgentResultEvent;
+import io.agentscope.core.event.RequireUserConfirmEvent;
+import io.agentscope.core.message.GenerateReason;
 import io.agentscope.core.message.Msg;
 import io.agentscope.core.message.MsgRole;
 import io.agentscope.harness.agent.HarnessAgent;
 import io.agentscope.harness.agent.middleware.SubagentEntry;
+import io.agentscope.harness.agent.subagent.task.TaskRunOutcome;
+import io.agentscope.harness.agent.subagent.task.TaskSuspension;
 import io.agentscope.harness.agent.tool.AgentSpawnTool;
 import io.agentscope.harness.agent.workspace.WorkspaceManager;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -196,6 +203,86 @@ public final class DefaultAgentManager {
             return harness.call(userMessage(prompt), ctx);
         }
         return agent.call(List.of(userMessage(prompt)));
+    }
+
+    /**
+     * Invokes a local child through typed {@link AgentEvent}s and returns a task lifecycle outcome.
+     * Permission pauses retain the exact reply and tool identities needed for durable resume.
+     */
+    public TaskRunOutcome invokeAgentTask(
+            Agent agent,
+            String sessionId,
+            String userId,
+            List<Msg> messages,
+            RuntimeContext parentRc) {
+        Objects.requireNonNull(agent, "agent must not be null");
+        Objects.requireNonNull(sessionId, "sessionId must not be null");
+        RuntimeContext childContext = childRuntimeContext(sessionId, userId, parentRc);
+        List<Msg> input = messages == null ? List.of() : List.copyOf(messages);
+        List<AgentEvent> events;
+        if (agent instanceof ReActAgent react) {
+            events = react.streamEvents(input, childContext).collectList().block();
+        } else if (agent instanceof HarnessAgent harness) {
+            events = harness.streamEvents(input, childContext).collectList().block();
+        } else {
+            Msg result = agent.call(input).block();
+            if (result != null && result.getGenerateReason() == GenerateReason.PERMISSION_ASKING) {
+                throw new IllegalStateException(
+                        "Permission-suspended task requires an AgentScope typed event stream");
+            }
+            return new TaskRunOutcome.Completed(result != null ? result.getTextContent() : "");
+        }
+        List<AgentEvent> captured = events != null ? events : List.of();
+        Msg result =
+                captured.stream()
+                        .filter(AgentResultEvent.class::isInstance)
+                        .map(AgentResultEvent.class::cast)
+                        .map(AgentResultEvent::getResult)
+                        .reduce((first, last) -> last)
+                        .orElseThrow(
+                                () ->
+                                        new IllegalStateException(
+                                                "Child event stream has no result"));
+        if (result.getGenerateReason() != GenerateReason.PERMISSION_ASKING) {
+            return new TaskRunOutcome.Completed(result.getTextContent());
+        }
+        RequireUserConfirmEvent approval =
+                captured.stream()
+                        .filter(RequireUserConfirmEvent.class::isInstance)
+                        .map(RequireUserConfirmEvent.class::cast)
+                        .reduce((first, last) -> last)
+                        .orElseThrow(
+                                () ->
+                                        new IllegalStateException(
+                                                "Permission pause has no confirmation event"));
+        String parentSessionId = parentRc != null ? parentRc.getSessionId() : null;
+        TaskSuspension suspension =
+                new TaskSuspension(
+                        userId,
+                        Objects.requireNonNull(
+                                parentSessionId,
+                                "parent RuntimeContext sessionId must not be null"),
+                        sessionId,
+                        approval.getReplyId(),
+                        approval.getToolCalls().stream()
+                                .map(
+                                        toolCall ->
+                                                new TaskSuspension.PendingToolCall(
+                                                        toolCall.getId(), toolCall.getName()))
+                                .toList());
+        return new TaskRunOutcome.WaitingForApproval(suspension);
+    }
+
+    public TaskRunOutcome invokeAgentTask(
+            Agent agent, String sessionId, String userId, String prompt, RuntimeContext parentRc) {
+        return invokeAgentTask(agent, sessionId, userId, List.of(userMessage(prompt)), parentRc);
+    }
+
+    private static RuntimeContext childRuntimeContext(
+            String sessionId, String userId, RuntimeContext parentRc) {
+        return parentRc != null
+                ? RuntimeContext.builder(parentRc).sessionId(sessionId).userId(userId).build()
+                : RuntimeContext.builder().sessionId(sessionId).userId(userId).build();
     }
 
     /**

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/subagent/task/BackgroundTask.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/subagent/task/BackgroundTask.java
@@ -40,6 +40,7 @@ public class BackgroundTask {
     private final Instant createdAt;
     private volatile Instant lastCheckedAt;
     private volatile boolean cancelled;
+    private volatile TaskStatus lifecycleStatus;
 
     public BackgroundTask(String taskId, String agentId, CompletableFuture<String> future) {
         this.taskId = taskId;
@@ -81,6 +82,11 @@ public class BackgroundTask {
         if (cancelled || future.isCancelled()) {
             return TaskStatus.CANCELLED;
         }
+        if (lifecycleStatus != null
+                && (lifecycleStatus.isTerminal()
+                        || lifecycleStatus == TaskStatus.WAITING_FOR_APPROVAL)) {
+            return lifecycleStatus;
+        }
         if (future.isCompletedExceptionally()) {
             return TaskStatus.FAILED;
         }
@@ -88,6 +94,23 @@ public class BackgroundTask {
             return TaskStatus.COMPLETED;
         }
         return TaskStatus.RUNNING;
+    }
+
+    void markStatus(TaskStatus status) {
+        this.lifecycleStatus = status;
+    }
+
+    void complete(String result, TaskStatus terminalStatus) {
+        if (!terminalStatus.isTerminal()) {
+            throw new IllegalArgumentException("terminalStatus must be terminal");
+        }
+        this.lifecycleStatus = terminalStatus;
+        future.complete(result);
+    }
+
+    void completeExceptionally(Throwable error) {
+        this.lifecycleStatus = TaskStatus.FAILED;
+        future.completeExceptionally(error);
     }
 
     /** Returns a human-readable status string. */
@@ -147,6 +170,7 @@ public class BackgroundTask {
      */
     public boolean cancel(boolean mayInterruptIfRunning) {
         this.cancelled = true;
+        this.lifecycleStatus = TaskStatus.CANCELLED;
         return future.cancel(mayInterruptIfRunning);
     }
 }

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/subagent/task/TaskDelivery.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/subagent/task/TaskDelivery.java
@@ -30,9 +30,9 @@ import java.time.Instant;
  * @param taskId        task identifier
  * @param agentId       which subagent type produced this result (may be {@code null} on legacy
  *                      records)
- * @param status        terminal status — one of COMPLETED / FAILED / CANCELLED
+ * @param status        terminal status — one of COMPLETED / FAILED / CANCELLED / DENIED
  * @param result        completion payload; {@code null} for FAILED / CANCELLED
- * @param errorMessage  failure message; {@code null} for COMPLETED / CANCELLED
+ * @param errorMessage  failure message; {@code null} for COMPLETED / CANCELLED / DENIED
  * @param completedAt   wall-clock instant the task reached its terminal status (best-effort —
  *                      typically {@link TaskRecord#getLastUpdatedAt()})
  */

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/subagent/task/TaskRecord.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/subagent/task/TaskRecord.java
@@ -41,7 +41,9 @@ public class TaskRecord {
     private String parentAgentId;
     private String parentSessionId;
     private String subSessionId;
+    private String userId;
     private TaskStatus status;
+    private TaskSuspension suspension;
     private String result;
     private String errorMessage;
     private boolean cancelRequested;
@@ -123,6 +125,22 @@ public class TaskRecord {
 
     public void setSubSessionId(String subSessionId) {
         this.subSessionId = subSessionId;
+    }
+
+    public String getUserId() {
+        return userId;
+    }
+
+    public void setUserId(String userId) {
+        this.userId = userId;
+    }
+
+    public TaskSuspension getSuspension() {
+        return suspension;
+    }
+
+    public void setSuspension(TaskSuspension suspension) {
+        this.suspension = suspension;
     }
 
     public TaskStatus getStatus() {

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/subagent/task/TaskRepository.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/subagent/task/TaskRepository.java
@@ -113,6 +113,14 @@ public interface TaskRepository {
         return Optional.empty();
     }
 
+    /** Identifies one waiting task by its exact owning user and child session. */
+    default Optional<SuspendedTaskRef> findSuspendedTaskByChildSession(
+            RuntimeContext childContext, String childSessionId) {
+        return Optional.empty();
+    }
+
+    record SuspendedTaskRef(String taskId, String parentSessionId, TaskSuspension suspension) {}
+
     // ------------------------------------------------------------------------
     // Phase B-3 — push delivery API.
     //

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/subagent/task/TaskRepository.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/subagent/task/TaskRepository.java
@@ -18,6 +18,7 @@ package io.agentscope.harness.agent.subagent.task;
 import io.agentscope.core.agent.RuntimeContext;
 import java.util.Collection;
 import java.util.List;
+import java.util.function.Supplier;
 
 /**
  * Repository for managing background subagent tasks, scoped by session.
@@ -89,6 +90,21 @@ public interface TaskRepository {
      * @return true if the task was found and cancellation was attempted
      */
     boolean cancelTask(RuntimeContext rc, String sessionId, String taskId);
+
+    /**
+     * Resume a task that is durably suspended in {@link TaskStatus#WAITING_FOR_APPROVAL}.
+     *
+     * <p>The repository owns continuation scheduling and all lifecycle transitions. The supplier
+     * is invoked only after the persisted waiting record is atomically claimed on this repository
+     * instance. Implementations that do not support durable suspension return {@code false}.
+     */
+    default boolean resumeTask(
+            RuntimeContext rc,
+            String sessionId,
+            String taskId,
+            Supplier<TaskRunOutcome> continuation) {
+        return false;
+    }
 
     // ------------------------------------------------------------------------
     // Phase B-3 — push delivery API.

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/subagent/task/TaskRepository.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/subagent/task/TaskRepository.java
@@ -18,6 +18,7 @@ package io.agentscope.harness.agent.subagent.task;
 import io.agentscope.core.agent.RuntimeContext;
 import java.util.Collection;
 import java.util.List;
+import java.util.Optional;
 import java.util.function.Supplier;
 
 /**
@@ -104,6 +105,12 @@ public interface TaskRepository {
             String taskId,
             Supplier<TaskRunOutcome> continuation) {
         return false;
+    }
+
+    /** Read the durable permission suspension for one waiting task. */
+    default Optional<TaskSuspension> getTaskSuspension(
+            RuntimeContext rc, String sessionId, String taskId) {
+        return Optional.empty();
     }
 
     // ------------------------------------------------------------------------

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/subagent/task/TaskRunOutcome.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/subagent/task/TaskRunOutcome.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.harness.agent.subagent.task;
+
+import java.util.Objects;
+
+/** Typed result of a local subagent task execution or permission continuation. */
+public sealed interface TaskRunOutcome {
+
+    /** The child turn completed normally. */
+    record Completed(String result) implements TaskRunOutcome {}
+
+    /** The child turn paused and must be resumed after a permission decision. */
+    record WaitingForApproval(TaskSuspension suspension) implements TaskRunOutcome {
+        public WaitingForApproval {
+            Objects.requireNonNull(suspension, "suspension must not be null");
+        }
+    }
+
+    /** The user denied the pending operation and the task is terminal. */
+    record Denied(String result) implements TaskRunOutcome {}
+}

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/subagent/task/TaskRunSpec.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/subagent/task/TaskRunSpec.java
@@ -25,12 +25,17 @@ import java.util.function.Supplier;
  * <p>{@link LocalTaskRunSpec} runs the supplier on a local executor. {@link RemoteTaskRunSpec}
  * delegates to an AgentScope task HTTP API (see {@code agentscope-extensions-agent-protocol}).
  * {@link AdoptedTaskRunSpec} wraps an already-running {@link CompletableFuture} (used when a sync
- * execution is promoted to async on timeout).
+ * execution is promoted to async on timeout). {@link SuspensibleLocalTaskRunSpec} returns a typed
+ * outcome so permission HITL pauses remain non-terminal.
  */
 public sealed interface TaskRunSpec {
 
     /** In-process execution via {@link Supplier}. */
     record LocalTaskRunSpec(Supplier<String> execution) implements TaskRunSpec {}
+
+    /** In-process child execution that may suspend for permission approval. */
+    record SuspensibleLocalTaskRunSpec(Supplier<TaskRunOutcome> execution, String subSessionId)
+            implements TaskRunSpec {}
 
     /**
      * Remote HTTP task execution. The {@code taskId} is chosen by the client and used as the

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/subagent/task/TaskStatus.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/subagent/task/TaskStatus.java
@@ -22,15 +22,17 @@ package io.agentscope.harness.agent.subagent.task;
 public enum TaskStatus {
     PENDING,
     RUNNING,
+    WAITING_FOR_APPROVAL,
     COMPLETED,
     FAILED,
-    CANCELLED;
+    CANCELLED,
+    DENIED;
 
     /**
      * Whether this status represents a final state that will never change. Useful for skipping
      * redundant status polling on tasks that are already done.
      */
     public boolean isTerminal() {
-        return this == COMPLETED || this == FAILED || this == CANCELLED;
+        return this == COMPLETED || this == FAILED || this == CANCELLED || this == DENIED;
     }
 }

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/subagent/task/TaskSuspension.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/subagent/task/TaskSuspension.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.harness.agent.subagent.task;
+
+import java.util.List;
+import java.util.Objects;
+
+/** Durable identity needed to resume a subagent task suspended for permission approval. */
+public record TaskSuspension(
+        String userId,
+        String parentSessionId,
+        String subSessionId,
+        String replyId,
+        List<PendingToolCall> pendingToolCalls) {
+
+    public TaskSuspension {
+        Objects.requireNonNull(parentSessionId, "parentSessionId must not be null");
+        Objects.requireNonNull(subSessionId, "subSessionId must not be null");
+        Objects.requireNonNull(replyId, "replyId must not be null");
+        pendingToolCalls = pendingToolCalls == null ? List.of() : List.copyOf(pendingToolCalls);
+    }
+
+    /** Stable tool identity carried without duplicating tool input or permission decisions. */
+    public record PendingToolCall(String toolCallId, String toolName) {
+        public PendingToolCall {
+            Objects.requireNonNull(toolCallId, "toolCallId must not be null");
+            Objects.requireNonNull(toolName, "toolName must not be null");
+        }
+    }
+}

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/subagent/task/WorkspaceTaskRepository.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/subagent/task/WorkspaceTaskRepository.java
@@ -23,6 +23,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -473,10 +474,31 @@ public class WorkspaceTaskRepository implements TaskRepository {
                 || childSessionId.isBlank()) {
             return Optional.empty();
         }
+        Map<String, TaskRecord> candidates = new LinkedHashMap<>();
+        for (Map.Entry<String, BackgroundTask> entry : localTasks.entrySet()) {
+            String key = entry.getKey();
+            RuntimeContext taskContext = localTaskContexts.get(key);
+            String parentSessionId = localTaskSessionIds.get(key);
+            if (taskContext == null
+                    || !Objects.equals(childContext.getUserId(), taskContext.getUserId())
+                    || parentSessionId == null) {
+                continue;
+            }
+            workspaceManager
+                    .readTaskRecord(
+                            taskContext,
+                            parentAgentId,
+                            parentSessionId,
+                            entry.getValue().getTaskId())
+                    .ifPresent(record -> candidates.put(record.getTaskId(), record));
+        }
+        for (TaskRecord record :
+                workspaceManager.listAllTaskRecords(
+                        childContext, parentAgentId, Duration.ofDays(36_500))) {
+            candidates.putIfAbsent(record.getTaskId(), record);
+        }
         List<SuspendedTaskRef> matches =
-                workspaceManager
-                        .listAllTaskRecords(childContext, parentAgentId, Duration.ofDays(36_500))
-                        .stream()
+                candidates.values().stream()
                         .filter(record -> record.getStatus() == TaskStatus.WAITING_FOR_APPROVAL)
                         .filter(record -> record.getSuspension() != null)
                         .filter(

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/subagent/task/WorkspaceTaskRepository.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/subagent/task/WorkspaceTaskRepository.java
@@ -463,6 +463,41 @@ public class WorkspaceTaskRepository implements TaskRepository {
                 .map(TaskRecord::getSuspension);
     }
 
+    @Override
+    public Optional<SuspendedTaskRef> findSuspendedTaskByChildSession(
+            RuntimeContext childContext, String childSessionId) {
+        if (childContext == null
+                || childContext.getUserId() == null
+                || childContext.getUserId().isBlank()
+                || childSessionId == null
+                || childSessionId.isBlank()) {
+            return Optional.empty();
+        }
+        List<SuspendedTaskRef> matches =
+                workspaceManager
+                        .listAllTaskRecords(childContext, parentAgentId, Duration.ofDays(36_500))
+                        .stream()
+                        .filter(record -> record.getStatus() == TaskStatus.WAITING_FOR_APPROVAL)
+                        .filter(record -> record.getSuspension() != null)
+                        .filter(
+                                record ->
+                                        childContext
+                                                .getUserId()
+                                                .equals(record.getSuspension().userId()))
+                        .filter(
+                                record ->
+                                        childSessionId.equals(
+                                                record.getSuspension().subSessionId()))
+                        .map(
+                                record ->
+                                        new SuspendedTaskRef(
+                                                record.getTaskId(),
+                                                record.getParentSessionId(),
+                                                record.getSuspension()))
+                        .toList();
+        return matches.size() == 1 ? Optional.of(matches.get(0)) : Optional.empty();
+    }
+
     private String runLocalSupplier(
             RuntimeContext rc,
             String sessionId,

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/subagent/task/WorkspaceTaskRepository.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/subagent/task/WorkspaceTaskRepository.java
@@ -453,6 +453,16 @@ public class WorkspaceTaskRepository implements TaskRepository {
         }
     }
 
+    @Override
+    public Optional<TaskSuspension> getTaskSuspension(
+            RuntimeContext rc, String sessionId, String taskId) {
+        RuntimeContext effectiveRc = rc != null ? rc : RuntimeContext.empty();
+        return workspaceManager
+                .readTaskRecord(effectiveRc, parentAgentId, sessionId, taskId)
+                .filter(record -> record.getStatus() == TaskStatus.WAITING_FOR_APPROVAL)
+                .map(TaskRecord::getSuspension);
+    }
+
     private String runLocalSupplier(
             RuntimeContext rc,
             String sessionId,

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/subagent/task/WorkspaceTaskRepository.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/subagent/task/WorkspaceTaskRepository.java
@@ -25,6 +25,7 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
@@ -108,6 +109,9 @@ public class WorkspaceTaskRepository implements TaskRepository {
      * user's namespace.
      */
     private final Map<String, RuntimeContext> localTaskContexts = new ConcurrentHashMap<>();
+
+    /** Per-task transition locks; lifecycle writes for one task are serialized in this process. */
+    private final Map<String, Object> taskTransitionLocks = new ConcurrentHashMap<>();
 
     private final ExecutorService executor;
     private final boolean ownsExecutor;
@@ -221,7 +225,13 @@ public class WorkspaceTaskRepository implements TaskRepository {
             String sessionId,
             TaskRunSpec spec) {
         RuntimeContext capturedRc = rc != null ? rc : RuntimeContext.empty();
-        TaskRecord record = new TaskRecord(taskId, subAgentId, parentAgentId, sessionId, null);
+        String subSessionId =
+                spec instanceof TaskRunSpec.SuspensibleLocalTaskRunSpec suspensible
+                        ? suspensible.subSessionId()
+                        : null;
+        TaskRecord record =
+                new TaskRecord(taskId, subAgentId, parentAgentId, sessionId, subSessionId);
+        record.setUserId(capturedRc.getUserId());
         record.setStatus(TaskStatus.PENDING);
         if (spec instanceof TaskRunSpec.RemoteTaskRunSpec remote) {
             record.setTransportType(TRANSPORT_AGENT_PROTOCOL);
@@ -274,6 +284,20 @@ public class WorkspaceTaskRepository implements TaskRepository {
                                             subAgentId,
                                             local.execution()),
                             executor);
+        } else if (spec instanceof TaskRunSpec.SuspensibleLocalTaskRunSpec suspensible) {
+            future = new CompletableFuture<>();
+            BackgroundTask bgTask = new BackgroundTask(taskId, subAgentId, future);
+            registerLocalTask(localKey, sessionId, capturedRc, bgTask);
+            executor.execute(
+                    () ->
+                            runSuspensibleSupplier(
+                                    capturedRc,
+                                    sessionId,
+                                    taskId,
+                                    subAgentId,
+                                    suspensible.execution(),
+                                    bgTask));
+            return bgTask;
         } else if (spec instanceof TaskRunSpec.RemoteTaskRunSpec remote) {
             future =
                     CompletableFuture.supplyAsync(
@@ -291,10 +315,142 @@ public class WorkspaceTaskRepository implements TaskRepository {
         }
 
         BackgroundTask bgTask = new BackgroundTask(taskId, subAgentId, future);
-        localTasks.put(localKey, bgTask);
-        localTaskSessionIds.put(localKey, sessionId != null ? sessionId : "");
-        localTaskContexts.put(localKey, capturedRc);
+        registerLocalTask(localKey, sessionId, capturedRc, bgTask);
         return bgTask;
+    }
+
+    private void registerLocalTask(
+            String localKey, String sessionId, RuntimeContext runtimeContext, BackgroundTask task) {
+        localTasks.put(localKey, task);
+        localTaskSessionIds.put(localKey, sessionId != null ? sessionId : "");
+        localTaskContexts.put(localKey, runtimeContext);
+    }
+
+    private void runSuspensibleSupplier(
+            RuntimeContext rc,
+            String sessionId,
+            String taskId,
+            String subAgentId,
+            Supplier<TaskRunOutcome> execution,
+            BackgroundTask task) {
+        task.markStatus(TaskStatus.RUNNING);
+        if (!tryUpdateStatus(rc, sessionId, taskId, TaskStatus.RUNNING, null, null)) {
+            restorePersistedStatus(rc, sessionId, taskId, task);
+            return;
+        }
+        applySuspensibleOutcome(rc, sessionId, taskId, subAgentId, task, execution);
+    }
+
+    private void applySuspensibleOutcome(
+            RuntimeContext rc,
+            String sessionId,
+            String taskId,
+            String subAgentId,
+            BackgroundTask task,
+            Supplier<TaskRunOutcome> execution) {
+        try {
+            TaskRunOutcome outcome = execution.get();
+            if (outcome instanceof TaskRunOutcome.WaitingForApproval waiting) {
+                task.markStatus(TaskStatus.WAITING_FOR_APPROVAL);
+                if (!persistWaiting(rc, sessionId, taskId, waiting.suspension())) {
+                    restorePersistedStatus(rc, sessionId, taskId, task);
+                }
+                return;
+            }
+            if (outcome instanceof TaskRunOutcome.Denied denied) {
+                if (!tryUpdateStatus(
+                        rc, sessionId, taskId, TaskStatus.DENIED, denied.result(), null)) {
+                    restorePersistedStatus(rc, sessionId, taskId, task);
+                    return;
+                }
+                task.complete(denied.result(), TaskStatus.DENIED);
+                fireCompletionCallback(rc, taskId, subAgentId, sessionId, denied.result());
+                return;
+            }
+            TaskRunOutcome.Completed completed = (TaskRunOutcome.Completed) outcome;
+            if (!tryUpdateStatus(
+                    rc, sessionId, taskId, TaskStatus.COMPLETED, completed.result(), null)) {
+                restorePersistedStatus(rc, sessionId, taskId, task);
+                return;
+            }
+            task.complete(completed.result(), TaskStatus.COMPLETED);
+            fireCompletionCallback(rc, taskId, subAgentId, sessionId, completed.result());
+        } catch (Exception e) {
+            String message = e.getMessage() != null ? e.getMessage() : e.getClass().getSimpleName();
+            if (!tryUpdateStatus(rc, sessionId, taskId, TaskStatus.FAILED, null, message)) {
+                restorePersistedStatus(rc, sessionId, taskId, task);
+                return;
+            }
+            task.completeExceptionally(e);
+            fireCompletionCallback(rc, taskId, subAgentId, sessionId, null);
+        }
+    }
+
+    private boolean persistWaiting(
+            RuntimeContext rc, String sessionId, String taskId, TaskSuspension suspension) {
+        Optional<TaskRecord> existing =
+                workspaceManager.readTaskRecord(rc, parentAgentId, sessionId, taskId);
+        if (existing.isEmpty() || existing.get().getStatus().isTerminal()) {
+            return false;
+        }
+        TaskRecord record = existing.get();
+        record.setStatus(TaskStatus.WAITING_FOR_APPROVAL);
+        record.setSuspension(suspension);
+        record.setSubSessionId(suspension.subSessionId());
+        record.setUserId(suspension.userId());
+        record.touch();
+        persistRecord(rc, sessionId, record);
+        return true;
+    }
+
+    private void restorePersistedStatus(
+            RuntimeContext rc, String sessionId, String taskId, BackgroundTask task) {
+        workspaceManager
+                .readTaskRecord(rc, parentAgentId, sessionId, taskId)
+                .map(TaskRecord::getStatus)
+                .ifPresent(task::markStatus);
+    }
+
+    @Override
+    public boolean resumeTask(
+            RuntimeContext rc,
+            String sessionId,
+            String taskId,
+            Supplier<TaskRunOutcome> continuation) {
+        Objects.requireNonNull(continuation, "continuation must not be null");
+        RuntimeContext effectiveRc = rc != null ? rc : RuntimeContext.empty();
+        String key = localKey(sessionId, taskId);
+        Object transitionLock = taskTransitionLocks.computeIfAbsent(key, ignored -> new Object());
+        synchronized (transitionLock) {
+            Optional<TaskRecord> existing =
+                    workspaceManager.readTaskRecord(effectiveRc, parentAgentId, sessionId, taskId);
+            if (existing.isEmpty()
+                    || existing.get().getStatus() != TaskStatus.WAITING_FOR_APPROVAL) {
+                return false;
+            }
+            TaskRecord record = existing.get();
+            record.setStatus(TaskStatus.RUNNING);
+            record.touch();
+            persistRecord(effectiveRc, sessionId, record);
+            CompletableFuture<String> future = new CompletableFuture<>();
+            BackgroundTask task =
+                    localTasks.computeIfAbsent(
+                            key,
+                            ignored -> new BackgroundTask(taskId, record.getSubAgentId(), future));
+            task.markStatus(TaskStatus.RUNNING);
+            localTaskSessionIds.put(key, sessionId != null ? sessionId : "");
+            localTaskContexts.put(key, effectiveRc);
+            executor.execute(
+                    () ->
+                            applySuspensibleOutcome(
+                                    effectiveRc,
+                                    sessionId,
+                                    taskId,
+                                    record.getSubAgentId(),
+                                    task,
+                                    continuation));
+            return true;
+        }
     }
 
     private String runLocalSupplier(
@@ -559,6 +715,7 @@ public class WorkspaceTaskRepository implements TaskRepository {
         localTasks.clear();
         localTaskSessionIds.clear();
         localTaskContexts.clear();
+        taskTransitionLocks.clear();
     }
 
     /** Shuts down the maintenance scheduler and (if owned) the task executor. */
@@ -749,22 +906,31 @@ public class WorkspaceTaskRepository implements TaskRepository {
             TaskStatus status,
             String result,
             String error) {
+        tryUpdateStatus(rc, sessionId, taskId, status, result, error);
+    }
+
+    private boolean tryUpdateStatus(
+            RuntimeContext rc,
+            String sessionId,
+            String taskId,
+            TaskStatus status,
+            String result,
+            String error) {
         Optional<TaskRecord> existing =
                 workspaceManager.readTaskRecord(rc, parentAgentId, sessionId, taskId);
-        // Guard 1: terminal states are immutable — never overwrite COMPLETED, FAILED, or CANCELLED
-        // with any other status. This prevents a late COMPLETED/FAILED write from a still-running
-        // thread from clobbering a CANCELLED status set concurrently by cancelTask().
+        // Guard 1: terminal states are immutable. This prevents a late terminal or non-terminal
+        // write from a still-running thread from clobbering the transition that won the race.
         if (existing.isPresent()
                 && existing.get().getStatus() != null
                 && existing.get().getStatus().isTerminal()) {
-            return;
+            return false;
         }
         // Guard 2: if cancellation has been requested but the workspace record has not yet reached
         // a terminal state (e.g. heartbeat races cancelTask()), refuse to persist non-terminal
         // updates. This stops the heartbeat from writing RUNNING back over a record whose
         // cancelRequested flag was just set by cancelTask().
         if (!status.isTerminal() && existing.isPresent() && existing.get().isCancelRequested()) {
-            return;
+            return false;
         }
         TaskRecord record =
                 existing.orElseGet(
@@ -783,6 +949,7 @@ public class WorkspaceTaskRepository implements TaskRepository {
             record.setErrorMessage(error);
         }
         persistRecord(rc, sessionId, record);
+        return true;
     }
 
     private void markCancelled(RuntimeContext rc, String sessionId, String taskId) {
@@ -809,6 +976,7 @@ public class WorkspaceTaskRepository implements TaskRepository {
                 future = new CompletableFuture<>();
                 future.cancel(false);
             }
+            case DENIED -> future = CompletableFuture.completedFuture(record.getResult());
             default -> {
                 if (record.isAgentProtocolTransport()
                         && record.getRemoteBaseUrl() != null
@@ -858,7 +1026,10 @@ public class WorkspaceTaskRepository implements TaskRepository {
                 }
             }
         }
-        return new BackgroundTask(record.getTaskId(), record.getSubAgentId(), future);
+        BackgroundTask task =
+                new BackgroundTask(record.getTaskId(), record.getSubAgentId(), future);
+        task.markStatus(record.getStatus());
+        return task;
     }
 
     private void fireCompletionCallback(
@@ -875,7 +1046,7 @@ public class WorkspaceTaskRepository implements TaskRepository {
     }
 
     /**
-     * Callback invoked when a background task reaches a terminal state (COMPLETED or FAILED).
+     * Callback invoked when a background task reaches a terminal state.
      * Implementations typically push the result to the session inbox and enqueue a wakeup signal.
      * {@code result} is {@code null} when the task failed; callers should read the persisted
      * {@link TaskRecord} for the error message.

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/tool/AgentSpawnTool.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/tool/AgentSpawnTool.java
@@ -26,8 +26,10 @@ import io.agentscope.core.event.AgentEndEvent;
 import io.agentscope.core.event.AgentEvent;
 import io.agentscope.core.event.AgentEventEmitter;
 import io.agentscope.core.event.AgentStartEvent;
+import io.agentscope.core.event.ConfirmResult;
 import io.agentscope.core.event.SubagentExposedEvent;
 import io.agentscope.core.message.Msg;
+import io.agentscope.core.message.MsgRole;
 import io.agentscope.core.permission.PermissionContextState;
 import io.agentscope.core.state.AgentState;
 import io.agentscope.core.tool.Tool;
@@ -40,8 +42,14 @@ import io.agentscope.harness.agent.subagent.DefaultAgentManager;
 import io.agentscope.harness.agent.subagent.SubagentDeclaration;
 import io.agentscope.harness.agent.subagent.task.BackgroundTask;
 import io.agentscope.harness.agent.subagent.task.TaskRepository;
+import io.agentscope.harness.agent.subagent.task.TaskRunOutcome;
 import io.agentscope.harness.agent.subagent.task.TaskRunSpec;
 import io.agentscope.harness.agent.subagent.task.TaskStatus;
+import io.agentscope.harness.agent.subagent.task.TaskSuspension;
+import java.util.HashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
@@ -330,93 +338,12 @@ public class AgentSpawnTool {
                     canonLabel);
         }
 
-        long timeoutMs = resolveTimeoutMs(timeoutSeconds, DEFAULT_TIMEOUT_SECONDS);
-        boolean remote = declOpt.map(SubagentDeclaration::isRemote).orElse(false);
-
-        if (timeoutMs == 0) {
-            String taskId = "task_" + UUID.randomUUID();
-            final String capturedTask = task;
-            TaskRunSpec spec;
-            if (remote) {
-                SubagentDeclaration d = declOpt.get();
-                spec =
-                        new TaskRunSpec.RemoteTaskRunSpec(
-                                d.getUrl(), d.getHeaders(), agentId, capturedTask);
-            } else {
-                spec =
-                        new TaskRunSpec.LocalTaskRunSpec(
-                                () -> {
-                                    try {
-                                        Msg reply =
-                                                agentManager
-                                                        .invokeAgent(
-                                                                agent,
-                                                                sessionId,
-                                                                currentUserId,
-                                                                capturedTask,
-                                                                runtimeContext)
-                                                        .block();
-                                        return reply != null ? reply.getTextContent() : "";
-                                    } catch (RuntimeException e) {
-                                        return "Error: "
-                                                + (e.getMessage() != null
-                                                        ? e.getMessage()
-                                                        : e.getClass().getSimpleName());
-                                    }
-                                });
-            }
-            taskRepository.putTask(runtimeContext, taskId, agentId, parentSessionId, spec);
-            return withSubagentExposedEvent(
-                    Mono.just(
-                            spawnInfo
-                                    + "\n"
-                                    + String.format(BG_RESULT_TEMPLATE, taskId, taskId, taskId)),
-                    subagentId,
-                    agentId,
-                    sessionId,
-                    canonLabel);
-        }
-
-        if (remote) {
-            final String finalTask = task;
-            return withSubagentExposedEvent(
-                    Mono.fromCallable(
-                            () ->
-                                    runRemoteSync(
-                                            runtimeContext,
-                                            spawnInfo,
-                                            agentId,
-                                            parentSessionId,
-                                            declOpt.get(),
-                                            finalTask.trim(),
-                                            timeoutMs)),
-                    subagentId,
-                    agentId,
-                    sessionId,
-                    canonLabel);
-        }
-
-        // Sync-local execution with timeout promotion: if the agent doesn't finish within the
-        // timeout, its in-flight execution is promoted to an async task instead of being lost.
-        final String finalTask = task.trim();
-        final String finalSpawnInfo = spawnInfo;
-        final String finalSubagentId = subagentId;
-        final String finalLabel = canonLabel;
         return withSubagentExposedEvent(
-                execWithTimeoutPromotion(
-                        agent,
-                        sessionId,
-                        currentUserId,
-                        finalTask,
-                        spawned,
-                        runtimeContext,
-                        finalSpawnInfo,
-                        timeoutMs,
-                        agentId),
-                finalSubagentId,
+                execSpawnTask(spawned, runtimeContext, spawnInfo, task, timeoutSeconds, declOpt),
+                subagentId,
                 agentId,
                 sessionId,
-                finalLabel);
+                canonLabel);
     }
 
     @Tool(
@@ -1132,26 +1059,15 @@ public class AgentSpawnTool {
                                 d.getUrl(), d.getHeaders(), spawned.agentId(), capturedTask);
             } else {
                 spec =
-                        new TaskRunSpec.LocalTaskRunSpec(
-                                () -> {
-                                    try {
-                                        Msg reply =
-                                                agentManager
-                                                        .invokeAgent(
-                                                                spawned.agent(),
-                                                                spawned.sessionId(),
-                                                                currentUserId,
-                                                                capturedTask,
-                                                                runtimeContext)
-                                                        .block();
-                                        return reply != null ? reply.getTextContent() : "";
-                                    } catch (RuntimeException e) {
-                                        return "Error: "
-                                                + (e.getMessage() != null
-                                                        ? e.getMessage()
-                                                        : e.getClass().getSimpleName());
-                                    }
-                                });
+                        new TaskRunSpec.SuspensibleLocalTaskRunSpec(
+                                () ->
+                                        agentManager.invokeAgentTask(
+                                                spawned.agent(),
+                                                spawned.sessionId(),
+                                                currentUserId,
+                                                capturedTask,
+                                                runtimeContext),
+                                spawned.sessionId());
             }
             taskRepository.putTask(
                     runtimeContext, taskId, spawned.agentId(), parentSessionId, spec);
@@ -1185,6 +1101,111 @@ public class AgentSpawnTool {
                 finalSpawnInfo,
                 timeoutMs,
                 spawned.agentId());
+    }
+
+    /**
+     * Resumes an async subagent task suspended for permission approval.
+     *
+     * <p>The task repository owns scheduling and lifecycle transitions. This method validates the
+     * complete user/parent/child/reply/tool lineage before re-materializing and resuming the same
+     * child slot.
+     */
+    public boolean resumeSuspendedTask(
+            RuntimeContext parentContext,
+            AgentState parentState,
+            String taskId,
+            String replyId,
+            List<ConfirmResult> confirmResults) {
+        if (taskRepository == null || parentContext == null || parentState == null) {
+            return false;
+        }
+        String parentSessionId = parentContext.getSessionId();
+        Optional<TaskSuspension> suspensionOpt =
+                taskRepository.getTaskSuspension(parentContext, parentSessionId, taskId);
+        if (suspensionOpt.isEmpty()) {
+            return false;
+        }
+        TaskSuspension suspension = suspensionOpt.get();
+        if (!Objects.equals(parentContext.getUserId(), suspension.userId())
+                || !Objects.equals(parentSessionId, suspension.parentSessionId())
+                || !Objects.equals(replyId, suspension.replyId())
+                || !matchesPendingTools(suspension, confirmResults)) {
+            return false;
+        }
+        SpawnedAgent spawned =
+                findSpawnedBySession(parentState, suspension.subSessionId(), parentContext);
+        if (spawned == null) {
+            return false;
+        }
+        Msg confirmation = confirmationMessage(confirmResults);
+        boolean allDenied = confirmResults.stream().noneMatch(ConfirmResult::isConfirmed);
+        return taskRepository.resumeTask(
+                parentContext,
+                parentSessionId,
+                taskId,
+                () -> {
+                    TaskRunOutcome outcome =
+                            agentManager.invokeAgentTask(
+                                    spawned.agent(),
+                                    spawned.sessionId(),
+                                    parentContext.getUserId(),
+                                    List.of(confirmation),
+                                    parentContext);
+                    if (allDenied && outcome instanceof TaskRunOutcome.Completed completed) {
+                        return new TaskRunOutcome.Denied(completed.result());
+                    }
+                    return outcome;
+                });
+    }
+
+    private SpawnedAgent findSpawnedBySession(
+            AgentState parentState, String childSessionId, RuntimeContext runtimeContext) {
+        for (SpawnedAgent spawned : agentsByKey.values()) {
+            if (Objects.equals(childSessionId, spawned.sessionId())) {
+                return spawned;
+            }
+        }
+        for (Map.Entry<String, io.agentscope.core.state.ToolContextState.SpawnEntry> entry :
+                parentState.getToolContext().getSpawnRegistry().entrySet()) {
+            if (Objects.equals(childSessionId, entry.getValue().sessionId())) {
+                return tryRestoreFromState(parentState, entry.getKey(), runtimeContext);
+            }
+        }
+        return null;
+    }
+
+    private static boolean matchesPendingTools(
+            TaskSuspension suspension, List<ConfirmResult> confirmResults) {
+        if (confirmResults == null || confirmResults.isEmpty()) {
+            return false;
+        }
+        LinkedHashSet<PendingToolIdentity> expected = new LinkedHashSet<>();
+        for (TaskSuspension.PendingToolCall pending : suspension.pendingToolCalls()) {
+            expected.add(new PendingToolIdentity(pending.toolCallId(), pending.toolName()));
+        }
+        LinkedHashSet<PendingToolIdentity> actual = new LinkedHashSet<>();
+        for (ConfirmResult result : confirmResults) {
+            if (result == null || result.getToolCall() == null) {
+                return false;
+            }
+            actual.add(
+                    new PendingToolIdentity(
+                            result.getToolCall().getId(), result.getToolCall().getName()));
+        }
+        return expected.equals(actual);
+    }
+
+    private record PendingToolIdentity(String toolCallId, String toolName) {}
+
+    private static Msg confirmationMessage(List<ConfirmResult> confirmResults) {
+        Map<String, Object> metadata = new HashMap<>();
+        metadata.put(Msg.METADATA_CONFIRM_RESULTS, List.copyOf(confirmResults));
+        return Msg.builder()
+                .name("user")
+                .role(MsgRole.USER)
+                .textContent("[confirm]")
+                .metadata(metadata)
+                .build();
     }
 
     /**

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/tool/AgentSpawnTool.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/tool/AgentSpawnTool.java
@@ -322,7 +322,8 @@ public class AgentSpawnTool {
                             ? runtimeContext.get("outboundAddress", OutboundAddress.class)
                             : null;
             SubagentGatewayBridge.ExposeResult er =
-                    gatewayBridge.expose(agentId, sessionId, agent, replyTo);
+                    gatewayBridge.expose(
+                            agentId, sessionId, agent, replyTo, currentUserId, parentSessionId);
             subagentId = er.subagentId();
         }
 

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/tool/AgentSpawnTool.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/tool/AgentSpawnTool.java
@@ -29,7 +29,6 @@ import io.agentscope.core.event.AgentStartEvent;
 import io.agentscope.core.event.SubagentExposedEvent;
 import io.agentscope.core.message.Msg;
 import io.agentscope.core.permission.PermissionContextState;
-import io.agentscope.core.permission.PermissionRule;
 import io.agentscope.core.state.AgentState;
 import io.agentscope.core.tool.Tool;
 import io.agentscope.core.tool.ToolParam;
@@ -43,8 +42,6 @@ import io.agentscope.harness.agent.subagent.task.BackgroundTask;
 import io.agentscope.harness.agent.subagent.task.TaskRepository;
 import io.agentscope.harness.agent.subagent.task.TaskRunSpec;
 import io.agentscope.harness.agent.subagent.task.TaskStatus;
-import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
@@ -240,20 +237,6 @@ public class AgentSpawnTool {
             return Mono.just("Error: Maximum spawn depth exceeded (max=" + MAX_SPAWN_DEPTH + ")");
         }
         String canonLabel = label != null && !label.isBlank() ? label.trim() : null;
-
-        Optional<Agent> agentOpt = agentManager.createAgentIfPresent(agentId, runtimeContext);
-        if (agentOpt.isEmpty()) {
-            if (agentManager.isPrimaryOnly(agentId)) {
-                return Mono.just(
-                        "Error: agent_id '"
-                                + agentId
-                                + "' is PRIMARY-only and cannot be spawned as a subagent.");
-            }
-            log.warn("agent_spawn unknown agentId={}, known={}", agentId, agentManager);
-            return Mono.just("Error: Unknown agent_id: " + agentId);
-        }
-        log.debug("agent_spawn resolved: agentId={}", agentId);
-        Agent agent = agentOpt.get();
         String currentUserId = runtimeContext != null ? runtimeContext.getUserId() : null;
         String parentSessionId = runtimeContext != null ? runtimeContext.getSessionId() : null;
         var declOpt = agentManager.getDeclaration(agentId);
@@ -268,6 +251,8 @@ public class AgentSpawnTool {
             // Reuse existing agent if same deterministic key was already spawned.
             SpawnedAgent existing = agentsByKey.get(key);
             if (existing != null) {
+                inheritParentPermissionContext(
+                        parentState, existing.agent(), currentUserId, sessionId, declOpt);
                 String spawnInfo = formatSpawnInfo(key, agentId, sessionId, null);
                 boolean hasTask = task != null && !task.isBlank();
                 if (!hasTask) {
@@ -280,6 +265,20 @@ public class AgentSpawnTool {
             key = "agent:" + agentId + ":" + UUID.randomUUID();
             sessionId = "sub-" + UUID.randomUUID();
         }
+
+        Optional<Agent> agentOpt = agentManager.createAgentIfPresent(agentId, runtimeContext);
+        if (agentOpt.isEmpty()) {
+            if (agentManager.isPrimaryOnly(agentId)) {
+                return Mono.just(
+                        "Error: agent_id '"
+                                + agentId
+                                + "' is PRIMARY-only and cannot be spawned as a subagent.");
+            }
+            log.warn("agent_spawn unknown agentId={}, known={}", agentId, agentManager);
+            return Mono.just("Error: Unknown agent_id: " + agentId);
+        }
+        log.debug("agent_spawn resolved: agentId={}", agentId);
+        Agent agent = agentOpt.get();
 
         // Label uniqueness check — skipped above for persist=true reuse path (already returned).
         if (canonLabel != null && labelToKey.containsKey(canonLabel.toLowerCase())) {
@@ -301,11 +300,7 @@ public class AgentSpawnTool {
             ha.enterPlanMode(currentUserId, sessionId);
         }
 
-        // Propagate DENY permission rules from parent to child (security boundary inheritance).
-        boolean inherit = declOpt.map(SubagentDeclaration::isInheritParentPermissions).orElse(true);
-        if (inherit && parentState != null && agent instanceof ReActAgent ra) {
-            propagateDenyRules(parentState, ra);
-        }
+        inheritParentPermissionContext(parentState, agent, currentUserId, sessionId, declOpt);
 
         // Expose subagent to user via gateway bridge if requested. The effective decision combines
         // (in priority order) a per-call RuntimeContext override, the declaration policy, and the
@@ -1203,25 +1198,34 @@ public class AgentSpawnTool {
                 : SessionIdUtils.deterministicHash(parent, agentId);
     }
 
-    /**
-     * Copies all DENY rules from the parent's permission context into the child's permission
-     * engine. This enforces the security boundary: anything the parent is explicitly denied, the
-     * child is also denied.
-     */
-    private static void propagateDenyRules(AgentState parentState, ReActAgent child) {
-        PermissionContextState parentPerms = parentState.getPermissionContext();
-        if (parentPerms == null || parentPerms.getDenyRules().isEmpty()) {
+    private static void inheritParentPermissionContext(
+            AgentState parentState,
+            Agent childAgent,
+            String userId,
+            String childSessionId,
+            Optional<SubagentDeclaration> declaration) {
+        boolean inherit =
+                declaration.map(SubagentDeclaration::isInheritParentPermissions).orElse(true);
+        if (!inherit || parentState == null) {
             return;
         }
-        var childEngine = child.getPermissionEngine();
-        if (childEngine == null) {
+        ReActAgent child = reactAgent(childAgent);
+        PermissionContextState parentPermissions = parentState.getPermissionContext();
+        if (child == null || parentPermissions == null) {
             return;
         }
-        for (Map.Entry<String, List<PermissionRule>> entry :
-                parentPerms.getDenyRules().entrySet()) {
-            for (PermissionRule rule : entry.getValue()) {
-                childEngine.addRule(rule);
-            }
+        PermissionContextState childPermissions =
+                child.getAgentState(userId, childSessionId).getPermissionContext();
+        PermissionContextState inherited = childPermissions.inheritFrom(parentPermissions);
+        if (!inherited.equals(childPermissions)) {
+            child.replacePermissionContext(userId, childSessionId, inherited);
         }
+    }
+
+    private static ReActAgent reactAgent(Agent agent) {
+        if (agent instanceof HarnessAgent harnessAgent) {
+            return harnessAgent.getDelegate();
+        }
+        return agent instanceof ReActAgent reactAgent ? reactAgent : null;
     }
 }

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/HarnessAgentTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/HarnessAgentTest.java
@@ -49,6 +49,7 @@ import io.agentscope.harness.agent.example.support.InMemorySandboxFilesystemSpec
 import io.agentscope.harness.agent.filesystem.AbstractFilesystem;
 import io.agentscope.harness.agent.filesystem.local.LocalFilesystem;
 import io.agentscope.harness.agent.filesystem.remote.store.InMemoryStore;
+import io.agentscope.harness.agent.filesystem.spec.LocalFilesystemSpec;
 import io.agentscope.harness.agent.filesystem.spec.RemoteFilesystemSpec;
 import io.agentscope.harness.agent.memory.compaction.CompactionConfig;
 import io.agentscope.harness.agent.middleware.AgentTraceMiddleware;
@@ -864,6 +865,43 @@ class HarnessAgentTest {
                 workspace.normalize(),
                 child.getWorkspaceManager().getWorkspace().normalize(),
                 "shared+no-path: runtime workspace must be mainWorkspace");
+    }
+
+    @Test
+    void sharedDeclarationUsesParentsResolvedLocalFilesystemSpec() throws Exception {
+        Files.createDirectories(workspace);
+        SubagentDeclaration declaration =
+                SubagentDeclaration.builder()
+                        .name("shared-native")
+                        .description("shared native filesystem")
+                        .workspaceMode(WorkspaceMode.SHARED)
+                        .inlineAgentsBody("Use the parent workspace.")
+                        .build();
+
+        try (HarnessAgent parent =
+                HarnessAgent.builder()
+                        .name("parent")
+                        .model(stubModel("ok"))
+                        .workspace(workspace)
+                        .filesystem(new LocalFilesystemSpec().project(workspace))
+                        .subagent(declaration)
+                        .build()) {
+            Agent materialized =
+                    parent.getSubagentAgentManager()
+                            .createAgentIfPresent(
+                                    "shared-native",
+                                    RuntimeContext.builder()
+                                            .userId("user-a")
+                                            .sessionId("parent-a")
+                                            .build())
+                            .orElseThrow();
+            try (HarnessAgent child = (HarnessAgent) materialized) {
+                assertSame(
+                        parent.getWorkspaceManager().getFilesystem(),
+                        child.getWorkspaceManager().getFilesystem(),
+                        "shared child must reuse the resolved parent filesystem owner");
+            }
+        }
     }
 
     /** Row 5 (built-in general-purpose): runtime root = mainWorkspace. */

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/gateway/SubagentRegistryRecoveryIntegrationTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/gateway/SubagentRegistryRecoveryIntegrationTest.java
@@ -20,6 +20,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import io.agentscope.core.agent.RuntimeContext;
 import io.agentscope.core.agent.test.MockModel;
 import io.agentscope.core.message.Msg;
 import io.agentscope.core.message.MsgRole;
@@ -31,6 +32,7 @@ import io.agentscope.harness.agent.HarnessAgent;
 import io.agentscope.harness.agent.filesystem.local.LocalFilesystem;
 import io.agentscope.harness.agent.filesystem.remote.store.BaseStore;
 import io.agentscope.harness.agent.filesystem.remote.store.InMemoryStore;
+import io.agentscope.harness.agent.gateway.channel.OutboundAddress;
 import java.nio.file.Path;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -110,6 +112,7 @@ class SubagentRegistryRecoveryIntegrationTest {
         // preventing background WorkspaceTaskRepository threads from writing to @TempDir after
         // JUnit begins cleanup.
         List<HarnessAgent> createdAgents = new ArrayList<>();
+        List<RuntimeContext> materializationContexts = new ArrayList<>();
         Supplier<HarnessAgent> subFactory =
                 () -> {
                     HarnessAgent a = buildEchoSubagent(sharedState);
@@ -121,11 +124,23 @@ class SubagentRegistryRecoveryIntegrationTest {
             // ---- Node A: expose a live subagent and run the first turn. ----
             HarnessGateway nodeA = HarnessGateway.create();
             nodeA.setSubagentRegistry(new StoreBackedSubagentRegistry(sharedBase));
-            nodeA.setSubagentMaterializer((agentId, rc) -> Optional.of(subFactory.get()));
+            nodeA.setSubagentMaterializer(
+                    (agentId, rc) -> {
+                        materializationContexts.add(rc);
+                        return Optional.of(subFactory.get());
+                    });
 
             HarnessAgent liveSub = subFactory.get();
-            String subagentId = nodeA.exposeSubagent("echo", SUB_SESSION, liveSub, null);
+            OutboundAddress replyTo =
+                    new OutboundAddress("chatui", "account-1", "chatui:DM:user-1", "thread-1");
+            String subagentId =
+                    nodeA.exposeSubagent(
+                            "echo", SUB_SESSION, liveSub, replyTo, "user-1", "parent-1");
             assertNotNull(subagentId);
+            SubagentRecord exposed =
+                    nodeA.findExposedSubagent("user-1", "parent-1", SUB_SESSION).orElseThrow();
+            assertEquals("echo", exposed.agentId());
+            assertEquals(replyTo, exposed.replyTo());
 
             Msg firstReply = nodeA.runSubagent(subagentId, List.of(ping())).block();
             assertEquals("turns=1", text(firstReply), "node A sees exactly its own turn");
@@ -133,7 +148,11 @@ class SubagentRegistryRecoveryIntegrationTest {
             // ---- Node B: a fresh gateway with an EMPTY live cache, sharing only the store. ----
             HarnessGateway nodeB = HarnessGateway.create();
             nodeB.setSubagentRegistry(new StoreBackedSubagentRegistry(sharedBase));
-            nodeB.setSubagentMaterializer((agentId, rc) -> Optional.of(subFactory.get()));
+            nodeB.setSubagentMaterializer(
+                    (agentId, rc) -> {
+                        materializationContexts.add(rc);
+                        return Optional.of(subFactory.get());
+                    });
 
             Msg secondReply = nodeB.runSubagent(subagentId, List.of(ping())).block();
             // turns=2 proves: (1) the subagentId was resolved from the shared registry on a node
@@ -141,6 +160,13 @@ class SubagentRegistryRecoveryIntegrationTest {
             // turn was loaded from the shared state store by sessionId.
             assertEquals(
                     "turns=2", text(secondReply), "node B recovered and continued the session");
+            RuntimeContext recoveredContext =
+                    materializationContexts.get(materializationContexts.size() - 1);
+            assertEquals("user-1", recoveredContext.getUserId());
+            assertEquals(SUB_SESSION, recoveredContext.getSessionId());
+            assertEquals(
+                    "parent-1",
+                    recoveredContext.get(SubagentRecord.RUNTIME_PARENT_SESSION_ID, String.class));
         } finally {
             for (HarnessAgent agent : createdAgents) {
                 try {
@@ -221,5 +247,39 @@ class SubagentRegistryRecoveryIntegrationTest {
                         Instant.now().minusSeconds(120),
                         Instant.now().minusSeconds(60)));
         assertTrue(reader.find("sub-expired").isEmpty(), "expired record must not resolve");
+    }
+
+    @Test
+    void lineageLookupFailsClosedOnAnyTenantOrParentMismatch() {
+        BaseStore sharedBase = new InMemoryStore();
+        SubagentRegistry writer = new StoreBackedSubagentRegistry(sharedBase);
+        SubagentRegistry reader = new StoreBackedSubagentRegistry(sharedBase);
+        SubagentRecord record =
+                new SubagentRecord(
+                        "sub-lineage",
+                        "echo",
+                        SUB_SESSION,
+                        "user-1",
+                        "parent-1",
+                        OutboundAddress.direct("chatui", "chatui:DM:user-1"),
+                        Instant.now(),
+                        null);
+        writer.register(record);
+
+        SubagentRecord found =
+                reader.findByLineage("user-1", "parent-1", SUB_SESSION).orElseThrow();
+        assertEquals(record.subagentId(), found.subagentId());
+        assertEquals(record.agentId(), found.agentId());
+        assertEquals(record.userId(), found.userId());
+        assertEquals(record.parentSessionId(), found.parentSessionId());
+        assertEquals(record.sessionId(), found.sessionId());
+        assertEquals(record.replyTo(), found.replyTo());
+        assertTrue(reader.findByLineage("user-2", "parent-1", SUB_SESSION).isEmpty());
+        assertTrue(reader.findByLineage("user-1", "parent-2", SUB_SESSION).isEmpty());
+        assertTrue(reader.findByLineage("user-1", "parent-1", "other-child").isEmpty());
+        assertTrue(reader.findByLineage(null, "parent-1", SUB_SESSION).isEmpty());
+
+        SubagentRecord roundTrip = reader.find("sub-lineage").orElseThrow();
+        assertEquals(record.replyTo(), roundTrip.replyTo());
     }
 }

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/middleware/SubagentDeliveryTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/middleware/SubagentDeliveryTest.java
@@ -173,6 +173,17 @@ class SubagentDeliveryTest {
     }
 
     @Test
+    void reminder_deniedRendersDeniedResult() {
+        Msg msg =
+                SubagentsMiddleware.buildDeliveryReminder(
+                        List.of(delivery("td", TaskStatus.DENIED, "user denied edit_file", null)));
+        String text = textOf(msg);
+        assertTrue(text.contains("state=\"denied\""));
+        assertTrue(text.contains("<task_denied>"));
+        assertTrue(text.contains("user denied edit_file"));
+    }
+
+    @Test
     void reminder_capsAndSummarisesOverflow() {
         List<TaskDelivery> ds = new ArrayList<>();
         for (int i = 0; i < SubagentsMiddleware.MAX_DELIVERIES_PER_REMINDER + 5; i++) {

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/subagent/DefaultAgentManagerRuntimeContextTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/subagent/DefaultAgentManagerRuntimeContextTest.java
@@ -99,4 +99,24 @@ class DefaultAgentManagerRuntimeContextTest {
         // We don't assert .equals() here — empty() may return a fresh instance — only that the
         // factory never sees null.
     }
+
+    @Test
+    void materializationCustomizerRunsForEveryPublicCreationPath() {
+        Agent stub = org.mockito.Mockito.mock(Agent.class);
+        DefaultAgentManager manager =
+                new DefaultAgentManager(
+                        List.of(
+                                new SubagentEntry(
+                                        "worker", "desc", ignored -> stub, plainDecl("worker"))),
+                        null);
+        AtomicReference<Agent> customized = new AtomicReference<>();
+        manager.setMaterializationCustomizer(customized::set);
+
+        assertSame(
+                stub, manager.createAgentIfPresent("worker", RuntimeContext.empty()).orElseThrow());
+        assertSame(stub, customized.get());
+        customized.set(null);
+        assertSame(stub, manager.createAgent("worker", RuntimeContext.empty()));
+        assertSame(stub, customized.get());
+    }
 }

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/subagent/task/SuspensibleTaskRunSpecTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/subagent/task/SuspensibleTaskRunSpecTest.java
@@ -71,6 +71,44 @@ class SuspensibleTaskRunSpecTest {
     }
 
     @Test
+    void waitingTaskLookupByChildSessionIsUserScopedAndReturnsParentLineage() throws Exception {
+        submitWaiting("task-child-lookup");
+        awaitStatus("task-child-lookup", TaskStatus.WAITING_FOR_APPROVAL);
+
+        TaskRepository.SuspendedTaskRef found =
+                repo.findSuspendedTaskByChildSession(
+                                RuntimeContext.builder()
+                                        .userId("user-a")
+                                        .sessionId("child-session")
+                                        .build(),
+                                "child-session")
+                        .orElseThrow();
+        assertEquals("task-child-lookup", found.taskId());
+        assertEquals("parent-session", found.parentSessionId());
+        assertEquals(suspension(), found.suspension());
+        assertTrue(
+                repo.findSuspendedTaskByChildSession(
+                                RuntimeContext.builder()
+                                        .userId("user-b")
+                                        .sessionId("child-session")
+                                        .build(),
+                                "child-session")
+                        .isEmpty());
+
+        submitWaiting("task-child-lookup-duplicate");
+        awaitStatus("task-child-lookup-duplicate", TaskStatus.WAITING_FOR_APPROVAL);
+        assertTrue(
+                repo.findSuspendedTaskByChildSession(
+                                RuntimeContext.builder()
+                                        .userId("user-a")
+                                        .sessionId("child-session")
+                                        .build(),
+                                "child-session")
+                        .isEmpty(),
+                "ambiguous waiting tasks for one child must fail closed");
+    }
+
+    @Test
     void repositoryOwnsResumeExecutionAndCompletesExactlyOnce() throws Exception {
         submitWaiting("task-resume");
         awaitStatus("task-resume", TaskStatus.WAITING_FOR_APPROVAL);

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/subagent/task/SuspensibleTaskRunSpecTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/subagent/task/SuspensibleTaskRunSpecTest.java
@@ -1,0 +1,243 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.harness.agent.subagent.task;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.agentscope.core.agent.RuntimeContext;
+import io.agentscope.harness.agent.workspace.WorkspaceManager;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class SuspensibleTaskRunSpecTest {
+
+    @TempDir Path tempDir;
+
+    private WorkspaceManager workspaceManager;
+    private WorkspaceTaskRepository repo;
+    private RuntimeContext runtimeContext;
+
+    @BeforeEach
+    void setUp() {
+        workspaceManager = new WorkspaceManager(tempDir);
+        repo = WorkspaceTaskRepository.forTests(workspaceManager, "parent-agent");
+        runtimeContext =
+                RuntimeContext.builder().userId("user-a").sessionId("parent-session").build();
+    }
+
+    @AfterEach
+    void tearDown() {
+        repo.shutdown();
+    }
+
+    @Test
+    void waitingOutcomeRemainsNonTerminalAndPersistsResumeIdentity() throws Exception {
+        submitWaiting("task-wait");
+
+        awaitStatus("task-wait", TaskStatus.WAITING_FOR_APPROVAL);
+
+        BackgroundTask task = repo.getTask(runtimeContext, "parent-session", "task-wait");
+        assertNotNull(task);
+        assertFalse(task.isCompleted());
+        Optional<TaskRecord> record = readRecord("task-wait");
+        assertTrue(record.isPresent());
+        assertEquals("user-a", record.get().getUserId());
+        assertEquals("child-session", record.get().getSubSessionId());
+        assertEquals(suspension(), record.get().getSuspension());
+        assertTrue(repo.findPendingDeliveries(runtimeContext, "parent-session").isEmpty());
+    }
+
+    @Test
+    void repositoryOwnsResumeExecutionAndCompletesExactlyOnce() throws Exception {
+        submitWaiting("task-resume");
+        awaitStatus("task-resume", TaskStatus.WAITING_FOR_APPROVAL);
+        CountDownLatch continuationStarted = new CountDownLatch(1);
+        CountDownLatch releaseContinuation = new CountDownLatch(1);
+
+        assertTrue(
+                repo.resumeTask(
+                        runtimeContext,
+                        "parent-session",
+                        "task-resume",
+                        () -> {
+                            continuationStarted.countDown();
+                            await(releaseContinuation);
+                            return new TaskRunOutcome.Completed("approved result");
+                        }));
+        continuationStarted.await();
+        awaitStatus("task-resume", TaskStatus.RUNNING);
+        assertFalse(
+                repo.resumeTask(
+                        runtimeContext,
+                        "parent-session",
+                        "task-resume",
+                        () -> new TaskRunOutcome.Completed("duplicate")));
+
+        releaseContinuation.countDown();
+        awaitStatus("task-resume", TaskStatus.COMPLETED);
+
+        assertEquals("approved result", readRecord("task-resume").orElseThrow().getResult());
+        assertFalse(
+                repo.resumeTask(
+                        runtimeContext,
+                        "parent-session",
+                        "task-resume",
+                        () -> new TaskRunOutcome.Completed("late")));
+    }
+
+    @Test
+    void waitingTaskCanResumeAfterRepositoryRestart() throws Exception {
+        submitWaiting("task-restart");
+        awaitStatus("task-restart", TaskStatus.WAITING_FOR_APPROVAL);
+        repo.shutdown();
+        repo = WorkspaceTaskRepository.forTests(workspaceManager, "parent-agent");
+
+        BackgroundTask restored = repo.getTask(runtimeContext, "parent-session", "task-restart");
+        assertEquals(TaskStatus.WAITING_FOR_APPROVAL, restored.getTaskStatus());
+        assertFalse(restored.isCompleted());
+        assertTrue(
+                repo.resumeTask(
+                        runtimeContext,
+                        "parent-session",
+                        "task-restart",
+                        () -> new TaskRunOutcome.Denied("user denied")));
+
+        awaitStatus("task-restart", TaskStatus.DENIED);
+        assertEquals("user denied", readRecord("task-restart").orElseThrow().getResult());
+    }
+
+    @Test
+    void cancellationWinsOverWaitingContinuation() throws Exception {
+        submitWaiting("task-cancel");
+        awaitStatus("task-cancel", TaskStatus.WAITING_FOR_APPROVAL);
+
+        assertTrue(repo.cancelTask(runtimeContext, "parent-session", "task-cancel"));
+        assertEquals(TaskStatus.CANCELLED, readRecord("task-cancel").orElseThrow().getStatus());
+        assertFalse(
+                repo.resumeTask(
+                        runtimeContext,
+                        "parent-session",
+                        "task-cancel",
+                        () -> new TaskRunOutcome.Completed("must not run")));
+    }
+
+    @Test
+    void cancellationDuringContinuationSuppressesLateCompletionAndDelivery() throws Exception {
+        submitWaiting("task-race");
+        awaitStatus("task-race", TaskStatus.WAITING_FOR_APPROVAL);
+        CountDownLatch continuationStarted = new CountDownLatch(1);
+        CountDownLatch releaseContinuation = new CountDownLatch(1);
+        AtomicBoolean continuationReturned = new AtomicBoolean();
+        AtomicBoolean completionCallbackFired = new AtomicBoolean();
+        repo.setCompletionCallback(
+                (rc, taskId, agentId, sessionId, result) -> completionCallbackFired.set(true));
+
+        assertTrue(
+                repo.resumeTask(
+                        runtimeContext,
+                        "parent-session",
+                        "task-race",
+                        () -> {
+                            continuationStarted.countDown();
+                            await(releaseContinuation);
+                            continuationReturned.set(true);
+                            return new TaskRunOutcome.Completed("late result");
+                        }));
+        continuationStarted.await();
+        assertTrue(repo.cancelTask(runtimeContext, "parent-session", "task-race"));
+        releaseContinuation.countDown();
+        awaitCondition(continuationReturned::get);
+
+        TaskRecord record = readRecord("task-race").orElseThrow();
+        assertEquals(TaskStatus.CANCELLED, record.getStatus());
+        assertFalse(completionCallbackFired.get());
+        assertTrue(
+                repo.findPendingDeliveries(runtimeContext, "parent-session").stream()
+                        .anyMatch(delivery -> delivery.status() == TaskStatus.CANCELLED));
+    }
+
+    private void submitWaiting(String taskId) {
+        repo.putTask(
+                runtimeContext,
+                taskId,
+                "worker",
+                "parent-session",
+                new TaskRunSpec.SuspensibleLocalTaskRunSpec(
+                        () -> new TaskRunOutcome.WaitingForApproval(suspension()),
+                        "child-session"));
+    }
+
+    private Optional<TaskRecord> readRecord(String taskId) {
+        return workspaceManager.readTaskRecord(
+                runtimeContext, "parent-agent", "parent-session", taskId);
+    }
+
+    private void awaitStatus(String taskId, TaskStatus status) throws Exception {
+        long deadline = System.currentTimeMillis() + 5_000;
+        while (System.currentTimeMillis() < deadline) {
+            Optional<TaskRecord> record = readRecord(taskId);
+            if (record.isPresent() && record.get().getStatus() == status) {
+                return;
+            }
+            Thread.sleep(20);
+        }
+        throw new AssertionError("Task " + taskId + " did not reach " + status);
+    }
+
+    private static void awaitCondition(Condition condition) throws Exception {
+        long deadline = System.currentTimeMillis() + 5_000;
+        while (System.currentTimeMillis() < deadline) {
+            if (condition.get()) {
+                return;
+            }
+            Thread.sleep(20);
+        }
+        throw new AssertionError("Condition not met");
+    }
+
+    private static TaskSuspension suspension() {
+        return new TaskSuspension(
+                "user-a",
+                "parent-session",
+                "child-session",
+                "reply-1",
+                List.of(new TaskSuspension.PendingToolCall("tool-1", "edit_file")));
+    }
+
+    private static void await(CountDownLatch latch) {
+        try {
+            latch.await();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IllegalStateException("Continuation interrupted", e);
+        }
+    }
+
+    @FunctionalInterface
+    private interface Condition {
+        boolean get();
+    }
+}

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/tool/AgentSpawnToolHitlTaskTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/tool/AgentSpawnToolHitlTaskTest.java
@@ -1,0 +1,396 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.harness.agent.tool;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.agentscope.core.ReActAgent;
+import io.agentscope.core.agent.RuntimeContext;
+import io.agentscope.core.event.ConfirmResult;
+import io.agentscope.core.message.ContentBlock;
+import io.agentscope.core.message.TextBlock;
+import io.agentscope.core.message.ToolResultBlock;
+import io.agentscope.core.message.ToolUseBlock;
+import io.agentscope.core.model.ChatModelBase;
+import io.agentscope.core.model.ChatResponse;
+import io.agentscope.core.model.GenerateOptions;
+import io.agentscope.core.model.ToolSchema;
+import io.agentscope.core.permission.PermissionContextState;
+import io.agentscope.core.permission.PermissionDecision;
+import io.agentscope.core.state.AgentState;
+import io.agentscope.core.state.JsonFileAgentStateStore;
+import io.agentscope.core.tool.ToolBase;
+import io.agentscope.core.tool.ToolCallParam;
+import io.agentscope.core.tool.Toolkit;
+import io.agentscope.harness.agent.middleware.SubagentEntry;
+import io.agentscope.harness.agent.subagent.DefaultAgentManager;
+import io.agentscope.harness.agent.subagent.SubagentDeclaration;
+import io.agentscope.harness.agent.subagent.task.TaskRecord;
+import io.agentscope.harness.agent.subagent.task.TaskRunOutcome;
+import io.agentscope.harness.agent.subagent.task.TaskStatus;
+import io.agentscope.harness.agent.subagent.task.TaskSuspension;
+import io.agentscope.harness.agent.subagent.task.WorkspaceTaskRepository;
+import io.agentscope.harness.agent.workspace.WorkspaceManager;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+class AgentSpawnToolHitlTaskTest {
+
+    @TempDir Path workspace;
+
+    private WorkspaceManager workspaceManager;
+    private WorkspaceTaskRepository taskRepository;
+    private DefaultAgentManager manager;
+    private AgentSpawnTool spawnTool;
+    private RuntimeContext parentContext;
+    private AgentState parentState;
+    private AtomicInteger toolExecutions;
+
+    @BeforeEach
+    void setUp() {
+        workspaceManager = new WorkspaceManager(workspace);
+        taskRepository = new WorkspaceTaskRepository(workspaceManager, "parent-agent");
+        toolExecutions = new AtomicInteger();
+        ScriptedModel sharedModel = scriptedModel();
+        manager =
+                new DefaultAgentManager(
+                        List.of(
+                                new SubagentEntry(
+                                        "worker",
+                                        "permission worker",
+                                        rc ->
+                                                childAgent(
+                                                        toolExecutions,
+                                                        sharedModel,
+                                                        workspace.resolve("child-state")),
+                                        SubagentDeclaration.builder()
+                                                .name("worker")
+                                                .description("permission worker")
+                                                .inlineAgentsBody("Use the guarded tool")
+                                                .persistSession(true)
+                                                .build())),
+                        workspaceManager);
+        spawnTool = new AgentSpawnTool(manager, taskRepository, 0);
+        parentContext =
+                RuntimeContext.builder().userId("user-a").sessionId("parent-session").build();
+        parentState = AgentState.builder().sessionId("parent-session").build();
+    }
+
+    @AfterEach
+    void tearDown() {
+        taskRepository.shutdown();
+    }
+
+    @Test
+    void managerTypedInvocationCapturesPermissionSuspension() {
+        DefaultAgentManager manager = new DefaultAgentManager(List.of(), workspaceManager);
+        AtomicInteger executions = new AtomicInteger();
+        ReActAgent child = childAgent(executions);
+
+        TaskRunOutcome outcome =
+                manager.invokeAgentTask(
+                        child, "child-session", "user-a", "perform guarded work", parentContext);
+
+        assertTrue(outcome instanceof TaskRunOutcome.WaitingForApproval, outcome.toString());
+        TaskSuspension suspension = ((TaskRunOutcome.WaitingForApproval) outcome).suspension();
+        TaskRunOutcome resumed =
+                manager.invokeAgentTask(
+                        child,
+                        "child-session",
+                        "user-a",
+                        List.of(confirmationMessage(true)),
+                        parentContext);
+        assertTrue(resumed instanceof TaskRunOutcome.Completed, resumed.toString());
+        assertEquals(
+                1,
+                executions.get(),
+                "approved continuation must execute the pending tool; context="
+                        + describeContext(child.getAgentState("user-a", "child-session")));
+        assertFalse(suspension.pendingToolCalls().isEmpty());
+    }
+
+    @Test
+    void asyncPermissionPauseResumesSameTaskToCompletion() throws Exception {
+        String taskId = spawnAsyncTask();
+        TaskSuspension suspension = awaitSuspension(taskId);
+        ConfirmResult approved = new ConfirmResult(true, askingToolCall());
+        RuntimeContext wrongUser = RuntimeContext.builder(parentContext).userId("user-b").build();
+
+        assertFalse(
+                spawnTool.resumeSuspendedTask(
+                        wrongUser, parentState, taskId, suspension.replyId(), List.of(approved)));
+        assertFalse(
+                spawnTool.resumeSuspendedTask(
+                        parentContext, parentState, taskId, "wrong-reply", List.of(approved)));
+        assertEquals(TaskStatus.WAITING_FOR_APPROVAL, readRecord(taskId).getStatus());
+        assertTrue(
+                spawnTool.resumeSuspendedTask(
+                        parentContext,
+                        parentState,
+                        taskId,
+                        suspension.replyId(),
+                        List.of(approved)));
+
+        TaskRecord completed = awaitStatus(taskId, TaskStatus.COMPLETED);
+        assertEquals("finished", completed.getResult());
+        assertEquals(1, toolExecutions.get());
+    }
+
+    @Test
+    void deniedPermissionBecomesDistinctTerminalTaskWithoutExecutingTool() throws Exception {
+        String taskId = spawnAsyncTask();
+        TaskSuspension suspension = awaitSuspension(taskId);
+
+        assertTrue(
+                spawnTool.resumeSuspendedTask(
+                        parentContext,
+                        parentState,
+                        taskId,
+                        suspension.replyId(),
+                        List.of(new ConfirmResult(false, askingToolCall()))));
+
+        TaskRecord denied = awaitStatus(taskId, TaskStatus.DENIED);
+        assertEquals("finished", denied.getResult());
+        assertEquals(0, toolExecutions.get());
+    }
+
+    @Test
+    void suspendedTaskResumesAfterRepositoryAndSpawnToolRestart() throws Exception {
+        String taskId = spawnAsyncTask();
+        TaskSuspension suspension = awaitSuspension(taskId);
+        taskRepository.shutdown();
+        taskRepository = new WorkspaceTaskRepository(workspaceManager, "parent-agent");
+        spawnTool = new AgentSpawnTool(manager, taskRepository, 0);
+
+        assertTrue(
+                spawnTool.resumeSuspendedTask(
+                        parentContext,
+                        parentState,
+                        taskId,
+                        suspension.replyId(),
+                        List.of(new ConfirmResult(true, askingToolCall()))));
+
+        TaskRecord completed = awaitStatus(taskId, TaskStatus.COMPLETED);
+        assertEquals("finished", completed.getResult());
+        assertEquals(1, toolExecutions.get());
+    }
+
+    private String spawnAsyncTask() {
+        String response =
+                spawnTool
+                        .agentSpawn(
+                                parentContext,
+                                parentState,
+                                "worker",
+                                "perform guarded work",
+                                "review",
+                                0,
+                                false)
+                        .block();
+        for (String line : response.split("\\R")) {
+            if (line.startsWith("task_id: ")) {
+                return line.substring("task_id: ".length()).trim();
+            }
+        }
+        throw new AssertionError("Spawn response has no task_id: " + response);
+    }
+
+    private TaskSuspension awaitSuspension(String taskId) throws Exception {
+        TaskRecord record = awaitStatus(taskId, TaskStatus.WAITING_FOR_APPROVAL);
+        assertFalse(taskRepository.getTask(parentContext, "parent-session", taskId).isCompleted());
+        return record.getSuspension();
+    }
+
+    private TaskRecord awaitStatus(String taskId, TaskStatus status) throws Exception {
+        long deadline = System.currentTimeMillis() + 5_000;
+        while (System.currentTimeMillis() < deadline) {
+            Optional<TaskRecord> record = readRecordOptional(taskId);
+            if (record.isPresent() && record.get().getStatus() == status) {
+                return record.get();
+            }
+            Thread.sleep(20);
+        }
+        throw new AssertionError(
+                "Task "
+                        + taskId
+                        + " did not reach "
+                        + status
+                        + "; final record="
+                        + readRecordOptional(taskId)
+                                .map(record -> record.getStatus() + ":" + record.getErrorMessage())
+                                .orElse("missing"));
+    }
+
+    private TaskRecord readRecord(String taskId) {
+        return readRecordOptional(taskId).orElseThrow();
+    }
+
+    private Optional<TaskRecord> readRecordOptional(String taskId) {
+        return workspaceManager.readTaskRecord(
+                parentContext, "parent-agent", "parent-session", taskId);
+    }
+
+    private static ReActAgent childAgent(AtomicInteger executions) {
+        return childAgent(executions, scriptedModel(), null);
+    }
+
+    private static ReActAgent childAgent(
+            AtomicInteger executions, ChatModelBase model, Path stateRoot) {
+        Toolkit toolkit = new Toolkit();
+        toolkit.registerAgentTool(new AskingTool(executions));
+        ReActAgent.Builder builder =
+                ReActAgent.builder().name("worker").model(model).toolkit(toolkit);
+        if (stateRoot != null) {
+            builder.stateStore(new JsonFileAgentStateStore(stateRoot));
+        }
+        return builder.build();
+    }
+
+    private static ScriptedModel scriptedModel() {
+        return new ScriptedModel(
+                List.of(
+                        () -> Flux.just(toolUseResponse()),
+                        () -> Flux.just(textResponse("finished"))));
+    }
+
+    private static ToolUseBlock askingToolCall() {
+        return ToolUseBlock.builder()
+                .id("tool-1")
+                .name("guarded")
+                .input(Map.of("query", "work"))
+                .content("{\"query\":\"work\"}")
+                .build();
+    }
+
+    private static io.agentscope.core.message.Msg confirmationMessage(boolean confirmed) {
+        return io.agentscope.core.message.Msg.builder()
+                .name("user")
+                .role(io.agentscope.core.message.MsgRole.USER)
+                .textContent("[confirm]")
+                .metadata(
+                        Map.of(
+                                io.agentscope.core.message.Msg.METADATA_CONFIRM_RESULTS,
+                                List.of(new ConfirmResult(confirmed, askingToolCall()))))
+                .build();
+    }
+
+    private static String describeContext(AgentState state) {
+        StringBuilder description = new StringBuilder();
+        for (io.agentscope.core.message.Msg message : state.getContext()) {
+            description.append(message.getRole()).append('[');
+            for (ContentBlock block : message.getContent()) {
+                if (block instanceof ToolUseBlock toolUse) {
+                    description
+                            .append("use:")
+                            .append(toolUse.getId())
+                            .append(':')
+                            .append(toolUse.getState());
+                } else if (block instanceof ToolResultBlock toolResult) {
+                    description
+                            .append("result:")
+                            .append(toolResult.getId())
+                            .append(':')
+                            .append(toolResult.getState())
+                            .append(':')
+                            .append(
+                                    toolResult.getOutput().stream()
+                                            .filter(TextBlock.class::isInstance)
+                                            .map(TextBlock.class::cast)
+                                            .map(TextBlock::getText)
+                                            .toList());
+                } else if (block instanceof TextBlock text) {
+                    description.append("text:").append(text.getText());
+                }
+                description.append(',');
+            }
+            description.append(']');
+        }
+        return description.toString();
+    }
+
+    private static ChatResponse toolUseResponse() {
+        return ChatResponse.builder().content(List.<ContentBlock>of(askingToolCall())).build();
+    }
+
+    private static ChatResponse textResponse(String text) {
+        return ChatResponse.builder()
+                .content(List.<ContentBlock>of(TextBlock.builder().text(text).build()))
+                .build();
+    }
+
+    private static final class ScriptedModel extends ChatModelBase {
+        private final List<Supplier<Flux<ChatResponse>>> scripts;
+        private final AtomicInteger index = new AtomicInteger();
+
+        private ScriptedModel(List<Supplier<Flux<ChatResponse>>> scripts) {
+            this.scripts = scripts;
+        }
+
+        @Override
+        public String getModelName() {
+            return "scripted";
+        }
+
+        @Override
+        protected Flux<ChatResponse> doStream(
+                List<io.agentscope.core.message.Msg> messages,
+                List<ToolSchema> tools,
+                GenerateOptions options) {
+            return scripts.get(index.getAndIncrement()).get();
+        }
+    }
+
+    private static final class AskingTool extends ToolBase {
+        private final AtomicInteger executions;
+
+        private AskingTool(AtomicInteger executions) {
+            super("guarded", "guarded tool", schema(), false, true, false, null, false, false);
+            this.executions = executions;
+        }
+
+        @Override
+        public Mono<PermissionDecision> checkPermissions(
+                Map<String, Object> toolInput, PermissionContextState context) {
+            return Mono.just(PermissionDecision.ask("approval required"));
+        }
+
+        @Override
+        public Mono<ToolResultBlock> callAsync(ToolCallParam param) {
+            executions.incrementAndGet();
+            return Mono.just(ToolResultBlock.text("executed"));
+        }
+
+        private static Map<String, Object> schema() {
+            Map<String, Object> schema = new HashMap<>();
+            schema.put("type", "object");
+            schema.put("properties", Map.of("query", Map.of("type", "string")));
+            return schema;
+        }
+    }
+}

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/tool/AgentSpawnToolPermissionTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/tool/AgentSpawnToolPermissionTest.java
@@ -1,0 +1,248 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.harness.agent.tool;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.agentscope.core.ReActAgent;
+import io.agentscope.core.agent.Agent;
+import io.agentscope.core.agent.RuntimeContext;
+import io.agentscope.core.agent.test.MockModel;
+import io.agentscope.core.permission.AdditionalWorkingDirectory;
+import io.agentscope.core.permission.PermissionBehavior;
+import io.agentscope.core.permission.PermissionContextState;
+import io.agentscope.core.permission.PermissionMode;
+import io.agentscope.core.permission.PermissionRule;
+import io.agentscope.core.state.AgentState;
+import io.agentscope.harness.agent.HarnessAgent;
+import io.agentscope.harness.agent.filesystem.local.LocalFilesystem;
+import io.agentscope.harness.agent.middleware.SubagentEntry;
+import io.agentscope.harness.agent.subagent.DefaultAgentManager;
+import io.agentscope.harness.agent.subagent.SubagentDeclaration;
+import io.agentscope.harness.agent.subagent.SubagentFactory;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class AgentSpawnToolPermissionTest {
+
+    @TempDir Path workspace;
+
+    @Test
+    void inheritsCompleteParentPermissionContextForReactChild() {
+        PermissionContextState childPermissions = childPermissions();
+        AtomicReference<Agent> childRef = new AtomicReference<>();
+        AgentSpawnTool tool =
+                tool(childPermissions, declaration(true), childRef, new AtomicInteger(), false);
+        AgentState parentState = parentState(parentPermissions("parent-v1"));
+        RuntimeContext parentContext = parentContext("user-a", "parent-a");
+
+        tool.agentSpawn(parentContext, parentState, "worker", null, "review", null, null).block();
+
+        ReActAgent child = (ReActAgent) childRef.get();
+        String childSessionId = childSessionId("parent-a", "review");
+        PermissionContextState inherited =
+                child.getAgentState("user-a", childSessionId).getPermissionContext();
+        assertInheritedContext(inherited, "parent-v1");
+    }
+
+    @Test
+    void inheritsCompleteParentPermissionContextForHarnessChild() throws Exception {
+        PermissionContextState childPermissions = childPermissions();
+        AtomicReference<Agent> childRef = new AtomicReference<>();
+        AgentSpawnTool tool =
+                tool(childPermissions, declaration(true), childRef, new AtomicInteger(), true);
+        AgentState parentState = parentState(parentPermissions("parent-v1"));
+        RuntimeContext parentContext = parentContext("user-a", "parent-a");
+
+        tool.agentSpawn(parentContext, parentState, "worker", null, "review", null, null).block();
+
+        try (HarnessAgent child = (HarnessAgent) childRef.get()) {
+            String childSessionId = childSessionId("parent-a", "review");
+            PermissionContextState inherited =
+                    child.getDelegate()
+                            .getAgentState("user-a", childSessionId)
+                            .getPermissionContext();
+            assertInheritedContext(inherited, "parent-v1");
+        }
+    }
+
+    @Test
+    void inheritanceCanBeDisabledPerDeclaration() {
+        PermissionContextState childPermissions = childPermissions();
+        AtomicReference<Agent> childRef = new AtomicReference<>();
+        AgentSpawnTool tool =
+                tool(childPermissions, declaration(false), childRef, new AtomicInteger(), false);
+
+        tool.agentSpawn(
+                        parentContext("user-a", "parent-a"),
+                        parentState(parentPermissions("parent-v1")),
+                        "worker",
+                        null,
+                        "review",
+                        null,
+                        null)
+                .block();
+
+        ReActAgent child = (ReActAgent) childRef.get();
+        PermissionContextState actual =
+                child.getAgentState("user-a", childSessionId("parent-a", "review"))
+                        .getPermissionContext();
+        assertEquals(childPermissions, actual);
+        assertFalse(actual.getDenyRules().containsKey("Bash"));
+    }
+
+    @Test
+    void persistentReuseReappliesCurrentParentPermissionContext() {
+        AtomicReference<Agent> childRef = new AtomicReference<>();
+        AtomicInteger factoryCalls = new AtomicInteger();
+        AgentSpawnTool tool =
+                tool(childPermissions(), declaration(true), childRef, factoryCalls, false);
+        RuntimeContext parentContext = parentContext("user-a", "parent-a");
+        AgentState parentState = parentState(parentPermissions("parent-v1"));
+
+        tool.agentSpawn(parentContext, parentState, "worker", null, "review", null, null).block();
+        parentState.setPermissionContext(parentPermissions("parent-v2"));
+        tool.agentSpawn(parentContext, parentState, "worker", null, "review", null, null).block();
+
+        ReActAgent child = (ReActAgent) childRef.get();
+        PermissionContextState actual =
+                child.getAgentState("user-a", childSessionId("parent-a", "review"))
+                        .getPermissionContext();
+        assertTrue(
+                actual.getAskRules().get("Write").stream()
+                        .anyMatch(rule -> "parent-v2".equals(rule.source())));
+        assertFalse(
+                actual.getAllowRules().get("Read").stream()
+                        .anyMatch(rule -> "parent-v1".equals(rule.source())),
+                "persistent reuse must revoke rules removed from the parent context");
+        assertEquals(
+                1, factoryCalls.get(), "persistent reuse must not materialize a throwaway child");
+    }
+
+    private AgentSpawnTool tool(
+            PermissionContextState childPermissions,
+            SubagentDeclaration declaration,
+            AtomicReference<Agent> childRef,
+            AtomicInteger factoryCalls,
+            boolean harnessChild) {
+        SubagentFactory factory =
+                rc -> {
+                    factoryCalls.incrementAndGet();
+                    Agent child;
+                    if (harnessChild) {
+                        child =
+                                HarnessAgent.builder()
+                                        .name("worker")
+                                        .model(new MockModel(messages -> List.of()))
+                                        .workspace(workspace)
+                                        .abstractFilesystem(new LocalFilesystem(workspace))
+                                        .permissionContext(childPermissions)
+                                        .disableMemoryTools()
+                                        .disableMemoryHooks()
+                                        .disableWorkspaceContext()
+                                        .build();
+                    } else {
+                        child =
+                                ReActAgent.builder()
+                                        .name("worker")
+                                        .model(new MockModel(messages -> List.of()))
+                                        .permissionContext(childPermissions)
+                                        .build();
+                    }
+                    childRef.set(child);
+                    return child;
+                };
+        DefaultAgentManager manager =
+                new DefaultAgentManager(
+                        List.of(
+                                new SubagentEntry(
+                                        "worker", "permission worker", factory, declaration)),
+                        null);
+        return new AgentSpawnTool(manager, null, 0);
+    }
+
+    private static SubagentDeclaration declaration(boolean inherit) {
+        return SubagentDeclaration.builder()
+                .name("worker")
+                .description("permission worker")
+                .inlineAgentsBody("Review permissions")
+                .persistSession(true)
+                .inheritParentPermissions(inherit)
+                .build();
+    }
+
+    private static RuntimeContext parentContext(String userId, String sessionId) {
+        return RuntimeContext.builder().userId(userId).sessionId(sessionId).build();
+    }
+
+    private static AgentState parentState(PermissionContextState permissions) {
+        return AgentState.builder().sessionId("parent-a").permissionContext(permissions).build();
+    }
+
+    private static PermissionContextState childPermissions() {
+        return PermissionContextState.builder()
+                .mode(PermissionMode.ACCEPT_EDITS)
+                .addWorkingDirectory(
+                        "child", new AdditionalWorkingDirectory("/child", "child-settings"))
+                .addAllowRule(
+                        "Read",
+                        new PermissionRule("Read", "child/**", PermissionBehavior.ALLOW, "child"))
+                .build();
+    }
+
+    private static PermissionContextState parentPermissions(String source) {
+        return PermissionContextState.builder()
+                .mode(PermissionMode.DONT_ASK)
+                .addWorkingDirectory(
+                        "parent", new AdditionalWorkingDirectory("/parent", "parent-settings"))
+                .addAllowRule(
+                        "Read",
+                        new PermissionRule("Read", "parent/**", PermissionBehavior.ALLOW, source))
+                .addDenyRule(
+                        "Bash",
+                        new PermissionRule("Bash", "rm -rf", PermissionBehavior.DENY, source))
+                .addAskRule(
+                        "Write",
+                        new PermissionRule("Write", "/etc/**", PermissionBehavior.ASK, source))
+                .build();
+    }
+
+    private static String childSessionId(String parentSessionId, String label) {
+        return "sub-" + AgentSpawnTool.deterministicHash(parentSessionId, "worker", label);
+    }
+
+    private static void assertInheritedContext(
+            PermissionContextState inherited, String parentSource) {
+        assertEquals(PermissionMode.ACCEPT_EDITS, inherited.getMode());
+        assertTrue(inherited.getWorkingDirectories().containsKey("child"));
+        assertTrue(inherited.getWorkingDirectories().containsKey("parent"));
+        assertTrue(
+                inherited.getAllowRules().get("Read").stream()
+                        .anyMatch(rule -> parentSource.equals(rule.source())));
+        assertTrue(
+                inherited.getDenyRules().get("Bash").stream()
+                        .anyMatch(rule -> parentSource.equals(rule.source())));
+        assertTrue(
+                inherited.getAskRules().get("Write").stream()
+                        .anyMatch(rule -> parentSource.equals(rule.source())));
+    }
+}

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/tool/AgentSpawnToolPermissionTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/tool/AgentSpawnToolPermissionTest.java
@@ -31,6 +31,7 @@ import io.agentscope.core.permission.PermissionRule;
 import io.agentscope.core.state.AgentState;
 import io.agentscope.harness.agent.HarnessAgent;
 import io.agentscope.harness.agent.filesystem.local.LocalFilesystem;
+import io.agentscope.harness.agent.gateway.SubagentGatewayBridge;
 import io.agentscope.harness.agent.middleware.SubagentEntry;
 import io.agentscope.harness.agent.subagent.DefaultAgentManager;
 import io.agentscope.harness.agent.subagent.SubagentDeclaration;
@@ -136,6 +137,33 @@ class AgentSpawnToolPermissionTest {
                 "persistent reuse must revoke rules removed from the parent context");
         assertEquals(
                 1, factoryCalls.get(), "persistent reuse must not materialize a throwaway child");
+    }
+
+    @Test
+    void exposedChildCarriesOwningUserAndParentSessionToGateway() {
+        AtomicReference<Agent> childRef = new AtomicReference<>();
+        AgentSpawnTool tool =
+                tool(childPermissions(), declaration(true), childRef, new AtomicInteger(), false);
+        AtomicReference<List<String>> lineage = new AtomicReference<>();
+        tool.setGatewayBridge(
+                (agentId, sessionId, agent, replyTo, userId, parentSessionId) -> {
+                    lineage.set(List.of(agentId, sessionId, userId, parentSessionId));
+                    return new SubagentGatewayBridge.ExposeResult("sub-visible");
+                });
+
+        tool.agentSpawn(
+                        parentContext("user-a", "parent-a"),
+                        parentState(parentPermissions("parent-v1")),
+                        "worker",
+                        null,
+                        "review",
+                        null,
+                        true)
+                .block();
+
+        assertEquals(
+                List.of("worker", childSessionId("parent-a", "review"), "user-a", "parent-a"),
+                lineage.get());
     }
 
     private AgentSpawnTool tool(


### PR DESCRIPTION
## Summary

- inherit the complete parent permission context when materializing or reusing a subagent
- persist permission-suspended background tasks with child-session lineage and resumable state
- resume approve/deny through Harness and transition the same task to a typed terminal state
- preserve cancellation, restart, delivery, and user/session isolation semantics

Closes #2137.

## Why

An async `agent_spawn` child that returned `PERMISSION_ASKING` could be collapsed into an empty completed result or remain `RUNNING` after approval. The task repository had no typed waiting state or durable resume identity, and reused children did not receive the complete current parent permission context.

This made child HITL impossible to resume reliably without consumer-side polling, private registry access, or a second task/permission owner.

## Design

- `PermissionContextState` gains an atomic replacement operation with inherited-rule provenance.
- `TaskStatus.WAITING` and `TaskSuspension` represent a non-terminal permission pause.
- `WorkspaceTaskRepository` owns suspension persistence, lookup, resume, cancellation races, terminal transition, and delivery.
- child session lineage is persisted in the subagent registry and exposed through public Harness APIs.
- `AgentSpawnTool` returns typed task outcomes and delegates resume execution to the repository/Harness lifecycle.

No consumer-specific code or polling store is introduced.

## Verification

Focused Core/Harness contracts:

- 65 tests, 0 failures, 0 errors

Full Core/Harness suite:

- 2866 tests
- 0 failures
- 0 errors
- 11 skipped

`git diff --check` passes.