### PR TITLE
Add Atlas Cloud OpenAI-compatible credential

### DIFF
--- a/agentscope-core/src/main/java/io/agentscope/core/credential/AtlasCloudCredential.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/credential/AtlasCloudCredential.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.core.credential;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import io.agentscope.core.model.ChatModelBase;
+import java.util.Objects;
+
+/**
+ * Credential for the Atlas Cloud OpenAI-compatible API.
+ *
+ * <p>No {@code AtlasCloudChatModel} class ships in agentscope-core yet, so {@link
+ * #getChatModelClass()} throws {@link UnsupportedOperationException}. Use the OpenAI model
+ * extension with this credential's base URL when creating a chat model.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonPropertyOrder({"id", "type", "api_key", "base_url"})
+public final class AtlasCloudCredential extends CredentialBase {
+
+    public static final String TYPE = "atlascloud_credential";
+
+    public static final String DEFAULT_BASE_URL = "https://api.atlascloud.ai/v1";
+
+    private final String apiKey;
+    private final String baseUrl;
+
+    private AtlasCloudCredential(String id, String apiKey, String baseUrl) {
+        super(id);
+        this.apiKey = Objects.requireNonNull(apiKey, "apiKey must not be null");
+        this.baseUrl = baseUrl == null ? DEFAULT_BASE_URL : baseUrl;
+    }
+
+    @JsonCreator
+    static AtlasCloudCredential fromJson(
+            @JsonProperty("id") String id,
+            @JsonProperty("api_key") String apiKey,
+            @JsonProperty("base_url") String baseUrl) {
+        return new AtlasCloudCredential(id, apiKey, baseUrl);
+    }
+
+    @JsonProperty("type")
+    public String getType() {
+        return TYPE;
+    }
+
+    @JsonProperty("api_key")
+    public String getApiKey() {
+        return apiKey;
+    }
+
+    @JsonProperty("base_url")
+    public String getBaseUrl() {
+        return baseUrl;
+    }
+
+    @Override
+    public Class<? extends ChatModelBase> getChatModelClass() {
+        throw new UnsupportedOperationException(
+                "AtlasCloudChatModel is not implemented in agentscope-core yet."
+                        + " Use io.agentscope.extensions.model.openai.OpenAIChatModel against the"
+                        + " Atlas Cloud base URL instead.");
+    }
+
+    @Override
+    public String toString() {
+        return "AtlasCloudCredential{id=" + getId() + ", baseUrl=" + baseUrl + ", apiKey=***}";
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static final class Builder {
+        private String id;
+        private String apiKey;
+        private String baseUrl;
+
+        private Builder() {}
+
+        public Builder id(String id) {
+            this.id = id;
+            return this;
+        }
+
+        public Builder apiKey(String apiKey) {
+            this.apiKey = apiKey;
+            return this;
+        }
+
+        public Builder baseUrl(String baseUrl) {
+            this.baseUrl = baseUrl;
+            return this;
+        }
+
+        public AtlasCloudCredential build() {
+            return new AtlasCloudCredential(id, apiKey, baseUrl);
+        }
+    }
+}

--- a/agentscope-core/src/test/java/io/agentscope/core/credential/CredentialsTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/credential/CredentialsTest.java
@@ -23,6 +23,14 @@ import org.junit.jupiter.api.Test;
 class CredentialsTest {
 
     @Test
+    void atlasCloudCredentialThrowsOnGetChatModelClass() {
+        AtlasCloudCredential c = AtlasCloudCredential.builder().apiKey("atlas-key").build();
+        assertEquals(AtlasCloudCredential.DEFAULT_BASE_URL, c.getBaseUrl());
+        assertEquals("atlascloud_credential", c.getType());
+        assertThrows(UnsupportedOperationException.class, c::getChatModelClass);
+    }
+
+    @Test
     void deepSeekCredentialThrowsOnGetChatModelClass() {
         DeepSeekCredential c = DeepSeekCredential.builder().apiKey("ds-key").build();
         assertEquals(DeepSeekCredential.DEFAULT_BASE_URL, c.getBaseUrl());
@@ -45,6 +53,7 @@ class CredentialsTest {
 
     @Test
     void allCredentialsRequireNonNullApiKey() {
+        assertThrows(NullPointerException.class, () -> AtlasCloudCredential.builder().build());
         assertThrows(NullPointerException.class, () -> DeepSeekCredential.builder().build());
         assertThrows(NullPointerException.class, () -> KimiCredential.builder().build());
         assertThrows(NullPointerException.class, () -> XAICredential.builder().build());

--- a/docs/v2/en/docs/building-blocks/model.md
+++ b/docs/v2/en/docs/building-blocks/model.md
@@ -218,7 +218,7 @@ A **Chat Model** is the LLM driving conversation and tool calling, with input an
 | Gemini | `GeminiChatModel` | Google Gemini; multi-modal |
 | Ollama | `OllamaChatModel` | Locally hosted LLMs; credential optional |
 
-Provider credential classes live with their model extension modules, for example `OpenAICredential`, `AnthropicCredential`, `DashScopeCredential`, `GeminiCredential`, and `OllamaCredential`. OpenAI-compatible credentials such as `DeepSeekCredential`, `KimiCredential`, and `XAICredential` remain available from core.
+Provider credential classes live with their model extension modules, for example `OpenAICredential`, `AnthropicCredential`, `DashScopeCredential`, `GeminiCredential`, and `OllamaCredential`. OpenAI-compatible credentials such as `AtlasCloudCredential`, `DeepSeekCredential`, `KimiCredential`, and `XAICredential` remain available from core.
 
 ### Creating a chat model
 
@@ -290,6 +290,10 @@ Common builder fields:
 | `defaultOptions` | `GenerateOptions` | Provider-specific options (`temperature`, `maxTokens`, `thinkingBudget`, `parallelToolCalls`, …) |
 | `formatter` | `Formatter` | Override the default message formatter |
 | `baseUrl` | `String` | Custom service endpoint (e.g. an OpenAI-compatible proxy) |
+
+Atlas Cloud can be used through the OpenAI model extension by setting
+`baseUrl("https://api.atlascloud.ai/v1")`, `apiKey(System.getenv("ATLASCLOUD_API_KEY"))`,
+and an Atlas Cloud model ID such as `qwen/qwen3.5-flash`.
 
 ### Calling a chat model
 


### PR DESCRIPTION
## Summary
- add `AtlasCloudCredential` as a core OpenAI-compatible credential with the default Atlas Cloud base URL
- extend the existing credential tests to cover Atlas Cloud defaults and required API key validation
- document using Atlas Cloud through the OpenAI model extension with `ATLASCLOUD_API_KEY`

## Validation
- `git diff --check`
- static source self-check for the new credential/test/doc references
- verified Atlas Cloud live model catalog includes `qwen/qwen3.5-flash` and `deepseek-ai/deepseek-v4-pro`

## Notes
- No root README changes.
- This does not add sponsor, logo, credits, or partner sections.
- I could not run the focused Maven test locally because this checkout does not include `mvnw` and the local environment does not have `mvn` installed.
