### PR TITLE
fix(harness): resolve shared skill cache paths

### DIFF
--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/workspace/WorkspacePathNormalizer.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/workspace/WorkspacePathNormalizer.java
@@ -31,6 +31,8 @@ import java.util.List;
  */
 public final class WorkspacePathNormalizer {
 
+    private static final String SHARED_SKILL_CACHE = ".skills-cache";
+
     private final List<String> prefixes;
 
     private WorkspacePathNormalizer(List<String> prefixes) {
@@ -81,10 +83,20 @@ public final class WorkspacePathNormalizer {
         for (String prefix : prefixes) {
             String stripped = tryStrip(path, prefix);
             if (stripped != null) {
+                // Marketplace skills are staged once at the workspace root and shared by all
+                // namespaces. Keep that root virtual-absolute so namespace-aware filesystems do
+                // not remap it to <workspace>/<userId>/.skills-cache.
+                if (isSharedSkillCachePath(stripped)) {
+                    return "/" + stripped;
+                }
                 return stripped;
             }
         }
         return path;
+    }
+
+    private static boolean isSharedSkillCachePath(String path) {
+        return path.equals(SHARED_SKILL_CACHE) || path.startsWith(SHARED_SKILL_CACHE + "/");
     }
 
     private static String tryStrip(String path, String prefix) {

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/tool/FilesystemToolTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/tool/FilesystemToolTest.java
@@ -23,13 +23,21 @@ import static org.mockito.Mockito.when;
 
 import io.agentscope.core.agent.RuntimeContext;
 import io.agentscope.harness.agent.filesystem.AbstractFilesystem;
+import io.agentscope.harness.agent.filesystem.local.LocalFilesystem;
 import io.agentscope.harness.agent.filesystem.model.EditResult;
 import io.agentscope.harness.agent.filesystem.model.FileInfo;
 import io.agentscope.harness.agent.filesystem.model.LsResult;
+import io.agentscope.harness.agent.workspace.LocalFsMode;
+import io.agentscope.harness.agent.workspace.PathPolicy;
 import io.agentscope.harness.agent.workspace.WorkspacePathNormalizer;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 /** Unit tests for {@link FilesystemTool}. */
 class FilesystemToolTest {
@@ -84,5 +92,30 @@ class FilesystemToolTest {
 
         assertTrue(result.contains("[DIR]"));
         verify(filesystem).ls(RT, "memory");
+    }
+
+    @Test
+    void readFile_readsSharedMarketplaceSkillResourceWithUserNamespace(@TempDir Path workspace)
+            throws IOException {
+        Path resource = workspace.resolve(".skills-cache/market/docx/docx-js.md");
+        Files.createDirectories(resource.getParent());
+        Files.writeString(resource, "shared resource", StandardCharsets.UTF_8);
+
+        LocalFilesystem localFilesystem =
+                new LocalFilesystem(
+                        workspace,
+                        LocalFsMode.ROOTED,
+                        PathPolicy.empty(),
+                        10,
+                        rc -> List.of(rc.getUserId()));
+        FilesystemTool namespacedTool =
+                new FilesystemTool(localFilesystem, WorkspacePathNormalizer.of("/workspace"));
+        RuntimeContext userContext = RuntimeContext.builder().userId("alice").build();
+
+        String result =
+                namespacedTool.readFile(
+                        userContext, "/workspace/.skills-cache/market/docx/docx-js.md", 0, 0);
+
+        assertTrue(result.contains("shared resource"));
     }
 }

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/workspace/WorkspacePathNormalizerTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/workspace/WorkspacePathNormalizerTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.harness.agent.workspace;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+class WorkspacePathNormalizerTest {
+
+    private final WorkspacePathNormalizer normalizer = WorkspacePathNormalizer.of("/workspace");
+
+    @Test
+    void keepsMarketplaceSkillCacheInSharedWorkspaceRoot() {
+        assertEquals(
+                "/.skills-cache/market/docx/docx-js.md",
+                normalizer.normalize("/workspace/.skills-cache/market/docx/docx-js.md"));
+    }
+
+    @Test
+    void stillNormalizesUserScopedWorkspacePaths() {
+        assertEquals(
+                "skills/docx/SKILL.md", normalizer.normalize("/workspace/skills/docx/SKILL.md"));
+    }
+}


### PR DESCRIPTION
## AgentScope-Java Version

2.0.1-SNAPSHOT

## Description

Fixes #2181.

Marketplace skill resources are staged in the shared workspace cache:

`/workspace/.skills-cache/<source>/<skill>/`

With `IsolationScope.USER`, `WorkspacePathNormalizer` previously converted this into a relative path. `LocalFilesystem` then applied the user namespace and incorrectly resolved it as:

`/workspace/<userId>/.skills-cache/<source>/<skill>/`

This caused auxiliary marketplace skill files, such as `docx-js.md`, to be inaccessible through filesystem tools.

This PR keeps `.skills-cache` as a virtual workspace-absolute path so it remains in the shared workspace root. Other paths, including `skills/...`, continue to use the existing user namespace behavior.

### Tests

Added regression coverage for:

- shared marketplace skill resources under `IsolationScope.USER`
- regular user-scoped workspace path normalization
- the complete `FilesystemTool` → `WorkspacePathNormalizer` → `LocalFilesystem` path

Related test suites passed:

- `WorkspacePathNormalizerTest`
- `FilesystemToolTest`
- `LocalFilesystemModeTest`
- `MarketplaceStagerExecBitTest`
- `SandboxLifecycleMiddlewareCallbackTest`

Result: 33 tests passed with no failures or errors.

## Checklist

- [x] Code passes Spotless formatting checks
- [x] Relevant tests are passing
- [x] Javadoc and comments follow project conventions
- [x] No documentation update is required because no public API changed
- [x] Code is ready for review
