### PR TITLE
refactor(builder): abstract session metadata storage

### DIFF
--- a/agentscope-examples/agents/agentscope-builder/src/main/java/io/agentscope/builder/runtime/BuilderBootstrap.java
+++ b/agentscope-examples/agents/agentscope-builder/src/main/java/io/agentscope/builder/runtime/BuilderBootstrap.java
@@ -25,6 +25,7 @@ import io.agentscope.builder.runtime.config.SkillRepositorySupport;
 import io.agentscope.builder.runtime.gateway.HarnessGateway;
 import io.agentscope.builder.runtime.outbound.OutboundTool;
 import io.agentscope.builder.runtime.session.AgentManagerConfig;
+import io.agentscope.builder.runtime.session.LocalSessionStore;
 import io.agentscope.builder.runtime.session.SessionAgentManager;
 import io.agentscope.builder.runtime.session.SessionStore;
 import io.agentscope.builder.runtime.session.SubagentRunRegistry;
@@ -426,6 +427,8 @@ public final class BuilderBootstrap {
         private final List<Consumer<HarnessAgent.Builder>> globalConfigurators =
                 new java.util.ArrayList<>();
         private final Map<String, Channel> channels = new LinkedHashMap<>();
+        private SessionStore sessionStore;
+        private boolean useRemoteSessionStore;
 
         private Builder() {}
 
@@ -485,6 +488,21 @@ public final class BuilderBootstrap {
                     this.channels.put(c.channelId(), c);
                 }
             }
+            return this;
+        }
+
+        /** Uses the provided session metadata store instead of the default local JSON store. */
+        public Builder sessionStore(SessionStore sessionStore) {
+            this.sessionStore = Objects.requireNonNull(sessionStore, "sessionStore");
+            return this;
+        }
+
+        /**
+         * Requires a concrete remote {@link SessionStore} to be provided via {@link
+         * #sessionStore(SessionStore)} when the runtime is configured for distributed storage.
+         */
+        public Builder remoteSessionStore(boolean remote) {
+            this.useRemoteSessionStore = remote;
             return this;
         }
 
@@ -563,7 +581,16 @@ public final class BuilderBootstrap {
             DefaultAgentManager dam = new DefaultAgentManager(entries, wsManager);
 
             Path storeFile = mainWorkspace.resolve("sessions.json");
-            SessionStore sessionStore = new SessionStore(storeFile);
+            if (this.sessionStore == null && useRemoteSessionStore) {
+                throw new IllegalStateException(
+                        "Distributed session metadata requires a SessionStore implementation; "
+                                + "call BuilderBootstrap.Builder.sessionStore(...) with a "
+                                + "shared remote store.");
+            }
+            SessionStore sessionStore =
+                    this.sessionStore != null
+                            ? this.sessionStore
+                            : new LocalSessionStore(storeFile);
             sessionStore.load();
 
             AgentManagerConfig amCfg = resolveAgentManagerConfig(fileConfig);

--- a/agentscope-examples/agents/agentscope-builder/src/main/java/io/agentscope/builder/runtime/session/LocalSessionStore.java
+++ b/agentscope-examples/agents/agentscope-builder/src/main/java/io/agentscope/builder/runtime/session/LocalSessionStore.java
@@ -1,0 +1,190 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.builder.runtime.session;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Local {@link SessionStore} backed by a JSON file ({@code sessions.json}). Mirrors OpenClaw's
+ * {@code sessions.json} store that tracks session metadata across restarts.
+ *
+ * <p>Thread-safe: uses a read-write lock so concurrent reads are non-blocking and writes are
+ * serialized. File writes are atomic (write to temp, then rename).
+ */
+public final class LocalSessionStore implements SessionStore {
+
+    private static final Logger log = LoggerFactory.getLogger(LocalSessionStore.class);
+    private static final ObjectMapper MAPPER =
+            new ObjectMapper().enable(SerializationFeature.INDENT_OUTPUT);
+
+    private final Path storeFile;
+    private final ReentrantReadWriteLock lock = new ReentrantReadWriteLock();
+    private final Map<String, StoredEntry> entries = new LinkedHashMap<>();
+
+    public LocalSessionStore(Path storeFile) {
+        this.storeFile = storeFile;
+    }
+
+    /**
+     * Loads all entries from the store file into memory. Call once on startup. If the file does not
+     * exist or is empty, the store starts empty.
+     */
+    @Override
+    public void load() {
+        lock.writeLock().lock();
+        try {
+            entries.clear();
+            if (!Files.isRegularFile(storeFile)) {
+                return;
+            }
+            String json = Files.readString(storeFile, StandardCharsets.UTF_8);
+            if (json.isBlank()) {
+                return;
+            }
+            Map<String, StoredEntry> loaded =
+                    MAPPER.readValue(
+                            json, new TypeReference<LinkedHashMap<String, StoredEntry>>() {});
+            if (loaded != null) {
+                entries.putAll(loaded);
+            }
+            log.info("Loaded {} session entries from {}", entries.size(), storeFile);
+        } catch (IOException e) {
+            log.warn("Failed to load session store from {}: {}", storeFile, e.getMessage());
+        } finally {
+            lock.writeLock().unlock();
+        }
+    }
+
+    @Override
+    public void save(SessionEntry entry) {
+        lock.writeLock().lock();
+        try {
+            entries.put(entry.sessionKey(), StoredEntry.from(entry));
+            flushToDisk();
+        } finally {
+            lock.writeLock().unlock();
+        }
+    }
+
+    @Override
+    public void touch(String sessionKey, long lastActivityMs) {
+        lock.writeLock().lock();
+        try {
+            StoredEntry existing = entries.get(sessionKey);
+            if (existing == null) {
+                return;
+            }
+            entries.put(
+                    sessionKey,
+                    new StoredEntry(
+                            existing.sessionKey(),
+                            existing.agentId(),
+                            existing.sessionId(),
+                            existing.label(),
+                            existing.kind(),
+                            existing.spawnedBy(),
+                            existing.spawnDepth(),
+                            existing.createdAtMs(),
+                            lastActivityMs,
+                            existing.sessionFilePath(),
+                            existing.spawnRunId(),
+                            existing.gateKey(),
+                            existing.userId()));
+            flushToDisk();
+        } finally {
+            lock.writeLock().unlock();
+        }
+    }
+
+    @Override
+    public void remove(String sessionKey) {
+        lock.writeLock().lock();
+        try {
+            if (entries.remove(sessionKey) != null) {
+                flushToDisk();
+            }
+        } finally {
+            lock.writeLock().unlock();
+        }
+    }
+
+    @Override
+    public Collection<StoredEntry> listAll() {
+        lock.readLock().lock();
+        try {
+            return List.copyOf(entries.values());
+        } finally {
+            lock.readLock().unlock();
+        }
+    }
+
+    @Override
+    public Optional<StoredEntry> get(String sessionKey) {
+        lock.readLock().lock();
+        try {
+            return Optional.ofNullable(entries.get(sessionKey));
+        } finally {
+            lock.readLock().unlock();
+        }
+    }
+
+    @Override
+    public int size() {
+        lock.readLock().lock();
+        try {
+            return entries.size();
+        } finally {
+            lock.readLock().unlock();
+        }
+    }
+
+    /** The path to the backing store file. */
+    public Path getStoreFile() {
+        return storeFile;
+    }
+
+    private void flushToDisk() {
+        try {
+            Files.createDirectories(storeFile.getParent());
+            Path tmp = storeFile.resolveSibling(storeFile.getFileName() + ".tmp");
+            byte[] bytes = MAPPER.writeValueAsBytes(entries);
+            Files.write(
+                    tmp, bytes, StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING);
+            Files.move(
+                    tmp,
+                    storeFile,
+                    java.nio.file.StandardCopyOption.REPLACE_EXISTING,
+                    java.nio.file.StandardCopyOption.ATOMIC_MOVE);
+        } catch (IOException e) {
+            log.warn("Failed to flush session store to {}: {}", storeFile, e.getMessage());
+        }
+    }
+}

--- a/agentscope-examples/agents/agentscope-builder/src/main/java/io/agentscope/builder/runtime/session/RemoteSessionStore.java
+++ b/agentscope-examples/agents/agentscope-builder/src/main/java/io/agentscope/builder/runtime/session/RemoteSessionStore.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.builder.runtime.session;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Fail-fast {@link SessionStore} placeholder for distributed deployments.
+ *
+ * <p>This class intentionally rejects mutations until a concrete remote backend is wired. It
+ * prevents the builder runtime from silently dropping session metadata when the rest of the runtime
+ * is configured for distributed storage.
+ */
+public final class RemoteSessionStore implements SessionStore {
+
+    @Override
+    public void load() {}
+
+    @Override
+    public void save(SessionEntry entry) {
+        throw unsupported();
+    }
+
+    @Override
+    public void touch(String sessionKey, long lastActivityMs) {
+        throw unsupported();
+    }
+
+    @Override
+    public void remove(String sessionKey) {
+        throw unsupported();
+    }
+
+    @Override
+    public Collection<StoredEntry> listAll() {
+        return List.of();
+    }
+
+    @Override
+    public Optional<StoredEntry> get(String sessionKey) {
+        return Optional.empty();
+    }
+
+    @Override
+    public int size() {
+        return 0;
+    }
+
+    private static UnsupportedOperationException unsupported() {
+        return new UnsupportedOperationException(
+                "RemoteSessionStore is a placeholder; provide a concrete SessionStore "
+                        + "implementation backed by shared storage.");
+    }
+}

--- a/agentscope-examples/agents/agentscope-builder/src/main/java/io/agentscope/builder/runtime/session/SessionStore.java
+++ b/agentscope-examples/agents/agentscope-builder/src/main/java/io/agentscope/builder/runtime/session/SessionStore.java
@@ -16,51 +16,49 @@
 package io.agentscope.builder.runtime.session;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
-import java.io.IOException;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.StandardOpenOption;
 import java.util.Collection;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
 import java.util.Optional;
-import java.util.concurrent.locks.ReentrantReadWriteLock;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
- * Durable session registry backed by a JSON file ({@code sessions.json}). Mirrors OpenClaw's
- * {@code sessions.json} store that tracks session metadata across restarts.
+ * Durable session metadata registry.
  *
- * <p>Thread-safe: uses a read-write lock so concurrent reads are non-blocking and writes are
- * serialized. File writes are atomic (write to temp, then rename).
- *
- * <p>The store file contains a JSON object keyed by {@code sessionKey}, where each value is a
- * {@link StoredEntry} capturing the subset of {@link SessionEntry} fields that need to survive
- * restarts.
+ * <p>Implementations decide where session metadata lives. The default local implementation keeps
+ * the current {@code sessions.json} behavior, while distributed deployments can provide a remote
+ * implementation shared by all replicas.
  */
-public final class SessionStore {
-
-    private static final Logger log = LoggerFactory.getLogger(SessionStore.class);
-    private static final ObjectMapper MAPPER =
-            new ObjectMapper().enable(SerializationFeature.INDENT_OUTPUT);
-
-    private final Path storeFile;
-    private final ReentrantReadWriteLock lock = new ReentrantReadWriteLock();
-    private final Map<String, StoredEntry> entries = new LinkedHashMap<>();
+public interface SessionStore {
 
     /**
-     * JSON-serializable subset of {@link SessionEntry} for disk persistence. Uses
+     * Loads the backing store into the implementation cache, if any. Implementations that read
+     * directly from a remote backend may no-op.
+     */
+    void load();
+
+    /** Persists a single session entry (upsert). */
+    void save(SessionEntry entry);
+
+    /** Updates only the {@code lastActivityMs} for the given key. */
+    void touch(String sessionKey, long lastActivityMs);
+
+    /** Removes a session entry by key. */
+    void remove(String sessionKey);
+
+    /** Returns a snapshot of all stored entries. */
+    Collection<StoredEntry> listAll();
+
+    /** Returns a single entry by key, if present. */
+    Optional<StoredEntry> get(String sessionKey);
+
+    /** Returns the current number of stored entries. */
+    int size();
+
+    /**
+     * JSON-serializable subset of {@link SessionEntry}. Uses
      * {@code @JsonIgnoreProperties(ignoreUnknown = true)} for forward compatibility when new
      * fields are added.
      */
     @JsonIgnoreProperties(ignoreUnknown = true)
-    public record StoredEntry(
+    record StoredEntry(
             String sessionKey,
             String agentId,
             String sessionId,
@@ -108,143 +106,6 @@ public final class SessionStore {
                     spawnRunId,
                     gateKey,
                     userId);
-        }
-    }
-
-    public SessionStore(Path storeFile) {
-        this.storeFile = storeFile;
-    }
-
-    /**
-     * Loads all entries from the store file into memory. Call once on startup. If the file does not
-     * exist or is empty, the store starts empty.
-     */
-    public void load() {
-        lock.writeLock().lock();
-        try {
-            entries.clear();
-            if (!Files.isRegularFile(storeFile)) {
-                return;
-            }
-            String json = Files.readString(storeFile, StandardCharsets.UTF_8);
-            if (json.isBlank()) {
-                return;
-            }
-            Map<String, StoredEntry> loaded =
-                    MAPPER.readValue(
-                            json, new TypeReference<LinkedHashMap<String, StoredEntry>>() {});
-            if (loaded != null) {
-                entries.putAll(loaded);
-            }
-            log.info("Loaded {} session entries from {}", entries.size(), storeFile);
-        } catch (IOException e) {
-            log.warn("Failed to load session store from {}: {}", storeFile, e.getMessage());
-        } finally {
-            lock.writeLock().unlock();
-        }
-    }
-
-    /** Persists a single session entry (upsert). */
-    public void save(SessionEntry entry) {
-        lock.writeLock().lock();
-        try {
-            entries.put(entry.sessionKey(), StoredEntry.from(entry));
-            flushToDisk();
-        } finally {
-            lock.writeLock().unlock();
-        }
-    }
-
-    /** Updates only the {@code lastActivityMs} for the given key without a full entry replace. */
-    public void touch(String sessionKey, long lastActivityMs) {
-        lock.writeLock().lock();
-        try {
-            StoredEntry existing = entries.get(sessionKey);
-            if (existing == null) {
-                return;
-            }
-            entries.put(
-                    sessionKey,
-                    new StoredEntry(
-                            existing.sessionKey(),
-                            existing.agentId(),
-                            existing.sessionId(),
-                            existing.label(),
-                            existing.kind(),
-                            existing.spawnedBy(),
-                            existing.spawnDepth(),
-                            existing.createdAtMs(),
-                            lastActivityMs,
-                            existing.sessionFilePath(),
-                            existing.spawnRunId(),
-                            existing.gateKey(),
-                            existing.userId()));
-            flushToDisk();
-        } finally {
-            lock.writeLock().unlock();
-        }
-    }
-
-    /** Removes a session entry by key. */
-    public void remove(String sessionKey) {
-        lock.writeLock().lock();
-        try {
-            if (entries.remove(sessionKey) != null) {
-                flushToDisk();
-            }
-        } finally {
-            lock.writeLock().unlock();
-        }
-    }
-
-    /** Returns a snapshot of all stored entries. */
-    public Collection<StoredEntry> listAll() {
-        lock.readLock().lock();
-        try {
-            return List.copyOf(entries.values());
-        } finally {
-            lock.readLock().unlock();
-        }
-    }
-
-    /** Returns a single entry by key, if present. */
-    public Optional<StoredEntry> get(String sessionKey) {
-        lock.readLock().lock();
-        try {
-            return Optional.ofNullable(entries.get(sessionKey));
-        } finally {
-            lock.readLock().unlock();
-        }
-    }
-
-    public int size() {
-        lock.readLock().lock();
-        try {
-            return entries.size();
-        } finally {
-            lock.readLock().unlock();
-        }
-    }
-
-    /** The path to the backing store file. */
-    public Path getStoreFile() {
-        return storeFile;
-    }
-
-    private void flushToDisk() {
-        try {
-            Files.createDirectories(storeFile.getParent());
-            Path tmp = storeFile.resolveSibling(storeFile.getFileName() + ".tmp");
-            byte[] bytes = MAPPER.writeValueAsBytes(entries);
-            Files.write(
-                    tmp, bytes, StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING);
-            Files.move(
-                    tmp,
-                    storeFile,
-                    java.nio.file.StandardCopyOption.REPLACE_EXISTING,
-                    java.nio.file.StandardCopyOption.ATOMIC_MOVE);
-        } catch (IOException e) {
-            log.warn("Failed to flush session store to {}: {}", storeFile, e.getMessage());
         }
     }
 }

--- a/agentscope-examples/agents/agentscope-builder/src/main/java/io/agentscope/builder/web/config/BuilderConfig.java
+++ b/agentscope-examples/agents/agentscope-builder/src/main/java/io/agentscope/builder/web/config/BuilderConfig.java
@@ -17,6 +17,7 @@ package io.agentscope.builder.web.config;
 
 import io.agentscope.builder.runtime.BuilderBootstrap;
 import io.agentscope.builder.runtime.config.ChannelConfigEntry;
+import io.agentscope.builder.runtime.session.SessionStore;
 import io.agentscope.builder.web.toolbus.ToolEventBus;
 import io.agentscope.builder.web.toolbus.ToolNotificationMiddleware;
 import io.agentscope.core.model.Model;
@@ -182,7 +183,8 @@ public class BuilderConfig {
             Optional<Model> modelOpt,
             ToolEventBus toolEventBus,
             BaseStore baseStore,
-            Optional<AgentStateStore> sessionOpt)
+            Optional<AgentStateStore> sessionOpt,
+            Optional<SessionStore> sessionStoreOpt)
             throws IOException {
         Path cwd = resolveCwd();
         ensureAgentscopeConfig();
@@ -220,6 +222,20 @@ public class BuilderConfig {
             log.info(
                     "Effective AgentStateStore is distributed ({}); using RemoteFilesystemSpec.",
                     stateStore.getClass().getSimpleName());
+        }
+
+        if (sessionStoreOpt.isPresent()) {
+            builder.sessionStore(sessionStoreOpt.get());
+            log.info(
+                    "Using custom SessionStore implementation: {}",
+                    sessionStoreOpt.get().getClass().getSimpleName());
+        } else if (localStore) {
+            log.info("Using built-in local session metadata store");
+        } else {
+            throw new IllegalStateException(
+                    "Distributed AgentStateStore requires a shared SessionStore bean for "
+                            + "session metadata. Provide a SessionStore implementation or use a "
+                            + "local AgentStateStore for single-node deployments.");
         }
 
         builder.configureAllAgents(

--- a/agentscope-examples/agents/agentscope-builder/src/test/java/io/agentscope/builder/BuilderAppContextLoadTest.java
+++ b/agentscope-examples/agents/agentscope-builder/src/test/java/io/agentscope/builder/BuilderAppContextLoadTest.java
@@ -101,14 +101,12 @@ class BuilderAppContextLoadTest {
             return new InMemoryStore();
         }
 
-        // Mockito.delegatesTo creates a proxy typed as AgentStateStore (not
-        // InMemoryAgentStateStore), bypassing HarnessAgent.isLocalSession() instanceof.
+        // Keep this hermetic context on the single-node topology. Using the concrete local store
+        // also lets BuilderConfig select its built-in local session metadata store.
         @Bean
         @Primary
         AgentStateStore testStateStore() {
-            return Mockito.mock(
-                    AgentStateStore.class,
-                    org.mockito.AdditionalAnswers.delegatesTo(new InMemoryAgentStateStore()));
+            return new InMemoryAgentStateStore();
         }
     }
 }

--- a/agentscope-examples/agents/agentscope-builder/src/test/java/io/agentscope/builder/BuilderBootstrapSmokeTest.java
+++ b/agentscope-examples/agents/agentscope-builder/src/test/java/io/agentscope/builder/BuilderBootstrapSmokeTest.java
@@ -15,13 +15,20 @@
  */
 package io.agentscope.builder;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.agentscope.builder.runtime.BuilderBootstrap;
+import io.agentscope.builder.runtime.session.LocalSessionStore;
+import io.agentscope.builder.runtime.session.SessionStore;
 import io.agentscope.core.message.Msg;
 import io.agentscope.core.message.TextBlock;
 import io.agentscope.core.model.ChatResponse;
@@ -101,6 +108,62 @@ class BuilderBootstrapSmokeTest {
         ChatUiChannel chat = bootstrap.chatUiChannel();
         Msg reply = chat.send("hello").block();
         assertTrue(reply.getTextContent().contains("from-main"));
+    }
+
+    @Test
+    void defaultsToLocalSessionStore() throws Exception {
+        BuilderBootstrap bootstrap =
+                BuilderBootstrap.builder()
+                        .skipConfigFile(true)
+                        .cwd(tempDir)
+                        .model(stubModel("reply"))
+                        .configureAgent("main", b -> b.name("main"))
+                        .mainAgent("main")
+                        .build();
+
+        SessionStore sessionStore = bootstrap.gateway().sessionAgentManager().getSessionStore();
+        LocalSessionStore localStore = assertInstanceOf(LocalSessionStore.class, sessionStore);
+        assertEquals(
+                tempDir.resolve(".agentscope/workspace/sessions.json").toAbsolutePath().normalize(),
+                localStore.getStoreFile());
+    }
+
+    @Test
+    void loadsAndInjectsCustomSessionStore() throws Exception {
+        SessionStore sessionStore = mock(SessionStore.class);
+        when(sessionStore.listAll()).thenReturn(List.of());
+
+        BuilderBootstrap bootstrap =
+                BuilderBootstrap.builder()
+                        .skipConfigFile(true)
+                        .cwd(tempDir)
+                        .model(stubModel("reply"))
+                        .configureAgent("main", b -> b.name("main"))
+                        .mainAgent("main")
+                        .remoteSessionStore(true)
+                        .sessionStore(sessionStore)
+                        .build();
+
+        verify(sessionStore).load();
+        assertSame(sessionStore, bootstrap.gateway().sessionAgentManager().getSessionStore());
+    }
+
+    @Test
+    void rejectsRemoteSessionModeWithoutSharedStore() {
+        IllegalStateException error =
+                assertThrows(
+                        IllegalStateException.class,
+                        () ->
+                                BuilderBootstrap.builder()
+                                        .skipConfigFile(true)
+                                        .cwd(tempDir)
+                                        .model(stubModel("reply"))
+                                        .configureAgent("main", b -> b.name("main"))
+                                        .mainAgent("main")
+                                        .remoteSessionStore(true)
+                                        .build());
+
+        assertTrue(error.getMessage().contains("requires a SessionStore implementation"));
     }
 
     private static Model stubModel(String assistantText) {

--- a/agentscope-examples/agents/agentscope-builder/src/test/java/io/agentscope/builder/runtime/session/SessionStoreTest.java
+++ b/agentscope-examples/agents/agentscope-builder/src/test/java/io/agentscope/builder/runtime/session/SessionStoreTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.builder.runtime.session;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class SessionStoreTest {
+
+    @TempDir Path tempDir;
+
+    @Test
+    void localSessionStorePersistsSessionsJson() {
+        Path storeFile = tempDir.resolve("sessions.json");
+        LocalSessionStore store = new LocalSessionStore(storeFile);
+
+        store.load();
+        store.save(entry("agent:main:main:session-1", 100L));
+        store.touch("agent:main:main:session-1", 200L);
+
+        LocalSessionStore reloaded = new LocalSessionStore(storeFile);
+        reloaded.load();
+
+        assertTrue(Files.isRegularFile(storeFile));
+        assertEquals(1, reloaded.size());
+        SessionEntry restored =
+                reloaded.get("agent:main:main:session-1").orElseThrow().toSessionEntry();
+        assertEquals("main", restored.agentId());
+        assertEquals(200L, restored.lastActivityMs());
+        assertEquals("user-1", restored.userId());
+    }
+
+    @Test
+    void remoteSessionStoreRejectsMutationsUntilConcreteBackendIsProvided() {
+        RemoteSessionStore store = new RemoteSessionStore();
+
+        store.load();
+
+        assertThrows(
+                UnsupportedOperationException.class,
+                () -> store.save(entry("agent:main:main:session-1", 100L)));
+        assertThrows(
+                UnsupportedOperationException.class,
+                () -> store.touch("agent:main:main:session-1", 200L));
+        assertThrows(
+                UnsupportedOperationException.class,
+                () -> store.remove("agent:main:main:session-1"));
+        assertEquals(0, store.size());
+        assertTrue(store.listAll().isEmpty());
+        assertTrue(store.get("agent:main:main:session-1").isEmpty());
+    }
+
+    private static SessionEntry entry(String sessionKey, long lastActivityMs) {
+        return new SessionEntry(
+                sessionKey,
+                "main",
+                "session-1",
+                "label",
+                SessionKind.MAIN,
+                null,
+                0,
+                100L,
+                lastActivityMs,
+                "/tmp/session-1.json",
+                null,
+                "gate-1",
+                "user-1");
+    }
+}

--- a/agentscope-examples/agents/agentscope-builder/src/test/java/io/agentscope/builder/runtime/session/SessionStoreTest.java
+++ b/agentscope-examples/agents/agentscope-builder/src/test/java/io/agentscope/builder/runtime/session/SessionStoreTest.java
@@ -15,12 +15,16 @@
  */
 package io.agentscope.builder.runtime.session;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Collection;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -47,6 +51,143 @@ class SessionStoreTest {
         assertEquals("main", restored.agentId());
         assertEquals(200L, restored.lastActivityMs());
         assertEquals("user-1", restored.userId());
+    }
+
+    @Test
+    void localSessionStoreStartsEmptyForMissingAndBlankFiles() throws IOException {
+        LocalSessionStore missingStore =
+                new LocalSessionStore(tempDir.resolve("missing-sessions.json"));
+
+        missingStore.load();
+
+        assertEquals(0, missingStore.size());
+
+        Path blankFile = tempDir.resolve("blank-sessions.json");
+        Files.writeString(blankFile, "  \n");
+        LocalSessionStore blankStore = new LocalSessionStore(blankFile);
+
+        blankStore.load();
+
+        assertEquals(0, blankStore.size());
+    }
+
+    @Test
+    void localSessionStoreUpsertsAndRemovesEntriesDurably() {
+        Path storeFile = tempDir.resolve("sessions.json");
+        LocalSessionStore store = new LocalSessionStore(storeFile);
+        String firstKey = "agent:main:main:session-1";
+        String secondKey = "agent:main:main:session-2";
+
+        store.save(entry(firstKey, 100L));
+        store.save(entry(firstKey, 300L));
+        store.save(entry(secondKey, 200L));
+
+        assertEquals(2, store.size());
+        assertEquals(300L, store.get(firstKey).orElseThrow().lastActivityMs());
+
+        store.remove(firstKey);
+
+        LocalSessionStore reloaded = new LocalSessionStore(storeFile);
+        reloaded.load();
+        assertEquals(1, reloaded.size());
+        assertTrue(reloaded.get(firstKey).isEmpty());
+        assertTrue(reloaded.get(secondKey).isPresent());
+        assertFalse(Files.exists(storeFile.resolveSibling("sessions.json.tmp")));
+    }
+
+    @Test
+    void localSessionStoreIgnoresUnknownKeysWithoutCreatingAFile() {
+        Path storeFile = tempDir.resolve("sessions.json");
+        LocalSessionStore store = new LocalSessionStore(storeFile);
+
+        store.touch("missing", 200L);
+        store.remove("missing");
+
+        assertEquals(0, store.size());
+        assertFalse(Files.exists(storeFile));
+    }
+
+    @Test
+    void localSessionStoreRecoversAsEmptyFromMalformedJson() throws IOException {
+        Path storeFile = tempDir.resolve("sessions.json");
+        LocalSessionStore store = new LocalSessionStore(storeFile);
+        store.save(entry("agent:main:main:session-1", 100L));
+        Files.writeString(storeFile, "{not-json");
+
+        assertDoesNotThrow(store::load);
+
+        assertEquals(0, store.size());
+        assertTrue(store.listAll().isEmpty());
+    }
+
+    @Test
+    void localSessionStoreIgnoresUnknownJsonFields() throws IOException {
+        Path storeFile = tempDir.resolve("sessions.json");
+        Files.writeString(
+                storeFile,
+                """
+                {
+                  "agent:main:main:session-1": {
+                    "sessionKey": "agent:main:main:session-1",
+                    "agentId": "main",
+                    "sessionId": "session-1",
+                    "label": "label",
+                    "kind": "main",
+                    "spawnDepth": 0,
+                    "createdAtMs": 100,
+                    "lastActivityMs": 200,
+                    "sessionFilePath": "/tmp/session-1.json",
+                    "gateKey": "gate-1",
+                    "userId": "user-1",
+                    "futureField": "ignored"
+                  }
+                }
+                """);
+        LocalSessionStore store = new LocalSessionStore(storeFile);
+
+        store.load();
+
+        SessionEntry restored =
+                store.get("agent:main:main:session-1").orElseThrow().toSessionEntry();
+        assertEquals("main", restored.agentId());
+        assertEquals(200L, restored.lastActivityMs());
+        assertEquals("user-1", restored.userId());
+    }
+
+    @Test
+    void localSessionStoreListAllReturnsAnImmutableSnapshot() {
+        LocalSessionStore store = new LocalSessionStore(tempDir.resolve("sessions.json"));
+        store.save(entry("agent:main:main:session-1", 100L));
+
+        Collection<SessionStore.StoredEntry> snapshot = store.listAll();
+        store.save(entry("agent:main:main:session-2", 200L));
+
+        assertEquals(1, snapshot.size());
+        assertEquals(2, store.size());
+        assertThrows(UnsupportedOperationException.class, snapshot::clear);
+    }
+
+    @Test
+    void storedEntryRoundTripsAllSessionMetadata() {
+        SessionEntry original =
+                new SessionEntry(
+                        "agent:main:subagent:session-2",
+                        "worker",
+                        "session-2",
+                        "worker-label",
+                        SessionKind.SUBAGENT,
+                        "agent:main:main:session-1",
+                        2,
+                        100L,
+                        200L,
+                        "/tmp/session-2.json",
+                        "run-2",
+                        "gate-2",
+                        "user-2");
+
+        SessionEntry restored = SessionStore.StoredEntry.from(original).toSessionEntry();
+
+        assertEquals(original, restored);
     }
 
     @Test

--- a/agentscope-examples/agents/agentscope-builder/src/test/java/io/agentscope/builder/web/persistence/jpa/H2DemoSeedTest.java
+++ b/agentscope-examples/agents/agentscope-builder/src/test/java/io/agentscope/builder/web/persistence/jpa/H2DemoSeedTest.java
@@ -167,9 +167,7 @@ class H2DemoSeedTest {
         @Bean
         @Primary
         AgentStateStore testStateStore() {
-            return Mockito.mock(
-                    AgentStateStore.class,
-                    org.mockito.AdditionalAnswers.delegatesTo(new InMemoryAgentStateStore()));
+            return new InMemoryAgentStateStore();
         }
     }
 }

--- a/agentscope-examples/agents/agentscope-builder/src/test/java/io/agentscope/builder/web/persistence/jpa/JpaPersistenceIntegrationTest.java
+++ b/agentscope-examples/agents/agentscope-builder/src/test/java/io/agentscope/builder/web/persistence/jpa/JpaPersistenceIntegrationTest.java
@@ -198,9 +198,7 @@ class JpaPersistenceIntegrationTest {
         @Bean
         @Primary
         AgentStateStore testStateStore() {
-            return Mockito.mock(
-                    AgentStateStore.class,
-                    org.mockito.AdditionalAnswers.delegatesTo(new InMemoryAgentStateStore()));
+            return new InMemoryAgentStateStore();
         }
     }
 }


### PR DESCRIPTION
## AgentScope-Java Version

2.0.1-SNAPSHOT

## Description

Closes #2068.

### Background

The builder session registry was directly backed by a local `sessions.json` file. This coupled session metadata management to local storage and prevented multiple builder replicas from sharing the same session metadata.

### Changes

- Convert `SessionStore` from a local file implementation into a storage interface.
- Move the existing JSON persistence behavior into `LocalSessionStore`.
- Add a fail-fast `RemoteSessionStore` placeholder for future shared storage implementations.
- Allow custom `SessionStore` implementations to be injected through `BuilderBootstrap.Builder`.
- Keep `LocalSessionStore` as the default for single-node deployments.
- Require a shared `SessionStore` when the builder uses a distributed `AgentStateStore`.
- Fail during startup instead of silently falling back to local storage in distributed mode.
- Add tests covering:
  - Local persistence, reload, upsert, touch, and removal
  - Missing, blank, malformed, and forward-compatible JSON
  - Immutable session snapshots and metadata conversion
  - Remote placeholder behavior
  - Default local store selection
  - Custom store injection
  - Distributed mode validation

This PR establishes the storage abstraction and wiring required for distributed session metadata. A concrete database or Redis-backed implementation is intentionally left for follow-up work.

## Checklist

- [x] Code has been formatted with `mvn spotless:apply`
- [x] All tests are passing (`mvn test`) — targeted builder tests pass; the full test suite was not run
- [x] Javadoc comments are complete and follow project conventions
- [x] Related documentation has been updated (not applicable beyond API Javadocs)
- [x] Code is ready for review