### PR TITLE
fix: preserve skill isolation and tool result history

### DIFF
--- a/agentscope-core/src/main/java/io/agentscope/core/ReActAgent.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/ReActAgent.java
@@ -113,6 +113,7 @@ import io.agentscope.core.skill.repository.AgentSkillRepository;
 import io.agentscope.core.state.AgentState;
 import io.agentscope.core.state.AgentStateStore;
 import io.agentscope.core.state.LegacyStateLoader;
+import io.agentscope.core.state.ToolContextState;
 import io.agentscope.core.tool.AgentTool;
 import io.agentscope.core.tool.ToolBase;
 import io.agentscope.core.tool.ToolCallParam;
@@ -236,6 +237,9 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
      */
     private final Toolkit toolkit;
 
+    /** Default active groups captured after builder-time toolkit configuration is complete. */
+    private final List<String> initialActiveToolGroups;
+
     private final ToolExecutionContext toolExecutionContext;
 
     private final List<MiddlewareBase> middlewares;
@@ -294,6 +298,7 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
         super(builder.name, builder.description, new ArrayList<>(builder.hooks));
 
         this.toolkit = agentToolkit != null ? agentToolkit : new Toolkit();
+        this.initialActiveToolGroups = List.copyOf(this.toolkit.getActiveGroups());
         this.sysPrompt = builder.sysPrompt;
         this.model = builder.model;
         this.maxIters = builder.maxIters;
@@ -364,8 +369,9 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
             String userId,
             String sessionId,
             PermissionContextState permCtx,
-            String agentId) {
-        AgentState fresh = freshState(permCtx, agentId, userId, sessionId);
+            String agentId,
+            List<String> initialActiveToolGroups) {
+        AgentState fresh = freshState(permCtx, agentId, userId, sessionId, initialActiveToolGroups);
         if (stateStore == null) {
             return fresh;
         }
@@ -374,15 +380,11 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
                     .get(userId, sessionId, "agent_state", AgentState.class)
                     .orElseGet(
                             () -> {
-                                AgentState legacy =
-                                        LegacyStateLoader.loadFromLegacySession(
+                                LegacyStateLoader.LegacyLoadResult legacy =
+                                        LegacyStateLoader.loadFromLegacySessionWithPresence(
                                                 stateStore, userId, sessionId);
-                                if (legacy != null
-                                        && (!legacy.getContext().isEmpty()
-                                                || !legacy.getToolContext()
-                                                        .getActivatedGroups()
-                                                        .isEmpty())) {
-                                    return legacy;
+                                if (legacy.found()) {
+                                    return legacy.state();
                                 }
                                 return fresh;
                             });
@@ -397,7 +399,11 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
     }
 
     private static AgentState freshState(
-            PermissionContextState permCtx, String agentId, String userId, String sessionId) {
+            PermissionContextState permCtx,
+            String agentId,
+            String userId,
+            String sessionId,
+            List<String> initialActiveToolGroups) {
         AgentState.Builder asb =
                 AgentState.builder().sessionId(sessionId != null ? sessionId : agentId);
         if (userId != null) {
@@ -406,6 +412,11 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
         if (permCtx != null) {
             asb.permissionContext(permCtx);
         }
+        ToolContextState.Builder toolContext = ToolContextState.builder();
+        if (initialActiveToolGroups != null) {
+            initialActiveToolGroups.forEach(toolContext::addActivatedGroup);
+        }
+        asb.toolContext(toolContext.build());
         return asb.build();
     }
 
@@ -452,7 +463,12 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
         if (stateStore != null) {
             loaded =
                     loadOrCreateAgentStateForSlot(
-                            stateStore, finalUid, finalSid, initialPermissionContext, getAgentId());
+                            stateStore,
+                            finalUid,
+                            finalSid,
+                            initialPermissionContext,
+                            getAgentId(),
+                            initialActiveToolGroups);
             stateCache.put(slot, loaded);
         } else {
             loaded =
@@ -464,7 +480,8 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
                                             finalUid,
                                             finalSid,
                                             initialPermissionContext,
-                                            getAgentId()));
+                                            getAgentId(),
+                                            initialActiveToolGroups));
         }
         PermissionEngine loadedEngine;
         if (stateStore != null) {
@@ -3650,7 +3667,8 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
                                 userId,
                                 sessionId,
                                 initialPermissionContext,
-                                getAgentId()));
+                                getAgentId(),
+                                initialActiveToolGroups));
     }
 
     /**

--- a/agentscope-core/src/main/java/io/agentscope/core/state/LegacyStateLoader.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/state/LegacyStateLoader.java
@@ -18,6 +18,7 @@ package io.agentscope.core.state;
 import io.agentscope.core.message.Msg;
 import io.agentscope.core.state.legacy.ToolkitState;
 import java.util.List;
+import java.util.Optional;
 
 /**
  * Utility for loading v1 session data into the 2.0 {@link AgentState} format.
@@ -47,21 +48,39 @@ public final class LegacyStateLoader {
      */
     public static AgentState loadFromLegacySession(
             AgentStateStore stateStore, String userId, String sessionId) {
+        return loadFromLegacySessionWithPresence(stateStore, userId, sessionId).state();
+    }
+
+    /**
+     * Loads legacy state without discarding the presence of the singleton tool-group key.
+     *
+     * <p>The presence bit is required because an explicitly persisted {@code
+     * toolkit_activeGroups=[]} has different semantics from a missing key even though both produce
+     * an empty {@link ToolContextState}.
+     */
+    public static LegacyLoadResult loadFromLegacySessionWithPresence(
+            AgentStateStore stateStore, String userId, String sessionId) {
         List<Msg> msgs = stateStore.getList(userId, sessionId, "memory_messages", Msg.class);
+        Optional<ToolkitState> toolkitState =
+                stateStore.get(userId, sessionId, "toolkit_activeGroups", ToolkitState.class);
 
         AgentState.Builder builder = AgentState.builder().context(msgs);
 
-        stateStore
-                .get(userId, sessionId, "toolkit_activeGroups", ToolkitState.class)
-                .ifPresent(
-                        toolkitState -> {
-                            ToolContextState.Builder tc = ToolContextState.builder();
-                            for (String group : toolkitState.activeGroups()) {
-                                tc.addActivatedGroup(group);
-                            }
-                            builder.toolContext(tc.build());
-                        });
+        toolkitState.ifPresent(
+                value -> {
+                    ToolContextState.Builder tc = ToolContextState.builder();
+                    for (String group : value.activeGroups()) {
+                        tc.addActivatedGroup(group);
+                    }
+                    builder.toolContext(tc.build());
+                });
 
-        return builder.build();
+        return new LegacyLoadResult(builder.build(), !msgs.isEmpty() || toolkitState.isPresent());
     }
+
+    /**
+     * Result of reading the v1 session keys. {@code found} is true for non-empty legacy messages or
+     * a present tool-group key, including a tool-group value whose list is explicitly empty.
+     */
+    public record LegacyLoadResult(AgentState state, boolean found) {}
 }

--- a/agentscope-core/src/main/java/io/agentscope/core/tool/ToolExecutor.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/tool/ToolExecutor.java
@@ -233,7 +233,7 @@ class ToolExecutor {
                     ToolExecutionContext.merge(
                             runtimeContext.asToolExecutionContext(), toolkitDefault);
             runtimeContext =
-                    io.agentscope.core.agent.RuntimeContext.builder()
+                    io.agentscope.core.agent.RuntimeContext.builder(runtimeContext)
                             .toolExecutionContext(merged)
                             .build();
         }

--- a/agentscope-core/src/test/java/io/agentscope/core/agent/ReActAgentPerSessionStateTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/agent/ReActAgentPerSessionStateTest.java
@@ -35,6 +35,8 @@ import io.agentscope.core.model.GenerateOptions;
 import io.agentscope.core.model.ToolSchema;
 import io.agentscope.core.state.AgentState;
 import io.agentscope.core.state.InMemoryAgentStateStore;
+import io.agentscope.core.state.legacy.ToolkitState;
+import io.agentscope.core.tool.Toolkit;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
@@ -76,6 +78,63 @@ class ReActAgentPerSessionStateTest {
                 .model(new NoopModel())
                 .stateStore(store)
                 .build();
+    }
+
+    @Test
+    @DisplayName("fresh slots inherit default tool groups without overriding persisted state")
+    void freshSlotsInheritDefaultToolGroupsWithoutOverridingPersistedState() {
+        InMemoryAgentStateStore store = new InMemoryAgentStateStore();
+        store.save(
+                "u1",
+                "persisted-empty",
+                "agent_state",
+                AgentState.builder().userId("u1").sessionId("persisted-empty").build());
+
+        Toolkit toolkit = new Toolkit();
+        toolkit.createToolGroup("default-active", "Enabled during agent construction");
+        ReActAgent agent =
+                ReActAgent.builder()
+                        .name("asst")
+                        .sysPrompt("hi")
+                        .model(new NoopModel())
+                        .toolkit(toolkit)
+                        .stateStore(store)
+                        .build();
+
+        assertEquals(
+                List.of("default-active"),
+                agent.getAgentState("u1", "fresh").getToolContext().getActivatedGroups());
+        assertTrue(
+                agent.getAgentState("u1", "persisted-empty")
+                        .getToolContext()
+                        .getActivatedGroups()
+                        .isEmpty(),
+                "An explicitly persisted empty group list must remain empty");
+    }
+
+    @Test
+    @DisplayName("legacy empty tool groups remain explicitly empty")
+    void legacyEmptyToolGroupsAreNotMistakenForMissingState() {
+        InMemoryAgentStateStore store = new InMemoryAgentStateStore();
+        store.save("u1", "legacy-empty", "toolkit_activeGroups", new ToolkitState(List.of()));
+
+        Toolkit toolkit = new Toolkit();
+        toolkit.createToolGroup("default-active", "Enabled during agent construction");
+        ReActAgent agent =
+                ReActAgent.builder()
+                        .name("asst")
+                        .sysPrompt("hi")
+                        .model(new NoopModel())
+                        .toolkit(toolkit)
+                        .stateStore(store)
+                        .build();
+
+        assertTrue(
+                agent.getAgentState("u1", "legacy-empty")
+                        .getToolContext()
+                        .getActivatedGroups()
+                        .isEmpty(),
+                "A present v1 toolkit_activeGroups=[] value must override fresh defaults");
     }
 
     @Test

--- a/agentscope-core/src/test/java/io/agentscope/core/tool/ToolExecutionContextIntegrationTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/tool/ToolExecutionContextIntegrationTest.java
@@ -20,6 +20,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import io.agentscope.core.agent.RuntimeContext;
 import io.agentscope.core.message.TextBlock;
 import io.agentscope.core.message.ToolResultBlock;
 import io.agentscope.core.message.ToolUseBlock;
@@ -200,6 +201,50 @@ class ToolExecutionContextIntegrationTest {
         assertNotNull(result);
         assertFalse(isError(result));
         assertEquals("Access granted for user123", getText(result));
+    }
+
+    @Test
+    void mergingToolkitDefaultPreservesRuntimeContextScope() {
+        class RuntimeContextProbe {
+            @Tool(name = "runtime_context_probe", description = "Reads the request context")
+            public ToolResultBlock read(RuntimeContext context) {
+                return ToolResultBlock.text(
+                        context.getSessionId() + ":" + context.get(String.class));
+            }
+        }
+
+        ToolExecutionContext toolkitContext =
+                ToolExecutionContext.builder()
+                        .register(new EnvironmentConfig("development", "1.0"))
+                        .build();
+        Toolkit toolkit =
+                new Toolkit(ToolkitConfig.builder().defaultContext(toolkitContext).build());
+        toolkit.registration().tool(new RuntimeContextProbe()).apply();
+
+        RuntimeContext requestContext =
+                RuntimeContext.builder()
+                        .sessionId("request-session")
+                        .put(String.class, "request-catalog")
+                        .build();
+        Map<String, Object> input = Map.of();
+        ToolUseBlock toolUse =
+                ToolUseBlock.builder()
+                        .id("runtime-context")
+                        .name("runtime_context_probe")
+                        .input(input)
+                        .content(JsonUtils.getJsonCodec().toJson(input))
+                        .build();
+
+        ToolResultBlock result =
+                toolkit.callTool(
+                                ToolCallParam.builder()
+                                        .toolUseBlock(toolUse)
+                                        .runtimeContext(requestContext)
+                                        .build())
+                        .block();
+
+        assertNotNull(result);
+        assertEquals("request-session:request-catalog", getText(result));
     }
 
     @Test

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/HarnessAgent.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/HarnessAgent.java
@@ -2399,10 +2399,7 @@ public class HarnessAgent implements Agent, AutoCloseable {
                 }
             }
 
-            if (!orderedSkillRepos.isEmpty() && !disableDynamicSkills) {
-                // Always opt out of core's auto-install; harness owns the skill middleware.
-                inner.dynamicSkillsEnabled(false);
-
+            if (!orderedSkillRepos.isEmpty()) {
                 io.agentscope.harness.agent.skill.runtime.MarketplaceStager stager =
                         resolvedWorkspace != null
                                 ? new io.agentscope.harness.agent.skill.runtime.MarketplaceStager(
@@ -2438,14 +2435,25 @@ public class HarnessAgent implements Agent, AutoCloseable {
                 }
 
                 HarnessSkillMiddleware skillMiddleware =
-                        new HarnessSkillMiddleware(
-                                orderedSkillRepos,
-                                agentToolkit,
-                                skillFilter,
-                                visibilityFilter,
-                                stager,
-                                shellPolicy);
+                        disableDynamicSkills
+                                ? HarnessSkillMiddleware.frozen(
+                                        orderedSkillRepos,
+                                        agentToolkit,
+                                        skillFilter,
+                                        visibilityFilter,
+                                        stager,
+                                        shellPolicy)
+                                : new HarnessSkillMiddleware(
+                                        orderedSkillRepos,
+                                        agentToolkit,
+                                        skillFilter,
+                                        visibilityFilter,
+                                        stager,
+                                        shellPolicy);
                 inner.middleware(skillMiddleware);
+
+                // Harness owns both the live and frozen repository paths.
+                inner.dynamicSkillsEnabled(false);
 
                 // Wire pre-start staging so sandbox projection picks up .skills-cache content
                 // that MarketplaceStager materialises from database-backed repositories.
@@ -2454,8 +2462,7 @@ public class HarnessAgent implements Agent, AutoCloseable {
                             skillMiddleware::prestageMarketplaceSkills);
                 }
             } else if (disableDynamicSkills) {
-                // Suppress core's auto-install so the static SkillBox fallback (constructed
-                // below by staticSkillBoxFromRepos) remains the only skill source.
+                // No composed repositories exist, but preserve the explicit core opt-out.
                 inner.dynamicSkillsEnabled(false);
             }
 

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/HarnessAgentBuilderSupport.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/HarnessAgentBuilderSupport.java
@@ -24,8 +24,6 @@ import io.agentscope.core.model.GenerateOptions;
 import io.agentscope.core.model.Model;
 import io.agentscope.core.model.ModelRegistry;
 import io.agentscope.core.model.ToolSchema;
-import io.agentscope.core.skill.AgentSkill;
-import io.agentscope.core.skill.SkillBox;
 import io.agentscope.core.skill.SkillFilter;
 import io.agentscope.core.skill.repository.AgentSkillRepository;
 import io.agentscope.core.skill.repository.FileSystemSkillRepository;
@@ -51,7 +49,6 @@ import io.agentscope.harness.agent.workspace.WorkspaceManager;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Objects;
 import java.util.function.Function;
@@ -761,42 +758,5 @@ final class HarnessAgentBuilderSupport {
         }
 
         return ordered;
-    }
-
-    /**
-     * Eagerly assembles a static {@link SkillBox} from {@code repos} (low-to-high priority) so
-     * callers using {@code disableDynamicSkills()} keep the legacy {@code SkillHook} path while
-     * still benefiting from the additive composition.
-     */
-    static SkillBox staticSkillBoxFromRepos(
-            List<AgentSkillRepository> repos, Toolkit agentToolkit) {
-        LinkedHashMap<String, AgentSkill> merged = new LinkedHashMap<>();
-        for (AgentSkillRepository repo : repos) {
-            try {
-                List<AgentSkill> skills = repo.getAllSkills();
-                if (skills == null) {
-                    continue;
-                }
-                for (AgentSkill skill : skills) {
-                    if (skill != null && skill.getName() != null) {
-                        merged.put(skill.getName(), skill);
-                    }
-                }
-            } catch (Exception e) {
-                log.warn(
-                        "Failed to load skills from {}: {}",
-                        repo.getClass().getSimpleName(),
-                        e.getMessage());
-            }
-        }
-        if (merged.isEmpty()) {
-            return null;
-        }
-        SkillBox box = new SkillBox(agentToolkit);
-        for (AgentSkill skill : merged.values()) {
-            box.registerSkill(skill);
-        }
-        log.info("Loaded {} skills from {} repositories (static)", merged.size(), repos.size());
-        return box;
     }
 }

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/memory/compaction/ToolResultEvictionConfig.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/memory/compaction/ToolResultEvictionConfig.java
@@ -36,7 +36,7 @@ import java.util.Set;
  * <ul>
  *   <li>Trigger at 80,000 characters (~20 K tokens at 4 chars/token)</li>
  *   <li>Preview: first + last 2,000 characters of the original output</li>
- *   <li>Eviction path prefix: {@code /large_tool_results}</li>
+ *   <li>Eviction path prefix: {@code large_tool_results} (relative to the workspace)</li>
  *   <li>Excluded tools: filesystem read/write/edit/list + memory tools (small or self-paginating)</li>
  * </ul>
  */
@@ -48,8 +48,8 @@ public class ToolResultEvictionConfig {
     /** Characters to show at head and tail in the eviction placeholder preview. */
     public static final int DEFAULT_PREVIEW_CHARS = 2_000;
 
-    /** Root path prefix under which evicted results are stored. */
-    public static final String DEFAULT_EVICTION_PATH = "/large_tool_results";
+    /** Workspace-relative path prefix under which evicted results are stored. */
+    public static final String DEFAULT_EVICTION_PATH = "large_tool_results";
 
     /**
      * Tools excluded from eviction by default.
@@ -102,7 +102,7 @@ public class ToolResultEvictionConfig {
         return previewChars;
     }
 
-    /** Root path under which evicted files are written (e.g. {@code /large_tool_results}). */
+    /** Root path under which evicted files are written (e.g. {@code large_tool_results}). */
     public String getEvictionPath() {
         return evictionPath;
     }

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/middleware/HarnessSkillMiddleware.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/middleware/HarnessSkillMiddleware.java
@@ -22,6 +22,7 @@ import io.agentscope.core.skill.SkillFilter;
 import io.agentscope.core.skill.repository.AgentSkillRepository;
 import io.agentscope.core.tool.Toolkit;
 import io.agentscope.harness.agent.skill.LazyResourceCapable;
+import io.agentscope.harness.agent.skill.RuntimeContextSkillRepository;
 import io.agentscope.harness.agent.skill.SkillResources;
 import io.agentscope.harness.agent.skill.curator.SkillVisibilityFilter;
 import io.agentscope.harness.agent.skill.runtime.HarnessSkillEntry;
@@ -32,6 +33,7 @@ import io.agentscope.harness.agent.skill.runtime.ShellPathPolicy;
 import io.agentscope.harness.agent.skill.runtime.SkillCatalog;
 import io.agentscope.harness.agent.skill.runtime.SkillRuntime;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.IdentityHashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -55,19 +57,16 @@ import reactor.core.publisher.Mono;
  *       {@code <wsRoot>/.skills-cache/<source-ns>/<skill>/} via {@link MarketplaceStager}.
  *   <li>Build a {@link SkillCatalog} of {@link HarnessSkillEntry} (with lazy resources and
  *       resolved {@code filesRoot}).
- *   <li>Install the catalog into the {@link SkillRuntime}, which (idempotently) registers the
- *       {@code load_skill_through_path} tool on the agent's runtime toolkit.
+ *   <li>Bind the catalog to the current {@link RuntimeContext} through {@link SkillRuntime}, which
+ *       also (idempotently) registers {@code load_skill_through_path} on the runtime toolkit.
  *   <li>Render the {@code <available_skills>} prompt block and append it to the current system
  *       prompt.
  * </ol>
  *
- * <p><b>Toolkit note:</b> the {@code toolkit} constructor parameter is accepted for API
- * compatibility but is <em>not</em> used for runtime tool registration. Instead,
- * {@link #onSystemPrompt} always installs into {@code agent.getToolkit()} so the tool is
- * registered on the toolkit that the running agent actually uses for reasoning. This matters
- * because {@link io.agentscope.harness.agent.HarnessAgent HarnessAgent} makes a deep copy of
- * the toolkit when building the inner {@link io.agentscope.core.ReActAgent ReActAgent}, so the
- * constructor-injected intermediate toolkit is not the same instance as the agent's live toolkit.
+ * <p><b>Toolkit note:</b> construction registers the load tool as ungrouped before {@link
+ * io.agentscope.core.ReActAgent ReActAgent} copies the toolkit, so persisted sessions with an empty
+ * active-group list still see it. Each system-prompt pass also verifies the live toolkit, so direct
+ * middleware usage remains supported.
  */
 @SuppressWarnings("deprecation")
 public class HarnessSkillMiddleware implements HarnessRuntimeMiddleware {
@@ -75,13 +74,13 @@ public class HarnessSkillMiddleware implements HarnessRuntimeMiddleware {
     private static final Logger log = LoggerFactory.getLogger(HarnessSkillMiddleware.class);
 
     private final List<AgentSkillRepository> repositories;
-    private final Toolkit toolkit;
     private final SkillFilter builderFilter;
     private final SkillVisibilityFilter visibilityFilter;
     private final MarketplaceStager stager;
     private final ShellPathPolicy shellPathPolicy;
     private final SkillRuntime runtime;
     private final Map<AgentSkillRepository, String> sourceNamespaces;
+    private final Map<String, RepoBound> frozenSkills;
 
     public HarnessSkillMiddleware(List<AgentSkillRepository> repositories, Toolkit toolkit) {
         this(repositories, toolkit, null, null, null, ShellPathPolicy.noShell());
@@ -110,8 +109,7 @@ public class HarnessSkillMiddleware implements HarnessRuntimeMiddleware {
      * Full constructor.
      *
      * @param repositories     compose-ordered list (low-to-high priority)
-     * @param toolkit          accepted for API compatibility; not used for runtime registration
-     *                         (see class-level note on toolkit copy semantics)
+     * @param toolkit          toolkit being assembled for the agent
      * @param builderFilter    skill filter passed at agent build time (may be {@code null})
      * @param visibilityFilter optional per-request filter (canary/allow-list)
      * @param stager           marketplace stager; {@code null} disables staging entirely
@@ -126,8 +124,46 @@ public class HarnessSkillMiddleware implements HarnessRuntimeMiddleware {
             SkillVisibilityFilter visibilityFilter,
             MarketplaceStager stager,
             ShellPathPolicy shellPathPolicy) {
+        this(
+                repositories,
+                toolkit,
+                builderFilter,
+                visibilityFilter,
+                stager,
+                shellPathPolicy,
+                false);
+    }
+
+    /**
+     * Creates a middleware whose merged repository view is captured once during construction.
+     * Filters remain per-call, and lazy resource access remains bound to the current context.
+     */
+    public static HarnessSkillMiddleware frozen(
+            List<AgentSkillRepository> repositories,
+            Toolkit toolkit,
+            SkillFilter builderFilter,
+            SkillVisibilityFilter visibilityFilter,
+            MarketplaceStager stager,
+            ShellPathPolicy shellPathPolicy) {
+        return new HarnessSkillMiddleware(
+                repositories,
+                toolkit,
+                builderFilter,
+                visibilityFilter,
+                stager,
+                shellPathPolicy,
+                true);
+    }
+
+    private HarnessSkillMiddleware(
+            List<AgentSkillRepository> repositories,
+            Toolkit toolkit,
+            SkillFilter builderFilter,
+            SkillVisibilityFilter visibilityFilter,
+            MarketplaceStager stager,
+            ShellPathPolicy shellPathPolicy,
+            boolean freezeRepositories) {
         this.repositories = repositories != null ? List.copyOf(repositories) : List.of();
-        this.toolkit = toolkit;
         this.builderFilter = builderFilter != null ? builderFilter : SkillFilter.all();
         this.visibilityFilter = visibilityFilter;
         this.stager = stager;
@@ -137,11 +173,22 @@ public class HarnessSkillMiddleware implements HarnessRuntimeMiddleware {
         // Pre-resolve source namespaces once at build time. The compose order is fixed for
         // the lifetime of the middleware, so this is safe and avoids repeated work per call.
         this.sourceNamespaces = MarketplaceStager.resolveSourceNamespaces(this.repositories);
+        this.frozenSkills =
+                freezeRepositories
+                        ? Collections.unmodifiableMap(
+                                new LinkedHashMap<>(mergeRepositories(RuntimeContext.empty())))
+                        : null;
+        this.runtime.prepareToolkit(toolkit);
     }
 
     /** Visible for tests / introspection. */
     public SkillRuntime runtime() {
         return runtime;
+    }
+
+    /** Whether repository enumeration is frozen to the construction-time snapshot. */
+    public boolean isFrozen() {
+        return frozenSkills != null;
     }
 
     /**
@@ -159,13 +206,14 @@ public class HarnessSkillMiddleware implements HarnessRuntimeMiddleware {
         if (ctx == null) {
             ctx = RuntimeContext.empty();
         }
-        Map<String, RepoBound> merged = mergeRepositories(ctx);
+        Map<String, RepoBound> merged = skillsForCall(ctx);
         if (merged.isEmpty()) {
             return;
         }
         List<RepoBound> visible = applyVisibility(merged.values(), ctx);
-        if (!visible.isEmpty()) {
-            stager.stage(visible, sourceNamespaces);
+        List<RepoBound> enabled = applySkillFilter(visible, effectiveFilter(ctx));
+        if (!enabled.isEmpty()) {
+            stager.stage(enabled, sourceNamespaces);
         }
     }
 
@@ -177,23 +225,24 @@ public class HarnessSkillMiddleware implements HarnessRuntimeMiddleware {
 
         Toolkit agentToolkit = agent != null ? agent.getToolkit() : null;
 
-        Map<String, RepoBound> merged = mergeRepositories(ctx);
+        Map<String, RepoBound> merged = skillsForCall(ctx);
         if (merged.isEmpty()) {
-            runtime.install(SkillCatalog.empty(), agentToolkit);
+            runtime.install(SkillCatalog.empty(), ctx, agentToolkit);
             return Mono.just(currentPrompt);
         }
 
         List<RepoBound> visible = applyVisibility(merged.values(), ctx);
-        if (visible.isEmpty()) {
-            runtime.install(SkillCatalog.empty(), agentToolkit);
+        List<RepoBound> enabled = applySkillFilter(visible, effectiveFilter(ctx));
+        if (enabled.isEmpty()) {
+            runtime.install(SkillCatalog.empty(), ctx, agentToolkit);
             return Mono.just(currentPrompt);
         }
 
         Map<String, StageResult> staged =
-                stager != null ? stager.stage(visible, sourceNamespaces) : Map.of();
+                stager != null ? stager.stage(enabled, sourceNamespaces) : Map.of();
 
-        List<HarnessSkillEntry> entries = new ArrayList<>(visible.size());
-        for (RepoBound bound : visible) {
+        List<HarnessSkillEntry> entries = new ArrayList<>(enabled.size());
+        for (RepoBound bound : enabled) {
             SkillResources lazy = null;
             if (bound.repo() instanceof LazyResourceCapable lrc) {
                 try {
@@ -211,11 +260,9 @@ public class HarnessSkillMiddleware implements HarnessRuntimeMiddleware {
         }
 
         SkillCatalog catalog = SkillCatalog.of(entries);
-        runtime.install(catalog, agentToolkit);
+        runtime.install(catalog, ctx, agentToolkit);
 
-        SkillFilter effective =
-                builderFilter.overlay(ctx != null ? ctx.get(SkillFilter.class) : null);
-        String append = runtime.renderPrompt(catalog, effective);
+        String append = runtime.renderPrompt(catalog, SkillFilter.all());
         if (append == null || append.isEmpty()) {
             return Mono.just(currentPrompt);
         }
@@ -228,6 +275,29 @@ public class HarnessSkillMiddleware implements HarnessRuntimeMiddleware {
     //  Internals
     // ---------------------------------------------------------------------
 
+    private Map<String, RepoBound> skillsForCall(RuntimeContext ctx) {
+        return frozenSkills != null ? frozenSkills : mergeRepositories(ctx);
+    }
+
+    private SkillFilter effectiveFilter(RuntimeContext ctx) {
+        return builderFilter.overlay(ctx != null ? ctx.get(SkillFilter.class) : null);
+    }
+
+    private List<RepoBound> applySkillFilter(
+            java.util.Collection<RepoBound> input, SkillFilter filter) {
+        if (input.isEmpty()) {
+            return List.of();
+        }
+        SkillFilter effective = filter != null ? filter : SkillFilter.all();
+        List<RepoBound> out = new ArrayList<>(input.size());
+        for (RepoBound bound : input) {
+            if (effective.isAllowed(bound.skill().getName())) {
+                out.add(bound);
+            }
+        }
+        return out;
+    }
+
     /**
      * Merge skills from every repository, in compose order. Later entries with the same
      * {@code AgentSkill.name} win. Also remembers the source repository per winning skill so
@@ -238,7 +308,10 @@ public class HarnessSkillMiddleware implements HarnessRuntimeMiddleware {
         for (AgentSkillRepository repo : repositories) {
             List<AgentSkill> skills;
             try {
-                skills = repo.getAllSkills();
+                skills =
+                        repo instanceof RuntimeContextSkillRepository contextRepository
+                                ? contextRepository.getAllSkills(ctx)
+                                : repo.getAllSkills();
             } catch (Exception e) {
                 log.warn(
                         "Skill repository {} failed to load: {}",

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/middleware/ToolResultEvictionMiddleware.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/middleware/ToolResultEvictionMiddleware.java
@@ -20,7 +20,6 @@ import io.agentscope.core.agent.RuntimeContext;
 import io.agentscope.core.event.AgentEvent;
 import io.agentscope.core.message.ContentBlock;
 import io.agentscope.core.message.Msg;
-import io.agentscope.core.message.MsgRole;
 import io.agentscope.core.message.TextBlock;
 import io.agentscope.core.message.ToolResultBlock;
 import io.agentscope.core.middleware.ReasoningInput;
@@ -28,27 +27,36 @@ import io.agentscope.core.state.AgentState;
 import io.agentscope.harness.agent.filesystem.AbstractFilesystem;
 import io.agentscope.harness.agent.filesystem.model.WriteResult;
 import io.agentscope.harness.agent.memory.compaction.ToolResultEvictionConfig;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HexFormat;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 import java.util.function.Function;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import reactor.core.publisher.Flux;
 
 /**
- * Middleware that evicts oversized tool results to the {@link AbstractFilesystem}
- * immediately after each acting phase, before downstream reasoning sees the bloated
- * message list.
+ * Middleware that evicts oversized tool results to the {@link AbstractFilesystem} before
+ * downstream reasoning sees the bloated message list.
  *
- * <p>When the text content of a {@link ToolResultBlock} in the freshly-added tool-result
- * messages exceeds {@link ToolResultEvictionConfig#getMaxResultChars()}, this middleware:
+ * <p>When the text content of a {@link ToolResultBlock} in canonical agent state or the current
+ * reasoning view exceeds {@link ToolResultEvictionConfig#getMaxResultChars()}, this middleware:
  * <ol>
  *   <li>Writes the full result to
- *       {@code {evictionPath}/{agentName}/{sanitized-toolCallId}} in the filesystem.</li>
- *   <li>Replaces the in-context {@code ToolResultBlock} with a compact placeholder containing
- *       a head+tail preview and an instruction to use {@code readFile} for the full content.</li>
- *   <li>Mutates {@link AgentState#contextMutable()} in place so subsequent reasoning rounds
- *       see only the placeholder.</li>
+ *       {@code {evictionPath}/{agentName}/{sanitized-toolCallId}-{contentHash}} in the
+ *       filesystem.</li>
+ *   <li>Compacts {@link AgentState#contextMutable()} first, so legacy pre-reasoning hooks cannot
+ *       hide an original result from persistence cleanup.</li>
+ *   <li>Rebuilds the current {@link ReasoningInput}, preserving hook deletions and rewrites while
+ *       replacing results that remain visible to the immediate model call.</li>
+ *   <li>Marks compacted results in metadata so they are not recursively evicted on later turns.</li>
  * </ol>
  *
  * <p>Tools listed in {@link ToolResultEvictionConfig#getExcludedToolNames()} are never evicted
@@ -57,6 +65,7 @@ import reactor.core.publisher.Flux;
 public class ToolResultEvictionMiddleware implements HarnessRuntimeMiddleware {
 
     private static final Logger log = LoggerFactory.getLogger(ToolResultEvictionMiddleware.class);
+    static final String EVICTED_METADATA_KEY = "agentscope.tool_result_evicted";
 
     private final AbstractFilesystem filesystem;
     private final ToolResultEvictionConfig config;
@@ -74,30 +83,63 @@ public class ToolResultEvictionMiddleware implements HarnessRuntimeMiddleware {
             ReasoningInput input,
             Function<ReasoningInput, Flux<AgentEvent>> next) {
         final RuntimeContext rc = ctx != null ? ctx : RuntimeContext.empty();
-        evictOversizedToolResults(agent, rc);
-        return next.apply(input);
-    }
+        Map<ToolResultFingerprint, String> replacements = new HashMap<>();
 
-    private void evictOversizedToolResults(Agent agent, RuntimeContext rc) {
+        // PreReasoning hooks run before middleware and may remove or rewrite messages. Evict the
+        // canonical state first so hook behavior cannot prevent the original result from being
+        // compacted before persistence.
         AgentState state = RuntimeContext.resolveAgentState(rc, agent);
-        if (state == null) {
-            return;
-        }
-        List<Msg> ctx = state.contextMutable();
-        String agentName = agent.getName();
-        for (int i = 0; i < ctx.size(); i++) {
-            Msg msg = ctx.get(i);
-            if (msg == null || msg.getRole() != MsgRole.TOOL) {
-                continue;
-            }
-            Msg rebuilt = evictMessage(msg, agentName, rc);
-            if (rebuilt != msg) {
-                ctx.set(i, rebuilt);
+        if (state != null) {
+            EvictionResult canonical =
+                    evictMessages(state.contextMutable(), agent.getName(), rc, replacements);
+            if (canonical.changed()) {
+                List<Msg> context = state.contextMutable();
+                for (int i = 0; i < context.size(); i++) {
+                    context.set(i, canonical.messages().get(i));
+                }
             }
         }
+
+        // Preserve the hook-produced model view, compacting only results that remain (or were
+        // newly added) in that view. Reuse canonical replacements to avoid duplicate writes.
+        EvictionResult result = evictMessages(input.messages(), agent.getName(), rc, replacements);
+        if (!result.changed()) {
+            return next.apply(input);
+        }
+
+        return next.apply(new ReasoningInput(result.messages(), input.tools(), input.options()));
     }
 
-    private Msg evictMessage(Msg msg, String agentName, RuntimeContext rc) {
+    private EvictionResult evictMessages(
+            List<Msg> messages,
+            String agentName,
+            RuntimeContext rc,
+            Map<ToolResultFingerprint, String> replacements) {
+        if (messages == null || messages.isEmpty()) {
+            return new EvictionResult(messages, false);
+        }
+
+        List<Msg> rebuiltMessages = new ArrayList<>(messages.size());
+        boolean changed = false;
+        for (Msg msg : messages) {
+            Msg rebuilt = evictMessage(msg, agentName, rc, replacements);
+            rebuiltMessages.add(rebuilt);
+            if (rebuilt != msg) {
+                changed = true;
+            }
+        }
+
+        return new EvictionResult(changed ? rebuiltMessages : messages, changed);
+    }
+
+    private Msg evictMessage(
+            Msg msg,
+            String agentName,
+            RuntimeContext rc,
+            Map<ToolResultFingerprint, String> replacements) {
+        if (msg == null) {
+            return null;
+        }
         List<ContentBlock> contentBlocks = msg.getContent();
         if (contentBlocks == null || contentBlocks.isEmpty()) {
             return msg;
@@ -106,10 +148,21 @@ public class ToolResultEvictionMiddleware implements HarnessRuntimeMiddleware {
         List<ContentBlock> rebuilt = new ArrayList<>(contentBlocks.size());
         for (ContentBlock block : contentBlocks) {
             if (block instanceof ToolResultBlock tr) {
-                ToolResultBlock maybeEvicted = maybeEvict(tr, agentName, rc);
-                if (maybeEvicted != tr) {
+                if (isEvicted(tr)) {
+                    rebuilt.add(block);
+                    continue;
+                }
+                ToolResultFingerprint original = fingerprint(tr);
+                String placeholder = replacements.get(original);
+                if (placeholder == null) {
+                    placeholder = maybeEvict(tr, agentName, rc);
+                    if (placeholder != null) {
+                        replacements.put(original, placeholder);
+                    }
+                }
+                if (placeholder != null) {
                     changed = true;
-                    rebuilt.add(maybeEvicted);
+                    rebuilt.add(withPlaceholder(tr, placeholder));
                     continue;
                 }
             }
@@ -118,29 +171,32 @@ public class ToolResultEvictionMiddleware implements HarnessRuntimeMiddleware {
         if (!changed) {
             return msg;
         }
-        return Msg.builder()
+        return rebuildMessage(msg, rebuilt);
+    }
+
+    private Msg rebuildMessage(Msg msg, List<ContentBlock> content) {
+        return Msg.builderForRole(msg.getRole())
                 .id(msg.getId())
                 .name(msg.getName())
-                .role(msg.getRole())
-                .content(rebuilt)
+                .content(content)
                 .metadata(msg.getMetadata())
                 .timestamp(msg.getTimestamp())
+                .usage(msg.getUsage())
                 .build();
     }
 
-    private ToolResultBlock maybeEvict(
-            ToolResultBlock toolResult, String agentName, RuntimeContext rc) {
+    private String maybeEvict(ToolResultBlock toolResult, String agentName, RuntimeContext rc) {
         String toolName = toolResult.getName();
         if (toolName != null && config.getExcludedToolNames().contains(toolName)) {
-            return toolResult;
+            return null;
         }
         String fullText = extractText(toolResult);
         if (fullText.length() <= config.getMaxResultChars()) {
-            return toolResult;
+            return null;
         }
         String toolCallId = toolResult.getId();
-        String evictionPath = buildEvictionPath(agentName, toolCallId);
         try {
+            String evictionPath = buildEvictionPath(agentName, toolCallId, fullText);
             WriteResult writeResult = filesystem.write(rc, evictionPath, fullText);
             if (!writeResult.isSuccess()) {
                 log.warn(
@@ -149,7 +205,7 @@ public class ToolResultEvictionMiddleware implements HarnessRuntimeMiddleware {
                         toolName,
                         toolCallId,
                         writeResult.error());
-                return toolResult;
+                return null;
             }
             String placeholder = buildPlaceholder(fullText, evictionPath);
             log.info(
@@ -159,11 +215,7 @@ public class ToolResultEvictionMiddleware implements HarnessRuntimeMiddleware {
                     toolCallId,
                     fullText.length(),
                     evictionPath);
-            return new ToolResultBlock(
-                    toolResult.getId(),
-                    toolResult.getName(),
-                    List.of(TextBlock.builder().text(placeholder).build()),
-                    null);
+            return placeholder;
         } catch (Exception e) {
             log.warn(
                     "[{}] Exception evicting tool result [tool={}, id={}]: {}",
@@ -171,8 +223,23 @@ public class ToolResultEvictionMiddleware implements HarnessRuntimeMiddleware {
                     toolName,
                     toolCallId,
                     e.getMessage());
-            return toolResult;
+            return null;
         }
+    }
+
+    private boolean isEvicted(ToolResultBlock toolResult) {
+        return Boolean.TRUE.equals(toolResult.getMetadata().get(EVICTED_METADATA_KEY));
+    }
+
+    private ToolResultBlock withPlaceholder(ToolResultBlock toolResult, String placeholder) {
+        Map<String, Object> metadata = new LinkedHashMap<>(toolResult.getMetadata());
+        metadata.put(EVICTED_METADATA_KEY, true);
+        return new ToolResultBlock(
+                toolResult.getId(),
+                toolResult.getName(),
+                List.of(TextBlock.builder().text(placeholder).build()),
+                metadata,
+                toolResult.getState());
     }
 
     private String extractText(ToolResultBlock toolResult) {
@@ -188,14 +255,25 @@ public class ToolResultEvictionMiddleware implements HarnessRuntimeMiddleware {
         return sb.toString();
     }
 
-    private String buildEvictionPath(String agentName, String toolCallId) {
+    private String buildEvictionPath(String agentName, String toolCallId, String fullText) {
         String base = config.getEvictionPath();
-        if (!base.startsWith("/")) {
-            base = "/" + base;
+        while (base.endsWith("/")) {
+            base = base.substring(0, base.length() - 1);
         }
         String safeAgent = agentName.replaceAll("[^a-zA-Z0-9_-]", "_");
         String safeId = toolCallId.replaceAll("[^a-zA-Z0-9_-]", "_");
-        return base + "/" + safeAgent + "/" + safeId;
+        return base + "/" + safeAgent + "/" + safeId + "-" + contentHash(fullText);
+    }
+
+    private String contentHash(String content) {
+        try {
+            byte[] digest =
+                    MessageDigest.getInstance("SHA-256")
+                            .digest(content.getBytes(StandardCharsets.UTF_8));
+            return HexFormat.of().formatHex(digest, 0, 8);
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-256 is not available", e);
+        }
     }
 
     private String buildPlaceholder(String fullText, String evictionPath) {
@@ -218,4 +296,17 @@ public class ToolResultEvictionMiddleware implements HarnessRuntimeMiddleware {
 
         return sb.toString();
     }
+
+    private ToolResultFingerprint fingerprint(ToolResultBlock block) {
+        return new ToolResultFingerprint(block.getId(), block.getName(), extractText(block));
+    }
+
+    private record ToolResultFingerprint(String id, String name, String text) {
+
+        private ToolResultFingerprint {
+            text = Objects.requireNonNullElse(text, "");
+        }
+    }
+
+    private record EvictionResult(List<Msg> messages, boolean changed) {}
 }

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/skill/RuntimeContextSkillRepository.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/skill/RuntimeContextSkillRepository.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.harness.agent.skill;
+
+import io.agentscope.core.agent.RuntimeContext;
+import io.agentscope.core.skill.AgentSkill;
+import io.agentscope.core.skill.repository.AgentSkillRepository;
+import java.util.List;
+
+/** A skill repository whose visible contents depend on the current request context. */
+public interface RuntimeContextSkillRepository extends AgentSkillRepository {
+
+    /** Returns the skills visible to exactly the supplied request context. */
+    List<AgentSkill> getAllSkills(RuntimeContext context);
+}

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/skill/WorkspaceSkillRepository.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/skill/WorkspaceSkillRepository.java
@@ -64,7 +64,8 @@ import org.yaml.snakeyaml.Yaml;
  * invariant.
  */
 @SuppressWarnings("deprecation")
-public class WorkspaceSkillRepository implements AgentSkillRepository, LazyResourceCapable {
+public class WorkspaceSkillRepository
+        implements RuntimeContextSkillRepository, LazyResourceCapable {
 
     private static final Logger log = LoggerFactory.getLogger(WorkspaceSkillRepository.class);
 
@@ -157,7 +158,16 @@ public class WorkspaceSkillRepository implements AgentSkillRepository, LazyResou
 
     @Override
     public List<AgentSkill> getAllSkills() {
-        RuntimeContext ctx = currentContext();
+        return getAllSkills(currentContext());
+    }
+
+    /**
+     * Lists skills using the caller's request-scoped context rather than the legacy shared context
+     * supplier.
+     */
+    @Override
+    public List<AgentSkill> getAllSkills(RuntimeContext context) {
+        RuntimeContext ctx = context != null ? context : RuntimeContext.empty();
         GlobResult glob;
         try {
             glob = filesystem.glob(ctx, SKILL_FILE, skillsRelativeDir);

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/skill/runtime/SkillLoadTool.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/skill/runtime/SkillLoadTool.java
@@ -46,9 +46,10 @@ import reactor.core.publisher.Mono;
  *       lazy listing
  * </ol>
  *
- * <p>The tool's catalog reference is held via an {@link AtomicReference} supplied by
- * {@link SkillRuntime} so the registered tool instance can be reused across {@code call()}
- * rounds without re-registering, while the catalog itself is rebuilt every round.
+ * <p>The registered tool resolves the filtered catalog from each {@link
+ * ToolCallParam#getRuntimeContext() tool call's RuntimeContext}, keeping concurrent calls and
+ * sessions isolated without re-registering the tool. A legacy catalog reference is consulted only
+ * for deprecated callers that invoke the tool without any RuntimeContext.
  */
 @SuppressWarnings("deprecation")
 public final class SkillLoadTool implements AgentTool {
@@ -58,13 +59,37 @@ public final class SkillLoadTool implements AgentTool {
 
     private static final Logger log = LoggerFactory.getLogger(SkillLoadTool.class);
 
-    private final AtomicReference<SkillCatalog> catalogRef;
+    private final AtomicReference<SkillCatalog> legacyCatalogRef;
+    private final boolean exposeLegacyCatalogInSchema;
 
+    /** Creates a context-scoped loader with an empty context-free compatibility catalog. */
+    public SkillLoadTool() {
+        this(new AtomicReference<>(SkillCatalog.empty()), false);
+    }
+
+    /**
+     * Creates a loader backed by a legacy context-free catalog reference.
+     *
+     * <p>This constructor is retained for source and binary compatibility. The supplied reference
+     * is never used when a tool call carries a RuntimeContext, preventing it from bypassing the
+     * request-scoped skill filter.
+     *
+     * @deprecated Prefer {@link #SkillLoadTool()} and bind catalogs through {@link
+     *     SkillRuntime#install(SkillCatalog, io.agentscope.core.agent.RuntimeContext,
+     *     io.agentscope.core.tool.Toolkit)}.
+     */
+    @Deprecated(since = "2.2.0")
     public SkillLoadTool(AtomicReference<SkillCatalog> catalogRef) {
-        if (catalogRef == null) {
+        this(catalogRef, true);
+    }
+
+    SkillLoadTool(
+            AtomicReference<SkillCatalog> legacyCatalogRef, boolean exposeLegacyCatalogInSchema) {
+        if (legacyCatalogRef == null) {
             throw new IllegalArgumentException("catalogRef must not be null");
         }
-        this.catalogRef = catalogRef;
+        this.legacyCatalogRef = legacyCatalogRef;
+        this.exposeLegacyCatalogInSchema = exposeLegacyCatalogInSchema;
     }
 
     @Override
@@ -90,27 +115,40 @@ public final class SkillLoadTool implements AgentTool {
 
     @Override
     public Map<String, Object> getParameters() {
-        SkillCatalog snapshot = catalogRef.get();
-        List<String> ids = snapshot == null ? List.of() : snapshot.ids();
+        Map<String, Object> skillIdSchema;
+        if (exposeLegacyCatalogInSchema) {
+            SkillCatalog snapshot = legacyCatalogRef.get();
+            List<String> ids = snapshot != null ? snapshot.ids() : List.of();
+            skillIdSchema =
+                    Map.of(
+                            "type", "string",
+                            "description", "Unique skill identifier.",
+                            "enum", ids);
+        } else {
+            skillIdSchema =
+                    Map.of(
+                            "type",
+                            "string",
+                            "description",
+                            "Unique skill identifier listed in the current <available_skills>"
+                                    + " block.");
+        }
         return Map.of(
                 "type", "object",
                 "properties",
                         Map.of(
                                 "skillId",
-                                        Map.of(
-                                                "type", "string",
-                                                "description", "Unique skill identifier.",
-                                                "enum", ids),
+                                skillIdSchema,
                                 "path",
-                                        Map.of(
-                                                "type",
-                                                "string",
-                                                "description",
-                                                "Exact resource path within the skill."
-                                                        + " Use 'SKILL.md' for the skill's"
-                                                        + " instructions; do not use '.',"
-                                                        + " './', directories, or absolute"
-                                                        + " paths.")),
+                                Map.of(
+                                        "type",
+                                        "string",
+                                        "description",
+                                        "Exact resource path within the skill."
+                                                + " Use 'SKILL.md' for the skill's"
+                                                + " instructions; do not use '.',"
+                                                + " './', directories, or absolute"
+                                                + " paths.")),
                 "required", List.of("skillId", "path"));
     }
 
@@ -129,8 +167,8 @@ public final class SkillLoadTool implements AgentTool {
                         ToolResultBlock.error("Missing or empty required parameter: path"));
             }
 
-            SkillCatalog catalog = catalogRef.get();
-            HarnessSkillEntry entry = catalog == null ? null : catalog.get(skillId);
+            SkillCatalog catalog = catalogFor(param);
+            HarnessSkillEntry entry = catalog.get(skillId);
             if (entry == null) {
                 return Mono.just(
                         ToolResultBlock.error(
@@ -144,6 +182,14 @@ public final class SkillLoadTool implements AgentTool {
             log.error("load_skill_through_path failed", e);
             return Mono.just(ToolResultBlock.error(e.getMessage()));
         }
+    }
+
+    private SkillCatalog catalogFor(ToolCallParam param) {
+        if (param.getRuntimeContext() != null) {
+            return SkillRuntime.catalogFor(param.getRuntimeContext());
+        }
+        SkillCatalog legacy = legacyCatalogRef.get();
+        return legacy != null ? legacy : SkillCatalog.empty();
     }
 
     private ToolResultBlock loadOne(HarnessSkillEntry entry, String path) {

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/skill/runtime/SkillRuntime.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/skill/runtime/SkillRuntime.java
@@ -15,30 +15,31 @@
  */
 package io.agentscope.harness.agent.skill.runtime;
 
+import io.agentscope.core.agent.RuntimeContext;
 import io.agentscope.core.skill.SkillFilter;
 import io.agentscope.core.tool.AgentTool;
 import io.agentscope.core.tool.Toolkit;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Aggregates the per-call {@link SkillCatalog}, the singleton {@link SkillLoadTool}, and the
- * {@link SkillPromptBuilder}. {@link io.agentscope.harness.agent.middleware.HarnessSkillMiddleware}
- * owns one instance and updates the catalog every {@code onSystemPrompt} pass.
+ * Aggregates the singleton {@link SkillLoadTool} and the {@link SkillPromptBuilder}. {@link
+ * io.agentscope.harness.agent.middleware.HarnessSkillMiddleware} owns one instance and installs
+ * each filtered {@link SkillCatalog} into that call's {@link RuntimeContext}.
  *
- * <p>The {@code load_skill_through_path} tool is registered on the toolkit exactly once, on the
- * first install. The tool instance holds the {@link AtomicReference} to the catalog, so swapping
- * the catalog from later rounds takes effect immediately without re-registering.
+ * <p>The {@code load_skill_through_path} tool is prepared during agent construction and verified
+ * idempotently on later installs. Normal tool calls resolve the catalog from their {@code
+ * RuntimeContext}, so concurrent sessions cannot overwrite or observe one another's filtered skill
+ * view. A separate compatibility catalog is retained only for deprecated, context-free callers.
  */
 public final class SkillRuntime {
 
     private static final Logger log = LoggerFactory.getLogger(SkillRuntime.class);
 
-    private final AtomicReference<SkillCatalog> catalogRef =
+    private final RuntimeContext legacyContext = RuntimeContext.empty();
+    private final AtomicReference<SkillCatalog> legacyCatalogRef =
             new AtomicReference<>(SkillCatalog.empty());
-    private final AtomicBoolean toolInstalled = new AtomicBoolean(false);
     private final SkillLoadTool loadTool;
     private final SkillPromptBuilder promptBuilder;
 
@@ -48,44 +49,100 @@ public final class SkillRuntime {
 
     public SkillRuntime(SkillPromptBuilder promptBuilder) {
         this.promptBuilder = promptBuilder != null ? promptBuilder : new SkillPromptBuilder();
-        this.loadTool = new SkillLoadTool(catalogRef);
+        this.loadTool = new SkillLoadTool(legacyCatalogRef, false);
     }
 
-    /** Snapshot accessor mainly for tests; not for runtime mutation. */
+    /**
+     * Returns the catalog installed through the deprecated context-free API.
+     *
+     * @deprecated Use {@link #currentCatalog(RuntimeContext)} so catalog lookup is request-scoped.
+     */
+    @Deprecated(since = "2.2.0")
     public SkillCatalog currentCatalog() {
-        return catalogRef.get();
+        return currentCatalog(legacyContext);
     }
 
-    /** Underlying tool instance. Use {@link #install(SkillCatalog, Toolkit)} for normal flow. */
+    /** Returns the catalog bound to {@code context}, or an empty catalog when none is bound. */
+    public SkillCatalog currentCatalog(RuntimeContext context) {
+        return catalogFor(context);
+    }
+
+    static SkillCatalog catalogFor(RuntimeContext context) {
+        if (context == null) {
+            return SkillCatalog.empty();
+        }
+        SkillCatalog catalog = context.get(SkillCatalog.class);
+        return catalog != null ? catalog : SkillCatalog.empty();
+    }
+
+    /**
+     * Underlying stateless tool instance. Use {@link #install(SkillCatalog, RuntimeContext,
+     * Toolkit)} for normal flow.
+     */
     public AgentTool loadTool() {
         return loadTool;
     }
 
     /**
-     * Update the current catalog and ensure the load tool is registered on the toolkit (idempotent).
+     * Ensures the skill loading tool is present as an ungrouped tool.
      *
-     * @param catalog the new snapshot; pass {@link SkillCatalog#empty()} to clear visibility
-     * @param toolkit the toolkit to install onto; may be {@code null} (then only catalog is updated)
+     * <p>Harness calls this while the agent toolkit is still being assembled. The toolkit copy
+     * made by {@code ReActAgent.Builder} therefore contains the tool before its first model call.
+     * Keeping the loader ungrouped is intentional: ungrouped tools remain visible regardless of a
+     * session's persisted active-group list, including sessions created before the loader existed.
      */
-    public void install(SkillCatalog catalog, Toolkit toolkit) {
-        catalogRef.set(catalog != null ? catalog : SkillCatalog.empty());
+    public void prepareToolkit(Toolkit toolkit) {
         if (toolkit == null) {
             return;
         }
-        if (toolInstalled.compareAndSet(false, true)) {
-            try {
-                AgentTool existing = toolkit.getTool(SkillLoadTool.TOOL_NAME);
-                if (existing != null && existing != loadTool) {
-                    toolkit.removeTool(SkillLoadTool.TOOL_NAME);
-                }
-                toolkit.registerAgentTool(loadTool);
-            } catch (Exception e) {
-                // Don't permanently latch installed=true if the registration failed: allow a
-                // retry on the next call.
-                toolInstalled.set(false);
-                log.warn("Failed to register {}: {}", SkillLoadTool.TOOL_NAME, e.getMessage());
+        try {
+            AgentTool existing = toolkit.getTool(SkillLoadTool.TOOL_NAME);
+            if (existing == loadTool) {
+                return;
             }
+            if (existing != null) {
+                toolkit.removeTool(SkillLoadTool.TOOL_NAME);
+            }
+            toolkit.registration().agentTool(loadTool).apply();
+        } catch (Exception e) {
+            log.warn("Failed to register {}: {}", SkillLoadTool.TOOL_NAME, e.getMessage());
         }
+    }
+
+    /**
+     * Bind a catalog to the current call and ensure the load tool is registered on the toolkit
+     * (idempotent).
+     *
+     * <p>The catalog is deliberately stored on {@code context}, not on this shared runtime. This is
+     * the authorization boundary used by {@link SkillLoadTool}; a skill omitted from the call's
+     * filtered catalog cannot be loaded even while another session exposes it.
+     *
+     * @param catalog the call snapshot; pass {@link SkillCatalog#empty()} to clear visibility
+     * @param context the current call context; may be {@code null}, in which case no catalog is
+     *     exposed
+     * @param toolkit the toolkit to install onto; may be {@code null} (then only catalog is updated)
+     */
+    public void install(SkillCatalog catalog, RuntimeContext context, Toolkit toolkit) {
+        if (context != null) {
+            context.put(SkillCatalog.class, catalog != null ? catalog : SkillCatalog.empty());
+        }
+        prepareToolkit(toolkit);
+    }
+
+    /**
+     * Installs a catalog for legacy context-free callers.
+     *
+     * <p>This overload is retained for source and binary compatibility. Its catalog is used only
+     * when {@link SkillLoadTool} is invoked without a {@link RuntimeContext}; context-bearing calls
+     * never fall back to it and therefore remain isolated.
+     *
+     * @deprecated Use {@link #install(SkillCatalog, RuntimeContext, Toolkit)}.
+     */
+    @Deprecated(since = "2.2.0")
+    public void install(SkillCatalog catalog, Toolkit toolkit) {
+        SkillCatalog normalized = catalog != null ? catalog : SkillCatalog.empty();
+        legacyCatalogRef.set(normalized);
+        install(normalized, legacyContext, toolkit);
     }
 
     /** Renders the {@code <available_skills>} block + (when applicable) the code-execution prompt. */

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/HarnessAgentDynamicHookBuilderTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/HarnessAgentDynamicHookBuilderTest.java
@@ -22,16 +22,23 @@ import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import io.agentscope.core.agent.RuntimeContext;
+import io.agentscope.core.message.Msg;
 import io.agentscope.core.message.TextBlock;
+import io.agentscope.core.message.ToolResultBlock;
 import io.agentscope.core.middleware.MiddlewareBase;
 import io.agentscope.core.model.ChatResponse;
 import io.agentscope.core.model.Model;
+import io.agentscope.core.model.ToolSchema;
 import io.agentscope.core.skill.AgentSkill;
 import io.agentscope.core.skill.repository.AgentSkillRepository;
 import io.agentscope.core.skill.repository.AgentSkillRepositoryInfo;
+import io.agentscope.core.tool.ToolCallParam;
 import io.agentscope.harness.agent.filesystem.local.LocalFilesystem;
 import io.agentscope.harness.agent.middleware.DynamicSubagentsMiddleware;
 import io.agentscope.harness.agent.middleware.SubagentsMiddleware;
@@ -40,8 +47,11 @@ import java.nio.file.Path;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.mockito.ArgumentCaptor;
 import reactor.core.publisher.Flux;
 
 /**
@@ -53,7 +63,8 @@ import reactor.core.publisher.Flux;
  *       are registered.
  *   <li>{@code skillRepository(custom)} composes <em>additively</em> with workspace skills — the
  *       dynamic middleware is still registered and exposes both sources.
- *   <li>{@code disableDynamicSkills()} → no {@link io.agentscope.core.skill.DynamicSkillMiddleware}.
+ *   <li>{@code disableDynamicSkills()} → repositories are frozen in the harness-native skill
+ *       middleware without reloading them per call.
  *   <li>{@code disableDynamicSubagents()} → no {@link DynamicSubagentsMiddleware}; falls back to
  *       the static {@link SubagentsMiddleware}.
  * </ul>
@@ -127,6 +138,192 @@ class HarnessAgentDynamicHookBuilderTest {
         assertFalse(
                 anyOfType(mws, io.agentscope.core.skill.DynamicSkillMiddleware.class),
                 "disableDynamicSkills() must skip the dynamic skill middleware");
+    }
+
+    @Test
+    void disableDynamicSkills_freezesRepositoriesIntoStaticMiddleware() throws Exception {
+        Files.createDirectories(workspace);
+        Model model = stubModel("ok");
+        CountingSkillRepository repository =
+                new CountingSkillRepository(
+                        List.of(
+                                new AgentSkill(
+                                        "frozen-skill",
+                                        "A skill loaded once during agent construction",
+                                        "# Frozen skill",
+                                        null)));
+
+        HarnessAgent agent =
+                HarnessAgent.builder()
+                        .name("t")
+                        .model(model)
+                        .workspace(workspace)
+                        .abstractFilesystem(new LocalFilesystem(workspace))
+                        .skillRepository(repository)
+                        .disableDynamicSkills()
+                        .build();
+
+        assertEquals(
+                1,
+                repository.readCount(),
+                "Static mode must read each repository once while building the agent");
+        io.agentscope.harness.agent.middleware.HarnessSkillMiddleware skillMiddleware =
+                agent.getDelegate().getMiddlewares().stream()
+                        .filter(
+                                io.agentscope.harness.agent.middleware.HarnessSkillMiddleware.class
+                                        ::isInstance)
+                        .map(
+                                io.agentscope.harness.agent.middleware.HarnessSkillMiddleware.class
+                                        ::cast)
+                        .findFirst()
+                        .orElseThrow();
+        assertTrue(skillMiddleware.isFrozen(), "Static mode must freeze repository enumeration");
+        assertNotNull(
+                agent.getDelegate().getToolkit().getTool("load_skill_through_path"),
+                "Static mode must register the skill loading tool during construction");
+
+        agent.call("hello", RuntimeContext.builder().sessionId("static-skills").build()).block();
+
+        assertEquals(
+                1,
+                repository.readCount(),
+                "Static mode must not refresh repositories for each model call");
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<List<ToolSchema>> toolsCaptor = ArgumentCaptor.forClass(List.class);
+        verify(model, atLeast(1)).stream(anyList(), toolsCaptor.capture(), any());
+        assertTrue(
+                toolsCaptor.getAllValues().stream()
+                        .flatMap(List::stream)
+                        .anyMatch(tool -> "load_skill_through_path".equals(tool.getName())),
+                "The ungrouped skill loader must remain visible with an empty active-group list");
+
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<List<Msg>> captor = ArgumentCaptor.forClass(List.class);
+        verify(model, atLeast(1)).stream(captor.capture(), any(), any());
+        String modelInput =
+                captor.getAllValues().stream()
+                        .flatMap(List::stream)
+                        .map(msg -> msg.getTextContent() == null ? "" : msg.getTextContent())
+                        .collect(Collectors.joining("\n"));
+        assertTrue(
+                modelInput.contains("frozen-skill"),
+                "Static skill middleware must expose repository skills in the model prompt");
+    }
+
+    @Test
+    void disableDynamicSkills_appliesBuilderAndVisibilityFiltersToPromptAndLoader()
+            throws Exception {
+        Files.createDirectories(workspace);
+        Model model = stubModel("ok");
+        CountingSkillRepository repository =
+                new CountingSkillRepository(
+                        List.of(
+                                skill("alpha", "alpha description"),
+                                skill("beta", "beta description"),
+                                skill("gamma", "gamma description")));
+
+        HarnessAgent agent =
+                HarnessAgent.builder()
+                        .name("t")
+                        .model(model)
+                        .workspace(workspace)
+                        .abstractFilesystem(new LocalFilesystem(workspace))
+                        .skillRepository(repository)
+                        .enableSkills("alpha", "beta")
+                        .enableSkillPromotionGate(
+                                null,
+                                (skills, ctx) ->
+                                        skills.stream()
+                                                .filter(skill -> !"alpha".equals(skill.getName()))
+                                                .toList())
+                        .disableDynamicSkills()
+                        .build();
+
+        RuntimeContext ctx = RuntimeContext.builder().sessionId("filtered-static").build();
+        agent.call("hello", ctx).block();
+
+        String modelInput = capturedModelInput(model);
+        assertFalse(modelInput.contains("alpha description"));
+        assertTrue(modelInput.contains("beta description"));
+        assertFalse(modelInput.contains("gamma description"));
+
+        io.agentscope.harness.agent.middleware.HarnessSkillMiddleware middleware =
+                frozenSkillMiddleware(agent);
+        middleware.onSystemPrompt(agent.getDelegate(), ctx, "").block();
+        assertEquals(1, middleware.runtime().currentCatalog(ctx).size());
+        assertEquals(
+                "beta",
+                middleware.runtime().currentCatalog(ctx).all().iterator().next().skill().getName(),
+                "The loader catalog must use the same filtered view as the prompt");
+        assertEquals(1, repository.readCount());
+    }
+
+    @Test
+    void disableDynamicSkills_skillsEnabledFalseLeavesCatalogEmpty() throws Exception {
+        Files.createDirectories(workspace);
+        Model model = stubModel("ok");
+        CountingSkillRepository repository =
+                new CountingSkillRepository(List.of(skill("disabled", "must stay hidden")));
+
+        HarnessAgent agent =
+                HarnessAgent.builder()
+                        .name("t")
+                        .model(model)
+                        .workspace(workspace)
+                        .abstractFilesystem(new LocalFilesystem(workspace))
+                        .skillRepository(repository)
+                        .skillsEnabled(false)
+                        .disableDynamicSkills()
+                        .build();
+
+        RuntimeContext ctx = RuntimeContext.builder().sessionId("no-static-skills").build();
+        agent.call("hello", ctx).block();
+
+        assertFalse(capturedModelInput(model).contains("must stay hidden"));
+        assertTrue(frozenSkillMiddleware(agent).runtime().currentCatalog(ctx).isEmpty());
+        assertEquals(1, repository.readCount());
+    }
+
+    @Test
+    void disableDynamicSkills_keepsWorkspaceLazyResourcesLoadable() throws Exception {
+        Path skillDir = workspace.resolve("skills/lazy-resource");
+        Files.createDirectories(skillDir.resolve("references"));
+        Files.writeString(
+                skillDir.resolve("SKILL.md"),
+                "---\nname: lazy-resource\ndescription: Loads a lazy reference\n---\n# Body\n");
+        Files.writeString(skillDir.resolve("references/guide.md"), "lazy reference body");
+
+        HarnessAgent agent =
+                HarnessAgent.builder()
+                        .name("t")
+                        .model(stubModel("ok"))
+                        .workspace(workspace)
+                        .abstractFilesystem(new LocalFilesystem(workspace))
+                        .disableDynamicSkills()
+                        .build();
+
+        RuntimeContext ctx = RuntimeContext.builder().sessionId("lazy-static").build();
+        agent.call("hello", ctx).block();
+        frozenSkillMiddleware(agent).onSystemPrompt(agent.getDelegate(), ctx, "").block();
+
+        ToolResultBlock result =
+                agent.getDelegate()
+                        .getToolkit()
+                        .getTool("load_skill_through_path")
+                        .callAsync(
+                                ToolCallParam.builder()
+                                        .runtimeContext(ctx)
+                                        .input(
+                                                Map.of(
+                                                        "skillId",
+                                                        "lazy-resource_workspace-namespaced",
+                                                        "path",
+                                                        "references/guide.md"))
+                                        .build())
+                        .block();
+
+        assertNotNull(result);
+        assertTrue(toolResultText(result).contains("lazy reference body"));
     }
 
     @Test
@@ -215,6 +412,40 @@ class HarnessAgentDynamicHookBuilderTest {
                 "Static SubagentsMiddleware must be registered when dynamic is disabled");
     }
 
+    private static io.agentscope.harness.agent.middleware.HarnessSkillMiddleware
+            frozenSkillMiddleware(HarnessAgent agent) {
+        return agent.getDelegate().getMiddlewares().stream()
+                .filter(
+                        io.agentscope.harness.agent.middleware.HarnessSkillMiddleware.class
+                                ::isInstance)
+                .map(io.agentscope.harness.agent.middleware.HarnessSkillMiddleware.class::cast)
+                .filter(io.agentscope.harness.agent.middleware.HarnessSkillMiddleware::isFrozen)
+                .findFirst()
+                .orElseThrow();
+    }
+
+    private static AgentSkill skill(String name, String description) {
+        return new AgentSkill(name, description, "# " + name, null);
+    }
+
+    private static String capturedModelInput(Model model) {
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<List<Msg>> captor = ArgumentCaptor.forClass(List.class);
+        verify(model, atLeast(1)).stream(captor.capture(), any(), any());
+        return captor.getAllValues().stream()
+                .flatMap(List::stream)
+                .map(msg -> msg.getTextContent() == null ? "" : msg.getTextContent())
+                .collect(Collectors.joining("\n"));
+    }
+
+    private static String toolResultText(ToolResultBlock result) {
+        return result.getOutput().stream()
+                .filter(TextBlock.class::isInstance)
+                .map(TextBlock.class::cast)
+                .map(TextBlock::getText)
+                .collect(Collectors.joining());
+    }
+
     private static boolean anyOfType(List<MiddlewareBase> mws, Class<?> type) {
         for (MiddlewareBase mw : mws) {
             if (type.isInstance(mw)) {
@@ -238,7 +469,7 @@ class HarnessAgentDynamicHookBuilderTest {
         return model;
     }
 
-    private static final class EmptySkillRepository implements AgentSkillRepository {
+    private static class EmptySkillRepository implements AgentSkillRepository {
         @Override
         public AgentSkill getSkill(String name) {
             return null;
@@ -287,6 +518,25 @@ class HarnessAgentDynamicHookBuilderTest {
         @Override
         public boolean isWriteable() {
             return false;
+        }
+    }
+
+    private static final class CountingSkillRepository extends EmptySkillRepository {
+        private final List<AgentSkill> skills;
+        private final AtomicInteger reads = new AtomicInteger();
+
+        private CountingSkillRepository(List<AgentSkill> skills) {
+            this.skills = skills;
+        }
+
+        @Override
+        public List<AgentSkill> getAllSkills() {
+            reads.incrementAndGet();
+            return skills;
+        }
+
+        private int readCount() {
+            return reads.get();
         }
     }
 }

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/middleware/HarnessSkillMiddlewareContextIsolationTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/middleware/HarnessSkillMiddlewareContextIsolationTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.harness.agent.middleware;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.agentscope.core.agent.RuntimeContext;
+import io.agentscope.core.tool.Toolkit;
+import io.agentscope.harness.agent.filesystem.local.LocalFilesystem;
+import io.agentscope.harness.agent.filesystem.remote.store.NamespaceFactory;
+import io.agentscope.harness.agent.skill.WorkspaceSkillRepository;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class HarnessSkillMiddlewareContextIsolationTest {
+
+    @TempDir Path workspace;
+
+    @Test
+    void usesCallContextWhenSharedActiveContextPointsToAnotherSession() throws IOException {
+        RuntimeContext alice =
+                RuntimeContext.builder().sessionId("alice-session").put("tenant", "alice").build();
+        RuntimeContext bob =
+                RuntimeContext.builder().sessionId("bob-session").put("tenant", "bob").build();
+        NamespaceFactory namespaces =
+                ctx -> List.of("tenants", ctx != null ? (String) ctx.get("tenant") : "anonymous");
+        LocalFilesystem filesystem = new LocalFilesystem(workspace, false, 64, namespaces);
+        writeSkill("alice", "alice-skill", "Alice private description", "Alice private body");
+        writeSkill("bob", "bob-skill", "Bob private description", "Bob private body");
+
+        // Reproduces the concurrent interleaving where session B overwrites ReActAgent.activeRc
+        // immediately before session A builds its skill catalog.
+        AtomicReference<RuntimeContext> sharedActiveContext = new AtomicReference<>(bob);
+        WorkspaceSkillRepository repository =
+                new WorkspaceSkillRepository(
+                        filesystem, "skills", sharedActiveContext::get, "workspace", false);
+        HarnessSkillMiddleware middleware =
+                new HarnessSkillMiddleware(List.of(repository), new Toolkit());
+
+        String prompt = middleware.onSystemPrompt(null, alice, "").block();
+
+        assertTrue(prompt.contains("Alice private description"));
+        assertFalse(prompt.contains("Bob private description"));
+        assertTrue(
+                middleware.runtime().currentCatalog(alice).ids().stream()
+                        .anyMatch(id -> id.startsWith("alice-skill_")));
+        assertFalse(
+                middleware.runtime().currentCatalog(alice).ids().stream()
+                        .anyMatch(id -> id.startsWith("bob-skill_")));
+    }
+
+    private void writeSkill(String tenant, String name, String description, String body)
+            throws IOException {
+        Path directory =
+                workspace.resolve("tenants").resolve(tenant).resolve("skills").resolve(name);
+        Files.createDirectories(directory);
+        Files.writeString(
+                directory.resolve("SKILL.md"),
+                "---\nname: " + name + "\ndescription: " + description + "\n---\n# " + body + "\n");
+    }
+}

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/middleware/PlanModeMiddlewareTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/middleware/PlanModeMiddlewareTest.java
@@ -230,7 +230,7 @@ class PlanModeMiddlewareTest {
     void skillLoadToolIsReadOnlyAndPermittedInPlanMode(
             @TempDir Path project, @TempDir Path workspace) {
         // SkillLoadTool implements AgentTool (not ToolBase) — verify isReadOnly() is true.
-        SkillLoadTool loadTool = new SkillLoadTool(new AtomicReference<>(null));
+        SkillLoadTool loadTool = new SkillLoadTool();
         assertTrue(loadTool.isReadOnly(), "SkillLoadTool must be read-only");
 
         // Build a toolkit containing the SkillLoadTool and wire a resolver matching

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/middleware/ToolResultEvictionMiddlewareTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/middleware/ToolResultEvictionMiddlewareTest.java
@@ -1,0 +1,436 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.harness.agent.middleware;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.agentscope.core.agent.Agent;
+import io.agentscope.core.agent.AgentBase;
+import io.agentscope.core.agent.RuntimeContext;
+import io.agentscope.core.interruption.InterruptContext;
+import io.agentscope.core.message.ContentBlock;
+import io.agentscope.core.message.Msg;
+import io.agentscope.core.message.MsgRole;
+import io.agentscope.core.message.TextBlock;
+import io.agentscope.core.message.ToolResultBlock;
+import io.agentscope.core.message.ToolResultState;
+import io.agentscope.core.middleware.ReasoningInput;
+import io.agentscope.core.state.AgentState;
+import io.agentscope.harness.agent.filesystem.local.LocalFilesystem;
+import io.agentscope.harness.agent.filesystem.model.WriteResult;
+import io.agentscope.harness.agent.memory.compaction.ToolResultEvictionConfig;
+import io.agentscope.harness.agent.workspace.LocalFsMode;
+import io.agentscope.harness.agent.workspace.PathPolicy;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+class ToolResultEvictionMiddlewareTest {
+
+    private static final String FULL_OUTPUT = "0123456789".repeat(10);
+
+    @TempDir Path tempDir;
+
+    @Test
+    void evictsImmediateReasoningInputAndAgentStateUsingDefaultLocalPath() throws IOException {
+        ToolResultEvictionConfig config =
+                ToolResultEvictionConfig.builder().maxResultChars(20).previewChars(4).build();
+        assertEquals("large_tool_results", config.getEvictionPath());
+
+        LocalFilesystem filesystem =
+                new LocalFilesystem(tempDir, LocalFsMode.ROOTED, PathPolicy.empty(), 10, null);
+        ToolResultEvictionMiddleware middleware =
+                new ToolResultEvictionMiddleware(filesystem, config);
+
+        Msg stateToolMessage = toolMessage(toolResult(FULL_OUTPUT));
+        AgentState state = AgentState.builder().addMessage(stateToolMessage).build();
+        RuntimeContext ctx = RuntimeContext.builder().agentState(state).build();
+
+        Msg systemMessage = Msg.builder().role(MsgRole.SYSTEM).textContent("system prompt").build();
+        Msg hookMessage = Msg.builder().role(MsgRole.ASSISTANT).textContent("hook message").build();
+        Msg inputToolMessage = toolMessage(toolResult(FULL_OUTPUT));
+        ReasoningInput input =
+                new ReasoningInput(
+                        List.of(systemMessage, hookMessage, inputToolMessage), List.of(), null);
+        AtomicReference<ReasoningInput> forwarded = new AtomicReference<>();
+
+        middleware
+                .onReasoning(
+                        agent("Test Agent"),
+                        ctx,
+                        input,
+                        compacted -> {
+                            forwarded.set(compacted);
+                            return Flux.empty();
+                        })
+                .collectList()
+                .block();
+
+        ReasoningInput compacted = forwarded.get();
+        assertNotNull(compacted);
+        assertNotSame(input, compacted);
+        assertSame(systemMessage, compacted.messages().get(0));
+        assertSame(hookMessage, compacted.messages().get(1));
+
+        String modelToolOutput = toolOutput(compacted.messages().get(2));
+        assertTrue(modelToolOutput.contains("Tool output was too large"));
+        assertFalse(modelToolOutput.contains(FULL_OUTPUT));
+
+        assertEquals(1, state.getContext().size());
+        String stateToolOutput = toolOutput(state.getContext().get(0));
+        assertTrue(stateToolOutput.contains("Tool output was too large"));
+        assertFalse(stateToolOutput.contains(FULL_OUTPUT));
+
+        ToolResultBlock compactedBlock =
+                compacted.messages().get(2).getContentBlocks(ToolResultBlock.class).get(0);
+        assertEquals("test", compactedBlock.getMetadata().get("source"));
+        assertEquals(
+                true,
+                compactedBlock
+                        .getMetadata()
+                        .get(ToolResultEvictionMiddleware.EVICTED_METADATA_KEY));
+        assertEquals(ToolResultState.SUCCESS, compactedBlock.getState());
+
+        // The original copied input remains unchanged, proving the downstream call received a
+        // newly rebuilt ReasoningInput rather than relying on AgentState mutation.
+        assertEquals(FULL_OUTPUT, toolOutput(inputToolMessage));
+        Path storedFile;
+        try (var files = Files.list(tempDir.resolve("large_tool_results/Test_Agent"))) {
+            storedFile = files.findFirst().orElseThrow();
+        }
+        String relativePath = tempDir.relativize(storedFile).toString().replace('\\', '/');
+        assertTrue(storedFile.getFileName().toString().startsWith("call_1-"));
+        assertTrue(modelToolOutput.contains("`" + relativePath + "`"));
+        assertEquals(FULL_OUTPUT, Files.readString(storedFile));
+    }
+
+    @Test
+    void evictsCanonicalAgentStateWhenReasoningHookRemovedLargeResult() throws IOException {
+        LocalFilesystem filesystem =
+                new LocalFilesystem(tempDir, LocalFsMode.ROOTED, PathPolicy.empty(), 10, null);
+        ToolResultEvictionMiddleware middleware =
+                new ToolResultEvictionMiddleware(filesystem, testConfig());
+        AgentState state =
+                AgentState.builder().addMessage(toolMessage(toolResult(FULL_OUTPUT))).build();
+        RuntimeContext ctx = RuntimeContext.builder().agentState(state).build();
+        Msg hookMessage = Msg.builder().role(MsgRole.ASSISTANT).textContent("hook view").build();
+        ReasoningInput hookModifiedInput =
+                new ReasoningInput(List.of(hookMessage), List.of(), null);
+        AtomicReference<ReasoningInput> forwarded = new AtomicReference<>();
+
+        middleware
+                .onReasoning(
+                        agent("Test Agent"),
+                        ctx,
+                        hookModifiedInput,
+                        downstream -> {
+                            forwarded.set(downstream);
+                            return Flux.empty();
+                        })
+                .collectList()
+                .block();
+
+        assertSame(
+                hookModifiedInput,
+                forwarded.get(),
+                "Evicting canonical state must not reintroduce a result removed by the hook");
+        String persistedOutput = toolOutput(state.getContext().get(0));
+        assertTrue(persistedOutput.contains("Tool output was too large"));
+        assertFalse(persistedOutput.contains(FULL_OUTPUT));
+        try (var files = Files.list(tempDir.resolve("large_tool_results/Test_Agent"))) {
+            Path stored = files.findFirst().orElseThrow();
+            assertEquals(FULL_OUTPUT, Files.readString(stored));
+        }
+    }
+
+    @Test
+    void cachedEvictionPreservesHookRewrittenMetadataAndState() {
+        LocalFilesystem filesystem =
+                new LocalFilesystem(tempDir, LocalFsMode.ROOTED, PathPolicy.empty(), 10, null);
+        ToolResultEvictionMiddleware middleware =
+                new ToolResultEvictionMiddleware(filesystem, testConfig());
+        AgentState state =
+                AgentState.builder().addMessage(toolMessage(toolResult(FULL_OUTPUT))).build();
+        RuntimeContext ctx = RuntimeContext.builder().agentState(state).build();
+        ToolResultBlock hookRewrite =
+                new ToolResultBlock(
+                        "call:1",
+                        "large_output",
+                        List.of(TextBlock.builder().text(FULL_OUTPUT).build()),
+                        Map.of("source", "hook", "hook_annotation", "preserve-me"),
+                        ToolResultState.ERROR);
+        ReasoningInput hookModifiedInput =
+                new ReasoningInput(List.of(toolMessage(hookRewrite)), List.of(), null);
+        AtomicReference<ReasoningInput> forwarded = new AtomicReference<>();
+
+        middleware
+                .onReasoning(
+                        agent("Test Agent"),
+                        ctx,
+                        hookModifiedInput,
+                        downstream -> {
+                            forwarded.set(downstream);
+                            return Flux.empty();
+                        })
+                .collectList()
+                .block();
+
+        ToolResultBlock compacted =
+                forwarded.get().messages().get(0).getContentBlocks(ToolResultBlock.class).get(0);
+        assertEquals("hook", compacted.getMetadata().get("source"));
+        assertEquals("preserve-me", compacted.getMetadata().get("hook_annotation"));
+        assertEquals(
+                true,
+                compacted.getMetadata().get(ToolResultEvictionMiddleware.EVICTED_METADATA_KEY));
+        assertEquals(ToolResultState.ERROR, compacted.getState());
+    }
+
+    @Test
+    void realLargeOutputUsingPlaceholderPrefixIsStillEvicted() throws IOException {
+        String prefixedOutput = "Tool output was too large (but this is real): " + FULL_OUTPUT;
+        LocalFilesystem filesystem =
+                new LocalFilesystem(tempDir, LocalFsMode.ROOTED, PathPolicy.empty(), 10, null);
+        ToolResultEvictionMiddleware middleware =
+                new ToolResultEvictionMiddleware(filesystem, testConfig());
+        AgentState state =
+                AgentState.builder().addMessage(toolMessage(toolResult(prefixedOutput))).build();
+        RuntimeContext ctx = RuntimeContext.builder().agentState(state).build();
+        ReasoningInput input =
+                new ReasoningInput(
+                        List.of(toolMessage(toolResult(prefixedOutput))), List.of(), null);
+        AtomicReference<ReasoningInput> forwarded = new AtomicReference<>();
+
+        middleware
+                .onReasoning(
+                        agent("Test Agent"),
+                        ctx,
+                        input,
+                        downstream -> {
+                            forwarded.set(downstream);
+                            return Flux.empty();
+                        })
+                .collectList()
+                .block();
+
+        ToolResultBlock modelResult =
+                forwarded.get().messages().get(0).getContentBlocks(ToolResultBlock.class).get(0);
+        assertFalse(prefixedOutput.equals(toolOutput(forwarded.get().messages().get(0))));
+        assertEquals(
+                true,
+                modelResult.getMetadata().get(ToolResultEvictionMiddleware.EVICTED_METADATA_KEY));
+        assertFalse(prefixedOutput.equals(toolOutput(state.getContext().get(0))));
+        try (var files = Files.list(tempDir.resolve("large_tool_results/Test_Agent"))) {
+            Path stored = files.findFirst().orElseThrow();
+            assertEquals(prefixedOutput, Files.readString(stored));
+        }
+    }
+
+    @Test
+    void writeFailureLeavesReasoningInputAndAgentStateUntouched() {
+        RecordingFilesystem filesystem =
+                new RecordingFilesystem(tempDir, WriteResult.fail("write denied"));
+        ToolResultEvictionMiddleware middleware =
+                new ToolResultEvictionMiddleware(filesystem, testConfig());
+
+        Msg stateToolMessage = toolMessage(toolResult(FULL_OUTPUT));
+        AgentState state = AgentState.builder().addMessage(stateToolMessage).build();
+        RuntimeContext ctx = RuntimeContext.builder().agentState(state).build();
+        Msg inputToolMessage = toolMessage(toolResult(FULL_OUTPUT));
+        ReasoningInput input = new ReasoningInput(List.of(inputToolMessage), List.of(), null);
+        AtomicReference<ReasoningInput> forwarded = new AtomicReference<>();
+
+        middleware
+                .onReasoning(
+                        agent("Test Agent"),
+                        ctx,
+                        input,
+                        downstream -> {
+                            forwarded.set(downstream);
+                            return Flux.empty();
+                        })
+                .collectList()
+                .block();
+
+        assertSame(input, forwarded.get());
+        assertSame(stateToolMessage, state.getContext().get(0));
+        assertEquals(FULL_OUTPUT, toolOutput(forwarded.get().messages().get(0)));
+        assertEquals(FULL_OUTPUT, toolOutput(state.getContext().get(0)));
+        assertSame(ctx, filesystem.lastContext);
+        assertTrue(filesystem.lastPath.startsWith("large_tool_results/Test_Agent/call_1-"));
+        assertEquals(FULL_OUTPUT, filesystem.lastContent);
+    }
+
+    @Test
+    void preservesConfiguredAbsolutePathWhileTrimmingTrailingSlashes() {
+        RecordingFilesystem filesystem = new RecordingFilesystem(tempDir, WriteResult.ok("stored"));
+        ToolResultEvictionConfig config =
+                ToolResultEvictionConfig.builder()
+                        .maxResultChars(20)
+                        .previewChars(4)
+                        .evictionPath("/workspace/results///")
+                        .build();
+        ToolResultEvictionMiddleware middleware =
+                new ToolResultEvictionMiddleware(filesystem, config);
+        RuntimeContext ctx = RuntimeContext.empty();
+        ReasoningInput input =
+                new ReasoningInput(List.of(toolMessage(toolResult(FULL_OUTPUT))), List.of(), null);
+
+        middleware
+                .onReasoning(agent("Test Agent"), ctx, input, ignored -> Flux.empty())
+                .collectList()
+                .block();
+
+        assertSame(ctx, filesystem.lastContext);
+        assertTrue(filesystem.lastPath.startsWith("/workspace/results/Test_Agent/call_1-"));
+        assertEquals(FULL_OUTPUT, filesystem.lastContent);
+    }
+
+    @Test
+    void reusedToolCallIdUpdatesOnlyLatestOccurrenceAndKeepsBothFiles() throws IOException {
+        String oldOutput = FULL_OUTPUT + "-old";
+        String newOutput = FULL_OUTPUT + "-new";
+        LocalFilesystem filesystem =
+                new LocalFilesystem(tempDir, LocalFsMode.ROOTED, PathPolicy.empty(), 10, null);
+        ToolResultEvictionMiddleware middleware =
+                new ToolResultEvictionMiddleware(filesystem, testConfig());
+        AgentState state =
+                AgentState.builder().addMessage(toolMessage(toolResult(oldOutput))).build();
+        RuntimeContext ctx = RuntimeContext.builder().agentState(state).build();
+        Agent testAgent = agent("Test Agent");
+
+        middleware
+                .onReasoning(
+                        testAgent,
+                        ctx,
+                        new ReasoningInput(
+                                List.of(toolMessage(toolResult(oldOutput))), List.of(), null),
+                        ignored -> Flux.empty())
+                .collectList()
+                .block();
+        String oldPlaceholder = toolOutput(state.getContext().get(0));
+
+        state.contextMutable().add(toolMessage(toolResult(newOutput)));
+        middleware
+                .onReasoning(
+                        testAgent,
+                        ctx,
+                        new ReasoningInput(
+                                List.of(toolMessage(toolResult(newOutput))), List.of(), null),
+                        ignored -> Flux.empty())
+                .collectList()
+                .block();
+
+        assertEquals(
+                oldPlaceholder,
+                toolOutput(state.getContext().get(0)),
+                "A reused id must not rewrite the earlier logical result");
+        assertTrue(toolOutput(state.getContext().get(1)).contains("Tool output was too large"));
+
+        List<Path> storedFiles;
+        try (var files = Files.list(tempDir.resolve("large_tool_results/Test_Agent"))) {
+            storedFiles = files.toList();
+        }
+        assertEquals(2, storedFiles.size(), "Different contents must receive different paths");
+        List<String> storedContents =
+                storedFiles.stream()
+                        .map(
+                                path -> {
+                                    try {
+                                        return Files.readString(path);
+                                    } catch (IOException e) {
+                                        throw new IllegalStateException(e);
+                                    }
+                                })
+                        .toList();
+        assertTrue(storedContents.contains(oldOutput));
+        assertTrue(storedContents.contains(newOutput));
+    }
+
+    private static ToolResultEvictionConfig testConfig() {
+        return ToolResultEvictionConfig.builder().maxResultChars(20).previewChars(4).build();
+    }
+
+    private static ToolResultBlock toolResult(String output) {
+        return new ToolResultBlock(
+                "call:1",
+                "large_output",
+                List.of(TextBlock.builder().text(output).build()),
+                Map.of("source", "test"),
+                ToolResultState.SUCCESS);
+    }
+
+    private static Msg toolMessage(ToolResultBlock result) {
+        return Msg.builder().role(MsgRole.TOOL).content(result).build();
+    }
+
+    private static String toolOutput(Msg message) {
+        ToolResultBlock result = message.getContentBlocks(ToolResultBlock.class).get(0);
+        StringBuilder output = new StringBuilder();
+        for (ContentBlock block : result.getOutput()) {
+            if (block instanceof TextBlock text && text.getText() != null) {
+                output.append(text.getText());
+            }
+        }
+        return output.toString();
+    }
+
+    private static Agent agent(String name) {
+        return new AgentBase(name) {
+            @Override
+            protected Mono<Msg> doCall(List<Msg> msgs) {
+                return Mono.empty();
+            }
+
+            @Override
+            protected Mono<Msg> handleInterrupt(InterruptContext context, Msg... originalArgs) {
+                return Mono.empty();
+            }
+        };
+    }
+
+    private static final class RecordingFilesystem extends LocalFilesystem {
+
+        private final WriteResult result;
+        private RuntimeContext lastContext;
+        private String lastPath;
+        private String lastContent;
+
+        private RecordingFilesystem(Path root, WriteResult result) {
+            super(root);
+            this.result = result;
+        }
+
+        @Override
+        public WriteResult write(RuntimeContext context, String path, String content) {
+            lastContext = context;
+            lastPath = path;
+            lastContent = content;
+            return result;
+        }
+    }
+}

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/skill/runtime/SkillLoadToolFrontmatterViewTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/skill/runtime/SkillLoadToolFrontmatterViewTest.java
@@ -18,6 +18,7 @@ package io.agentscope.harness.agent.skill.runtime;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import io.agentscope.core.agent.RuntimeContext;
 import io.agentscope.core.message.TextBlock;
 import io.agentscope.core.message.ToolResultBlock;
 import io.agentscope.core.message.ToolUseBlock;
@@ -26,7 +27,6 @@ import io.agentscope.core.tool.ToolCallParam;
 import java.time.Duration;
 import java.util.LinkedHashMap;
 import java.util.Map;
-import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -52,9 +52,11 @@ class SkillLoadToolFrontmatterViewTest {
 
         SkillCatalog catalog =
                 SkillCatalog.of(java.util.List.of(HarnessSkillEntry.of(skill, null)));
-        SkillLoadTool tool = new SkillLoadTool(new AtomicReference<>(catalog));
+        SkillLoadTool tool = new SkillLoadTool();
+        RuntimeContext ctx = RuntimeContext.empty();
+        ctx.put(SkillCatalog.class, catalog);
 
-        String text = runTool(tool, Map.of("skillId", skill.getSkillId(), "path", "SKILL.md"));
+        String text = runTool(tool, ctx, Map.of("skillId", skill.getSkillId(), "path", "SKILL.md"));
 
         assertTrue(
                 text.contains("name: alpha"),
@@ -84,10 +86,12 @@ class SkillLoadToolFrontmatterViewTest {
                         "custom");
         SkillCatalog catalog =
                 SkillCatalog.of(java.util.List.of(HarnessSkillEntry.of(skill, null)));
-        SkillLoadTool tool = new SkillLoadTool(new AtomicReference<>(catalog));
+        SkillLoadTool tool = new SkillLoadTool();
+        RuntimeContext ctx = RuntimeContext.empty();
+        ctx.put(SkillCatalog.class, catalog);
 
         String text =
-                runTool(tool, Map.of("skillId", skill.getSkillId(), "path", "scripts/run.sh"));
+                runTool(tool, ctx, Map.of("skillId", skill.getSkillId(), "path", "scripts/run.sh"));
 
         assertTrue(text.contains("scripts/run.sh"), "resource path should appear in header");
         assertTrue(text.contains("echo hi"), "resource body should be present");
@@ -96,14 +100,20 @@ class SkillLoadToolFrontmatterViewTest {
         assertEquals(2, fenceCount, "expected exactly one open + one close fence, got " + text);
     }
 
-    private static String runTool(SkillLoadTool tool, Map<String, Object> input) {
+    private static String runTool(
+            SkillLoadTool tool, RuntimeContext ctx, Map<String, Object> input) {
         ToolUseBlock useBlock =
                 ToolUseBlock.builder()
                         .id("view-test")
                         .name(SkillLoadTool.TOOL_NAME)
                         .input(input)
                         .build();
-        ToolCallParam param = ToolCallParam.builder().toolUseBlock(useBlock).input(input).build();
+        ToolCallParam param =
+                ToolCallParam.builder()
+                        .toolUseBlock(useBlock)
+                        .input(input)
+                        .runtimeContext(ctx)
+                        .build();
         ToolResultBlock result = tool.callAsync(param).block(TIMEOUT);
         if (result == null || result.getOutput() == null) {
             return "";

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/skill/runtime/SkillRuntimeTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/skill/runtime/SkillRuntimeTest.java
@@ -22,6 +22,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import io.agentscope.core.agent.RuntimeContext;
 import io.agentscope.core.message.ContentBlock;
 import io.agentscope.core.message.TextBlock;
 import io.agentscope.core.message.ToolResultBlock;
@@ -36,6 +37,11 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
@@ -234,12 +240,13 @@ class SkillRuntimeTest {
         @Test
         void returnsSkillMarkdownForSkillMdPath() {
             SkillRuntime r = new SkillRuntime();
+            RuntimeContext ctx = RuntimeContext.builder().sessionId("alpha").build();
             HarnessSkillEntry e =
                     HarnessSkillEntry.of(
                             skillWith("alpha", "Alpha description.", "# Body line\n", null), null);
-            r.install(SkillCatalog.of(List.of(e)), null);
+            r.install(SkillCatalog.of(List.of(e)), ctx, null);
 
-            ToolResultBlock res = invoke(r, "alpha_workspace", "SKILL.md");
+            ToolResultBlock res = invoke(r, ctx, "alpha_workspace", "SKILL.md");
             String text = textOf(res);
             assertTrue(text.contains("Successfully loaded skill: alpha_workspace"));
             assertTrue(text.contains("# Body line"));
@@ -248,14 +255,15 @@ class SkillRuntimeTest {
         @Test
         void inMemoryResourceHitsBeforeLazyFallback() {
             SkillRuntime r = new SkillRuntime();
+            RuntimeContext ctx = RuntimeContext.builder().sessionId("alpha").build();
             Map<String, String> mem = new HashMap<>();
             mem.put("scripts/run.py", "in-memory-body");
             SkillResources lazy = recording(Map.of("scripts/run.py", "lazy-body"));
             HarnessSkillEntry e =
                     HarnessSkillEntry.of(skillWith("alpha", "Alpha desc.", "# body", mem), lazy);
-            r.install(SkillCatalog.of(List.of(e)), null);
+            r.install(SkillCatalog.of(List.of(e)), ctx, null);
 
-            String text = textOf(invoke(r, "alpha_workspace", "scripts/run.py"));
+            String text = textOf(invoke(r, ctx, "alpha_workspace", "scripts/run.py"));
             assertTrue(text.contains("in-memory-body"));
             assertFalse(text.contains("lazy-body"));
         }
@@ -263,25 +271,27 @@ class SkillRuntimeTest {
         @Test
         void lazyFallbackUsedWhenInMemoryMisses() {
             SkillRuntime r = new SkillRuntime();
+            RuntimeContext ctx = RuntimeContext.builder().sessionId("alpha").build();
             SkillResources lazy = recording(Map.of("references/guide.md", "from-fs"));
             HarnessSkillEntry e =
                     HarnessSkillEntry.of(skillWith("alpha", "Alpha desc.", "# body", null), lazy);
-            r.install(SkillCatalog.of(List.of(e)), null);
+            r.install(SkillCatalog.of(List.of(e)), ctx, null);
 
-            String text = textOf(invoke(r, "alpha_workspace", "references/guide.md"));
+            String text = textOf(invoke(r, ctx, "alpha_workspace", "references/guide.md"));
             assertTrue(text.contains("from-fs"));
         }
 
         @Test
         void notFoundEnumeratesBothSources() {
             SkillRuntime r = new SkillRuntime();
+            RuntimeContext ctx = RuntimeContext.builder().sessionId("alpha").build();
             Map<String, String> mem = Map.of("references/a.md", "x");
             SkillResources lazy = recording(Map.of("scripts/b.py", "y"));
             HarnessSkillEntry e =
                     HarnessSkillEntry.of(skillWith("alpha", "Alpha desc.", "# body", mem), lazy);
-            r.install(SkillCatalog.of(List.of(e)), null);
+            r.install(SkillCatalog.of(List.of(e)), ctx, null);
 
-            String err = errorOf(invoke(r, "alpha_workspace", "does-not-exist"));
+            String err = errorOf(invoke(r, ctx, "alpha_workspace", "does-not-exist"));
             assertTrue(err.contains("Resource not found"));
             assertTrue(err.contains("SKILL.md"));
             assertTrue(err.contains("references/a.md"));
@@ -291,26 +301,36 @@ class SkillRuntimeTest {
         @Test
         void unknownSkillIdReturnsError() {
             SkillRuntime r = new SkillRuntime();
-            r.install(SkillCatalog.empty(), null);
-            String err = errorOf(invoke(r, "ghost_x", "SKILL.md"));
+            RuntimeContext ctx = RuntimeContext.builder().sessionId("empty").build();
+            r.install(SkillCatalog.empty(), ctx, null);
+            String err = errorOf(invoke(r, ctx, "ghost_x", "SKILL.md"));
             assertTrue(err.contains("Skill not found"));
         }
 
         @Test
         void missingParametersReturnsError() {
             SkillRuntime r = new SkillRuntime();
-            r.install(SkillCatalog.empty(), null);
+            RuntimeContext ctx = RuntimeContext.builder().sessionId("empty").build();
+            r.install(SkillCatalog.empty(), ctx, null);
             String err1 =
                     errorOf(
                             r.loadTool()
-                                    .callAsync(ToolCallParam.builder().input(Map.of()).build())
+                                    .callAsync(
+                                            ToolCallParam.builder()
+                                                    .runtimeContext(ctx)
+                                                    .input(Map.of())
+                                                    .build())
                                     .block());
             assertTrue(err1.contains("skillId"));
         }
 
-        private ToolResultBlock invoke(SkillRuntime r, String skillId, String path) {
+        private ToolResultBlock invoke(
+                SkillRuntime r, RuntimeContext ctx, String skillId, String path) {
             ToolCallParam p =
-                    ToolCallParam.builder().input(Map.of("skillId", skillId, "path", path)).build();
+                    ToolCallParam.builder()
+                            .runtimeContext(ctx)
+                            .input(Map.of("skillId", skillId, "path", path))
+                            .build();
             return r.loadTool().callAsync(p).block();
         }
     }
@@ -323,30 +343,147 @@ class SkillRuntimeTest {
     class RuntimeLifecycle {
 
         @Test
-        void firstInstallRegistersToolThenIdempotent() {
+        void firstInstallRegistersUngroupedToolVisibleToPersistedEmptyGroupState() {
             Toolkit tk = new Toolkit();
             SkillRuntime r = new SkillRuntime();
+            RuntimeContext ctx = RuntimeContext.builder().sessionId("lifecycle").build();
             assertNull(tk.getTool(SkillLoadTool.TOOL_NAME));
-            r.install(SkillCatalog.empty(), tk);
+            r.install(SkillCatalog.empty(), ctx, tk);
             assertNotNull(tk.getTool(SkillLoadTool.TOOL_NAME));
+            assertTrue(tk.getActiveGroups().isEmpty());
+            assertTrue(
+                    tk.getToolSchemas(List.of()).stream()
+                            .anyMatch(schema -> SkillLoadTool.TOOL_NAME.equals(schema.getName())));
             // Second install must not throw or replace with a new instance.
-            r.install(SkillCatalog.empty(), tk);
+            r.install(SkillCatalog.empty(), ctx, tk);
             assertSame(r.loadTool(), tk.getTool(SkillLoadTool.TOOL_NAME));
         }
 
         @Test
-        void catalogSwapVisibleViaToolWithoutReRegistering() {
+        void catalogsRemainIsolatedByRuntimeContextWithoutReRegistering() {
             Toolkit tk = new Toolkit();
             SkillRuntime r = new SkillRuntime();
+            RuntimeContext firstCtx = RuntimeContext.builder().sessionId("first").build();
+            RuntimeContext secondCtx = RuntimeContext.builder().sessionId("second").build();
             HarnessSkillEntry first = HarnessSkillEntry.of(skill("first", "src"), null);
-            r.install(SkillCatalog.of(List.of(first)), tk);
-            assertEquals(List.of("first_src"), r.currentCatalog().ids());
+            r.install(SkillCatalog.of(List.of(first)), firstCtx, tk);
 
             HarnessSkillEntry second = HarnessSkillEntry.of(skill("second", "src"), null);
-            r.install(SkillCatalog.of(List.of(second)), tk);
-            assertEquals(List.of("second_src"), r.currentCatalog().ids());
-            // Same instance still registered.
+            r.install(SkillCatalog.of(List.of(second)), secondCtx, tk);
+
+            assertEquals(List.of("first_src"), r.currentCatalog(firstCtx).ids());
+            assertEquals(List.of("second_src"), r.currentCatalog(secondCtx).ids());
+            assertTrue(
+                    textOf(invoke(r, firstCtx, "first_src", "SKILL.md"))
+                            .contains("Successfully loaded skill"));
+            assertTrue(
+                    errorOf(invoke(r, firstCtx, "second_src", "SKILL.md")).contains("not found"));
+            assertTrue(
+                    textOf(invoke(r, secondCtx, "second_src", "SKILL.md"))
+                            .contains("Successfully loaded skill"));
+            assertTrue(
+                    errorOf(invoke(r, secondCtx, "first_src", "SKILL.md")).contains("not found"));
+
+            // Both contexts use the same stateless registered tool instance.
             assertSame(r.loadTool(), tk.getTool(SkillLoadTool.TOOL_NAME));
+        }
+
+        @Test
+        void concurrentSessionsCannotLoadEachOthersSkills() throws Exception {
+            SkillRuntime r = new SkillRuntime();
+            RuntimeContext firstCtx = RuntimeContext.builder().sessionId("first").build();
+            RuntimeContext secondCtx = RuntimeContext.builder().sessionId("second").build();
+            r.install(
+                    SkillCatalog.of(List.of(HarnessSkillEntry.of(skill("first", "src"), null))),
+                    firstCtx,
+                    null);
+            r.install(
+                    SkillCatalog.of(List.of(HarnessSkillEntry.of(skill("second", "src"), null))),
+                    secondCtx,
+                    null);
+
+            ExecutorService executor = Executors.newFixedThreadPool(2);
+            try {
+                Future<Boolean> first =
+                        executor.submit(
+                                () ->
+                                        textOf(invoke(r, firstCtx, "first_src", "SKILL.md"))
+                                                        .contains("Successfully loaded skill")
+                                                && errorOf(
+                                                                invoke(
+                                                                        r,
+                                                                        firstCtx,
+                                                                        "second_src",
+                                                                        "SKILL.md"))
+                                                        .contains("not found"));
+                Future<Boolean> second =
+                        executor.submit(
+                                () ->
+                                        textOf(invoke(r, secondCtx, "second_src", "SKILL.md"))
+                                                        .contains("Successfully loaded skill")
+                                                && errorOf(
+                                                                invoke(
+                                                                        r,
+                                                                        secondCtx,
+                                                                        "first_src",
+                                                                        "SKILL.md"))
+                                                        .contains("not found"));
+
+                assertTrue(first.get(5, TimeUnit.SECONDS));
+                assertTrue(second.get(5, TimeUnit.SECONDS));
+            } finally {
+                executor.shutdownNow();
+            }
+        }
+
+        @Test
+        void deprecatedRuntimeApiRemainsFunctionalWithoutLeakingIntoScopedCalls() {
+            SkillRuntime r = new SkillRuntime();
+            Toolkit tk = new Toolkit();
+            HarnessSkillEntry legacy = HarnessSkillEntry.of(skill("legacy", "src"), null);
+
+            r.install(SkillCatalog.of(List.of(legacy)), tk);
+
+            assertEquals(List.of("legacy_src"), r.currentCatalog().ids());
+            assertTrue(
+                    textOf(invoke(r, null, "legacy_src", "SKILL.md"))
+                            .contains("Successfully loaded skill"));
+            assertTrue(
+                    errorOf(invoke(r, RuntimeContext.empty(), "legacy_src", "SKILL.md"))
+                            .contains("not found"));
+        }
+
+        @Test
+        void deprecatedLoadToolConstructorRemainsContextFreeOnly() {
+            HarnessSkillEntry legacy = HarnessSkillEntry.of(skill("legacy", "src"), null);
+            AtomicReference<SkillCatalog> ref =
+                    new AtomicReference<>(SkillCatalog.of(List.of(legacy)));
+            SkillLoadTool tool = new SkillLoadTool(ref);
+            Map<String, Object> input = Map.of("skillId", "legacy_src", "path", "SKILL.md");
+
+            ToolResultBlock contextFree =
+                    tool.callAsync(ToolCallParam.builder().input(input).build()).block();
+            ToolResultBlock contextScoped =
+                    tool.callAsync(
+                                    ToolCallParam.builder()
+                                            .runtimeContext(RuntimeContext.empty())
+                                            .input(input)
+                                            .build())
+                            .block();
+
+            assertTrue(textOf(contextFree).contains("Successfully loaded skill"));
+            assertTrue(errorOf(contextScoped).contains("not found"));
+        }
+
+        private ToolResultBlock invoke(
+                SkillRuntime r, RuntimeContext ctx, String skillId, String path) {
+            return r.loadTool()
+                    .callAsync(
+                            ToolCallParam.builder()
+                                    .runtimeContext(ctx)
+                                    .input(Map.of("skillId", skillId, "path", path))
+                                    .build())
+                    .block();
         }
     }
 

--- a/docs/v1/en/docs/harness/memory.md
+++ b/docs/v1/en/docs/harness/memory.md
@@ -113,7 +113,7 @@ Independent from compaction. When a `tool_call` return text exceeds the threshol
 |-----------|---------|-------------|
 | `maxResultChars` | `80_000` | Evict if exceeded |
 | `previewChars` | `2_000` | Number of head and tail preview characters |
-| `evictionPath` | `/large_tool_results` | Root path for evicted files |
+| `evictionPath` | `large_tool_results` | Workspace-relative root path for evicted files |
 | `excludedToolNames` | Built-in set (includes `read_file` etc.) | Tools excluded from eviction |
 
 ```java

--- a/docs/v1/zh/docs/harness/memory.md
+++ b/docs/v1/zh/docs/harness/memory.md
@@ -113,7 +113,7 @@ CompactionConfig.builder()
 |------|------|------|
 | `maxResultChars` | `80_000` | 超过则卸载 |
 | `previewChars` | `2_000` | 首尾预览字符数 |
-| `evictionPath` | `/large_tool_results` | 卸载文件根路径 |
+| `evictionPath` | `large_tool_results` | 相对于工作区的卸载文件根路径 |
 | `excludedToolNames` | 内置集（含 `read_file` 等） | 不参与卸载的工具 |
 
 ```java


### PR DESCRIPTION
## AgentScope-Java Version

2.0.1-SNAPSHOT

## Description

### Background

This PR fixes several correctness, compatibility, and session-isolation issues in the Harness skill runtime and tool-result eviction flow.

Previously:

- Fresh sessions could lose tool groups that were active when the agent was built.
- Explicitly persisted empty tool-group state could be mistaken for missing state.
- Static skill mode bypassed skill and visibility filters and lost access to lazily loaded skill resources.
- Concurrent sessions shared a mutable `SkillCatalog`, allowing one session to overwrite or observe another session's filtered skill view.
- `WorkspaceSkillRepository` could resolve skills using another concurrent session's active runtime context.
- Persisted sessions with an empty active-group list could not see `load_skill_through_path` after upgrading.
- Tool-result eviction modified canonical agent state but could leave the copied reasoning input unchanged.
- Reused tool-call IDs could overwrite previously evicted results.
- Cached eviction replacements could overwrite metadata or state rewritten by pre-reasoning hooks.
- Real tool output beginning with the eviction placeholder text could bypass eviction.

### Changes

#### Session and toolkit state

- Capture the toolkit's initially active groups after agent construction.
- Apply those groups only when creating a genuinely new session.
- Preserve explicitly persisted empty active-group state.
- Distinguish a missing legacy `toolkit_activeGroups` key from a present but empty value.
- Preserve the complete `RuntimeContext` when merging toolkit-level execution context.

#### Skill runtime

- Use `HarnessSkillMiddleware` for both live and frozen repository modes.
- Freeze repository enumeration when dynamic skills are disabled while retaining per-request filtering.
- Apply `SkillFilter` and `SkillVisibilityFilter` before staging, prompt rendering, and catalog installation.
- Preserve the source repository association needed for lazy resource loading.
- Add `RuntimeContextSkillRepository` for repositories whose contents depend on the current request.
- Make `WorkspaceSkillRepository` enumerate skills using the supplied request context.
- Store `SkillCatalog` in the request-scoped `RuntimeContext` instead of a shared mutable reference.
- Resolve `load_skill_through_path` authorization from the tool call's runtime context.
- Register the skill loader as an ungrouped tool during agent construction so persisted sessions can continue to access it.
- Retain the previous public constructors and methods as deprecated compatibility overloads.

#### Tool-result eviction

- Evict oversized results from both canonical `AgentState` and the hook-modified `ReasoningInput`.
- Preserve hook deletions, rewrites, metadata, result state, message metadata, timestamps, and usage.
- Use content-addressed paths so reused tool-call IDs do not overwrite historical results.
- Include result text in the in-call eviction fingerprint.
- Cache only the generated placeholder instead of an entire `ToolResultBlock`.
- Mark evicted results with dedicated metadata instead of recognizing them by text prefix.
- Change the default eviction directory to the workspace-relative `large_tool_results` path.
- Update the English and Chinese memory documentation accordingly.

### Compatibility

The following previously published APIs remain available as deprecated compatibility paths:

- `SkillRuntime.currentCatalog()`
- `SkillRuntime.install(SkillCatalog, Toolkit)`
- `SkillLoadTool(AtomicReference<SkillCatalog>)`

Context-bearing tool calls never fall back to the legacy shared catalog, preserving session isolation.

### How to test

The focused core and Harness regression suite can be run with:

```bash
mvn -pl agentscope-harness -am \
  -Dtest=ReActAgentPerSessionStateTest,ToolExecutionContextIntegrationTest,ToolResultEvictionMiddlewareTest,HarnessSkillMiddlewareContextIsolationTest,WorkspaceSkillRepositoryTest,SkillRuntimeTest,SkillLoadToolFrontmatterViewTest,HarnessAgentDynamicHookBuilderTest \
  -Dsurefire.failIfNoSpecifiedTests=false \
  test