### PR TITLE
fix(harness): use ':' separator in sandbox slot session id so SQL stores accept it

### DIFF
--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/sandbox/SessionSandboxStateStore.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/sandbox/SessionSandboxStateStore.java
@@ -80,14 +80,21 @@ public final class SessionSandboxStateStore {
      * {@link AgentStateStore} 2-arg slot model. The userId column is always {@code null} because
      * sandbox state is conceptually agent-scoped, not user-scoped: USER/AGENT/GLOBAL scopes are
      * encoded into the sessionId prefix rather than the userId slot.
+     *
+     * <p>Uses {@code :} rather than {@code /} as the segment separator: SQL-backed
+     * {@link AgentStateStore} implementations validate the sessionId and reject {@code /} and
+     * {@code \} as path separators (e.g. {@code PostgresAgentStateStore}/{@code MysqlAgentStateStore}
+     * {@code validateSessionId}), so a {@code /}-delimited slot id makes sandbox state persistence
+     * throw {@code IllegalArgumentException} on those stores under any isolation scope. {@code :} is
+     * the same separator {@code MysqlAgentStateStore#slotId} already relies on for that reason.
      */
     private String slotSessionId(SandboxIsolationKey key) {
         IsolationScope scope = key.getScope();
         return switch (scope) {
-            case SESSION -> "sandbox/session/" + key.getValue();
-            case USER -> "sandbox/user/" + agentId + "/" + key.getValue();
-            case AGENT -> "sandbox/agent/" + agentId;
-            case GLOBAL -> "sandbox/global";
+            case SESSION -> "sandbox:session:" + key.getValue();
+            case USER -> "sandbox:user:" + agentId + ":" + key.getValue();
+            case AGENT -> "sandbox:agent:" + agentId;
+            case GLOBAL -> "sandbox:global";
         };
     }
 

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/sandbox/SessionSandboxStateStoreTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/sandbox/SessionSandboxStateStoreTest.java
@@ -21,7 +21,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.agentscope.core.agent.RuntimeContext;
 import io.agentscope.core.state.InMemoryAgentStateStore;
+import io.agentscope.core.state.State;
 import io.agentscope.harness.agent.IsolationScope;
+import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -72,6 +74,28 @@ class SessionSandboxStateStoreTest {
     }
 
     @Test
+    void slotSessionId_hasNoPathSeparators_soSqlStoresAccept_allScopes() throws Exception {
+        // SQL-backed AgentStateStore impls (Postgres/MySQL) reject '/' and '\' in the sessionId
+        // via validateSessionId. A store whose slot ids contain path separators makes sandbox
+        // state persistence throw on those backends for every isolation scope (issue #2327).
+        SessionSandboxStateStore sqlLikeStore =
+                new SessionSandboxStateStore(new PathSeparatorRejectingStore(), AGENT_ID);
+
+        for (SandboxIsolationKey key :
+                new SandboxIsolationKey[] {
+                    isolationKey(IsolationScope.SESSION, "sess-001"),
+                    isolationKey(IsolationScope.USER, "user-123"),
+                    isolationKey(IsolationScope.AGENT, AGENT_ID),
+                    isolationKey(IsolationScope.GLOBAL, SandboxIsolationKey.GLOBAL_VALUE)
+                }) {
+            sqlLikeStore.save(key, JSON);
+            assertEquals(JSON, sqlLikeStore.load(key).orElseThrow());
+            sqlLikeStore.delete(key);
+            assertFalse(sqlLikeStore.load(key).isPresent());
+        }
+    }
+
+    @Test
     void deleteUsesTombstone_evenWhenSessionDeleteUnsupported() throws Exception {
         SessionSandboxStateStore redisLikeStore =
                 new SessionSandboxStateStore(new NoDeleteSession(), AGENT_ID);
@@ -104,6 +128,39 @@ class SessionSandboxStateStoreTest {
         @Override
         public void delete(String userId, String sessionId, String key) {
             // no-op
+        }
+    }
+
+    /**
+     * Mirrors the {@code validateSessionId} contract of the SQL-backed stores
+     * ({@code PostgresAgentStateStore}/{@code MysqlAgentStateStore}): the sessionId must not contain
+     * a path separator. Lets the round-trip test fail exactly the way those backends do.
+     */
+    private static final class PathSeparatorRejectingStore extends InMemoryAgentStateStore {
+        private static void validate(String sessionId) {
+            if (sessionId != null && (sessionId.contains("/") || sessionId.contains("\\"))) {
+                throw new IllegalArgumentException(
+                        "AgentStateStore ID cannot contain path separators: " + sessionId);
+            }
+        }
+
+        @Override
+        public void save(String userId, String sessionId, String key, State value) {
+            validate(sessionId);
+            super.save(userId, sessionId, key, value);
+        }
+
+        @Override
+        public <T extends State> Optional<T> get(
+                String userId, String sessionId, String key, Class<T> type) {
+            validate(sessionId);
+            return super.get(userId, sessionId, key, type);
+        }
+
+        @Override
+        public void delete(String userId, String sessionId, String key) {
+            validate(sessionId);
+            super.delete(userId, sessionId, key);
         }
     }
 }


### PR DESCRIPTION
## AgentScope-Java Version

2.0.1-SNAPSHOT (main); bug also present in 2.0.0.

## Description

Fixes #2327.

**Background.** `SessionSandboxStateStore.slotSessionId()` packs the sandbox `SandboxIsolationKey` into a single sessionId string using `/` as the segment separator (e.g. `sandbox/session/<id>`, `sandbox/user/<agentId>/<id>`, `sandbox/agent/<agentId>`, `sandbox/global`). That string is then passed as the `sessionId` argument to the backing `AgentStateStore`.

**Problem.** SQL-backed stores validate the sessionId and reject `/` and `\` as path separators — `PostgresAgentStateStore.validateSessionId` and `MysqlAgentStateStore.validateSessionId` both throw `IllegalArgumentException` in that case. As a result, sandbox state persistence fails on **every** SQL backend under **any** `IsolationScope` (SESSION/USER/AGENT/GLOBAL). The original issue reported Postgres, but MySQL is affected too: its `slotId()` uses `:` only to join `userId`/`sessionId`, so it cannot dodge the `/` that already lives inside the sandbox slot's sessionId.

**Fix.** Switch the slot-id segment separator from `/` to `:`. This is exactly the convention `MysqlAgentStateStore#slotId` already relies on (and documents) for the same `validateSessionId` reason, so it stays consistent with the codebase. The change is on the producer side (`SessionSandboxStateStore`), so it fixes all backing stores at once; no store-specific changes needed. No code reverse-parses these slot strings on `/`, so changing the separator is safe.

**How to test.** Added `slotSessionId_hasNoPathSeparators_soSqlStoresAccept_allScopes` in `SessionSandboxStateStoreTest`. It drives the store through a backend that mirrors the `validateSessionId` contract (rejects `/`/`\`) and round-trips save/load/delete for all four isolation scopes. It fails (RED) with the old `/` separators — `IllegalArgumentException: ... cannot contain path separators: sandbox/session/sess-001`, the same error seen on Postgres/MySQL — and passes (GREEN) with the fix. The pre-existing tests (which use `InMemoryAgentStateStore`, no validation) are unchanged.

`mvn -pl agentscope-harness test`: all green; `spotless:check` clean.

## Checklist

Please check the following items before code is ready to be reviewed.

- [x]  Code has been formatted with `mvn spotless:apply`
- [x]  All tests are passing (`mvn test`)
- [x]  Javadoc comments are complete and follow project conventions
- [x]  Related documentation has been updated (e.g. links, examples, etc.)
- [x]  Code is ready for review