### PR TITLE
fix(harness): drain session-tree-mirror on HarnessAgent.close

### DIFF
--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/HarnessAgent.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/HarnessAgent.java
@@ -59,6 +59,7 @@ import io.agentscope.harness.agent.memory.MemoryFlushManager;
 import io.agentscope.harness.agent.memory.compaction.CompactionConfig;
 import io.agentscope.harness.agent.memory.compaction.ConversationCompactor;
 import io.agentscope.harness.agent.memory.compaction.ToolResultEvictionConfig;
+import io.agentscope.harness.agent.memory.session.SessionTree;
 import io.agentscope.harness.agent.middleware.AgentTraceMiddleware;
 import io.agentscope.harness.agent.middleware.AsyncToolMiddleware;
 import io.agentscope.harness.agent.middleware.AtPathExpansionMiddleware;
@@ -115,6 +116,7 @@ import java.util.ArrayList;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiFunction;
 import java.util.function.Function;
@@ -382,7 +384,13 @@ public class HarnessAgent implements Agent, AutoCloseable {
                     ownedWorkspaceIndex.close();
                 }
             } finally {
-                delegate.close();
+                try {
+                    // Drain fire-and-forget session mirrors so they cannot race TempDir / workspace
+                    // cleanup after the agent is closed (see #2251).
+                    SessionTree.awaitPendingMirrors(30, TimeUnit.SECONDS);
+                } finally {
+                    delegate.close();
+                }
             }
         }
     }

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/memory/session/SessionTree.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/memory/session/SessionTree.java
@@ -34,8 +34,12 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -471,6 +475,38 @@ public class SessionTree {
      * Fetches the remote copy of {@code file} and parses it as JSONL session entries.
      * Returns an empty list if no filesystem is configured or the remote read fails.
      */
+
+    /**
+     * Blocks until all previously scheduled remote mirror tasks have finished (or the timeout
+     * elapses). Safe to call from {@code HarnessAgent.close()} / test teardown so that background
+     * {@code session-tree-mirror} uploads cannot race JUnit {@code @TempDir} cleanup.
+     *
+     * <p>Because {@link #MIRROR_EXECUTOR} is a single-thread FIFO queue, submitting a no-op and
+     * waiting for it drains every mirror task scheduled before this call.
+     *
+     * @param timeout maximum time to wait
+     * @param unit timeout unit
+     * @return {@code true} if the queue drained in time; {@code false} on timeout/interrupt
+     */
+    public static boolean awaitPendingMirrors(long timeout, TimeUnit unit) {
+        Future<?> drain = MIRROR_EXECUTOR.submit(() -> {});
+        try {
+            drain.get(timeout, unit);
+            return true;
+        } catch (TimeoutException e) {
+            log.warn("Timed out waiting for session-tree-mirror drain after {} {}", timeout, unit);
+            drain.cancel(false);
+            return false;
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            log.warn("Interrupted while waiting for session-tree-mirror drain");
+            return false;
+        } catch (ExecutionException e) {
+            log.warn("session-tree-mirror drain task failed: {}", e.getMessage());
+            return false;
+        }
+    }
+
     private List<SessionEntry> pullRemoteEntries(Path file) {
         if (filesystem == null || workspaceRoot == null) {
             return List.of();

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/memory/session/SessionTreeMirrorTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/memory/session/SessionTreeMirrorTest.java
@@ -204,7 +204,9 @@ class SessionTreeMirrorTest {
     //  Helper
     // -----------------------------------------------------------------------
 
-    private static void awaitMirror() throws InterruptedException {
-        TimeUnit.MILLISECONDS.sleep(300);
+    private static void awaitMirror() {
+        assertTrue(
+                SessionTree.awaitPendingMirrors(5, TimeUnit.SECONDS),
+                "session-tree-mirror should drain within timeout");
     }
 }


### PR DESCRIPTION
## AgentScope-Java Version

2.0.x (main)

## Description

`SessionTree` schedules fire-and-forget remote mirrors on a daemon `session-tree-mirror` executor. Example tests that close `HarnessAgent` via try-with-resources can still race JUnit `@TempDir` cleanup when that thread writes under the workspace (`agents/.../sessions`), causing intermittent `DirectoryNotEmptyException` failures in CI.

This change adds `SessionTree.awaitPendingMirrors` and calls it from `HarnessAgent.close()` so teardown waits for in-flight mirrors. `SessionTreeMirrorTest` now uses the same drain helper instead of a fixed sleep.

Fixes #2251

## Checklist

- [x] Code has been formatted with `mvn spotless:apply`
- [x] Targeted tests passing
- [x] Javadoc comments are complete and follow project conventions
- [x] Related documentation has been updated — N/A
- [x] Code is ready for review