### PR TITLE
fix(harness): inherit parent execution configs in declared subagents

### DIFF
--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/HarnessAgentBuilderSupport.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/HarnessAgentBuilderSupport.java
@@ -388,6 +388,12 @@ final class HarnessAgentBuilderSupport {
         final boolean capturedDisableMemoryHooks = b.disableMemoryHooks;
         final boolean capturedDisableSessionPersistence = b.disableSessionPersistence;
         final GenerateOptions capturedGenOpts = b.generateOptions;
+        // See buildGeneralPurposeFactory: propagate the parent's model/tool execution configs so
+        // declared subagents honor the parent's timeouts. Without this they fall back to
+        // ExecutionConfig defaults (e.g. the 5-minute tool timeout), ignoring a longer timeout
+        // configured on the main agent.
+        final ExecutionConfig capturedModelExec = b.modelExecutionConfig;
+        final ExecutionConfig capturedToolExec = b.toolExecutionConfig;
         // Snapshot of main agent's Local filesystem configuration. ISOLATED subagents get a
         // fresh spec carrying the same project / additionalRoots / mode so PathPolicy stays in
         // sync; without this, every isolated subagent would default to project=${user.dir} and
@@ -463,6 +469,9 @@ final class HarnessAgentBuilderSupport {
             if (capturedStateStore != null) {
                 sub.stateStore(capturedStateStore);
             }
+
+            if (capturedModelExec != null) sub.modelExecutionConfig(capturedModelExec);
+            if (capturedToolExec != null) sub.toolExecutionConfig(capturedToolExec);
 
             if (capturedDisableFilesystemTools) sub.disableFilesystemTools();
             if (capturedDisableShellTool) sub.disableShellTool();

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/HarnessAgentTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/HarnessAgentTest.java
@@ -37,6 +37,7 @@ import io.agentscope.core.message.MsgRole;
 import io.agentscope.core.message.TextBlock;
 import io.agentscope.core.middleware.MiddlewareBase;
 import io.agentscope.core.model.ChatResponse;
+import io.agentscope.core.model.ExecutionConfig;
 import io.agentscope.core.model.Model;
 import io.agentscope.core.model.ToolSchema;
 import io.agentscope.core.shutdown.GracefulShutdownMiddleware;
@@ -61,6 +62,7 @@ import io.agentscope.harness.agent.workspace.WorkspaceConstants;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.time.Duration;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
@@ -888,6 +890,57 @@ class HarnessAgentTest {
                 workspace.normalize(),
                 child.getWorkspaceManager().getWorkspace().normalize(),
                 "general-purpose must share mainWorkspace");
+    }
+
+    // =========================================================================
+    // declared subagent execution-config inheritance (issue #2230)
+    // =========================================================================
+
+    /**
+     * A declared subagent must inherit the parent agent's {@code toolExecutionConfig} and {@code
+     * modelExecutionConfig}. Before the fix, {@code buildDeclaredFactory} never propagated them, so
+     * a declared subagent silently fell back to {@link ExecutionConfig} defaults (e.g. the
+     * 5-minute tool timeout), ignoring a longer timeout configured on the main agent.
+     */
+    @Test
+    void declaredSubagent_inheritsExecutionConfigsFromParent() throws Exception {
+        Files.createDirectories(workspace);
+
+        ExecutionConfig toolExec =
+                ExecutionConfig.builder().timeout(Duration.ofHours(1)).maxAttempts(2).build();
+        ExecutionConfig modelExec =
+                ExecutionConfig.builder().timeout(Duration.ofMinutes(3)).maxAttempts(4).build();
+
+        SubagentDeclaration decl =
+                SubagentDeclaration.builder()
+                        .name("worker")
+                        .description("declared worker")
+                        .workspaceMode(WorkspaceMode.ISOLATED)
+                        .inlineAgentsBody("You are a worker subagent.")
+                        .build();
+
+        List<SubagentEntry> entries =
+                HarnessAgent.builder()
+                        .model(stubModel("ok"))
+                        .workspace(workspace)
+                        .toolExecutionConfig(toolExec)
+                        .modelExecutionConfig(modelExec)
+                        .subagent(decl)
+                        .buildSubagentEntries(workspace);
+
+        SubagentEntry entry =
+                entries.stream().filter(e -> "worker".equals(e.name())).findFirst().orElseThrow();
+        HarnessAgent child = (HarnessAgent) entry.factory().create(RuntimeContext.empty());
+        ReActAgent delegate = child.getDelegate();
+
+        assertSame(
+                toolExec,
+                delegate.getToolExecutionConfig(),
+                "declared subagent must inherit parent toolExecutionConfig");
+        assertSame(
+                modelExec,
+                delegate.getModelExecutionConfig(),
+                "declared subagent must inherit parent modelExecutionConfig");
     }
 
     // =========================================================================


### PR DESCRIPTION
## AgentScope-Java Version

`2.0.1-SNAPSHOT` (reproduced on latest `main`)

## Description

**Background.** `HarnessAgentBuilderSupport` has two subagent factories that are meant to behave consistently: `buildGeneralPurposeFactory` and `buildDeclaredFactory`. The general-purpose factory captures the parent agent's `modelExecutionConfig` / `toolExecutionConfig` and applies them to the child, but `buildDeclaredFactory` never did.

**Symptom.** A declared subagent (registered via `HarnessAgent.Builder.subagent(SubagentDeclaration)` / `.subagents(...)`) silently falls back to `ExecutionConfig` defaults — e.g. the 5-minute tool timeout — even when the main agent configures a longer `toolExecutionConfig`. In COORDINATOR mode a slow-tool worker subagent hits `Tool execution timeout after PT5M` despite the parent being configured for, say, 1 hour.

**Fix.** Capture `modelExecutionConfig` / `toolExecutionConfig` in `buildDeclaredFactory` and apply them to the child builder, mirroring the existing pattern in `buildGeneralPurposeFactory`. `SubagentDeclaration` carries no execution-config fields of its own, so straight inheritance is correct (no per-declaration overlay needed, unlike temperature/topP).

**Testing.** Added `HarnessAgentTest#declaredSubagent_inheritsExecutionConfigsFromParent`: builds a parent with non-default tool/model execution configs, materializes the declared subagent through the real factory path (`buildSubagentEntries` → `factory().create(...)`), and asserts the child's delegate carries the same configs. Verified the test fails before the fix (`expected <ExecutionConfig> but was <null>`) and passes after. Full `agentscope-harness` suite green (635 run, 0 failures, 3 pre-existing skips).

Closes #2230

## Checklist

- [x] Code has been formatted with `mvn spotless:apply`
- [x] All tests are passing (`mvn test`)
- [x] Javadoc comments are complete and follow project conventions
- [x] Related documentation has been updated (e.g. links, examples, etc.)
- [x] Code is ready for review