### PR TITLE
fix(harness): use stable agent id for session paths

### DIFF
--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/HarnessAgent.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/HarnessAgent.java
@@ -154,6 +154,7 @@ public class HarnessAgent implements Agent, AutoCloseable {
     private static final Logger log = LoggerFactory.getLogger(HarnessAgent.class);
 
     private final ReActAgent delegate;
+    private final String namespaceAgentId;
     private final WorkspaceManager workspaceManager;
     private final BiFunction<String, String, WorkspaceManager> workspaceFactory;
     private final WorkspaceIndex ownedWorkspaceIndex;
@@ -186,6 +187,7 @@ public class HarnessAgent implements Agent, AutoCloseable {
 
     private HarnessAgent(
             ReActAgent delegate,
+            String namespaceAgentId,
             WorkspaceManager workspaceManager,
             BiFunction<String, String, WorkspaceManager> workspaceFactory,
             WorkspaceIndex ownedWorkspaceIndex,
@@ -203,6 +205,7 @@ public class HarnessAgent implements Agent, AutoCloseable {
             DistributedStore distributedStore,
             WorkspacePathNormalizer pathNormalizer) {
         this.delegate = delegate;
+        this.namespaceAgentId = namespaceAgentId;
         this.workspaceManager = workspaceManager;
         this.workspaceFactory = workspaceFactory;
         this.ownedWorkspaceIndex = ownedWorkspaceIndex;
@@ -911,7 +914,6 @@ public class HarnessAgent implements Agent, AutoCloseable {
             return Mono.error(
                     new RuntimeException("Context overflow: context is empty, cannot compact"));
         }
-        String agentId = getName();
         String sessionId =
                 effective != null && effective.getSessionId() != null
                         ? effective.getSessionId()
@@ -931,7 +933,7 @@ public class HarnessAgent implements Agent, AutoCloseable {
                         effective != null ? effective : RuntimeContext.empty(),
                         allMsgs,
                         forceConfig,
-                        agentId,
+                        namespaceAgentId,
                         sessionId)
                 .flatMap(
                         opt -> {
@@ -2143,7 +2145,8 @@ public class HarnessAgent implements Agent, AutoCloseable {
                                 memoryModel,
                                 effectiveFlushPrompt,
                                 memoryConfig.flushTrigger(),
-                                effectiveIsolationScope));
+                                effectiveIsolationScope,
+                                resolvedAgentId));
 
                 String effectiveConsolidationPrompt =
                         memoryConfig.consolidationPrompt() != null
@@ -2170,7 +2173,8 @@ public class HarnessAgent implements Agent, AutoCloseable {
                         compactionConfig.getModel() != null ? compactionConfig.getModel() : model;
                 if (compactionModel != null) {
                     compactionHook =
-                            new CompactionMiddleware(wsManager, compactionModel, compactionConfig);
+                            new CompactionMiddleware(
+                                    wsManager, compactionModel, compactionConfig, resolvedAgentId);
                     inner.middleware(compactionHook);
                 }
             }
@@ -2478,6 +2482,7 @@ public class HarnessAgent implements Agent, AutoCloseable {
 
             return new HarnessAgent(
                     delegate,
+                    resolvedAgentId,
                     wsManager,
                     workspaceFactoryFn,
                     workspaceIndex,

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/middleware/CompactionMiddleware.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/middleware/CompactionMiddleware.java
@@ -61,12 +61,30 @@ public class CompactionMiddleware implements HarnessRuntimeMiddleware {
     private final WorkspaceManager workspaceManager;
     private final Model model;
     private final CompactionConfig config;
+    private final String agentId;
 
     public CompactionMiddleware(
             WorkspaceManager workspaceManager, Model model, CompactionConfig config) {
+        this(workspaceManager, model, config, null);
+    }
+
+    /**
+     * Creates a compaction middleware with a stable agent namespace for session archives.
+     *
+     * @param workspaceManager workspace manager used for session archive IO
+     * @param model model used to summarize compacted messages
+     * @param config compaction trigger and retention configuration
+     * @param agentId stable agent namespace; falls back to the runtime agent name when blank
+     */
+    public CompactionMiddleware(
+            WorkspaceManager workspaceManager,
+            Model model,
+            CompactionConfig config,
+            String agentId) {
         this.workspaceManager = workspaceManager;
         this.model = model;
         this.config = config;
+        this.agentId = agentId != null && !agentId.isBlank() ? agentId : null;
     }
 
     @Override
@@ -94,7 +112,7 @@ public class CompactionMiddleware implements HarnessRuntimeMiddleware {
                         conversation = messages != null ? new ArrayList<>(messages) : List.of();
                     }
 
-                    String agentId = agent.getName();
+                    String effectiveAgentId = agentId != null ? agentId : agent.getName();
                     String sessionId =
                             rc != null && rc.getSessionId() != null ? rc.getSessionId() : "default";
 
@@ -107,7 +125,8 @@ public class CompactionMiddleware implements HarnessRuntimeMiddleware {
                     final Msg sys = systemMsg;
 
                     return compactor
-                            .compactIfNeeded(rc, conversation, effectiveConfig, agentId, sessionId)
+                            .compactIfNeeded(
+                                    rc, conversation, effectiveConfig, effectiveAgentId, sessionId)
                             .flatMapMany(
                                     optResult -> {
                                         if (optResult.isEmpty()) {

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/middleware/MemoryFlushMiddleware.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/middleware/MemoryFlushMiddleware.java
@@ -76,6 +76,7 @@ public class MemoryFlushMiddleware implements HarnessRuntimeMiddleware {
     private final String flushPrompt;
     private final MemoryConfig.FlushTrigger flushTrigger;
     private final IsolationScope isolationScope;
+    private final String agentId;
 
     /**
      * Process-wide per-isolation-key flush timestamps. Static so that the throttle window
@@ -109,7 +110,8 @@ public class MemoryFlushMiddleware implements HarnessRuntimeMiddleware {
                 model,
                 MemoryFlushManager.DEFAULT_FLUSH_PROMPT,
                 MemoryConfig.FlushTrigger.always(),
-                IsolationScope.USER);
+                IsolationScope.USER,
+                null);
     }
 
     public MemoryFlushMiddleware(
@@ -117,7 +119,7 @@ public class MemoryFlushMiddleware implements HarnessRuntimeMiddleware {
             Model model,
             String flushPrompt,
             MemoryConfig.FlushTrigger flushTrigger) {
-        this(workspaceManager, model, flushPrompt, flushTrigger, IsolationScope.USER);
+        this(workspaceManager, model, flushPrompt, flushTrigger, IsolationScope.USER, null);
     }
 
     public MemoryFlushMiddleware(
@@ -126,6 +128,26 @@ public class MemoryFlushMiddleware implements HarnessRuntimeMiddleware {
             String flushPrompt,
             MemoryConfig.FlushTrigger flushTrigger,
             IsolationScope isolationScope) {
+        this(workspaceManager, model, flushPrompt, flushTrigger, isolationScope, null);
+    }
+
+    /**
+     * Creates a memory flush middleware with a stable agent namespace for session paths.
+     *
+     * @param workspaceManager workspace manager used for memory and session IO
+     * @param model model used to extract long-term memories
+     * @param flushPrompt prompt used for memory extraction
+     * @param flushTrigger policy controlling memory extraction frequency
+     * @param isolationScope identity dimension used for flush throttling
+     * @param agentId stable agent namespace; falls back to the runtime agent name when blank
+     */
+    public MemoryFlushMiddleware(
+            WorkspaceManager workspaceManager,
+            Model model,
+            String flushPrompt,
+            MemoryConfig.FlushTrigger flushTrigger,
+            IsolationScope isolationScope,
+            String agentId) {
         this.workspaceManager = workspaceManager;
         this.model = model;
         this.flushPrompt =
@@ -133,6 +155,7 @@ public class MemoryFlushMiddleware implements HarnessRuntimeMiddleware {
         this.flushTrigger =
                 flushTrigger != null ? flushTrigger : MemoryConfig.FlushTrigger.always();
         this.isolationScope = isolationScope != null ? isolationScope : IsolationScope.USER;
+        this.agentId = agentId != null && !agentId.isBlank() ? agentId : null;
     }
 
     @Override
@@ -184,14 +207,14 @@ public class MemoryFlushMiddleware implements HarnessRuntimeMiddleware {
             flushMono = Mono.empty();
         }
 
-        String agentId = agent.getName();
+        String effectiveAgentId = agentId != null ? agentId : agent.getName();
         String sessionId = rc != null && rc.getSessionId() != null ? rc.getSessionId() : "default";
 
         Mono<Void> offloadMono =
                 Mono.fromRunnable(
                                 () ->
                                         flushManager.offloadMessages(
-                                                rc, messages, agentId, sessionId))
+                                                rc, messages, effectiveAgentId, sessionId))
                         .then()
                         .doOnSuccess(v -> log.debug("Message offload completed"))
                         .onErrorResume(

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/HarnessAgentSessionPathTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/HarnessAgentSessionPathTest.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.harness.agent;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.agentscope.core.agent.RuntimeContext;
+import io.agentscope.core.message.Msg;
+import io.agentscope.core.message.MsgRole;
+import io.agentscope.core.message.TextBlock;
+import io.agentscope.core.model.ChatResponse;
+import io.agentscope.core.model.Model;
+import io.agentscope.core.state.InMemoryAgentStateStore;
+import io.agentscope.harness.agent.filesystem.local.LocalFilesystem;
+import io.agentscope.harness.agent.memory.MemoryConfig;
+import io.agentscope.harness.agent.memory.compaction.CompactionConfig;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import reactor.core.publisher.Flux;
+
+class HarnessAgentSessionPathTest {
+
+    private static final String AGENT_NAME = "display-name";
+    private static final String AGENT_ID = "stable-agent-id";
+    private static final String SESSION_ID = "session-1";
+
+    @TempDir Path workspace;
+
+    @Test
+    void memoryOffloadUsesConfiguredAgentIdInsteadOfAgentName() {
+        try (HarnessAgent agent =
+                baseBuilder(successfulModel("ok"))
+                        .memory(
+                                MemoryConfig.builder()
+                                        .flushTrigger(MemoryConfig.FlushTrigger.never())
+                                        .build())
+                        .build()) {
+            assertNotNull(
+                    agent.call(message("m1", MsgRole.USER, "hello"), runtimeContext()).block());
+        }
+
+        assertUsesConfiguredAgentId();
+    }
+
+    @Test
+    void compactionUsesConfiguredAgentIdInsteadOfAgentName() {
+        CompactionConfig config =
+                CompactionConfig.builder()
+                        .triggerMessages(3)
+                        .keepMessages(1)
+                        .keepTokens(0)
+                        .flushBeforeCompact(false)
+                        .build();
+
+        try (HarnessAgent agent =
+                baseBuilder(successfulModel("summary"))
+                        .disableMemoryHooks()
+                        .compaction(config)
+                        .build()) {
+            assertNotNull(
+                    agent.call(
+                                    List.of(
+                                            message("m1", MsgRole.USER, "first"),
+                                            message("m2", MsgRole.ASSISTANT, "second"),
+                                            message("m3", MsgRole.USER, "third")),
+                                    runtimeContext())
+                            .block());
+        }
+
+        assertUsesConfiguredAgentId();
+    }
+
+    private HarnessAgent.Builder baseBuilder(Model model) {
+        return HarnessAgent.builder()
+                .name(AGENT_NAME)
+                .agentId(AGENT_ID)
+                .model(model)
+                .workspace(workspace)
+                .abstractFilesystem(new LocalFilesystem(workspace))
+                .stateStore(new InMemoryAgentStateStore());
+    }
+
+    private RuntimeContext runtimeContext() {
+        return RuntimeContext.builder().sessionId(SESSION_ID).build();
+    }
+
+    private void assertUsesConfiguredAgentId() {
+        assertTrue(Files.exists(sessionPath(AGENT_ID)));
+        assertFalse(Files.exists(sessionPath(AGENT_NAME)));
+    }
+
+    private Path sessionPath(String agentId) {
+        return workspace
+                .resolve("agents")
+                .resolve(agentId)
+                .resolve("sessions")
+                .resolve(SESSION_ID + ".jsonl");
+    }
+
+    private static Model successfulModel(String text) {
+        Model model = mock(Model.class);
+        when(model.getModelName()).thenReturn("stub-model");
+        when(model.stream(anyList(), any(), any())).thenReturn(Flux.just(response(text)));
+        return model;
+    }
+
+    private static ChatResponse response(String text) {
+        return new ChatResponse(
+                "stub-id", List.of(TextBlock.builder().text(text).build()), null, Map.of(), "stop");
+    }
+
+    private static Msg message(String id, MsgRole role, String text) {
+        return Msg.builder()
+                .id(id)
+                .role(role)
+                .content(TextBlock.builder().text(text).build())
+                .build();
+    }
+}

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/HarnessAgentSessionPathTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/HarnessAgentSessionPathTest.java
@@ -23,16 +23,26 @@ import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import io.agentscope.core.ReActAgent;
+import io.agentscope.core.agent.Agent;
 import io.agentscope.core.agent.RuntimeContext;
+import io.agentscope.core.event.AgentEvent;
 import io.agentscope.core.message.Msg;
 import io.agentscope.core.message.MsgRole;
 import io.agentscope.core.message.TextBlock;
+import io.agentscope.core.middleware.AgentInput;
+import io.agentscope.core.middleware.ReasoningInput;
 import io.agentscope.core.model.ChatResponse;
 import io.agentscope.core.model.Model;
+import io.agentscope.core.state.AgentState;
 import io.agentscope.core.state.InMemoryAgentStateStore;
 import io.agentscope.harness.agent.filesystem.local.LocalFilesystem;
 import io.agentscope.harness.agent.memory.MemoryConfig;
+import io.agentscope.harness.agent.memory.MemoryFlushManager;
 import io.agentscope.harness.agent.memory.compaction.CompactionConfig;
+import io.agentscope.harness.agent.middleware.CompactionMiddleware;
+import io.agentscope.harness.agent.middleware.MemoryFlushMiddleware;
+import io.agentscope.harness.agent.workspace.WorkspaceManager;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
@@ -93,6 +103,80 @@ class HarnessAgentSessionPathTest {
         assertUsesConfiguredAgentId();
     }
 
+    @Test
+    void memoryOffloadLegacyConstructorFallsBackToAgentName() {
+        Msg msg = message("m1", MsgRole.USER, "hello");
+        AgentState state = AgentState.builder().context(List.of(msg)).build();
+        RuntimeContext rc =
+                RuntimeContext.builder().sessionId(SESSION_ID).agentState(state).build();
+        Agent agent = mock(Agent.class);
+        when(agent.getName()).thenReturn(AGENT_NAME);
+
+        try (WorkspaceManager workspaceManager = new WorkspaceManager(workspace)) {
+            MemoryFlushMiddleware middleware =
+                    new MemoryFlushMiddleware(
+                            workspaceManager,
+                            successfulModel("unused"),
+                            MemoryFlushManager.DEFAULT_FLUSH_PROMPT,
+                            MemoryConfig.FlushTrigger.never(),
+                            IsolationScope.USER);
+            middleware
+                    .onAgent(
+                            agent,
+                            rc,
+                            new AgentInput(List.of(msg)),
+                            ignored -> Flux.<AgentEvent>empty())
+                    .blockLast();
+        }
+
+        assertUsesAgentName();
+    }
+
+    @Test
+    void memoryConvenienceConstructorsRemainBackwardCompatible() {
+        assertNotNull(new MemoryFlushMiddleware(null, null));
+        assertNotNull(
+                new MemoryFlushMiddleware(
+                        null,
+                        null,
+                        MemoryFlushManager.DEFAULT_FLUSH_PROMPT,
+                        MemoryConfig.FlushTrigger.never()));
+    }
+
+    @Test
+    void compactionLegacyConstructorFallsBackToAgentName() {
+        List<Msg> messages =
+                List.of(
+                        message("m1", MsgRole.USER, "first"),
+                        message("m2", MsgRole.ASSISTANT, "second"));
+        AgentState state = AgentState.builder().context(messages).build();
+        RuntimeContext rc =
+                RuntimeContext.builder().sessionId(SESSION_ID).agentState(state).build();
+        ReActAgent agent = mock(ReActAgent.class);
+        when(agent.getName()).thenReturn(AGENT_NAME);
+        CompactionConfig config =
+                CompactionConfig.builder()
+                        .triggerMessages(2)
+                        .keepMessages(1)
+                        .keepTokens(0)
+                        .flushBeforeCompact(false)
+                        .build();
+
+        try (WorkspaceManager workspaceManager = new WorkspaceManager(workspace)) {
+            CompactionMiddleware middleware =
+                    new CompactionMiddleware(workspaceManager, successfulModel("summary"), config);
+            middleware
+                    .onReasoning(
+                            agent,
+                            rc,
+                            new ReasoningInput(messages, List.of(), null),
+                            ignored -> Flux.<AgentEvent>empty())
+                    .blockLast();
+        }
+
+        assertUsesAgentName();
+    }
+
     private HarnessAgent.Builder baseBuilder(Model model) {
         return HarnessAgent.builder()
                 .name(AGENT_NAME)
@@ -110,6 +194,11 @@ class HarnessAgentSessionPathTest {
     private void assertUsesConfiguredAgentId() {
         assertTrue(Files.exists(sessionPath(AGENT_ID)));
         assertFalse(Files.exists(sessionPath(AGENT_NAME)));
+    }
+
+    private void assertUsesAgentName() {
+        assertTrue(Files.exists(sessionPath(AGENT_NAME)));
+        assertFalse(Files.exists(sessionPath(AGENT_ID)));
     }
 
     private Path sessionPath(String agentId) {


### PR DESCRIPTION
## AgentScope-Java Version

2.0.1-SNAPSHOT

## Description

Fixes #2298.

Use the builder's resolved agent ID consistently for session archive paths in:

- MemoryFlushMiddleware
- CompactionMiddleware
- Context overflow recovery

This prevents session files from being written under the agent display name when `name` and `agentId` differ.

Added regression tests covering memory offload and compaction with different `name` and `agentId` values. Existing middleware constructors remain backward compatible.

## Testing

- `mvn -pl agentscope-harness spotless:check`
- `mvn -pl agentscope-harness -am test`

Both passed successfully.

## Checklist

- [x] Code has been formatted with `mvn spotless:apply`
- [x] All tests are passing
- [x] Javadoc comments are complete
- [x] Documentation changes are not required
- [x] Code is ready for review