### PR TITLE
fix(harness): return absolute paths from LocalFilesystem write results

### DIFF
--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/filesystem/local/LocalFilesystem.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/filesystem/local/LocalFilesystem.java
@@ -335,7 +335,7 @@ public class LocalFilesystem implements AbstractFilesystem {
                 Files.createDirectories(resolved.getParent());
             }
             Files.writeString(resolved, content, StandardCharsets.UTF_8);
-            return WriteResult.ok(filePath);
+            return WriteResult.ok(absoluteResultPath(resolved));
         } catch (IOException e) {
             return WriteResult.fail("Error writing file '" + filePath + "': " + e.getMessage());
         }
@@ -378,7 +378,7 @@ public class LocalFilesystem implements AbstractFilesystem {
             int occurrences = (int) result[1];
 
             Files.writeString(resolved, newContent, StandardCharsets.UTF_8);
-            return EditResult.ok(filePath, occurrences);
+            return EditResult.ok(absoluteResultPath(resolved), occurrences);
         } catch (IOException e) {
             return EditResult.fail("Error editing file '" + filePath + "': " + e.getMessage());
         } finally {
@@ -527,7 +527,7 @@ public class LocalFilesystem implements AbstractFilesystem {
         AbstractFilesystem.validatePath(path);
         Path resolved = resolvePath(runtimeContext, path);
         if (!Files.exists(resolved)) {
-            return WriteResult.ok(path); // idempotent
+            return WriteResult.ok(absoluteResultPath(resolved)); // idempotent
         }
         try {
             if (Files.isDirectory(resolved)) {
@@ -565,7 +565,7 @@ public class LocalFilesystem implements AbstractFilesystem {
                 Files.createDirectories(to.getParent());
             }
             Files.move(from, to, StandardCopyOption.REPLACE_EXISTING);
-            return WriteResult.ok(toPath);
+            return WriteResult.ok(absoluteResultPath(to));
         } catch (IOException e) {
             return WriteResult.fail(
                     "Error moving '" + fromPath + "' to '" + toPath + "': " + e.getMessage());
@@ -582,6 +582,11 @@ public class LocalFilesystem implements AbstractFilesystem {
         } catch (SecurityException e) {
             return false;
         }
+    }
+
+    /** Absolute on-disk path for WriteResult/EditResult (matches their javadoc contract). */
+    private static String absoluteResultPath(Path resolved) {
+        return resolved.toAbsolutePath().normalize().toString();
     }
 
     // ==================== Path resolution ====================

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/filesystem/local/LocalFilesystem.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/filesystem/local/LocalFilesystem.java
@@ -545,7 +545,7 @@ public class LocalFilesystem implements AbstractFilesystem {
             } else {
                 Files.delete(resolved);
             }
-            return WriteResult.ok(path);
+            return WriteResult.ok(absoluteResultPath(resolved));
         } catch (IOException e) {
             return WriteResult.fail("Error deleting '" + path + "': " + e.getMessage());
         }

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/filesystem/LocalFilesystemWritePathTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/filesystem/LocalFilesystemWritePathTest.java
@@ -92,4 +92,20 @@ class LocalFilesystemWritePathTest {
         assertEquals(expected.toString(), result.path());
         assertTrue(Files.exists(expected));
     }
+
+    @Test
+    void delete_returnsAbsolutePathIncludingNamespace(@TempDir Path workspace) throws Exception {
+        Path nsFile = workspace.resolve("web-user").resolve("gone.txt");
+        Files.createDirectories(nsFile.getParent());
+        Files.writeString(nsFile, "x");
+
+        LocalFilesystem fs =
+                new LocalFilesystem(workspace, LocalFsMode.ROOTED, PathPolicy.empty(), 10, USER_NS);
+        RuntimeContext rc = RuntimeContext.builder().userId("web-user").build();
+
+        WriteResult result = fs.delete(rc, "gone.txt");
+        assertTrue(result.isSuccess(), () -> "delete failed: " + result.error());
+        assertEquals(nsFile.toAbsolutePath().normalize().toString(), result.path());
+        assertTrue(Files.notExists(nsFile));
+    }
 }

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/filesystem/LocalFilesystemWritePathTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/filesystem/LocalFilesystemWritePathTest.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.harness.agent.filesystem;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.agentscope.core.agent.RuntimeContext;
+import io.agentscope.harness.agent.filesystem.local.LocalFilesystem;
+import io.agentscope.harness.agent.filesystem.model.EditResult;
+import io.agentscope.harness.agent.filesystem.model.WriteResult;
+import io.agentscope.harness.agent.filesystem.remote.store.NamespaceFactory;
+import io.agentscope.harness.agent.workspace.LocalFsMode;
+import io.agentscope.harness.agent.workspace.PathPolicy;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Regression for issue #2266: WriteResult/EditResult must report the absolute on-disk path
+ * after namespace isolation, not the caller-supplied logical path.
+ */
+class LocalFilesystemWritePathTest {
+
+    private static final NamespaceFactory USER_NS = rc -> List.of("web-user");
+
+    @Test
+    void write_returnsAbsolutePathIncludingNamespace(@TempDir Path workspace) throws Exception {
+        LocalFilesystem fs =
+                new LocalFilesystem(workspace, LocalFsMode.ROOTED, PathPolicy.empty(), 10, USER_NS);
+        RuntimeContext rc = RuntimeContext.builder().userId("web-user").build();
+
+        WriteResult result = fs.write(rc, "hello_world.py", "print('hi')\n");
+        assertTrue(result.isSuccess(), () -> "write failed: " + result.error());
+
+        Path expected =
+                workspace
+                        .resolve("web-user")
+                        .resolve("hello_world.py")
+                        .toAbsolutePath()
+                        .normalize();
+        assertEquals(expected.toString(), result.path());
+        assertTrue(Files.exists(Path.of(result.path())));
+        assertEquals("print('hi')\n", Files.readString(expected));
+    }
+
+    @Test
+    void edit_returnsAbsolutePathIncludingNamespace(@TempDir Path workspace) throws Exception {
+        Path nsFile = workspace.resolve("web-user").resolve("notes.txt");
+        Files.createDirectories(nsFile.getParent());
+        Files.writeString(nsFile, "hello\n");
+
+        LocalFilesystem fs =
+                new LocalFilesystem(workspace, LocalFsMode.ROOTED, PathPolicy.empty(), 10, USER_NS);
+        RuntimeContext rc = RuntimeContext.builder().userId("web-user").build();
+
+        EditResult result = fs.edit(rc, "notes.txt", "hello", "world", false);
+        assertTrue(result.isSuccess(), () -> "edit failed: " + result.error());
+        assertEquals(nsFile.toAbsolutePath().normalize().toString(), result.path());
+        assertEquals("world\n", Files.readString(nsFile));
+    }
+
+    @Test
+    void move_returnsAbsoluteDestinationPath(@TempDir Path workspace) throws Exception {
+        Path src = workspace.resolve("web-user").resolve("a.txt");
+        Files.createDirectories(src.getParent());
+        Files.writeString(src, "x");
+
+        LocalFilesystem fs =
+                new LocalFilesystem(workspace, LocalFsMode.ROOTED, PathPolicy.empty(), 10, USER_NS);
+        RuntimeContext rc = RuntimeContext.builder().userId("web-user").build();
+
+        WriteResult result = fs.move(rc, "a.txt", "b.txt");
+        assertTrue(result.isSuccess(), () -> "move failed: " + result.error());
+
+        Path expected = workspace.resolve("web-user").resolve("b.txt").toAbsolutePath().normalize();
+        assertEquals(expected.toString(), result.path());
+        assertTrue(Files.exists(expected));
+    }
+}


### PR DESCRIPTION
## AgentScope-Java Version

2.0.x (main)

## Description

`WriteResult` / `EditResult` document that `path` is the absolute on-disk path, but `LocalFilesystem.write` / `edit` / `delete` / `move` returned the caller-supplied logical path. With namespace isolation, tools then reported a path that did not match the real file (e.g. workspace `hello_world.py` vs `web-user/hello_world.py`).

This change returns the resolved absolute path after `resolvePath`.

Fixes #2266

## Checklist

- [x] Code has been formatted with `mvn spotless:apply`
- [x] Targeted tests passing (`LocalFilesystemWritePathTest`, `FilesystemDeleteMoveExistsTest`)
- [x] Javadoc comments are complete and follow project conventions
- [x] Related documentation has been updated — N/A
- [x] Code is ready for review