### PR TITLE
docs(harness): clarify grep_files/edit_file/glob_files tool descriptions

### DIFF
--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/tool/FilesystemTool.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/tool/FilesystemTool.java
@@ -95,7 +95,12 @@ public class FilesystemTool {
     public String editFile(
             RuntimeContext runtimeContext,
             @ToolParam(name = "path", description = "File to edit") String path,
-            @ToolParam(name = "old_string", description = "Text to find") String oldString,
+            @ToolParam(
+                            name = "old_string",
+                            description =
+                                    "Text to find. Must match exactly once unless replace_all is"
+                                            + " true; otherwise the edit fails.")
+                    String oldString,
             @ToolParam(name = "new_string", description = "Replacement text") String newString,
             @ToolParam(
                             name = "replace_all",
@@ -120,7 +125,13 @@ public class FilesystemTool {
             @ToolParam(name = "pattern", description = "Literal text pattern to search for")
                     String pattern,
             @ToolParam(name = "path", description = "Directory or file to search") String path,
-            @ToolParam(name = "glob", description = "Optional file glob filter (e.g., *.java)")
+            @ToolParam(
+                            name = "glob",
+                            description =
+                                    "Optional file glob filter matched against the file name only"
+                                            + " (e.g., *.java). Path-based patterns such as"
+                                            + " **/*.java are not supported here; the search"
+                                            + " already recurses into subdirectories.")
                     String glob) {
         GrepResult r = abstractFilesystem.grep(runtimeContext, pattern, norm(path), glob);
         if (!r.isSuccess()) {
@@ -135,7 +146,13 @@ public class FilesystemTool {
                 .collect(Collectors.joining("\n"));
     }
 
-    @Tool(name = "glob_files", readOnly = true, description = "Find files matching a glob pattern.")
+    @Tool(
+            name = "glob_files",
+            readOnly = true,
+            description =
+                    "Find files by name using a glob pattern (e.g., **/*.java). Use this to locate"
+                            + " files by path/name; use grep_files instead to search file"
+                            + " contents.")
     public String globFiles(
             RuntimeContext runtimeContext,
             @ToolParam(name = "pattern", description = "Glob pattern (e.g., **/*.java)")


### PR DESCRIPTION
### Summary

Improve the descriptions of three harness built-in tools so models pick the
right tool and pass valid arguments. Documentation-only; no behavior change.

### Changes

**`grep_files` — `glob` parameter**
Clarify that the filter is matched against the *file name only*, and that
path-based patterns such as `**/*.java` are not supported here. The search
already recurses into subdirectories, so a bare `*.java` is what's expected.
This reflects the `javaSearch` fallback in `LocalFilesystem`, which filters via
`path.getFileName()`:

```java
if (finalGlobMatcher != null) {
    return finalGlobMatcher.matches(p.getFileName());
}
```

**`edit_file` — `old_string` parameter**
Note at the parameter level that `old_string` must match exactly once unless
`replace_all` is true, otherwise the edit fails. Previously this was only stated
in the method-level description.

**`glob_files` — tool description**
Clarify that it finds files *by name*, and point to `grep_files` for searching
file *contents*, reducing tool-selection confusion.

### Rationale

These descriptions are surfaced to the model in the tool schema. Vague or missing
guidance leads models to, e.g., pass `**/*.java` to `grep_files` (which then
matches nothing via the Java fallback), or to confuse `glob_files` with
`grep_files`.

### Testing

- `mvn -pl agentscope-harness spotless:check` → BUILD SUCCESS.
- No logic changed; only annotation description strings.
