### PR TITLE
Fix shell working directory on Windows

### DIFF
--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/tool/ShellExecuteTool.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/tool/ShellExecuteTool.java
@@ -83,7 +83,8 @@ public class ShellExecuteTool {
         if (result.truncated()) {
             sb.append("\n(output was truncated)");
         }
-        return sb.toString();    }
+        return sb.toString();
+    }
 
     static String prefixWorkingDirectory(String command, String workingDirectory, String osName) {
         if (isWindows(osName)) {

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/tool/ShellExecuteTool.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/tool/ShellExecuteTool.java
@@ -20,6 +20,7 @@ import io.agentscope.core.tool.Tool;
 import io.agentscope.core.tool.ToolParam;
 import io.agentscope.harness.agent.filesystem.model.ExecuteResponse;
 import io.agentscope.harness.agent.filesystem.sandbox.AbstractSandboxFilesystem;
+import java.util.Locale;
 
 /**
  * Shell execution tool backed by a {@link AbstractSandboxFilesystem}.
@@ -68,7 +69,7 @@ public class ShellExecuteTool {
                 return "Error: working_directory must be a relative path within the workspace"
                         + " (absolute paths, '~', and '..' are not allowed).";
             }
-            effectiveCommand = "cd '" + wd.replace("'", "'\\''") + "' && " + command;
+            effectiveCommand = prefixWorkingDirectory(command, wd, System.getProperty("os.name"));
         }
 
         int timeoutSeconds = timeout != null && timeout > 0 ? timeout : 30;
@@ -82,6 +83,16 @@ public class ShellExecuteTool {
         if (result.truncated()) {
             sb.append("\n(output was truncated)");
         }
-        return sb.toString();
+        return sb.toString();    }
+
+    static String prefixWorkingDirectory(String command, String workingDirectory, String osName) {
+        if (isWindows(osName)) {
+            return "cd /d \"" + workingDirectory.replace("\"", "\\\"") + "\" && " + command;
+        }
+        return "cd '" + workingDirectory.replace("'", "'\\''") + "' && " + command;
+    }
+
+    private static boolean isWindows(String osName) {
+        return osName != null && osName.toLowerCase(Locale.ROOT).contains("win");
     }
 }

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/tool/ShellExecuteToolTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/tool/ShellExecuteToolTest.java
@@ -15,6 +15,7 @@
  */
 package io.agentscope.harness.agent.tool;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -65,12 +66,27 @@ class ShellExecuteToolTest {
 
     @Test
     void execute_withWorkingDirectory_prefixesCd() {
-        when(sandbox.execute(eq(RT), eq("cd 'sub' && ls"), eq(30)))
+        String expectedCommand = ShellExecuteTool.prefixWorkingDirectory("ls", "sub", System.getProperty("os.name"));
+        when(sandbox.execute(eq(RT), eq(expectedCommand), eq(30)))
                 .thenReturn(new ExecuteResponse("out", 0, false));
 
         String result = tool.execute(RT, "ls", "sub", null);
 
         assertTrue(result.contains("Exit code: 0"));
-        verify(sandbox).execute(RT, "cd 'sub' && ls", 30);
+        verify(sandbox).execute(RT, expectedCommand, 30);
+    }
+
+    @Test
+    void prefixWorkingDirectory_onWindows_usesCmdCompatibleCd() {
+        assertEquals(
+                "cd /d \"sub dir\" && dir",
+                ShellExecuteTool.prefixWorkingDirectory("dir", "sub dir", "Windows 11"));
+    }
+
+    @Test
+    void prefixWorkingDirectory_onUnix_keepsSingleQuotedCd() {
+        assertEquals(
+                "cd 'it'\\''s' && ls",
+                ShellExecuteTool.prefixWorkingDirectory("ls", "it's", "Linux"));
     }
 }

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/tool/ShellExecuteToolTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/tool/ShellExecuteToolTest.java
@@ -66,7 +66,8 @@ class ShellExecuteToolTest {
 
     @Test
     void execute_withWorkingDirectory_prefixesCd() {
-        String expectedCommand = ShellExecuteTool.prefixWorkingDirectory("ls", "sub", System.getProperty("os.name"));
+        String expectedCommand =
+                ShellExecuteTool.prefixWorkingDirectory("ls", "sub", System.getProperty("os.name"));
         when(sandbox.execute(eq(RT), eq(expectedCommand), eq(30)))
                 .thenReturn(new ExecuteResponse("out", 0, false));
 


### PR DESCRIPTION
﻿## What changed
- Build the `working_directory` shell prefix based on the current OS.
- Keep the existing Unix-style single-quoted `cd 'dir' && command` behavior for non-Windows systems.
- Use a Windows cmd-compatible `cd /d "dir" && command` prefix on Windows.
- Added unit coverage for Windows and Unix command-prefix generation, and made the existing working-directory test derive the expected command from the same OS-aware helper.

## Why
Fixes #2271. The previous implementation always used Unix single-quote syntax, which `cmd.exe` does not understand on Windows.

## Validation
- Compared `main...xujunfeng1:agent/windows-shell-working-directory` through the GitHub API and verified only `ShellExecuteTool.java` and `ShellExecuteToolTest.java` changed.
- Attempted a sparse shallow clone of `xujunfeng1/agentscope-java` to run the targeted Maven test, but GitHub HTTPS clone timed out from this environment twice: `Failed to connect to github.com port 443 after 21112 ms` and `21471 ms`.
- Targeted tests were added, but could not be executed locally until the clone/network issue is resolved.
