### PR TITLE
fix(tool): correct sessionId parameter description

### DIFF
--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/tool/SessionSearchTool.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/tool/SessionSearchTool.java
@@ -171,7 +171,7 @@ public class SessionSearchTool {
     public String sessionHistory(
             RuntimeContext runtimeContext,
             @ToolParam(name = "agentId", description = "Agent ID") String agentId,
-            @ToolParam(name = "sessionId", description = "Session ID") String sessionId,
+            @ToolParam(name = "sessionId", description = "AgentStateStore Session ID") String sessionId,
             @ToolParam(
                             name = "lastN",
                             description = "Number of recent messages to return (default: 20)",

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/tool/SessionSearchTool.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/tool/SessionSearchTool.java
@@ -171,7 +171,7 @@ public class SessionSearchTool {
     public String sessionHistory(
             RuntimeContext runtimeContext,
             @ToolParam(name = "agentId", description = "Agent ID") String agentId,
-            @ToolParam(name = "sessionId", description = "AgentStateStore ID") String sessionId,
+            @ToolParam(name = "sessionId", description = "Session ID") String sessionId,
             @ToolParam(
                             name = "lastN",
                             description = "Number of recent messages to return (default: 20)",


### PR DESCRIPTION
## Summary

- Fix misleading parameter description in `SessionSearchTool.sessionHistory()`: `"AgentStateStore ID"` → `"Session ID"`

## Test plan

- [x] `mvn compile` — passed