### PR TITLE
fix(harness): match search-root files for recursive glob in RemoteFilesystem

### DIFF
--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/filesystem/remote/RemoteFilesystem.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/filesystem/remote/RemoteFilesystem.java
@@ -425,8 +425,16 @@ public class RemoteFilesystem implements AbstractFilesystem {
                                         + (effectivePattern.startsWith("**")
                                                 ? effectivePattern
                                                 : "**/" + effectivePattern));
+        // The recursive matcher never matches files directly at the search root: a leading "**/"
+        // requires at least one directory separator, so "**/hello.txt" misses "/hello.txt". The
+        // direct matcher covers that zero-directory case — strip the leading "**/" so the pattern
+        // applies to a bare file name at the root.
+        String directPattern =
+                effectivePattern.startsWith("**/")
+                        ? effectivePattern.substring(3)
+                        : effectivePattern;
         PathMatcher directMatcher =
-                FileSystems.getDefault().getPathMatcher("glob:" + effectivePattern);
+                FileSystems.getDefault().getPathMatcher("glob:" + directPattern);
 
         // Fast path: index has entries for this prefix
         if (index != null && index.hasPrefix(normalizedPath)) {

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/filesystem/FilesystemGlobTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/filesystem/FilesystemGlobTest.java
@@ -76,4 +76,42 @@ class FilesystemGlobTest {
                 Set.of("/agents/demo-session.log.jsonl", "/agents/sub/demo-session.log.jsonl"),
                 paths);
     }
+
+    @Test
+    void remote_glob_recursivePattern_matchesFileAtSearchRoot() {
+        InMemoryStore store = new InMemoryStore();
+        List<String> ns = List.of("test-ns");
+        store.put(ns, "/hello.txt", Map.of("content", "root"));
+        store.put(ns, "/reports/hello.txt", Map.of("content", "nested"));
+
+        RemoteFilesystem fs = new RemoteFilesystem(store, ns);
+        GlobResult result = fs.glob(RT, "**/hello.txt", "/");
+
+        assertTrue(result.isSuccess());
+        Set<String> paths =
+                result.matches().stream()
+                        .map(fi -> fi.path().replace('\\', '/'))
+                        .collect(Collectors.toSet());
+        // "**/" must also match zero intermediate directories, i.e. the file at the search root.
+        assertEquals(Set.of("/hello.txt", "/reports/hello.txt"), paths);
+    }
+
+    @Test
+    void remote_glob_recursiveWildcardPattern_matchesFileAtSearchRoot() {
+        InMemoryStore store = new InMemoryStore();
+        List<String> ns = List.of("test-ns");
+        store.put(ns, "/hello.txt", Map.of("content", "root"));
+        store.put(ns, "/reports/note.txt", Map.of("content", "nested"));
+        store.put(ns, "/reports/data.bin", Map.of("content", "ignored"));
+
+        RemoteFilesystem fs = new RemoteFilesystem(store, ns);
+        GlobResult result = fs.glob(RT, "**/*.txt", "/");
+
+        assertTrue(result.isSuccess());
+        Set<String> paths =
+                result.matches().stream()
+                        .map(fi -> fi.path().replace('\\', '/'))
+                        .collect(Collectors.toSet());
+        assertEquals(Set.of("/hello.txt", "/reports/note.txt"), paths);
+    }
 }


### PR DESCRIPTION
## 问题

Fixes #2342

`RemoteFilesystem.glob()` 用 `**/hello.txt`、`**/*.txt` 这类递归模式时，匹配不到**搜索根目录下**的文件。例如根下有 `/hello.txt` 和 `/reports/hello.txt`，`glob("**/hello.txt", "/")` 只返回 `/reports/hello.txt`。

## 根因

Java glob 里前缀 `**/` 要求至少一个目录分隔符，所以 `**/hello.txt` 匹配不到没有 `/` 的根层文件名 `hello.txt`。代码本有一个 `directMatcher` 用来兜底这种「零层目录」情况，但它是用原始 pattern 构造的——当 pattern 以 `**` 开头时，`directMatcher` 塌缩成和 `matcher` 完全相同的 `**/hello.txt`，兜底失效。

## 修复

构造 `directMatcher` 时剥掉前导 `**/`，让它以根层裸文件名去匹配。索引快路径和全量扫描兜底两条路径都用到这对 matcher，一处修好覆盖两者。

## 测试

在 `FilesystemGlobTest` 新增两个回归用例（`**/hello.txt`、`**/*.txt`）。已验证：**未修复时**这两个用例复现 issue 症状（根层文件缺失），**修复后**全部通过，原有用例不受影响。