### PR TITLE
fix(tool): mark ToolResultBlock.error() results with state=ERROR

### DIFF
--- a/agentscope-core/src/main/java/io/agentscope/core/message/ToolResultBlock.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/message/ToolResultBlock.java
@@ -199,15 +199,19 @@ public final class ToolResultBlock extends ContentBlock {
     /**
      * Create an error result (for tool method return values).
      *
+     * <p>The result carries {@link ToolResultState#ERROR} so that failures are
+     * recognized by state, independent of the output text prefix.
+     *
      * @param errorMessage Error message
-     * @return ToolResultBlock with error output
+     * @return ToolResultBlock with error output and {@code state = ERROR}
      */
     public static ToolResultBlock error(String errorMessage) {
         return new ToolResultBlock(
                 null,
                 null,
                 List.of(TextBlock.builder().text("Error: " + errorMessage).build()),
-                null);
+                null,
+                ToolResultState.ERROR);
     }
 
     /**

--- a/agentscope-core/src/test/java/io/agentscope/core/tool/ToolExecutorTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/tool/ToolExecutorTest.java
@@ -22,6 +22,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import io.agentscope.core.message.ContentBlock;
 import io.agentscope.core.message.TextBlock;
 import io.agentscope.core.message.ToolResultBlock;
+import io.agentscope.core.message.ToolResultState;
 import io.agentscope.core.message.ToolUseBlock;
 import io.agentscope.core.tool.test.SampleTools;
 import io.agentscope.core.tool.test.ToolTestUtils;
@@ -124,6 +125,20 @@ class ToolExecutorTest {
                 "Error: Tool execution failed: Tool error: test failure",
                 content,
                 "Error message should be wrapped by executor");
+        assertEquals(
+                ToolResultState.ERROR,
+                responses.get(0).getState(),
+                "A failed tool call must be reported with state=ERROR, not SUCCESS");
+    }
+
+    @Test
+    @DisplayName("ToolResultBlock.error() carries state=ERROR (issue #2157)")
+    void errorResultCarriesErrorState() {
+        // Regression guard: previously error() left state=null (defaulting to
+        // RUNNING) and relied on an "[ERROR]" text prefix it never produced, so
+        // determineToolResultState() misclassified failures as SUCCESS.
+        ToolResultBlock result = ToolResultBlock.error("boom");
+        assertEquals(ToolResultState.ERROR, result.getState());
     }
 
     @Test


### PR DESCRIPTION
## What

`ToolResultBlock.error()` returned a result whose `state` was left unset (the
constructor defaults it to `RUNNING`) with an `"Error: "` text prefix. But
`ReActAgent.determineToolResultState()` only classifies a result as `ERROR`
when either the structured state is a non-`RUNNING` value, or the output text
starts with `"[ERROR]"`. Neither held, so failed tool calls fell through to the
default `SUCCESS` branch — the agent never saw the failure.

This affected every `error()` call site: MCP timeouts, tool-not-found, empty
results, and generic execution failures.

Reproduced in the issue with an MCP tool timing out after 3 retries:

```
WARN  Retrying tool call 'maps_weather' (attempt 2/2) due to: Tool execution timeout after PT30S
INFO  POST_ACTING | name=maps_weather, result_len=96, state=SUCCESS   <-- should be ERROR
```

## Fix

Set `state = ToolResultState.ERROR` in `ToolResultBlock.error()`, so failures are
classified by structured state, decoupled from the fragile text-prefix heuristic.
This fixes all error paths at once. The output text (`"Error: ..."`) is
unchanged, so existing behavior and assertions are preserved.

## Tests

- Extended `shouldReturnErrorWhenToolThrows` to assert the failing-tool response
  carries `state == ERROR`.
- Added `errorResultCarriesErrorState` as a focused regression guard.
- Full `agentscope-core` suite: **2210 passed, 0 failed** (9 skipped).

Closes #2157
