### PR TITLE
fix: ToolChoice.None 映射错误导致强制调用工具

### DIFF
--- a/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-anthropic/src/main/java/io/agentscope/extensions/model/anthropic/formatter/AnthropicToolsHelper.java
+++ b/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-anthropic/src/main/java/io/agentscope/extensions/model/anthropic/formatter/AnthropicToolsHelper.java
@@ -55,6 +55,16 @@ public class AnthropicToolsHelper {
             return;
         }
 
+        // ToolChoice.None means "prevent the model from calling any tools".
+        // The Anthropic API has no native "none" value for tool_choice,
+        // so the only correct way to enforce this is to omit tools entirely.
+        if (options != null && options.getToolChoice() instanceof ToolChoice.None) {
+            log.debug(
+                    "ToolChoice.None specified, suppressing all tools in Anthropic request"
+                            + " (Anthropic API has no native 'none' tool_choice)");
+            return;
+        }
+
         // Convert and add tools
         for (ToolSchema schema : tools) {
             Tool tool =
@@ -92,18 +102,20 @@ public class AnthropicToolsHelper {
             MessageCreateParams.Builder builder, ToolChoice toolChoice) {
         if (toolChoice instanceof ToolChoice.Auto) {
             builder.toolChoice(ofAuto(ToolChoiceAuto.builder().build()));
-        } else if (toolChoice instanceof ToolChoice.None) {
-            // Anthropic doesn't have None, use Any instead
-            builder.toolChoice(ofAny(ToolChoiceAny.builder().build()));
         } else if (toolChoice instanceof ToolChoice.Required) {
-            // Anthropic doesn't have a direct "required" option, use "any" which forces tool
-            // use
+            // Anthropic doesn't have a direct "required" option, use "any" which forces tool use
             log.warn(
                     "Anthropic API doesn't support ToolChoice.Required directly, using 'any'"
                             + " instead");
             builder.toolChoice(ofAny(ToolChoiceAny.builder().build()));
         } else if (toolChoice instanceof ToolChoice.Specific specific) {
             builder.toolChoice(ofTool(ToolChoiceTool.builder().name(specific.toolName()).build()));
+        } else if (toolChoice instanceof ToolChoice.None) {
+            // Should not reach here — None is handled earlier in applyTools by suppressing tools.
+            // Guard against misuse if this method is called directly.
+            log.warn(
+                    "ToolChoice.None should be handled by suppressing tools, not by setting"
+                            + " tool_choice. Ignoring tool_choice for None.");
         } else {
             log.warn("Unknown tool choice type: {}", toolChoice);
         }

--- a/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-anthropic/src/test/java/io/agentscope/extensions/model/anthropic/formatter/AnthropicToolsHelperTest.java
+++ b/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-anthropic/src/test/java/io/agentscope/extensions/model/anthropic/formatter/AnthropicToolsHelperTest.java
@@ -155,9 +155,9 @@ class AnthropicToolsHelperTest {
         AnthropicToolsHelper.applyTools(builder, List.of(schema), options);
 
         MessageCreateParams params = builder.build();
-        assertTrue(params.toolChoice().isPresent());
-        // None maps to "any" in Anthropic
-        assertTrue(params.toolChoice().get().isAny());
+        // ToolChoice.None must suppress tools entirely — no tools and no tool_choice
+        assertTrue(params.tools().isEmpty());
+        assertTrue(params.toolChoice().isEmpty());
     }
 
     @Test
@@ -200,6 +200,74 @@ class AnthropicToolsHelperTest {
         assertTrue(params.toolChoice().isPresent());
         assertTrue(params.toolChoice().get().isTool());
         assertEquals("search", params.toolChoice().get().asTool().name());
+    }
+
+    @Test
+    void testApplyToolChoiceNoneWithMultipleTools() {
+        MessageCreateParams.Builder builder = createBuilder();
+
+        ToolSchema schema1 =
+                ToolSchema.builder()
+                        .name("search")
+                        .description("Search")
+                        .parameters(Map.of("type", "object"))
+                        .build();
+        ToolSchema schema2 =
+                ToolSchema.builder()
+                        .name("calculator")
+                        .description("Calculate")
+                        .parameters(Map.of("type", "object"))
+                        .build();
+
+        GenerateOptions options =
+                GenerateOptions.builder().toolChoice(new ToolChoice.None()).build();
+        AnthropicToolsHelper.applyTools(builder, List.of(schema1, schema2), options);
+
+        MessageCreateParams params = builder.build();
+        // None must suppress all tools
+        assertTrue(params.tools().isEmpty());
+        assertTrue(params.toolChoice().isEmpty());
+    }
+
+    @Test
+    void testApplyToolChoiceNoneWithNullOptions() {
+        MessageCreateParams.Builder builder = createBuilder();
+
+        ToolSchema schema =
+                ToolSchema.builder()
+                        .name("search")
+                        .description("Search")
+                        .parameters(Map.of("type", "object"))
+                        .build();
+
+        // null options — tools should still be applied normally
+        AnthropicToolsHelper.applyTools(builder, List.of(schema), null);
+
+        MessageCreateParams params = builder.build();
+        assertTrue(params.tools().isPresent());
+        assertEquals(1, params.tools().get().size());
+        assertTrue(params.toolChoice().isEmpty());
+    }
+
+    @Test
+    void testApplyToolChoiceNoneWithEmptyOptions() {
+        MessageCreateParams.Builder builder = createBuilder();
+
+        ToolSchema schema =
+                ToolSchema.builder()
+                        .name("search")
+                        .description("Search")
+                        .parameters(Map.of("type", "object"))
+                        .build();
+
+        // Options without toolChoice — tools should be applied normally
+        GenerateOptions options = GenerateOptions.builder().build();
+        AnthropicToolsHelper.applyTools(builder, List.of(schema), options);
+
+        MessageCreateParams params = builder.build();
+        assertTrue(params.tools().isPresent());
+        assertEquals(1, params.tools().get().size());
+        assertTrue(params.toolChoice().isEmpty());
     }
 
     @Test

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/tool/SessionSearchTool.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/tool/SessionSearchTool.java
@@ -171,7 +171,8 @@ public class SessionSearchTool {
     public String sessionHistory(
             RuntimeContext runtimeContext,
             @ToolParam(name = "agentId", description = "Agent ID") String agentId,
-            @ToolParam(name = "sessionId", description = "AgentStateStore Session ID") String sessionId,
+            @ToolParam(name = "sessionId", description = "AgentStateStore Session ID")
+                    String sessionId,
             @ToolParam(
                             name = "lastN",
                             description = "Number of recent messages to return (default: 20)",


### PR DESCRIPTION
## 关联 issue
- Fixes #2221

## AgentScope-Java Version

2.0.1-SNAPSHOT

## Description

### Background

`ToolChoice` 抽象定义了四种工具调用策略：`Auto`（模型自主决定）、`None`（禁止工具调用，仅返回文本）、`Required`（强制调用工具）和 `Specific`（强制调用指定工具）。其中 `ToolChoice.None` 的语义明确为"阻止模型调用任何工具"。

OpenAI API 原生支持 `tool_choice: "none"` 值，可直接表达此语义。但 Anthropic API 的 `tool_choice` 参数仅支持 `auto`、`any` 和 `tool` 三种类型，不存在 `none` 值。

### Root Cause

`AnthropicToolsHelper.applyToolChoice()` 在处理 `ToolChoice.None` 时，将其映射为 Anthropic SDK 的 `ToolChoiceAny`（即 API 值 `"any"`）。`"any"` 的语义是**强制模型必须调用某个工具**，与 `None` 的预期语义"禁止工具调用"完全相反。

原代码注释 `// Anthropic doesn't have None, use Any instead` 表明这是一个有意识的 fallback 决策，但选择了语义错误的映射方向。

**影响：** 当调用方指定 `ToolChoice.None` 试图获取纯文本响应时，模型反而被强制进行工具调用，导致非预期行为。

### Fix

在 `AnthropicToolsHelper.applyTools()` 方法中，检测到 `ToolChoice.None` 时直接返回，不向 `MessageCreateParams.Builder` 添加任何工具定义。Anthropic API 在请求中不包含 `tools` 字段时，模型不会进行工具调用，自然产生纯文本响应——这是 Anthropic 平台上表达"禁用工具"的唯一正确方式。

`applyToolChoice()` 移除了 `None → any` 的错误映射，添加防御性日志以防此方法被直接调用时误传 `None`。

### **Changed files:**

#### 1. `agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-anthropic/src/main/java/io/agentscope/extensions/model/anthropic/formatter/AnthropicToolsHelper.java`

- `applyTools()`: 在工具添加逻辑之前增加 `ToolChoice.None` 检查，若匹配则记录 debug 日志并直接返回，不向请求添加任何工具
- `applyToolChoice()`: 移除 `ToolChoice.None → ToolChoiceAny` 的错误映射，增加防御性 warn 日志

#### 2. `agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-anthropic/src/test/java/io/agentscope/extensions/model/anthropic/formatter/AnthropicToolsHelperTest.java`

- `testApplyToolChoiceNone()`: 修正断言，验证 None 时 tools 为空且 toolChoice 为空（原错误断言 `isAny()`）
- 新增 `testApplyToolChoiceNoneWithMultipleTools()`: 验证多个工具场景下 None 同样抑制所有工具
- 新增 `testApplyToolChoiceNoneWithNullOptions()`: 验证 options 为 null 时工具正常应用
- 新增 `testApplyToolChoiceNoneWithEmptyOptions()`: 验证无 toolChoice 的空 options 时工具正常应用

## Checklist

- [x] Code has been formatted with `mvn spotless:apply`
- [x] All tests are passing (`mvn test`)
- [x] Javadoc comments are complete and follow project conventions
- [ ] Related documentation has been updated (e.g. links, examples, etc.)
- [x] Code is ready for review