### PR TITLE
fix(harness): evict oversized tool results from reasoning input

### DIFF
--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/memory/compaction/ToolResultEvictionConfig.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/memory/compaction/ToolResultEvictionConfig.java
@@ -36,7 +36,7 @@ import java.util.Set;
  * <ul>
  *   <li>Trigger at 80,000 characters (~20 K tokens at 4 chars/token)</li>
  *   <li>Preview: first + last 2,000 characters of the original output</li>
- *   <li>Eviction path prefix: {@code /large_tool_results}</li>
+ *   <li>Eviction path prefix: {@code large_tool_results} (relative to the workspace)</li>
  *   <li>Excluded tools: filesystem read/write/edit/list + memory tools (small or self-paginating)</li>
  * </ul>
  */
@@ -48,8 +48,8 @@ public class ToolResultEvictionConfig {
     /** Characters to show at head and tail in the eviction placeholder preview. */
     public static final int DEFAULT_PREVIEW_CHARS = 2_000;
 
-    /** Root path prefix under which evicted results are stored. */
-    public static final String DEFAULT_EVICTION_PATH = "/large_tool_results";
+    /** Workspace-relative path prefix under which evicted results are stored. */
+    public static final String DEFAULT_EVICTION_PATH = "large_tool_results";
 
     /**
      * Tools excluded from eviction by default.
@@ -102,7 +102,7 @@ public class ToolResultEvictionConfig {
         return previewChars;
     }
 
-    /** Root path under which evicted files are written (e.g. {@code /large_tool_results}). */
+    /** Root path under which evicted files are written (e.g. {@code large_tool_results}). */
     public String getEvictionPath() {
         return evictionPath;
     }

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/middleware/ToolResultEvictionMiddleware.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/middleware/ToolResultEvictionMiddleware.java
@@ -20,7 +20,6 @@ import io.agentscope.core.agent.RuntimeContext;
 import io.agentscope.core.event.AgentEvent;
 import io.agentscope.core.message.ContentBlock;
 import io.agentscope.core.message.Msg;
-import io.agentscope.core.message.MsgRole;
 import io.agentscope.core.message.TextBlock;
 import io.agentscope.core.message.ToolResultBlock;
 import io.agentscope.core.middleware.ReasoningInput;
@@ -29,16 +28,17 @@ import io.agentscope.harness.agent.filesystem.AbstractFilesystem;
 import io.agentscope.harness.agent.filesystem.model.WriteResult;
 import io.agentscope.harness.agent.memory.compaction.ToolResultEvictionConfig;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.function.Function;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import reactor.core.publisher.Flux;
 
 /**
- * Middleware that evicts oversized tool results to the {@link AbstractFilesystem}
- * immediately after each acting phase, before downstream reasoning sees the bloated
- * message list.
+ * Middleware that evicts oversized tool results to the {@link AbstractFilesystem} before
+ * downstream reasoning sees the bloated message list.
  *
  * <p>When the text content of a {@link ToolResultBlock} in the freshly-added tool-result
  * messages exceeds {@link ToolResultEvictionConfig#getMaxResultChars()}, this middleware:
@@ -47,8 +47,10 @@ import reactor.core.publisher.Flux;
  *       {@code {evictionPath}/{agentName}/{sanitized-toolCallId}} in the filesystem.</li>
  *   <li>Replaces the in-context {@code ToolResultBlock} with a compact placeholder containing
  *       a head+tail preview and an instruction to use {@code readFile} for the full content.</li>
- *   <li>Mutates {@link AgentState#contextMutable()} in place so subsequent reasoning rounds
- *       see only the placeholder.</li>
+ *   <li>Rebuilds the current {@link ReasoningInput} so the immediate model call sees only the
+ *       placeholder.</li>
+ *   <li>Applies the same replacements to {@link AgentState#contextMutable()} so subsequent
+ *       reasoning rounds and persisted state also see only the placeholder.</li>
  * </ol>
  *
  * <p>Tools listed in {@link ToolResultEvictionConfig#getExcludedToolNames()} are never evicted
@@ -74,30 +76,42 @@ public class ToolResultEvictionMiddleware implements HarnessRuntimeMiddleware {
             ReasoningInput input,
             Function<ReasoningInput, Flux<AgentEvent>> next) {
         final RuntimeContext rc = ctx != null ? ctx : RuntimeContext.empty();
-        evictOversizedToolResults(agent, rc);
-        return next.apply(input);
+        EvictionResult result = evictMessages(input.messages(), agent.getName(), rc);
+        if (!result.changed()) {
+            return next.apply(input);
+        }
+
+        applyReplacementsToAgentState(agent, rc, result.replacements());
+        return next.apply(new ReasoningInput(result.messages(), input.tools(), input.options()));
     }
 
-    private void evictOversizedToolResults(Agent agent, RuntimeContext rc) {
-        AgentState state = RuntimeContext.resolveAgentState(rc, agent);
-        if (state == null) {
-            return;
+    private EvictionResult evictMessages(List<Msg> messages, String agentName, RuntimeContext rc) {
+        if (messages == null || messages.isEmpty()) {
+            return new EvictionResult(messages, Map.of(), false);
         }
-        List<Msg> ctx = state.contextMutable();
-        String agentName = agent.getName();
-        for (int i = 0; i < ctx.size(); i++) {
-            Msg msg = ctx.get(i);
-            if (msg == null || msg.getRole() != MsgRole.TOOL) {
-                continue;
-            }
-            Msg rebuilt = evictMessage(msg, agentName, rc);
+
+        List<Msg> rebuiltMessages = new ArrayList<>(messages.size());
+        Map<ToolResultKey, ToolResultBlock> replacements = new HashMap<>();
+        boolean changed = false;
+        for (Msg msg : messages) {
+            Msg rebuilt = evictMessage(msg, agentName, rc, replacements);
+            rebuiltMessages.add(rebuilt);
             if (rebuilt != msg) {
-                ctx.set(i, rebuilt);
+                changed = true;
             }
         }
+
+        return new EvictionResult(changed ? rebuiltMessages : messages, replacements, changed);
     }
 
-    private Msg evictMessage(Msg msg, String agentName, RuntimeContext rc) {
+    private Msg evictMessage(
+            Msg msg,
+            String agentName,
+            RuntimeContext rc,
+            Map<ToolResultKey, ToolResultBlock> replacements) {
+        if (msg == null) {
+            return null;
+        }
         List<ContentBlock> contentBlocks = msg.getContent();
         if (contentBlocks == null || contentBlocks.isEmpty()) {
             return msg;
@@ -108,6 +122,7 @@ public class ToolResultEvictionMiddleware implements HarnessRuntimeMiddleware {
             if (block instanceof ToolResultBlock tr) {
                 ToolResultBlock maybeEvicted = maybeEvict(tr, agentName, rc);
                 if (maybeEvicted != tr) {
+                    replacements.put(ToolResultKey.from(tr), maybeEvicted);
                     changed = true;
                     rebuilt.add(maybeEvicted);
                     continue;
@@ -118,13 +133,56 @@ public class ToolResultEvictionMiddleware implements HarnessRuntimeMiddleware {
         if (!changed) {
             return msg;
         }
-        return Msg.builder()
+        return rebuildMessage(msg, rebuilt);
+    }
+
+    private void applyReplacementsToAgentState(
+            Agent agent, RuntimeContext rc, Map<ToolResultKey, ToolResultBlock> replacements) {
+        AgentState state = RuntimeContext.resolveAgentState(rc, agent);
+        if (state == null || replacements.isEmpty()) {
+            return;
+        }
+
+        List<Msg> context = state.contextMutable();
+        for (int i = 0; i < context.size(); i++) {
+            Msg msg = context.get(i);
+            Msg rebuilt = replaceToolResults(msg, replacements);
+            if (rebuilt != msg) {
+                context.set(i, rebuilt);
+            }
+        }
+    }
+
+    private Msg replaceToolResults(Msg msg, Map<ToolResultKey, ToolResultBlock> replacements) {
+        if (msg == null || msg.getContent() == null || msg.getContent().isEmpty()) {
+            return msg;
+        }
+
+        List<ContentBlock> rebuilt = new ArrayList<>(msg.getContent().size());
+        boolean changed = false;
+        for (ContentBlock block : msg.getContent()) {
+            if (block instanceof ToolResultBlock toolResult) {
+                ToolResultBlock replacement = replacements.get(ToolResultKey.from(toolResult));
+                if (replacement != null && replacement != toolResult) {
+                    rebuilt.add(replacement);
+                    changed = true;
+                    continue;
+                }
+            }
+            rebuilt.add(block);
+        }
+
+        return changed ? rebuildMessage(msg, rebuilt) : msg;
+    }
+
+    private Msg rebuildMessage(Msg msg, List<ContentBlock> content) {
+        return Msg.builderForRole(msg.getRole())
                 .id(msg.getId())
                 .name(msg.getName())
-                .role(msg.getRole())
-                .content(rebuilt)
+                .content(content)
                 .metadata(msg.getMetadata())
                 .timestamp(msg.getTimestamp())
+                .usage(msg.getUsage())
                 .build();
     }
 
@@ -139,8 +197,8 @@ public class ToolResultEvictionMiddleware implements HarnessRuntimeMiddleware {
             return toolResult;
         }
         String toolCallId = toolResult.getId();
-        String evictionPath = buildEvictionPath(agentName, toolCallId);
         try {
+            String evictionPath = buildEvictionPath(agentName, toolCallId);
             WriteResult writeResult = filesystem.write(rc, evictionPath, fullText);
             if (!writeResult.isSuccess()) {
                 log.warn(
@@ -163,7 +221,8 @@ public class ToolResultEvictionMiddleware implements HarnessRuntimeMiddleware {
                     toolResult.getId(),
                     toolResult.getName(),
                     List.of(TextBlock.builder().text(placeholder).build()),
-                    null);
+                    toolResult.getMetadata(),
+                    toolResult.getState());
         } catch (Exception e) {
             log.warn(
                     "[{}] Exception evicting tool result [tool={}, id={}]: {}",
@@ -190,8 +249,8 @@ public class ToolResultEvictionMiddleware implements HarnessRuntimeMiddleware {
 
     private String buildEvictionPath(String agentName, String toolCallId) {
         String base = config.getEvictionPath();
-        if (!base.startsWith("/")) {
-            base = "/" + base;
+        while (base.endsWith("/")) {
+            base = base.substring(0, base.length() - 1);
         }
         String safeAgent = agentName.replaceAll("[^a-zA-Z0-9_-]", "_");
         String safeId = toolCallId.replaceAll("[^a-zA-Z0-9_-]", "_");
@@ -218,4 +277,16 @@ public class ToolResultEvictionMiddleware implements HarnessRuntimeMiddleware {
 
         return sb.toString();
     }
+
+    private record ToolResultKey(String id, String name) {
+
+        private static ToolResultKey from(ToolResultBlock block) {
+            return new ToolResultKey(block.getId(), block.getName());
+        }
+    }
+
+    private record EvictionResult(
+            List<Msg> messages,
+            Map<ToolResultKey, ToolResultBlock> replacements,
+            boolean changed) {}
 }

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/middleware/ToolResultEvictionMiddlewareTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/middleware/ToolResultEvictionMiddlewareTest.java
@@ -1,0 +1,245 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.harness.agent.middleware;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.agentscope.core.agent.Agent;
+import io.agentscope.core.agent.AgentBase;
+import io.agentscope.core.agent.RuntimeContext;
+import io.agentscope.core.interruption.InterruptContext;
+import io.agentscope.core.message.ContentBlock;
+import io.agentscope.core.message.Msg;
+import io.agentscope.core.message.MsgRole;
+import io.agentscope.core.message.TextBlock;
+import io.agentscope.core.message.ToolResultBlock;
+import io.agentscope.core.message.ToolResultState;
+import io.agentscope.core.middleware.ReasoningInput;
+import io.agentscope.core.state.AgentState;
+import io.agentscope.harness.agent.filesystem.local.LocalFilesystem;
+import io.agentscope.harness.agent.filesystem.model.WriteResult;
+import io.agentscope.harness.agent.memory.compaction.ToolResultEvictionConfig;
+import io.agentscope.harness.agent.workspace.LocalFsMode;
+import io.agentscope.harness.agent.workspace.PathPolicy;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+class ToolResultEvictionMiddlewareTest {
+
+    private static final String FULL_OUTPUT = "0123456789".repeat(10);
+
+    @TempDir Path tempDir;
+
+    @Test
+    void evictsImmediateReasoningInputAndAgentStateUsingDefaultLocalPath() throws IOException {
+        ToolResultEvictionConfig config =
+                ToolResultEvictionConfig.builder().maxResultChars(20).previewChars(4).build();
+        assertEquals("large_tool_results", config.getEvictionPath());
+
+        LocalFilesystem filesystem =
+                new LocalFilesystem(tempDir, LocalFsMode.ROOTED, PathPolicy.empty(), 10, null);
+        ToolResultEvictionMiddleware middleware =
+                new ToolResultEvictionMiddleware(filesystem, config);
+
+        Msg stateToolMessage = toolMessage(toolResult(FULL_OUTPUT));
+        AgentState state = AgentState.builder().addMessage(stateToolMessage).build();
+        RuntimeContext ctx = RuntimeContext.builder().agentState(state).build();
+
+        Msg systemMessage = Msg.builder().role(MsgRole.SYSTEM).textContent("system prompt").build();
+        Msg hookMessage = Msg.builder().role(MsgRole.ASSISTANT).textContent("hook message").build();
+        Msg inputToolMessage = toolMessage(toolResult(FULL_OUTPUT));
+        ReasoningInput input =
+                new ReasoningInput(
+                        List.of(systemMessage, hookMessage, inputToolMessage), List.of(), null);
+        AtomicReference<ReasoningInput> forwarded = new AtomicReference<>();
+
+        middleware
+                .onReasoning(
+                        agent("Test Agent"),
+                        ctx,
+                        input,
+                        compacted -> {
+                            forwarded.set(compacted);
+                            return Flux.empty();
+                        })
+                .collectList()
+                .block();
+
+        ReasoningInput compacted = forwarded.get();
+        assertNotNull(compacted);
+        assertNotSame(input, compacted);
+        assertSame(systemMessage, compacted.messages().get(0));
+        assertSame(hookMessage, compacted.messages().get(1));
+
+        String modelToolOutput = toolOutput(compacted.messages().get(2));
+        assertTrue(modelToolOutput.contains("Tool output was too large"));
+        assertTrue(modelToolOutput.contains("`large_tool_results/Test_Agent/call_1`"));
+        assertFalse(modelToolOutput.contains(FULL_OUTPUT));
+
+        assertEquals(1, state.getContext().size());
+        String stateToolOutput = toolOutput(state.getContext().get(0));
+        assertTrue(stateToolOutput.contains("Tool output was too large"));
+        assertFalse(stateToolOutput.contains(FULL_OUTPUT));
+
+        ToolResultBlock compactedBlock =
+                compacted.messages().get(2).getContentBlocks(ToolResultBlock.class).get(0);
+        assertEquals(Map.of("source", "test"), compactedBlock.getMetadata());
+        assertEquals(ToolResultState.SUCCESS, compactedBlock.getState());
+
+        // The original copied input remains unchanged, proving the downstream call received a
+        // newly rebuilt ReasoningInput rather than relying on AgentState mutation.
+        assertEquals(FULL_OUTPUT, toolOutput(inputToolMessage));
+        assertEquals(
+                FULL_OUTPUT,
+                Files.readString(tempDir.resolve("large_tool_results/Test_Agent/call_1")));
+    }
+
+    @Test
+    void writeFailureLeavesReasoningInputAndAgentStateUntouched() {
+        RecordingFilesystem filesystem =
+                new RecordingFilesystem(tempDir, WriteResult.fail("write denied"));
+        ToolResultEvictionMiddleware middleware =
+                new ToolResultEvictionMiddleware(filesystem, testConfig());
+
+        Msg stateToolMessage = toolMessage(toolResult(FULL_OUTPUT));
+        AgentState state = AgentState.builder().addMessage(stateToolMessage).build();
+        RuntimeContext ctx = RuntimeContext.builder().agentState(state).build();
+        Msg inputToolMessage = toolMessage(toolResult(FULL_OUTPUT));
+        ReasoningInput input = new ReasoningInput(List.of(inputToolMessage), List.of(), null);
+        AtomicReference<ReasoningInput> forwarded = new AtomicReference<>();
+
+        middleware
+                .onReasoning(
+                        agent("Test Agent"),
+                        ctx,
+                        input,
+                        downstream -> {
+                            forwarded.set(downstream);
+                            return Flux.empty();
+                        })
+                .collectList()
+                .block();
+
+        assertSame(input, forwarded.get());
+        assertSame(stateToolMessage, state.getContext().get(0));
+        assertEquals(FULL_OUTPUT, toolOutput(forwarded.get().messages().get(0)));
+        assertEquals(FULL_OUTPUT, toolOutput(state.getContext().get(0)));
+        assertSame(ctx, filesystem.lastContext);
+        assertEquals("large_tool_results/Test_Agent/call_1", filesystem.lastPath);
+        assertEquals(FULL_OUTPUT, filesystem.lastContent);
+    }
+
+    @Test
+    void preservesConfiguredAbsolutePathWhileTrimmingTrailingSlashes() {
+        RecordingFilesystem filesystem = new RecordingFilesystem(tempDir, WriteResult.ok("stored"));
+        ToolResultEvictionConfig config =
+                ToolResultEvictionConfig.builder()
+                        .maxResultChars(20)
+                        .previewChars(4)
+                        .evictionPath("/workspace/results///")
+                        .build();
+        ToolResultEvictionMiddleware middleware =
+                new ToolResultEvictionMiddleware(filesystem, config);
+        RuntimeContext ctx = RuntimeContext.empty();
+        ReasoningInput input =
+                new ReasoningInput(List.of(toolMessage(toolResult(FULL_OUTPUT))), List.of(), null);
+
+        middleware
+                .onReasoning(agent("Test Agent"), ctx, input, ignored -> Flux.empty())
+                .collectList()
+                .block();
+
+        assertSame(ctx, filesystem.lastContext);
+        assertEquals("/workspace/results/Test_Agent/call_1", filesystem.lastPath);
+        assertEquals(FULL_OUTPUT, filesystem.lastContent);
+    }
+
+    private static ToolResultEvictionConfig testConfig() {
+        return ToolResultEvictionConfig.builder().maxResultChars(20).previewChars(4).build();
+    }
+
+    private static ToolResultBlock toolResult(String output) {
+        return new ToolResultBlock(
+                "call:1",
+                "large_output",
+                List.of(TextBlock.builder().text(output).build()),
+                Map.of("source", "test"),
+                ToolResultState.SUCCESS);
+    }
+
+    private static Msg toolMessage(ToolResultBlock result) {
+        return Msg.builder().role(MsgRole.TOOL).content(result).build();
+    }
+
+    private static String toolOutput(Msg message) {
+        ToolResultBlock result = message.getContentBlocks(ToolResultBlock.class).get(0);
+        StringBuilder output = new StringBuilder();
+        for (ContentBlock block : result.getOutput()) {
+            if (block instanceof TextBlock text && text.getText() != null) {
+                output.append(text.getText());
+            }
+        }
+        return output.toString();
+    }
+
+    private static Agent agent(String name) {
+        return new AgentBase(name) {
+            @Override
+            protected Mono<Msg> doCall(List<Msg> msgs) {
+                return Mono.empty();
+            }
+
+            @Override
+            protected Mono<Msg> handleInterrupt(InterruptContext context, Msg... originalArgs) {
+                return Mono.empty();
+            }
+        };
+    }
+
+    private static final class RecordingFilesystem extends LocalFilesystem {
+
+        private final WriteResult result;
+        private RuntimeContext lastContext;
+        private String lastPath;
+        private String lastContent;
+
+        private RecordingFilesystem(Path root, WriteResult result) {
+            super(root);
+            this.result = result;
+        }
+
+        @Override
+        public WriteResult write(RuntimeContext context, String path, String content) {
+            lastContext = context;
+            lastPath = path;
+            lastContent = content;
+            return result;
+        }
+    }
+}

--- a/docs/v1/en/docs/harness/memory.md
+++ b/docs/v1/en/docs/harness/memory.md
@@ -113,7 +113,7 @@ Independent from compaction. When a `tool_call` return text exceeds the threshol
 |-----------|---------|-------------|
 | `maxResultChars` | `80_000` | Evict if exceeded |
 | `previewChars` | `2_000` | Number of head and tail preview characters |
-| `evictionPath` | `/large_tool_results` | Root path for evicted files |
+| `evictionPath` | `large_tool_results` | Workspace-relative root path for evicted files |
 | `excludedToolNames` | Built-in set (includes `read_file` etc.) | Tools excluded from eviction |
 
 ```java

--- a/docs/v1/zh/docs/harness/memory.md
+++ b/docs/v1/zh/docs/harness/memory.md
@@ -113,7 +113,7 @@ CompactionConfig.builder()
 |------|------|------|
 | `maxResultChars` | `80_000` | 超过则卸载 |
 | `previewChars` | `2_000` | 首尾预览字符数 |
-| `evictionPath` | `/large_tool_results` | 卸载文件根路径 |
+| `evictionPath` | `large_tool_results` | 相对于工作区的卸载文件根路径 |
 | `excludedToolNames` | 内置集（含 `read_file` 等） | 不参与卸载的工具 |
 
 ```java

--- a/docs/v2/en/docs/harness/memory.md
+++ b/docs/v2/en/docs/harness/memory.md
@@ -221,6 +221,7 @@ Defaults:
 
 - Triggered at 80K characters
 - Keeps ~2K chars at head + tail + a line "full content at `{path}`"
+- Stores full output under the workspace-relative `large_tool_results` directory
 - `read_file` is excluded by default (to avoid re-offloading what was just read back)
 
 Customize threshold or destination via `ToolResultEvictionConfig.builder()...build()`.

--- a/docs/v2/zh/docs/harness/memory.md
+++ b/docs/v2/zh/docs/harness/memory.md
@@ -221,6 +221,7 @@ HarnessAgent.builder()
 
 - 超过 80K 字符触发
 - 上下文里只保留首尾各约 2K 字符 + 一行"完整内容见 `{path}`"
+- 全文默认写入相对于工作区的 `large_tool_results` 目录
 - 默认排除 `read_file`（避免回读完又被卸载）
 
 需要自己定阈值或卸载根目录用 `ToolResultEvictionConfig.builder()...build()`。


### PR DESCRIPTION
## Summary

Fix tool-result eviction so oversized tool outputs are removed from the
immediate next model call, not only from the persisted agent state.

## Problem

`PreReasoningEvent` copies the agent context before middleware execution.
`ToolResultEvictionMiddleware` previously replaced messages only in
`AgentState.contextMutable()` and then forwarded the original
`ReasoningInput`.

As a result:

- `AgentState` contained the compact placeholder
- the immediate next model call still received the complete tool output
- sufficiently large results could still trigger context-length errors

The default `/large_tool_results` path could also be treated as a host
absolute path by rooted local filesystems.

## Changes

- Rebuild `ReasoningInput` with evicted tool-result blocks before calling
  downstream reasoning
- Apply the same replacements to `AgentState` for persistence and later
  reasoning rounds
- Preserve system and hook-injected messages
- Preserve message usage and tool-result metadata/state
- Keep the original result when filesystem writes fail
- Change the default eviction directory to the workspace-relative
  `large_tool_results`
- Preserve explicitly configured absolute paths
- Update V1/V2 English and Chinese documentation
- Add regression coverage for model input, agent state, paths, and write
  failures

## Testing

- `ToolResultEvictionMiddlewareTest`
- `ProjectAwareOverlayTest`

19 tests passed with no failures.