### PR TITLE
fix(harness): bind RuntimeContext before sandbox start

### DIFF
--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/middleware/SandboxLifecycleMiddleware.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/middleware/SandboxLifecycleMiddleware.java
@@ -33,6 +33,7 @@ import org.slf4j.LoggerFactory;
  * <ol>
  *   <li>Read {@link SandboxContext} from the current {@link RuntimeContext}</li>
  *   <li>Acquire a session via {@link SandboxManager}</li>
+ *   <li>Bind the per-call {@link RuntimeContext} to the sandbox</li>
  *   <li>Start the session (4-branch workspace init)</li>
  *   <li>Inject the live session into the {@link SandboxBackedFilesystem} proxy</li>
  * </ol>
@@ -107,6 +108,7 @@ public class SandboxLifecycleMiddleware implements HarnessRuntimeMiddleware {
             SandboxAcquireResult result = sandboxManager.acquire(sandboxContext, ctx);
             Sandbox sandbox = result.getSandbox();
             try {
+                sandbox.bindRuntimeContext(ctx);
                 sandbox.start();
                 filesystemProxy.setSandbox(sandbox);
                 currentAcquireResult.set(result);

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/sandbox/Sandbox.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/sandbox/Sandbox.java
@@ -24,6 +24,7 @@ import java.io.InputStream;
  * <p>Lifecycle:
  * <ol>
  *   <li>Acquire via {@link SandboxClient#create} (new) or {@link SandboxClient#resume} (existing)
+ *   <li>Call {@link #bindRuntimeContext(RuntimeContext)} with the current call context
  *   <li>Call {@link #start()} — initializes or restores the workspace
  *   <li>Use {@link #exec} for command execution, {@link #persistWorkspace}/{@link #hydrateWorkspace}
  *       for archive operations
@@ -40,6 +41,19 @@ import java.io.InputStream;
  * </ul>
  */
 public interface Sandbox extends AutoCloseable {
+
+    /**
+     * Binds the per-call runtime context before {@link #start()}.
+     *
+     * <p>Sandbox implementations that derive ownership or isolation metadata from the current
+     * user/session should override this method. The harness invokes it for every acquired sandbox,
+     * including caller-provided sandboxes, so implementations must treat repeated calls as normal.
+     *
+     * @param runtimeContext per-call agent context; never {@code null} in the managed lifecycle
+     */
+    default void bindRuntimeContext(RuntimeContext runtimeContext) {
+        // no-op by default
+    }
 
     void start() throws Exception;
 

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/middleware/SandboxLifecycleMiddlewareRuntimeContextTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/middleware/SandboxLifecycleMiddlewareRuntimeContextTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.harness.agent.middleware;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.agentscope.core.agent.RuntimeContext;
+import io.agentscope.harness.agent.filesystem.sandbox.SandboxBackedFilesystem;
+import io.agentscope.harness.agent.sandbox.Sandbox;
+import io.agentscope.harness.agent.sandbox.SandboxAcquireResult;
+import io.agentscope.harness.agent.sandbox.SandboxContext;
+import io.agentscope.harness.agent.sandbox.SandboxLease;
+import io.agentscope.harness.agent.sandbox.SandboxManager;
+import org.junit.jupiter.api.Test;
+import org.mockito.InOrder;
+
+class SandboxLifecycleMiddlewareRuntimeContextTest {
+
+    @Test
+    void bindsRuntimeContextBeforeStartingSandbox() throws Exception {
+        SandboxManager sandboxManager = mock(SandboxManager.class);
+        SandboxBackedFilesystem filesystem = mock(SandboxBackedFilesystem.class);
+        Sandbox sandbox = mock(Sandbox.class);
+        SandboxContext sandboxContext = SandboxContext.builder().build();
+        RuntimeContext runtimeContext =
+                RuntimeContext.builder()
+                        .userId("scheduled-job-author")
+                        .sessionId("job-42")
+                        .put(SandboxContext.class, sandboxContext)
+                        .build();
+
+        when(sandboxManager.acquire(sandboxContext, runtimeContext))
+                .thenReturn(SandboxAcquireResult.userManaged(sandbox));
+
+        new SandboxLifecycleMiddleware(sandboxManager, filesystem).acquireForCall(runtimeContext);
+
+        InOrder lifecycle = inOrder(sandbox);
+        lifecycle.verify(sandbox).bindRuntimeContext(runtimeContext);
+        lifecycle.verify(sandbox).start();
+    }
+
+    @Test
+    void releasesSandboxAndLeaseWhenRuntimeContextBindingFails() throws Exception {
+        SandboxManager sandboxManager = mock(SandboxManager.class);
+        SandboxBackedFilesystem filesystem = mock(SandboxBackedFilesystem.class);
+        Sandbox sandbox = mock(Sandbox.class);
+        SandboxLease lease = mock(SandboxLease.class);
+        SandboxContext sandboxContext = SandboxContext.builder().build();
+        RuntimeContext runtimeContext =
+                RuntimeContext.builder()
+                        .userId("scheduled-job-author")
+                        .sessionId("job-42")
+                        .put(SandboxContext.class, sandboxContext)
+                        .build();
+        SandboxAcquireResult result = SandboxAcquireResult.selfManaged(sandbox, lease);
+
+        when(sandboxManager.acquire(sandboxContext, runtimeContext)).thenReturn(result);
+        doThrow(new IllegalStateException("invalid runtime identity"))
+                .when(sandbox)
+                .bindRuntimeContext(runtimeContext);
+
+        assertThrows(
+                RuntimeException.class,
+                () ->
+                        new SandboxLifecycleMiddleware(sandboxManager, filesystem)
+                                .acquireForCall(runtimeContext));
+
+        verify(sandbox, never()).start();
+        verify(filesystem).setSandbox(null);
+        verify(sandboxManager).release(result);
+        verify(lease).close();
+    }
+}


### PR DESCRIPTION
## Summary

- add a backward-compatible Sandbox.bindRuntimeContext(RuntimeContext) lifecycle hook
- invoke it after acquire and before start for every sandbox path
- verify binding order and cleanup when binding fails

## Motivation

Sandbox implementations may need the per-call user/session identity before start creates or resumes remote resources. Previously RuntimeContext was available to SandboxLifecycleMiddleware but was not passed to Sandbox until exec, which is too late for ownership and isolation metadata.

## Testing

- mvn -pl agentscope-harness -am -Dtest=SandboxLifecycleMiddlewareRuntimeContextTest,SandboxLifecycleMiddlewareCallbackTest -Dsurefire.failIfNoSpecifiedTests=false test

6 focused tests passed.