### PR TITLE
fix(dashscope): preserve SSE error response body

### DIFF
--- a/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-dashscope/src/main/java/io/agentscope/extensions/model/dashscope/DashScopeHttpClient.java
+++ b/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-dashscope/src/main/java/io/agentscope/extensions/model/dashscope/DashScopeHttpClient.java
@@ -277,8 +277,10 @@ public class DashScopeHttpClient {
                                     if (finalEncryptionContext != null) {
                                         data = decryptResponse(data, finalEncryptionContext);
                                     }
-                                    return JsonUtils.getJsonCodec()
-                                            .fromJson(data, DashScopeResponse.class);
+                                    return new ParsedStreamResponse(
+                                            data,
+                                            JsonUtils.getJsonCodec()
+                                                    .fromJson(data, DashScopeResponse.class));
                                 } catch (JsonException e) {
                                     log.warn(
                                             "Failed to parse SSE data: {}. Error: {}",
@@ -288,15 +290,16 @@ public class DashScopeHttpClient {
                                     return null;
                                 }
                             })
-                    .filter(response -> response != null)
+                    .filter(streamResponse -> streamResponse != null)
                     .handle(
-                            (response, sink) -> {
+                            (streamResponse, sink) -> {
+                                DashScopeResponse response = streamResponse.response();
                                 if (response.isError()) {
                                     sink.error(
                                             new DashScopeHttpException(
                                                     "DashScope API error: " + response.getMessage(),
                                                     response.getCode(),
-                                                    null));
+                                                    streamResponse.responseBody()));
                                 } else {
                                     sink.next(response);
                                 }
@@ -833,6 +836,8 @@ public class DashScopeHttpClient {
             return new DashScopeHttpClient(transport, apiKey, baseUrl, publicKeyId, publicKey);
         }
     }
+
+    private record ParsedStreamResponse(String responseBody, DashScopeResponse response) {}
 
     /**
      * Exception thrown when DashScope HTTP operations fail.

--- a/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-dashscope/src/main/java/io/agentscope/extensions/model/dashscope/DashScopeHttpClient.java
+++ b/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-dashscope/src/main/java/io/agentscope/extensions/model/dashscope/DashScopeHttpClient.java
@@ -270,27 +270,27 @@ public class DashScopeHttpClient {
                             .build();
 
             return transport.stream(httpRequest)
-                    .map(
-                            data -> {
+                    .<ParsedStreamResponse>handle(
+                            (data, sink) -> {
                                 try {
                                     // Decrypt response if encryption is enabled
                                     if (finalEncryptionContext != null) {
                                         data = decryptResponse(data, finalEncryptionContext);
                                     }
-                                    return new ParsedStreamResponse(
-                                            data,
-                                            JsonUtils.getJsonCodec()
-                                                    .fromJson(data, DashScopeResponse.class));
+                                    sink.next(
+                                            new ParsedStreamResponse(
+                                                    data,
+                                                    JsonUtils.getJsonCodec()
+                                                            .fromJson(
+                                                                    data,
+                                                                    DashScopeResponse.class)));
                                 } catch (JsonException e) {
                                     log.warn(
                                             "Failed to parse SSE data: {}. Error: {}",
                                             data,
                                             e.getMessage());
-                                    // Return null and filter out later
-                                    return null;
                                 }
                             })
-                    .filter(streamResponse -> streamResponse != null)
                     .handle(
                             (streamResponse, sink) -> {
                                 DashScopeResponse response = streamResponse.response();

--- a/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-dashscope/src/test/java/io/agentscope/extensions/model/dashscope/DashScopeHttpClientTest.java
+++ b/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-dashscope/src/test/java/io/agentscope/extensions/model/dashscope/DashScopeHttpClientTest.java
@@ -655,6 +655,19 @@ class DashScopeHttpClientTest {
     }
 
     @Test
+    void testStreamIgnoresMalformedSseData() {
+        mockServer.enqueue(
+                new MockResponse()
+                        .setResponseCode(200)
+                        .setBody("data: malformed-json\\n\\n")
+                        .setHeader("Content-Type", "text/event-stream"));
+
+        DashScopeRequest request = createTestRequest("qwen-plus", "test");
+
+        StepVerifier.create(client.stream(request, null, null, null)).verifyComplete();
+    }
+
+    @Test
     void testHeaderOverride() throws Exception {
         mockServer.enqueue(
                 new MockResponse()

--- a/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-dashscope/src/test/java/io/agentscope/extensions/model/dashscope/DashScopeHttpClientTest.java
+++ b/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-dashscope/src/test/java/io/agentscope/extensions/model/dashscope/DashScopeHttpClientTest.java
@@ -647,7 +647,10 @@ class DashScopeHttpClientTest {
                                         && dashScopeHttpException.getErrorCode().equals(errorCode)
                                         && dashScopeHttpException
                                                 .getMessage()
-                                                .equals("DashScope API error: " + errorMessage))
+                                                .equals("DashScope API error: " + errorMessage)
+                                        && dashScopeHttpException
+                                                .getResponseBody()
+                                                .contains("\"request_id\":\"request_id_123\""))
                 .verify();
     }
 


### PR DESCRIPTION
## AgentScope-Java Version

2.0.1-SNAPSHOT

## Description

Fixes #2197.

DashScope SSE error events contain the model `request_id`, but `DashScopeHttpClient.stream()` previously discarded the raw error payload and constructed `DashScopeHttpException` with a `null` response body.

This change preserves the parsed response together with its raw SSE payload, then propagates that payload through `DashScopeHttpException#getResponseBody()`. Callers can therefore retrieve the DashScope `request_id` from the error response body.

A regression test verifies that a streaming error preserves `request_id` in the exception response body.

## Checklist

- [x] Code formatting was verified by the Maven Spotless check.
- [x] All tests are passing (`mvn test`)
- [x] Javadoc comments are complete and follow project conventions (no public API added).
- [x] Related documentation has been updated (not required for this internal error-propagation fix).
- [x] Code is ready for review.