### PR TITLE
fix(openai): preserve system role in DeepSeek formatter

### DIFF
--- a/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-openai/src/main/java/io/agentscope/extensions/model/openai/formatter/DeepSeekFormatter.java
+++ b/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-openai/src/main/java/io/agentscope/extensions/model/openai/formatter/DeepSeekFormatter.java
@@ -27,7 +27,6 @@ import java.util.List;
  * <p>DeepSeek API has the following specific requirements:
  * <ul>
  *   <li>No name field in messages (returns HTTP 400 if present)</li>
- *   <li>System messages should be converted to user messages</li>
  *   <li>Does NOT support strict parameter in tool definitions</li>
  *   <li>In thinking mode, reasoning_content is preserved for segments with tool calls</li>
  * </ul>
@@ -84,7 +83,6 @@ public class DeepSeekFormatter extends OpenAIChatFormatter {
      * <p>DeepSeek API requires:
      * <ul>
      *   <li>No name field in messages</li>
-     *   <li>System messages converted to user</li>
      *   <li>In thinking mode, reasoning_content preserved for segments with tool calls</li>
      *   <li>reasoning_content removed for segments without tool calls in thinking mode</li>
      * </ul>
@@ -169,20 +167,18 @@ public class DeepSeekFormatter extends OpenAIChatFormatter {
 
     @SuppressWarnings("unchecked")
     private static OpenAIMessage fixMessage(OpenAIMessage msg, boolean needReasoning) {
-        boolean isSystem = "system".equals(msg.getRole());
         boolean hasName = msg.getName() != null;
         boolean hasReasoning = msg.getReasoningContent() != null;
         // needReasoning is determined by applyDeepSeekFixes:
         // true = current turn, or segment had tool calls in thinking mode
         boolean shouldRemoveReasoning = hasReasoning && !needReasoning;
 
-        if (!isSystem && !hasName && !shouldRemoveReasoning) {
+        if (!hasName && !shouldRemoveReasoning) {
             return msg;
         }
 
-        // Build new message: convert system to user, remove name field
-        OpenAIMessage.Builder builder =
-                OpenAIMessage.builder().role(isSystem ? "user" : msg.getRole());
+        // Build new message without the name field or stale reasoning content
+        OpenAIMessage.Builder builder = OpenAIMessage.builder().role(msg.getRole());
 
         Object content = msg.getContent();
         if (content instanceof String s) {

--- a/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-openai/src/main/java/io/agentscope/extensions/model/openai/formatter/DeepSeekMultiAgentFormatter.java
+++ b/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-openai/src/main/java/io/agentscope/extensions/model/openai/formatter/DeepSeekMultiAgentFormatter.java
@@ -25,7 +25,6 @@ import java.util.List;
  * <p>This formatter extends {@link OpenAIMultiAgentFormatter} with DeepSeek-specific handling:
  * <ul>
  *   <li>No name field in messages (returns HTTP 400 if present)</li>
- *   <li>System messages converted to user messages</li>
  *   <li>Does NOT support strict parameter in tool definitions</li>
  *   <li>reasoning_content handling for thinking mode</li>
  * </ul>

--- a/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-openai/src/test/java/io/agentscope/extensions/model/openai/formatter/DeepSeekFormatterTest.java
+++ b/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-openai/src/test/java/io/agentscope/extensions/model/openai/formatter/DeepSeekFormatterTest.java
@@ -44,7 +44,7 @@ import org.junit.jupiter.api.Test;
  * <p>Tests verify DeepSeek-specific requirements:
  * <ul>
  *   <li>No name field in messages</li>
- *   <li>System messages converted to user</li>
+ *   <li>System message roles are preserved</li>
  *   <li>Does NOT support strict parameter in tool definitions</li>
  *   <li>reasoning_content handling for current vs previous turns</li>
  *   <li>Optional empty user message appending</li>
@@ -187,8 +187,8 @@ class DeepSeekFormatterTest {
         }
 
         @Test
-        @DisplayName("Should convert system message to user message")
-        void testConvertSystemToUser() {
+        @DisplayName("Should preserve system message role")
+        void testPreserveSystemRole() {
             List<OpenAIMessage> messages =
                     List.of(
                             OpenAIMessage.builder()
@@ -199,7 +199,7 @@ class DeepSeekFormatterTest {
             List<OpenAIMessage> result = DeepSeekFormatter.applyDeepSeekFixes(messages);
 
             assertEquals(1, result.size());
-            assertEquals("user", result.get(0).getRole());
+            assertEquals("system", result.get(0).getRole());
             assertEquals("You are helpful", result.get(0).getContentAsString());
         }
 
@@ -294,7 +294,7 @@ class DeepSeekFormatterTest {
         }
 
         @Test
-        @DisplayName("Should handle content as list")
+        @DisplayName("Should preserve system role and list content when removing name")
         void testHandleContentAsList() {
             List<OpenAIContentPart> contentParts =
                     List.of(OpenAIContentPart.text("Hello"), OpenAIContentPart.text("World"));
@@ -310,7 +310,7 @@ class DeepSeekFormatterTest {
             List<OpenAIMessage> result = DeepSeekFormatter.applyDeepSeekFixes(messages);
 
             assertEquals(1, result.size());
-            assertEquals("user", result.get(0).getRole());
+            assertEquals("system", result.get(0).getRole());
             assertNull(result.get(0).getName());
             assertTrue(result.get(0).getContent() instanceof List);
         }
@@ -701,8 +701,8 @@ class DeepSeekFormatterTest {
             List<OpenAIMessage> result = formatter.format(messages);
 
             assertEquals(2, result.size());
-            // System converted to user
-            assertEquals("user", result.get(0).getRole());
+            // System role preserved
+            assertEquals("system", result.get(0).getRole());
             // Name removed
             assertNull(result.get(1).getName());
         }
@@ -731,9 +731,9 @@ class DeepSeekFormatterTest {
             List<OpenAIMessage> result = formatter.format(messages);
 
             assertEquals(2, result.size());
-            // Both should be converted to user
-            assertEquals("user", result.get(0).getRole());
-            assertEquals("user", result.get(1).getRole());
+            // Both system roles should be preserved
+            assertEquals("system", result.get(0).getRole());
+            assertEquals("system", result.get(1).getRole());
         }
     }
 }

--- a/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-openai/src/test/java/io/agentscope/extensions/model/openai/formatter/DeepSeekMultiAgentFormatterTest.java
+++ b/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-openai/src/test/java/io/agentscope/extensions/model/openai/formatter/DeepSeekMultiAgentFormatterTest.java
@@ -44,7 +44,7 @@ import org.junit.jupiter.api.Test;
  * <p>Tests verify DeepSeek multi-agent specific requirements:
  * <ul>
  *   <li>Inherits multi-agent conversation merging from OpenAIMultiAgentFormatter</li>
- *   <li>Applies DeepSeek-specific fixes (no name, system to user, reasoning_content)</li>
+ *   <li>Applies DeepSeek-specific fixes (no name and reasoning_content handling)</li>
  *   <li>Does NOT support strict parameter in tool definitions</li>
  *   <li>Optional empty user message appending</li>
  * </ul>
@@ -261,8 +261,8 @@ class DeepSeekMultiAgentFormatterTest {
         }
 
         @Test
-        @DisplayName("Should convert system to user in merged output")
-        void testConvertSystemToUser() {
+        @DisplayName("Should preserve system role in merged output")
+        void testPreserveSystemRole() {
             List<Msg> messages =
                     List.of(
                             Msg.builder()
@@ -280,8 +280,8 @@ class DeepSeekMultiAgentFormatterTest {
 
             List<OpenAIMessage> result = formatter.format(messages);
 
-            // First message (system) should be converted to user
-            assertEquals("user", result.get(0).getRole());
+            // First message should preserve the system role
+            assertEquals("system", result.get(0).getRole());
         }
 
         @Test
@@ -433,10 +433,10 @@ class DeepSeekMultiAgentFormatterTest {
             List<OpenAIMessage> result = formatter.format(messages);
 
             assertNotNull(result);
-            // Should have: system (converted to user) + merged conversation + tool sequence
+            // Should have: system + merged conversation + tool sequence
             assertTrue(result.size() >= 3);
-            // First message should be user (converted from system)
-            assertEquals("user", result.get(0).getRole());
+            // First message should preserve the system role
+            assertEquals("system", result.get(0).getRole());
         }
 
         @Test


### PR DESCRIPTION
## AgentScope-Java Version

2.0.1-SNAPSHOT

## Description

Fixes #2168.

DeepSeek's current API supports the `system` role, but `DeepSeekFormatter` was rewriting system messages to `user`. This changed the intended message semantics and made the formatter inconsistent with the API behavior.

This PR:

- preserves the original `system` role in `DeepSeekFormatter` and `DeepSeekMultiAgentFormatter` output;
- keeps the existing DeepSeek-specific handling for removing message names and stale `reasoning_content`;
- updates formatter tests and Javadocs to describe and verify the corrected behavior.

### How to test

```bash
mvn -pl agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-openai -am \
  -Dtest=DeepSeekFormatterTest,DeepSeekMultiAgentFormatterTest \
  -Dsurefire.failIfNoSpecifiedTests=false test

mvn -pl agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-openai -am verify
mvn spotless:apply
mvn spotless:check
```

## Checklist

Please check the following items before code is ready to be reviewed.

- [x] Code has been formatted with `mvn spotless:apply`
- [x] All tests are passing (`mvn test`)
- [x] Javadoc comments are complete and follow project conventions
- [x] Related documentation has been updated (e.g. links, examples, etc.)
- [x] Code is ready for review
