### PR TITLE
fix(core): handle malformed Unicode when writing agent state files

### DIFF
--- a/agentscope-core/src/main/java/io/agentscope/core/state/JsonFileAgentStateStore.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/state/JsonFileAgentStateStore.java
@@ -19,6 +19,9 @@ import io.agentscope.core.util.JsonUtils;
 import java.io.BufferedReader;
 import java.io.BufferedWriter;
 import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.nio.charset.CharsetEncoder;
+import java.nio.charset.CodingErrorAction;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -135,9 +138,8 @@ public class JsonFileAgentStateStore implements AgentStateStore {
     private void rewriteEntireList(Path file, List<? extends State> values) throws IOException {
         Path tmp = file.resolveSibling(file.getFileName() + ".tmp");
         try (BufferedWriter writer =
-                Files.newBufferedWriter(
+                newUtf8ReplacingWriter(
                         tmp,
-                        StandardCharsets.UTF_8,
                         StandardOpenOption.CREATE,
                         StandardOpenOption.TRUNCATE_EXISTING,
                         StandardOpenOption.WRITE)) {
@@ -151,11 +153,8 @@ public class JsonFileAgentStateStore implements AgentStateStore {
 
     private void appendToList(Path file, List<? extends State> items) throws IOException {
         try (BufferedWriter writer =
-                Files.newBufferedWriter(
-                        file,
-                        StandardCharsets.UTF_8,
-                        StandardOpenOption.CREATE,
-                        StandardOpenOption.APPEND)) {
+                newUtf8ReplacingWriter(
+                        file, StandardOpenOption.CREATE, StandardOpenOption.APPEND)) {
             for (State item : items) {
                 writer.write(JsonUtils.getJsonCodec().toJson(item));
                 writer.newLine();
@@ -318,8 +317,30 @@ public class JsonFileAgentStateStore implements AgentStateStore {
 
     private static void atomicWriteString(Path file, String content) throws IOException {
         Path tmp = file.resolveSibling(file.getFileName() + ".tmp");
-        Files.writeString(tmp, content, StandardCharsets.UTF_8);
+        try (BufferedWriter writer =
+                newUtf8ReplacingWriter(
+                        tmp,
+                        StandardOpenOption.CREATE,
+                        StandardOpenOption.TRUNCATE_EXISTING,
+                        StandardOpenOption.WRITE)) {
+            writer.write(content);
+        }
         Files.move(tmp, file, StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING);
+    }
+
+    private static BufferedWriter newUtf8ReplacingWriter(Path file, StandardOpenOption... options)
+            throws IOException {
+        return new BufferedWriter(
+                new OutputStreamWriter(
+                        Files.newOutputStream(file, options), utf8ReplacingEncoder()));
+    }
+
+    private static CharsetEncoder utf8ReplacingEncoder() {
+        return StandardCharsets.UTF_8
+                .newEncoder()
+                .replaceWith(new byte[] {(byte) 0xEF, (byte) 0xBF, (byte) 0xBD})
+                .onMalformedInput(CodingErrorAction.REPLACE)
+                .onUnmappableCharacter(CodingErrorAction.REPLACE);
     }
 
     private long countLines(Path file) {

--- a/agentscope-core/src/test/java/io/agentscope/core/state/JsonFileAgentStateStoreTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/state/JsonFileAgentStateStoreTest.java
@@ -29,7 +29,7 @@ import org.junit.jupiter.api.io.TempDir;
 class JsonFileAgentStateStoreTest {
 
     @Test
-    @DisplayName("Should sanitize invalid unicode when saving single state")
+    @DisplayName("Should sanitize invalid Unicode when saving single state")
     void saveSanitizesInvalidUnicode(@TempDir Path tempDir) {
         JsonFileAgentStateStore store = new JsonFileAgentStateStore(tempDir);
 
@@ -41,7 +41,7 @@ class JsonFileAgentStateStoreTest {
     }
 
     @Test
-    @DisplayName("Should sanitize invalid unicode when saving list state")
+    @DisplayName("Should sanitize invalid Unicode when saving list state")
     void saveListSanitizesInvalidUnicode(@TempDir Path tempDir) {
         JsonFileAgentStateStore store = new JsonFileAgentStateStore(tempDir);
 
@@ -57,5 +57,28 @@ class JsonFileAgentStateStoreTest {
         assertEquals("before \uFFFD after", loaded.get(0).value());
     }
 
+    @Test
+    @DisplayName("Should sanitize invalid Unicode when rewriting list state")
+    void rewriteListSanitizesInvalidUnicode(@TempDir Path tempDir) {
+        JsonFileAgentStateStore store = new JsonFileAgentStateStore(tempDir);
+
+        store.save(
+                null,
+                "session1",
+                "memory_messages",
+                List.of(new TestState("ok", 1), new TestState("ok2", 2)));
+
+        // Shrink list to force rewriteEntireList(...)
+        store.save(
+                null,
+                "session1",
+                "memory_messages",
+                List.of(new TestState("before \uD800 after", 1)));
+
+        List<TestState> loaded =
+                store.getList(null, "session1", "memory_messages", TestState.class);
+        assertEquals(1, loaded.size());
+        assertEquals("before \uFFFD after", loaded.get(0).value());
+    }
+
     public record TestState(String value, int count) implements State {}
-}

--- a/agentscope-core/src/test/java/io/agentscope/core/state/JsonFileAgentStateStoreTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/state/JsonFileAgentStateStoreTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.core.state;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Path;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/** Tests for JsonFileAgentStateStore. */
+@DisplayName("JsonFileAgentStateStore Tests")
+class JsonFileAgentStateStoreTest {
+
+    @Test
+    @DisplayName("Should sanitize invalid unicode when saving single state")
+    void saveSanitizesInvalidUnicode(@TempDir Path tempDir) {
+        JsonFileAgentStateStore store = new JsonFileAgentStateStore(tempDir);
+
+        store.save(null, "session1", "agent_state", new TestState("before \uD800 after", 1));
+
+        var loaded = store.get(null, "session1", "agent_state", TestState.class);
+        assertTrue(loaded.isPresent());
+        assertEquals("before \uFFFD after", loaded.get().value());
+    }
+
+    @Test
+    @DisplayName("Should sanitize invalid unicode when saving list state")
+    void saveListSanitizesInvalidUnicode(@TempDir Path tempDir) {
+        JsonFileAgentStateStore store = new JsonFileAgentStateStore(tempDir);
+
+        store.save(
+                null,
+                "session1",
+                "memory_messages",
+                List.of(new TestState("before \uD800 after", 1)));
+
+        List<TestState> loaded =
+                store.getList(null, "session1", "memory_messages", TestState.class);
+        assertEquals(1, loaded.size());
+        assertEquals("before \uFFFD after", loaded.get(0).value());
+    }
+
+    public record TestState(String value, int count) implements State {}
+}

--- a/agentscope-core/src/test/java/io/agentscope/core/state/JsonFileAgentStateStoreTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/state/JsonFileAgentStateStoreTest.java
@@ -82,3 +82,4 @@ class JsonFileAgentStateStoreTest {
     }
 
     public record TestState(String value, int count) implements State {}
+}


### PR DESCRIPTION
## AgentScope-Java Version

2.0.1-SNAPSHOT

## Description

Fixes #2204.

`JsonFileAgentStateStore` could throw an `UnmappableCharacterException` when serialized state contained malformed UTF-16 input, such as an unpaired surrogate (`\uD800`). This caused state persistence to fail and could interrupt `HarnessAgent.streamEvents()`.

This PR:

- Adds a UTF-8 writer configured to replace malformed or unmappable input with the Unicode replacement character (`\uFFFD`).
- Applies the writer to single-state atomic writes, full list rewrites, and list appends.
- Keeps the existing `JsonCodec.toPrettyJson()` and `JsonCodec.toJson()` serialization behavior unchanged.
- Adds tests covering malformed Unicode in single-state and list-state persistence.

Tested with:

`mvn -pl agentscope-core -Dtest=JsonFileAgentStateStoreTest test`

## Checklist

Please check the following items before code is ready to be reviewed.

- [x] Code has been formatted with `mvn spotless:apply`
- [x] All tests are passing (`mvn test`)
- [x] Javadoc comments are complete and follow project conventions
- [x] Related documentation has been updated (not applicable; no documentation changes required)
- [x] Code is ready for review