### PR TITLE
fix(core): mark user interrupts with interrupted reason

### DIFF
--- a/agentscope-core/src/main/java/io/agentscope/core/ReActAgent.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/ReActAgent.java
@@ -3550,6 +3550,7 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
                             AssistantMessage.builder()
                                     .name(getName())
                                     .content(TextBlock.builder().text(recoveryText).build())
+                                    .generateReason(GenerateReason.INTERRUPTED)
                                     .build();
                     scope.state.contextMutable().add(recoveryMsg);
                     return saveStateToSession(scope)

--- a/agentscope-core/src/test/java/io/agentscope/core/agent/ReActAgentPerSessionStateTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/agent/ReActAgentPerSessionStateTest.java
@@ -26,6 +26,7 @@ import io.agentscope.core.event.AgentEndEvent;
 import io.agentscope.core.event.AgentEvent;
 import io.agentscope.core.event.AgentStartEvent;
 import io.agentscope.core.message.ContentBlock;
+import io.agentscope.core.message.GenerateReason;
 import io.agentscope.core.message.Msg;
 import io.agentscope.core.message.MsgRole;
 import io.agentscope.core.message.TextBlock;
@@ -145,13 +146,24 @@ class ReActAgentPerSessionStateTest {
         assertEquals(
                 "I noticed that you have interrupted me. What can I do for you?",
                 reply.getTextContent());
+        assertEquals(GenerateReason.INTERRUPTED, reply.getGenerateReason());
 
         ReActAgent reborn = agent(store);
-        List<String> texts = allText(reborn.getAgentState("u1", "sessA"));
+        AgentState restoredState = reborn.getAgentState("u1", "sessA");
+        List<String> texts = allText(restoredState);
         assertTrue(texts.contains("hello"), "user input should remain in persisted session state");
         assertTrue(
                 texts.contains("I noticed that you have interrupted me. What can I do for you?"),
                 "interrupt recovery message should be persisted to the state store");
+        Msg restoredRecovery =
+                restoredState.getContext().stream()
+                        .filter(
+                                msg ->
+                                        "I noticed that you have interrupted me. What can I do for you?"
+                                                .equals(msg.getTextContent()))
+                        .findFirst()
+                        .orElseThrow();
+        assertEquals(GenerateReason.INTERRUPTED, restoredRecovery.getGenerateReason());
     }
 
     private static final class DelayedFirstChunkModel extends ChatModelBase {

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/HarnessAgentSubagentStreamEventsTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/HarnessAgentSubagentStreamEventsTest.java
@@ -61,6 +61,7 @@ class HarnessAgentSubagentStreamEventsTest {
     @TempDir Path stateHome;
 
     private String previousStateHome;
+    private HarnessAgent parent;
 
     @BeforeEach
     void overrideStateHome() {
@@ -69,11 +70,17 @@ class HarnessAgentSubagentStreamEventsTest {
     }
 
     @AfterEach
-    void restoreStateHome() {
-        if (previousStateHome != null) {
-            System.setProperty("agentscope.state.home", previousStateHome);
-        } else {
-            System.clearProperty("agentscope.state.home");
+    void tearDown() {
+        try {
+            if (parent != null) {
+                parent.close();
+            }
+        } finally {
+            if (previousStateHome != null) {
+                System.setProperty("agentscope.state.home", previousStateHome);
+            } else {
+                System.clearProperty("agentscope.state.home");
+            }
         }
     }
 
@@ -141,7 +148,7 @@ class HarnessAgentSubagentStreamEventsTest {
                                 stopChunk("c1", "research complete")))
                 .thenReturn(Flux.just(stopChunk("p2", "summary done")));
 
-        HarnessAgent parent =
+        parent =
                 HarnessAgent.builder()
                         .name("parent")
                         .model(model)
@@ -214,7 +221,7 @@ class HarnessAgentSubagentStreamEventsTest {
                 .thenReturn(Flux.just(stopChunk("c1", "formatted")))
                 .thenReturn(Flux.just(stopChunk("p2", "all done")));
 
-        HarnessAgent parent =
+        parent =
                 HarnessAgent.builder()
                         .name("parent")
                         .model(model)
@@ -281,7 +288,7 @@ class HarnessAgentSubagentStreamEventsTest {
                 .thenReturn(Flux.just(stopChunk("c1", "analysis complete")))
                 .thenReturn(Flux.just(stopChunk("p2", "result obtained")));
 
-        HarnessAgent parent =
+        parent =
                 HarnessAgent.builder()
                         .name("parent")
                         .model(model)
@@ -347,7 +354,7 @@ class HarnessAgentSubagentStreamEventsTest {
                 .thenReturn(Flux.just(stopChunk("c1", "helped")))
                 .thenReturn(Flux.just(stopChunk("p2", "done")));
 
-        HarnessAgent parent =
+        parent =
                 HarnessAgent.builder()
                         .name("parent")
                         .model(model)


### PR DESCRIPTION
## AgentScope-Java Version

2.0.1-SNAPSHOT

## Description

Fixes #2242.

User-triggered interrupts currently return a recovery `AssistantMessage` without an explicit generate reason. As a result, callers observe the default `GenerateReason.MODEL_STOP` and cannot distinguish an interrupted execution from normal model completion.

This PR:

- Sets `GenerateReason.INTERRUPTED` on the user-interrupt recovery message.
- Keeps the existing system-shutdown interrupt behavior unchanged.
- Extends the per-session state regression test to verify:
  - The returned recovery message is marked as `INTERRUPTED`.
  - The generate reason remains `INTERRUPTED` after session state is persisted and restored.

### Testing

```bash
mvn -pl agentscope-core -am -Dtest=ReActAgentPerSessionStateTest test
```

Result: 6 tests passed, 0 failures, 0 errors.

## Checklist

Please check the following items before code is ready to be reviewed.

- [x] Code formatting passes Spotless checks
- [x] All tests are passing (`mvn test`)
- [x] No Javadoc changes are required
- [x] No documentation changes are required
- [x] Code is ready for review