### PR TITLE
fix(agent): forward reasoning middleware events

### DIFF
--- a/agentscope-core/src/main/java/io/agentscope/core/ReActAgent.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/ReActAgent.java
@@ -1978,10 +1978,12 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
                                                         new ReasoningInput(
                                                                 modelInput, tools, options));
                                 // Track any RequestStopEvent emitted by middlewares while still
-                                // exhausting the stream (publishEvent already fires on each event).
+                                // exhausting the stream. Publish at the outer reasoning boundary
+                                // so events added by onReasoning middlewares are forwarded too.
                                 AtomicReference<RequestStopEvent> stopRequested =
                                         new AtomicReference<>();
-                                return stream.doOnNext(
+                                return stream.doOnNext(this::publishEvent)
+                                        .doOnNext(
                                                 ev -> {
                                                     if (ev instanceof RequestStopEvent rs) {
                                                         stopRequested.compareAndSet(null, rs);
@@ -2118,8 +2120,7 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
                             rc,
                             MiddlewareBase::onModelCall,
                             modelCallCore)
-                    .apply(new ModelCallInput(messages, tools, options, modelForCall()))
-                    .doOnNext(this::publishEvent);
+                    .apply(new ModelCallInput(messages, tools, options, modelForCall()));
         }
 
         private Flux<AgentEvent> modelCallStream(

--- a/agentscope-core/src/test/java/io/agentscope/core/agent/ReActAgentMiddlewareIntegrationTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/agent/ReActAgentMiddlewareIntegrationTest.java
@@ -23,6 +23,8 @@ import io.agentscope.core.ReActAgent;
 import io.agentscope.core.event.AgentEndEvent;
 import io.agentscope.core.event.AgentEvent;
 import io.agentscope.core.event.AgentStartEvent;
+import io.agentscope.core.event.HintBlockEvent;
+import io.agentscope.core.event.ModelCallStartEvent;
 import io.agentscope.core.message.ContentBlock;
 import io.agentscope.core.message.Msg;
 import io.agentscope.core.message.TextBlock;
@@ -158,6 +160,43 @@ class ReActAgentMiddlewareIntegrationTest {
         assertTrue(trace.contains("A:reply:exit"), trace.toString());
         assertTrue(trace.contains("A:reasoning:exit"), trace.toString());
         assertTrue(trace.contains("A:modelCall:exit"), trace.toString());
+    }
+
+    @Test
+    void reasoningMiddlewareEventsAreForwardedExactlyOnce() {
+        MiddlewareBase hintMiddleware =
+                new MiddlewareBase() {
+                    @Override
+                    public Flux<AgentEvent> onReasoning(
+                            Agent agent,
+                            RuntimeContext ctx,
+                            ReasoningInput input,
+                            Function<ReasoningInput, Flux<AgentEvent>> next) {
+                        HintBlockEvent hint =
+                                new HintBlockEvent(
+                                        "reply-hint", "block-hint", "child-agent", "completed");
+                        return Flux.concat(Flux.just(hint), next.apply(input));
+                    }
+                };
+        ReActAgent agent = buildAgent(new FixedTextModel("ok"), List.of(hintMiddleware));
+
+        List<AgentEvent> events = agent.streamEvents(List.of()).collectList().block();
+
+        assertNotNull(events);
+        List<HintBlockEvent> hints =
+                events.stream()
+                        .filter(HintBlockEvent.class::isInstance)
+                        .map(HintBlockEvent.class::cast)
+                        .toList();
+        assertEquals(1, hints.size());
+        assertEquals("reply-hint", hints.get(0).getReplyId());
+        assertEquals("block-hint", hints.get(0).getBlockId());
+        assertEquals("child-agent", hints.get(0).getHintSource());
+        assertEquals("completed", hints.get(0).getHint());
+        assertEquals(
+                1,
+                events.stream().filter(ModelCallStartEvent.class::isInstance).count(),
+                "core model events must not be published twice");
     }
 
     @Test


### PR DESCRIPTION
## AgentScope-Java Version

2.0.1-SNAPSHOT

## Description

Fixes #2160.

`InboxMiddleware` emits `HintBlockEvent` values from its `onReasoning(...)`
middleware hook, but these events were not observable through
`HarnessAgent.streamEvents()`.

The reasoning middleware stream was exhausted with `.then(...)`, while event
publication happened inside the nested model-call stream. As a result, events
added directly by `onReasoning` middleware were discarded from the public event
stream.

This change moves event publication to the outer reasoning middleware boundary
and removes the nested publication point. This ensures that:

- `HintBlockEvent` emitted by `InboxMiddleware` is forwarded through
  `streamEvents()`.
- Hint source identity, block ID, reply ID, and content are preserved.
- Core model events are still emitted exactly once.

## Testing

- Added `reasoningMiddlewareEventsAreForwardedExactlyOnce`.
- Verified `HintBlockEvent` fields are preserved.
- Verified `ModelCallStartEvent` is not duplicated.
- `agentscope-core`: 2210 tests passed, 9 skipped, 0 failures.
- `InboxMiddlewareTest`: 6 tests passed.
- `agentscope-core` Spotless check passed.

## Checklist

- [x] Code has been formatted and checked with Spotless
- [x] Relevant unit tests are passing
- [x] Regression test has been added
- [x] No