### PR TITLE
fix(examples): correct skill example resource path

### DIFF
--- a/agentscope-examples/documentation/src/main/java/io/agentscope/examples/documentation2/skill/AgentSkillExample.java
+++ b/agentscope-examples/documentation/src/main/java/io/agentscope/examples/documentation2/skill/AgentSkillExample.java
@@ -46,7 +46,7 @@ public class AgentSkillExample {
      * Set this to the absolute path of your skills directory before running.
      */
     private static final String SKILLS_DIR =
-            "agentscope-examples/documentation/quickstart/src/main/resources/skills";
+            "agentscope-examples/documentation/src/main/resources/skills";
 
     /**
      * Output directory where the agent may write new skill files during the demo.


### PR DESCRIPTION
## AgentScope-Java Version

2.0.1-SNAPSHOT

## Description

Correct the skills resource path in `AgentSkillExample` after the documentation example directory reorganization. The example now points to the existing `agentscope-examples/documentation/src/main/resources/skills` directory.

Validation:
- `mvn -pl agentscope-examples/documentation -am compile -DskipTests -Dspotless.check.skip=true -q`
- `git diff --cached --check`

Note: the reactor-wide Spotless check is currently blocked by pre-existing CRLF formatting violations in 104 files under `agentscope-core`; the changed file itself has no formatting violations.

## Checklist

- [x] Code has been checked for formatting
- [x] Relevant module compiles successfully
- [x] Javadoc comments are complete and follow project conventions
- [x] Related documentation/examples have been updated
- [x] Code is ready for review