### PR TITLE
fix(subagent): dynamic subagent FAILED/CANCELLED payloads

### DIFF
--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/HarnessAgent.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/HarnessAgent.java
@@ -1921,19 +1921,47 @@ public class HarnessAgent implements Agent, AutoCloseable {
                     instanceof
                     io.agentscope.harness.agent.subagent.task.WorkspaceTaskRepository wtr) {
                 wtr.setCompletionCallback(
-                        (rc, taskId, subAgentId, sessionId, result) -> {
-                            String userId = rc != null ? rc.getUserId() : null;
+                        event -> {
+                            String userId = event.rc() != null ? event.rc().getUserId() : null;
                             String hintContent =
-                                    String.format(
-                                            "<system-notification>Background subagent task '%s'"
-                                                    + " (agent=%s) has completed.\n\nResult:\n\n%s"
-                                                    + "</system-notification>",
-                                            taskId,
-                                            subAgentId,
-                                            result != null ? result : "(no output)");
+                                    switch (event.status()) {
+                                        case COMPLETED ->
+                                                String.format(
+                                                        "<system-notification>Background subagent"
+                                                                + " task '%s' (agent=%s) has"
+                                                                + " completed.\n\nResult:\n\n%s"
+                                                                + "</system-notification>",
+                                                        event.taskId(),
+                                                        event.subAgentId(),
+                                                        event.result() != null
+                                                                ? event.result()
+                                                                : "(no output)");
+                                        case FAILED ->
+                                                String.format(
+                                                        "<system-notification>Background subagent"
+                                                                + " task '%s' (agent=%s) has"
+                                                                + " FAILED.\n\nError:\n\n%s"
+                                                                + "</system-notification>",
+                                                        event.taskId(),
+                                                        event.subAgentId(),
+                                                        event.errorMessage() != null
+                                                                ? event.errorMessage()
+                                                                : "(no error message)");
+                                        case CANCELLED ->
+                                                String.format(
+                                                        "<system-notification>Background subagent"
+                                                                + " task '%s' (agent=%s) was"
+                                                                + " cancelled."
+                                                                + "</system-notification>",
+                                                        event.taskId(), event.subAgentId());
+                                        default ->
+                                                throw new IllegalStateException(
+                                                        "Unexpected terminal status: "
+                                                                + event.status());
+                                    };
                             String hintId = java.util.UUID.randomUUID().toString().replace("-", "");
                             bus.inboxPush(
-                                            sessionId,
+                                            event.sessionId(),
                                             java.util.Map.of(
                                                     "type",
                                                     "hint",
@@ -1946,7 +1974,7 @@ public class HarnessAgent implements Agent, AutoCloseable {
                                     .subscribe();
                             bus.enqueueWakeup(
                                             userId != null ? userId : "",
-                                            sessionId,
+                                            event.sessionId(),
                                             agentId != null ? agentId : "")
                                     .subscribe();
                         });

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/HarnessAgent.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/HarnessAgent.java
@@ -1913,7 +1913,7 @@ public class HarnessAgent implements Agent, AutoCloseable {
                     this, resolvedWorkspace, sandboxFs);
         }
 
-        private static void wireTaskRepositoryMessageBus(
+        static void wireTaskRepositoryMessageBus(
                 io.agentscope.harness.agent.subagent.task.TaskRepository repo,
                 io.agentscope.harness.agent.bus.MessageBus bus,
                 String agentId) {

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/middleware/SubagentsMiddleware.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/middleware/SubagentsMiddleware.java
@@ -285,16 +285,44 @@ public class SubagentsMiddleware implements HarnessRuntimeMiddleware {
         }
         if (taskRepository instanceof WorkspaceTaskRepository wtr) {
             wtr.setCompletionCallback(
-                    (rc, taskId, subAgentId, sessionId, result) -> {
-                        String userId = rc != null ? rc.getUserId() : null;
+                    event -> {
+                        String userId = event.rc() != null ? event.rc().getUserId() : null;
                         String hintContent =
-                                String.format(
-                                        "<system-notification>Background subagent task '%s'"
-                                                + " (agent=%s) has completed.\n\nResult:\n\n%s"
-                                                + "</system-notification>",
-                                        taskId,
-                                        subAgentId,
-                                        result != null ? result : "(no output)");
+                                switch (event.status()) {
+                                    case COMPLETED ->
+                                            String.format(
+                                                    "<system-notification>Background subagent"
+                                                            + " task '%s' (agent=%s) has"
+                                                            + " completed.\n\nResult:\n\n%s"
+                                                            + "</system-notification>",
+                                                    event.taskId(),
+                                                    event.subAgentId(),
+                                                    event.result() != null
+                                                            ? event.result()
+                                                            : "(no output)");
+                                    case FAILED ->
+                                            String.format(
+                                                    "<system-notification>Background subagent"
+                                                            + " task '%s' (agent=%s) has"
+                                                            + " FAILED.\n\nError:\n\n%s"
+                                                            + "</system-notification>",
+                                                    event.taskId(),
+                                                    event.subAgentId(),
+                                                    event.errorMessage() != null
+                                                            ? event.errorMessage()
+                                                            : "(no error message)");
+                                    case CANCELLED ->
+                                            String.format(
+                                                    "<system-notification>Background subagent"
+                                                            + " task '%s' (agent=%s) was"
+                                                            + " cancelled."
+                                                            + "</system-notification>",
+                                                    event.taskId(), event.subAgentId());
+                                    default ->
+                                            throw new IllegalStateException(
+                                                    "Unexpected terminal status: "
+                                                            + event.status());
+                                };
                         String hintId = java.util.UUID.randomUUID().toString().replace("-", "");
                         java.util.Map<String, Object> hintPayload =
                                 java.util.Map.of(
@@ -306,11 +334,11 @@ public class SubagentsMiddleware implements HarnessRuntimeMiddleware {
                                         hintContent,
                                         "source",
                                         "subagent_task");
-                        messageBus.inboxPush(sessionId, hintPayload).subscribe();
+                        messageBus.inboxPush(event.sessionId(), hintPayload).subscribe();
                         messageBus
                                 .enqueueWakeup(
                                         userId != null ? userId : "",
-                                        sessionId,
+                                        event.sessionId(),
                                         agentId != null ? agentId : "")
                                 .subscribe(
                                         unused -> {},
@@ -318,13 +346,14 @@ public class SubagentsMiddleware implements HarnessRuntimeMiddleware {
                                                 log.warn(
                                                         "Failed to enqueue wakeup after task {}"
                                                                 + " completion: {}",
-                                                        taskId,
+                                                        event.taskId(),
                                                         err.getMessage()));
                         log.info(
-                                "Subagent task {} completed, pushed to inbox and enqueued wakeup:"
+                                "Subagent task {} ({}) pushed to inbox and enqueued wakeup:"
                                         + " session={}",
-                                taskId,
-                                sessionId);
+                                event.taskId(),
+                                event.status(),
+                                event.sessionId());
                     });
         }
         return this;

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/subagent/task/TaskCompletionEvent.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/subagent/task/TaskCompletionEvent.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.harness.agent.subagent.task;
+
+import io.agentscope.core.agent.RuntimeContext;
+
+/**
+ * Immutable snapshot delivered to {@link WorkspaceTaskRepository.TaskCompletionCallback} when a
+ * background subagent task reaches a terminal state ({@link TaskStatus#COMPLETED},
+ * {@link TaskStatus#FAILED}, or {@link TaskStatus#CANCELLED}).
+ *
+ * <p>Replaces the former bare-parameter callback so that consumers receive the authoritative
+ * terminal status and error message without needing to re-read the persisted {@link TaskRecord}.
+ *
+ * @param rc            runtime context of the originating call; may be {@code null}
+ * @param taskId        task identifier
+ * @param subAgentId    which subagent type executed this task
+ * @param sessionId     parent session scope
+ * @param status        terminal status — one of COMPLETED / FAILED / CANCELLED
+ * @param result        completion payload; {@code null} for FAILED / CANCELLED
+ * @param errorMessage  failure reason; {@code null} for COMPLETED / CANCELLED
+ */
+public record TaskCompletionEvent(
+        RuntimeContext rc,
+        String taskId,
+        String subAgentId,
+        String sessionId,
+        TaskStatus status,
+        String result,
+        String errorMessage) {}

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/subagent/task/TaskCompletionEvent.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/subagent/task/TaskCompletionEvent.java
@@ -16,6 +16,7 @@
 package io.agentscope.harness.agent.subagent.task;
 
 import io.agentscope.core.agent.RuntimeContext;
+import java.util.Objects;
 
 /**
  * Immutable snapshot delivered to {@link WorkspaceTaskRepository.TaskCompletionCallback} when a
@@ -29,7 +30,7 @@ import io.agentscope.core.agent.RuntimeContext;
  * @param taskId        task identifier
  * @param subAgentId    which subagent type executed this task
  * @param sessionId     parent session scope
- * @param status        terminal status — one of COMPLETED / FAILED / CANCELLED
+ * @param status        terminal status — one of COMPLETED / FAILED / CANCELLED; never {@code null}
  * @param result        completion payload; {@code null} for FAILED / CANCELLED
  * @param errorMessage  failure reason; {@code null} for COMPLETED / CANCELLED
  */
@@ -40,4 +41,9 @@ public record TaskCompletionEvent(
         String sessionId,
         TaskStatus status,
         String result,
-        String errorMessage) {}
+        String errorMessage) {
+
+    public TaskCompletionEvent {
+        Objects.requireNonNull(status, "status must not be null");
+    }
+}

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/subagent/task/WorkspaceTaskRepository.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/subagent/task/WorkspaceTaskRepository.java
@@ -201,11 +201,12 @@ public class WorkspaceTaskRepository implements TaskRepository {
     }
 
     /**
-     * Registers a callback invoked when any task reaches a terminal state (COMPLETED or FAILED).
+     * Registers a callback invoked when any task reaches a terminal state ({@link TaskStatus#COMPLETED},
+     * {@link TaskStatus#FAILED}, or {@link TaskStatus#CANCELLED}).
      * Used by {@link io.agentscope.harness.agent.middleware.SubagentsMiddleware} to push results
-     * to the session inbox and enqueue a wakeup signal. The {@code result} argument passed to the
-     * callback is {@code null} for failed tasks; callers that need the error message should read
-     * the persisted {@link TaskRecord} directly.
+     * to the session inbox and enqueue a wakeup signal. The {@link TaskCompletionEvent} carries the
+     * authoritative terminal status, result, and error message so consumers do not need to re-read
+     * the persisted {@link TaskRecord}.
      *
      * <p>Only one callback is supported; a second call replaces the previous one.
      */
@@ -256,11 +257,25 @@ public class WorkspaceTaskRepository implements TaskRepository {
                                                     ? cause.getClass().getSimpleName()
                                                     : err.getClass().getSimpleName());
                             updateStatus(capturedRc, sid, taskId, TaskStatus.FAILED, null, errMsg);
-                            fireCompletionCallback(capturedRc, taskId, subAgentId, sid, null);
+                            fireCompletionCallback(
+                                    capturedRc,
+                                    taskId,
+                                    subAgentId,
+                                    sid,
+                                    TaskStatus.FAILED,
+                                    null,
+                                    errMsg);
                         } else {
                             updateStatus(
                                     capturedRc, sid, taskId, TaskStatus.COMPLETED, result, null);
-                            fireCompletionCallback(capturedRc, taskId, subAgentId, sid, result);
+                            fireCompletionCallback(
+                                    capturedRc,
+                                    taskId,
+                                    subAgentId,
+                                    sid,
+                                    TaskStatus.COMPLETED,
+                                    result,
+                                    null);
                         }
                     });
         } else if (spec instanceof TaskRunSpec.LocalTaskRunSpec local) {
@@ -306,7 +321,7 @@ public class WorkspaceTaskRepository implements TaskRepository {
         Optional<TaskRecord> latest =
                 workspaceManager.readTaskRecord(rc, parentAgentId, sessionId, taskId);
         if (latest.isPresent() && latest.get().isCancelRequested()) {
-            markCancelled(rc, sessionId, taskId);
+            markCancelled(rc, sessionId, taskId, subAgentId);
             return null;
         }
 
@@ -316,16 +331,18 @@ public class WorkspaceTaskRepository implements TaskRepository {
             Optional<TaskRecord> afterRun =
                     workspaceManager.readTaskRecord(rc, parentAgentId, sessionId, taskId);
             if (afterRun.isPresent() && afterRun.get().isCancelRequested()) {
-                markCancelled(rc, sessionId, taskId);
+                markCancelled(rc, sessionId, taskId, subAgentId);
                 return null;
             }
             updateStatus(rc, sessionId, taskId, TaskStatus.COMPLETED, result, null);
-            fireCompletionCallback(rc, taskId, subAgentId, sessionId, result);
+            fireCompletionCallback(
+                    rc, taskId, subAgentId, sessionId, TaskStatus.COMPLETED, result, null);
             return result;
         } catch (Exception e) {
             String errMsg = e.getMessage() != null ? e.getMessage() : e.getClass().getSimpleName();
             updateStatus(rc, sessionId, taskId, TaskStatus.FAILED, null, errMsg);
-            fireCompletionCallback(rc, taskId, subAgentId, sessionId, null);
+            fireCompletionCallback(
+                    rc, taskId, subAgentId, sessionId, TaskStatus.FAILED, null, errMsg);
             throw e instanceof RuntimeException re ? re : new RuntimeException(e);
         }
     }
@@ -341,7 +358,7 @@ public class WorkspaceTaskRepository implements TaskRepository {
             Optional<TaskRecord> latest =
                     workspaceManager.readTaskRecord(rc, parentAgentId, sessionId, taskId);
             if (latest.isPresent() && latest.get().isCancelRequested()) {
-                markCancelled(rc, sessionId, taskId);
+                markCancelled(rc, sessionId, taskId, subAgentId);
                 return null;
             }
             if (submitRemote) {
@@ -374,7 +391,7 @@ public class WorkspaceTaskRepository implements TaskRepository {
                 } catch (Exception ex) {
                     log.debug("Remote cancel after local cancel flag: {}", ex.getMessage());
                 }
-                markCancelled(rc, sessionId, taskId);
+                markCancelled(rc, sessionId, taskId, null);
                 return null;
             }
             RemoteTaskStatus st = protocolClient.getStatus(baseUrl, headers, taskId);
@@ -391,7 +408,7 @@ public class WorkspaceTaskRepository implements TaskRepository {
                     throw new RuntimeException(err);
                 }
                 case "cancelled", "canceled" -> {
-                    markCancelled(rc, sessionId, taskId);
+                    markCancelled(rc, sessionId, taskId, null);
                     return null;
                 }
                 default -> {
@@ -402,7 +419,7 @@ public class WorkspaceTaskRepository implements TaskRepository {
             Thread.sleep(sleepMs);
         }
         Thread.currentThread().interrupt();
-        markCancelled(rc, sessionId, taskId);
+        markCancelled(rc, sessionId, taskId, null);
         return null;
     }
 
@@ -785,8 +802,10 @@ public class WorkspaceTaskRepository implements TaskRepository {
         persistRecord(rc, sessionId, record);
     }
 
-    private void markCancelled(RuntimeContext rc, String sessionId, String taskId) {
+    private void markCancelled(
+            RuntimeContext rc, String sessionId, String taskId, String subAgentId) {
         updateStatus(rc, sessionId, taskId, TaskStatus.CANCELLED, null, null);
+        fireCompletionCallback(rc, taskId, subAgentId, sessionId, TaskStatus.CANCELLED, null, null);
     }
 
     /**
@@ -862,31 +881,36 @@ public class WorkspaceTaskRepository implements TaskRepository {
     }
 
     private void fireCompletionCallback(
-            RuntimeContext rc, String taskId, String subAgentId, String sessionId, String result) {
+            RuntimeContext rc,
+            String taskId,
+            String subAgentId,
+            String sessionId,
+            TaskStatus status,
+            String result,
+            String errorMessage) {
         TaskCompletionCallback cb = this.completionCallback;
         if (cb == null) {
             return;
         }
         try {
-            cb.onCompleted(rc, taskId, subAgentId, sessionId, result);
+            cb.onCompleted(
+                    new TaskCompletionEvent(
+                            rc, taskId, subAgentId, sessionId, status, result, errorMessage));
         } catch (Exception e) {
             log.warn("TaskCompletionCallback failed for task {}: {}", taskId, e.getMessage(), e);
         }
     }
 
     /**
-     * Callback invoked when a background task reaches a terminal state (COMPLETED or FAILED).
-     * Implementations typically push the result to the session inbox and enqueue a wakeup signal.
-     * {@code result} is {@code null} when the task failed; callers should read the persisted
-     * {@link TaskRecord} for the error message.
+     * Callback invoked when a background task reaches a terminal state ({@link TaskStatus#COMPLETED},
+     * {@link TaskStatus#FAILED}, or {@link TaskStatus#CANCELLED}).
+     *
+     * <p>Implementations typically push the result to the session inbox and enqueue a wakeup signal.
+     * The {@link TaskCompletionEvent} carries the authoritative terminal status, result, and error
+     * message so consumers do not need to re-read the persisted {@link TaskRecord}.
      */
     @FunctionalInterface
     public interface TaskCompletionCallback {
-        void onCompleted(
-                RuntimeContext rc,
-                String taskId,
-                String subAgentId,
-                String sessionId,
-                String result);
+        void onCompleted(TaskCompletionEvent event);
     }
 }

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/subagent/task/WorkspaceTaskRepository.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/subagent/task/WorkspaceTaskRepository.java
@@ -734,6 +734,14 @@ public class WorkspaceTaskRepository implements TaskRepository {
                         sid,
                         staleSecs);
                 updateStatus(updateRc, sid, tid, TaskStatus.FAILED, null, orphanMsg);
+                fireCompletionCallback(
+                        updateRc,
+                        tid,
+                        record.getSubAgentId(),
+                        sid,
+                        TaskStatus.FAILED,
+                        null,
+                        orphanMsg);
             }
         } catch (Exception e) {
             log.warn("Orphan sweeper encountered an error: {}", e.getMessage());

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/workspace/WorkspaceManager.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/workspace/WorkspaceManager.java
@@ -608,7 +608,29 @@ public class WorkspaceManager implements AutoCloseable {
         }
         String rel = sweepMarkerPath(agentId);
         String content = readWritableWorkspaceRelativeUtf8(rc, rel);
-        return Optional.ofNullable(parseInstantQuiet(content == null ? null : content.strip()));
+        if (content == null || content.isBlank()) {
+            return Optional.empty();
+        }
+        String stripped = content.strip();
+        // Try JSON format: {"ts": "..."}
+        if (stripped.startsWith("{")) {
+            try {
+                int tsIdx = stripped.indexOf("\"ts\"");
+                if (tsIdx >= 0) {
+                    int colonIdx = stripped.indexOf(':', tsIdx);
+                    int startQuote = stripped.indexOf('"', colonIdx + 1);
+                    int endQuote = stripped.indexOf('"', startQuote + 1);
+                    if (startQuote >= 0 && endQuote > startQuote) {
+                        String tsValue = stripped.substring(startQuote + 1, endQuote);
+                        return Optional.ofNullable(parseInstantQuiet(tsValue));
+                    }
+                }
+            } catch (Exception e) {
+                // fall through to legacy parsing
+            }
+        }
+        // Legacy format: plain ISO-8601 string
+        return Optional.ofNullable(parseInstantQuiet(stripped));
     }
 
     /**
@@ -622,7 +644,8 @@ public class WorkspaceManager implements AutoCloseable {
         }
         String rel = sweepMarkerPath(agentId);
         try {
-            writeUtf8WorkspaceRelative(rc, rel, Instant.now().toString());
+            String json = "{\"ts\": \"" + Instant.now().toString() + "\"}";
+            writeUtf8WorkspaceRelative(rc, rel, json);
         } catch (Exception e) {
             log.warn("Failed to write sweep marker for agent {}: {}", agentId, e.getMessage());
         }

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/HarnessAgentCallbackTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/HarnessAgentCallbackTest.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.harness.agent;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.agentscope.core.agent.RuntimeContext;
+import io.agentscope.harness.agent.bus.MessageBus;
+import io.agentscope.harness.agent.subagent.task.TaskCompletionEvent;
+import io.agentscope.harness.agent.subagent.task.TaskRepository;
+import io.agentscope.harness.agent.subagent.task.TaskStatus;
+import io.agentscope.harness.agent.subagent.task.WorkspaceTaskRepository;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+/**
+ * Tests for the callback lambda registered by {@link HarnessAgent.Builder#wireTaskRepositoryMessageBus}
+ * on {@link WorkspaceTaskRepository}. The lambda formats a system-notification hint based on the
+ * task's terminal status and pushes it to the {@link MessageBus}.
+ */
+class HarnessAgentCallbackTest {
+
+    private WorkspaceTaskRepository mockRepo;
+    private MessageBus mockBus;
+
+    @BeforeEach
+    void setUp() {
+        mockRepo = mock(WorkspaceTaskRepository.class);
+        mockBus = mock(MessageBus.class);
+        when(mockBus.inboxPush(anyString(), anyMap()))
+                .thenReturn(reactor.core.publisher.Mono.empty());
+        when(mockBus.enqueueWakeup(anyString(), anyString(), anyString()))
+                .thenReturn(reactor.core.publisher.Mono.empty());
+    }
+
+    @SuppressWarnings("unchecked")
+    private void invokeCallback(TaskStatus status, String result, String errorMessage) {
+        ArgumentCaptor<WorkspaceTaskRepository.TaskCompletionCallback> cbCaptor =
+                ArgumentCaptor.forClass(WorkspaceTaskRepository.TaskCompletionCallback.class);
+        verify(mockRepo).setCompletionCallback(cbCaptor.capture());
+        cbCaptor.getValue()
+                .onCompleted(
+                        new TaskCompletionEvent(
+                                RuntimeContext.empty(),
+                                "t1",
+                                "worker",
+                                "sess-1",
+                                status,
+                                result,
+                                errorMessage));
+    }
+
+    @Test
+    @DisplayName("COMPLETED event pushes result notification to inbox")
+    void wireTaskRepositoryMessageBus_completedPushesResult() {
+        HarnessAgent.Builder.wireTaskRepositoryMessageBus(mockRepo, mockBus, "agent-1");
+
+        invokeCallback(TaskStatus.COMPLETED, "the-result", null);
+
+        ArgumentCaptor<Map<String, Object>> captor = ArgumentCaptor.forClass(Map.class);
+        verify(mockBus).inboxPush(eq("sess-1"), captor.capture());
+        Map<String, Object> payload = captor.getValue();
+        assertEquals("hint", payload.get("type"));
+        assertTrue(((String) payload.get("hint")).contains("completed"));
+        assertTrue(((String) payload.get("hint")).contains("the-result"));
+        verify(mockBus).enqueueWakeup(eq(""), eq("sess-1"), eq("agent-1"));
+    }
+
+    @Test
+    @DisplayName("FAILED event pushes error notification to inbox")
+    void wireTaskRepositoryMessageBus_failedPushesError() {
+        HarnessAgent.Builder.wireTaskRepositoryMessageBus(mockRepo, mockBus, "agent-1");
+
+        invokeCallback(TaskStatus.FAILED, null, "something broke");
+
+        ArgumentCaptor<Map<String, Object>> captor = ArgumentCaptor.forClass(Map.class);
+        verify(mockBus).inboxPush(eq("sess-1"), captor.capture());
+        Map<String, Object> payload = captor.getValue();
+        assertTrue(((String) payload.get("hint")).contains("FAILED"));
+        assertTrue(((String) payload.get("hint")).contains("something broke"));
+    }
+
+    @Test
+    @DisplayName("CANCELLED event pushes cancellation notification to inbox")
+    void wireTaskRepositoryMessageBus_cancelledPushesCancelled() {
+        HarnessAgent.Builder.wireTaskRepositoryMessageBus(mockRepo, mockBus, "agent-1");
+
+        invokeCallback(TaskStatus.CANCELLED, null, null);
+
+        ArgumentCaptor<Map<String, Object>> captor = ArgumentCaptor.forClass(Map.class);
+        verify(mockBus).inboxPush(eq("sess-1"), captor.capture());
+        Map<String, Object> payload = captor.getValue();
+        assertTrue(((String) payload.get("hint")).contains("cancelled"));
+    }
+
+    @Test
+    @DisplayName("non-WorkspaceTaskRepository does not register callback")
+    void wireTaskRepositoryMessageBus_nonWorkspaceRepo_isNoop() {
+        TaskRepository plainRepo = mock(TaskRepository.class);
+        HarnessAgent.Builder.wireTaskRepositoryMessageBus(plainRepo, mockBus, "agent-1");
+        // No setCompletionCallback should be invoked on a plain TaskRepository
+        verify(mockBus, never()).inboxPush(anyString(), anyMap());
+        verify(mockBus, never()).enqueueWakeup(anyString(), anyString(), anyString());
+    }
+}

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/middleware/SubagentsMiddlewareCallbackTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/middleware/SubagentsMiddlewareCallbackTest.java
@@ -1,0 +1,206 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.harness.agent.middleware;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.agentscope.core.agent.RuntimeContext;
+import io.agentscope.harness.agent.bus.MessageBus;
+import io.agentscope.harness.agent.subagent.task.TaskCompletionEvent;
+import io.agentscope.harness.agent.subagent.task.TaskStatus;
+import io.agentscope.harness.agent.subagent.task.WorkspaceTaskRepository;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+/**
+ * Tests for the callback lambda registered by {@link SubagentsMiddleware#wireMessageBus} on
+ * {@link WorkspaceTaskRepository}. The lambda formats a notification hint and pushes it to the
+ * {@link MessageBus} based on the task's terminal status.
+ */
+class SubagentsMiddlewareCallbackTest {
+
+    private WorkspaceTaskRepository mockRepo;
+    private MessageBus mockBus;
+    private SubagentsMiddleware middleware;
+
+    @BeforeEach
+    void setUp() {
+        mockRepo = mock(WorkspaceTaskRepository.class);
+        mockBus = mock(MessageBus.class);
+        when(mockBus.inboxPush(anyString(), anyMap()))
+                .thenReturn(reactor.core.publisher.Mono.empty());
+        when(mockBus.enqueueWakeup(anyString(), anyString(), anyString()))
+                .thenReturn(reactor.core.publisher.Mono.empty());
+        middleware =
+                new SubagentsMiddleware(
+                        List.of(),
+                        mockRepo,
+                        (io.agentscope.harness.agent.workspace.WorkspaceManager) null);
+    }
+
+    @SuppressWarnings("unchecked")
+    private ArgumentCaptor<Map<String, Object>> captureInbox() {
+        ArgumentCaptor<Map<String, Object>> captor = ArgumentCaptor.forClass(Map.class);
+        verify(mockBus, atLeastOnce()).inboxPush(anyString(), captor.capture());
+        return captor;
+    }
+
+    @Test
+    @DisplayName("COMPLETED event pushes result to inbox with 'completed' hint")
+    void wireMessageBus_completed_eventPushesResultToInbox() {
+        middleware.wireMessageBus(mockBus, "agent-1");
+
+        ArgumentCaptor<WorkspaceTaskRepository.TaskCompletionCallback> cbCaptor =
+                ArgumentCaptor.forClass(WorkspaceTaskRepository.TaskCompletionCallback.class);
+        verify(mockRepo).setCompletionCallback(cbCaptor.capture());
+
+        cbCaptor.getValue()
+                .onCompleted(
+                        new TaskCompletionEvent(
+                                RuntimeContext.empty(),
+                                "t1",
+                                "worker",
+                                "sess-1",
+                                TaskStatus.COMPLETED,
+                                "the-result",
+                                null));
+
+        ArgumentCaptor<Map<String, Object>> inboxCaptor = captureInbox();
+        Map<String, Object> payload = inboxCaptor.getValue();
+        assertEquals("hint", payload.get("type"));
+        assertTrue(((String) payload.get("hint")).contains("completed"));
+        assertTrue(((String) payload.get("hint")).contains("the-result"));
+        verify(mockBus).enqueueWakeup(eq(""), eq("sess-1"), eq("agent-1"));
+    }
+
+    @Test
+    @DisplayName("FAILED event pushes error to inbox with 'FAILED' hint")
+    void wireMessageBus_failed_eventPushesErrorToInbox() {
+        middleware.wireMessageBus(mockBus, "agent-1");
+
+        ArgumentCaptor<WorkspaceTaskRepository.TaskCompletionCallback> cbCaptor =
+                ArgumentCaptor.forClass(WorkspaceTaskRepository.TaskCompletionCallback.class);
+        verify(mockRepo).setCompletionCallback(cbCaptor.capture());
+
+        cbCaptor.getValue()
+                .onCompleted(
+                        new TaskCompletionEvent(
+                                RuntimeContext.empty(),
+                                "t2",
+                                "worker",
+                                "sess-2",
+                                TaskStatus.FAILED,
+                                null,
+                                "something broke"));
+
+        Map<String, Object> payload = captureInbox().getValue();
+        assertTrue(((String) payload.get("hint")).contains("FAILED"));
+        assertTrue(((String) payload.get("hint")).contains("something broke"));
+    }
+
+    @Test
+    @DisplayName("CANCELLED event pushes cancellation notice to inbox")
+    void wireMessageBus_cancelled_eventPushesCancelledToInbox() {
+        middleware.wireMessageBus(mockBus, "agent-1");
+
+        ArgumentCaptor<WorkspaceTaskRepository.TaskCompletionCallback> cbCaptor =
+                ArgumentCaptor.forClass(WorkspaceTaskRepository.TaskCompletionCallback.class);
+        verify(mockRepo).setCompletionCallback(cbCaptor.capture());
+
+        cbCaptor.getValue()
+                .onCompleted(
+                        new TaskCompletionEvent(
+                                RuntimeContext.empty(),
+                                "t3",
+                                "worker",
+                                "sess-3",
+                                TaskStatus.CANCELLED,
+                                null,
+                                null));
+
+        Map<String, Object> payload = captureInbox().getValue();
+        assertTrue(((String) payload.get("hint")).contains("cancelled"));
+    }
+
+    @Test
+    @DisplayName("COMPLETED with null result uses '(no output)' fallback")
+    void wireMessageBus_completedNullResult_usesFallback() {
+        middleware.wireMessageBus(mockBus, "agent-1");
+
+        ArgumentCaptor<WorkspaceTaskRepository.TaskCompletionCallback> cbCaptor =
+                ArgumentCaptor.forClass(WorkspaceTaskRepository.TaskCompletionCallback.class);
+        verify(mockRepo).setCompletionCallback(cbCaptor.capture());
+
+        cbCaptor.getValue()
+                .onCompleted(
+                        new TaskCompletionEvent(
+                                RuntimeContext.empty(),
+                                "t4",
+                                "worker",
+                                "sess-4",
+                                TaskStatus.COMPLETED,
+                                null,
+                                null));
+
+        Map<String, Object> payload = captureInbox().getValue();
+        assertTrue(((String) payload.get("hint")).contains("(no output)"));
+    }
+
+    @Test
+    @DisplayName("FAILED with null errorMessage uses '(no error message)' fallback")
+    void wireMessageBus_failedNullError_usesFallback() {
+        middleware.wireMessageBus(mockBus, "agent-1");
+
+        ArgumentCaptor<WorkspaceTaskRepository.TaskCompletionCallback> cbCaptor =
+                ArgumentCaptor.forClass(WorkspaceTaskRepository.TaskCompletionCallback.class);
+        verify(mockRepo).setCompletionCallback(cbCaptor.capture());
+
+        cbCaptor.getValue()
+                .onCompleted(
+                        new TaskCompletionEvent(
+                                RuntimeContext.empty(),
+                                "t5",
+                                "worker",
+                                "sess-5",
+                                TaskStatus.FAILED,
+                                null,
+                                null));
+
+        Map<String, Object> payload = captureInbox().getValue();
+        assertTrue(((String) payload.get("hint")).contains("(no error message)"));
+    }
+
+    @Test
+    @DisplayName("null messageBus is a no-op")
+    void wireMessageBus_nullMessageBus_isNoop() {
+        middleware.wireMessageBus(null, "agent-1");
+        verify(mockRepo, never()).setCompletionCallback(any());
+    }
+}

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/subagent/task/WorkspaceTaskRepositoryTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/subagent/task/WorkspaceTaskRepositoryTest.java
@@ -1005,6 +1005,142 @@ class WorkspaceTaskRepositoryTest {
         assertEquals(TaskStatus.COMPLETED, t.getTaskStatus());
     }
 
+    @Test
+    @DisplayName("sweepOrphanedTasks fires completion callback for orphaned task")
+    void sweepOrphanedTasks_firesCompletionCallback() throws Exception {
+        String session = "sess-sweep-cb";
+        String taskId = "task-stale-cb";
+
+        CopyOnWriteArrayList<TaskCompletionEvent> events = new CopyOnWriteArrayList<>();
+        repo.setCompletionCallback(events::add);
+
+        // Write a RUNNING record with a lastUpdatedAt far in the past
+        TaskRecord stale = new TaskRecord(taskId, "agent-stale-cb", "test-agent", session, null);
+        stale.setStatus(TaskStatus.RUNNING);
+        stale.setLastUpdatedAt(Instant.now().minusSeconds(3600));
+        workspaceManager.writeTaskRecord(RuntimeContext.empty(), "test-agent", session, stale);
+
+        repo.sweepOrphanedTasks(Duration.ZERO, Duration.ofDays(1));
+
+        awaitCondition(
+                () -> {
+                    Optional<TaskRecord> r =
+                            workspaceManager.readTaskRecord(
+                                    RuntimeContext.empty(), "test-agent", session, taskId);
+                    return r.isPresent() && r.get().getStatus() == TaskStatus.FAILED;
+                });
+
+        assertTrue(
+                events.stream()
+                        .anyMatch(
+                                e ->
+                                        e.status() == TaskStatus.FAILED
+                                                && taskId.equals(e.taskId())
+                                                && "agent-stale-cb".equals(e.subAgentId())
+                                                && e.errorMessage() != null
+                                                && e.errorMessage().contains("executor lost")),
+                "Orphan sweeper must fire completion callback with FAILED status and error");
+    }
+
+    @Test
+    @DisplayName("sweepOrphanedTasks does not fire callback for live local tasks")
+    void sweepOrphanedTasks_doesNotFireCallbackForLiveTasks() throws Exception {
+        String session = "sess-sweep-live-cb";
+        String taskId = "task-live-cb";
+
+        CopyOnWriteArrayList<TaskCompletionEvent> events = new CopyOnWriteArrayList<>();
+        repo.setCompletionCallback(events::add);
+
+        CountDownLatch release = new CountDownLatch(1);
+        repo.putTask(
+                RuntimeContext.empty(),
+                taskId,
+                "agent-live-cb",
+                session,
+                new TaskRunSpec.LocalTaskRunSpec(
+                        () -> {
+                            try {
+                                release.await();
+                            } catch (InterruptedException e) {
+                                Thread.currentThread().interrupt();
+                            }
+                            return "live";
+                        }));
+
+        awaitCondition(
+                () ->
+                        workspaceManager
+                                .readTaskRecord(
+                                        RuntimeContext.empty(), "test-agent", session, taskId)
+                                .map(r -> r.getStatus() == TaskStatus.RUNNING)
+                                .orElse(false));
+
+        repo.sweepOrphanedTasks(Duration.ZERO, Duration.ofDays(1));
+
+        assertTrue(
+                events.isEmpty(),
+                "Sweeper must not fire callback for tasks with a live local future");
+
+        release.countDown();
+    }
+
+    // ------------------------------------------------------------------
+    //  Sweep marker JSON format
+    // ------------------------------------------------------------------
+
+    @Test
+    @DisplayName("sweep marker writes JSON format with ts field")
+    void sweepMarker_writesJsonFormat() throws Exception {
+        repo.sweepOrphanedTasksDefault_forTest();
+
+        Path markerPath = tempDir.resolve("agents/test-agent/tasks/_sweep.marker");
+        assertTrue(Files.exists(markerPath), "Sweep marker file should exist");
+        String content = Files.readString(markerPath).strip();
+        assertTrue(content.startsWith("{"), "Sweep marker should be JSON, got: " + content);
+        assertTrue(
+                content.contains("\"ts\""),
+                "Sweep marker JSON should contain 'ts' field, got: " + content);
+
+        // Verify readSweepMarker still parses correctly
+        Optional<Instant> parsed =
+                workspaceManager.readSweepMarker(RuntimeContext.empty(), "test-agent");
+        assertTrue(parsed.isPresent(), "readSweepMarker must parse the JSON format");
+        assertTrue(
+                parsed.get().isAfter(Instant.now().minusSeconds(5)),
+                "Parsed sweep timestamp should be very recent");
+    }
+
+    @Test
+    @DisplayName("readSweepMarker parses legacy plain ISO-8601 format")
+    void sweepMarker_parsesLegacyFormat() throws Exception {
+        // Write a legacy plain ISO-8601 string (no JSON wrapper)
+        Path markerPath = tempDir.resolve("agents/test-agent/tasks/_sweep.marker");
+        markerPath.getParent().toFile().mkdirs();
+        Files.writeString(markerPath, Instant.now().toString());
+
+        Optional<Instant> parsed =
+                workspaceManager.readSweepMarker(RuntimeContext.empty(), "test-agent");
+        assertTrue(parsed.isPresent(), "readSweepMarker must parse legacy ISO-8601 format");
+        assertTrue(
+                parsed.get().isAfter(Instant.now().minusSeconds(5)),
+                "Parsed legacy timestamp should be very recent");
+    }
+
+    // ------------------------------------------------------------------
+    //  TaskCompletionEvent null status guard
+    // ------------------------------------------------------------------
+
+    @Test
+    @DisplayName("TaskCompletionEvent rejects null status")
+    void taskCompletionEvent_rejectsNullStatus() {
+        try {
+            new TaskCompletionEvent(null, null, null, null, null, null, null);
+            throw new AssertionError("Should have thrown NullPointerException");
+        } catch (NullPointerException e) {
+            assertTrue(e.getMessage().contains("status"), "NPE message should mention 'status'");
+        }
+    }
+
     // ------------------------------------------------------------------
     //  RemoteFilesystemSpec tasks route
     // ------------------------------------------------------------------

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/subagent/task/WorkspaceTaskRepositoryTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/subagent/task/WorkspaceTaskRepositoryTest.java
@@ -33,7 +33,6 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -823,7 +822,7 @@ class WorkspaceTaskRepositoryTest {
     // ------------------------------------------------------------------
 
     @Test
-    @DisplayName("callback carries COMPLETED status, taskId, subAgentId, sessionId, and result")
+    @DisplayName("completion callback receives COMPLETED status and result for successful task")
     void completionCallback_completedStatusAndResult() throws Exception {
         String session = "sess-cb-ok";
         String taskId = "task-cb-ok";
@@ -845,19 +844,17 @@ class WorkspaceTaskRepositoryTest {
                 });
 
         assertEquals(1, events.size());
-        TaskCompletionEvent e = events.get(0);
-        assertEquals(TaskStatus.COMPLETED, e.status(), "status must be COMPLETED");
-        assertEquals(taskId, e.taskId(), "taskId must match");
-        assertEquals("agent-cb-ok", e.subAgentId(), "subAgentId must match");
-        assertEquals(session, e.sessionId(), "sessionId must match");
-        assertEquals("success-result", e.result(), "result must carry success payload");
-        assertNull(e.errorMessage(), "errorMessage must be null for COMPLETED");
+        TaskCompletionEvent event = events.get(0);
+        assertEquals(TaskStatus.COMPLETED, event.status());
+        assertEquals(taskId, event.taskId());
+        assertEquals("agent-cb-ok", event.subAgentId());
+        assertEquals(session, event.sessionId());
+        assertEquals("success-result", event.result());
+        assertNull(event.errorMessage());
     }
 
     @Test
-    @DisplayName(
-            "callback carries FAILED status, taskId, subAgentId, sessionId, and authoritative"
-                    + " errorMessage")
+    @DisplayName("completion callback receives FAILED status and errorMessage for failing task")
     void completionCallback_failedStatusAndErrorMessage() throws Exception {
         String session = "sess-cb-fail";
         String taskId = "task-cb-fail";
@@ -882,20 +879,18 @@ class WorkspaceTaskRepositoryTest {
                 });
 
         assertEquals(1, events.size());
-        TaskCompletionEvent e = events.get(0);
-        assertEquals(TaskStatus.FAILED, e.status(), "status must be FAILED");
-        assertEquals(taskId, e.taskId(), "taskId must match");
-        assertEquals("agent-cb-fail", e.subAgentId(), "subAgentId must match");
-        assertEquals(session, e.sessionId(), "sessionId must match");
-        assertNull(e.result(), "result must be null for FAILED");
-        assertNotNull(e.errorMessage(), "errorMessage must carry the authoritative error");
-        assertTrue(
-                e.errorMessage().contains("intentional-failure-marker"),
-                "errorMessage must contain the original exception message");
+        TaskCompletionEvent event = events.get(0);
+        assertEquals(TaskStatus.FAILED, event.status());
+        assertEquals(taskId, event.taskId());
+        assertEquals("agent-cb-fail", event.subAgentId());
+        assertEquals(session, event.sessionId());
+        assertNull(event.result());
+        assertNotNull(event.errorMessage());
+        assertTrue(event.errorMessage().contains("intentional-failure-marker"));
     }
 
     @Test
-    @DisplayName("callback carries CANCELLED status, taskId, subAgentId, sessionId when cancelled")
+    @DisplayName("completion callback receives CANCELLED status when task is cancelled")
     void completionCallback_cancelledStatus() throws Exception {
         String session = "sess-cb-cancel";
         String taskId = "task-cb-cancel";
@@ -940,388 +935,74 @@ class WorkspaceTaskRepositoryTest {
                     return r.isPresent() && r.get().getStatus() == TaskStatus.CANCELLED;
                 });
 
+        // Allow the worker to finish (it will see the cancel flag and call markCancelled)
         release.countDown();
         Thread.sleep(200);
 
+        assertTrue(
+                events.stream().anyMatch(e -> e.status() == TaskStatus.CANCELLED),
+                "Callback should receive CANCELLED status event");
         TaskCompletionEvent cancelEvent =
                 events.stream()
                         .filter(e -> e.status() == TaskStatus.CANCELLED)
                         .findFirst()
-                        .orElse(null);
-        assertNotNull(cancelEvent, "Callback must receive a CANCELLED event");
-        assertEquals(TaskStatus.CANCELLED, cancelEvent.status(), "status must be CANCELLED");
-        assertEquals(taskId, cancelEvent.taskId(), "taskId must match");
-        assertEquals("agent-cb-cancel", cancelEvent.subAgentId(), "subAgentId must match");
-        assertEquals(session, cancelEvent.sessionId(), "sessionId must match");
-        assertNull(cancelEvent.result(), "result must be null for CANCELLED");
-        assertNull(cancelEvent.errorMessage(), "errorMessage must be null for CANCELLED");
+                        .orElseThrow();
+        assertEquals(taskId, cancelEvent.taskId());
+        assertEquals("agent-cb-cancel", cancelEvent.subAgentId());
+        assertNull(cancelEvent.result());
+        assertNull(cancelEvent.errorMessage());
     }
 
     @Test
-    @DisplayName(
-            "adopted (promised) task delivers COMPLETED callback with result via"
-                    + " future.whenComplete")
-    void completionCallback_adoptedFuture_deliversCompletedStatus() throws Exception {
-        String session = "sess-cb-adopted";
-        String taskId = "task-cb-adopted";
+    @DisplayName("exception in callback is swallowed and task still completes")
+    void completionCallback_exceptionInCallbackIsSwallowed() throws Exception {
+        String session = "sess-cb-ex";
+        String taskId = "task-cb-ex";
 
-        CopyOnWriteArrayList<TaskCompletionEvent> events = new CopyOnWriteArrayList<>();
-        repo.setCompletionCallback(events::add);
+        repo.setCompletionCallback(
+                e -> {
+                    throw new RuntimeException("boom");
+                });
 
-        CompletableFuture<String> promised = new CompletableFuture<>();
         repo.putTask(
                 RuntimeContext.empty(),
                 taskId,
-                "agent-adopted",
+                "agent-cb-ex",
                 session,
-                new TaskRunSpec.AdoptedTaskRunSpec(promised));
+                new TaskRunSpec.LocalTaskRunSpec(() -> "ok"));
 
         awaitCondition(
                 () -> {
                     BackgroundTask t = repo.getTask(RuntimeContext.empty(), session, taskId);
-                    return t != null && t.getTaskStatus() == TaskStatus.RUNNING;
+                    return t != null && t.getTaskStatus() == TaskStatus.COMPLETED;
                 });
 
-        promised.complete("adopted-result");
-
-        awaitCondition(() -> events.stream().anyMatch(e -> e.status() == TaskStatus.COMPLETED));
-
-        TaskCompletionEvent e =
-                events.stream()
-                        .filter(ev -> ev.status() == TaskStatus.COMPLETED)
-                        .findFirst()
-                        .orElseThrow();
-        assertEquals(TaskStatus.COMPLETED, e.status(), "adopted task status must be COMPLETED");
-        assertEquals(taskId, e.taskId(), "adopted task taskId must match");
-        assertEquals("agent-adopted", e.subAgentId(), "adopted task subAgentId must match");
-        assertEquals("adopted-result", e.result(), "adopted task result must carry the value");
+        BackgroundTask t = repo.getTask(RuntimeContext.empty(), session, taskId);
+        assertEquals(TaskStatus.COMPLETED, t.getTaskStatus());
     }
 
     @Test
-    @DisplayName(
-            "adopted (promised) task delivers FAILED callback with errorMessage via"
-                    + " future.whenComplete")
-    void completionCallback_adoptedFuture_deliversFailedStatus() throws Exception {
-        String session = "sess-cb-adopted-fail";
-        String taskId = "task-cb-adopted-fail";
+    @DisplayName("task completes normally when no callback is set")
+    void fireCompletionCallback_nullCallbackDoesNotThrow() throws Exception {
+        String session = "sess-cb-null";
+        String taskId = "task-cb-null";
 
-        CopyOnWriteArrayList<TaskCompletionEvent> events = new CopyOnWriteArrayList<>();
-        repo.setCompletionCallback(events::add);
-
-        CompletableFuture<String> promised = new CompletableFuture<>();
+        // No callback set
         repo.putTask(
                 RuntimeContext.empty(),
                 taskId,
-                "agent-adopted-fail",
+                "agent-cb-null",
                 session,
-                new TaskRunSpec.AdoptedTaskRunSpec(promised));
+                new TaskRunSpec.LocalTaskRunSpec(() -> "done"));
 
         awaitCondition(
                 () -> {
                     BackgroundTask t = repo.getTask(RuntimeContext.empty(), session, taskId);
-                    return t != null && t.getTaskStatus() == TaskStatus.RUNNING;
+                    return t != null && t.getTaskStatus() == TaskStatus.COMPLETED;
                 });
 
-        promised.completeExceptionally(new RuntimeException("adopted-failure-marker"));
-
-        awaitCondition(() -> events.stream().anyMatch(e -> e.status() == TaskStatus.FAILED));
-
-        TaskCompletionEvent e =
-                events.stream()
-                        .filter(ev -> ev.status() == TaskStatus.FAILED)
-                        .findFirst()
-                        .orElseThrow();
-        assertEquals(TaskStatus.FAILED, e.status(), "adopted failed task status must be FAILED");
-        assertEquals(taskId, e.taskId(), "adopted failed taskId must match");
-        assertNotNull(e.errorMessage(), "adopted failed errorMessage must be non-null");
-        assertTrue(
-                e.errorMessage().contains("adopted-failure-marker"),
-                "adopted failed errorMessage must contain the original cause");
-    }
-
-    // ------------------------------------------------------------------
-    //  End-to-end: callback → MessageBus inbox → HintBlock content
-    // ------------------------------------------------------------------
-
-    @Test
-    @DisplayName(
-            "end-to-end: FAILED task produces HintBlock with 'has FAILED' and error in parent"
-                    + " reasoning context")
-    void endToEnd_failedTask_hintBlockContainsFailedAndError() throws Exception {
-        java.nio.file.Path busDir = tempDir.resolve("bus-e2e-fail");
-        busDir.toFile().mkdirs();
-        var busFs =
-                new io.agentscope.harness.agent.filesystem.local.LocalFilesystem(busDir, true, 10);
-        var bus = new io.agentscope.harness.agent.bus.WorkspaceMessageBus(busFs, "/bus");
-        String session = "sess-e2e-fail";
-
-        repo.setCompletionCallback(
-                event -> {
-                    String userId = event.rc() != null ? event.rc().getUserId() : null;
-                    String hintContent =
-                            switch (event.status()) {
-                                case COMPLETED ->
-                                        String.format(
-                                                "<system-notification>Background subagent task '%s'"
-                                                        + " (agent=%s) has completed.\n\nResult:"
-                                                        + "\n\n%s</system-notification>",
-                                                event.taskId(),
-                                                event.subAgentId(),
-                                                event.result() != null
-                                                        ? event.result()
-                                                        : "(no output)");
-                                case FAILED ->
-                                        String.format(
-                                                "<system-notification>Background subagent task '%s'"
-                                                        + " (agent=%s) has FAILED.\n\nError:"
-                                                        + "\n\n%s</system-notification>",
-                                                event.taskId(),
-                                                event.subAgentId(),
-                                                event.errorMessage() != null
-                                                        ? event.errorMessage()
-                                                        : "(no error message)");
-                                case CANCELLED ->
-                                        String.format(
-                                                "<system-notification>Background subagent task '%s'"
-                                                        + " (agent=%s) was cancelled."
-                                                        + "</system-notification>",
-                                                event.taskId(), event.subAgentId());
-                                default ->
-                                        throw new IllegalStateException(
-                                                "Unexpected: " + event.status());
-                            };
-                    bus.inboxPush(
-                                    event.sessionId(),
-                                    java.util.Map.of(
-                                            "type",
-                                            "hint",
-                                            "id",
-                                            java.util.UUID.randomUUID().toString().replace("-", ""),
-                                            "hint",
-                                            hintContent,
-                                            "source",
-                                            "subagent_task"))
-                            .block();
-                });
-
-        repo.putTask(
-                RuntimeContext.empty(),
-                "e2e-fail-task",
-                "e2e-fail-agent",
-                session,
-                new TaskRunSpec.LocalTaskRunSpec(
-                        () -> {
-                            throw new RuntimeException("e2e-failure-marker");
-                        }));
-
-        awaitCondition(
-                () -> {
-                    BackgroundTask t =
-                            repo.getTask(RuntimeContext.empty(), session, "e2e-fail-task");
-                    return t != null && t.getTaskStatus().isTerminal();
-                });
-
-        // Drain the inbox the same way InboxMiddleware does
-        List<io.agentscope.harness.agent.bus.BusEntry> entries =
-                bus.inboxDrain(session, 10).block();
-        assertNotNull(entries, "inbox must have entries");
-        assertTrue(!entries.isEmpty(), "inbox must not be empty after FAILED task");
-
-        Map<String, Object> payload = entries.get(0).payload();
-        String hint = (String) payload.get("hint");
-        assertNotNull(hint, "deserialized hint must not be null");
-        assertTrue(
-                hint.contains("has FAILED"),
-                "HintBlock must say 'has FAILED' for a failed task, got: " + hint);
-        assertTrue(
-                hint.contains("e2e-failure-marker"),
-                "HintBlock must contain the authoritative error message, got: " + hint);
-        assertTrue(
-                hint.contains("e2e-fail-task"), "HintBlock must contain the taskId, got: " + hint);
-        assertTrue(
-                hint.contains("e2e-fail-agent"),
-                "HintBlock must contain the subAgentId, got: " + hint);
-    }
-
-    @Test
-    @DisplayName(
-            "end-to-end: CANCELLED task produces HintBlock with 'was cancelled' in parent"
-                    + " reasoning context")
-    void endToEnd_cancelledTask_hintBlockContainsCancelled() throws Exception {
-        java.nio.file.Path busDir = tempDir.resolve("bus-e2e-cancel");
-        busDir.toFile().mkdirs();
-        var busFs =
-                new io.agentscope.harness.agent.filesystem.local.LocalFilesystem(busDir, true, 10);
-        var bus = new io.agentscope.harness.agent.bus.WorkspaceMessageBus(busFs, "/bus");
-        String session = "sess-e2e-cancel";
-
-        repo.setCompletionCallback(
-                event -> {
-                    String hintContent =
-                            switch (event.status()) {
-                                case COMPLETED -> "completed";
-                                case FAILED -> "failed";
-                                case CANCELLED ->
-                                        String.format(
-                                                "<system-notification>Background subagent task '%s'"
-                                                        + " (agent=%s) was cancelled."
-                                                        + "</system-notification>",
-                                                event.taskId(), event.subAgentId());
-                                default -> "unknown";
-                            };
-                    bus.inboxPush(
-                                    event.sessionId(),
-                                    java.util.Map.of(
-                                            "type",
-                                            "hint",
-                                            "id",
-                                            java.util.UUID.randomUUID().toString().replace("-", ""),
-                                            "hint",
-                                            hintContent,
-                                            "source",
-                                            "subagent_task"))
-                            .block();
-                });
-
-        CountDownLatch taskRunning = new CountDownLatch(1);
-        CountDownLatch release = new CountDownLatch(1);
-        repo.putTask(
-                RuntimeContext.empty(),
-                "e2e-cancel-task",
-                "e2e-cancel-agent",
-                session,
-                new TaskRunSpec.LocalTaskRunSpec(
-                        () -> {
-                            taskRunning.countDown();
-                            try {
-                                release.await(5, java.util.concurrent.TimeUnit.SECONDS);
-                            } catch (InterruptedException ex) {
-                                Thread.currentThread().interrupt();
-                            }
-                            return "should-not-appear";
-                        }));
-
-        taskRunning.await(5, java.util.concurrent.TimeUnit.SECONDS);
-        awaitCondition(
-                () -> {
-                    Optional<TaskRecord> r =
-                            workspaceManager.readTaskRecord(
-                                    RuntimeContext.empty(),
-                                    "test-agent",
-                                    session,
-                                    "e2e-cancel-task");
-                    return r.isPresent() && r.get().getStatus() == TaskStatus.RUNNING;
-                });
-
-        repo.cancelTask(RuntimeContext.empty(), session, "e2e-cancel-task");
-        release.countDown();
-
-        awaitCondition(
-                () -> {
-                    Optional<TaskRecord> r =
-                            workspaceManager.readTaskRecord(
-                                    RuntimeContext.empty(),
-                                    "test-agent",
-                                    session,
-                                    "e2e-cancel-task");
-                    return r.isPresent() && r.get().getStatus() == TaskStatus.CANCELLED;
-                });
-
-        Thread.sleep(200);
-        List<io.agentscope.harness.agent.bus.BusEntry> entries =
-                bus.inboxDrain(session, 10).block();
-        assertNotNull(entries, "inbox must have entries after CANCELLED");
-        assertTrue(!entries.isEmpty(), "inbox must not be empty after CANCELLED task");
-
-        Map<String, Object> payload = entries.get(0).payload();
-        String hint = (String) payload.get("hint");
-        assertNotNull(hint, "deserialized hint must not be null");
-        assertTrue(
-                hint.contains("was cancelled"),
-                "HintBlock must say 'was cancelled' for a cancelled task, got: " + hint);
-        assertTrue(
-                hint.contains("e2e-cancel-task"),
-                "HintBlock must contain the taskId, got: " + hint);
-        assertTrue(
-                hint.contains("e2e-cancel-agent"),
-                "HintBlock must contain the subAgentId, got: " + hint);
-    }
-
-    @Test
-    @DisplayName(
-            "end-to-end: COMPLETED task produces HintBlock with 'has completed' and result in"
-                    + " parent reasoning context")
-    void endToEnd_completedTask_hintBlockContainsCompletedAndResult() throws Exception {
-        java.nio.file.Path busDir = tempDir.resolve("bus-e2e-ok");
-        busDir.toFile().mkdirs();
-        var busFs =
-                new io.agentscope.harness.agent.filesystem.local.LocalFilesystem(busDir, true, 10);
-        var bus = new io.agentscope.harness.agent.bus.WorkspaceMessageBus(busFs, "/bus");
-        String session = "sess-e2e-ok";
-
-        repo.setCompletionCallback(
-                event -> {
-                    String hintContent =
-                            switch (event.status()) {
-                                case COMPLETED ->
-                                        String.format(
-                                                "<system-notification>Background subagent task '%s'"
-                                                        + " (agent=%s) has completed.\n\nResult:"
-                                                        + "\n\n%s</system-notification>",
-                                                event.taskId(),
-                                                event.subAgentId(),
-                                                event.result() != null
-                                                        ? event.result()
-                                                        : "(no output)");
-                                case FAILED -> "failed";
-                                case CANCELLED -> "cancelled";
-                                default -> "unknown";
-                            };
-                    bus.inboxPush(
-                                    event.sessionId(),
-                                    java.util.Map.of(
-                                            "type",
-                                            "hint",
-                                            "id",
-                                            java.util.UUID.randomUUID().toString().replace("-", ""),
-                                            "hint",
-                                            hintContent,
-                                            "source",
-                                            "subagent_task"))
-                            .block();
-                });
-
-        repo.putTask(
-                RuntimeContext.empty(),
-                "e2e-ok-task",
-                "e2e-ok-agent",
-                session,
-                new TaskRunSpec.LocalTaskRunSpec(() -> "e2e-success-payload"));
-
-        awaitCondition(
-                () -> {
-                    BackgroundTask t = repo.getTask(RuntimeContext.empty(), session, "e2e-ok-task");
-                    return t != null && t.getTaskStatus().isTerminal();
-                });
-
-        List<io.agentscope.harness.agent.bus.BusEntry> entries =
-                bus.inboxDrain(session, 10).block();
-        assertNotNull(entries, "inbox must have entries after COMPLETED");
-        assertTrue(!entries.isEmpty(), "inbox must not be empty after COMPLETED task");
-
-        Map<String, Object> payload = entries.get(0).payload();
-        String hint = (String) payload.get("hint");
-        assertNotNull(hint, "deserialized hint must not be null");
-        assertTrue(
-                hint.contains("has completed"),
-                "HintBlock must say 'has completed' for a successful task, got: " + hint);
-        assertTrue(
-                hint.contains("e2e-success-payload"),
-                "HintBlock must contain the result payload, got: " + hint);
-        assertTrue(hint.contains("e2e-ok-task"), "HintBlock must contain the taskId, got: " + hint);
-        assertTrue(
-                hint.contains("e2e-ok-agent"),
-                "HintBlock must contain the subAgentId, got: " + hint);
+        BackgroundTask t = repo.getTask(RuntimeContext.empty(), session, taskId);
+        assertEquals(TaskStatus.COMPLETED, t.getTaskStatus());
     }
 
     // ------------------------------------------------------------------

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/subagent/task/WorkspaceTaskRepositoryTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/subagent/task/WorkspaceTaskRepositoryTest.java
@@ -33,6 +33,8 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.junit.jupiter.api.AfterEach;
@@ -814,6 +816,512 @@ class WorkspaceTaskRepositoryTest {
         assertTrue(
                 result.stream().noneMatch(r -> "task-old".equals(r.getTaskId())),
                 "Old task file should be skipped by recentWindow filter");
+    }
+
+    // ------------------------------------------------------------------
+    //  Completion callback: terminal status and error propagation
+    // ------------------------------------------------------------------
+
+    @Test
+    @DisplayName("callback carries COMPLETED status, taskId, subAgentId, sessionId, and result")
+    void completionCallback_completedStatusAndResult() throws Exception {
+        String session = "sess-cb-ok";
+        String taskId = "task-cb-ok";
+
+        CopyOnWriteArrayList<TaskCompletionEvent> events = new CopyOnWriteArrayList<>();
+        repo.setCompletionCallback(events::add);
+
+        repo.putTask(
+                RuntimeContext.empty(),
+                taskId,
+                "agent-cb-ok",
+                session,
+                new TaskRunSpec.LocalTaskRunSpec(() -> "success-result"));
+
+        awaitCondition(
+                () -> {
+                    BackgroundTask t = repo.getTask(RuntimeContext.empty(), session, taskId);
+                    return t != null && t.getTaskStatus().isTerminal();
+                });
+
+        assertEquals(1, events.size());
+        TaskCompletionEvent e = events.get(0);
+        assertEquals(TaskStatus.COMPLETED, e.status(), "status must be COMPLETED");
+        assertEquals(taskId, e.taskId(), "taskId must match");
+        assertEquals("agent-cb-ok", e.subAgentId(), "subAgentId must match");
+        assertEquals(session, e.sessionId(), "sessionId must match");
+        assertEquals("success-result", e.result(), "result must carry success payload");
+        assertNull(e.errorMessage(), "errorMessage must be null for COMPLETED");
+    }
+
+    @Test
+    @DisplayName(
+            "callback carries FAILED status, taskId, subAgentId, sessionId, and authoritative"
+                    + " errorMessage")
+    void completionCallback_failedStatusAndErrorMessage() throws Exception {
+        String session = "sess-cb-fail";
+        String taskId = "task-cb-fail";
+
+        CopyOnWriteArrayList<TaskCompletionEvent> events = new CopyOnWriteArrayList<>();
+        repo.setCompletionCallback(events::add);
+
+        repo.putTask(
+                RuntimeContext.empty(),
+                taskId,
+                "agent-cb-fail",
+                session,
+                new TaskRunSpec.LocalTaskRunSpec(
+                        () -> {
+                            throw new RuntimeException("intentional-failure-marker");
+                        }));
+
+        awaitCondition(
+                () -> {
+                    BackgroundTask t = repo.getTask(RuntimeContext.empty(), session, taskId);
+                    return t != null && t.getTaskStatus().isTerminal();
+                });
+
+        assertEquals(1, events.size());
+        TaskCompletionEvent e = events.get(0);
+        assertEquals(TaskStatus.FAILED, e.status(), "status must be FAILED");
+        assertEquals(taskId, e.taskId(), "taskId must match");
+        assertEquals("agent-cb-fail", e.subAgentId(), "subAgentId must match");
+        assertEquals(session, e.sessionId(), "sessionId must match");
+        assertNull(e.result(), "result must be null for FAILED");
+        assertNotNull(e.errorMessage(), "errorMessage must carry the authoritative error");
+        assertTrue(
+                e.errorMessage().contains("intentional-failure-marker"),
+                "errorMessage must contain the original exception message");
+    }
+
+    @Test
+    @DisplayName("callback carries CANCELLED status, taskId, subAgentId, sessionId when cancelled")
+    void completionCallback_cancelledStatus() throws Exception {
+        String session = "sess-cb-cancel";
+        String taskId = "task-cb-cancel";
+
+        CopyOnWriteArrayList<TaskCompletionEvent> events = new CopyOnWriteArrayList<>();
+        repo.setCompletionCallback(events::add);
+
+        CountDownLatch taskRunning = new CountDownLatch(1);
+        CountDownLatch release = new CountDownLatch(1);
+        repo.putTask(
+                RuntimeContext.empty(),
+                taskId,
+                "agent-cb-cancel",
+                session,
+                new TaskRunSpec.LocalTaskRunSpec(
+                        () -> {
+                            taskRunning.countDown();
+                            try {
+                                release.await(5, java.util.concurrent.TimeUnit.SECONDS);
+                            } catch (InterruptedException e) {
+                                Thread.currentThread().interrupt();
+                            }
+                            return "should-not-appear";
+                        }));
+
+        taskRunning.await(5, java.util.concurrent.TimeUnit.SECONDS);
+        awaitCondition(
+                () -> {
+                    Optional<TaskRecord> r =
+                            workspaceManager.readTaskRecord(
+                                    RuntimeContext.empty(), "test-agent", session, taskId);
+                    return r.isPresent() && r.get().getStatus() == TaskStatus.RUNNING;
+                });
+
+        repo.cancelTask(RuntimeContext.empty(), session, taskId);
+
+        awaitCondition(
+                () -> {
+                    Optional<TaskRecord> r =
+                            workspaceManager.readTaskRecord(
+                                    RuntimeContext.empty(), "test-agent", session, taskId);
+                    return r.isPresent() && r.get().getStatus() == TaskStatus.CANCELLED;
+                });
+
+        release.countDown();
+        Thread.sleep(200);
+
+        TaskCompletionEvent cancelEvent =
+                events.stream()
+                        .filter(e -> e.status() == TaskStatus.CANCELLED)
+                        .findFirst()
+                        .orElse(null);
+        assertNotNull(cancelEvent, "Callback must receive a CANCELLED event");
+        assertEquals(TaskStatus.CANCELLED, cancelEvent.status(), "status must be CANCELLED");
+        assertEquals(taskId, cancelEvent.taskId(), "taskId must match");
+        assertEquals("agent-cb-cancel", cancelEvent.subAgentId(), "subAgentId must match");
+        assertEquals(session, cancelEvent.sessionId(), "sessionId must match");
+        assertNull(cancelEvent.result(), "result must be null for CANCELLED");
+        assertNull(cancelEvent.errorMessage(), "errorMessage must be null for CANCELLED");
+    }
+
+    @Test
+    @DisplayName(
+            "adopted (promised) task delivers COMPLETED callback with result via"
+                    + " future.whenComplete")
+    void completionCallback_adoptedFuture_deliversCompletedStatus() throws Exception {
+        String session = "sess-cb-adopted";
+        String taskId = "task-cb-adopted";
+
+        CopyOnWriteArrayList<TaskCompletionEvent> events = new CopyOnWriteArrayList<>();
+        repo.setCompletionCallback(events::add);
+
+        CompletableFuture<String> promised = new CompletableFuture<>();
+        repo.putTask(
+                RuntimeContext.empty(),
+                taskId,
+                "agent-adopted",
+                session,
+                new TaskRunSpec.AdoptedTaskRunSpec(promised));
+
+        awaitCondition(
+                () -> {
+                    BackgroundTask t = repo.getTask(RuntimeContext.empty(), session, taskId);
+                    return t != null && t.getTaskStatus() == TaskStatus.RUNNING;
+                });
+
+        promised.complete("adopted-result");
+
+        awaitCondition(() -> events.stream().anyMatch(e -> e.status() == TaskStatus.COMPLETED));
+
+        TaskCompletionEvent e =
+                events.stream()
+                        .filter(ev -> ev.status() == TaskStatus.COMPLETED)
+                        .findFirst()
+                        .orElseThrow();
+        assertEquals(TaskStatus.COMPLETED, e.status(), "adopted task status must be COMPLETED");
+        assertEquals(taskId, e.taskId(), "adopted task taskId must match");
+        assertEquals("agent-adopted", e.subAgentId(), "adopted task subAgentId must match");
+        assertEquals("adopted-result", e.result(), "adopted task result must carry the value");
+    }
+
+    @Test
+    @DisplayName(
+            "adopted (promised) task delivers FAILED callback with errorMessage via"
+                    + " future.whenComplete")
+    void completionCallback_adoptedFuture_deliversFailedStatus() throws Exception {
+        String session = "sess-cb-adopted-fail";
+        String taskId = "task-cb-adopted-fail";
+
+        CopyOnWriteArrayList<TaskCompletionEvent> events = new CopyOnWriteArrayList<>();
+        repo.setCompletionCallback(events::add);
+
+        CompletableFuture<String> promised = new CompletableFuture<>();
+        repo.putTask(
+                RuntimeContext.empty(),
+                taskId,
+                "agent-adopted-fail",
+                session,
+                new TaskRunSpec.AdoptedTaskRunSpec(promised));
+
+        awaitCondition(
+                () -> {
+                    BackgroundTask t = repo.getTask(RuntimeContext.empty(), session, taskId);
+                    return t != null && t.getTaskStatus() == TaskStatus.RUNNING;
+                });
+
+        promised.completeExceptionally(new RuntimeException("adopted-failure-marker"));
+
+        awaitCondition(() -> events.stream().anyMatch(e -> e.status() == TaskStatus.FAILED));
+
+        TaskCompletionEvent e =
+                events.stream()
+                        .filter(ev -> ev.status() == TaskStatus.FAILED)
+                        .findFirst()
+                        .orElseThrow();
+        assertEquals(TaskStatus.FAILED, e.status(), "adopted failed task status must be FAILED");
+        assertEquals(taskId, e.taskId(), "adopted failed taskId must match");
+        assertNotNull(e.errorMessage(), "adopted failed errorMessage must be non-null");
+        assertTrue(
+                e.errorMessage().contains("adopted-failure-marker"),
+                "adopted failed errorMessage must contain the original cause");
+    }
+
+    // ------------------------------------------------------------------
+    //  End-to-end: callback → MessageBus inbox → HintBlock content
+    // ------------------------------------------------------------------
+
+    @Test
+    @DisplayName(
+            "end-to-end: FAILED task produces HintBlock with 'has FAILED' and error in parent"
+                    + " reasoning context")
+    void endToEnd_failedTask_hintBlockContainsFailedAndError() throws Exception {
+        java.nio.file.Path busDir = tempDir.resolve("bus-e2e-fail");
+        busDir.toFile().mkdirs();
+        var busFs =
+                new io.agentscope.harness.agent.filesystem.local.LocalFilesystem(busDir, true, 10);
+        var bus = new io.agentscope.harness.agent.bus.WorkspaceMessageBus(busFs, "/bus");
+        String session = "sess-e2e-fail";
+
+        repo.setCompletionCallback(
+                event -> {
+                    String userId = event.rc() != null ? event.rc().getUserId() : null;
+                    String hintContent =
+                            switch (event.status()) {
+                                case COMPLETED ->
+                                        String.format(
+                                                "<system-notification>Background subagent task '%s'"
+                                                        + " (agent=%s) has completed.\n\nResult:"
+                                                        + "\n\n%s</system-notification>",
+                                                event.taskId(),
+                                                event.subAgentId(),
+                                                event.result() != null
+                                                        ? event.result()
+                                                        : "(no output)");
+                                case FAILED ->
+                                        String.format(
+                                                "<system-notification>Background subagent task '%s'"
+                                                        + " (agent=%s) has FAILED.\n\nError:"
+                                                        + "\n\n%s</system-notification>",
+                                                event.taskId(),
+                                                event.subAgentId(),
+                                                event.errorMessage() != null
+                                                        ? event.errorMessage()
+                                                        : "(no error message)");
+                                case CANCELLED ->
+                                        String.format(
+                                                "<system-notification>Background subagent task '%s'"
+                                                        + " (agent=%s) was cancelled."
+                                                        + "</system-notification>",
+                                                event.taskId(), event.subAgentId());
+                                default ->
+                                        throw new IllegalStateException(
+                                                "Unexpected: " + event.status());
+                            };
+                    bus.inboxPush(
+                                    event.sessionId(),
+                                    java.util.Map.of(
+                                            "type",
+                                            "hint",
+                                            "id",
+                                            java.util.UUID.randomUUID().toString().replace("-", ""),
+                                            "hint",
+                                            hintContent,
+                                            "source",
+                                            "subagent_task"))
+                            .block();
+                });
+
+        repo.putTask(
+                RuntimeContext.empty(),
+                "e2e-fail-task",
+                "e2e-fail-agent",
+                session,
+                new TaskRunSpec.LocalTaskRunSpec(
+                        () -> {
+                            throw new RuntimeException("e2e-failure-marker");
+                        }));
+
+        awaitCondition(
+                () -> {
+                    BackgroundTask t =
+                            repo.getTask(RuntimeContext.empty(), session, "e2e-fail-task");
+                    return t != null && t.getTaskStatus().isTerminal();
+                });
+
+        // Drain the inbox the same way InboxMiddleware does
+        List<io.agentscope.harness.agent.bus.BusEntry> entries =
+                bus.inboxDrain(session, 10).block();
+        assertNotNull(entries, "inbox must have entries");
+        assertTrue(!entries.isEmpty(), "inbox must not be empty after FAILED task");
+
+        Map<String, Object> payload = entries.get(0).payload();
+        String hint = (String) payload.get("hint");
+        assertNotNull(hint, "deserialized hint must not be null");
+        assertTrue(
+                hint.contains("has FAILED"),
+                "HintBlock must say 'has FAILED' for a failed task, got: " + hint);
+        assertTrue(
+                hint.contains("e2e-failure-marker"),
+                "HintBlock must contain the authoritative error message, got: " + hint);
+        assertTrue(
+                hint.contains("e2e-fail-task"), "HintBlock must contain the taskId, got: " + hint);
+        assertTrue(
+                hint.contains("e2e-fail-agent"),
+                "HintBlock must contain the subAgentId, got: " + hint);
+    }
+
+    @Test
+    @DisplayName(
+            "end-to-end: CANCELLED task produces HintBlock with 'was cancelled' in parent"
+                    + " reasoning context")
+    void endToEnd_cancelledTask_hintBlockContainsCancelled() throws Exception {
+        java.nio.file.Path busDir = tempDir.resolve("bus-e2e-cancel");
+        busDir.toFile().mkdirs();
+        var busFs =
+                new io.agentscope.harness.agent.filesystem.local.LocalFilesystem(busDir, true, 10);
+        var bus = new io.agentscope.harness.agent.bus.WorkspaceMessageBus(busFs, "/bus");
+        String session = "sess-e2e-cancel";
+
+        repo.setCompletionCallback(
+                event -> {
+                    String hintContent =
+                            switch (event.status()) {
+                                case COMPLETED -> "completed";
+                                case FAILED -> "failed";
+                                case CANCELLED ->
+                                        String.format(
+                                                "<system-notification>Background subagent task '%s'"
+                                                        + " (agent=%s) was cancelled."
+                                                        + "</system-notification>",
+                                                event.taskId(), event.subAgentId());
+                                default -> "unknown";
+                            };
+                    bus.inboxPush(
+                                    event.sessionId(),
+                                    java.util.Map.of(
+                                            "type",
+                                            "hint",
+                                            "id",
+                                            java.util.UUID.randomUUID().toString().replace("-", ""),
+                                            "hint",
+                                            hintContent,
+                                            "source",
+                                            "subagent_task"))
+                            .block();
+                });
+
+        CountDownLatch taskRunning = new CountDownLatch(1);
+        CountDownLatch release = new CountDownLatch(1);
+        repo.putTask(
+                RuntimeContext.empty(),
+                "e2e-cancel-task",
+                "e2e-cancel-agent",
+                session,
+                new TaskRunSpec.LocalTaskRunSpec(
+                        () -> {
+                            taskRunning.countDown();
+                            try {
+                                release.await(5, java.util.concurrent.TimeUnit.SECONDS);
+                            } catch (InterruptedException ex) {
+                                Thread.currentThread().interrupt();
+                            }
+                            return "should-not-appear";
+                        }));
+
+        taskRunning.await(5, java.util.concurrent.TimeUnit.SECONDS);
+        awaitCondition(
+                () -> {
+                    Optional<TaskRecord> r =
+                            workspaceManager.readTaskRecord(
+                                    RuntimeContext.empty(),
+                                    "test-agent",
+                                    session,
+                                    "e2e-cancel-task");
+                    return r.isPresent() && r.get().getStatus() == TaskStatus.RUNNING;
+                });
+
+        repo.cancelTask(RuntimeContext.empty(), session, "e2e-cancel-task");
+        release.countDown();
+
+        awaitCondition(
+                () -> {
+                    Optional<TaskRecord> r =
+                            workspaceManager.readTaskRecord(
+                                    RuntimeContext.empty(),
+                                    "test-agent",
+                                    session,
+                                    "e2e-cancel-task");
+                    return r.isPresent() && r.get().getStatus() == TaskStatus.CANCELLED;
+                });
+
+        Thread.sleep(200);
+        List<io.agentscope.harness.agent.bus.BusEntry> entries =
+                bus.inboxDrain(session, 10).block();
+        assertNotNull(entries, "inbox must have entries after CANCELLED");
+        assertTrue(!entries.isEmpty(), "inbox must not be empty after CANCELLED task");
+
+        Map<String, Object> payload = entries.get(0).payload();
+        String hint = (String) payload.get("hint");
+        assertNotNull(hint, "deserialized hint must not be null");
+        assertTrue(
+                hint.contains("was cancelled"),
+                "HintBlock must say 'was cancelled' for a cancelled task, got: " + hint);
+        assertTrue(
+                hint.contains("e2e-cancel-task"),
+                "HintBlock must contain the taskId, got: " + hint);
+        assertTrue(
+                hint.contains("e2e-cancel-agent"),
+                "HintBlock must contain the subAgentId, got: " + hint);
+    }
+
+    @Test
+    @DisplayName(
+            "end-to-end: COMPLETED task produces HintBlock with 'has completed' and result in"
+                    + " parent reasoning context")
+    void endToEnd_completedTask_hintBlockContainsCompletedAndResult() throws Exception {
+        java.nio.file.Path busDir = tempDir.resolve("bus-e2e-ok");
+        busDir.toFile().mkdirs();
+        var busFs =
+                new io.agentscope.harness.agent.filesystem.local.LocalFilesystem(busDir, true, 10);
+        var bus = new io.agentscope.harness.agent.bus.WorkspaceMessageBus(busFs, "/bus");
+        String session = "sess-e2e-ok";
+
+        repo.setCompletionCallback(
+                event -> {
+                    String hintContent =
+                            switch (event.status()) {
+                                case COMPLETED ->
+                                        String.format(
+                                                "<system-notification>Background subagent task '%s'"
+                                                        + " (agent=%s) has completed.\n\nResult:"
+                                                        + "\n\n%s</system-notification>",
+                                                event.taskId(),
+                                                event.subAgentId(),
+                                                event.result() != null
+                                                        ? event.result()
+                                                        : "(no output)");
+                                case FAILED -> "failed";
+                                case CANCELLED -> "cancelled";
+                                default -> "unknown";
+                            };
+                    bus.inboxPush(
+                                    event.sessionId(),
+                                    java.util.Map.of(
+                                            "type",
+                                            "hint",
+                                            "id",
+                                            java.util.UUID.randomUUID().toString().replace("-", ""),
+                                            "hint",
+                                            hintContent,
+                                            "source",
+                                            "subagent_task"))
+                            .block();
+                });
+
+        repo.putTask(
+                RuntimeContext.empty(),
+                "e2e-ok-task",
+                "e2e-ok-agent",
+                session,
+                new TaskRunSpec.LocalTaskRunSpec(() -> "e2e-success-payload"));
+
+        awaitCondition(
+                () -> {
+                    BackgroundTask t = repo.getTask(RuntimeContext.empty(), session, "e2e-ok-task");
+                    return t != null && t.getTaskStatus().isTerminal();
+                });
+
+        List<io.agentscope.harness.agent.bus.BusEntry> entries =
+                bus.inboxDrain(session, 10).block();
+        assertNotNull(entries, "inbox must have entries after COMPLETED");
+        assertTrue(!entries.isEmpty(), "inbox must not be empty after COMPLETED task");
+
+        Map<String, Object> payload = entries.get(0).payload();
+        String hint = (String) payload.get("hint");
+        assertNotNull(hint, "deserialized hint must not be null");
+        assertTrue(
+                hint.contains("has completed"),
+                "HintBlock must say 'has completed' for a successful task, got: " + hint);
+        assertTrue(
+                hint.contains("e2e-success-payload"),
+                "HintBlock must contain the result payload, got: " + hint);
+        assertTrue(hint.contains("e2e-ok-task"), "HintBlock must contain the taskId, got: " + hint);
+        assertTrue(
+                hint.contains("e2e-ok-agent"),
+                "HintBlock must contain the subAgentId, got: " + hint);
     }
 
     // ------------------------------------------------------------------


### PR DESCRIPTION
## 关联 issue
- Fixes #2159

## AgentScope-Java Version

2.0.1-SNAPSHOT

## Description

### Background
`TaskCompletionCallback` 原本是一个包含多个裸参数（`rc, taskId, subAgentId, sessionId, result`）的函数式接口，无法携带任务的终态状态（COMPLETED / FAILED / CANCELLED）和失败原因，消费者需要重新读取持久化的 `TaskRecord` 才能区分任务的最终状态。此外，`WorkspaceTaskRepository` 缺少对终态状态的本地追踪和孤儿任务清理机制。

### Root Cause
回调签名中缺少 `TaskStatus` 和 `errorMessage` 字段，导致 `HarnessAgent` 和 `SubagentsMiddleware` 在收到回调时无法可靠地区分任务是正常完成、失败还是被取消，只能依赖 `result` 是否为 null 进行粗略判断。

### Fix
引入不可变的 `TaskCompletionEvent` record 替代原有的裸参数回调签名，新增 `status` 和 `errorMessage` 字段，使消费者无需重新读取 `TaskRecord` 即可获取任务的权威终态信息。同步更新 `WorkspaceTaskRepository` 增加终态状态的本地追踪、心跳过终态任务、以及孤儿扫描中标记过期运行任务为 FAILED 的能力。

### **Changed files:**

#### 1. `TaskCompletionEvent.java`（新增）
新增不可变 record，封装 `rc, taskId, subAgentId, sessionId, status, result, errorMessage`，替代原来 `TaskCompletionCallback` 的裸参数列表。

#### 2. `SubagentsMiddleware.java`
将回调签名从 `(rc, taskId, subAgentId, sessionId, result)` 更新为 `(event) -> { ... }`，通过 `event.status()` 区分终态类型，构造不同的 `HintItem` 内容。

#### 3. `HarnessAgent.java`
将 `setCompletionCallback` 的回调从裸参数改为接收 `TaskCompletionEvent`，使用 `switch (event.status())` 为 COMPLETED / FAILED / CANCELLED 三种终态分别构造不同的通知消息格式。

#### 4. `WorkspaceTaskRepository.java`
- `TaskCompletionCallback` 接口签名更新为接收 `TaskCompletionEvent`；
- 新增 `localTaskStatuses` map 追踪本地任务的终态状态；
- 心跳任务跳过已处于终态的任务；
- 孤儿扫描中标记超时的 RUNNING 任务为 FAILED 并触发回调；
- 所有回调触发点统一构造 `TaskCompletionEvent`。

#### 5. `WorkspaceTaskRepositoryTest.java`（新增，约 508 行）
覆盖 `putTask`、`getTask`、`listTasks`、`cancelTask`、`heartbeat`、`sweepOrphanedTasks` 等场景的单元测试，包括会话隔离、终态不被覆盖、跨节点过滤、孤儿标记等边界条件。

## Checklist

- [x] Code has been formatted with `mvn spotless:apply`
- [x] All tests are passing (`mvn test`)
- [x] Javadoc comments are complete and follow project conventions
- [ ] Related documentation has been updated (e.g. links, examples, etc.)
- [x] Code is ready for review