### PR TITLE
feat(gemini): 支持 Gemini Thinking 并持久化 thought signature

### DIFF
--- a/agentscope-core/src/main/java/io/agentscope/core/agent/accumulator/ReasoningContext.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/agent/accumulator/ReasoningContext.java
@@ -149,12 +149,12 @@ public class ReasoningContext {
 
         // Add thinking content if present
         if (thinkingAcc.hasContent()) {
-            blocks.add(thinkingAcc.buildAggregated());
+            blocks.addAll(thinkingAcc.buildAllThinkingBlocks());
         }
 
         // Add text content if present
         if (textAcc.hasContent()) {
-            blocks.add(textAcc.buildAggregated());
+            blocks.addAll(textAcc.buildAllTextBlocks());
         }
 
         // Add all tool calls

--- a/agentscope-core/src/main/java/io/agentscope/core/agent/accumulator/TextAccumulator.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/agent/accumulator/TextAccumulator.java
@@ -17,6 +17,8 @@ package io.agentscope.core.agent.accumulator;
 
 import io.agentscope.core.message.ContentBlock;
 import io.agentscope.core.message.TextBlock;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * Text content accumulator for accumulating streaming text chunks.
@@ -27,6 +29,7 @@ import io.agentscope.core.message.TextBlock;
 public class TextAccumulator implements ContentAccumulator<TextBlock> {
 
     private final StringBuilder accumulated = new StringBuilder();
+    private final Map<String, Object> metadata = new HashMap<>();
 
     /**
      * @hidden
@@ -36,6 +39,9 @@ public class TextAccumulator implements ContentAccumulator<TextBlock> {
         if (block != null && block.getText() != null) {
             accumulated.append(block.getText());
         }
+        if (block != null && block.getMetadata() != null) {
+            metadata.putAll(block.getMetadata());
+        }
     }
 
     /**
@@ -43,7 +49,7 @@ public class TextAccumulator implements ContentAccumulator<TextBlock> {
      */
     @Override
     public boolean hasContent() {
-        return accumulated.length() > 0;
+        return accumulated.length() > 0 || !metadata.isEmpty();
     }
 
     /**
@@ -54,7 +60,10 @@ public class TextAccumulator implements ContentAccumulator<TextBlock> {
         if (!hasContent()) {
             return null;
         }
-        return TextBlock.builder().text(accumulated.toString()).build();
+        return TextBlock.builder()
+                .text(accumulated.toString())
+                .metadata(metadata.isEmpty() ? null : metadata)
+                .build();
     }
 
     /**
@@ -63,6 +72,7 @@ public class TextAccumulator implements ContentAccumulator<TextBlock> {
     @Override
     public void reset() {
         accumulated.setLength(0);
+        metadata.clear();
     }
 
     /**

--- a/agentscope-core/src/main/java/io/agentscope/core/agent/accumulator/TextAccumulator.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/agent/accumulator/TextAccumulator.java
@@ -16,8 +16,11 @@
 package io.agentscope.core.agent.accumulator;
 
 import io.agentscope.core.message.ContentBlock;
+import io.agentscope.core.message.ContentBlockMetadataKeys;
 import io.agentscope.core.message.TextBlock;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -30,17 +33,33 @@ public class TextAccumulator implements ContentAccumulator<TextBlock> {
 
     private final StringBuilder accumulated = new StringBuilder();
     private final Map<String, Object> metadata = new HashMap<>();
+    private final List<TextBlock> completedBlocks = new ArrayList<>();
+    private final StringBuilder currentBlock = new StringBuilder();
+    private final Map<String, Object> currentMetadata = new HashMap<>();
 
     /**
      * @hidden
      */
     @Override
     public void add(TextBlock block) {
-        if (block != null && block.getText() != null) {
-            accumulated.append(block.getText());
+        if (block == null) {
+            return;
         }
-        if (block != null && block.getMetadata() != null) {
-            metadata.putAll(block.getMetadata());
+
+        accumulated.append(block.getText());
+        currentBlock.append(block.getText());
+
+        Map<String, Object> blockMetadata = block.getMetadata();
+        if (blockMetadata != null) {
+            metadata.putAll(blockMetadata);
+            currentMetadata.putAll(blockMetadata);
+        }
+
+        // A thought signature terminates its provider Part. Keep that boundary so distinct
+        // signature-bearing Parts can be replayed without merging their metadata.
+        if (blockMetadata != null
+                && blockMetadata.get(ContentBlockMetadataKeys.THOUGHT_SIGNATURE) != null) {
+            completeCurrentBlock();
         }
     }
 
@@ -67,12 +86,33 @@ public class TextAccumulator implements ContentAccumulator<TextBlock> {
     }
 
     /**
+     * Build accumulated text blocks while preserving thought-signature Part boundaries.
+     *
+     * @hidden
+     * @return accumulated text blocks in their original order
+     */
+    public List<TextBlock> buildAllTextBlocks() {
+        if (!hasContent()) {
+            return List.of();
+        }
+
+        List<TextBlock> blocks = new ArrayList<>(completedBlocks);
+        if (currentBlock.length() > 0 || !currentMetadata.isEmpty()) {
+            blocks.add(buildCurrentBlock());
+        }
+        return List.copyOf(blocks);
+    }
+
+    /**
      * @hidden
      */
     @Override
     public void reset() {
         accumulated.setLength(0);
         metadata.clear();
+        completedBlocks.clear();
+        currentBlock.setLength(0);
+        currentMetadata.clear();
     }
 
     /**
@@ -88,12 +128,29 @@ public class TextAccumulator implements ContentAccumulator<TextBlock> {
     /**
      * Replace the accumulated text with content reconstructed from the model-call event stream.
      *
+     * <p>Resets any in-flight thought-signature Part boundary and makes the new content the
+     * current block, so {@link #buildAllTextBlocks()} reflects the replaced text.
+     *
      * @hidden
      */
     public void replace(String text) {
-        accumulated.setLength(0);
+        reset();
         if (text != null) {
             accumulated.append(text);
+            currentBlock.append(text);
         }
+    }
+
+    private void completeCurrentBlock() {
+        completedBlocks.add(buildCurrentBlock());
+        currentBlock.setLength(0);
+        currentMetadata.clear();
+    }
+
+    private TextBlock buildCurrentBlock() {
+        return TextBlock.builder()
+                .text(currentBlock.toString())
+                .metadata(currentMetadata.isEmpty() ? null : currentMetadata)
+                .build();
     }
 }

--- a/agentscope-core/src/main/java/io/agentscope/core/agent/accumulator/ThinkingAccumulator.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/agent/accumulator/ThinkingAccumulator.java
@@ -17,6 +17,8 @@ package io.agentscope.core.agent.accumulator;
 
 import io.agentscope.core.message.ContentBlock;
 import io.agentscope.core.message.ThinkingBlock;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * Thinking content accumulator for accumulating streaming thinking chunks.
@@ -28,6 +30,7 @@ import io.agentscope.core.message.ThinkingBlock;
 public class ThinkingAccumulator implements ContentAccumulator<ThinkingBlock> {
 
     private final StringBuilder accumulated = new StringBuilder();
+    private final Map<String, Object> metadata = new HashMap<>();
 
     /**
      * @hidden
@@ -37,6 +40,9 @@ public class ThinkingAccumulator implements ContentAccumulator<ThinkingBlock> {
         if (block != null && block.getThinking() != null) {
             accumulated.append(block.getThinking());
         }
+        if (block != null && block.getMetadata() != null) {
+            metadata.putAll(block.getMetadata());
+        }
     }
 
     /**
@@ -44,7 +50,7 @@ public class ThinkingAccumulator implements ContentAccumulator<ThinkingBlock> {
      */
     @Override
     public boolean hasContent() {
-        return accumulated.length() > 0;
+        return accumulated.length() > 0 || !metadata.isEmpty();
     }
 
     /**
@@ -55,7 +61,10 @@ public class ThinkingAccumulator implements ContentAccumulator<ThinkingBlock> {
         if (!hasContent()) {
             return null;
         }
-        return ThinkingBlock.builder().thinking(accumulated.toString()).build();
+        return ThinkingBlock.builder()
+                .thinking(accumulated.toString())
+                .metadata(metadata.isEmpty() ? null : metadata)
+                .build();
     }
 
     /**
@@ -64,6 +73,7 @@ public class ThinkingAccumulator implements ContentAccumulator<ThinkingBlock> {
     @Override
     public void reset() {
         accumulated.setLength(0);
+        metadata.clear();
     }
 
     /**

--- a/agentscope-core/src/main/java/io/agentscope/core/agent/accumulator/ThinkingAccumulator.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/agent/accumulator/ThinkingAccumulator.java
@@ -16,8 +16,11 @@
 package io.agentscope.core.agent.accumulator;
 
 import io.agentscope.core.message.ContentBlock;
+import io.agentscope.core.message.ContentBlockMetadataKeys;
 import io.agentscope.core.message.ThinkingBlock;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -31,17 +34,33 @@ public class ThinkingAccumulator implements ContentAccumulator<ThinkingBlock> {
 
     private final StringBuilder accumulated = new StringBuilder();
     private final Map<String, Object> metadata = new HashMap<>();
+    private final List<ThinkingBlock> completedBlocks = new ArrayList<>();
+    private final StringBuilder currentBlock = new StringBuilder();
+    private final Map<String, Object> currentMetadata = new HashMap<>();
 
     /**
      * @hidden
      */
     @Override
     public void add(ThinkingBlock block) {
-        if (block != null && block.getThinking() != null) {
-            accumulated.append(block.getThinking());
+        if (block == null) {
+            return;
         }
-        if (block != null && block.getMetadata() != null) {
-            metadata.putAll(block.getMetadata());
+
+        accumulated.append(block.getThinking());
+        currentBlock.append(block.getThinking());
+
+        Map<String, Object> blockMetadata = block.getMetadata();
+        if (blockMetadata != null) {
+            metadata.putAll(blockMetadata);
+            currentMetadata.putAll(blockMetadata);
+        }
+
+        // A thought signature terminates its provider Part. Keep that boundary so distinct
+        // signature-bearing Parts can be replayed without merging their metadata.
+        if (blockMetadata != null
+                && blockMetadata.get(ContentBlockMetadataKeys.THOUGHT_SIGNATURE) != null) {
+            completeCurrentBlock();
         }
     }
 
@@ -68,12 +87,33 @@ public class ThinkingAccumulator implements ContentAccumulator<ThinkingBlock> {
     }
 
     /**
+     * Build accumulated thinking blocks while preserving thought-signature Part boundaries.
+     *
+     * @hidden
+     * @return accumulated thinking blocks in their original order
+     */
+    public List<ThinkingBlock> buildAllThinkingBlocks() {
+        if (!hasContent()) {
+            return List.of();
+        }
+
+        List<ThinkingBlock> blocks = new ArrayList<>(completedBlocks);
+        if (currentBlock.length() > 0 || !currentMetadata.isEmpty()) {
+            blocks.add(buildCurrentBlock());
+        }
+        return List.copyOf(blocks);
+    }
+
+    /**
      * @hidden
      */
     @Override
     public void reset() {
         accumulated.setLength(0);
         metadata.clear();
+        completedBlocks.clear();
+        currentBlock.setLength(0);
+        currentMetadata.clear();
     }
 
     /**
@@ -84,5 +124,18 @@ public class ThinkingAccumulator implements ContentAccumulator<ThinkingBlock> {
      */
     public String getAccumulated() {
         return accumulated.toString();
+    }
+
+    private void completeCurrentBlock() {
+        completedBlocks.add(buildCurrentBlock());
+        currentBlock.setLength(0);
+        currentMetadata.clear();
+    }
+
+    private ThinkingBlock buildCurrentBlock() {
+        return ThinkingBlock.builder()
+                .thinking(currentBlock.toString())
+                .metadata(currentMetadata.isEmpty() ? null : currentMetadata)
+                .build();
     }
 }

--- a/agentscope-core/src/main/java/io/agentscope/core/message/ContentBlockMetadataKeys.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/message/ContentBlockMetadataKeys.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.core.message;
+
+/** Constants for well-known content block metadata keys. */
+public final class ContentBlockMetadataKeys {
+
+    private ContentBlockMetadataKeys() {}
+
+    /**
+     * Metadata key for an opaque model thought signature.
+     *
+     * <p>The value representation is provider-specific. For example, Gemini stores signatures as
+     * {@code byte[]} in memory; after a generic JSON round trip, the value is restored as a
+     * Base64-encoded {@link String}.
+     */
+    public static final String THOUGHT_SIGNATURE = "thoughtSignature";
+}

--- a/agentscope-core/src/main/java/io/agentscope/core/message/TextBlock.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/message/TextBlock.java
@@ -16,7 +16,10 @@
 package io.agentscope.core.message;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * Represents plain text content in a message.
@@ -25,21 +28,27 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  * Text blocks are commonly used for user messages, assistant responses,
  * and any other textual communication.
  *
- * <p>The text content can be empty but never null. The toString() method
- * returns the text content for convenience.
+ * <p>The text content can be empty but never null. Optional metadata preserves provider-specific
+ * information associated with the text content. The toString() method returns the text content for
+ * convenience.
  */
 public final class TextBlock extends ContentBlock {
 
     private final String text;
+    private final Map<String, Object> metadata;
 
     /**
      * Creates a new text block for JSON deserialization.
      *
      * @param text The text content (null will be converted to empty string)
+     * @param metadata Optional provider-specific metadata
      */
     @JsonCreator
-    private TextBlock(@JsonProperty("text") String text) {
+    private TextBlock(
+            @JsonProperty("text") String text,
+            @JsonProperty("metadata") Map<String, Object> metadata) {
         this.text = text != null ? text : "";
+        this.metadata = metadata != null ? new HashMap<>(metadata) : null;
     }
 
     /**
@@ -49,6 +58,16 @@ public final class TextBlock extends ContentBlock {
      */
     public String getText() {
         return text;
+    }
+
+    /**
+     * Gets provider-specific metadata associated with this text block.
+     *
+     * @return The metadata map, or null if no metadata is set
+     */
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public Map<String, Object> getMetadata() {
+        return metadata;
     }
 
     @Override
@@ -71,6 +90,7 @@ public final class TextBlock extends ContentBlock {
     public static class Builder {
 
         private String text;
+        private Map<String, Object> metadata;
 
         /**
          * Sets the text content for the block.
@@ -84,12 +104,23 @@ public final class TextBlock extends ContentBlock {
         }
 
         /**
+         * Sets provider-specific metadata for the block.
+         *
+         * @param metadata The metadata map
+         * @return This builder for chaining
+         */
+        public Builder metadata(Map<String, Object> metadata) {
+            this.metadata = metadata;
+            return this;
+        }
+
+        /**
          * Builds a new TextBlock with the configured text.
          *
          * @return A new TextBlock instance (null text will be converted to empty string)
          */
         public TextBlock build() {
-            return new TextBlock(text != null ? text : "");
+            return new TextBlock(text != null ? text : "", metadata);
         }
     }
 }

--- a/agentscope-core/src/main/java/io/agentscope/core/message/ToolUseBlock.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/message/ToolUseBlock.java
@@ -25,16 +25,19 @@ import java.util.Map;
  * Represents a tool use request within a message.
  *
  * <p>This content block is used when an agent requests to execute a tool.
- * It contains the tool's unique identifier, name, input parameters, and optionally
- * the raw content for streaming tool calls.
+ * It contains the tool's unique identifier, name, input parameters, and optionally the raw content for streaming tool
+ * calls.
  *
  * <p>The tool input is stored as a generic map of string keys to object values,
  * allowing for flexible parameter passing to different tool implementations.
  */
 public final class ToolUseBlock extends ContentBlock {
 
-    /** Metadata key for Gemini thought signature (byte[] value). */
-    public static final String METADATA_THOUGHT_SIGNATURE = "thoughtSignature";
+    /**
+     * Metadata key for an opaque model thought signature.
+     */
+    public static final String METADATA_THOUGHT_SIGNATURE =
+            ContentBlockMetadataKeys.THOUGHT_SIGNATURE;
 
     private final String id;
     private final String name;
@@ -46,9 +49,9 @@ public final class ToolUseBlock extends ContentBlock {
     /**
      * Creates a new tool use block for JSON deserialization.
      *
-     * @param id Unique identifier for this tool call
-     * @param name Name of the tool to execute
-     * @param input Input parameters for the tool (will be defensively copied)
+     * @param id       Unique identifier for this tool call
+     * @param name     Name of the tool to execute
+     * @param input    Input parameters for the tool (will be defensively copied)
      * @param metadata Provider-specific metadata (will be defensively copied)
      */
     public ToolUseBlock(
@@ -59,8 +62,8 @@ public final class ToolUseBlock extends ContentBlock {
     /**
      * Creates a new tool use block without metadata (convenience constructor).
      *
-     * @param id Unique identifier for this tool call
-     * @param name Name of the tool to execute
+     * @param id    Unique identifier for this tool call
+     * @param name  Name of the tool to execute
      * @param input Input parameters for the tool (will be defensively copied)
      */
     public ToolUseBlock(String id, String name, Map<String, Object> input) {
@@ -70,10 +73,10 @@ public final class ToolUseBlock extends ContentBlock {
     /**
      * Creates a new tool use block with raw content for streaming.
      *
-     * @param id Unique identifier for this tool call
-     * @param name Name of the tool to execute
-     * @param input Input parameters for the tool (will be defensively copied)
-     * @param content Raw content for streaming tool calls
+     * @param id       Unique identifier for this tool call
+     * @param name     Name of the tool to execute
+     * @param input    Input parameters for the tool (will be defensively copied)
+     * @param content  Raw content for streaming tool calls
      * @param metadata Provider-specific metadata (will be defensively copied)
      */
     public ToolUseBlock(
@@ -88,12 +91,12 @@ public final class ToolUseBlock extends ContentBlock {
     /**
      * Creates a new tool use block with all fields.
      *
-     * @param id Unique identifier for this tool call
-     * @param name Name of the tool to execute
-     * @param input Input parameters for the tool (will be defensively copied)
-     * @param content Raw content for streaming tool calls
+     * @param id       Unique identifier for this tool call
+     * @param name     Name of the tool to execute
+     * @param input    Input parameters for the tool (will be defensively copied)
+     * @param content  Raw content for streaming tool calls
      * @param metadata Provider-specific metadata (will be defensively copied)
-     * @param state The tool call state, defaults to PENDING if null
+     * @param state    The tool call state, defaults to PENDING if null
      */
     @JsonCreator
     public ToolUseBlock(
@@ -198,6 +201,7 @@ public final class ToolUseBlock extends ContentBlock {
      * Builder for constructing ToolUseBlock instances.
      */
     public static class Builder {
+
         private String id;
         private String name;
         private Map<String, Object> input;

--- a/agentscope-core/src/main/java/io/agentscope/core/model/GenerateOptions.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/model/GenerateOptions.java
@@ -45,6 +45,8 @@ public class GenerateOptions {
     private final Double frequencyPenalty;
     private final Double presencePenalty;
     private final Integer thinkingBudget;
+    private final Boolean includeThoughts;
+    private final String thinkingLevel;
     private final String reasoningEffort;
     private final ExecutionConfig executionConfig;
     private final ToolChoice toolChoice;
@@ -75,6 +77,8 @@ public class GenerateOptions {
         this.frequencyPenalty = builder.frequencyPenalty;
         this.presencePenalty = builder.presencePenalty;
         this.thinkingBudget = builder.thinkingBudget;
+        this.includeThoughts = builder.includeThoughts;
+        this.thinkingLevel = builder.thinkingLevel;
         this.reasoningEffort = builder.reasoningEffort;
         this.executionConfig = builder.executionConfig;
         this.toolChoice = builder.toolChoice;
@@ -235,14 +239,38 @@ public class GenerateOptions {
     /**
      * Gets the maximum number of tokens for reasoning/thinking content.
      *
-     * <p>This parameter is specific to models that support thinking mode (e.g., DashScope).
-     * When set, it enables the model to show its reasoning process before generating the final
-     * answer.
+     * <p>This parameter is specific to models that support thinking mode. Whether thought summaries
+     * are returned is controlled separately by {@link #getIncludeThoughts()} when supported by the
+     * provider.
      *
      * @return the thinking budget in tokens, or null if not set
      */
     public Integer getThinkingBudget() {
         return thinkingBudget;
+    }
+
+    /**
+     * Gets whether model thoughts should be included in the response.
+     *
+     * <p>This option only controls whether supported models return their thought summaries. It does
+     * not by itself control the amount of thinking performed by the model.
+     *
+     * @return whether thoughts should be included, or null if not set
+     */
+    public Boolean getIncludeThoughts() {
+        return includeThoughts;
+    }
+
+    /**
+     * Gets the model-specific thinking level.
+     *
+     * <p>Supported values are model dependent. Providers that support this option are responsible
+     * for translating it to their native request type.
+     *
+     * @return the thinking level, or null if not set
+     */
+    public String getThinkingLevel() {
+        return thinkingLevel;
     }
 
     /**
@@ -469,6 +497,12 @@ public class GenerateOptions {
                         : fallback.presencePenalty);
         builder.thinkingBudget(
                 primary.thinkingBudget != null ? primary.thinkingBudget : fallback.thinkingBudget);
+        builder.includeThoughts(
+                primary.includeThoughts != null
+                        ? primary.includeThoughts
+                        : fallback.includeThoughts);
+        builder.thinkingLevel(
+                primary.thinkingLevel != null ? primary.thinkingLevel : fallback.thinkingLevel);
         builder.reasoningEffort(
                 primary.reasoningEffort != null
                         ? primary.reasoningEffort
@@ -531,6 +565,8 @@ public class GenerateOptions {
         private Double frequencyPenalty;
         private Double presencePenalty;
         private Integer thinkingBudget;
+        private Boolean includeThoughts;
+        private String thinkingLevel;
         private String reasoningEffort;
         private ExecutionConfig executionConfig;
         private ToolChoice toolChoice;
@@ -688,15 +724,42 @@ public class GenerateOptions {
         /**
          * Sets the thinking budget (maximum tokens for reasoning/thinking content).
          *
-         * <p>This parameter is specific to models that support thinking mode. When set, the model
-         * will show its reasoning process before generating the final answer. Setting this
-         * parameter may automatically enable thinking mode in some models.
+         * <p>This parameter is specific to models that support thinking mode. Setting it may
+         * automatically enable thinking mode in some models. Use {@link #includeThoughts(Boolean)}
+         * to control whether supported providers return thought summaries.
          *
          * @param thinkingBudget the maximum tokens for thinking content
          * @return this builder
          */
         public Builder thinkingBudget(Integer thinkingBudget) {
             this.thinkingBudget = thinkingBudget;
+            return this;
+        }
+
+        /**
+         * Sets whether model thought summaries should be included in the response.
+         *
+         * <p>Use {@code false} to explicitly suppress thought summaries while retaining any
+         * provider-specific thinking configuration.
+         *
+         * @param includeThoughts whether thoughts should be included in the response
+         * @return this builder
+         */
+        public Builder includeThoughts(Boolean includeThoughts) {
+            this.includeThoughts = includeThoughts;
+            return this;
+        }
+
+        /**
+         * Sets the model-specific thinking level.
+         *
+         * <p>Supported values are model dependent and are validated by the target provider.
+         *
+         * @param thinkingLevel the thinking level
+         * @return this builder
+         */
+        public Builder thinkingLevel(String thinkingLevel) {
+            this.thinkingLevel = thinkingLevel;
             return this;
         }
 

--- a/agentscope-core/src/test/java/io/agentscope/core/agent/accumulator/ReasoningContextTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/agent/accumulator/ReasoningContextTest.java
@@ -20,12 +20,15 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import io.agentscope.core.message.ContentBlockMetadataKeys;
 import io.agentscope.core.message.Msg;
 import io.agentscope.core.message.TextBlock;
+import io.agentscope.core.message.ThinkingBlock;
 import io.agentscope.core.message.ToolUseBlock;
 import io.agentscope.core.model.ChatResponse;
 import io.agentscope.core.model.ChatUsage;
 import java.util.List;
+import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -332,5 +335,57 @@ class ReasoningContextTest {
 
         // Verify text is accumulated correctly
         assertEquals("Let me check the weather for you.", context.getAccumulatedText());
+    }
+
+    @Test
+    @DisplayName("Should preserve text and thinking metadata while accumulating")
+    void testContentMetadataAccumulation() {
+        String textSignature = "dGV4dC1zaWduYXR1cmU=";
+        String thinkingSignature = "dGhpbmtpbmctc2lnbmF0dXJl";
+
+        ChatResponse firstChunk =
+                ChatResponse.builder()
+                        .id("msg-1")
+                        .content(
+                                List.of(
+                                        ThinkingBlock.builder().thinking("Think carefully").build(),
+                                        TextBlock.builder().text("Answer").build()))
+                        .build();
+        ChatResponse secondChunk =
+                ChatResponse.builder()
+                        .id("msg-1")
+                        .content(
+                                List.of(
+                                        ThinkingBlock.builder()
+                                                .thinking("")
+                                                .metadata(
+                                                        Map.of(
+                                                                ContentBlockMetadataKeys
+                                                                        .THOUGHT_SIGNATURE,
+                                                                thinkingSignature))
+                                                .build(),
+                                        TextBlock.builder()
+                                                .text("")
+                                                .metadata(
+                                                        Map.of(
+                                                                ContentBlockMetadataKeys
+                                                                        .THOUGHT_SIGNATURE,
+                                                                textSignature))
+                                                .build()))
+                        .build();
+
+        context.processChunk(firstChunk);
+        context.processChunk(secondChunk);
+        Msg result = context.buildFinalMessage();
+
+        ThinkingBlock thinking = result.getFirstContentBlock(ThinkingBlock.class);
+        TextBlock text = result.getFirstContentBlock(TextBlock.class);
+        assertEquals("Think carefully", thinking.getThinking());
+        assertEquals("Answer", text.getText());
+        assertEquals(
+                thinkingSignature,
+                thinking.getMetadata().get(ContentBlockMetadataKeys.THOUGHT_SIGNATURE));
+        assertEquals(
+                textSignature, text.getMetadata().get(ContentBlockMetadataKeys.THOUGHT_SIGNATURE));
     }
 }

--- a/agentscope-core/src/test/java/io/agentscope/core/agent/accumulator/ThinkingAccumulatorTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/agent/accumulator/ThinkingAccumulatorTest.java
@@ -22,26 +22,15 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.agentscope.core.message.ContentBlockMetadataKeys;
-import io.agentscope.core.message.TextBlock;
+import io.agentscope.core.message.ThinkingBlock;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 
-class TextAccumulatorTest {
+class ThinkingAccumulatorTest {
 
-    private final TextAccumulator accumulator = new TextAccumulator();
-
-    @Test
-    void replaceNullClearsAccumulatedText() {
-        TextAccumulator accumulator = new TextAccumulator();
-        accumulator.add(TextBlock.builder().text("original").build());
-
-        accumulator.replace(null);
-
-        assertFalse(accumulator.hasContent());
-        assertEquals("", accumulator.getAccumulated());
-    }
+    private final ThinkingAccumulator accumulator = new ThinkingAccumulator();
 
     @Test
     void shouldIgnoreNullAndRemainEmpty() {
@@ -49,70 +38,76 @@ class TextAccumulatorTest {
 
         assertFalse(accumulator.hasContent());
         assertNull(accumulator.buildAggregated());
-        assertTrue(accumulator.buildAllTextBlocks().isEmpty());
+        assertTrue(accumulator.buildAllThinkingBlocks().isEmpty());
     }
 
     @Test
-    void shouldAccumulateTextAndMetadata() {
-        accumulator.add(TextBlock.builder().text("Hello").build());
+    void shouldAccumulateThinkingAndMetadata() {
+        accumulator.add(ThinkingBlock.builder().thinking("Think").build());
         accumulator.add(
-                TextBlock.builder().text(" world").metadata(Map.of("provider", "gemini")).build());
+                ThinkingBlock.builder()
+                        .thinking(" carefully")
+                        .metadata(Map.of("provider", "gemini"))
+                        .build());
 
-        TextBlock aggregated = (TextBlock) accumulator.buildAggregated();
-        List<TextBlock> blocks = accumulator.buildAllTextBlocks();
+        ThinkingBlock aggregated = (ThinkingBlock) accumulator.buildAggregated();
+        List<ThinkingBlock> blocks = accumulator.buildAllThinkingBlocks();
 
-        assertEquals("Hello world", aggregated.getText());
+        assertEquals("Think carefully", aggregated.getThinking());
         assertEquals("gemini", aggregated.getMetadata().get("provider"));
         assertEquals(1, blocks.size());
-        assertEquals("Hello world", blocks.get(0).getText());
+        assertEquals("Think carefully", blocks.get(0).getThinking());
         assertEquals("gemini", blocks.get(0).getMetadata().get("provider"));
     }
 
     @Test
-    void shouldBuildTextOnlyBlockWithoutMetadata() {
-        accumulator.add(TextBlock.builder().text("Answer").build());
+    void shouldBuildThinkingOnlyBlockWithoutMetadata() {
+        accumulator.add(ThinkingBlock.builder().thinking("Reasoning").build());
 
-        TextBlock aggregated = (TextBlock) accumulator.buildAggregated();
-        List<TextBlock> blocks = accumulator.buildAllTextBlocks();
+        ThinkingBlock aggregated = (ThinkingBlock) accumulator.buildAggregated();
+        List<ThinkingBlock> blocks = accumulator.buildAllThinkingBlocks();
 
         assertTrue(accumulator.hasContent());
-        assertEquals("Answer", aggregated.getText());
+        assertEquals("Reasoning", aggregated.getThinking());
         assertNull(aggregated.getMetadata());
         assertEquals(1, blocks.size());
-        assertEquals("Answer", blocks.get(0).getText());
+        assertEquals("Reasoning", blocks.get(0).getThinking());
         assertNull(blocks.get(0).getMetadata());
     }
 
     @Test
     void shouldBuildMetadataOnlyBlock() {
         accumulator.add(
-                TextBlock.builder().text("").metadata(Map.of("provider", "gemini")).build());
+                ThinkingBlock.builder()
+                        .thinking("")
+                        .metadata(Map.of("provider", "gemini"))
+                        .build());
 
-        TextBlock aggregated = (TextBlock) accumulator.buildAggregated();
-        List<TextBlock> blocks = accumulator.buildAllTextBlocks();
+        ThinkingBlock aggregated = (ThinkingBlock) accumulator.buildAggregated();
+        List<ThinkingBlock> blocks = accumulator.buildAllThinkingBlocks();
 
         assertTrue(accumulator.hasContent());
-        assertEquals("", aggregated.getText());
+        assertEquals("", aggregated.getThinking());
         assertEquals("gemini", aggregated.getMetadata().get("provider"));
         assertEquals(1, blocks.size());
-        assertEquals("", blocks.get(0).getText());
+        assertEquals("", blocks.get(0).getThinking());
         assertEquals("gemini", blocks.get(0).getMetadata().get("provider"));
     }
 
     @Test
     void shouldAttachMetadataOnlySignatureChunkToCurrentPart() {
         byte[] signature = "signature".getBytes(StandardCharsets.UTF_8);
-        accumulator.add(TextBlock.builder().text("Answer").build());
+        accumulator.add(ThinkingBlock.builder().thinking("Reasoning").build());
         accumulator.add(
-                TextBlock.builder()
-                        .text("")
+                ThinkingBlock.builder()
+                        .thinking("")
                         .metadata(Map.of(ContentBlockMetadataKeys.THOUGHT_SIGNATURE, signature))
                         .build());
 
-        List<TextBlock> blocks = accumulator.buildAllTextBlocks();
+        List<ThinkingBlock> blocks = accumulator.buildAllThinkingBlocks();
 
         assertEquals(1, blocks.size());
-        assertEquals("Answer", blocks.get(0).getText());
+        assertEquals("Reasoning", blocks.get(0).getThinking());
         assertArrayEquals(
                 signature,
                 (byte[])
@@ -128,37 +123,37 @@ class TextAccumulatorTest {
         accumulator.add(signedBlock("First", firstSignature));
         accumulator.add(signedBlock("Second", secondSignature));
 
-        List<TextBlock> blocks = accumulator.buildAllTextBlocks();
+        List<ThinkingBlock> blocks = accumulator.buildAllThinkingBlocks();
 
         assertEquals(2, blocks.size());
-        assertEquals("First", blocks.get(0).getText());
-        assertEquals("Second", blocks.get(1).getText());
+        assertEquals("First", blocks.get(0).getThinking());
+        assertEquals("Second", blocks.get(1).getThinking());
         assertArrayEquals(firstSignature, signatureOf(blocks.get(0)));
         assertArrayEquals(secondSignature, signatureOf(blocks.get(1)));
         assertEquals("FirstSecond", accumulator.getAccumulated());
     }
 
     @Test
-    void shouldClearTextMetadataAndPartBoundariesOnReset() {
+    void shouldClearThinkingMetadataAndPartBoundariesOnReset() {
         accumulator.add(signedBlock("Completed", "signature".getBytes(StandardCharsets.UTF_8)));
-        accumulator.add(TextBlock.builder().text("Pending").build());
+        accumulator.add(ThinkingBlock.builder().thinking("Pending").build());
 
         accumulator.reset();
 
         assertEquals("", accumulator.getAccumulated());
         assertFalse(accumulator.hasContent());
         assertNull(accumulator.buildAggregated());
-        assertTrue(accumulator.buildAllTextBlocks().isEmpty());
+        assertTrue(accumulator.buildAllThinkingBlocks().isEmpty());
     }
 
-    private TextBlock signedBlock(String text, byte[] signature) {
-        return TextBlock.builder()
-                .text(text)
+    private ThinkingBlock signedBlock(String thinking, byte[] signature) {
+        return ThinkingBlock.builder()
+                .thinking(thinking)
                 .metadata(Map.of(ContentBlockMetadataKeys.THOUGHT_SIGNATURE, signature))
                 .build();
     }
 
-    private byte[] signatureOf(TextBlock block) {
+    private byte[] signatureOf(ThinkingBlock block) {
         return (byte[]) block.getMetadata().get(ContentBlockMetadataKeys.THOUGHT_SIGNATURE);
     }
 }

--- a/agentscope-core/src/test/java/io/agentscope/core/message/TextBlockTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/message/TextBlockTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.core.message;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import io.agentscope.core.util.JsonUtils;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class TextBlockTest {
+
+    @Test
+    void shouldPreserveMetadataAcrossJsonRoundTrip() {
+        TextBlock original =
+                TextBlock.builder()
+                        .text("answer")
+                        .metadata(
+                                Map.of(ContentBlockMetadataKeys.THOUGHT_SIGNATURE, "c2lnbmF0dXJl"))
+                        .build();
+
+        String json = JsonUtils.getJsonCodec().toJson(original);
+        TextBlock restored = JsonUtils.getJsonCodec().fromJson(json, TextBlock.class);
+
+        assertEquals("answer", restored.getText());
+        assertEquals(
+                "c2lnbmF0dXJl",
+                restored.getMetadata().get(ContentBlockMetadataKeys.THOUGHT_SIGNATURE));
+    }
+
+    @Test
+    void shouldRemainBackwardCompatibleWithoutMetadata() {
+        TextBlock restored =
+                JsonUtils.getJsonCodec()
+                        .fromJson("{\"type\":\"text\",\"text\":\"answer\"}", TextBlock.class);
+        String serialized = JsonUtils.getJsonCodec().toJson(restored);
+
+        assertEquals("answer", restored.getText());
+        assertNull(restored.getMetadata());
+        assertFalse(serialized.contains("metadata"));
+    }
+}

--- a/agentscope-core/src/test/java/io/agentscope/core/message/TextBlockTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/message/TextBlockTest.java
@@ -54,4 +54,15 @@ class TextBlockTest {
         assertNull(restored.getMetadata());
         assertFalse(serialized.contains("metadata"));
     }
+
+    @Test
+    void shouldNormalizeNullTextFromBuilderAndJson() {
+        TextBlock built = TextBlock.builder().text(null).build();
+        TextBlock restored =
+                JsonUtils.getJsonCodec()
+                        .fromJson("{\"type\":\"text\",\"text\":null}", TextBlock.class);
+
+        assertEquals("", built.getText());
+        assertEquals("", restored.getText());
+    }
 }

--- a/agentscope-core/src/test/java/io/agentscope/core/model/GenerateOptionsTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/model/GenerateOptionsTest.java
@@ -41,6 +41,9 @@ class GenerateOptionsTest {
                         .maxTokens(4096)
                         .frequencyPenalty(0.3)
                         .presencePenalty(0.4)
+                        .thinkingBudget(2048)
+                        .includeThoughts(false)
+                        .thinkingLevel("high")
                         .build();
 
         assertNotNull(options);
@@ -49,6 +52,24 @@ class GenerateOptionsTest {
         assertEquals(4096, options.getMaxTokens());
         assertEquals(0.3, options.getFrequencyPenalty());
         assertEquals(0.4, options.getPresencePenalty());
+        assertEquals(2048, options.getThinkingBudget());
+        assertEquals(Boolean.FALSE, options.getIncludeThoughts());
+        assertEquals("high", options.getThinkingLevel());
+    }
+
+    @Test
+    @DisplayName("Should merge thinking options and preserve explicit false")
+    void testMergeThinkingOptions() {
+        GenerateOptions primary =
+                GenerateOptions.builder().includeThoughts(false).thinkingLevel("low").build();
+        GenerateOptions fallback =
+                GenerateOptions.builder().includeThoughts(true).thinkingBudget(4096).build();
+
+        GenerateOptions merged = GenerateOptions.mergeOptions(primary, fallback);
+
+        assertEquals(Boolean.FALSE, merged.getIncludeThoughts());
+        assertEquals(4096, merged.getThinkingBudget());
+        assertEquals("low", merged.getThinkingLevel());
     }
 
     @Test

--- a/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-gemini/src/main/java/io/agentscope/extensions/model/gemini/formatter/GeminiChatFormatter.java
+++ b/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-gemini/src/main/java/io/agentscope/extensions/model/gemini/formatter/GeminiChatFormatter.java
@@ -117,14 +117,30 @@ public class GeminiChatFormatter
                 defaultOptions,
                 configBuilder::presencePenalty);
 
-        // Apply ThinkingConfig if either includeThoughts or thinkingBudget is set
+        // Apply ThinkingConfig when any thinking option is configured.
         Integer thinkingBudget =
                 getOptionOrDefault(options, defaultOptions, GenerateOptions::getThinkingBudget);
+        Boolean includeThoughts =
+                getOptionOrDefault(options, defaultOptions, GenerateOptions::getIncludeThoughts);
+        String thinkingLevel =
+                getOptionOrDefault(options, defaultOptions, GenerateOptions::getThinkingLevel);
 
-        if (thinkingBudget != null) {
+        if (thinkingBudget != null || includeThoughts != null || thinkingLevel != null) {
             ThinkingConfig.Builder thinkingConfigBuilder = ThinkingConfig.builder();
-            thinkingConfigBuilder.includeThoughts(true);
-            thinkingConfigBuilder.thinkingBudget(thinkingBudget);
+
+            if (includeThoughts != null) {
+                thinkingConfigBuilder.includeThoughts(includeThoughts);
+            } else if (thinkingBudget != null) {
+                // Preserve the existing behavior for callers that only set thinkingBudget.
+                thinkingConfigBuilder.includeThoughts(true);
+            }
+            if (thinkingBudget != null) {
+                thinkingConfigBuilder.thinkingBudget(thinkingBudget);
+            }
+            if (thinkingLevel != null) {
+                thinkingConfigBuilder.thinkingLevel(thinkingLevel);
+            }
+
             configBuilder.thinkingConfig(thinkingConfigBuilder.build());
         }
     }

--- a/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-gemini/src/main/java/io/agentscope/extensions/model/gemini/formatter/GeminiMessageConverter.java
+++ b/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-gemini/src/main/java/io/agentscope/extensions/model/gemini/formatter/GeminiMessageConverter.java
@@ -52,6 +52,7 @@ import org.slf4j.LoggerFactory;
  * <p>This converter handles the core message transformation logic, including:
  * <ul>
  *   <li>Text blocks</li>
+ *   <li>Thinking blocks</li>
  *   <li>Tool use blocks (function_call)</li>
  *   <li>Tool result blocks (function_response as independent Content)</li>
  *   <li>Multimodal content (image, audio, video)</li>
@@ -88,10 +89,15 @@ public class GeminiMessageConverter {
 
         for (Msg msg : msgs) {
             List<Part> parts = new ArrayList<>();
+            boolean modelRole = msg.getRole() == MsgRole.ASSISTANT;
 
             for (ContentBlock block : msg.getContent()) {
                 if (block instanceof TextBlock tb) {
-                    parts.add(Part.builder().text(tb.getText()).build());
+                    Part.Builder partBuilder = Part.builder().text(tb.getText());
+                    if (modelRole) {
+                        GeminiThoughtSignatureUtils.applyMetadata(partBuilder, tb.getMetadata());
+                    }
+                    parts.add(partBuilder.build());
 
                 } else if (block instanceof ToolUseBlock tub) {
                     // Prioritize using content field (raw arguments string), fallback to input map
@@ -124,14 +130,8 @@ public class GeminiMessageConverter {
                     // Build Part with FunctionCall and optional thought signature
                     Part.Builder partBuilder = Part.builder().functionCall(functionCall);
 
-                    // Check for thought signature in metadata
-                    Map<String, Object> metadata = tub.getMetadata();
-                    if (metadata != null
-                            && metadata.containsKey(ToolUseBlock.METADATA_THOUGHT_SIGNATURE)) {
-                        Object signature = metadata.get(ToolUseBlock.METADATA_THOUGHT_SIGNATURE);
-                        if (signature instanceof byte[]) {
-                            partBuilder.thoughtSignature((byte[]) signature);
-                        }
+                    if (modelRole) {
+                        GeminiThoughtSignatureUtils.applyMetadata(partBuilder, tub.getMetadata());
                     }
 
                     parts.add(partBuilder.build());
@@ -179,9 +179,19 @@ public class GeminiMessageConverter {
                 } else if (block instanceof HintBlock hb) {
                     parts.add(Part.builder().text(hb.getHint()).build());
 
-                } else if (block instanceof ThinkingBlock) {
-                    log.debug("Skipping ThinkingBlock when formatting message for Gemini API");
-                    continue;
+                } else if (block instanceof ThinkingBlock thinkingBlock) {
+                    if (!modelRole) {
+                        log.debug(
+                                "Skipping ThinkingBlock from non-assistant message when formatting"
+                                        + " for Gemini API");
+                        continue;
+                    }
+
+                    Part.Builder partBuilder =
+                            Part.builder().text(thinkingBlock.getThinking()).thought(true);
+                    GeminiThoughtSignatureUtils.applyMetadata(
+                            partBuilder, thinkingBlock.getMetadata());
+                    parts.add(partBuilder.build());
 
                 } else {
                     log.warn(

--- a/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-gemini/src/main/java/io/agentscope/extensions/model/gemini/formatter/GeminiResponseParser.java
+++ b/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-gemini/src/main/java/io/agentscope/extensions/model/gemini/formatter/GeminiResponseParser.java
@@ -138,7 +138,7 @@ public class GeminiResponseParser {
             // Check for thinking content first (parts with thought=true flag)
             if (part.thought().isPresent() && part.thought().get() && part.text().isPresent()) {
                 String thinkingText = part.text().get();
-                if (thinkingText != null && (!thinkingText.isEmpty() || metadata != null)) {
+                if (!thinkingText.isEmpty() || metadata != null) {
                     blocks.add(
                             ThinkingBlock.builder()
                                     .thinking(thinkingText)
@@ -158,7 +158,7 @@ public class GeminiResponseParser {
             // Check for text content
             if (part.text().isPresent()) {
                 String text = part.text().get();
-                if (text != null && (!text.isEmpty() || metadata != null)) {
+                if (!text.isEmpty() || metadata != null) {
                     blocks.add(TextBlock.builder().text(text).metadata(metadata).build());
                 }
             }

--- a/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-gemini/src/main/java/io/agentscope/extensions/model/gemini/formatter/GeminiResponseParser.java
+++ b/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-gemini/src/main/java/io/agentscope/extensions/model/gemini/formatter/GeminiResponseParser.java
@@ -126,36 +126,41 @@ public class GeminiResponseParser {
     }
 
     /**
-     * Parse Gemini Part objects to AgentScope ContentBlocks.
-     * Order of block types: ThinkingBlock, TextBlock, ToolUseBlock
+     * Parse Gemini Part objects to AgentScope ContentBlocks while preserving Part order.
      *
      * @param parts List of Gemini Part objects
      * @param blocks List to add parsed ContentBlocks to
      */
     protected void parsePartsToBlocks(List<Part> parts, List<ContentBlock> blocks) {
         for (Part part : parts) {
+            Map<String, Object> metadata = GeminiThoughtSignatureUtils.extractMetadata(part);
+
             // Check for thinking content first (parts with thought=true flag)
             if (part.thought().isPresent() && part.thought().get() && part.text().isPresent()) {
                 String thinkingText = part.text().get();
-                if (thinkingText != null && !thinkingText.isEmpty()) {
-                    blocks.add(ThinkingBlock.builder().thinking(thinkingText).build());
+                if (thinkingText != null && (!thinkingText.isEmpty() || metadata != null)) {
+                    blocks.add(
+                            ThinkingBlock.builder()
+                                    .thinking(thinkingText)
+                                    .metadata(metadata)
+                                    .build());
                 }
+                continue;
+            }
+
+            // Check for function call (tool use)
+            if (part.functionCall().isPresent()) {
+                FunctionCall functionCall = part.functionCall().get();
+                parseToolCall(functionCall, metadata, blocks);
                 continue;
             }
 
             // Check for text content
             if (part.text().isPresent()) {
                 String text = part.text().get();
-                if (text != null && !text.isEmpty()) {
-                    blocks.add(TextBlock.builder().text(text).build());
+                if (text != null && (!text.isEmpty() || metadata != null)) {
+                    blocks.add(TextBlock.builder().text(text).metadata(metadata).build());
                 }
-            }
-
-            // Check for function call (tool use)
-            if (part.functionCall().isPresent()) {
-                FunctionCall functionCall = part.functionCall().get();
-                byte[] thoughtSignature = part.thoughtSignature().orElse(null);
-                parseToolCall(functionCall, thoughtSignature, blocks);
             }
         }
     }
@@ -164,11 +169,11 @@ public class GeminiResponseParser {
      * Parse Gemini FunctionCall to ToolUseBlock.
      *
      * @param functionCall Gemini FunctionCall object
-     * @param thoughtSignature Thought signature from the Part (may be null)
+     * @param metadata Provider-specific metadata from the Part (may be null)
      * @param blocks List to add parsed ToolUseBlock to
      */
     protected void parseToolCall(
-            FunctionCall functionCall, byte[] thoughtSignature, List<ContentBlock> blocks) {
+            FunctionCall functionCall, Map<String, Object> metadata, List<ContentBlock> blocks) {
         try {
             String id = functionCall.id().orElse("tool_call_" + System.currentTimeMillis());
             String name = functionCall.name().orElse("");
@@ -193,13 +198,6 @@ public class GeminiResponseParser {
                         log.warn("Failed to serialize function call arguments: {}", e.getMessage());
                     }
                 }
-            }
-
-            // Build metadata with thought signature if present
-            Map<String, Object> metadata = null;
-            if (thoughtSignature != null) {
-                metadata = new HashMap<>();
-                metadata.put(ToolUseBlock.METADATA_THOUGHT_SIGNATURE, thoughtSignature);
             }
 
             blocks.add(

--- a/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-gemini/src/main/java/io/agentscope/extensions/model/gemini/formatter/GeminiThoughtSignatureUtils.java
+++ b/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-gemini/src/main/java/io/agentscope/extensions/model/gemini/formatter/GeminiThoughtSignatureUtils.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.extensions.model.gemini.formatter;
+
+import com.google.genai.types.Part;
+import io.agentscope.core.formatter.FormatterException;
+import io.agentscope.core.message.ContentBlockMetadataKeys;
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.Map;
+
+/** Utilities for persisting and restoring Gemini thought signatures. */
+final class GeminiThoughtSignatureUtils {
+
+    private GeminiThoughtSignatureUtils() {}
+
+    /** Extract a Part signature into content block metadata. */
+    static Map<String, Object> extractMetadata(Part part) {
+        byte[] signature = part.thoughtSignature().orElse(null);
+        if (signature == null) {
+            return null;
+        }
+
+        Map<String, Object> metadata = new HashMap<>();
+        metadata.put(ContentBlockMetadataKeys.THOUGHT_SIGNATURE, signature.clone());
+        return metadata;
+    }
+
+    /** Restore a persisted signature onto a Gemini Part builder. */
+    static void applyMetadata(Part.Builder partBuilder, Map<String, Object> metadata) {
+        if (metadata == null || metadata.isEmpty()) {
+            return;
+        }
+
+        Object value = metadata.get(ContentBlockMetadataKeys.THOUGHT_SIGNATURE);
+        if (value == null) {
+            return;
+        }
+
+        if (value instanceof byte[] signature) {
+            partBuilder.thoughtSignature(signature.clone());
+            return;
+        }
+
+        if (!(value instanceof String encodedSignature)) {
+            throw new FormatterException(
+                    "Unsupported Gemini thought signature metadata type: "
+                            + value.getClass().getName());
+        }
+
+        if (encodedSignature.isEmpty()) {
+            throw new FormatterException("Gemini thought signature must not be empty");
+        }
+
+        try {
+            partBuilder.thoughtSignature(Base64.getDecoder().decode(encodedSignature));
+        } catch (IllegalArgumentException e) {
+            throw new FormatterException("Invalid Base64 Gemini thought signature", e);
+        }
+    }
+}

--- a/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-gemini/src/test/java/io/agentscope/extensions/model/gemini/formatter/GeminiChatFormatterTest.java
+++ b/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-gemini/src/test/java/io/agentscope/extensions/model/gemini/formatter/GeminiChatFormatterTest.java
@@ -16,6 +16,7 @@
 package io.agentscope.extensions.model.gemini.formatter;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -92,6 +93,59 @@ class GeminiChatFormatterTest {
 
         assertTrue(config.presencePenalty().isPresent());
         assertEquals(0.3f, config.presencePenalty().get(), 0.001f);
+    }
+
+    @Test
+    void testApplyThinkingBudgetPreservesLegacyIncludeThoughts() {
+        GenerateContentConfig.Builder configBuilder = GenerateContentConfig.builder();
+        GenerateOptions options = GenerateOptions.builder().thinkingBudget(2048).build();
+
+        formatter.applyOptions(configBuilder, options, null);
+
+        var thinkingConfig = configBuilder.build().thinkingConfig().orElseThrow();
+        assertEquals(2048, thinkingConfig.thinkingBudget().orElseThrow());
+        assertTrue(thinkingConfig.includeThoughts().orElseThrow());
+        assertFalse(thinkingConfig.thinkingLevel().isPresent());
+    }
+
+    @Test
+    void testApplyStandaloneIncludeThoughts() {
+        GenerateContentConfig.Builder configBuilder = GenerateContentConfig.builder();
+        GenerateOptions options = GenerateOptions.builder().includeThoughts(false).build();
+
+        formatter.applyOptions(configBuilder, options, null);
+
+        var thinkingConfig = configBuilder.build().thinkingConfig().orElseThrow();
+        assertFalse(thinkingConfig.includeThoughts().orElseThrow());
+        assertFalse(thinkingConfig.thinkingBudget().isPresent());
+        assertFalse(thinkingConfig.thinkingLevel().isPresent());
+    }
+
+    @Test
+    void testApplyThinkingLevel() {
+        GenerateContentConfig.Builder configBuilder = GenerateContentConfig.builder();
+        GenerateOptions options = GenerateOptions.builder().thinkingLevel("high").build();
+
+        formatter.applyOptions(configBuilder, options, null);
+
+        var thinkingConfig = configBuilder.build().thinkingConfig().orElseThrow();
+        assertEquals("high", thinkingConfig.thinkingLevel().orElseThrow().toString());
+        assertFalse(thinkingConfig.includeThoughts().isPresent());
+        assertFalse(thinkingConfig.thinkingBudget().isPresent());
+    }
+
+    @Test
+    void testExplicitIncludeThoughtsOverridesDefaultAndLegacyBehavior() {
+        GenerateContentConfig.Builder configBuilder = GenerateContentConfig.builder();
+        GenerateOptions options = GenerateOptions.builder().includeThoughts(false).build();
+        GenerateOptions defaults =
+                GenerateOptions.builder().thinkingBudget(4096).includeThoughts(true).build();
+
+        formatter.applyOptions(configBuilder, options, defaults);
+
+        var thinkingConfig = configBuilder.build().thinkingConfig().orElseThrow();
+        assertFalse(thinkingConfig.includeThoughts().orElseThrow());
+        assertEquals(4096, thinkingConfig.thinkingBudget().orElseThrow());
     }
 
     @Test

--- a/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-gemini/src/test/java/io/agentscope/extensions/model/gemini/formatter/GeminiMessageConverterTest.java
+++ b/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-gemini/src/test/java/io/agentscope/extensions/model/gemini/formatter/GeminiMessageConverterTest.java
@@ -553,6 +553,49 @@ class GeminiMessageConverterTest {
     }
 
     @Test
+    @DisplayName("Should skip ThinkingBlock from a non-assistant message")
+    void testSkipThinkingBlockFromNonAssistantMessage() {
+        Msg msg =
+                Msg.builder()
+                        .name("tool")
+                        .content(
+                                List.of(
+                                        ThinkingBlock.builder()
+                                                .thinking("Internal reasoning")
+                                                .build()))
+                        .role(MsgRole.TOOL)
+                        .build();
+
+        List<Content> result = converter.convertMessages(List.of(msg));
+
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    @DisplayName("Should not apply tool thoughtSignature to a non-assistant message")
+    void testIgnoreToolUseSignatureFromNonAssistantMessage() {
+        byte[] signature = "signature".getBytes();
+        ToolUseBlock toolUseBlock =
+                ToolUseBlock.builder()
+                        .id("call_123")
+                        .name("search")
+                        .input(Map.of("query", "AgentScope"))
+                        .metadata(Map.of(ToolUseBlock.METADATA_THOUGHT_SIGNATURE, signature))
+                        .build();
+        Msg msg =
+                Msg.builder()
+                        .name("tool")
+                        .content(List.of(toolUseBlock))
+                        .role(MsgRole.TOOL)
+                        .build();
+
+        List<Content> result = converter.convertMessages(List.of(msg));
+
+        assertEquals("user", result.get(0).role().orElseThrow());
+        assertFalse(result.get(0).parts().orElseThrow().get(0).thoughtSignature().isPresent());
+    }
+
+    @Test
     @DisplayName("Should handle mixed content types")
     void testMixedContentTypes() {
         String base64Data = Base64.getEncoder().encodeToString("fake image".getBytes());

--- a/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-gemini/src/test/java/io/agentscope/extensions/model/gemini/formatter/GeminiMessageConverterTest.java
+++ b/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-gemini/src/test/java/io/agentscope/extensions/model/gemini/formatter/GeminiMessageConverterTest.java
@@ -506,8 +506,8 @@ class GeminiMessageConverterTest {
     }
 
     @Test
-    @DisplayName("Should skip ThinkingBlock")
-    void testSkipThinkingBlock() {
+    @DisplayName("Should convert ThinkingBlock to a thought Part")
+    void testConvertThinkingBlock() {
         ThinkingBlock thinkingBlock =
                 ThinkingBlock.builder().thinking("Internal reasoning").build();
 
@@ -525,13 +525,15 @@ class GeminiMessageConverterTest {
 
         assertEquals(1, result.size());
         Content content = result.get(0);
-        assertEquals(1, content.parts().get().size());
-        assertEquals("Visible response", content.parts().get().get(0).text().get());
+        assertEquals(2, content.parts().get().size());
+        assertEquals("Internal reasoning", content.parts().get().get(0).text().get());
+        assertTrue(content.parts().get().get(0).thought().orElse(false));
+        assertEquals("Visible response", content.parts().get().get(1).text().get());
     }
 
     @Test
-    @DisplayName("Should skip message with only ThinkingBlock")
-    void testSkipMessageWithOnlyThinkingBlock() {
+    @DisplayName("Should convert message with only ThinkingBlock")
+    void testConvertMessageWithOnlyThinkingBlock() {
         ThinkingBlock thinkingBlock =
                 ThinkingBlock.builder().thinking("Internal reasoning").build();
 
@@ -544,7 +546,10 @@ class GeminiMessageConverterTest {
 
         List<Content> result = converter.convertMessages(List.of(msg));
 
-        assertTrue(result.isEmpty());
+        assertEquals(1, result.size());
+        Part part = result.get(0).parts().orElseThrow().get(0);
+        assertEquals("Internal reasoning", part.text().orElseThrow());
+        assertTrue(part.thought().orElse(false));
     }
 
     @Test

--- a/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-gemini/src/test/java/io/agentscope/extensions/model/gemini/formatter/GeminiResponseParserTest.java
+++ b/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-gemini/src/test/java/io/agentscope/extensions/model/gemini/formatter/GeminiResponseParserTest.java
@@ -28,11 +28,13 @@ import com.google.genai.types.GenerateContentResponse;
 import com.google.genai.types.GenerateContentResponseUsageMetadata;
 import com.google.genai.types.Part;
 import io.agentscope.core.message.ContentBlock;
+import io.agentscope.core.message.ContentBlockMetadataKeys;
 import io.agentscope.core.message.TextBlock;
 import io.agentscope.core.message.ThinkingBlock;
 import io.agentscope.core.message.ToolUseBlock;
 import io.agentscope.core.model.ChatResponse;
 import io.agentscope.core.model.ChatUsage;
+import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.HashMap;
 import java.util.List;
@@ -110,6 +112,56 @@ class GeminiResponseParserTest {
         ContentBlock block2 = chatResponse.getContent().get(1);
         assertInstanceOf(TextBlock.class, block2);
         assertEquals("The answer is 42.", ((TextBlock) block2).getText());
+    }
+
+    @Test
+    void testParseTextAndThinkingThoughtSignatures() {
+        byte[] thinkingSignature = "thinking-signature".getBytes(StandardCharsets.UTF_8);
+        byte[] textSignature = "text-signature".getBytes(StandardCharsets.UTF_8);
+        Part thinkingPart =
+                Part.builder()
+                        .text("Let me think.")
+                        .thought(true)
+                        .thoughtSignature(thinkingSignature)
+                        .build();
+        Part textPart = Part.builder().text("The answer.").thoughtSignature(textSignature).build();
+        Content content =
+                Content.builder().role("model").parts(List.of(thinkingPart, textPart)).build();
+        GenerateContentResponse response =
+                GenerateContentResponse.builder()
+                        .candidates(List.of(Candidate.builder().content(content).build()))
+                        .build();
+
+        ChatResponse chatResponse = parser.parseResponse(response, startTime);
+
+        ThinkingBlock thinking = (ThinkingBlock) chatResponse.getContent().get(0);
+        TextBlock text = (TextBlock) chatResponse.getContent().get(1);
+        assertArrayEquals(
+                thinkingSignature,
+                (byte[]) thinking.getMetadata().get(ContentBlockMetadataKeys.THOUGHT_SIGNATURE));
+        assertArrayEquals(
+                textSignature,
+                (byte[]) text.getMetadata().get(ContentBlockMetadataKeys.THOUGHT_SIGNATURE));
+    }
+
+    @Test
+    void testParseEmptyTextPartWithThoughtSignature() {
+        byte[] signature = "signature-only-chunk".getBytes(StandardCharsets.UTF_8);
+        Part part = Part.builder().text("").thoughtSignature(signature).build();
+        Content content = Content.builder().role("model").parts(List.of(part)).build();
+        GenerateContentResponse response =
+                GenerateContentResponse.builder()
+                        .candidates(List.of(Candidate.builder().content(content).build()))
+                        .build();
+
+        ChatResponse chatResponse = parser.parseResponse(response, startTime);
+
+        assertEquals(1, chatResponse.getContent().size());
+        TextBlock text = (TextBlock) chatResponse.getContent().get(0);
+        assertEquals("", text.getText());
+        assertArrayEquals(
+                signature,
+                (byte[]) text.getMetadata().get(ContentBlockMetadataKeys.THOUGHT_SIGNATURE));
     }
 
     @Test

--- a/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-gemini/src/test/java/io/agentscope/extensions/model/gemini/formatter/GeminiResponseParserTest.java
+++ b/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-gemini/src/test/java/io/agentscope/extensions/model/gemini/formatter/GeminiResponseParserTest.java
@@ -165,6 +165,61 @@ class GeminiResponseParserTest {
     }
 
     @Test
+    void testParseEmptyThinkingPartWithThoughtSignature() {
+        byte[] signature = "thinking-signature-only".getBytes(StandardCharsets.UTF_8);
+        Part part = Part.builder().text("").thought(true).thoughtSignature(signature).build();
+        Content content = Content.builder().role("model").parts(List.of(part)).build();
+        GenerateContentResponse response =
+                GenerateContentResponse.builder()
+                        .candidates(List.of(Candidate.builder().content(content).build()))
+                        .build();
+
+        ChatResponse chatResponse = parser.parseResponse(response, startTime);
+
+        assertEquals(1, chatResponse.getContent().size());
+        ThinkingBlock thinking = (ThinkingBlock) chatResponse.getContent().get(0);
+        assertEquals("", thinking.getThinking());
+        assertArrayEquals(
+                signature,
+                (byte[]) thinking.getMetadata().get(ContentBlockMetadataKeys.THOUGHT_SIGNATURE));
+    }
+
+    @Test
+    void testSkipEmptyTextAndThinkingPartsWithoutThoughtSignature() {
+        Part thinkingPart = Part.builder().text("").thought(true).build();
+        Part textPart = Part.builder().text("").build();
+        Part thoughtFlagOnlyPart = Part.builder().thought(true).build();
+        Content content =
+                Content.builder()
+                        .role("model")
+                        .parts(List.of(thinkingPart, textPart, thoughtFlagOnlyPart))
+                        .build();
+        GenerateContentResponse response =
+                GenerateContentResponse.builder()
+                        .candidates(List.of(Candidate.builder().content(content).build()))
+                        .build();
+
+        ChatResponse chatResponse = parser.parseResponse(response, startTime);
+
+        assertTrue(chatResponse.getContent().isEmpty());
+    }
+
+    @Test
+    void testParseTextPartWithExplicitFalseThoughtFlag() {
+        Part part = Part.builder().text("Visible answer").thought(false).build();
+        Content content = Content.builder().role("model").parts(List.of(part)).build();
+        GenerateContentResponse response =
+                GenerateContentResponse.builder()
+                        .candidates(List.of(Candidate.builder().content(content).build()))
+                        .build();
+
+        ChatResponse chatResponse = parser.parseResponse(response, startTime);
+
+        assertEquals(1, chatResponse.getContent().size());
+        assertEquals("Visible answer", ((TextBlock) chatResponse.getContent().get(0)).getText());
+    }
+
+    @Test
     void testParseToolCallResponse() {
         // Build response with function call
         Map<String, Object> args = new HashMap<>();

--- a/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-gemini/src/test/java/io/agentscope/extensions/model/gemini/formatter/GeminiThoughtSignatureLifecycleTest.java
+++ b/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-gemini/src/test/java/io/agentscope/extensions/model/gemini/formatter/GeminiThoughtSignatureLifecycleTest.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.extensions.model.gemini.formatter;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.google.genai.types.Candidate;
+import com.google.genai.types.Content;
+import com.google.genai.types.FunctionCall;
+import com.google.genai.types.GenerateContentResponse;
+import com.google.genai.types.Part;
+import io.agentscope.core.agent.accumulator.ReasoningContext;
+import io.agentscope.core.formatter.FormatterException;
+import io.agentscope.core.message.AssistantMessage;
+import io.agentscope.core.message.ContentBlockMetadataKeys;
+import io.agentscope.core.message.Msg;
+import io.agentscope.core.message.TextBlock;
+import io.agentscope.core.model.ChatResponse;
+import io.agentscope.core.util.JsonUtils;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class GeminiThoughtSignatureLifecycleTest {
+
+    private final GeminiResponseParser parser = new GeminiResponseParser();
+    private final GeminiMessageConverter converter = new GeminiMessageConverter();
+
+    @Test
+    void shouldPreserveSignaturesThroughStreamingMemoryAndJsonRoundTrip() {
+        byte[] thinkingSignature = "thinking-signature".getBytes(StandardCharsets.UTF_8);
+        byte[] textSignature = "text-signature".getBytes(StandardCharsets.UTF_8);
+        byte[] toolSignature = "tool-signature".getBytes(StandardCharsets.UTF_8);
+
+        Part thinkingPart =
+                Part.builder()
+                        .text("Thinking")
+                        .thought(true)
+                        .thoughtSignature(thinkingSignature)
+                        .build();
+        Part textPart = Part.builder().text("Answer").thoughtSignature(textSignature).build();
+        FunctionCall functionCall =
+                FunctionCall.builder()
+                        .id("call-1")
+                        .name("search")
+                        .args(Map.of("query", "AgentScope"))
+                        .build();
+        Part toolPart =
+                Part.builder().functionCall(functionCall).thoughtSignature(toolSignature).build();
+        Content modelContent =
+                Content.builder()
+                        .role("model")
+                        .parts(List.of(thinkingPart, textPart, toolPart))
+                        .build();
+        GenerateContentResponse response =
+                GenerateContentResponse.builder()
+                        .responseId("response-1")
+                        .candidates(List.of(Candidate.builder().content(modelContent).build()))
+                        .build();
+
+        ChatResponse parsed = parser.parseResponse(response, Instant.now());
+        ReasoningContext reasoningContext = new ReasoningContext("assistant");
+        reasoningContext.processChunk(parsed);
+        Msg accumulated = reasoningContext.buildFinalMessage();
+        String json = JsonUtils.getJsonCodec().toJson(accumulated);
+        Msg restored = JsonUtils.getJsonCodec().fromJson(json, Msg.class);
+
+        List<Part> replayedParts =
+                converter.convertMessages(List.of(restored)).get(0).parts().orElseThrow();
+
+        assertEquals(3, replayedParts.size());
+        assertArrayEquals(thinkingSignature, replayedParts.get(0).thoughtSignature().orElseThrow());
+        assertArrayEquals(textSignature, replayedParts.get(1).thoughtSignature().orElseThrow());
+        assertArrayEquals(toolSignature, replayedParts.get(2).thoughtSignature().orElseThrow());
+    }
+
+    @Test
+    void shouldRejectInvalidBase64Signature() {
+        Msg message =
+                AssistantMessage.builder()
+                        .content(
+                                TextBlock.builder()
+                                        .text("Answer")
+                                        .metadata(
+                                                Map.of(
+                                                        ContentBlockMetadataKeys.THOUGHT_SIGNATURE,
+                                                        "not-valid-base64!"))
+                                        .build())
+                        .build();
+
+        assertThrows(FormatterException.class, () -> converter.convertMessages(List.of(message)));
+    }
+}

--- a/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-gemini/src/test/java/io/agentscope/extensions/model/gemini/formatter/GeminiThoughtSignatureLifecycleTest.java
+++ b/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-gemini/src/test/java/io/agentscope/extensions/model/gemini/formatter/GeminiThoughtSignatureLifecycleTest.java
@@ -92,6 +92,47 @@ class GeminiThoughtSignatureLifecycleTest {
     }
 
     @Test
+    void shouldPreserveDistinctSignaturesOnMultipleTextParts() {
+        byte[] firstSignature = "first-signature".getBytes(StandardCharsets.UTF_8);
+        byte[] secondSignature = "second-signature".getBytes(StandardCharsets.UTF_8);
+        Content modelContent =
+                Content.builder()
+                        .role("model")
+                        .parts(
+                                List.of(
+                                        Part.builder()
+                                                .text("First")
+                                                .thoughtSignature(firstSignature)
+                                                .build(),
+                                        Part.builder()
+                                                .text("Second")
+                                                .thoughtSignature(secondSignature)
+                                                .build()))
+                        .build();
+        GenerateContentResponse response =
+                GenerateContentResponse.builder()
+                        .responseId("response-multiple-text-parts")
+                        .candidates(List.of(Candidate.builder().content(modelContent).build()))
+                        .build();
+
+        ChatResponse parsed = parser.parseResponse(response, Instant.now());
+        ReasoningContext reasoningContext = new ReasoningContext("assistant");
+        reasoningContext.processChunk(parsed);
+        Msg accumulated = reasoningContext.buildFinalMessage();
+        String json = JsonUtils.getJsonCodec().toJson(accumulated);
+        Msg restored = JsonUtils.getJsonCodec().fromJson(json, Msg.class);
+
+        List<Part> replayedParts =
+                converter.convertMessages(List.of(restored)).get(0).parts().orElseThrow();
+
+        assertEquals(2, replayedParts.size());
+        assertEquals("First", replayedParts.get(0).text().orElseThrow());
+        assertEquals("Second", replayedParts.get(1).text().orElseThrow());
+        assertArrayEquals(firstSignature, replayedParts.get(0).thoughtSignature().orElseThrow());
+        assertArrayEquals(secondSignature, replayedParts.get(1).thoughtSignature().orElseThrow());
+    }
+
+    @Test
     void shouldRejectInvalidBase64Signature() {
         Msg message =
                 AssistantMessage.builder()

--- a/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-gemini/src/test/java/io/agentscope/extensions/model/gemini/formatter/GeminiThoughtSignatureUtilsTest.java
+++ b/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-gemini/src/test/java/io/agentscope/extensions/model/gemini/formatter/GeminiThoughtSignatureUtilsTest.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.extensions.model.gemini.formatter;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.google.genai.types.Part;
+import io.agentscope.core.formatter.FormatterException;
+import io.agentscope.core.message.ContentBlockMetadataKeys;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class GeminiThoughtSignatureUtilsTest {
+
+    @Test
+    void shouldReturnNullMetadataWhenPartHasNoSignature() {
+        assertNull(
+                GeminiThoughtSignatureUtils.extractMetadata(Part.builder().text("text").build()));
+    }
+
+    @Test
+    void shouldExtractDefensiveSignatureCopy() {
+        byte[] signature = "signature".getBytes(StandardCharsets.UTF_8);
+        Part part = Part.builder().thoughtSignature(signature).build();
+
+        Map<String, Object> metadata = GeminiThoughtSignatureUtils.extractMetadata(part);
+        byte[] extracted = (byte[]) metadata.get(ContentBlockMetadataKeys.THOUGHT_SIGNATURE);
+
+        assertArrayEquals(signature, extracted);
+        assertNotSame(part.thoughtSignature().orElseThrow(), extracted);
+    }
+
+    @Test
+    void shouldIgnoreAbsentSignatureMetadata() {
+        Part.Builder nullMetadataBuilder = Part.builder().text("text");
+        Part.Builder emptyMetadataBuilder = Part.builder().text("text");
+        Part.Builder unrelatedMetadataBuilder = Part.builder().text("text");
+        Part.Builder nullValueBuilder = Part.builder().text("text");
+        Map<String, Object> nullValueMetadata = new HashMap<>();
+        nullValueMetadata.put(ContentBlockMetadataKeys.THOUGHT_SIGNATURE, null);
+
+        GeminiThoughtSignatureUtils.applyMetadata(nullMetadataBuilder, null);
+        GeminiThoughtSignatureUtils.applyMetadata(emptyMetadataBuilder, Map.of());
+        GeminiThoughtSignatureUtils.applyMetadata(
+                unrelatedMetadataBuilder, Map.of("provider", "gemini"));
+        GeminiThoughtSignatureUtils.applyMetadata(nullValueBuilder, nullValueMetadata);
+
+        assertFalse(nullMetadataBuilder.build().thoughtSignature().isPresent());
+        assertFalse(emptyMetadataBuilder.build().thoughtSignature().isPresent());
+        assertFalse(unrelatedMetadataBuilder.build().thoughtSignature().isPresent());
+        assertFalse(nullValueBuilder.build().thoughtSignature().isPresent());
+    }
+
+    @Test
+    void shouldApplyDefensiveByteArrayCopy() {
+        byte[] signature = "signature".getBytes(StandardCharsets.UTF_8);
+        byte[] expected = signature.clone();
+        Part.Builder partBuilder = Part.builder().text("text");
+
+        GeminiThoughtSignatureUtils.applyMetadata(
+                partBuilder, Map.of(ContentBlockMetadataKeys.THOUGHT_SIGNATURE, signature));
+        signature[0] = (byte) (signature[0] + 1);
+
+        assertArrayEquals(expected, partBuilder.build().thoughtSignature().orElseThrow());
+    }
+
+    @Test
+    void shouldDecodeBase64Signature() {
+        byte[] signature = "signature".getBytes(StandardCharsets.UTF_8);
+        String encoded = Base64.getEncoder().encodeToString(signature);
+        Part.Builder partBuilder = Part.builder().text("text");
+
+        GeminiThoughtSignatureUtils.applyMetadata(
+                partBuilder, Map.of(ContentBlockMetadataKeys.THOUGHT_SIGNATURE, encoded));
+
+        assertArrayEquals(signature, partBuilder.build().thoughtSignature().orElseThrow());
+    }
+
+    @Test
+    void shouldRejectUnsupportedSignatureType() {
+        Part.Builder partBuilder = Part.builder().text("text");
+
+        FormatterException exception =
+                assertThrows(
+                        FormatterException.class,
+                        () ->
+                                GeminiThoughtSignatureUtils.applyMetadata(
+                                        partBuilder,
+                                        Map.of(ContentBlockMetadataKeys.THOUGHT_SIGNATURE, 123)));
+
+        assertEquals(
+                "Unsupported Gemini thought signature metadata type: java.lang.Integer",
+                exception.getMessage());
+    }
+
+    @Test
+    void shouldRejectEmptySignature() {
+        Part.Builder partBuilder = Part.builder().text("text");
+
+        FormatterException exception =
+                assertThrows(
+                        FormatterException.class,
+                        () ->
+                                GeminiThoughtSignatureUtils.applyMetadata(
+                                        partBuilder,
+                                        Map.of(ContentBlockMetadataKeys.THOUGHT_SIGNATURE, "")));
+
+        assertEquals("Gemini thought signature must not be empty", exception.getMessage());
+    }
+
+    @Test
+    void shouldRejectInvalidBase64Signature() {
+        Part.Builder partBuilder = Part.builder().text("text");
+
+        FormatterException exception =
+                assertThrows(
+                        FormatterException.class,
+                        () ->
+                                GeminiThoughtSignatureUtils.applyMetadata(
+                                        partBuilder,
+                                        Map.of(
+                                                ContentBlockMetadataKeys.THOUGHT_SIGNATURE,
+                                                "not-valid-base64!")));
+
+        assertEquals("Invalid Base64 Gemini thought signature", exception.getMessage());
+    }
+}

--- a/docs/v2/en/integration/model/gemini-request-flow.md
+++ b/docs/v2/en/integration/model/gemini-request-flow.md
@@ -1,0 +1,92 @@
+# Gemini End-to-End Request Flow
+
+This diagram follows one streaming Gemini request from the user's question to the final answer. The tool-call and history-replay branches are part of the same request loop: when the model asks for a tool, the Agent executes it and calls the model again with the tool result.
+
+```{mermaid}
+flowchart TD
+    U(["User question"]) --> APP["Application receives input"]
+    APP --> AGENT["ReActAgent.call(...) / streamEvents(...)"]
+    AGENT --> HISTORY["Load conversation history, tools, and GenerateOptions"]
+    HISTORY --> MODEL["ChatModelBase.stream(...)<br/>-> GeminiChatModel.doStream(...)"]
+
+    subgraph REQUEST["Request preparation"]
+        MODEL --> BUILDER["Create GenerateContentConfig.Builder"]
+        BUILDER --> FORMAT["formatter.format(messages)"]
+        FORMAT --> CONVERT["GeminiMessageConverter.convertMessages(...)"]
+        CONVERT --> CONTENT["Build Gemini Content / Part<br/>Text / Thinking / FunctionCall<br/>Restore thoughtSignature on assistant Parts"]
+        CONTENT --> TOOLS["formatter.applyTools(...)<br/>Apply ToolChoice when configured"]
+        TOOLS --> OPTIONS["GeminiChatFormatter.applyOptions(...)"]
+        OPTIONS --> THINKING["Build ThinkingConfig by field<br/>thinkingBudget / thinkingLevel / includeThoughts"]
+        THINKING --> CONFIG["configBuilder.build()<br/>Create GenerateContentConfig"]
+    end
+
+    CONFIG --> SDK["Google Gen AI Client<br/>generateContentStream(...)"]
+    SDK --> API(["Gemini API"])
+
+    subgraph RESPONSE["Response processing"]
+        API --> STREAM["ResponseStream&lt;GenerateContentResponse&gt;"]
+        STREAM --> PARSER["GeminiResponseParser.parseResponse(...)"]
+        PARSER --> BLOCKS["ChatResponse content blocks<br/>ThinkingBlock / TextBlock / ToolUseBlock<br/>with thoughtSignature metadata"]
+        BLOCKS --> ACC["ReasoningContext.processChunk(...)"]
+        ACC --> LIVE["Live streaming events / UI output"]
+        ACC --> FINAL["ReasoningContext.buildFinalMessage()<br/>Aggregate Thinking / Text / ToolUse"]
+        FINAL --> STATE["Write this AssistantMessage to AgentState / context"]
+        STATE --> ROUND{"Does this message contain ToolUseBlock?"}
+    end
+
+    ROUND -->|Yes| EXEC["Execute the ToolUseBlock tool"]
+    EXEC --> RESULT["Create ToolResultBlock"]
+    RESULT --> APPEND["Write the ToolResultBlock to AgentState / context"]
+    APPEND -. Next model request .-> MODEL
+
+    ROUND -->|No| RESULT_MSG["AgentResultEvent / final Msg"]
+    RESULT_MSG --> SAVE["After doCall, saveStateToSession(...)"]
+    SAVE --> PERSIST{"Is cross-process state persistence configured?"}
+    PERSIST -->|No| ANSWER(["Return final answer to user"])
+    PERSIST -->|Yes| JSON["Serialize Msg as JSON<br/>byte[] thoughtSignature -> Base64 String"]
+    JSON --> ANSWER
+    JSON --> RESTORE["Read and deserialize Msg on the next turn"]
+    RESTORE -. Next request .-> MODEL
+
+    classDef input fill:#e3f2fd,stroke:#1976d2,color:#0d47a1
+    classDef core fill:#fff3e0,stroke:#ef6c00,color:#4e342e
+    classDef gemini fill:#e8f5e9,stroke:#2e7d32,color:#1b5e20
+    classDef state fill:#f3e5f5,stroke:#7b1fa2,color:#4a148c
+    classDef decision fill:#fffde7,stroke:#f9a825,color:#5d4037
+    classDef terminal fill:#e0f2f1,stroke:#00796b,color:#004d40
+
+    class U input
+    class ANSWER terminal
+    class APP,AGENT,HISTORY,MODEL,BUILDER,FORMAT,CONVERT,TOOLS,OPTIONS,THINKING,CONFIG core
+    class CONTENT,SDK,API,STREAM,PARSER,BLOCKS gemini
+    class ACC,LIVE,FINAL,STATE,EXEC,RESULT,APPEND,RESULT_MSG,SAVE,JSON,RESTORE state
+    class ROUND,PERSIST decision
+```
+
+Legend: blue is user input, teal is the final output, orange is the Agent and request preparation, green is Gemini/SDK, purple is accumulated state, and yellow is a branch decision.
+
+## Key Nodes and Source Code
+
+| Flow node | Main implementation | Responsibility |
+| --- | --- | --- |
+| Model entry point | `ChatModelBase.stream` -> `GeminiChatModel.doStream` | The public `stream` entry reaches Gemini's implementation, which builds request configuration, formats messages, and calls the Google Gen AI SDK |
+| Request option mapping | `GeminiChatFormatter.applyOptions` | Maps `GenerateOptions` to `GenerateContentConfig` |
+| Message conversion | `GeminiMessageConverter.convertMessages` | Converts `Msg` objects to Gemini `Content` and `Part` objects |
+| Response parsing | `GeminiResponseParser.parseResponse` | Converts each Gemini response chunk to `ChatResponse` |
+| Streaming aggregation | `ReasoningContext.processChunk` | Aggregates text, thinking, and tool calls while emitting live messages |
+| Signature restoration | `GeminiThoughtSignatureUtils` | Converts between in-memory `byte[]` and Base64 strings after JSON persistence |
+
+## Three Completion Paths
+
+1. **Ordinary answer**: When there is no `ToolUseBlock`, the Agent aggregates the final message and returns the text to the user.
+2. **Tool call**: The model returns a `ToolUseBlock`; the Agent executes the tool, adds a `ToolResultBlock` to history, and starts another model turn.
+3. **Persistent history**: After a `Msg` is serialized as JSON, the Gemini signature becomes a Base64 string. The next request restores it to the `byte[]` required by the SDK.
+
+## Thinking and Signatures
+
+- `thinkingBudget`, `thinkingLevel`, and `includeThoughts` enter `ThinkingConfig` during request preparation.
+- Gemini thinking Parts become `ThinkingBlock` objects, ordinary text Parts become `TextBlock` objects, and function-call Parts become `ToolUseBlock` objects.
+- `thoughtSignature` belongs to a Part, not only to tool calls; parsing, streaming aggregation, and JSON round trips must preserve it.
+- Historical assistant `ThinkingBlock`, signed `TextBlock`, and signed `ToolUseBlock` objects are regenerated as their corresponding Gemini Parts on the next request.
+
+The multi-agent formatter rewrites ordinary multi-agent history into tagged user text, so an original signature cannot be attached to rewritten content. Exact tool sequences still use the same Part replay path.

--- a/docs/v2/en/integration/model/gemini.md
+++ b/docs/v2/en/integration/model/gemini.md
@@ -37,6 +37,29 @@ GeminiChatModel model = GeminiChatModel.builder()
     .build();
 ```
 
+## Thinking
+
+Gemini thinking is configured through `GenerateOptions`:
+
+```java
+import io.agentscope.core.model.GenerateOptions;
+
+GenerateOptions thinkingOptions = GenerateOptions.builder()
+    .thinkingLevel("high")
+    .includeThoughts(true)
+    .build();
+```
+
+- `thinkingBudget(Integer)` sets a token budget for models that support budget-based thinking.
+- `thinkingLevel(String)` sets a model-supported level such as `"minimal"`, `"low"`, `"medium"`, or `"high"`.
+- `includeThoughts(Boolean)` independently controls whether thoughts are included in the response.
+
+Use either `thinkingBudget` or `thinkingLevel` according to the selected model. For backward compatibility, setting only `thinkingBudget` also enables `includeThoughts`; setting `includeThoughts` explicitly always takes precedence.
+
+The chat formatter replays historical assistant `ThinkingBlock` content and preserves Gemini `thoughtSignature` values on thinking, text, and tool-call parts, including after message JSON serialization. Keep content-block metadata intact when storing or transforming conversation history.
+
+See [Gemini End-to-End Request Flow](gemini-request-flow.md) for the complete single-request path.
+
 ## Spring Boot
 
 Spring Boot applications can use the Gemini starter:

--- a/docs/v2/zh/integration/model/gemini-request-flow.md
+++ b/docs/v2/zh/integration/model/gemini-request-flow.md
@@ -1,0 +1,92 @@
+# Gemini 完整请求流程
+
+本文以一次启用流式输出的 Gemini 请求为例，展示从用户输入问题到最终回答返回的完整链路。图中的工具调用分支和历史消息回放分支属于同一个请求循环：如果模型请求工具，Agent 执行工具后会带着工具结果再次调用模型。
+
+```{mermaid}
+flowchart TD
+    U(["用户输入问题"]) --> APP["应用层接收输入"]
+    APP --> AGENT["ReActAgent.call(...) / streamEvents(...)"]
+    AGENT --> HISTORY["读取会话历史、工具定义和 GenerateOptions"]
+    HISTORY --> MODEL["ChatModelBase.stream(...)<br/>-> GeminiChatModel.doStream(...)"]
+
+    subgraph REQUEST["请求准备"]
+        MODEL --> BUILDER["创建 GenerateContentConfig.Builder"]
+        BUILDER --> FORMAT["formatter.format(messages)"]
+        FORMAT --> CONVERT["GeminiMessageConverter.convertMessages(...)"]
+        CONVERT --> CONTENT["构造 Gemini Content / Part<br/>Text / Thinking / FunctionCall<br/>恢复 assistant Part 的 thoughtSignature"]
+        CONTENT --> TOOLS["formatter.applyTools(...)<br/>必要时设置 ToolChoice"]
+        TOOLS --> OPTIONS["GeminiChatFormatter.applyOptions(...)"]
+        OPTIONS --> THINKING["按字段创建 ThinkingConfig<br/>thinkingBudget / thinkingLevel / includeThoughts"]
+        THINKING --> CONFIG["configBuilder.build()<br/>得到 GenerateContentConfig"]
+    end
+
+    CONFIG --> SDK["Google GenAI Client<br/>generateContentStream(...)"]
+    SDK --> API(["Gemini API"])
+
+    subgraph RESPONSE["响应处理"]
+        API --> STREAM["ResponseStream&lt;GenerateContentResponse&gt;"]
+        STREAM --> PARSER["GeminiResponseParser.parseResponse(...)"]
+        PARSER --> BLOCKS["ChatResponse 内容块<br/>ThinkingBlock / TextBlock / ToolUseBlock<br/>附带 thoughtSignature metadata"]
+        BLOCKS --> ACC["ReasoningContext.processChunk(...)"]
+        ACC --> LIVE["实时流式事件 / UI 输出"]
+        ACC --> FINAL["ReasoningContext.buildFinalMessage()<br/>聚合 Thinking / Text / ToolUse"]
+        FINAL --> STATE["将本轮 AssistantMessage 写入 AgentState / context"]
+        STATE --> ROUND{"本轮消息是否包含 ToolUseBlock？"}
+    end
+
+    ROUND -->|是| EXEC["执行 ToolUseBlock 对应工具"]
+    EXEC --> RESULT["生成 ToolResultBlock"]
+    RESULT --> APPEND["将 ToolResultBlock 写入 AgentState / context"]
+    APPEND -. 下一轮模型请求 .-> MODEL
+
+    ROUND -->|否| RESULT_MSG["AgentResultEvent / 最终 Msg"]
+    RESULT_MSG --> SAVE["doCall 完成后 saveStateToSession(...)"]
+    SAVE --> PERSIST{"是否配置跨进程状态持久化？"}
+    PERSIST -->|否| ANSWER(["返回最终回答给用户"])
+    PERSIST -->|是| JSON["JSON 序列化保存 Msg<br/>byte[] thoughtSignature -> Base64 String"]
+    JSON --> ANSWER
+    JSON --> RESTORE["下一轮读取并反序列化 Msg"]
+    RESTORE -. 下一轮请求 .-> MODEL
+
+    classDef input fill:#e3f2fd,stroke:#1976d2,color:#0d47a1
+    classDef core fill:#fff3e0,stroke:#ef6c00,color:#4e342e
+    classDef gemini fill:#e8f5e9,stroke:#2e7d32,color:#1b5e20
+    classDef state fill:#f3e5f5,stroke:#7b1fa2,color:#4a148c
+    classDef decision fill:#fffde7,stroke:#f9a825,color:#5d4037
+    classDef terminal fill:#e0f2f1,stroke:#00796b,color:#004d40
+
+    class U input
+    class ANSWER terminal
+    class APP,AGENT,HISTORY,MODEL,BUILDER,FORMAT,CONVERT,TOOLS,OPTIONS,THINKING,CONFIG core
+    class CONTENT,SDK,API,STREAM,PARSER,BLOCKS gemini
+    class ACC,LIVE,FINAL,STATE,EXEC,RESULT,APPEND,RESULT_MSG,SAVE,JSON,RESTORE state
+    class ROUND,PERSIST decision
+```
+
+图例：蓝色表示用户输入，青绿色表示最终输出，橙色表示 Agent 和请求准备，绿色表示 Gemini/SDK，紫色表示上下文状态，黄色表示分支判断。
+
+## 关键节点与源码
+
+| 流程节点 | 主要实现 | 作用 |
+| --- | --- | --- |
+| 模型调用入口 | `ChatModelBase.stream` -> `GeminiChatModel.doStream` | 公共 `stream` 入口进入 Gemini 的实际实现，创建请求配置、格式化消息并调用 Google GenAI SDK |
+| 请求参数映射 | `GeminiChatFormatter.applyOptions` | 将 `GenerateOptions` 映射为 Gemini `GenerateContentConfig` |
+| 消息转换 | `GeminiMessageConverter.convertMessages` | 将 `Msg` 转换为 Gemini `Content` 和 `Part` |
+| 响应解析 | `GeminiResponseParser.parseResponse` | 将每个 Gemini 响应 chunk 转成 `ChatResponse` |
+| 流式聚合 | `ReasoningContext.processChunk` | 聚合 text、thinking 和 tool call，并生成实时消息 |
+| 签名恢复 | `GeminiThoughtSignatureUtils` | 在 `byte[]` 与 JSON 后的 Base64 字符串之间转换 signature |
+
+## 三条结束路径
+
+1. **普通回答**：没有 `ToolUseBlock` 时，Agent 聚合最终消息并把文本返回给用户。
+2. **工具调用**：模型返回 `ToolUseBlock`，Agent 执行工具，将 `ToolResultBlock` 加入历史，再发起下一轮模型请求。
+3. **跨轮次持久化**：最终 `Msg` 写入 JSON 后，Gemini signature 会变成 Base64 字符串；下一轮转换请求时会恢复成 SDK 要求的 `byte[]`。
+
+## Thinking 与 signature 在图中的位置
+
+- `thinkingBudget`、`thinkingLevel` 和 `includeThoughts` 在请求准备阶段进入 `ThinkingConfig`。
+- Gemini 返回的 thinking Part 会解析为 `ThinkingBlock`，普通文本 Part 会解析为 `TextBlock`，function-call Part 会解析为 `ToolUseBlock`。
+- `thoughtSignature` 是 Part 级别的 metadata，不只存在于 tool call；解析、流式聚合和 JSON 往返都必须保留它。
+- 历史 assistant 的 `ThinkingBlock`、带 signature 的 `TextBlock` 和 `ToolUseBlock` 会在下一轮请求中重新生成对应的 Gemini Part。
+
+多 Agent formatter 会将普通多 Agent 历史重写成带标签的 user 文本，因此不能把原始 signature 附加到被重写的文本上；精确的 tool sequence 仍走同一套 Part 回放逻辑。

--- a/docs/v2/zh/integration/model/gemini.md
+++ b/docs/v2/zh/integration/model/gemini.md
@@ -37,6 +37,29 @@ GeminiChatModel model = GeminiChatModel.builder()
     .build();
 ```
 
+## Thinking 配置
+
+Gemini 的 thinking 能力通过 `GenerateOptions` 配置：
+
+```java
+import io.agentscope.core.model.GenerateOptions;
+
+GenerateOptions thinkingOptions = GenerateOptions.builder()
+    .thinkingLevel("high")
+    .includeThoughts(true)
+    .build();
+```
+
+- `thinkingBudget(Integer)` 为支持 token 预算的模型设置 thinking 预算。
+- `thinkingLevel(String)` 设置模型支持的等级，例如 `"minimal"`、`"low"`、`"medium"` 或 `"high"`。
+- `includeThoughts(Boolean)` 独立控制响应中是否包含 thoughts。
+
+请根据所选模型使用 `thinkingBudget` 或 `thinkingLevel`。为保持向后兼容，仅设置 `thinkingBudget` 时仍会同时启用 `includeThoughts`；显式设置的 `includeThoughts` 始终优先。
+
+Chat formatter 会自动回放历史 assistant `ThinkingBlock`，并保留 thinking、text 和 tool-call Part 上的 Gemini `thoughtSignature`，即使消息经过 JSON 序列化也不会丢失。存储或转换对话历史时，请保留 content block metadata。
+
+完整的单次请求链路见[Gemini 完整请求流程](gemini-request-flow.md)。
+
 ## Spring Boot
 
 Spring Boot 应用可以使用 Gemini starter：


### PR DESCRIPTION
Background

  https://github.com/agentscope-ai/agentscope-java/issues/2240 — The Gemini model adapter lacked first-class support for Gemini's built-in thinking capability. There were several gaps:

  1. No includeThoughts / thinkingLevel options — GenerateOptions only had thinkingBudget, but Gemini's API requires includeThoughts (to independently control whether thoughts appear in responses) and thinkingLevel (e.g., "minimal",
  "low", "medium", "high") for the latest models.
  2. thoughtSignature was not persisted — Gemini returns an opaque thoughtSignature on each part. This signature must be round-tripped back to Gemini on subsequent turns, but the codebase only captured it on ToolUseBlock (via
  ToolUseBlock.METADATA_THOUGHT_SIGNATURE), not on TextBlock or ThinkingBlock. After a JSON serialization round-trip, the byte-array signature was lost or corrupted.
  3. Part boundaries were lost during accumulation — ThinkingAccumulator and TextAccumulator merged all chunks into a single block. When a Gemini response contained multiple parts each with its own thoughtSignature, the boundaries
  were destroyed, making it impossible to reconstruct distinct signed parts in the next request.

  Changes

  Core (agentscope-core)

  - GenerateOptions: Added includeThoughts(Boolean) and thinkingLevel(String) options alongside the existing thinkingBudget. These are now properly merged in merge(GenerateOptions, GenerateOptions).
  - ContentBlockMetadataKeys: New constant class with THOUGHT_SIGNATURE key, replacing the ad-hoc constant previously defined on ToolUseBlock. This is the single source of truth for the thought signature metadata key across all
  content block types.
  - TextBlock: Added metadata field (provider-specific Map<String, Object>) with getter and builder support. This enables text blocks to carry thoughtSignature.
  - ThinkingBlock: Already had metadata support; wired into the new signature persistence pipeline.
  - ToolUseBlock: Replaced the local METADATA_THOUGHT_SIGNATURE constant with ContentBlockMetadataKeys.THOUGHT_SIGNATURE reference. No behavioral change.
  - TextAccumulator / ThinkingAccumulator: Introduced buildAllTextBlocks() / buildAllThinkingBlocks() methods that preserve thought-signature Part boundaries. When a chunk carries a thoughtSignature, the current block is completed
  and a new one begins. The existing buildAggregated() method continues to return a single merged block for backward compatibility.
  - ReasoningContext: Switched from buildAggregated() to buildAllXXXBlocks() for both text and thinking, ensuring the final assistant message preserves distinct signed parts.

  Gemini Extension (agentscope-extensions-model-gemini)

  - GeminiThoughtSignatureUtils (new): Utility class that:
    - Extracts thoughtSignature from a Gemini Part into content block metadata (as byte[] in memory).
    - Restores a persisted signature back onto a Gemini Part.Builder — supports both byte[] (in-memory) and Base64-encoded String (after JSON serialization).
  - GeminiChatFormatter: Updated applyOptions to build ThinkingConfig from all three fields (thinkingBudget, thinkingLevel, includeThoughts). When only thinkingBudget is set (legacy callers), includeThoughts defaults to true
  preserving existing behavior. When includeThoughts is explicitly set, it always takes precedence.
  - GeminiResponseParser: Refactored parsePartsToBlocks to:
    - Preserve original Part order (no longer reorders thinking → text → toolCall).
    - Attach thoughtSignature metadata to ALL block types (ThinkingBlock, TextBlock, ToolUseBlock) via GeminiThoughtSignatureUtils.extractMetadata.
    - Emit empty blocks when only metadata (signature) is present.
  - GeminiMessageConverter: Updated to restore thoughtSignature from content block metadata onto Gemini Part objects for all assistant-role blocks (ThinkingBlock → Part.thought(true), TextBlock → text Part, ToolUseBlock →
  functionCall Part) via GeminiThoughtSignatureUtils.applyMetadata.

  Documentation

  - docs/v2/en/integration/model/gemini.md: Added "Thinking" section documenting thinkingLevel, includeThoughts, and the signature round-trip behavior.
  - docs/v2/zh/integration/model/gemini.md: Chinese translation.
  - docs/v2/en/integration/model/gemini-request-flow.md (new): Full end-to-end Mermaid diagram of a Gemini request, covering message conversion, thinking config, signature extraction/persistence, and the three completion paths (plain
   answer / tool call / persistent history replay).
  - docs/v2/zh/integration/model/gemini-request-flow.md (new): Chinese translation.