### PR TITLE
fix(examples): correct DashScope model name in RuntimeContextExample

### DIFF
--- a/agentscope-examples/documentation/src/main/java/io/agentscope/examples/documentation2/context/RuntimeContextExample.java
+++ b/agentscope-examples/documentation/src/main/java/io/agentscope/examples/documentation2/context/RuntimeContextExample.java
@@ -63,7 +63,7 @@ public class RuntimeContextExample {
                         .model(
                                 DashScopeChatModel.builder()
                                         .apiKey(apiKey)
-                                        .modelName("dashscope:qwen-plus")
+                                        .modelName("qwen-plus")
                                         .stream(false)
                                         .formatter(new DashScopeChatFormatter())
                                         .build())

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/tool/SessionSearchTool.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/tool/SessionSearchTool.java
@@ -171,7 +171,8 @@ public class SessionSearchTool {
     public String sessionHistory(
             RuntimeContext runtimeContext,
             @ToolParam(name = "agentId", description = "Agent ID") String agentId,
-            @ToolParam(name = "sessionId", description = "AgentStateStore Session ID") String sessionId,
+            @ToolParam(name = "sessionId", description = "AgentStateStore Session ID")
+                    String sessionId,
             @ToolParam(
                             name = "lastN",
                             description = "Number of recent messages to return (default: 20)",


### PR DESCRIPTION
Remove the invalid 'dashscope:' prefix from the model name so DashScopeChatModel receives the actual model identifier 'qwen-plus'.

Refs:  #2229 

## AgentScope-Java Version

2.0.1-SNAPSHOT

