### PR TITLE
docs: generate version-scoped llms.txt artifacts

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -48,13 +48,13 @@ sphinx:
     - sphinx.ext.napoleon
     - sphinx.ext.intersphinx
     - sphinx.ext.autosummary
-    - sphinx_llms_txt
     - sphinx_sitemap
     - sphinx_design
     - sphinxcontrib.mermaid
   # Patches root index.html redirect stub so docs_site_notice appears on "/".
   local_extensions:
     root_index_notice: ./_sphinx_extensions
+    versioned_llms: ./_sphinx_extensions
   config:
     # Mermaid Configuration (CDN client-side rendering, no Node.js required)
     mermaid_version: "11"
@@ -76,10 +76,6 @@ sphinx:
     html_baseurl: "https://java.agentscope.io/"
     sitemap_url_scheme: "{link}"
     sitemap_show_lastmod: true
-
-    # LLMs.txt Configuration (English only)
-    llms_txt_exclude:
-      - "v1/zh/*"
 
     # API Documentation Configuration
     autosummary_generate: True

--- a/docs/_sphinx_extensions/versioned_llms.py
+++ b/docs/_sphinx_extensions/versioned_llms.py
@@ -1,0 +1,247 @@
+# Copyright 2024-2026 the original author or authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Generate version-scoped llms.txt files for AgentScope Java."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from urllib.parse import urljoin
+
+
+VERSIONS = ("v1", "v2")
+LANGUAGE = "en"
+EXCLUDED_SEGMENTS = ("/blogs/", "/community/")
+
+
+def _normalize_docname(value: str) -> str:
+    docname = value.replace("\\", "/").strip()
+    if docname.endswith(".md"):
+        docname = docname[:-3]
+    return docname.strip("/")
+
+
+def _unquote_yaml_scalar(value: str) -> str:
+    value = value.strip()
+    if len(value) >= 2 and value[0] == value[-1] and value[0] in ("'", '"'):
+        return value[1:-1]
+    return value
+
+
+def _load_ordered_docs(srcdir: Path, version: str) -> list[tuple[str, str]]:
+    toc_path = srcdir / "_toc.yml"
+    prefix = f"{version}/{LANGUAGE}/"
+    docs: list[tuple[str, str]] = []
+    seen: set[str] = set()
+    active_index: int | None = None
+
+    for line in toc_path.read_text(encoding="utf-8").splitlines():
+        file_match = re.match(r"^\s*-\s*file:\s*(.+?)\s*$", line)
+        if file_match:
+            docname = _normalize_docname(_unquote_yaml_scalar(file_match.group(1)))
+            should_keep = (
+                docname.startswith(prefix)
+                and not any(segment in f"/{docname}/" for segment in EXCLUDED_SEGMENTS)
+                and docname not in seen
+            )
+            if should_keep:
+                seen.add(docname)
+                docs.append((docname, ""))
+                active_index = len(docs) - 1
+            else:
+                active_index = None
+            continue
+
+        title_match = re.match(r"^\s*title:\s*(.+?)\s*$", line)
+        if title_match and active_index is not None and not docs[active_index][1]:
+            docname, _old_title = docs[active_index]
+            docs[active_index] = (docname, _unquote_yaml_scalar(title_match.group(1)))
+
+    docnames = {docname for docname, _ in docs}
+    filtered: list[tuple[str, str]] = []
+    for docname, toc_title in docs:
+        parent = docname.rsplit("/", 1)[0] if "/" in docname else ""
+        sibling_overview = f"{parent}/overview"
+        is_duplicate_index = (
+            docname.endswith("/index")
+            and docname != f"{version}/{LANGUAGE}/docs/index"
+            and sibling_overview in docnames
+        )
+        if not is_duplicate_index:
+            filtered.append((docname, toc_title))
+    return filtered
+
+
+def _source_path(srcdir: Path, docname: str) -> Path:
+    return srcdir / f"{docname}.md"
+
+
+def _extract_frontmatter(text: str) -> tuple[dict[str, str], str]:
+    if not text.startswith("---\n"):
+        return {}, text
+    end = text.find("\n---", 4)
+    if end == -1:
+        return {}, text
+    raw = text[4:end].strip()
+    body = text[end + len("\n---") :].lstrip()
+    metadata: dict[str, str] = {}
+    for line in raw.splitlines():
+        match = re.match(r"^\s*([A-Za-z0-9_-]+):\s*(.*?)\s*$", line)
+        if not match:
+            continue
+        metadata[match.group(1)] = _unquote_yaml_scalar(match.group(2))
+    return metadata, body
+
+
+def _first_markdown_heading(text: str) -> str:
+    match = re.search(r"^#\s+(.+?)\s*$", text, flags=re.MULTILINE)
+    if not match:
+        return ""
+    return re.sub(r"\s+#*$", "", match.group(1)).strip()
+
+
+def _page_metadata(srcdir: Path, docname: str, toc_title: str) -> tuple[str, str]:
+    source = _source_path(srcdir, docname)
+    if not source.is_file():
+        return toc_title or docname.rsplit("/", 1)[-1], ""
+    raw = source.read_text(encoding="utf-8")
+    frontmatter, body = _extract_frontmatter(raw)
+    title = frontmatter.get("title") or _first_markdown_heading(body) or toc_title
+    description = frontmatter.get("description", "")
+    return title.strip() or docname.rsplit("/", 1)[-1], description.strip()
+
+
+def _strip_raw_html_blocks(text: str) -> str:
+    def replace(match: re.Match[str]) -> str:
+        html = match.group(1)
+        html = re.sub(r"<script\b.*?</script>", "", html, flags=re.IGNORECASE | re.DOTALL)
+        html = re.sub(r"<style\b.*?</style>", "", html, flags=re.IGNORECASE | re.DOTALL)
+        html = re.sub(r"<[^>]+>", " ", html)
+        return re.sub(r"\s+", " ", html).strip()
+
+    return re.sub(r"```\{raw\}\s+html\s*\n(.*?)\n```", replace, text, flags=re.DOTALL)
+
+
+def _clean_body(title: str, body: str) -> str:
+    body = _strip_raw_html_blocks(body).strip()
+    if not body:
+        return f"# {title}\n"
+    if re.search(r"^#\s+", body, flags=re.MULTILINE):
+        return body + "\n"
+    return f"# {title}\n\n{body}\n"
+
+
+def _source_url(base_url: str, docname: str) -> str:
+    return urljoin(base_url, f"_sources/{docname}.md")
+
+
+def _version_intro(version: str) -> str:
+    if version == "v2":
+        return (
+            "AgentScope Java 2.0 documentation for new projects and production "
+            "agent engineering with HarnessAgent."
+        )
+    return (
+        "AgentScope Java 1.x documentation for existing applications and "
+        "compatibility-oriented maintenance."
+    )
+
+
+def _write_llms_index(outdir: Path, base_url: str, version: str, pages: list[tuple[str, str, str]]) -> None:
+    target = outdir / version / "llms.txt"
+    target.parent.mkdir(parents=True, exist_ok=True)
+    lines = [
+        f"# AgentScope Java {version}",
+        "",
+        f"> {_version_intro(version)}",
+        "",
+        "## Docs",
+        "",
+    ]
+    for docname, title, description in pages:
+        suffix = f": {description}" if description else ""
+        lines.append(f"- [{title}]({_source_url(base_url, docname)}){suffix}")
+    target.write_text("\n".join(lines).rstrip() + "\n", encoding="utf-8")
+
+
+def _write_llms_full(
+    srcdir: Path,
+    outdir: Path,
+    base_url: str,
+    version: str,
+    pages: list[tuple[str, str, str]],
+) -> None:
+    target = outdir / version / "llms-full.txt"
+    target.parent.mkdir(parents=True, exist_ok=True)
+    sections = [
+        f"# AgentScope Java {version} Documentation",
+        "",
+        _version_intro(version),
+    ]
+    for docname, title, _description in pages:
+        source = _source_path(srcdir, docname)
+        if not source.is_file():
+            continue
+        raw = source.read_text(encoding="utf-8")
+        _frontmatter, body = _extract_frontmatter(raw)
+        sections.extend(
+            [
+                "",
+                "---",
+                "",
+                f"Source: {_source_url(base_url, docname)}",
+                "",
+                _clean_body(title, body).strip(),
+            ]
+        )
+    target.write_text("\n".join(sections).rstrip() + "\n", encoding="utf-8")
+
+
+def _remove_root_llms(outdir: Path) -> None:
+    for filename in ("llms.txt", "llms-full.txt"):
+        target = outdir / filename
+        if target.exists():
+            target.unlink()
+
+
+def _generate_versioned_llms(app, exception) -> None:
+    if exception is not None:
+        return
+    if app.builder.format != "html":
+        return
+
+    srcdir = Path(app.srcdir)
+    outdir = Path(app.outdir)
+    base_url = str(getattr(app.config, "html_baseurl", "") or "").rstrip("/") + "/"
+
+    for version in VERSIONS:
+        docs = _load_ordered_docs(srcdir, version)
+        pages: list[tuple[str, str, str]] = []
+        for docname, toc_title in docs:
+            title, description = _page_metadata(srcdir, docname, toc_title)
+            pages.append((docname, title, description))
+        _write_llms_index(outdir, base_url, version, pages)
+        _write_llms_full(srcdir, outdir, base_url, version, pages)
+
+    _remove_root_llms(outdir)
+
+
+def setup(app):
+    app.connect("build-finished", _generate_versioned_llms)
+    return {
+        "version": "1.0.0",
+        "parallel_read_safe": True,
+        "parallel_write_safe": True,
+    }

--- a/docs/_static/ai-context-menu.js
+++ b/docs/_static/ai-context-menu.js
@@ -162,7 +162,8 @@
   }
 
   function openLlmsTxt() {
-    window.open(SITE_URL + "/llms.txt", "_blank");
+    var version = window.location.pathname.indexOf("/v1/") !== -1 ? "v1" : "v2";
+    window.open(SITE_URL + "/" + version + "/llms.txt", "_blank");
   }
 
   // ── Dropdown items (shown in the "more" menu) ─────────────────────

--- a/docs/pyproject.toml
+++ b/docs/pyproject.toml
@@ -36,7 +36,6 @@ build-backend = "setuptools.build_meta"
 dev = [
     "jupyter-book>=1.0.4.post1,<2.0.0",
     "sphinx-autoapi>=3.6.0",
-    "sphinx-llms-txt>=0.5.3",
     "sphinx-sitemap>=2.5.0",
     "sphinx-design>=0.6.0",
     "furo>=2025.7.19",

--- a/docs/v1/en/docs/task/ai-coding.md
+++ b/docs/v1/en/docs/task/ai-coding.md
@@ -10,8 +10,10 @@ AgentScope provides the following files:
 
 | File | Best For | URL |
 |------|----------|-----|
-| `llms.txt` | Tools that can fetch links dynamically | `https://java.agentscope.io/llms.txt` |
-| `llms-full.txt` | Tools that need a single, static text dump | `https://java.agentscope.io/llms-full.txt` |
+| `v2/llms.txt` | New projects using AgentScope Java 2.0 | `https://java.agentscope.io/v2/llms.txt` |
+| `v2/llms-full.txt` | Single-file AgentScope Java 2.0 context | `https://java.agentscope.io/v2/llms-full.txt` |
+| `v1/llms.txt` | Existing AgentScope Java 1.x projects | `https://java.agentscope.io/v1/llms.txt` |
+| `v1/llms-full.txt` | Single-file AgentScope Java 1.x context | `https://java.agentscope.io/v1/llms-full.txt` |
 
 ## Development Tools
 
@@ -22,7 +24,7 @@ AgentScope provides the following files:
 **Installation:**
 
 ```bash
-claude mcp add agentscope-docs -- uvx --from mcpdoc mcpdoc --urls AgentScopeJava:https://java.agentscope.io/llms.txt
+claude mcp add agentscope-docs -- uvx --from mcpdoc mcpdoc --urls AgentScopeJava:https://java.agentscope.io/v2/llms.txt
 ```
 
 **Usage:**
@@ -39,7 +41,7 @@ Once installed, you can ask questions about AgentScope directly in Claude Code:
 
 1. Open **Cursor Settings** -> **Features** -> **Docs**
 2. Click **+ Add new Doc**
-3. Add URL: `https://java.agentscope.io/llms-full.txt`
+3. Add URL: `https://java.agentscope.io/v2/llms-full.txt`
 
 **Method 2: MCP Server**
 
@@ -54,7 +56,7 @@ Once installed, you can ask questions about AgentScope directly in Claude Code:
       "command": "uvx",
       "args": [
         "--from", "mcpdoc", "mcpdoc",
-        "--urls", "AgentScopeJava:https://java.agentscope.io/llms.txt"
+        "--urls", "AgentScopeJava:https://java.agentscope.io/v2/llms.txt"
       ]
     }
   }
@@ -84,7 +86,7 @@ Once configured, you can prompt the coding agent:
       "command": "uvx",
       "args": [
         "--from", "mcpdoc", "mcpdoc",
-        "--urls", "AgentScopeJava:https://java.agentscope.io/llms.txt"
+        "--urls", "AgentScopeJava:https://java.agentscope.io/v2/llms.txt"
       ]
     }
   }
@@ -96,7 +98,7 @@ Once configured, you can prompt the coding agent:
 Any tool that supports the `llms.txt` standard or can ingest documentation from a URL can benefit from these files.
 
 **For tools with Docs/Knowledge Base feature:**
-- Add URL: `https://java.agentscope.io/llms-full.txt`
+- Add URL: `https://java.agentscope.io/v2/llms-full.txt`
 
 **For tools with MCP support:**
 - Use the MCP configuration template above with `mcpdoc`
@@ -104,3 +106,8 @@ Any tool that supports the `llms.txt` standard or can ingest documentation from 
 **Prerequisites:**
 
 MCP configurations require [`uv`](https://docs.astral.sh/uv/) to be installed, as they use `uvx` to run the documentation server.
+
+For AgentScope Java 1.x projects, use the v1 URLs instead:
+
+- `https://java.agentscope.io/v1/llms.txt`
+- `https://java.agentscope.io/v1/llms-full.txt`

--- a/docs/v1/zh/docs/task/ai-coding.md
+++ b/docs/v1/zh/docs/task/ai-coding.md
@@ -6,28 +6,30 @@ AgentScope Java 文档支持 [`llms.txt` 标准](https://llmstxt.org/)，让 AI 
 
 `llms.txt` 是一个专为大模型设计的文档索引文件，包含文档结构和关键页面说明，方便 AI 工具快速定位所需内容。
 
-AgentScope 提供两个文件：
+AgentScope Java 现在按版本提供文档入口：
 
 | 文件 | 说明 | URL |
 |------|------|-----|
-| `llms.txt` | 索引文件，包含各页面链接 | `https://java.agentscope.io/llms.txt` |
-| `llms-full.txt` | 完整文档，单文件包含所有内容 | `https://java.agentscope.io/llms-full.txt` |
+| `v2/llms.txt` | AgentScope Java 2.0 文档索引 | `https://java.agentscope.io/v2/llms.txt` |
+| `v2/llms-full.txt` | AgentScope Java 2.0 单文件完整上下文 | `https://java.agentscope.io/v2/llms-full.txt` |
+| `v1/llms.txt` | AgentScope Java 1.x 文档索引 | `https://java.agentscope.io/v1/llms.txt` |
+| `v1/llms-full.txt` | AgentScope Java 1.x 单文件完整上下文 | `https://java.agentscope.io/v1/llms-full.txt` |
 
 ## 配置指南
 
 ### Claude Code
 
-[Claude Code](https://docs.anthropic.com/en/docs/claude-code) 通过 MCP 服务器接入文档。
+[Claude Code](https://docs.anthropic.com/en/docs/claude-code) 可以通过 MCP 服务接入文档。
 
 **安装：**
 
 ```bash
-claude mcp add agentscope-docs -- uvx --from mcpdoc mcpdoc --urls AgentScopeJava:https://java.agentscope.io/llms.txt
+claude mcp add agentscope-docs -- uvx --from mcpdoc mcpdoc --urls AgentScopeJava:https://java.agentscope.io/v2/llms.txt
 ```
 
 **示例：**
 
-安装后直接提问即可：
+安装后可以直接提问：
 
 > 如何用 AgentScope Java 创建一个工具？
 
@@ -39,9 +41,9 @@ claude mcp add agentscope-docs -- uvx --from mcpdoc mcpdoc --urls AgentScopeJava
 
 1. 打开 **Cursor Settings** -> **Features** -> **Docs**
 2. 点击 **+ Add new Doc**
-3. 填入：`https://java.agentscope.io/llms-full.txt`
+3. 填入：`https://java.agentscope.io/v2/llms-full.txt`
 
-**方式二：MCP 服务器**
+**方式二：MCP 服务**
 
 1. 打开 **Cursor Settings** -> **Tools & MCP**
 2. 点击 **New MCP Server** 编辑 `mcp.json`
@@ -54,7 +56,7 @@ claude mcp add agentscope-docs -- uvx --from mcpdoc mcpdoc --urls AgentScopeJava
       "command": "uvx",
       "args": [
         "--from", "mcpdoc", "mcpdoc",
-        "--urls", "AgentScopeJava:https://java.agentscope.io/llms.txt"
+        "--urls", "AgentScopeJava:https://java.agentscope.io/v2/llms.txt"
       ]
     }
   }
@@ -67,10 +69,10 @@ claude mcp add agentscope-docs -- uvx --from mcpdoc mcpdoc --urls AgentScopeJava
 
 ### Windsurf
 
-[Windsurf](https://codeium.com/windsurf) 通过 MCP 服务器接入。
+[Windsurf](https://codeium.com/windsurf) 可以通过 MCP 服务接入。
 
 1. 打开设置，进入 MCP 配置
-2. 添加服务器：
+2. 添加服务：
 
 ```json
 {
@@ -79,7 +81,7 @@ claude mcp add agentscope-docs -- uvx --from mcpdoc mcpdoc --urls AgentScopeJava
       "command": "uvx",
       "args": [
         "--from", "mcpdoc", "mcpdoc",
-        "--urls", "AgentScopeJava:https://java.agentscope.io/llms.txt"
+        "--urls", "AgentScopeJava:https://java.agentscope.io/v2/llms.txt"
       ]
     }
   }
@@ -90,11 +92,18 @@ claude mcp add agentscope-docs -- uvx --from mcpdoc mcpdoc --urls AgentScopeJava
 
 **支持文档/知识库的工具：**
 
-直接添加 `https://java.agentscope.io/llms-full.txt`
+直接添加 `https://java.agentscope.io/v2/llms-full.txt`。
 
 **支持 MCP 的工具：**
 
-参考上述 MCP 配置模板
+参考上面的 MCP 配置模板。
+
+**使用 AgentScope Java 1.x：**
+
+如果项目仍在使用 1.x，请改用：
+
+- `https://java.agentscope.io/v1/llms.txt`
+- `https://java.agentscope.io/v1/llms-full.txt`
 
 **环境要求：**
 


### PR DESCRIPTION
## Summary

Close #2185 
This PR replaces the root-level LLM documentation artifacts with version-scoped outputs:

- `/v1/llms.txt`
- `/v1/llms-full.txt`
- `/v2/llms.txt`
- `/v2/llms-full.txt`

The goal is to avoid mixing AgentScope Java 1.x and 2.x documentation in a single `llms-full.txt`, so AI coding tools can ingest the correct documentation set for the target version.

## Changes

- Add a local Sphinx `build-finished` extension to generate version-scoped `llms.txt` and `llms-full.txt` files from `docs/_toc.yml`.
- Remove the default `sphinx_llms_txt` integration to stop generating root-level `/llms.txt` and `/llms-full.txt`.
- Filter generated LLM docs to English `v1/en` and `v2/en` pages, excluding blogs and community pages.
- Update AI coding docs and the AI context menu to use versioned LLM documentation URLs.
