### PR TITLE
fix(RemoteFilesystem): 添加glob时无法匹配搜索目录根层文件

### DIFF
--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/filesystem/remote/RemoteFilesystem.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/filesystem/remote/RemoteFilesystem.java
@@ -425,8 +425,19 @@ public class RemoteFilesystem implements AbstractFilesystem {
                                         + (effectivePattern.startsWith("**")
                                                 ? effectivePattern
                                                 : "**/" + effectivePattern));
+        // Java NIO requires a path separator for patterns that start with "**/", so the
+        // recursive matcher does not match files located directly in the search root. Strip the
+        // recursive prefix for a second matcher that covers those root-level files.
+        String directPattern;
+        if (effectivePattern.startsWith("**/")) {
+            directPattern = effectivePattern.substring(3);
+        } else if (effectivePattern.equals("**")) {
+            directPattern = "*";
+        } else {
+            directPattern = effectivePattern;
+        }
         PathMatcher directMatcher =
-                FileSystems.getDefault().getPathMatcher("glob:" + effectivePattern);
+                FileSystems.getDefault().getPathMatcher("glob:" + directPattern);
 
         // Fast path: index has entries for this prefix
         if (index != null && index.hasPrefix(normalizedPath)) {

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/filesystem/FilesystemGlobTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/filesystem/FilesystemGlobTest.java
@@ -76,4 +76,49 @@ class FilesystemGlobTest {
                 Set.of("/agents/demo-session.log.jsonl", "/agents/sub/demo-session.log.jsonl"),
                 paths);
     }
+
+    @Test
+    void remote_glob_recursivePattern_matchesFilesInSearchRootAndSubdirectories() {
+        InMemoryStore store = new InMemoryStore();
+        List<String> ns = List.of("test-ns");
+        store.put(ns, "/hello.txt", Map.of("content", "root file"));
+        store.put(ns, "/reports/hello.txt", Map.of("content", "nested file"));
+        store.put(ns, "/hello.md", Map.of("content", "different extension"));
+
+        RemoteFilesystem fs = new RemoteFilesystem(store, ns);
+        GlobResult result = fs.glob(RT, "**/hello.txt", "/");
+
+        assertTrue(result.isSuccess());
+        Set<String> paths =
+                result.matches().stream()
+                        .map(fi -> fi.path().replace('\\', '/'))
+                        .collect(Collectors.toSet());
+        assertEquals(Set.of("/hello.txt", "/reports/hello.txt"), paths);
+
+        GlobResult wildcardResult = fs.glob(RT, "**/*.txt", "/");
+        assertTrue(wildcardResult.isSuccess());
+        Set<String> wildcardPaths =
+                wildcardResult.matches().stream()
+                        .map(fi -> fi.path().replace('\\', '/'))
+                        .collect(Collectors.toSet());
+        assertEquals(Set.of("/hello.txt", "/reports/hello.txt"), wildcardPaths);
+    }
+
+    @Test
+    void remote_glob_doubleStar_matchesFilesInSearchRootAndSubdirectories() {
+        InMemoryStore store = new InMemoryStore();
+        List<String> ns = List.of("test-ns");
+        store.put(ns, "/root.txt", Map.of("content", "root file"));
+        store.put(ns, "/reports/nested.txt", Map.of("content", "nested file"));
+
+        RemoteFilesystem fs = new RemoteFilesystem(store, ns);
+        GlobResult result = fs.glob(RT, "**", "/");
+
+        assertTrue(result.isSuccess());
+        Set<String> paths =
+                result.matches().stream()
+                        .map(fi -> fi.path().replace('\\', '/'))
+                        .collect(Collectors.toSet());
+        assertEquals(Set.of("/root.txt", "/reports/nested.txt"), paths);
+    }
 }


### PR DESCRIPTION
fix #2342 

## 原因分析

`RemoteFilesystem.glob()` 当前创建了两个 `PathMatcher`：

```java
PathMatcher matcher =
    FileSystems.getDefault()
        .getPathMatcher(
            "glob:"
                + (effectivePattern.startsWith("**")
                    ? effectivePattern
                    : "**/" + effectivePattern)
        );

PathMatcher directMatcher =
    FileSystems.getDefault()
        .getPathMatcher("glob:" + effectivePattern);
```

当调用参数为：

```text
effectivePattern = **/hello.txt
```

两个匹配器实际上完全相同：

```text
matcher       = glob:**/hello.txt
directMatcher = glob:**/hello.txt
```

在 Windows JDK 17 中，该模式会被编译为类似正则：

```text
^.*\\hello\.txt$
```

它要求 `hello.txt` 前面至少存在一个路径分隔符，因此：

```text
hello.txt          不匹配
reports\hello.txt  匹配
```

可以通过以下代码验证：

```java
PathMatcher matcher =
    FileSystems.getDefault()
        .getPathMatcher("glob:**/hello.txt");

assertFalse(matcher.matches(Path.of("hello.txt")));
assertTrue(matcher.matches(Path.of("reports/hello.txt")));
```

`RemoteFilesystem.glob()` 在搜索根路径 `/` 时，会把 Store key：

```text
/hello.txt
```

正确转换为相对路径：

```text
hello.txt
```

但随后使用 `glob:**/hello.txt` 进行匹配，导致该文件被过滤。

## 相关实现对比

`CompositeFilesystem.glob()` 已经处理了相同的 Java NIO glob 行为：

```java
String directExpr;
if (effectivePattern.startsWith("**/")) {
    directExpr = effectivePattern.substring(3);
} else if (effectivePattern.equals("**")) {
    directExpr = "*";
} else {
    directExpr = effectivePattern;
}

PathMatcher directFileMatcher =
    FileSystems.getDefault()
        .getPathMatcher("glob:" + directExpr);
```

但 `RemoteFilesystem.glob()` 没有采用相同逻辑，因此其中的 `directMatcher` 无法匹配根层文件。

## 修复

在 `RemoteFilesystem.glob()` 中为直接匹配器去掉开头的 `**/`：

```java
String directExpr;
if (effectivePattern.startsWith("**/")) {
    directExpr = effectivePattern.substring(3);
} else if (effectivePattern.equals("**")) {
    directExpr = "*";
} else {
    directExpr = effectivePattern;
}

PathMatcher directMatcher =
    FileSystems.getDefault()
        .getPathMatcher("glob:" + directExpr);
```

这样对于：

```text
effectivePattern = **/hello.txt
```

可以得到：

```text
matcher       = glob:**/hello.txt
directMatcher = glob:hello.txt
```

从而同时匹配：

```text
hello.txt
reports/hello.txt
```