### PR TITLE
feat(anthropic): support PDF documents and citations

### DIFF
--- a/agentscope-core/src/main/java/io/agentscope/core/agent/accumulator/ReasoningContext.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/agent/accumulator/ReasoningContext.java
@@ -154,7 +154,7 @@ public class ReasoningContext {
 
         // Add text content if present
         if (textAcc.hasContent()) {
-            blocks.add(textAcc.buildAggregated());
+            blocks.addAll(textAcc.buildAggregatedBlocks());
         }
 
         // Add all tool calls

--- a/agentscope-core/src/main/java/io/agentscope/core/agent/accumulator/TextAccumulator.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/agent/accumulator/TextAccumulator.java
@@ -15,8 +15,13 @@
  */
 package io.agentscope.core.agent.accumulator;
 
+import io.agentscope.core.message.Citation;
 import io.agentscope.core.message.ContentBlock;
 import io.agentscope.core.message.TextBlock;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
 
 /**
  * Text content accumulator for accumulating streaming text chunks.
@@ -26,16 +31,32 @@ import io.agentscope.core.message.TextBlock;
  */
 public class TextAccumulator implements ContentAccumulator<TextBlock> {
 
+    private static final Long DEFAULT_PROVIDER_BLOCK_INDEX = -1L;
+
     private final StringBuilder accumulated = new StringBuilder();
+    private final Map<Long, TextSegment> segments = new LinkedHashMap<>();
 
     /**
      * @hidden
      */
     @Override
     public void add(TextBlock block) {
-        if (block != null && block.getText() != null) {
-            accumulated.append(block.getText());
+        if (block == null) {
+            return;
         }
+
+        String text = block.getText() != null ? block.getText() : "";
+        accumulated.append(text);
+
+        Long providerBlockIndex =
+                block.getProviderBlockIndex() != null
+                        ? block.getProviderBlockIndex()
+                        : DEFAULT_PROVIDER_BLOCK_INDEX;
+
+        TextSegment segment =
+                segments.computeIfAbsent(providerBlockIndex, ignored -> new TextSegment());
+        segment.text.append(text);
+        segment.citations.addAll(block.getCitations());
     }
 
     /**
@@ -43,7 +64,7 @@ public class TextAccumulator implements ContentAccumulator<TextBlock> {
      */
     @Override
     public boolean hasContent() {
-        return accumulated.length() > 0;
+        return accumulated.length() > 0 || segments.values().stream().anyMatch(TextSegment::cited);
     }
 
     /**
@@ -54,7 +75,44 @@ public class TextAccumulator implements ContentAccumulator<TextBlock> {
         if (!hasContent()) {
             return null;
         }
-        return TextBlock.builder().text(accumulated.toString()).build();
+
+        List<Citation> citations =
+                segments.values().stream().flatMap(segment -> segment.citations.stream()).toList();
+        return TextBlock.builder().text(accumulated.toString()).citations(citations).build();
+    }
+
+    /**
+     * Builds text blocks while preserving provider block boundaries when citations are present.
+     *
+     * <p>Uncited text keeps the historical behavior of producing one aggregated block. When any
+     * segment is cited, every provider segment is returned in original order so each citation
+     * remains attached to the exact claim it supports.
+     *
+     * @hidden
+     * @return aggregated text blocks, or an empty list when no text or citations were received
+     */
+    public List<TextBlock> buildAggregatedBlocks() {
+        if (!hasContent()) {
+            return List.of();
+        }
+
+        boolean hasCitations = segments.values().stream().anyMatch(TextSegment::cited);
+        if (!hasCitations) {
+            return List.of(TextBlock.builder().text(accumulated.toString()).build());
+        }
+
+        List<TextBlock> blocks = new ArrayList<>();
+        for (TextSegment segment : segments.values()) {
+            if (segment.text.length() == 0 && segment.citations.isEmpty()) {
+                continue;
+            }
+            blocks.add(
+                    TextBlock.builder()
+                            .text(segment.text.toString())
+                            .citations(segment.citations)
+                            .build());
+        }
+        return blocks;
     }
 
     /**
@@ -63,6 +121,7 @@ public class TextAccumulator implements ContentAccumulator<TextBlock> {
     @Override
     public void reset() {
         accumulated.setLength(0);
+        segments.clear();
     }
 
     /**
@@ -73,5 +132,15 @@ public class TextAccumulator implements ContentAccumulator<TextBlock> {
      */
     public String getAccumulated() {
         return accumulated.toString();
+    }
+
+    private static final class TextSegment {
+
+        private final StringBuilder text = new StringBuilder();
+        private final List<Citation> citations = new ArrayList<>();
+
+        private boolean cited() {
+            return !citations.isEmpty();
+        }
     }
 }

--- a/agentscope-core/src/main/java/io/agentscope/core/formatter/AbstractBaseFormatter.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/formatter/AbstractBaseFormatter.java
@@ -39,6 +39,7 @@ import java.util.ArrayList;
 import java.util.Base64;
 import java.util.List;
 import java.util.function.Function;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.slf4j.Logger;
@@ -72,7 +73,22 @@ public abstract class AbstractBaseFormatter<TReq, TResp, TParams>
      */
     @Override
     public List<TReq> format(List<Msg> msgs) {
-        return TracerRegistry.get().callFormat(this, msgs, () -> doFormat(msgs));
+        return formatWithTracing(msgs, () -> doFormat(msgs));
+    }
+
+    /**
+     * Execute a formatting action within the standard tracing context.
+     *
+     * <p>Subclasses with request-scoped options (e.g. citation mode) can use this helper to run
+     * a custom formatting action while preserving tracing behavior, without depending on the
+     * tracing implementation directly.
+     *
+     * @param msgs messages being formatted
+     * @param formattingAction the formatting action to execute
+     * @return formatted provider request messages
+     */
+    protected List<TReq> formatWithTracing(List<Msg> msgs, Supplier<List<TReq>> formattingAction) {
+        return TracerRegistry.get().callFormat(this, msgs, formattingAction);
     }
 
     protected abstract List<TReq> doFormat(List<Msg> msgs);

--- a/agentscope-core/src/main/java/io/agentscope/core/formatter/MediaUtils.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/formatter/MediaUtils.java
@@ -276,6 +276,9 @@ public class MediaUtils {
             case "flv" -> "video/x-flv";
             case "3gpp", "3gp" -> "video/3gpp";
 
+            // Document formats
+            case "pdf" -> "application/pdf";
+
             default -> "application/octet-stream";
         };
     }

--- a/agentscope-core/src/main/java/io/agentscope/core/message/Citation.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/message/Citation.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.core.message;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import io.agentscope.core.state.State;
+import java.util.Objects;
+
+/**
+ * A source location cited by a model-generated {@link TextBlock}.
+ *
+ * <p>Citations are attached to the text block whose claim they support. Location indices follow
+ * the source provider's conventions; end indices are exclusive.
+ */
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "type")
+@JsonSubTypes({
+    @JsonSubTypes.Type(value = Citation.PageLocation.class, name = "page_location"),
+    @JsonSubTypes.Type(value = Citation.CharLocation.class, name = "char_location"),
+    @JsonSubTypes.Type(value = Citation.ContentBlockLocation.class, name = "content_block_location")
+})
+public sealed interface Citation extends State
+        permits Citation.PageLocation, Citation.CharLocation, Citation.ContentBlockLocation {
+
+    /**
+     * A citation into a PDF document, using 1-based page numbers and an exclusive end page.
+     *
+     * @param citedText text extracted from the cited source range
+     * @param documentIndex zero-based document index in the model request
+     * @param documentTitle optional document title
+     * @param fileId optional provider file identifier
+     * @param startPageNumber one-based first cited page
+     * @param endPageNumber exclusive one-based end page
+     */
+    record PageLocation(
+            String citedText,
+            long documentIndex,
+            String documentTitle,
+            String fileId,
+            long startPageNumber,
+            long endPageNumber)
+            implements Citation {
+
+        public PageLocation {
+            Objects.requireNonNull(citedText, "citedText cannot be null");
+        }
+    }
+
+    /**
+     * A citation into a plain-text document, using zero-based character indices.
+     *
+     * @param citedText text extracted from the cited source range
+     * @param documentIndex zero-based document index in the model request
+     * @param documentTitle optional document title
+     * @param fileId optional provider file identifier
+     * @param startCharIndex zero-based first cited character
+     * @param endCharIndex exclusive end character
+     */
+    record CharLocation(
+            String citedText,
+            long documentIndex,
+            String documentTitle,
+            String fileId,
+            long startCharIndex,
+            long endCharIndex)
+            implements Citation {
+
+        public CharLocation {
+            Objects.requireNonNull(citedText, "citedText cannot be null");
+        }
+    }
+
+    /**
+     * A citation into a custom-content document, using zero-based content-block indices.
+     *
+     * @param citedText text extracted from the cited source blocks
+     * @param documentIndex zero-based document index in the model request
+     * @param documentTitle optional document title
+     * @param fileId optional provider file identifier
+     * @param startBlockIndex zero-based first cited content block
+     * @param endBlockIndex exclusive end content block
+     */
+    record ContentBlockLocation(
+            String citedText,
+            long documentIndex,
+            String documentTitle,
+            String fileId,
+            long startBlockIndex,
+            long endBlockIndex)
+            implements Citation {
+
+        public ContentBlockLocation {
+            Objects.requireNonNull(citedText, "citedText cannot be null");
+        }
+    }
+}

--- a/agentscope-core/src/main/java/io/agentscope/core/message/TextBlock.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/message/TextBlock.java
@@ -16,7 +16,10 @@
 package io.agentscope.core.message;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
 
 /**
  * Represents plain text content in a message.
@@ -28,18 +31,42 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  * <p>The text content can be empty but never null. The toString() method
  * returns the text content for convenience.
  */
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public final class TextBlock extends ContentBlock {
 
     private final String text;
+    private final List<Citation> citations;
+
+    /**
+     * Provider block index used to preserve text-block boundaries during aggregation.
+     * This field is internal to the accumulator pipeline and is not serialized.
+     *
+     * @hidden
+     */
+    @JsonIgnore private final Long providerBlockIndex;
 
     /**
      * Creates a new text block for JSON deserialization.
      *
      * @param text The text content (null will be converted to empty string)
+     * @param citations Optional citations supporting this text block
      */
     @JsonCreator
-    private TextBlock(@JsonProperty("text") String text) {
+    private TextBlock(
+            @JsonProperty("text") String text,
+            @JsonProperty("citations") List<Citation> citations) {
         this.text = text != null ? text : "";
+        this.citations = citations == null || citations.isEmpty() ? null : List.copyOf(citations);
+        this.providerBlockIndex = null;
+    }
+
+    /**
+     * Internal constructor used by the builder to set the provider block index.
+     */
+    private TextBlock(String text, List<Citation> citations, Long providerBlockIndex) {
+        this.text = text != null ? text : "";
+        this.citations = citations == null || citations.isEmpty() ? null : List.copyOf(citations);
+        this.providerBlockIndex = providerBlockIndex;
     }
 
     /**
@@ -49,6 +76,27 @@ public final class TextBlock extends ContentBlock {
      */
     public String getText() {
         return text;
+    }
+
+    /**
+     * Gets citations supporting the claim in this text block.
+     *
+     * @return immutable citation list, or an empty list when uncited
+     */
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public List<Citation> getCitations() {
+        return citations != null ? citations : List.of();
+    }
+
+    /**
+     * Gets the provider block index, used internally during aggregation.
+     *
+     * @hidden
+     * @return the provider block index, or null when not set
+     */
+    @JsonIgnore
+    public Long getProviderBlockIndex() {
+        return providerBlockIndex;
     }
 
     @Override
@@ -71,6 +119,8 @@ public final class TextBlock extends ContentBlock {
     public static class Builder {
 
         private String text;
+        private List<Citation> citations;
+        private Long providerBlockIndex;
 
         /**
          * Sets the text content for the block.
@@ -84,12 +134,35 @@ public final class TextBlock extends ContentBlock {
         }
 
         /**
+         * Sets citations supporting this text block.
+         *
+         * @param citations citations attached to the complete text block
+         * @return This builder for chaining
+         */
+        public Builder citations(List<Citation> citations) {
+            this.citations = citations;
+            return this;
+        }
+
+        /**
+         * Sets the provider block index for aggregation.
+         *
+         * @param providerBlockIndex the provider block index
+         * @return This builder for chaining
+         * @hidden
+         */
+        public Builder providerBlockIndex(long providerBlockIndex) {
+            this.providerBlockIndex = providerBlockIndex;
+            return this;
+        }
+
+        /**
          * Builds a new TextBlock with the configured text.
          *
          * @return A new TextBlock instance (null text will be converted to empty string)
          */
         public TextBlock build() {
-            return new TextBlock(text != null ? text : "");
+            return new TextBlock(text != null ? text : "", citations, providerBlockIndex);
         }
     }
 }

--- a/agentscope-core/src/main/java/io/agentscope/core/model/GenerateOptions.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/model/GenerateOptions.java
@@ -52,6 +52,7 @@ public class GenerateOptions {
     private final Long seed;
     private final Boolean cacheControl;
     private final Boolean parallelToolCalls;
+    private final Boolean citationsEnabled;
     private final ResponseFormat responseFormat;
     private final Map<String, String> additionalHeaders;
     private final Map<String, Object> additionalBodyParams;
@@ -82,6 +83,7 @@ public class GenerateOptions {
         this.seed = builder.seed;
         this.cacheControl = builder.cacheControl;
         this.parallelToolCalls = builder.parallelToolCalls;
+        this.citationsEnabled = builder.citationsEnabled;
         this.responseFormat = builder.responseFormat;
         this.additionalHeaders =
                 builder.additionalHeaders != null
@@ -337,6 +339,19 @@ public class GenerateOptions {
     }
 
     /**
+     * Gets whether native source citations are enabled for supported model providers.
+     *
+     * <p>Providers may restrict citations to specific input types. For Anthropic, this option is
+     * applied to every document in the request because the Messages API requires citations to be
+     * enabled for all documents or none of them.
+     *
+     * @return true to enable citations, false to disable them, or null to use provider defaults
+     */
+    public Boolean getCitationsEnabled() {
+        return citationsEnabled;
+    }
+
+    /**
      * Gets the response format for structured output.
      *
      * <p>When set, the model will return a response conforming to the specified format
@@ -484,6 +499,10 @@ public class GenerateOptions {
                 primary.parallelToolCalls != null
                         ? primary.parallelToolCalls
                         : fallback.parallelToolCalls);
+        builder.citationsEnabled(
+                primary.citationsEnabled != null
+                        ? primary.citationsEnabled
+                        : fallback.citationsEnabled);
         builder.responseFormat(
                 primary.responseFormat != null ? primary.responseFormat : fallback.responseFormat);
 
@@ -538,6 +557,7 @@ public class GenerateOptions {
         private Long seed;
         private Boolean cacheControl;
         private Boolean parallelToolCalls;
+        private Boolean citationsEnabled;
         private ResponseFormat responseFormat;
         private Map<String, String> additionalHeaders;
         private Map<String, Object> additionalBodyParams;
@@ -799,6 +819,17 @@ public class GenerateOptions {
          */
         public Builder parallelToolCalls(Boolean parallelToolCalls) {
             this.parallelToolCalls = parallelToolCalls;
+            return this;
+        }
+
+        /**
+         * Sets whether native source citations are enabled for supported model providers.
+         *
+         * @param citationsEnabled true to enable citations, false to disable them
+         * @return this builder instance
+         */
+        public Builder citationsEnabled(Boolean citationsEnabled) {
+            this.citationsEnabled = citationsEnabled;
             return this;
         }
 

--- a/agentscope-core/src/test/java/io/agentscope/core/agent/accumulator/ReasoningContextTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/agent/accumulator/ReasoningContextTest.java
@@ -20,6 +20,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import io.agentscope.core.message.Citation;
 import io.agentscope.core.message.Msg;
 import io.agentscope.core.message.TextBlock;
 import io.agentscope.core.message.ToolUseBlock;
@@ -332,5 +333,50 @@ class ReasoningContextTest {
 
         // Verify text is accumulated correctly
         assertEquals("Let me check the weather for you.", context.getAccumulatedText());
+    }
+
+    @Test
+    @DisplayName("Should preserve cited text block boundaries in final message")
+    void testCitedTextBlockBoundariesPreserved() {
+        Citation.PageLocation citation =
+                new Citation.PageLocation("source", 0, "guide.pdf", null, 2, 3);
+
+        TextBlock intro =
+                TextBlock.builder().text("According to the guide, ").providerBlockIndex(0L).build();
+        TextBlock cited =
+                TextBlock.builder().text("the feature is supported").providerBlockIndex(1L).build();
+        TextBlock citationDelta =
+                TextBlock.builder().citations(List.of(citation)).providerBlockIndex(1L).build();
+        TextBlock ending = TextBlock.builder().text(".").providerBlockIndex(2L).build();
+
+        context.processChunk(
+                ChatResponse.builder()
+                        .id("msg-cited")
+                        .content(List.of(intro, cited, citationDelta, ending))
+                        .build());
+
+        Msg finalMessage = context.buildFinalMessage();
+        List<TextBlock> textBlocks = finalMessage.getContentBlocks(TextBlock.class);
+
+        assertEquals(3, textBlocks.size());
+        assertEquals("According to the guide, ", textBlocks.get(0).getText());
+        assertEquals("the feature is supported", textBlocks.get(1).getText());
+        assertEquals(List.of(citation), textBlocks.get(1).getCitations());
+        assertEquals(".", textBlocks.get(2).getText());
+        assertNull(textBlocks.get(1).getProviderBlockIndex());
+    }
+
+    @Test
+    @DisplayName("Should aggregate uncited text into a single block")
+    void testUncitedTextAggregatedIntoSingleBlock() {
+        TextBlock first = TextBlock.builder().text("Hello ").providerBlockIndex(0L).build();
+        TextBlock second = TextBlock.builder().text("world").providerBlockIndex(1L).build();
+
+        context.processChunk(
+                ChatResponse.builder().id("msg-uncited").content(List.of(first, second)).build());
+
+        TextBlock aggregated = (TextBlock) context.buildFinalMessage().getFirstContentBlock();
+
+        assertEquals("Hello world", aggregated.getText());
     }
 }

--- a/agentscope-core/src/test/java/io/agentscope/core/agent/accumulator/ReasoningContextTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/agent/accumulator/ReasoningContextTest.java
@@ -375,8 +375,9 @@ class ReasoningContextTest {
         context.processChunk(
                 ChatResponse.builder().id("msg-uncited").content(List.of(first, second)).build());
 
-        TextBlock aggregated = (TextBlock) context.buildFinalMessage().getFirstContentBlock();
+        List<TextBlock> textBlocks = context.buildFinalMessage().getContentBlocks(TextBlock.class);
 
-        assertEquals("Hello world", aggregated.getText());
+        assertEquals(1, textBlocks.size());
+        assertEquals("Hello world", textBlocks.get(0).getText());
     }
 }

--- a/agentscope-core/src/test/java/io/agentscope/core/formatter/MediaUtilsTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/formatter/MediaUtilsTest.java
@@ -190,6 +190,9 @@ class MediaUtilsTest {
         assertEquals("video/quicktime", MediaUtils.determineMediaType("video.mov"));
         assertEquals("video/x-msvideo", MediaUtils.determineMediaType("video.avi"));
 
+        // Documents
+        assertEquals("application/pdf", MediaUtils.determineMediaType("document.pdf"));
+
         // Fallback
         assertEquals("application/octet-stream", MediaUtils.determineMediaType("file.unknown"));
         assertEquals("application/octet-stream", MediaUtils.determineMediaType("file"));

--- a/agentscope-core/src/test/java/io/agentscope/core/message/MsgSubclassesTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/message/MsgSubclassesTest.java
@@ -16,6 +16,7 @@
 package io.agentscope.core.message;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -176,10 +177,39 @@ class MsgSubclassesTest {
     void jsonRoundTrip_assistantMessage() {
         JsonCodec codec = JsonUtils.getJsonCodec();
         Msg orig = new AssistantMessage("ok");
-        Msg restored = codec.fromJson(codec.toJson(orig), Msg.class);
+        String json = codec.toJson(orig);
+        Msg restored = codec.fromJson(json, Msg.class);
 
         assertInstanceOf(AssistantMessage.class, restored);
         assertEquals("ok", restored.getTextContent());
+        assertFalse(json.contains("\"citations\""));
+    }
+
+    @Test
+    void jsonRoundTrip_assistantMessageWithCitations() {
+        JsonCodec codec = JsonUtils.getJsonCodec();
+        TextBlock citedText =
+                TextBlock.builder()
+                        .text("Supported claim")
+                        .citations(
+                                List.of(
+                                        new Citation.PageLocation(
+                                                "source text", 0, "guide.pdf", null, 2, 3),
+                                        new Citation.CharLocation(
+                                                "source text", 1, "guide.txt", "file-1", 4, 15),
+                                        new Citation.ContentBlockLocation(
+                                                "source text", 2, "guide", null, 5, 7)))
+                        .build();
+        Msg restored = codec.fromJson(codec.toJson(new AssistantMessage(citedText)), Msg.class);
+
+        TextBlock restoredText = (TextBlock) restored.getFirstContentBlock();
+        assertEquals(3, restoredText.getCitations().size());
+        assertInstanceOf(Citation.PageLocation.class, restoredText.getCitations().get(0));
+        assertInstanceOf(Citation.CharLocation.class, restoredText.getCitations().get(1));
+        assertInstanceOf(Citation.ContentBlockLocation.class, restoredText.getCitations().get(2));
+        Citation.PageLocation page = (Citation.PageLocation) restoredText.getCitations().get(0);
+        assertEquals("guide.pdf", page.documentTitle());
+        assertEquals(2, page.startPageNumber());
     }
 
     @Test

--- a/agentscope-core/src/test/java/io/agentscope/core/model/GenerateOptionsTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/model/GenerateOptionsTest.java
@@ -41,6 +41,7 @@ class GenerateOptionsTest {
                         .maxTokens(4096)
                         .frequencyPenalty(0.3)
                         .presencePenalty(0.4)
+                        .citationsEnabled(true)
                         .build();
 
         assertNotNull(options);
@@ -49,6 +50,7 @@ class GenerateOptionsTest {
         assertEquals(4096, options.getMaxTokens());
         assertEquals(0.3, options.getFrequencyPenalty());
         assertEquals(0.4, options.getPresencePenalty());
+        assertTrue(options.getCitationsEnabled());
     }
 
     @Test
@@ -76,6 +78,18 @@ class GenerateOptionsTest {
         assertNull(options.getMaxTokens());
         assertNull(options.getFrequencyPenalty());
         assertNull(options.getPresencePenalty());
+        assertNull(options.getCitationsEnabled());
+    }
+
+    @Test
+    @DisplayName("Should merge request citation setting over model defaults")
+    void testMergeCitationsEnabled() {
+        GenerateOptions defaults = GenerateOptions.builder().citationsEnabled(true).build();
+        GenerateOptions request = GenerateOptions.builder().citationsEnabled(false).build();
+
+        GenerateOptions merged = GenerateOptions.mergeOptions(request, defaults);
+
+        assertEquals(false, merged.getCitationsEnabled());
     }
 
     @Test

--- a/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-anthropic/src/main/java/io/agentscope/extensions/model/anthropic/AnthropicChatModel.java
+++ b/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-anthropic/src/main/java/io/agentscope/extensions/model/anthropic/AnthropicChatModel.java
@@ -164,7 +164,8 @@ public class AnthropicChatModel extends ChatModelBase {
 
                                 // Use formatter to convert Msg to Anthropic
                                 // MessageParam
-                                List<MessageParam> formattedMessages = formatter.format(messages);
+                                List<MessageParam> formattedMessages =
+                                        formatter.format(messages, options, defaultOptions);
                                 for (MessageParam param : formattedMessages) {
                                     paramsBuilder.addMessage(param);
                                 }

--- a/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-anthropic/src/main/java/io/agentscope/extensions/model/anthropic/formatter/AnthropicBaseFormatter.java
+++ b/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-anthropic/src/main/java/io/agentscope/extensions/model/anthropic/formatter/AnthropicBaseFormatter.java
@@ -47,6 +47,54 @@ public abstract class AnthropicBaseFormatter
     }
 
     /**
+     * Format messages with request and default options, applying Anthropic-specific conversion
+     * settings such as citation mode.
+     *
+     * <p>Creates a request-scoped {@link AnthropicMessageConverter} when citations are enabled.
+     * The converter is a local variable — the formatter's {@link #messageConverter} field is never
+     * mutated, so concurrent requests are safe.
+     *
+     * @param messages messages to format
+     * @param options request-specific generation options
+     * @param defaultOptions model default generation options
+     * @return formatted Anthropic messages
+     */
+    public List<MessageParam> format(
+            List<Msg> messages, GenerateOptions options, GenerateOptions defaultOptions) {
+        boolean enabled =
+                Boolean.TRUE.equals(
+                        getOptionOrDefault(
+                                options, defaultOptions, GenerateOptions::getCitationsEnabled));
+        if (!enabled) {
+            return format(messages);
+        }
+
+        AnthropicMessageConverter requestConverter =
+                new AnthropicMessageConverter(
+                        this::convertToolResultToString, CitationMode.ENABLED);
+
+        return formatWithTracing(messages, () -> doFormat(messages, requestConverter));
+    }
+
+    /**
+     * Format messages using a request-scoped message converter.
+     *
+     * <p>This non-abstract hook allows built-in formatters to receive the request-scoped converter
+     * (which may have citations enabled) without exposing mutable state. External subclasses that
+     * only override {@link #doFormat(List)} continue to work unchanged.
+     *
+     * <p>The default implementation delegates to {@link #doFormat(List)}, ignoring the converter.
+     *
+     * @param messages messages to format
+     * @param requestConverter converter configured for this request's options
+     * @return formatted Anthropic messages
+     */
+    protected List<MessageParam> doFormat(
+            List<Msg> messages, AnthropicMessageConverter requestConverter) {
+        return doFormat(messages);
+    }
+
+    /**
      * Apply generation options to Anthropic request parameters.
      *
      * @param paramsBuilder Anthropic request parameters builder

--- a/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-anthropic/src/main/java/io/agentscope/extensions/model/anthropic/formatter/AnthropicChatFormatter.java
+++ b/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-anthropic/src/main/java/io/agentscope/extensions/model/anthropic/formatter/AnthropicChatFormatter.java
@@ -42,6 +42,12 @@ public class AnthropicChatFormatter extends AnthropicBaseFormatter {
     }
 
     @Override
+    protected List<MessageParam> doFormat(
+            List<Msg> msgs, AnthropicMessageConverter requestConverter) {
+        return requestConverter.convert(msgs);
+    }
+
+    @Override
     public ChatResponse parseResponse(Object response, Instant startTime) {
         if (response instanceof Message message) {
             return AnthropicResponseParser.parseMessage(message, startTime);

--- a/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-anthropic/src/main/java/io/agentscope/extensions/model/anthropic/formatter/AnthropicCitationConverter.java
+++ b/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-anthropic/src/main/java/io/agentscope/extensions/model/anthropic/formatter/AnthropicCitationConverter.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.extensions.model.anthropic.formatter;
+
+import com.anthropic.models.messages.CitationCharLocation;
+import com.anthropic.models.messages.CitationCharLocationParam;
+import com.anthropic.models.messages.CitationContentBlockLocation;
+import com.anthropic.models.messages.CitationContentBlockLocationParam;
+import com.anthropic.models.messages.CitationPageLocation;
+import com.anthropic.models.messages.CitationPageLocationParam;
+import com.anthropic.models.messages.CitationsDelta;
+import com.anthropic.models.messages.TextCitation;
+import com.anthropic.models.messages.TextCitationParam;
+import io.agentscope.core.message.Citation;
+import java.util.List;
+import java.util.Optional;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** Converts Anthropic document citation unions to provider-neutral AgentScope citations. */
+final class AnthropicCitationConverter {
+
+    private static final Logger log = LoggerFactory.getLogger(AnthropicCitationConverter.class);
+
+    private AnthropicCitationConverter() {}
+
+    static List<Citation> convert(List<TextCitation> citations) {
+        if (citations == null || citations.isEmpty()) {
+            return List.of();
+        }
+        return citations.stream()
+                .map(AnthropicCitationConverter::convert)
+                .flatMap(Optional::stream)
+                .toList();
+    }
+
+    static Optional<Citation> convert(TextCitation citation) {
+        if (citation == null) {
+            return Optional.empty();
+        }
+        if (citation.isPageLocation()) {
+            return Optional.of(convert(citation.asPageLocation()));
+        }
+        if (citation.isCharLocation()) {
+            return Optional.of(convert(citation.asCharLocation()));
+        }
+        if (citation.isContentBlockLocation()) {
+            return Optional.of(convert(citation.asContentBlockLocation()));
+        }
+        logUnsupportedCitation(
+                citation.isWebSearchResultLocation(), citation.isSearchResultLocation());
+        return Optional.empty();
+    }
+
+    static Optional<Citation> convert(CitationsDelta.Citation citation) {
+        if (citation == null) {
+            return Optional.empty();
+        }
+        if (citation.isPageLocation()) {
+            return Optional.of(convert(citation.asPageLocation()));
+        }
+        if (citation.isCharLocation()) {
+            return Optional.of(convert(citation.asCharLocation()));
+        }
+        if (citation.isContentBlockLocation()) {
+            return Optional.of(convert(citation.asContentBlockLocation()));
+        }
+        logUnsupportedCitation(
+                citation.isWebSearchResultLocation(), citation.isSearchResultLocation());
+        return Optional.empty();
+    }
+
+    static List<TextCitationParam> convertToParams(List<Citation> citations) {
+        if (citations == null || citations.isEmpty()) {
+            return List.of();
+        }
+        return citations.stream()
+                .map(AnthropicCitationConverter::convertToParam)
+                .flatMap(Optional::stream)
+                .toList();
+    }
+
+    private static Optional<TextCitationParam> convertToParam(Citation citation) {
+        if (citation instanceof Citation.PageLocation page) {
+            CitationPageLocationParam.Builder builder =
+                    CitationPageLocationParam.builder()
+                            .citedText(page.citedText())
+                            .documentIndex(page.documentIndex())
+                            .documentTitle(Optional.ofNullable(page.documentTitle()))
+                            .startPageNumber(page.startPageNumber())
+                            .endPageNumber(page.endPageNumber());
+            return Optional.of(TextCitationParam.ofPageLocation(builder.build()));
+        }
+        if (citation instanceof Citation.CharLocation character) {
+            CitationCharLocationParam.Builder builder =
+                    CitationCharLocationParam.builder()
+                            .citedText(character.citedText())
+                            .documentIndex(character.documentIndex())
+                            .documentTitle(Optional.ofNullable(character.documentTitle()))
+                            .startCharIndex(character.startCharIndex())
+                            .endCharIndex(character.endCharIndex());
+            return Optional.of(TextCitationParam.ofCharLocation(builder.build()));
+        }
+        if (citation instanceof Citation.ContentBlockLocation contentBlock) {
+            CitationContentBlockLocationParam.Builder builder =
+                    CitationContentBlockLocationParam.builder()
+                            .citedText(contentBlock.citedText())
+                            .documentIndex(contentBlock.documentIndex())
+                            .documentTitle(Optional.ofNullable(contentBlock.documentTitle()))
+                            .startBlockIndex(contentBlock.startBlockIndex())
+                            .endBlockIndex(contentBlock.endBlockIndex());
+            return Optional.of(TextCitationParam.ofContentBlockLocation(builder.build()));
+        }
+        return Optional.empty();
+    }
+
+    private static Citation.PageLocation convert(CitationPageLocation citation) {
+        return new Citation.PageLocation(
+                citation.citedText(),
+                citation.documentIndex(),
+                citation.documentTitle().orElse(null),
+                citation.fileId().orElse(null),
+                citation.startPageNumber(),
+                citation.endPageNumber());
+    }
+
+    private static Citation.CharLocation convert(CitationCharLocation citation) {
+        return new Citation.CharLocation(
+                citation.citedText(),
+                citation.documentIndex(),
+                citation.documentTitle().orElse(null),
+                citation.fileId().orElse(null),
+                citation.startCharIndex(),
+                citation.endCharIndex());
+    }
+
+    private static Citation.ContentBlockLocation convert(CitationContentBlockLocation citation) {
+        return new Citation.ContentBlockLocation(
+                citation.citedText(),
+                citation.documentIndex(),
+                citation.documentTitle().orElse(null),
+                citation.fileId().orElse(null),
+                citation.startBlockIndex(),
+                citation.endBlockIndex());
+    }
+
+    private static void logUnsupportedCitation(boolean webSearchResult, boolean searchResult) {
+        String variant =
+                webSearchResult
+                        ? "web_search_result_location"
+                        : searchResult ? "search_result_location" : "unknown";
+        log.debug("Ignoring unsupported Anthropic citation variant: {}", variant);
+    }
+}

--- a/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-anthropic/src/main/java/io/agentscope/extensions/model/anthropic/formatter/AnthropicMediaConverter.java
+++ b/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-anthropic/src/main/java/io/agentscope/extensions/model/anthropic/formatter/AnthropicMediaConverter.java
@@ -65,8 +65,9 @@ public class AnthropicMediaConverter {
 
         if (source instanceof URLSource urlSource) {
             String url = urlSource.getUrl();
-            MediaUtils.validateImageExtension(url);
-            String mediaType = MediaUtils.determineMediaType(url);
+            String mediaPath = isFileUri(url) ? Path.of(URI.create(url)).toString() : url;
+            MediaUtils.validateImageExtension(mediaPath);
+            String mediaType = MediaUtils.determineMediaType(mediaPath);
             return convertUrlImage(url, mediaType != null ? mediaType : "image/png");
         } else if (source instanceof Base64Source base64Source) {
             String mediaType = base64Source.getMediaType();

--- a/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-anthropic/src/main/java/io/agentscope/extensions/model/anthropic/formatter/AnthropicMediaConverter.java
+++ b/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-anthropic/src/main/java/io/agentscope/extensions/model/anthropic/formatter/AnthropicMediaConverter.java
@@ -16,19 +16,45 @@
 package io.agentscope.extensions.model.anthropic.formatter;
 
 import com.anthropic.models.messages.Base64ImageSource;
+import com.anthropic.models.messages.Base64PdfSource;
+import com.anthropic.models.messages.CitationsConfigParam;
+import com.anthropic.models.messages.ContentBlockParam;
+import com.anthropic.models.messages.DocumentBlockParam;
 import com.anthropic.models.messages.ImageBlockParam;
 import com.anthropic.models.messages.UrlImageSource;
+import com.anthropic.models.messages.UrlPdfSource;
 import io.agentscope.core.formatter.MediaUtils;
 import io.agentscope.core.message.Base64Source;
 import io.agentscope.core.message.DataBlock;
 import io.agentscope.core.message.ImageBlock;
 import io.agentscope.core.message.Source;
 import io.agentscope.core.message.URLSource;
+import java.net.URI;
+import java.nio.file.Path;
+import java.util.Objects;
 
 /**
  * Handles media content conversion for Anthropic API.
  */
 public class AnthropicMediaConverter {
+
+    private static final String PDF_MEDIA_TYPE = "application/pdf";
+
+    private final CitationMode citationMode;
+
+    /** Create an Anthropic media converter with citations disabled. */
+    public AnthropicMediaConverter() {
+        this(CitationMode.DISABLED);
+    }
+
+    /**
+     * Create an Anthropic media converter with the given citation mode.
+     *
+     * @param citationMode whether PDF documents should enable native citations
+     */
+    AnthropicMediaConverter(CitationMode citationMode) {
+        this.citationMode = Objects.requireNonNull(citationMode);
+    }
 
     /**
      * Convert ImageBlock to Anthropic ImageBlockParam. For local files, converts to base64. For
@@ -40,29 +66,8 @@ public class AnthropicMediaConverter {
         if (source instanceof URLSource urlSource) {
             String url = urlSource.getUrl();
             MediaUtils.validateImageExtension(url);
-
-            if (MediaUtils.isLocalFile(url)) {
-                // Convert local file to base64
-                String base64Data = MediaUtils.fileToBase64(url);
-                String mediaType = MediaUtils.determineMediaType(url);
-
-                return ImageBlockParam.builder()
-                        .source(
-                                Base64ImageSource.builder()
-                                        .data(base64Data)
-                                        .mediaType(
-                                                Base64ImageSource.MediaType.of(
-                                                        mediaType != null
-                                                                ? mediaType
-                                                                : "image/png"))
-                                        .build())
-                        .build();
-            } else {
-                // Use remote URL directly
-                return ImageBlockParam.builder()
-                        .source(UrlImageSource.builder().url(url).build())
-                        .build();
-            }
+            String mediaType = MediaUtils.determineMediaType(url);
+            return convertUrlImage(url, mediaType != null ? mediaType : "image/png");
         } else if (source instanceof Base64Source base64Source) {
             String mediaType = base64Source.getMediaType();
             String base64Data = base64Source.getData();
@@ -84,9 +89,10 @@ public class AnthropicMediaConverter {
     /**
      * Convert DataBlock to Anthropic ImageBlockParam by resolving MIME type and routing to image.
      *
-     * <p>Anthropic currently supports image modality only via this SDK type. Audio and video
-     * DataBlocks will throw {@link IllegalArgumentException} since the Anthropic API does not
-     * expose a generic binary content block param yet.
+     * <p>This image-only conversion method returns {@link ImageBlockParam}. Use {@link
+     * #convertDataBlockContent(DataBlock)} when the input may be either an image or a PDF.
+     * Audio and video DataBlocks throw {@link IllegalArgumentException} because the Anthropic API
+     * does not expose a generic binary content block param.
      *
      * <p>MIME type resolution order:
      * <ol>
@@ -109,23 +115,7 @@ public class AnthropicMediaConverter {
         }
 
         if (source instanceof URLSource urlSource) {
-            String url = urlSource.getUrl();
-            if (MediaUtils.isLocalFile(url)) {
-                String base64Data = MediaUtils.fileToBase64(url);
-                return ImageBlockParam.builder()
-                        .source(
-                                Base64ImageSource.builder()
-                                        .data(base64Data)
-                                        .mediaType(Base64ImageSource.MediaType.of(mimeType))
-                                        .build())
-                        .build();
-            } else {
-                // mimeType already verified to be image/* above; skip extension check
-                // so that extension-less CDN URLs with an explicit mimeType hint work
-                return ImageBlockParam.builder()
-                        .source(UrlImageSource.builder().url(url).build())
-                        .build();
-            }
+            return convertUrlImage(urlSource.getUrl(), mimeType);
         } else if (source instanceof Base64Source base64Source) {
             return ImageBlockParam.builder()
                     .source(
@@ -137,5 +127,115 @@ public class AnthropicMediaConverter {
         } else {
             throw new IllegalArgumentException("Unsupported source type: " + source.getClass());
         }
+    }
+
+    /**
+     * Convert a generic DataBlock to an Anthropic image or PDF document content block.
+     *
+     * @param dataBlock The data block to convert
+     * @return Anthropic image or document content block
+     * @throws Exception If conversion fails or the MIME type is unsupported
+     */
+    public ContentBlockParam convertDataBlockContent(DataBlock dataBlock) throws Exception {
+        String mimeType = MediaUtils.resolveMimeType(dataBlock.getSource());
+        if (mimeType.startsWith("image/")) {
+            return ContentBlockParam.ofImage(convertDataBlock(dataBlock));
+        }
+        if (PDF_MEDIA_TYPE.equalsIgnoreCase(mimeType)) {
+            return ContentBlockParam.ofDocument(convertPdfDataBlock(dataBlock));
+        }
+        throw new IllegalArgumentException(
+                "Anthropic API only supports image and PDF DataBlocks; got MIME type: " + mimeType);
+    }
+
+    /**
+     * Convert a PDF DataBlock to an Anthropic document block.
+     *
+     * <p>Local files are encoded as base64. Remote HTTP(S) URLs are passed through as URL PDF
+     * sources. Citations are enabled based on the context provided at construction time.
+     *
+     * @param dataBlock PDF data block
+     * @return Anthropic PDF document block
+     * @throws Exception If the source cannot be resolved or read as a PDF
+     */
+    public DocumentBlockParam convertPdfDataBlock(DataBlock dataBlock) throws Exception {
+        Source source = dataBlock.getSource();
+        String mimeType = MediaUtils.resolveMimeType(source);
+        if (!PDF_MEDIA_TYPE.equalsIgnoreCase(mimeType)) {
+            throw new IllegalArgumentException(
+                    "Expected PDF DataBlock; got MIME type: " + mimeType);
+        }
+
+        DocumentBlockParam.Builder builder = DocumentBlockParam.builder();
+        if (dataBlock.getName() != null && !dataBlock.getName().isBlank()) {
+            builder.title(dataBlock.getName());
+        }
+        if (citationMode.isEnabled()) {
+            builder.citations(CitationsConfigParam.builder().enabled(true).build());
+        }
+
+        if (source instanceof URLSource urlSource) {
+            String url = urlSource.getUrl();
+            if (isFileUri(url)) {
+                Path path = Path.of(URI.create(url));
+                builder.source(
+                        Base64PdfSource.builder()
+                                .data(MediaUtils.fileToBase64(path.toString()))
+                                .build());
+            } else if (MediaUtils.isLocalFile(url)) {
+                builder.source(
+                        Base64PdfSource.builder().data(MediaUtils.fileToBase64(url)).build());
+            } else if (isHttpUrl(url)) {
+                builder.source(UrlPdfSource.builder().url(url).build());
+            } else {
+                throw new IllegalArgumentException(
+                        "Anthropic PDF URLs must use HTTP(S) or the file scheme: " + url);
+            }
+        } else if (source instanceof Base64Source base64Source) {
+            builder.source(Base64PdfSource.builder().data(base64Source.getData()).build());
+        } else {
+            throw new IllegalArgumentException("Unsupported source type: " + source.getClass());
+        }
+
+        return builder.build();
+    }
+
+    private ImageBlockParam convertUrlImage(String url, String mimeType) throws Exception {
+        if (isFileUri(url)) {
+            Path path = Path.of(URI.create(url));
+            return createBase64Image(MediaUtils.fileToBase64(path.toString()), mimeType);
+        }
+        if (MediaUtils.isLocalFile(url)) {
+            return createBase64Image(MediaUtils.fileToBase64(url), mimeType);
+        }
+        if (isHttpUrl(url)) {
+            // The MIME type was resolved before this method, so extension-less HTTP(S) URLs with
+            // an explicit hint remain supported.
+            return ImageBlockParam.builder()
+                    .source(UrlImageSource.builder().url(url).build())
+                    .build();
+        }
+        throw new IllegalArgumentException(
+                "Anthropic image URLs must use HTTP(S) or the file scheme: " + url);
+    }
+
+    private ImageBlockParam createBase64Image(String data, String mimeType) {
+        return ImageBlockParam.builder()
+                .source(
+                        Base64ImageSource.builder()
+                                .data(data)
+                                .mediaType(Base64ImageSource.MediaType.of(mimeType))
+                                .build())
+                .build();
+    }
+
+    private static boolean isFileUri(String url) {
+        return url != null && url.regionMatches(true, 0, "file:", 0, "file:".length());
+    }
+
+    private static boolean isHttpUrl(String url) {
+        return url != null
+                && (url.regionMatches(true, 0, "http://", 0, "http://".length())
+                        || url.regionMatches(true, 0, "https://", 0, "https://".length()));
     }
 }

--- a/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-anthropic/src/main/java/io/agentscope/extensions/model/anthropic/formatter/AnthropicMessageConverter.java
+++ b/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-anthropic/src/main/java/io/agentscope/extensions/model/anthropic/formatter/AnthropicMessageConverter.java
@@ -37,6 +37,7 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.function.Function;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -63,8 +64,37 @@ public class AnthropicMessageConverter {
      * @param toolResultConverter Function to convert tool result blocks to strings
      */
     public AnthropicMessageConverter(Function<List<ContentBlock>, String> toolResultConverter) {
-        this.mediaConverter = new AnthropicMediaConverter();
-        this.toolResultConverter = toolResultConverter;
+        this(toolResultConverter, CitationMode.DISABLED);
+    }
+
+    /**
+     * Create an AnthropicMessageConverter with citation mode.
+     *
+     * @param toolResultConverter Function to convert tool result blocks to strings
+     * @param citationMode whether PDF documents should enable native citations
+     */
+    AnthropicMessageConverter(
+            Function<List<ContentBlock>, String> toolResultConverter, CitationMode citationMode) {
+        this.mediaConverter = new AnthropicMediaConverter(citationMode);
+        this.toolResultConverter = Objects.requireNonNull(toolResultConverter);
+    }
+
+    /**
+     * Convert an image or data block to an Anthropic content block param.
+     *
+     * @param block the content block to convert
+     * @return Anthropic content block param
+     * @throws Exception if conversion fails
+     */
+    ContentBlockParam convertMediaBlock(ContentBlock block) throws Exception {
+        if (block instanceof ImageBlock imageBlock) {
+            return ContentBlockParam.ofImage(mediaConverter.convertImageBlock(imageBlock));
+        }
+        if (block instanceof DataBlock dataBlock) {
+            return mediaConverter.convertDataBlockContent(dataBlock);
+        }
+        throw new IllegalArgumentException(
+                "Unsupported media block: " + block.getClass().getSimpleName());
     }
 
     /**
@@ -79,7 +109,6 @@ public class AnthropicMessageConverter {
 
         for (int i = 0; i < messages.size(); i++) {
             Msg msg = messages.get(i);
-            boolean isFirstMessage = (i == 0);
 
             if (msg.getRole() == MsgRole.ASSISTANT
                     && msg.getContentBlocks(ToolUseBlock.class).size() > 1) {
@@ -107,7 +136,7 @@ public class AnthropicMessageConverter {
 
                 // Add regular content if present
                 if (!nonToolBlocks.isEmpty()) {
-                    MessageParam regularMsg = convertMessageContent(msg, nonToolBlocks, i == 0);
+                    MessageParam regularMsg = convertMessageContent(msg, nonToolBlocks);
                     if (regularMsg != null) {
                         result.add(regularMsg);
                     }
@@ -118,7 +147,7 @@ public class AnthropicMessageConverter {
                     result.add(convertToolResult(toolResult));
                 }
             } else {
-                MessageParam param = convertMessageContent(msg, msg.getContent(), isFirstMessage);
+                MessageParam param = convertMessageContent(msg, msg.getContent());
                 if (param != null) {
                     result.add(param);
                 }
@@ -223,8 +252,7 @@ public class AnthropicMessageConverter {
             }
             assistantBlocks.add(toolUse);
 
-            MessageParam assistantParam =
-                    convertMessageContent(assistantMsg, assistantBlocks, false);
+            MessageParam assistantParam = convertMessageContent(assistantMsg, assistantBlocks);
             if (assistantParam != null) {
                 converted.add(assistantParam);
             }
@@ -242,16 +270,13 @@ public class AnthropicMessageConverter {
     /**
      * Convert message content to MessageParam.
      */
-    private MessageParam convertMessageContent(
-            Msg msg, List<ContentBlock> blocks, boolean isFirstMessage) {
-        Role role = convertRole(msg.getRole(), isFirstMessage);
+    private MessageParam convertMessageContent(Msg msg, List<ContentBlock> blocks) {
+        Role role = convertRole(msg.getRole());
         List<ContentBlockParam> contentBlocks = new ArrayList<>();
 
         for (ContentBlock block : blocks) {
             if (block instanceof TextBlock tb) {
-                contentBlocks.add(
-                        ContentBlockParam.ofText(
-                                TextBlockParam.builder().text(tb.getText()).build()));
+                contentBlocks.add(ContentBlockParam.ofText(convertTextBlock(tb)));
             } else if (block instanceof HintBlock hb) {
                 contentBlocks.add(
                         ContentBlockParam.ofText(
@@ -280,8 +305,8 @@ public class AnthropicMessageConverter {
                 }
             } else if (block instanceof DataBlock db) {
                 try {
-                    ImageBlockParam imageParam = mediaConverter.convertDataBlock(db);
-                    contentBlocks.add(ContentBlockParam.ofImage(imageParam));
+                    ContentBlockParam converted = mediaConverter.convertDataBlockContent(db);
+                    contentBlocks.add(converted);
                 } catch (Exception e) {
                     log.warn("Failed to process DataBlock: {}", e.getMessage());
                     contentBlocks.add(
@@ -337,9 +362,7 @@ public class AnthropicMessageConverter {
             for (Object item : outputList) {
                 if (item instanceof ContentBlock cb) {
                     if (cb instanceof TextBlock tb) {
-                        blocks.add(
-                                ToolResultBlockParam.Content.Block.ofText(
-                                        TextBlockParam.builder().text(tb.getText()).build()));
+                        blocks.add(ToolResultBlockParam.Content.Block.ofText(convertTextBlock(tb)));
                     } else if (cb instanceof ImageBlock ib) {
                         try {
                             ImageBlockParam imageParam = mediaConverter.convertImageBlock(ib);
@@ -349,8 +372,17 @@ public class AnthropicMessageConverter {
                         }
                     } else if (cb instanceof DataBlock db) {
                         try {
-                            ImageBlockParam imageParam = mediaConverter.convertDataBlock(db);
-                            blocks.add(ToolResultBlockParam.Content.Block.ofImage(imageParam));
+                            ContentBlockParam converted =
+                                    mediaConverter.convertDataBlockContent(db);
+                            if (converted.isImage()) {
+                                blocks.add(
+                                        ToolResultBlockParam.Content.Block.ofImage(
+                                                converted.asImage()));
+                            } else if (converted.isDocument()) {
+                                blocks.add(
+                                        ToolResultBlockParam.Content.Block.ofDocument(
+                                                converted.asDocument()));
+                            }
                         } catch (Exception e) {
                             log.warn("Failed to process DataBlock in tool result: {}", e);
                         }
@@ -386,17 +418,25 @@ public class AnthropicMessageConverter {
                 .build();
     }
 
+    private TextBlockParam convertTextBlock(TextBlock textBlock) {
+        TextBlockParam.Builder builder = TextBlockParam.builder().text(textBlock.getText());
+        var citations = AnthropicCitationConverter.convertToParams(textBlock.getCitations());
+        if (!citations.isEmpty()) {
+            builder.citations(citations);
+        }
+        return builder.build();
+    }
+
     /**
-     * Convert AgentScope MsgRole to Anthropic Role. Important: Anthropic only allows the first
-     * message to be system. Non-first system messages are converted to user.
+     * Convert AgentScope MsgRole to Anthropic Role. System messages are converted to USER role
+     * because Anthropic uses the system parameter instead of system messages.
      */
-    private Role convertRole(MsgRole msgRole, boolean isFirstMessage) {
+    private Role convertRole(MsgRole msgRole) {
         return switch (msgRole) {
-            case SYSTEM -> isFirstMessage ? Role.USER : Role.USER; // Anthropic uses user for
-            // system messages
+            case SYSTEM -> Role.USER;
             case USER -> Role.USER;
             case ASSISTANT -> Role.ASSISTANT;
-            case TOOL -> Role.USER; // Tool results are always user messages
+            case TOOL -> Role.USER;
         };
     }
 

--- a/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-anthropic/src/main/java/io/agentscope/extensions/model/anthropic/formatter/AnthropicMultiAgentFormatter.java
+++ b/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-anthropic/src/main/java/io/agentscope/extensions/model/anthropic/formatter/AnthropicMultiAgentFormatter.java
@@ -16,12 +16,10 @@
 package io.agentscope.extensions.model.anthropic.formatter;
 
 import com.anthropic.models.messages.ContentBlockParam;
-import com.anthropic.models.messages.ImageBlockParam;
 import com.anthropic.models.messages.Message;
 import com.anthropic.models.messages.MessageParam;
 import com.anthropic.models.messages.TextBlockParam;
-import io.agentscope.core.message.DataBlock;
-import io.agentscope.core.message.ImageBlock;
+import io.agentscope.core.message.ContentBlock;
 import io.agentscope.core.message.Msg;
 import io.agentscope.core.message.MsgRole;
 import io.agentscope.core.message.ToolResultBlock;
@@ -54,9 +52,7 @@ public class AnthropicMultiAgentFormatter extends AnthropicBaseFormatter {
                     + "The content between <history></history> tags contains your conversation"
                     + " history\n";
 
-    private final AnthropicMediaConverter mediaConverter;
     private final String conversationHistoryPrompt;
-    private boolean isFirstAgentMessageGroup = true;
 
     /** Create an AnthropicMultiAgentFormatter with default conversation history prompt. */
     public AnthropicMultiAgentFormatter() {
@@ -69,14 +65,19 @@ public class AnthropicMultiAgentFormatter extends AnthropicBaseFormatter {
      * @param conversationHistoryPrompt The prompt to prepend before conversation history
      */
     public AnthropicMultiAgentFormatter(String conversationHistoryPrompt) {
-        this.mediaConverter = new AnthropicMediaConverter();
         this.conversationHistoryPrompt = conversationHistoryPrompt;
     }
 
     @Override
     public List<MessageParam> doFormat(List<Msg> msgs) {
+        return doFormat(msgs, messageConverter);
+    }
+
+    @Override
+    protected List<MessageParam> doFormat(
+            List<Msg> msgs, AnthropicMessageConverter requestConverter) {
         List<MessageParam> result = new ArrayList<>();
-        this.isFirstAgentMessageGroup = true;
+        boolean isFirstAgentMessageGroup = true;
 
         // Group messages
         List<MessageGroup> groups = groupMessages(msgs);
@@ -85,10 +86,18 @@ public class AnthropicMultiAgentFormatter extends AnthropicBaseFormatter {
             switch (group.type) {
                 case SYSTEM -> {
                     Msg systemMsg = group.messages.get(0);
-                    result.addAll(messageConverter.convert(List.of(systemMsg)));
+                    result.addAll(requestConverter.convert(List.of(systemMsg)));
                 }
-                case TOOL_SEQUENCE -> result.addAll(formatToolSequence(group.messages));
-                case AGENT_CONVERSATION -> result.addAll(formatAgentConversation(group.messages));
+                case TOOL_SEQUENCE ->
+                        result.addAll(formatToolSequence(group.messages, requestConverter));
+                case AGENT_CONVERSATION -> {
+                    String historyPrompt =
+                            isFirstAgentMessageGroup ? conversationHistoryPrompt : "";
+                    result.addAll(
+                            formatAgentConversation(
+                                    group.messages, requestConverter, historyPrompt));
+                    isFirstAgentMessageGroup = false;
+                }
             }
         }
 
@@ -175,20 +184,17 @@ public class AnthropicMultiAgentFormatter extends AnthropicBaseFormatter {
     }
 
     /** Format tool sequence (tool calls and results). */
-    private List<MessageParam> formatToolSequence(List<Msg> messages) {
-        return messageConverter.convert(messages);
+    private List<MessageParam> formatToolSequence(
+            List<Msg> messages, AnthropicMessageConverter requestConverter) {
+        return requestConverter.convert(messages);
     }
 
     /** Format agent conversation messages with history tags. */
-    private List<MessageParam> formatAgentConversation(List<Msg> messages) {
-        boolean isFirst = isFirstAgentMessageGroup;
-        isFirstAgentMessageGroup = false;
-
-        String prompt = isFirst ? conversationHistoryPrompt : "";
-
+    private List<MessageParam> formatAgentConversation(
+            List<Msg> messages, AnthropicMessageConverter requestConverter, String historyPrompt) {
         // Merge conversation with history tags
         List<Object> conversationBlocks =
-                AnthropicConversationMerger.mergeConversation(messages, prompt);
+                AnthropicConversationMerger.mergeConversation(messages, historyPrompt);
 
         // Convert to ContentBlockParam list
         List<ContentBlockParam> contentBlocks = new ArrayList<>();
@@ -197,19 +203,11 @@ public class AnthropicMultiAgentFormatter extends AnthropicBaseFormatter {
             if (block instanceof String text) {
                 contentBlocks.add(
                         ContentBlockParam.ofText(TextBlockParam.builder().text(text).build()));
-            } else if (block instanceof ImageBlock ib) {
+            } else if (block instanceof ContentBlock cb) {
                 try {
-                    ImageBlockParam imageParam = mediaConverter.convertImageBlock(ib);
-                    contentBlocks.add(ContentBlockParam.ofImage(imageParam));
+                    contentBlocks.add(requestConverter.convertMediaBlock(cb));
                 } catch (Exception e) {
-                    log.warn("Failed to process ImageBlock in multi-agent conversation: {}", e);
-                }
-            } else if (block instanceof DataBlock db) {
-                try {
-                    ImageBlockParam imageParam = mediaConverter.convertDataBlock(db);
-                    contentBlocks.add(ContentBlockParam.ofImage(imageParam));
-                } catch (Exception e) {
-                    log.warn("Failed to process DataBlock in multi-agent conversation: {}", e);
+                    log.warn("Failed to process media block in multi-agent conversation: {}", e);
                 }
             }
         }

--- a/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-anthropic/src/main/java/io/agentscope/extensions/model/anthropic/formatter/AnthropicResponseParser.java
+++ b/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-anthropic/src/main/java/io/agentscope/extensions/model/anthropic/formatter/AnthropicResponseParser.java
@@ -19,6 +19,7 @@ import com.anthropic.core.JsonValue;
 import com.anthropic.core.ObjectMappers;
 import com.anthropic.models.messages.Message;
 import com.anthropic.models.messages.RawMessageStreamEvent;
+import io.agentscope.core.message.Citation;
 import io.agentscope.core.message.ContentBlock;
 import io.agentscope.core.message.TextBlock;
 import io.agentscope.core.message.ThinkingBlock;
@@ -50,13 +51,25 @@ public class AnthropicResponseParser {
         List<ContentBlock> contentBlocks = new ArrayList<>();
 
         // Process content blocks
-        for (var block : message.content()) {
+        for (int index = 0; index < message.content().size(); index++) {
+            long blockIndex = index;
+            var block = message.content().get(index);
             // Text block
             block.text()
                     .ifPresent(
-                            textBlock ->
-                                    contentBlocks.add(
-                                            TextBlock.builder().text(textBlock.text()).build()));
+                            textBlock -> {
+                                List<Citation> citations =
+                                        textBlock
+                                                .citations()
+                                                .map(AnthropicCitationConverter::convert)
+                                                .orElse(List.of());
+                                contentBlocks.add(
+                                        TextBlock.builder()
+                                                .text(textBlock.text())
+                                                .citations(citations)
+                                                .providerBlockIndex(blockIndex)
+                                                .build());
+                            });
 
             // Tool use block
             block.toolUse()
@@ -138,7 +151,24 @@ public class AnthropicResponseParser {
                     .ifPresent(
                             textDelta ->
                                     contentBlocks.add(
-                                            TextBlock.builder().text(textDelta.text()).build()));
+                                            TextBlock.builder()
+                                                    .text(textDelta.text())
+                                                    .providerBlockIndex(deltaEvent.index())
+                                                    .build()));
+
+            deltaEvent
+                    .delta()
+                    .citations()
+                    .flatMap(
+                            citationsDelta ->
+                                    AnthropicCitationConverter.convert(citationsDelta.citation()))
+                    .ifPresent(
+                            citation ->
+                                    contentBlocks.add(
+                                            TextBlock.builder()
+                                                    .citations(List.of(citation))
+                                                    .providerBlockIndex(deltaEvent.index())
+                                                    .build()));
 
             deltaEvent
                     .delta()

--- a/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-anthropic/src/main/java/io/agentscope/extensions/model/anthropic/formatter/CitationMode.java
+++ b/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-anthropic/src/main/java/io/agentscope/extensions/model/anthropic/formatter/CitationMode.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.extensions.model.anthropic.formatter;
+
+/** Controls whether Anthropic's native document citations are enabled for a request. */
+enum CitationMode {
+    ENABLED,
+    DISABLED;
+
+    boolean isEnabled() {
+        return this == ENABLED;
+    }
+}

--- a/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-anthropic/src/test/java/io/agentscope/extensions/model/anthropic/AnthropicChatModelTest.java
+++ b/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-anthropic/src/test/java/io/agentscope/extensions/model/anthropic/AnthropicChatModelTest.java
@@ -17,9 +17,14 @@ package io.agentscope.extensions.model.anthropic;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
+import com.anthropic.models.messages.MessageParam;
+import io.agentscope.core.message.Msg;
 import io.agentscope.core.model.GenerateOptions;
+import io.agentscope.core.model.ModelException;
 import io.agentscope.core.model.ToolChoice;
 import io.agentscope.core.model.ToolSchema;
 import io.agentscope.core.model.test.ModelTestUtils;
@@ -31,6 +36,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import reactor.test.StepVerifier;
 
 /**
  * Unit tests for AnthropicChatModel.
@@ -448,5 +454,61 @@ class AnthropicChatModelTest {
                         .build();
 
         assertNotNull(model);
+    }
+
+    @Test
+    @DisplayName("Should pass request and default options to formatter")
+    void testPassesRequestAndDefaultOptionsToFormatter() {
+        GenerateOptions defaultOptions =
+                GenerateOptions.builder().citationsEnabled(true).temperature(0.7).build();
+        GenerateOptions requestOptions = GenerateOptions.builder().maxTokens(1024).build();
+        RecordingAnthropicChatFormatter formatter = new RecordingAnthropicChatFormatter();
+
+        AnthropicChatModel model =
+                AnthropicChatModel.builder()
+                        .apiKey(mockApiKey)
+                        .modelName("claude-sonnet-4-5-20250929")
+                        .defaultOptions(defaultOptions)
+                        .formatter(formatter)
+                        .build();
+
+        StepVerifier.create(model.stream(List.of(), null, requestOptions))
+                .expectErrorMatches(
+                        error ->
+                                error instanceof ModelException
+                                        && error.getCause() instanceof StopAfterFormattingException)
+                .verify();
+
+        assertFalse(formatter.singleArgumentFormatCalled);
+        assertSame(requestOptions, formatter.requestOptions);
+        assertSame(defaultOptions, formatter.defaultOptions);
+    }
+
+    private static final class RecordingAnthropicChatFormatter extends AnthropicChatFormatter {
+
+        private boolean singleArgumentFormatCalled;
+        private GenerateOptions requestOptions;
+        private GenerateOptions defaultOptions;
+
+        @Override
+        public List<MessageParam> format(List<Msg> messages) {
+            singleArgumentFormatCalled = true;
+            throw new StopAfterFormattingException();
+        }
+
+        @Override
+        public List<MessageParam> format(
+                List<Msg> messages,
+                GenerateOptions requestOptions,
+                GenerateOptions defaultOptions) {
+            this.requestOptions = requestOptions;
+            this.defaultOptions = defaultOptions;
+            throw new StopAfterFormattingException();
+        }
+    }
+
+    private static final class StopAfterFormattingException extends RuntimeException {
+
+        private static final long serialVersionUID = 1L;
     }
 }

--- a/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-anthropic/src/test/java/io/agentscope/extensions/model/anthropic/formatter/AnthropicChatFormatterTest.java
+++ b/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-anthropic/src/test/java/io/agentscope/extensions/model/anthropic/formatter/AnthropicChatFormatterTest.java
@@ -17,6 +17,7 @@ package io.agentscope.extensions.model.anthropic.formatter;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
@@ -29,6 +30,8 @@ import com.anthropic.models.messages.MessageCreateParams;
 import com.anthropic.models.messages.MessageParam;
 import com.anthropic.models.messages.TextBlockParam;
 import com.anthropic.models.messages.Usage;
+import io.agentscope.core.message.Base64Source;
+import io.agentscope.core.message.DataBlock;
 import io.agentscope.core.message.Msg;
 import io.agentscope.core.message.MsgRole;
 import io.agentscope.core.message.TextBlock;
@@ -459,5 +462,63 @@ class AnthropicChatFormatterTest extends AnthropicFormatterTestBase {
         assertEquals(1, result.size());
         // Tool results are converted to USER messages
         assertEquals(MessageParam.Role.USER, result.get(0).role());
+    }
+
+    @Test
+    void testFormatPdfWithRequestLevelCitations() {
+        DataBlock pdf =
+                DataBlock.builder()
+                        .name("guide.pdf")
+                        .source(
+                                Base64Source.builder()
+                                        .mediaType("application/pdf")
+                                        .data("JVBERi0xLjQK")
+                                        .build())
+                        .build();
+        Msg msg = Msg.builder().role(MsgRole.USER).content(pdf).build();
+
+        List<MessageParam> result =
+                formatter.format(
+                        List.of(msg),
+                        GenerateOptions.builder().citationsEnabled(true).build(),
+                        null);
+
+        ContentBlockParam document = result.get(0).content().asBlockParams().get(0);
+        assertTrue(document.isDocument());
+        assertTrue(document.asDocument().citations().orElseThrow().enabled().orElseThrow());
+
+        ContentBlockParam withoutCitations =
+                formatter.format(List.of(msg)).get(0).content().asBlockParams().get(0);
+        assertTrue(withoutCitations.asDocument().citations().isEmpty());
+    }
+
+    @Test
+    void testFormatWithCitationsDisabledDelegatesToSingleParamFormat() {
+        RecordingChatFormatter recordingFormatter = new RecordingChatFormatter();
+        List<Msg> messages =
+                List.of(
+                        Msg.builder()
+                                .role(MsgRole.USER)
+                                .content(TextBlock.builder().text("Hello").build())
+                                .build());
+
+        List<MessageParam> result =
+                recordingFormatter.format(
+                        messages, GenerateOptions.builder().citationsEnabled(false).build(), null);
+
+        assertTrue(recordingFormatter.singleArgumentFormatCalled);
+        assertSame(recordingFormatter.formattedMessages, result);
+    }
+
+    private static final class RecordingChatFormatter extends AnthropicChatFormatter {
+
+        private final List<MessageParam> formattedMessages = List.of();
+        private boolean singleArgumentFormatCalled;
+
+        @Override
+        public List<MessageParam> format(List<Msg> msgs) {
+            singleArgumentFormatCalled = true;
+            return formattedMessages;
+        }
     }
 }

--- a/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-anthropic/src/test/java/io/agentscope/extensions/model/anthropic/formatter/AnthropicCitationConverterTest.java
+++ b/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-anthropic/src/test/java/io/agentscope/extensions/model/anthropic/formatter/AnthropicCitationConverterTest.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.extensions.model.anthropic.formatter;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.anthropic.models.messages.CitationCharLocation;
+import com.anthropic.models.messages.CitationContentBlockLocation;
+import com.anthropic.models.messages.CitationsDelta;
+import com.anthropic.models.messages.CitationsSearchResultLocation;
+import com.anthropic.models.messages.CitationsWebSearchResultLocation;
+import com.anthropic.models.messages.TextCitation;
+import io.agentscope.core.message.Citation;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+
+class AnthropicCitationConverterTest {
+
+    @Test
+    void charLocationRoundTrip() {
+        CitationCharLocation providerCitation =
+                CitationCharLocation.builder()
+                        .citedText("source text")
+                        .documentIndex(1)
+                        .documentTitle("guide.txt")
+                        .fileId(Optional.empty())
+                        .startCharIndex(4)
+                        .endCharIndex(15)
+                        .build();
+
+        Citation.CharLocation coreCitation =
+                assertInstanceOf(
+                        Citation.CharLocation.class,
+                        AnthropicCitationConverter.convert(
+                                        TextCitation.ofCharLocation(providerCitation))
+                                .orElseThrow());
+        var convertedBack =
+                AnthropicCitationConverter.convertToParams(List.of(coreCitation))
+                        .get(0)
+                        .asCharLocation();
+
+        assertEquals("source text", coreCitation.citedText());
+        assertEquals("guide.txt", coreCitation.documentTitle());
+        assertEquals(4, coreCitation.startCharIndex());
+        assertEquals(15, coreCitation.endCharIndex());
+        assertEquals(coreCitation.citedText(), convertedBack.citedText());
+        assertEquals(coreCitation.documentIndex(), convertedBack.documentIndex());
+        assertEquals(coreCitation.startCharIndex(), convertedBack.startCharIndex());
+        assertEquals(coreCitation.endCharIndex(), convertedBack.endCharIndex());
+    }
+
+    @Test
+    void contentBlockLocationRoundTrip() {
+        CitationContentBlockLocation providerCitation =
+                CitationContentBlockLocation.builder()
+                        .citedText("source blocks")
+                        .documentIndex(2)
+                        .documentTitle(Optional.empty())
+                        .fileId("file-2")
+                        .startBlockIndex(3)
+                        .endBlockIndex(6)
+                        .build();
+
+        Citation.ContentBlockLocation coreCitation =
+                assertInstanceOf(
+                        Citation.ContentBlockLocation.class,
+                        AnthropicCitationConverter.convert(
+                                        TextCitation.ofContentBlockLocation(providerCitation))
+                                .orElseThrow());
+        var convertedBack =
+                AnthropicCitationConverter.convertToParams(List.of(coreCitation))
+                        .get(0)
+                        .asContentBlockLocation();
+
+        assertEquals("file-2", coreCitation.fileId());
+        assertEquals(3, coreCitation.startBlockIndex());
+        assertEquals(6, coreCitation.endBlockIndex());
+        assertEquals(coreCitation.citedText(), convertedBack.citedText());
+        assertEquals(coreCitation.documentIndex(), convertedBack.documentIndex());
+        assertEquals(coreCitation.startBlockIndex(), convertedBack.startBlockIndex());
+        assertEquals(coreCitation.endBlockIndex(), convertedBack.endBlockIndex());
+    }
+
+    @Test
+    void unsupportedSearchCitationVariantsAreIgnored() {
+        CitationsWebSearchResultLocation webSearchCitation =
+                CitationsWebSearchResultLocation.builder()
+                        .citedText("web result")
+                        .encryptedIndex("encrypted-index")
+                        .title(Optional.empty())
+                        .url("https://example.com")
+                        .build();
+        CitationsSearchResultLocation searchCitation =
+                CitationsSearchResultLocation.builder()
+                        .citedText("search result")
+                        .startBlockIndex(0)
+                        .endBlockIndex(1)
+                        .searchResultIndex(0)
+                        .source("knowledge-base")
+                        .title(Optional.empty())
+                        .build();
+
+        assertTrue(
+                AnthropicCitationConverter.convert(
+                                TextCitation.ofWebSearchResultLocation(webSearchCitation))
+                        .isEmpty());
+        assertTrue(
+                AnthropicCitationConverter.convert(
+                                CitationsDelta.Citation.ofSearchResultLocation(searchCitation))
+                        .isEmpty());
+    }
+}

--- a/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-anthropic/src/test/java/io/agentscope/extensions/model/anthropic/formatter/AnthropicMediaConverterTest.java
+++ b/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-anthropic/src/test/java/io/agentscope/extensions/model/anthropic/formatter/AnthropicMediaConverterTest.java
@@ -21,6 +21,8 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.anthropic.models.messages.Base64ImageSource;
+import com.anthropic.models.messages.ContentBlockParam;
+import com.anthropic.models.messages.DocumentBlockParam;
 import com.anthropic.models.messages.ImageBlockParam;
 import com.anthropic.models.messages.UrlImageSource;
 import io.agentscope.core.message.Base64Source;
@@ -28,6 +30,8 @@ import io.agentscope.core.message.DataBlock;
 import io.agentscope.core.message.ImageBlock;
 import io.agentscope.core.message.Source;
 import io.agentscope.core.message.URLSource;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Base64;
 import org.junit.jupiter.api.Test;
 
@@ -69,6 +73,18 @@ class AnthropicMediaConverterTest extends AnthropicFormatterTestBase {
         assertNotNull(base64Source.data());
         // Verify it's valid base64
         byte[] decoded = Base64.getDecoder().decode(base64Source.data());
+        assertEquals("fake image content", new String(decoded));
+    }
+
+    @Test
+    void testConvertImageBlockWithFileUri() throws Exception {
+        URLSource source = URLSource.builder().url(tempImageFile.toUri().toString()).build();
+        ImageBlock block = ImageBlock.builder().source(source).build();
+
+        ImageBlockParam result = converter.convertImageBlock(block);
+
+        assertTrue(result.source().isBase64());
+        byte[] decoded = Base64.getDecoder().decode(result.source().asBase64().data());
         assertEquals("fake image content", new String(decoded));
     }
 
@@ -234,6 +250,55 @@ class AnthropicMediaConverterTest extends AnthropicFormatterTestBase {
     }
 
     @Test
+    void testConvertDataBlockWithFileUri() throws Exception {
+        URLSource source =
+                URLSource.builder()
+                        .url(tempImageFile.toUri().toString())
+                        .mimeType("image/png")
+                        .build();
+        DataBlock block = DataBlock.builder().source(source).build();
+
+        ImageBlockParam result = converter.convertDataBlock(block);
+
+        assertTrue(result.source().isBase64());
+        byte[] decoded = Base64.getDecoder().decode(result.source().asBase64().data());
+        assertEquals("fake image content", new String(decoded));
+    }
+
+    @Test
+    void testConvertDataBlockContentWithImage() throws Exception {
+        Base64Source source =
+                Base64Source.builder()
+                        .data("ZmFrZSBpbWFnZSBjb250ZW50")
+                        .mediaType("image/png")
+                        .build();
+        DataBlock block = DataBlock.builder().source(source).build();
+
+        ContentBlockParam result = converter.convertDataBlockContent(block);
+
+        assertTrue(result.isImage());
+        assertEquals("ZmFrZSBpbWFnZSBjb250ZW50", result.asImage().source().asBase64().data());
+    }
+
+    @Test
+    void testConvertImageWithUnsupportedRemoteSchemeThrows() {
+        DataBlock block =
+                DataBlock.builder()
+                        .source(
+                                URLSource.builder()
+                                        .url("ftp://example.com/image.png")
+                                        .mimeType("image/png")
+                                        .build())
+                        .build();
+
+        IllegalArgumentException error =
+                assertThrows(
+                        IllegalArgumentException.class, () -> converter.convertDataBlock(block));
+
+        assertTrue(error.getMessage().contains("HTTP(S)"));
+    }
+
+    @Test
     void testConvertDataBlockNonImageMimeTypeThrows() {
         // Anthropic only supports image — audio/video DataBlocks must throw
         Base64Source source =
@@ -250,10 +315,144 @@ class AnthropicMediaConverterTest extends AnthropicFormatterTestBase {
     }
 
     @Test
+    void testConvertDataBlockContentUnsupportedMimeTypeThrows() {
+        Base64Source source =
+                Base64Source.builder().data("e30=").mediaType("application/json").build();
+        DataBlock block = DataBlock.builder().source(source).build();
+
+        IllegalArgumentException ex =
+                assertThrows(
+                        IllegalArgumentException.class,
+                        () -> converter.convertDataBlockContent(block));
+
+        assertTrue(ex.getMessage().contains("image and PDF"));
+        assertTrue(ex.getMessage().contains("application/json"));
+    }
+
+    @Test
     void testConvertDataBlockNoExtensionNoHintThrows() {
         URLSource source = URLSource.builder().url("https://cdn.example.com/media/abc123").build();
         DataBlock block = DataBlock.builder().source(source).build();
 
         assertThrows(Exception.class, () -> converter.convertDataBlock(block));
+    }
+
+    @Test
+    void testConvertBase64PdfDataBlockWithCitations() throws Exception {
+        Base64Source source =
+                Base64Source.builder().data("JVBERi0xLjQK").mediaType("application/pdf").build();
+        DataBlock block = DataBlock.builder().source(source).name("guide.pdf").build();
+
+        AnthropicMediaConverter citationsConverter =
+                new AnthropicMediaConverter(CitationMode.ENABLED);
+        ContentBlockParam result = citationsConverter.convertDataBlockContent(block);
+
+        assertTrue(result.isDocument());
+        DocumentBlockParam document = result.asDocument();
+        assertTrue(document.source().isBase64());
+        assertEquals("JVBERi0xLjQK", document.source().asBase64().data());
+        assertEquals("guide.pdf", document.title().orElseThrow());
+        assertTrue(document.citations().orElseThrow().enabled().orElseThrow());
+    }
+
+    @Test
+    void testConvertRemotePdfDataBlockWithoutCitations() throws Exception {
+        String url = "https://example.com/guide.pdf";
+        DataBlock block =
+                DataBlock.builder()
+                        .source(URLSource.builder().url(url).mimeType("application/pdf").build())
+                        .build();
+
+        ContentBlockParam result = converter.convertDataBlockContent(block);
+
+        assertTrue(result.isDocument());
+        DocumentBlockParam document = result.asDocument();
+        assertTrue(document.source().isUrl());
+        assertEquals(url, document.source().asUrl().url());
+        assertTrue(document.citations().isEmpty());
+    }
+
+    @Test
+    void testConvertLocalPdfDataBlockToBase64() throws Exception {
+        Path pdf = Files.createTempFile("test_document", ".pdf");
+        try {
+            Files.writeString(pdf, "%PDF-1.4");
+            DataBlock block =
+                    DataBlock.builder()
+                            .source(
+                                    URLSource.builder()
+                                            .url(pdf.toString())
+                                            .mimeType("application/pdf")
+                                            .build())
+                            .build();
+
+            ContentBlockParam result = converter.convertDataBlockContent(block);
+
+            assertTrue(result.asDocument().source().isBase64());
+            byte[] decoded =
+                    Base64.getDecoder().decode(result.asDocument().source().asBase64().data());
+            assertEquals("%PDF-1.4", new String(decoded));
+        } finally {
+            Files.deleteIfExists(pdf);
+        }
+    }
+
+    @Test
+    void testConvertFileUriPdfDataBlockToBase64() throws Exception {
+        Path pdf = Files.createTempFile("test_document_uri", ".pdf");
+        try {
+            Files.writeString(pdf, "%PDF-1.4");
+            DataBlock block =
+                    DataBlock.builder()
+                            .source(
+                                    URLSource.builder()
+                                            .url(pdf.toUri().toString())
+                                            .mimeType("application/pdf")
+                                            .build())
+                            .build();
+
+            ContentBlockParam result = converter.convertDataBlockContent(block);
+
+            assertTrue(result.asDocument().source().isBase64());
+            byte[] decoded =
+                    Base64.getDecoder().decode(result.asDocument().source().asBase64().data());
+            assertEquals("%PDF-1.4", new String(decoded));
+        } finally {
+            Files.deleteIfExists(pdf);
+        }
+    }
+
+    @Test
+    void testConvertPdfWithUnsupportedRemoteSchemeThrows() {
+        DataBlock block =
+                DataBlock.builder()
+                        .source(
+                                URLSource.builder()
+                                        .url("ftp://example.com/document.pdf")
+                                        .mimeType("application/pdf")
+                                        .build())
+                        .build();
+
+        IllegalArgumentException error =
+                assertThrows(
+                        IllegalArgumentException.class,
+                        () -> converter.convertDataBlockContent(block));
+
+        assertTrue(error.getMessage().contains("HTTP(S)"));
+    }
+
+    @Test
+    void testConvertPdfDataBlockFromExtensionWithoutExplicitMimeType() throws Exception {
+        DataBlock block =
+                DataBlock.builder()
+                        .source(URLSource.builder().url("https://example.com/document.pdf").build())
+                        .build();
+
+        ContentBlockParam result = converter.convertDataBlockContent(block);
+
+        assertTrue(result.isDocument());
+        assertTrue(result.asDocument().source().isUrl());
+        assertEquals(
+                "https://example.com/document.pdf", result.asDocument().source().asUrl().url());
     }
 }

--- a/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-anthropic/src/test/java/io/agentscope/extensions/model/anthropic/formatter/AnthropicMessageConverterTest.java
+++ b/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-anthropic/src/test/java/io/agentscope/extensions/model/anthropic/formatter/AnthropicMessageConverterTest.java
@@ -24,7 +24,9 @@ import com.anthropic.models.messages.MessageParam;
 import com.anthropic.models.messages.ToolResultBlockParam;
 import com.anthropic.models.messages.ToolUseBlockParam;
 import io.agentscope.core.message.Base64Source;
+import io.agentscope.core.message.Citation;
 import io.agentscope.core.message.ContentBlock;
+import io.agentscope.core.message.DataBlock;
 import io.agentscope.core.message.ImageBlock;
 import io.agentscope.core.message.Msg;
 import io.agentscope.core.message.MsgRole;
@@ -94,6 +96,32 @@ class AnthropicMessageConverterTest extends AnthropicFormatterTestBase {
         assertEquals(1, result.size());
         MessageParam param = result.get(0);
         assertEquals(MessageParam.Role.ASSISTANT, param.role());
+    }
+
+    @Test
+    void testConvertAssistantMessagePreservesPdfCitation() {
+        Citation.PageLocation citation =
+                new Citation.PageLocation("Source text", 0, "guide.pdf", null, 3, 4);
+        Msg msg =
+                Msg.builder()
+                        .name("Assistant")
+                        .role(MsgRole.ASSISTANT)
+                        .content(
+                                TextBlock.builder()
+                                        .text("Cited answer")
+                                        .citations(List.of(citation))
+                                        .build())
+                        .build();
+
+        ContentBlockParam converted =
+                converter.convert(List.of(msg)).get(0).content().asBlockParams().get(0);
+
+        var convertedCitation =
+                converted.asText().citations().orElseThrow().get(0).asPageLocation();
+        assertEquals("Source text", convertedCitation.citedText());
+        assertEquals("guide.pdf", convertedCitation.documentTitle().orElseThrow());
+        assertEquals(3, convertedCitation.startPageNumber());
+        assertEquals(4, convertedCitation.endPageNumber());
     }
 
     @Test
@@ -320,6 +348,53 @@ class AnthropicMessageConverterTest extends AnthropicFormatterTestBase {
         assertEquals(1, result.size());
         List<ContentBlockParam> blocks = result.get(0).content().asBlockParams();
         assertTrue(blocks.get(0).isToolResult());
+    }
+
+    @Test
+    void testConvertToolResultBlockWithPdfDataBlock() {
+        DataBlock pdf =
+                DataBlock.builder()
+                        .name("tool-output.pdf")
+                        .source(
+                                Base64Source.builder()
+                                        .data("JVBERi0xLjQK")
+                                        .mediaType("application/pdf")
+                                        .build())
+                        .build();
+        Msg msg =
+                Msg.builder()
+                        .name("Tool")
+                        .role(MsgRole.TOOL)
+                        .content(
+                                ToolResultBlock.builder()
+                                        .id("call_pdf")
+                                        .name("read_pdf")
+                                        .output(List.of(pdf))
+                                        .build())
+                        .build();
+
+        AnthropicMessageConverter citationsConverter =
+                new AnthropicMessageConverter(
+                        blocks -> {
+                            StringBuilder sb = new StringBuilder();
+                            for (ContentBlock block : blocks) {
+                                if (block instanceof TextBlock tb) {
+                                    sb.append(tb.getText());
+                                }
+                            }
+                            return sb.toString();
+                        },
+                        CitationMode.ENABLED);
+        List<MessageParam> result = citationsConverter.convert(List.of(msg));
+
+        ToolResultBlockParam toolResult =
+                result.get(0).content().asBlockParams().get(0).asToolResult();
+        var toolContent = toolResult.content().orElseThrow().asBlocks();
+        assertEquals(1, toolContent.size());
+        assertTrue(toolContent.get(0).isDocument());
+        assertEquals("JVBERi0xLjQK", toolContent.get(0).asDocument().source().asBase64().data());
+        assertTrue(
+                toolContent.get(0).asDocument().citations().orElseThrow().enabled().orElseThrow());
     }
 
     @Test

--- a/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-anthropic/src/test/java/io/agentscope/extensions/model/anthropic/formatter/AnthropicMultiAgentFormatterGroundTruthTest.java
+++ b/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-anthropic/src/test/java/io/agentscope/extensions/model/anthropic/formatter/AnthropicMultiAgentFormatterGroundTruthTest.java
@@ -16,10 +16,14 @@
 package io.agentscope.extensions.model.anthropic.formatter;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.anthropic.core.ObjectMappers;
+import com.anthropic.models.messages.ContentBlockParam;
 import com.anthropic.models.messages.MessageParam;
 import com.fasterxml.jackson.databind.JsonNode;
+import io.agentscope.core.message.Base64Source;
+import io.agentscope.core.message.DataBlock;
 import io.agentscope.core.message.ImageBlock;
 import io.agentscope.core.message.Msg;
 import io.agentscope.core.message.MsgRole;
@@ -27,6 +31,7 @@ import io.agentscope.core.message.TextBlock;
 import io.agentscope.core.message.ToolResultBlock;
 import io.agentscope.core.message.ToolUseBlock;
 import io.agentscope.core.message.URLSource;
+import io.agentscope.core.model.GenerateOptions;
 import io.agentscope.core.util.JsonCodec;
 import io.agentscope.core.util.JsonUtils;
 import java.util.ArrayList;
@@ -461,5 +466,31 @@ class AnthropicMultiAgentFormatterGroundTruthTest {
 
         JsonNode groundTruthNode = jsonCodec.fromJson(groundTruthJson, JsonNode.class);
         assertEquals(groundTruthNode, resultNode);
+    }
+
+    @Test
+    void testMultiAgentFormatterConvertsPdfDataBlockWithCitations() {
+        DataBlock pdf =
+                DataBlock.builder()
+                        .name("conversation.pdf")
+                        .source(
+                                Base64Source.builder()
+                                        .data("JVBERi0xLjQK")
+                                        .mediaType("application/pdf")
+                                        .build())
+                        .build();
+        Msg message = Msg.builder().name("user").role(MsgRole.USER).content(List.of(pdf)).build();
+        GenerateOptions options = GenerateOptions.builder().citationsEnabled(true).build();
+
+        List<MessageParam> result =
+                formatter.format(List.of(message), options, GenerateOptions.builder().build());
+
+        ContentBlockParam document =
+                result.get(0).content().asBlockParams().stream()
+                        .filter(ContentBlockParam::isDocument)
+                        .findFirst()
+                        .orElseThrow();
+        assertEquals("JVBERi0xLjQK", document.asDocument().source().asBase64().data());
+        assertTrue(document.asDocument().citations().orElseThrow().enabled().orElseThrow());
     }
 }

--- a/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-anthropic/src/test/java/io/agentscope/extensions/model/anthropic/formatter/AnthropicResponseParserTest.java
+++ b/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-anthropic/src/test/java/io/agentscope/extensions/model/anthropic/formatter/AnthropicResponseParserTest.java
@@ -24,12 +24,15 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import com.anthropic.core.JsonValue;
+import com.anthropic.models.messages.CitationPageLocation;
 import com.anthropic.models.messages.ContentBlock;
 import com.anthropic.models.messages.Message;
 import com.anthropic.models.messages.RawContentBlockDeltaEvent;
 import com.anthropic.models.messages.RawMessageStartEvent;
 import com.anthropic.models.messages.RawMessageStreamEvent;
 import com.anthropic.models.messages.Usage;
+import io.agentscope.core.message.Citation;
 import io.agentscope.core.message.TextBlock;
 import io.agentscope.core.message.ThinkingBlock;
 import io.agentscope.core.message.ToolUseBlock;
@@ -103,6 +106,56 @@ class AnthropicResponseParserTest extends AnthropicFormatterTestBase {
         assertNotNull(responseUsage);
         assertEquals(100, responseUsage.getInputTokens());
         assertEquals(50, responseUsage.getOutputTokens());
+    }
+
+    @Test
+    void testParseMessageWithPdfCitation() {
+        CitationPageLocation providerCitation =
+                CitationPageLocation.builder()
+                        .citedText("PDF source text")
+                        .documentIndex(0)
+                        .documentTitle("guide.pdf")
+                        .fileId(Optional.empty())
+                        .startPageNumber(2)
+                        .endPageNumber(3)
+                        .build();
+        com.anthropic.models.messages.TextBlock providerText =
+                com.anthropic.models.messages.TextBlock.builder()
+                        .text("The feature is supported.")
+                        .addCitation(providerCitation)
+                        .build();
+        Message message =
+                Message.builder()
+                        .id("msg_cited")
+                        .addContent(providerText)
+                        .model("claude-sonnet-4-20250514")
+                        .role(JsonValue.from("assistant"))
+                        .stopReason(Optional.empty())
+                        .stopSequence(Optional.empty())
+                        .type(JsonValue.from("message"))
+                        .usage(
+                                Usage.builder()
+                                        .cacheCreation(Optional.empty())
+                                        .cacheCreationInputTokens(Optional.empty())
+                                        .cacheReadInputTokens(Optional.empty())
+                                        .inferenceGeo(Optional.empty())
+                                        .inputTokens(10)
+                                        .outputTokens(5)
+                                        .serverToolUse(Optional.empty())
+                                        .serviceTier(Optional.empty())
+                                        .build())
+                        .build();
+
+        ChatResponse response = AnthropicResponseParser.parseMessage(message, Instant.now());
+
+        TextBlock parsed = assertInstanceOf(TextBlock.class, response.getContent().get(0));
+        assertEquals(0L, parsed.getProviderBlockIndex());
+        Citation.PageLocation citation =
+                assertInstanceOf(Citation.PageLocation.class, parsed.getCitations().get(0));
+        assertEquals("PDF source text", citation.citedText());
+        assertEquals("guide.pdf", citation.documentTitle());
+        assertEquals(2, citation.startPageNumber());
+        assertEquals(3, citation.endPageNumber());
     }
 
     @Test
@@ -335,6 +388,37 @@ class AnthropicResponseParserTest extends AnthropicFormatterTestBase {
                 assertInstanceOf(ThinkingBlock.class, response.getContent().get(0));
         assertEquals("Let me reason through this.", parsedThinking.getThinking());
         assertNull(response.getUsage());
+    }
+
+    @Test
+    void testParseStreamEventCitationDelta() throws Exception {
+        CitationPageLocation providerCitation =
+                CitationPageLocation.builder()
+                        .citedText("Streamed PDF source")
+                        .documentIndex(1)
+                        .documentTitle(Optional.empty())
+                        .fileId(Optional.empty())
+                        .startPageNumber(4)
+                        .endPageNumber(5)
+                        .build();
+        RawContentBlockDeltaEvent deltaEvent =
+                RawContentBlockDeltaEvent.builder()
+                        .index(2)
+                        .citationsDelta(providerCitation)
+                        .build();
+
+        ChatResponse response =
+                invokeParseStreamEvent(
+                        RawMessageStreamEvent.ofContentBlockDelta(deltaEvent), Instant.now());
+
+        TextBlock parsed = assertInstanceOf(TextBlock.class, response.getContent().get(0));
+        assertEquals("", parsed.getText());
+        assertEquals(1, parsed.getCitations().size());
+        assertEquals(2L, parsed.getProviderBlockIndex());
+        Citation.PageLocation citation =
+                assertInstanceOf(Citation.PageLocation.class, parsed.getCitations().get(0));
+        assertEquals("Streamed PDF source", citation.citedText());
+        assertEquals(4, citation.startPageNumber());
     }
 
     @Test

--- a/docs/v2/en/integration/model/anthropic.md
+++ b/docs/v2/en/integration/model/anthropic.md
@@ -37,6 +37,49 @@ AnthropicChatModel model = AnthropicChatModel.builder()
     .build();
 ```
 
+## PDF documents and citations
+
+PDF `DataBlock` content is sent as an Anthropic document block. Base64 data, local file paths or
+`file://` URLs, and remote HTTP(S) URLs are supported. Local PDFs are encoded as base64 before the
+request is sent.
+
+```java
+import io.agentscope.core.message.DataBlock;
+import io.agentscope.core.message.Msg;
+import io.agentscope.core.message.MsgRole;
+import io.agentscope.core.message.TextBlock;
+import io.agentscope.core.message.URLSource;
+import io.agentscope.core.model.GenerateOptions;
+import java.util.List;
+
+DataBlock document = DataBlock.builder()
+    .name("guide.pdf")
+    .source(URLSource.builder()
+        .url("file:///absolute/path/to/guide.pdf")
+        .mimeType("application/pdf")
+        .build())
+    .build();
+
+Msg request = Msg.builder()
+    .role(MsgRole.USER)
+    .content(document, TextBlock.builder().text("Summarize this document.").build())
+    .build();
+
+GenerateOptions options = GenerateOptions.builder()
+    .citationsEnabled(true)
+    .build();
+
+model.stream(List.of(request), List.of(), options);
+```
+
+Anthropic requires citations to be enabled on all documents in a request or on none of them, so
+`citationsEnabled` is request-scoped and is applied to every PDF document. Returned citations are
+available from `TextBlock.getCitations()`. Cited responses may contain multiple text blocks because
+each citation remains attached to the exact claim it supports.
+
+This integration currently supports PDF document blocks. Plain-text documents, custom-content
+documents, and Anthropic Files API `file_id` sources are not yet supported.
+
 ## Spring Boot
 
 Spring Boot applications can use the Anthropic starter:

--- a/docs/v2/zh/integration/model/anthropic.md
+++ b/docs/v2/zh/integration/model/anthropic.md
@@ -37,6 +37,48 @@ AnthropicChatModel model = AnthropicChatModel.builder()
     .build();
 ```
 
+## PDF 文档与引用
+
+PDF `DataBlock` 会转换为 Anthropic document block。支持 Base64、本地文件路径或 `file://` URL，
+以及远程 HTTP(S) URL；本地 PDF 会在发送请求前编码为 Base64。
+
+```java
+import io.agentscope.core.message.DataBlock;
+import io.agentscope.core.message.Msg;
+import io.agentscope.core.message.MsgRole;
+import io.agentscope.core.message.TextBlock;
+import io.agentscope.core.message.URLSource;
+import io.agentscope.core.model.GenerateOptions;
+import java.util.List;
+
+DataBlock document = DataBlock.builder()
+    .name("guide.pdf")
+    .source(URLSource.builder()
+        .url("file:///absolute/path/to/guide.pdf")
+        .mimeType("application/pdf")
+        .build())
+    .build();
+
+Msg request = Msg.builder()
+    .role(MsgRole.USER)
+    .content(document, TextBlock.builder().text("请总结这个文档。").build())
+    .build();
+
+GenerateOptions options = GenerateOptions.builder()
+    .citationsEnabled(true)
+    .build();
+
+model.stream(List.of(request), List.of(), options);
+```
+
+Anthropic 要求一次请求中的 document 必须全部开启 citations 或全部关闭，因此
+`citationsEnabled` 是请求级选项，并会应用到所有 PDF document。返回的引用可以通过
+`TextBlock.getCitations()` 获取。带引用的响应可能包含多个文本块，以保证每条引用仍然与其
+支持的具体文本片段关联。
+
+当前仅支持 PDF document block，暂不支持 plain-text document、custom-content document 和
+Anthropic Files API 的 `file_id` source。
+
 ## Spring Boot
 
 Spring Boot 应用可以使用 Anthropic starter：


### PR DESCRIPTION
## AgentScope-Java Version

2.0.1-SNAPSHOT

## Description

Closes #2224

### Background

The Anthropic integration currently supports images but cannot send PDF documents through DataBlock or preserve native document citations in model responses. This change adds the complete PDF and citation flow while keeping the core message model provider-neutral.

### Changes

- Add provider-neutral citation location types and attach citations to TextBlock.
- Add citationsEnabled to GenerateOptions with request-over-default resolution.
- Support Anthropic PDF document inputs from Base64, local paths, file URIs, and remote HTTP(S) URLs.
- Convert Anthropic page, character, and content-block citations in both streaming and non-streaming responses.
- Preserve provider text-block boundaries during response accumulation so citations remain attached to the text they support.
- Keep citation conversion request-scoped and preserve compatibility with custom Anthropic formatters.
- Add unit tests for conversion, MIME inference, formatter dispatch, model option wiring, response parsing, aggregation, and message round trips.
- Document PDF input and citation usage in the English and Chinese Anthropic integration guides.

## Testing

- Focused core and Anthropic PDF/citation suite: 135 tests, 0 failures, 1 existing skipped test.
- AnthropicChatModelTest: 25 tests passed.
- Spotless passed for the affected core and Anthropic reactor modules.
- git diff --check passed.

### Local validation notes

- A root-level mvn spotless:check is currently blocked by a pre-existing formatting mismatch in agentscope-harness/src/main/java/io/agentscope/harness/agent/tool/SessionSearchTool.java, which is outside this PR.
- The full AnthropicChatFormatterTest class has one pre-existing Mockito inline mock-maker failure because the local Homebrew JDK 17 cannot self-attach the Byte Buddy agent. The new formatter tests and the focused suite pass; CI uses Temurin JDK 17.

## Checklist

- [x] Code formatting passed for all affected modules
- [x] Relevant unit tests are passing
- [x] Javadoc comments are complete and follow project conventions
- [x] Related English and Chinese documentation has been updated
- [x] Code is ready for review