### PR TITLE
fix(core): guard null input in ToolValidator.validateInput to prevent NPE

### DIFF
--- a/agentscope-core/src/main/java/io/agentscope/core/tool/ToolValidator.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/tool/ToolValidator.java
@@ -79,6 +79,13 @@ public final class ToolValidator {
             return null; // No schema, validation passes
         }
 
+        // Defensive: treat null/blank input as empty JSON object so that
+        // networknt-schema does not throw NPE ("argument 'content' is null")
+        // when a ToolUseBlock carries parsed arguments but no raw content string.
+        if (input == null || input.isBlank()) {
+            input = "{}";
+        }
+
         try {
             // Convert schema to JSON string
             String schemaJson = JsonUtils.getJsonCodec().toJson(schema);


### PR DESCRIPTION
When a ToolUseBlock has parsed arguments in its `input` map but no raw
  `content` string, `ToolExecutor.executeCore` passes `null` to
  `ToolValidator.validateInput()`, which forwards it to networknt-schema's
  `validate(null, …)`.  networknt-schema then throws:

      NullPointerException: argument "content" is null

  This causes tool calls to fail with a misleading error:
      Parameter validation failed: Schema validation error: argument "content" is null

  Treat null/blank input as `"{}"` before validation so that optional-field
  schemas pass cleanly and required-field schemas still surface the expected
  validation errors.