### PR TITLE
fix(harness): avoid local files in remote mode

### DIFF
--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/HarnessAgent.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/HarnessAgent.java
@@ -1862,7 +1862,11 @@ public class HarnessAgent implements Agent, AutoCloseable {
             return this;
         }
 
-        /** No-op since 2.0; session persistence is owned by ReActAgent itself. */
+        /**
+         * Disables Harness session transcript persistence ({@code .jsonl} and
+         * {@code .log.jsonl}). Agent state persistence configured on the underlying ReActAgent is
+         * unaffected.
+         */
         public Builder disableSessionPersistence() {
             this.disableSessionPersistence = true;
             return this;
@@ -2037,10 +2041,14 @@ public class HarnessAgent implements Agent, AutoCloseable {
                             + " .distributedStore(...).");
             }
             WorkspaceIndex workspaceIndex =
-                    remoteFilesystemSpec != null ? WorkspaceIndex.open(resolvedWorkspace) : null;
+                    remoteFilesystemSpec != null ? remoteFilesystemSpec.getWorkspaceIndex() : null;
             AbstractFilesystem filesystem =
                     HarnessAgentBuilderSupport.resolveFilesystem(
-                            this, resolvedWorkspace, resolvedAgentId, workspaceIndex, nsFactory);
+                            this, resolvedWorkspace, resolvedAgentId, nsFactory);
+            // Remote deployments persist the complete ReActAgent state in AgentStateStore. Avoid
+            // creating a second, ever-growing host-local transcript cache in this mode.
+            boolean sessionTranscriptEnabled =
+                    !disableSessionPersistence && remoteFilesystemSpec == null;
 
             // ---- Sandbox integration ----
             SandboxLifecycleMiddleware sandboxLifecycleMw = null;
@@ -2143,7 +2151,8 @@ public class HarnessAgent implements Agent, AutoCloseable {
                                 memoryModel,
                                 effectiveFlushPrompt,
                                 memoryConfig.flushTrigger(),
-                                effectiveIsolationScope));
+                                effectiveIsolationScope,
+                                sessionTranscriptEnabled));
 
                 String effectiveConsolidationPrompt =
                         memoryConfig.consolidationPrompt() != null
@@ -2170,7 +2179,11 @@ public class HarnessAgent implements Agent, AutoCloseable {
                         compactionConfig.getModel() != null ? compactionConfig.getModel() : model;
                 if (compactionModel != null) {
                     compactionHook =
-                            new CompactionMiddleware(wsManager, compactionModel, compactionConfig);
+                            new CompactionMiddleware(
+                                    wsManager,
+                                    compactionModel,
+                                    compactionConfig,
+                                    sessionTranscriptEnabled);
                     inner.middleware(compactionHook);
                 }
             }
@@ -2480,7 +2493,7 @@ public class HarnessAgent implements Agent, AutoCloseable {
                     delegate,
                     wsManager,
                     workspaceFactoryFn,
-                    workspaceIndex,
+                    null,
                     defaultSandboxContext,
                     compactionHook,
                     sandboxLifecycleMw,

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/HarnessAgentBuilderSupport.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/HarnessAgentBuilderSupport.java
@@ -46,7 +46,6 @@ import io.agentscope.harness.agent.subagent.SubagentFactory;
 import io.agentscope.harness.agent.subagent.WorkspaceMode;
 import io.agentscope.harness.agent.subagent.task.TaskRepository;
 import io.agentscope.harness.agent.subagent.task.WorkspaceTaskRepository;
-import io.agentscope.harness.agent.workspace.WorkspaceIndex;
 import io.agentscope.harness.agent.workspace.WorkspaceManager;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -134,18 +133,11 @@ final class HarnessAgentBuilderSupport {
     // -----------------------------------------------------------------
 
     static AbstractFilesystem resolveFilesystem(
-            HarnessAgent.Builder b,
-            Path workspace,
-            String agentId,
-            WorkspaceIndex workspaceIndex,
-            NamespaceFactory nsFactory) {
+            HarnessAgent.Builder b, Path workspace, String agentId, NamespaceFactory nsFactory) {
         if (b.abstractFilesystem != null) {
             return b.abstractFilesystem;
         }
         if (b.remoteFilesystemSpec != null) {
-            if (workspaceIndex != null) {
-                b.remoteFilesystemSpec.workspaceIndex(workspaceIndex);
-            }
             return b.remoteFilesystemSpec.toFilesystem(workspace, agentId, nsFactory);
         }
         if (b.localFilesystemSpec != null) {
@@ -296,7 +288,8 @@ final class HarnessAgentBuilderSupport {
         final boolean capturedDisableShellTool = b.disableShellTool;
         final boolean capturedDisableMemoryTools = b.disableMemoryTools;
         final boolean capturedDisableMemoryHooks = b.disableMemoryHooks;
-        final boolean capturedDisableSessionPersistence = b.disableSessionPersistence;
+        final boolean capturedDisableSessionPersistence =
+                b.disableSessionPersistence || b.remoteFilesystemSpec != null;
         final boolean capturedDisableWorkspaceContext = b.disableWorkspaceContext;
         final CompactionConfig capturedCompactionConfig = b.compactionConfig;
         final boolean capturedDisableCompaction = b.disableCompaction;
@@ -386,7 +379,8 @@ final class HarnessAgentBuilderSupport {
         final boolean capturedDisableShellTool = b.disableShellTool;
         final boolean capturedDisableMemoryTools = b.disableMemoryTools;
         final boolean capturedDisableMemoryHooks = b.disableMemoryHooks;
-        final boolean capturedDisableSessionPersistence = b.disableSessionPersistence;
+        final boolean capturedDisableSessionPersistence =
+                b.disableSessionPersistence || b.remoteFilesystemSpec != null;
         final GenerateOptions capturedGenOpts = b.generateOptions;
         // Snapshot of main agent's Local filesystem configuration. ISOLATED subagents get a
         // fresh spec carrying the same project / additionalRoots / mode so PathPolicy stays in

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/filesystem/spec/RemoteFilesystemSpec.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/filesystem/spec/RemoteFilesystemSpec.java
@@ -160,12 +160,18 @@ public class RemoteFilesystemSpec {
     }
 
     /**
-     * Sets the workspace index for accelerating remote filesystem reads (ls/glob/exists/grep).
-     * If not set, the remote filesystem falls back to full store scans.
+     * Sets an optional caller-managed local index for accelerating remote filesystem reads
+     * (ls/glob/exists/grep). If not set, no local database is created and the remote filesystem
+     * falls back to store scans.
      */
     public RemoteFilesystemSpec workspaceIndex(WorkspaceIndex index) {
         this.workspaceIndex = index;
         return this;
+    }
+
+    /** Returns the explicitly configured local workspace index, or {@code null} when disabled. */
+    public WorkspaceIndex getWorkspaceIndex() {
+        return workspaceIndex;
     }
 
     /**

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/memory/compaction/ConversationCompactor.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/memory/compaction/ConversationCompactor.java
@@ -63,10 +63,17 @@ public class ConversationCompactor {
 
     private final Model model;
     private final MemoryFlushManager flushManager;
+    private final boolean sessionPersistenceEnabled;
 
     public ConversationCompactor(Model model, MemoryFlushManager flushManager) {
+        this(model, flushManager, true);
+    }
+
+    public ConversationCompactor(
+            Model model, MemoryFlushManager flushManager, boolean sessionPersistenceEnabled) {
         this.model = model;
         this.flushManager = flushManager;
+        this.sessionPersistenceEnabled = sessionPersistenceEnabled;
     }
 
     // -------------------------------------------------------------------------
@@ -146,7 +153,7 @@ public class ConversationCompactor {
         // If offload fails, we continue with null — the summary message falls back to the
         // simple format without a file reference.
         Mono<String> offloadStep;
-        if (config.isOffloadBeforeCompact()) {
+        if (sessionPersistenceEnabled && config.isOffloadBeforeCompact()) {
             offloadStep =
                     Mono.fromCallable(
                                     () -> {

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/middleware/CompactionMiddleware.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/middleware/CompactionMiddleware.java
@@ -61,12 +61,22 @@ public class CompactionMiddleware implements HarnessRuntimeMiddleware {
     private final WorkspaceManager workspaceManager;
     private final Model model;
     private final CompactionConfig config;
+    private final boolean sessionPersistenceEnabled;
 
     public CompactionMiddleware(
             WorkspaceManager workspaceManager, Model model, CompactionConfig config) {
+        this(workspaceManager, model, config, true);
+    }
+
+    public CompactionMiddleware(
+            WorkspaceManager workspaceManager,
+            Model model,
+            CompactionConfig config,
+            boolean sessionPersistenceEnabled) {
         this.workspaceManager = workspaceManager;
         this.model = model;
         this.config = config;
+        this.sessionPersistenceEnabled = sessionPersistenceEnabled;
     }
 
     @Override
@@ -103,7 +113,8 @@ public class CompactionMiddleware implements HarnessRuntimeMiddleware {
                     MemoryFlushManager flushManager =
                             new MemoryFlushManager(workspaceManager, model);
                     ConversationCompactor compactor =
-                            new ConversationCompactor(model, flushManager);
+                            new ConversationCompactor(
+                                    model, flushManager, sessionPersistenceEnabled);
                     final Msg sys = systemMsg;
 
                     return compactor

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/middleware/MemoryFlushMiddleware.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/middleware/MemoryFlushMiddleware.java
@@ -76,6 +76,7 @@ public class MemoryFlushMiddleware implements HarnessRuntimeMiddleware {
     private final String flushPrompt;
     private final MemoryConfig.FlushTrigger flushTrigger;
     private final IsolationScope isolationScope;
+    private final boolean sessionPersistenceEnabled;
 
     /**
      * Process-wide per-isolation-key flush timestamps. Static so that the throttle window
@@ -109,7 +110,8 @@ public class MemoryFlushMiddleware implements HarnessRuntimeMiddleware {
                 model,
                 MemoryFlushManager.DEFAULT_FLUSH_PROMPT,
                 MemoryConfig.FlushTrigger.always(),
-                IsolationScope.USER);
+                IsolationScope.USER,
+                true);
     }
 
     public MemoryFlushMiddleware(
@@ -117,7 +119,7 @@ public class MemoryFlushMiddleware implements HarnessRuntimeMiddleware {
             Model model,
             String flushPrompt,
             MemoryConfig.FlushTrigger flushTrigger) {
-        this(workspaceManager, model, flushPrompt, flushTrigger, IsolationScope.USER);
+        this(workspaceManager, model, flushPrompt, flushTrigger, IsolationScope.USER, true);
     }
 
     public MemoryFlushMiddleware(
@@ -126,6 +128,16 @@ public class MemoryFlushMiddleware implements HarnessRuntimeMiddleware {
             String flushPrompt,
             MemoryConfig.FlushTrigger flushTrigger,
             IsolationScope isolationScope) {
+        this(workspaceManager, model, flushPrompt, flushTrigger, isolationScope, true);
+    }
+
+    public MemoryFlushMiddleware(
+            WorkspaceManager workspaceManager,
+            Model model,
+            String flushPrompt,
+            MemoryConfig.FlushTrigger flushTrigger,
+            IsolationScope isolationScope,
+            boolean sessionPersistenceEnabled) {
         this.workspaceManager = workspaceManager;
         this.model = model;
         this.flushPrompt =
@@ -133,6 +145,7 @@ public class MemoryFlushMiddleware implements HarnessRuntimeMiddleware {
         this.flushTrigger =
                 flushTrigger != null ? flushTrigger : MemoryConfig.FlushTrigger.always();
         this.isolationScope = isolationScope != null ? isolationScope : IsolationScope.USER;
+        this.sessionPersistenceEnabled = sessionPersistenceEnabled;
     }
 
     @Override
@@ -187,18 +200,21 @@ public class MemoryFlushMiddleware implements HarnessRuntimeMiddleware {
         String agentId = agent.getName();
         String sessionId = rc != null && rc.getSessionId() != null ? rc.getSessionId() : "default";
 
-        Mono<Void> offloadMono =
-                Mono.fromRunnable(
-                                () ->
-                                        flushManager.offloadMessages(
-                                                rc, messages, agentId, sessionId))
-                        .then()
-                        .doOnSuccess(v -> log.debug("Message offload completed"))
-                        .onErrorResume(
-                                e -> {
-                                    log.warn("Message offload failed: {}", e.getMessage());
-                                    return Mono.empty();
-                                });
+        Mono<Void> offloadMono = Mono.empty();
+        if (sessionPersistenceEnabled) {
+            offloadMono =
+                    Mono.fromRunnable(
+                                    () ->
+                                            flushManager.offloadMessages(
+                                                    rc, messages, agentId, sessionId))
+                            .then()
+                            .doOnSuccess(v -> log.debug("Message offload completed"))
+                            .onErrorResume(
+                                    e -> {
+                                        log.warn("Message offload failed: {}", e.getMessage());
+                                        return Mono.empty();
+                                    });
+        }
 
         return flushMono.then(offloadMono);
     }

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/HarnessAgentTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/HarnessAgentTest.java
@@ -50,6 +50,7 @@ import io.agentscope.harness.agent.filesystem.AbstractFilesystem;
 import io.agentscope.harness.agent.filesystem.local.LocalFilesystem;
 import io.agentscope.harness.agent.filesystem.remote.store.InMemoryStore;
 import io.agentscope.harness.agent.filesystem.spec.RemoteFilesystemSpec;
+import io.agentscope.harness.agent.memory.MemoryConfig;
 import io.agentscope.harness.agent.memory.compaction.CompactionConfig;
 import io.agentscope.harness.agent.middleware.AgentTraceMiddleware;
 import io.agentscope.harness.agent.middleware.SubagentEntry;
@@ -141,6 +142,84 @@ class HarnessAgentTest {
         assertFalse(toolNames.contains("memory_search"));
         assertFalse(toolNames.contains("memory_get"));
         assertFalse(toolNames.contains("session_search"));
+    }
+
+    @Test
+    void defaultSessionPersistence_memoryFlushOffloadCreatesSessionFiles() throws Exception {
+        HarnessAgent agent =
+                HarnessAgent.builder()
+                        .name("t")
+                        .model(stubModel("assistant-done"))
+                        .workspace(workspace)
+                        .abstractFilesystem(new LocalFilesystem(workspace))
+                        .memory(
+                                MemoryConfig.builder()
+                                        .flushTrigger(MemoryConfig.FlushTrigger.never())
+                                        .build())
+                        .disableCompaction()
+                        .build();
+
+        agent.call(userText("hi"), RuntimeContext.builder().sessionId("persisted").build()).block();
+
+        assertSessionFilesExist();
+    }
+
+    @Test
+    void disableSessionPersistence_memoryFlushOffloadDoesNotCreateSessionFiles() throws Exception {
+        HarnessAgent agent =
+                HarnessAgent.builder()
+                        .name("t")
+                        .model(stubModel("assistant-done"))
+                        .workspace(workspace)
+                        .abstractFilesystem(new LocalFilesystem(workspace))
+                        .memory(
+                                MemoryConfig.builder()
+                                        .flushTrigger(MemoryConfig.FlushTrigger.never())
+                                        .build())
+                        .disableCompaction()
+                        .disableSessionPersistence()
+                        .build();
+
+        agent.call(userText("hi"), RuntimeContext.builder().sessionId("not-persisted").build())
+                .block();
+
+        assertNoSessionFiles();
+    }
+
+    @Test
+    void defaultSessionPersistence_compactionOffloadCreatesSessionFiles() throws Exception {
+        HarnessAgent agent =
+                HarnessAgent.builder()
+                        .name("t")
+                        .model(stubModel("summary"))
+                        .workspace(workspace)
+                        .abstractFilesystem(new LocalFilesystem(workspace))
+                        .disableMemoryHooks()
+                        .compaction(compactionThatAlwaysOffloads())
+                        .build();
+
+        agent.call(userText("hi"), RuntimeContext.builder().sessionId("compacted").build()).block();
+
+        assertSessionFilesExist();
+    }
+
+    @Test
+    void disableSessionPersistence_compactionOffloadDoesNotCreateSessionFiles() throws Exception {
+        HarnessAgent agent =
+                HarnessAgent.builder()
+                        .name("t")
+                        .model(stubModel("summary"))
+                        .workspace(workspace)
+                        .abstractFilesystem(new LocalFilesystem(workspace))
+                        .disableMemoryHooks()
+                        .compaction(compactionThatAlwaysOffloads())
+                        .disableSessionPersistence()
+                        .build();
+
+        agent.call(userText("hi"), RuntimeContext.builder().sessionId("not-compacted").build())
+                .block();
+
+        assertNoSessionFiles();
     }
 
     @Test
@@ -712,6 +791,108 @@ class HarnessAgentTest {
         }
     }
 
+    @Test
+    void remoteFilesystemSpec_doesNotCreateLocalIndexAndScansStore() throws Exception {
+        Files.createDirectories(workspace);
+        Files.writeString(workspace.resolve(WorkspaceConstants.AGENTS_MD), "# Test\n");
+        InMemoryStore store = new InMemoryStore();
+
+        try (HarnessAgent agent =
+                HarnessAgent.builder()
+                        .name("agent-a")
+                        .model(stubModel("ok"))
+                        .workspace(workspace)
+                        .filesystem(new RemoteFilesystemSpec(store))
+                        .stateStore(mock(AgentStateStore.class))
+                        .build()) {
+            assertNull(
+                    agent.getWorkspaceManager().getIndex(),
+                    "remote mode should use store scans instead of a local workspace index");
+            assertFalse(
+                    Files.exists(workspace.resolve(".index/workspace.db")),
+                    "building a remote agent must not create a local SQLite database");
+
+            AbstractFilesystem filesystem = agent.getWorkspaceManager().getFilesystem();
+            assertTrue(
+                    filesystem
+                            .write(
+                                    RuntimeContext.empty(),
+                                    "/memory/remote-note.md",
+                                    "stored remotely")
+                            .isSuccess());
+            assertTrue(
+                    filesystem.ls(RuntimeContext.empty(), "/memory").entries().stream()
+                            .anyMatch(entry -> entry.path().endsWith("remote-note.md")),
+                    "ls should discover remote files via the store-scan fallback");
+            assertEquals(
+                    "stored remotely",
+                    filesystem
+                            .read(
+                                    RuntimeContext.empty(),
+                                    "/memory/remote-note.md",
+                                    0,
+                                    Integer.MAX_VALUE)
+                            .fileData()
+                            .content());
+        }
+    }
+
+    @Test
+    void remoteFilesystemSpec_doesNotCreateLocalSessionTranscripts() throws Exception {
+        Files.createDirectories(workspace);
+        AgentStateStore stateStore = mock(AgentStateStore.class);
+
+        try (HarnessAgent agent =
+                HarnessAgent.builder()
+                        .name("agent-a")
+                        .model(stubModel("ok"))
+                        .workspace(workspace)
+                        .filesystem(new RemoteFilesystemSpec(new InMemoryStore()))
+                        .stateStore(stateStore)
+                        .memory(
+                                MemoryConfig.builder()
+                                        .flushTrigger(MemoryConfig.FlushTrigger.never())
+                                        .build())
+                        .disableCompaction()
+                        .build()) {
+            agent.call(userText("hi"), RuntimeContext.builder().sessionId("remote").build())
+                    .block();
+
+            assertNoSessionFiles();
+        }
+    }
+
+    @Test
+    void remoteFilesystemSpec_disablesLocalSessionTranscriptsForSubagents() throws Exception {
+        Files.createDirectories(workspace);
+        HarnessAgent.Builder builder =
+                HarnessAgent.builder()
+                        .name("agent-a")
+                        .model(stubModel("ok"))
+                        .workspace(workspace)
+                        .filesystem(new RemoteFilesystemSpec(new InMemoryStore()))
+                        .stateStore(mock(AgentStateStore.class))
+                        .memory(
+                                MemoryConfig.builder()
+                                        .flushTrigger(MemoryConfig.FlushTrigger.never())
+                                        .build())
+                        .disableCompaction();
+
+        HarnessAgent subagent =
+                (HarnessAgent)
+                        builder.buildSubagentEntries(workspace).stream()
+                                .filter(entry -> "general-purpose".equals(entry.name()))
+                                .findFirst()
+                                .orElseThrow()
+                                .factory()
+                                .create(RuntimeContext.empty());
+
+        subagent.call(userText("hi"), RuntimeContext.builder().sessionId("remote-child").build())
+                .block();
+
+        assertNoSessionFiles();
+    }
+
     private static Msg userText(String text) {
         return Msg.builder()
                 .role(MsgRole.USER)
@@ -1179,6 +1360,56 @@ class HarnessAgentTest {
         assertTrue(
                 decl.getInlineAgentsBody().contains("inline sysPrompt"),
                 "body should be inline agents body when no workspace.path");
+    }
+
+    private static CompactionConfig compactionThatAlwaysOffloads() {
+        return CompactionConfig.builder()
+                .triggerMessages(1)
+                .triggerTokens(Integer.MAX_VALUE)
+                .keepMessages(0)
+                .keepTokens(0)
+                .flushBeforeCompact(false)
+                .offloadBeforeCompact(true)
+                .build();
+    }
+
+    private void assertSessionFilesExist() throws IOException {
+        try (var files = Files.walk(workspace)) {
+            List<Path> sessionFiles =
+                    files.filter(Files::isRegularFile)
+                            .filter(HarnessAgentTest::isSessionFile)
+                            .toList();
+            assertTrue(
+                    sessionFiles.stream()
+                            .anyMatch(
+                                    path -> {
+                                        String filename = path.getFileName().toString();
+                                        return filename.endsWith(".jsonl")
+                                                && !filename.endsWith(".log.jsonl");
+                                    }));
+            assertTrue(
+                    sessionFiles.stream()
+                            .anyMatch(
+                                    path -> path.getFileName().toString().endsWith(".log.jsonl")));
+        }
+    }
+
+    private void assertNoSessionFiles() throws IOException {
+        try (var files = Files.walk(workspace)) {
+            List<Path> sessionFiles =
+                    files.filter(Files::isRegularFile)
+                            .filter(HarnessAgentTest::isSessionFile)
+                            .toList();
+            assertTrue(sessionFiles.isEmpty(), "session persistence created " + sessionFiles);
+        }
+    }
+
+    private static boolean isSessionFile(Path path) {
+        String filename = path.getFileName().toString();
+        Path parent = path.getParent();
+        return parent != null
+                && WorkspaceConstants.SESSIONS_DIR.equals(parent.getFileName().toString())
+                && filename.endsWith(".jsonl");
     }
 
     private static Model stubModel(String assistantText) {


### PR DESCRIPTION
## Summary

- Stop creating `.index/workspace.db` by default when using `RemoteFilesystemSpec`.
- Disable local Harness session transcript files for remote main agents and subagents.
- Keep `AgentStateStore` persistence unaffected.
- Make `disableSessionPersistence()` cover both memory-flush and compaction offload paths.
- Allow callers to explicitly provide a caller-managed `WorkspaceIndex` when needed.
- Fall back to distributed-store scans when no local workspace index is configured.

## Testing

- `HarnessAgentTest`: 39 tests passed
- Core test suite: 2209 tests passed, 9 skipped
- Harness test suite: 643 tests passed, 3 skipped
- Spotless and `git diff --check` passed

Fixes #2182