### PR TITLE
fix: ensure AgentRun workspace root before hydration

### DIFF
--- a/agentscope-extensions/agentscope-extensions-sandbox/agentscope-extensions-sandbox-agentrun/src/main/java/io/agentscope/extensions/sandbox/agentrun/AgentRunMcpChannel.java
+++ b/agentscope-extensions/agentscope-extensions-sandbox/agentscope-extensions-sandbox-agentrun/src/main/java/io/agentscope/extensions/sandbox/agentrun/AgentRunMcpChannel.java
@@ -34,7 +34,7 @@ import java.util.Objects;
  * header, and exposes the three tool names that an AgentRun sandbox template enables for
  * AgentScope: {@code process_exec_cmd}, {@code read_file}, {@code write_file}.
  */
-final class AgentRunMcpChannel implements AutoCloseable {
+final class AgentRunMcpChannel implements AgentRunSandbox.AgentRunExecutor {
 
     /** MCP tool name for shell-style command execution. */
     static final String TOOL_EXEC = "process_exec_cmd";
@@ -57,7 +57,8 @@ final class AgentRunMcpChannel implements AutoCloseable {
     }
 
     /** Connects the MCP client. Idempotent — repeated calls are a no-op. */
-    void connect() {
+    @Override
+    public void connect() {
         if (client != null) {
             return;
         }
@@ -87,7 +88,8 @@ final class AgentRunMcpChannel implements AutoCloseable {
     }
 
     /** Runs {@code command} via the AgentRun {@code process_exec_cmd} MCP tool. */
-    ExecResult exec(String command, String cwd, int timeoutSeconds) {
+    @Override
+    public ExecResult exec(String command, String cwd, int timeoutSeconds) {
         ensureConnected();
         Map<String, Object> args = new LinkedHashMap<>();
         args.put("command", command);

--- a/agentscope-extensions/agentscope-extensions-sandbox/agentscope-extensions-sandbox-agentrun/src/main/java/io/agentscope/extensions/sandbox/agentrun/AgentRunSandbox.java
+++ b/agentscope-extensions/agentscope-extensions-sandbox/agentscope-extensions-sandbox-agentrun/src/main/java/io/agentscope/extensions/sandbox/agentrun/AgentRunSandbox.java
@@ -48,13 +48,13 @@ public class AgentRunSandbox extends AbstractBaseSandbox {
     private final AgentRunSandboxState arState;
     private final AgentRunSandboxClientOptions options;
     private final AgentRunDataPlaneHttp http;
-    private final AgentRunMcpChannel mcp;
+    private final AgentRunExecutor mcp;
 
     public AgentRunSandbox(
             AgentRunSandboxState state,
             AgentRunSandboxClientOptions options,
             AgentRunDataPlaneHttp http,
-            AgentRunMcpChannel mcp) {
+            AgentRunExecutor mcp) {
         super(state);
         this.arState = state;
         this.options = options;
@@ -155,6 +155,7 @@ public class AgentRunSandbox extends AbstractBaseSandbox {
         if (all.length == 0) {
             return;
         }
+        ensureWorkspaceRoot();
         String b64 = Base64.getEncoder().encodeToString(all);
         mcp.exec("rm -f /tmp/agentscope-ws.b64", null, 30);
         for (int i = 0; i < b64.length(); i += B64_CHUNK) {
@@ -187,7 +188,7 @@ public class AgentRunSandbox extends AbstractBaseSandbox {
 
     @Override
     protected void doSetupWorkspace() throws Exception {
-        mcp.exec("mkdir -p " + shellSingleQuote(arState.getWorkspaceRoot()), null, 30);
+        ensureWorkspaceRoot();
     }
 
     @Override
@@ -206,6 +207,16 @@ public class AgentRunSandbox extends AbstractBaseSandbox {
     @Override
     protected String getWorkspaceRoot() {
         return arState.getWorkspaceRoot();
+    }
+
+    private void ensureWorkspaceRoot() throws Exception {
+        AgentRunMcpChannel.ExecResult r =
+                mcp.exec("mkdir -p " + shellSingleQuote(arState.getWorkspaceRoot()), null, 30);
+        if (r.exitCode != 0) {
+            throw new SandboxException.SandboxRuntimeException(
+                    SandboxErrorCode.WORKSPACE_START_ERROR,
+                    "AgentRun workspace root setup failed (exit=" + r.exitCode + "): " + r.stderr);
+        }
     }
 
     private void ensureSandbox() throws Exception {
@@ -262,5 +273,14 @@ public class AgentRunSandbox extends AbstractBaseSandbox {
         }
         sb.append('\'');
         return sb.toString();
+    }
+
+    interface AgentRunExecutor extends AutoCloseable {
+        void connect();
+
+        AgentRunMcpChannel.ExecResult exec(String command, String cwd, int timeoutSeconds);
+
+        @Override
+        void close();
     }
 }

--- a/agentscope-extensions/agentscope-extensions-sandbox/agentscope-extensions-sandbox-agentrun/src/test/java/io/agentscope/extensions/sandbox/agentrun/AgentRunSandboxTest.java
+++ b/agentscope-extensions/agentscope-extensions-sandbox/agentscope-extensions-sandbox-agentrun/src/test/java/io/agentscope/extensions/sandbox/agentrun/AgentRunSandboxTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.extensions.sandbox.agentrun;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.agentscope.harness.agent.sandbox.SandboxException;
+import io.agentscope.harness.agent.sandbox.WorkspaceSpec;
+import java.io.ByteArrayInputStream;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class AgentRunSandboxTest {
+
+    @Test
+    void setupWorkspaceFailsWhenRootCannotBeCreated() throws Exception {
+        FakeExecutor mcp = new FakeExecutor();
+        mcp.failWorkspaceRootSetup();
+
+        SandboxException.SandboxRuntimeException ex =
+                assertThrows(
+                        SandboxException.SandboxRuntimeException.class,
+                        () -> sandbox(mcp).doSetupWorkspace());
+
+        assertTrue(ex.getMessage().contains("AgentRun workspace root setup failed"));
+        assertTrue(ex.getMessage().contains("permission denied"));
+    }
+
+    @Test
+    void hydrateWorkspaceCreatesRootBeforeExtractingArchive() throws Exception {
+        FakeExecutor mcp = new FakeExecutor();
+
+        sandbox(mcp).doHydrateWorkspace(new ByteArrayInputStream(new byte[] {1, 2, 3}));
+
+        assertTrue(mcp.commands.size() >= 2);
+        assertTrue(mcp.commands.get(0).equals("mkdir -p '/home/agentscope/workspace'"));
+        assertTrue(mcp.commands.get(1).equals("rm -f /tmp/agentscope-ws.b64"));
+    }
+
+    @Test
+    void hydrateWorkspaceDoesNotExtractWhenRootCannotBeCreated() throws Exception {
+        FakeExecutor mcp = new FakeExecutor();
+        mcp.failWorkspaceRootSetup();
+
+        assertThrows(
+                SandboxException.SandboxRuntimeException.class,
+                () -> sandbox(mcp).doHydrateWorkspace(new ByteArrayInputStream(new byte[] {1})));
+
+        assertTrue(mcp.commands.stream().noneMatch("rm -f /tmp/agentscope-ws.b64"::equals));
+    }
+
+    private static AgentRunSandbox sandbox(AgentRunSandbox.AgentRunExecutor mcp) {
+        AgentRunSandboxState state = new AgentRunSandboxState();
+        state.setWorkspaceRoot("/home/agentscope/workspace");
+        WorkspaceSpec workspaceSpec = new WorkspaceSpec();
+        workspaceSpec.setRoot("/home/agentscope/workspace");
+        state.setWorkspaceSpec(workspaceSpec);
+        return new AgentRunSandbox(state, null, null, mcp);
+    }
+
+    private static final class FakeExecutor implements AgentRunSandbox.AgentRunExecutor {
+
+        private final List<String> commands = new ArrayList<>();
+        private boolean failWorkspaceRootSetup;
+
+        void failWorkspaceRootSetup() {
+            this.failWorkspaceRootSetup = true;
+        }
+
+        @Override
+        public void connect() {}
+
+        @Override
+        public AgentRunMcpChannel.ExecResult exec(String command, String cwd, int timeoutSeconds) {
+            commands.add(command);
+            if (failWorkspaceRootSetup && command.equals("mkdir -p '/home/agentscope/workspace'")) {
+                return new AgentRunMcpChannel.ExecResult(2, "", "permission denied");
+            }
+            return new AgentRunMcpChannel.ExecResult(0, "", "");
+        }
+
+        @Override
+        public void close() {}
+    }
+}


### PR DESCRIPTION
Fixes #2216

## Summary
- ensure AgentRun workspace root is created before hydration
- fail fast when workspace root setup returns a non-zero exit code
- add AgentRun sandbox tests for setup failure and hydration ordering

## Tests
- mvn -pl agentscope-extensions/agentscope-extensions-sandbox/agentscope-extensions-sandbox-agentrun test