### PR TITLE
fix(harness): support Windows shell execution

### DIFF
--- a/agentscope-examples/agents/agentscope-paw/src/main/java/io/agentscope/claw2/runtime/ClawBootstrap.java
+++ b/agentscope-examples/agents/agentscope-paw/src/main/java/io/agentscope/claw2/runtime/ClawBootstrap.java
@@ -80,7 +80,7 @@ import org.slf4j.LoggerFactory;
  *   <li>{@link #start()} — initialize and start all pre-registered channel adapters.
  * </ol>
  */
-public final class ClawBootstrap {
+public final class ClawBootstrap implements AutoCloseable {
 
     private static final Logger log = LoggerFactory.getLogger(ClawBootstrap.class);
     private static final String DEFAULT_MAIN_ID = "default";
@@ -197,6 +197,32 @@ public final class ClawBootstrap {
     public void stop() {
         if (channelManager != null) {
             channelManager.stopAll();
+        }
+    }
+
+    /**
+     * Stops managed channels and closes all agents created by this bootstrap.
+     *
+     * <p>Closing agents releases background task repositories and workspace indexes associated
+     * with the claw home directory.
+     */
+    @Override
+    public void close() {
+        stop();
+        RuntimeException failure = null;
+        for (HarnessAgent agent : new LinkedHashSet<>(agents.values())) {
+            try {
+                agent.close();
+            } catch (RuntimeException e) {
+                if (failure == null) {
+                    failure = e;
+                } else {
+                    failure.addSuppressed(e);
+                }
+            }
+        }
+        if (failure != null) {
+            throw failure;
         }
     }
 

--- a/agentscope-examples/agents/agentscope-paw/src/test/java/io/agentscope/builder/BuilderBootstrapSmokeTest.java
+++ b/agentscope-examples/agents/agentscope-paw/src/test/java/io/agentscope/builder/BuilderBootstrapSmokeTest.java
@@ -47,40 +47,42 @@ class BuilderBootstrapSmokeTest {
     @Test
     void singleAgent_chatUiChannel() throws Exception {
         Model model = stubModel("single-agent-reply");
-        ClawBootstrap bootstrap =
+        try (ClawBootstrap bootstrap =
                 ClawBootstrap.builder()
                         .skipConfigFile(true)
                         .cwd(tempDir)
                         .model(model)
                         .configureAgent("main", b -> b.name("main").description("main"))
                         .mainAgent("main")
-                        .build();
-
-        ChatUiChannel chat = bootstrap.chatUiChannel();
-        Msg reply = chat.send("Hello from test").block();
-        assertTrue(reply.getTextContent().contains("single-agent-reply"));
+                        .build()) {
+            ChatUiChannel chat = bootstrap.chatUiChannel();
+            Msg reply = chat.send("Hello from test").block();
+            assertTrue(reply.getTextContent().contains("single-agent-reply"));
+        }
     }
 
     @Test
     void singleAgent_chatUiChannel_perPeer() throws Exception {
         Model model = stubModel("per-peer-reply");
-        ClawBootstrap bootstrap =
+        try (ClawBootstrap bootstrap =
                 ClawBootstrap.builder()
                         .skipConfigFile(true)
                         .cwd(tempDir)
                         .model(model)
                         .configureAgent("main", b -> b.name("main"))
                         .mainAgent("main")
-                        .build();
+                        .build()) {
+            ChannelConfig perPeerConfig =
+                    ChannelConfig.builder(ChatUiChannel.CHANNEL_ID)
+                            .dmScope(DmScope.PER_PEER)
+                            .build();
+            ChatUiChannel chat = bootstrap.chatUiChannel(perPeerConfig);
 
-        ChannelConfig perPeerConfig =
-                ChannelConfig.builder(ChatUiChannel.CHANNEL_ID).dmScope(DmScope.PER_PEER).build();
-        ChatUiChannel chat = bootstrap.chatUiChannel(perPeerConfig);
-
-        Msg reply1 = chat.send("alice", "Hi!").block();
-        Msg reply2 = chat.send("bob", "Hi!").block();
-        assertTrue(reply1.getTextContent().contains("per-peer-reply"));
-        assertTrue(reply2.getTextContent().contains("per-peer-reply"));
+            Msg reply1 = chat.send("alice", "Hi!").block();
+            Msg reply2 = chat.send("bob", "Hi!").block();
+            assertTrue(reply1.getTextContent().contains("per-peer-reply"));
+            assertTrue(reply2.getTextContent().contains("per-peer-reply"));
+        }
     }
 
     @Test
@@ -88,7 +90,7 @@ class BuilderBootstrapSmokeTest {
         Model mainModel = stubModel("from-main");
         Model supportModel = stubModel("from-support");
 
-        ClawBootstrap bootstrap =
+        try (ClawBootstrap bootstrap =
                 ClawBootstrap.builder()
                         .skipConfigFile(true)
                         .cwd(tempDir)
@@ -96,11 +98,11 @@ class BuilderBootstrapSmokeTest {
                         .configureAgent("main", b -> b.name("main-agent").model(mainModel))
                         .configureAgent("support", b -> b.name("support-agent").model(supportModel))
                         .mainAgent("main")
-                        .build();
-
-        ChatUiChannel chat = bootstrap.chatUiChannel();
-        Msg reply = chat.send("hello").block();
-        assertTrue(reply.getTextContent().contains("from-main"));
+                        .build()) {
+            ChatUiChannel chat = bootstrap.chatUiChannel();
+            Msg reply = chat.send("hello").block();
+            assertTrue(reply.getTextContent().contains("from-main"));
+        }
     }
 
     private static Model stubModel(String assistantText) {

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/filesystem/local/LocalFilesystemWithShell.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/filesystem/local/LocalFilesystemWithShell.java
@@ -22,10 +22,12 @@ import io.agentscope.harness.agent.filesystem.sandbox.AbstractSandboxFilesystem;
 import io.agentscope.harness.agent.workspace.LocalFsMode;
 import io.agentscope.harness.agent.workspace.PathPolicy;
 import java.io.IOException;
+import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
@@ -335,10 +337,9 @@ public class LocalFilesystemWithShell extends LocalFilesystem implements Abstrac
 
             boolean finished = proc.waitFor(effectiveTimeout, TimeUnit.SECONDS);
 
-            String stdout =
-                    new String(proc.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
-            String stderr =
-                    new String(proc.getErrorStream().readAllBytes(), StandardCharsets.UTF_8);
+            Charset outputCharset = outputCharset(osName);
+            String stdout = new String(proc.getInputStream().readAllBytes(), outputCharset);
+            String stderr = new String(proc.getErrorStream().readAllBytes(), outputCharset);
 
             if (!finished) {
                 proc.destroyForcibly();
@@ -429,5 +430,20 @@ public class LocalFilesystemWithShell extends LocalFilesystem implements Abstrac
             log.warn("Failed to create namespace directory {}: {}", namespaced, e.getMessage());
         }
         return namespaced;
+    }
+
+    static Charset outputCharset(String osName) {
+        return outputCharset(osName, System.getProperty("native.encoding"));
+    }
+
+    static Charset outputCharset(String osName, String nativeEncoding) {
+        if (!osName.toLowerCase(Locale.ROOT).contains("win")) {
+            return StandardCharsets.UTF_8;
+        }
+
+        if (nativeEncoding != null && Charset.isSupported(nativeEncoding)) {
+            return Charset.forName(nativeEncoding);
+        }
+        return Charset.defaultCharset();
     }
 }

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/tool/ShellExecuteTool.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/tool/ShellExecuteTool.java
@@ -60,7 +60,11 @@ public class ShellExecuteTool {
                 return "Error: working_directory must be a relative path within the workspace"
                         + " (absolute paths, '~', and '..' are not allowed).";
             }
-            effectiveCommand = "cd '" + wd.replace("'", "'\\''") + "' && " + command;
+            effectiveCommand =
+                    commandWithWorkingDirectory(
+                            wd,
+                            command,
+                            System.getProperty("os.name").toLowerCase().contains("win"));
         }
 
         ExecuteResponse result =
@@ -75,5 +79,13 @@ public class ShellExecuteTool {
             sb.append("\n(output was truncated)");
         }
         return sb.toString();
+    }
+
+    static String commandWithWorkingDirectory(
+            String workingDirectory, String command, boolean windows) {
+        if (windows) {
+            return "cd /d \"" + workingDirectory.replace("\"", "\"\"") + "\" && " + command;
+        }
+        return "cd '" + workingDirectory.replace("'", "'\\''") + "' && " + command;
     }
 }

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/filesystem/local/LocalFilesystemWithShellTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/filesystem/local/LocalFilesystemWithShellTest.java
@@ -34,4 +34,11 @@ class LocalFilesystemWithShellTest {
     void outputCharset_usesUtf8OnNonWindowsSystems() {
         assertEquals(StandardCharsets.UTF_8, LocalFilesystemWithShell.outputCharset("Linux"));
     }
+
+    @Test
+    void outputCharset_fallsBackToDefaultWhenWindowsNativeEncodingIsUnavailable() {
+        assertEquals(
+                Charset.defaultCharset(),
+                LocalFilesystemWithShell.outputCharset("Windows 10", null));
+    }
 }

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/filesystem/local/LocalFilesystemWithShellTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/filesystem/local/LocalFilesystemWithShellTest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.harness.agent.filesystem.local;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import org.junit.jupiter.api.Test;
+
+class LocalFilesystemWithShellTest {
+
+    @Test
+    void outputCharset_usesNativeEncodingOnWindows() {
+        assertEquals(
+                Charset.forName("windows-1252"),
+                LocalFilesystemWithShell.outputCharset("Windows 10", "windows-1252"));
+    }
+
+    @Test
+    void outputCharset_usesUtf8OnNonWindowsSystems() {
+        assertEquals(StandardCharsets.UTF_8, LocalFilesystemWithShell.outputCharset("Linux"));
+    }
+}

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/tool/ShellExecuteToolTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/tool/ShellExecuteToolTest.java
@@ -62,7 +62,8 @@ class ShellExecuteToolTest {
         String result = tool.execute(RT, "ls", "sub", null);
 
         assertTrue(result.contains("Exit code: 0"));
-        assertEquals("cd 'sub' && ls", sandbox.command);
+        assertTrue(sandbox.command.startsWith("cd "));
+        assertTrue(sandbox.command.endsWith(" && ls"));
         assertEquals(30, sandbox.timeoutSeconds);
     }
 

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/tool/ShellExecuteToolTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/tool/ShellExecuteToolTest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.harness.agent.tool;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+class ShellExecuteToolTest {
+
+    @Test
+    void commandWithWorkingDirectory_usesCmdCompatibleQuotingOnWindows() {
+        assertEquals(
+                "cd /d \"workspace dir\" && dir",
+                ShellExecuteTool.commandWithWorkingDirectory("workspace dir", "dir", true));
+    }
+
+    @Test
+    void commandWithWorkingDirectory_preservesShellSafeQuotingOnUnix() {
+        assertEquals(
+                "cd 'workspace dir' && ls",
+                ShellExecuteTool.commandWithWorkingDirectory("workspace dir", "ls", false));
+    }
+}


### PR DESCRIPTION
## AgentScope-Java Version

2.0.1-SNAPSHOT

## Description

Fixes #2268.

- Generate cmd-compatible working-directory commands on Windows.
- Decode local shell output with the JVM native encoding on Windows, with a default-charset fallback.
- Preserve UTF-8 decoding on non-Windows platforms.
- Add unit tests for platform-specific command construction and output-charset selection.

Validated with:

```bash
mvn -q -pl agentscope-harness -am \
  -Dtest=ShellExecuteToolTest,LocalFilesystemWithShellTest \
  -DfailIfNoTests=false test
```

## Checklist

Please check the following items before code is ready to be reviewed.

- [x]  Code has been formatted with `mvn spotless:apply`
- [x]  All tests are passing (`mvn test`)
- [x]  Javadoc comments are complete and follow project conventions
- [x]  Related documentation has been updated (e.g. links, examples, etc.)
- [x]  Code is ready for review
