### PR TITLE
fix(models): sanitize name field in OpenAIMessageConverter to satisfy…

### DIFF
--- a/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-openai/src/main/java/io/agentscope/extensions/model/openai/formatter/OpenAIMessageConverter.java
+++ b/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-openai/src/main/java/io/agentscope/extensions/model/openai/formatter/OpenAIMessageConverter.java
@@ -41,6 +41,7 @@ import io.agentscope.extensions.model.openai.dto.OpenAIToolCall;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Function;
+import java.util.regex.Pattern;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -123,7 +124,7 @@ public class OpenAIMessageConverter {
         OpenAIMessage.Builder builder = OpenAIMessage.builder().role("user");
 
         if (msg.getName() != null) {
-            builder.name(msg.getName());
+            builder.name(sanitizeName(msg.getName()));
         }
 
         List<ContentBlock> blocks = msg.getContent();
@@ -350,7 +351,7 @@ public class OpenAIMessageConverter {
         }
 
         if (msg.getName() != null) {
-            builder.name(msg.getName());
+            builder.name(sanitizeName(msg.getName()));
         }
 
         // Handle tool calls
@@ -513,6 +514,66 @@ public class OpenAIMessageConverter {
     private String detectAudioFormat(String mediaType) {
         return OpenAIConverterUtils.detectAudioFormat(mediaType);
     }
+
+    /**
+     * Sanitizes an agent/user name to comply with the OpenAI {@code name} field constraint
+     * {@code ^[a-zA-Z0-9_-]{1,64}$}.
+     *
+     * <p>Transformation rules applied in order:
+     * <ol>
+     *   <li>Spaces are replaced with {@code _}.</li>
+     *   <li>Any remaining characters outside {@code [a-zA-Z0-9_-]} are replaced with {@code _}.</li>
+     *   <li>Consecutive underscores are collapsed to a single {@code _}.</li>
+     *   <li>Leading and trailing underscores are stripped.</li>
+     *   <li>If the result is empty (e.g. a purely non-ASCII name), {@code "agent"} is returned
+     *       as a safe fallback so the field is still included.</li>
+     *   <li>If the result exceeds 64 characters it is truncated and trailing underscores are
+     *       stripped from the cut point.</li>
+     * </ol>
+     *
+     * <p>When sanitization actually changes the name a single {@code WARN}-level log line is
+     * emitted so operators can rename their agents to avoid the silent transformation.
+     *
+     * @param name the raw agent/user name (must be non-null; callers are responsible for the
+     *             null-check)
+     * @return a non-null, non-empty string that satisfies {@code ^[a-zA-Z0-9_-]{1,64}$}
+     */
+    static String sanitizeName(String name) {
+        // Replace spaces explicitly so the intent is clear, then replace all other illegal chars
+        String sanitized = name.replace(' ', '_');
+        sanitized = OPENAI_NAME_ILLEGAL_CHARS.matcher(sanitized).replaceAll("_");
+        // Collapse consecutive underscores and strip leading/trailing ones
+        sanitized = MULTIPLE_UNDERSCORES.matcher(sanitized).replaceAll("_");
+        sanitized = sanitized.replaceAll("^_+|_+$", "");
+
+        if (sanitized.isEmpty()) {
+            sanitized = "agent";
+        }
+
+        // Enforce 64-char max
+        if (sanitized.length() > 64) {
+            sanitized = sanitized.substring(0, 64).replaceAll("_+$", "");
+            if (sanitized.isEmpty()) {
+                sanitized = "agent";
+            }
+        }
+
+        if (!sanitized.equals(name)) {
+            log.warn(
+                    "Agent name '{}' contains characters not allowed by the OpenAI API"
+                            + " (^[a-zA-Z0-9_-]{{1,64}}$); using '{}' instead."
+                            + " Consider renaming the agent to an ASCII-only name.",
+                    name,
+                    sanitized);
+        }
+        return sanitized;
+    }
+
+    /** Matches any character outside the OpenAI-permitted set {@code [a-zA-Z0-9_-]}. */
+    private static final Pattern OPENAI_NAME_ILLEGAL_CHARS = Pattern.compile("[^a-zA-Z0-9_\\-]");
+
+    /** Matches two or more consecutive underscores. */
+    private static final Pattern MULTIPLE_UNDERSCORES = Pattern.compile("_{2,}");
 
     /**
      * Apply cache_control from Msg metadata to the converted OpenAIMessage.

--- a/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-openai/src/main/java/io/agentscope/extensions/model/openai/formatter/OpenAIMessageConverter.java
+++ b/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-openai/src/main/java/io/agentscope/extensions/model/openai/formatter/OpenAIMessageConverter.java
@@ -515,65 +515,16 @@ public class OpenAIMessageConverter {
         return OpenAIConverterUtils.detectAudioFormat(mediaType);
     }
 
-    /**
-     * Sanitizes an agent/user name to comply with the OpenAI {@code name} field constraint
-     * {@code ^[a-zA-Z0-9_-]{1,64}$}.
-     *
-     * <p>Transformation rules applied in order:
-     * <ol>
-     *   <li>Spaces are replaced with {@code _}.</li>
-     *   <li>Any remaining characters outside {@code [a-zA-Z0-9_-]} are replaced with {@code _}.</li>
-     *   <li>Consecutive underscores are collapsed to a single {@code _}.</li>
-     *   <li>Leading and trailing underscores are stripped.</li>
-     *   <li>If the result is empty (e.g. a purely non-ASCII name), {@code "agent"} is returned
-     *       as a safe fallback so the field is still included.</li>
-     *   <li>If the result exceeds 64 characters it is truncated and trailing underscores are
-     *       stripped from the cut point.</li>
-     * </ol>
-     *
-     * <p>When sanitization actually changes the name a single {@code WARN}-level log line is
-     * emitted so operators can rename their agents to avoid the silent transformation.
-     *
-     * @param name the raw agent/user name (must be non-null; callers are responsible for the
-     *             null-check)
-     * @return a non-null, non-empty string that satisfies {@code ^[a-zA-Z0-9_-]{1,64}$}
-     */
+    /** Sanitizes a message name to satisfy OpenAI's {@code ^[a-zA-Z0-9_-]{1,64}$} constraint. */
     static String sanitizeName(String name) {
-        // Replace spaces explicitly so the intent is clear, then replace all other illegal chars
-        String sanitized = name.replace(' ', '_');
-        sanitized = OPENAI_NAME_ILLEGAL_CHARS.matcher(sanitized).replaceAll("_");
-        // Collapse consecutive underscores and strip leading/trailing ones
-        sanitized = MULTIPLE_UNDERSCORES.matcher(sanitized).replaceAll("_");
-        sanitized = sanitized.replaceAll("^_+|_+$", "");
-
-        if (sanitized.isEmpty()) {
-            sanitized = "agent";
-        }
-
-        // Enforce 64-char max
+        String sanitized = OPENAI_NAME_ILLEGAL_CHARS.matcher(name).replaceAll("_");
         if (sanitized.length() > 64) {
-            sanitized = sanitized.substring(0, 64).replaceAll("_+$", "");
-            if (sanitized.isEmpty()) {
-                sanitized = "agent";
-            }
+            sanitized = sanitized.substring(0, 64);
         }
-
-        if (!sanitized.equals(name)) {
-            log.warn(
-                    "Agent name '{}' contains characters not allowed by the OpenAI API"
-                            + " (^[a-zA-Z0-9_-]{{1,64}}$); using '{}' instead."
-                            + " Consider renaming the agent to an ASCII-only name.",
-                    name,
-                    sanitized);
-        }
-        return sanitized;
+        return sanitized.isEmpty() ? "agent" : sanitized;
     }
 
-    /** Matches any character outside the OpenAI-permitted set {@code [a-zA-Z0-9_-]}. */
-    private static final Pattern OPENAI_NAME_ILLEGAL_CHARS = Pattern.compile("[^a-zA-Z0-9_\\-]");
-
-    /** Matches two or more consecutive underscores. */
-    private static final Pattern MULTIPLE_UNDERSCORES = Pattern.compile("_{2,}");
+    private static final Pattern OPENAI_NAME_ILLEGAL_CHARS = Pattern.compile("[^a-zA-Z0-9_-]");
 
     /**
      * Apply cache_control from Msg metadata to the converted OpenAIMessage.

--- a/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-openai/src/test/java/io/agentscope/extensions/model/openai/formatter/OpenAIMessageConverterTest.java
+++ b/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-openai/src/test/java/io/agentscope/extensions/model/openai/formatter/OpenAIMessageConverterTest.java
@@ -704,7 +704,7 @@ class OpenAIMessageConverterTest {
     class NameFieldTests {
 
         @Test
-        @DisplayName("Should set name field for user message")
+        @DisplayName("Should set name field for user message when already valid")
         void testUserMessageWithName() {
             Msg msg =
                     Msg.builder()
@@ -720,7 +720,7 @@ class OpenAIMessageConverterTest {
         }
 
         @Test
-        @DisplayName("Should set name field for assistant message")
+        @DisplayName("Should set name field for assistant message when already valid")
         void testAssistantMessageWithName() {
             Msg msg =
                     Msg.builder()
@@ -749,6 +749,112 @@ class OpenAIMessageConverterTest {
 
             assertNotNull(result);
             assertNull(result.getName());
+        }
+
+        // --- sanitizeName unit tests (package-private method via same-package test) ---
+
+        @Test
+        @DisplayName("sanitizeName: valid ASCII name passes through unchanged")
+        void testSanitizeNameValid() {
+            assertEquals("My_Agent", OpenAIMessageConverter.sanitizeName("My_Agent"));
+            assertEquals("agent-1", OpenAIMessageConverter.sanitizeName("agent-1"));
+            assertEquals("Alice", OpenAIMessageConverter.sanitizeName("Alice"));
+        }
+
+        @Test
+        @DisplayName("sanitizeName: spaces are replaced with underscores")
+        void testSanitizeNameWithSpaces() {
+            assertEquals("My_Agent", OpenAIMessageConverter.sanitizeName("My Agent"));
+            assertEquals("hello_world", OpenAIMessageConverter.sanitizeName("hello world"));
+        }
+
+        @Test
+        @DisplayName("sanitizeName: non-ASCII characters are replaced with underscores")
+        void testSanitizeNameNonAscii() {
+            String result = OpenAIMessageConverter.sanitizeName("智能助手");
+            // all Chinese chars become '_', consecutive collapse, leading/trailing stripped → "agent"
+            assertTrue(
+                    result.matches("^[a-zA-Z0-9_\\-]{1,64}$"),
+                    "Result must satisfy OpenAI constraint but was: " + result);
+        }
+
+        @Test
+        @DisplayName("sanitizeName: mixed name with spaces and Chinese collapses correctly")
+        void testSanitizeNameMixed() {
+            String result = OpenAIMessageConverter.sanitizeName("My Agent 你好");
+            // "My_Agent___" → collapse → "My_Agent"
+            assertEquals("My_Agent", result);
+            assertTrue(result.matches("^[a-zA-Z0-9_\\-]{1,64}$"));
+        }
+
+        @Test
+        @DisplayName("sanitizeName: name exceeding 64 chars is truncated")
+        void testSanitizeNameTooLong() {
+            String longName = "a".repeat(80);
+            String result = OpenAIMessageConverter.sanitizeName(longName);
+            assertTrue(result.length() <= 64, "Result must be at most 64 chars");
+            assertTrue(result.matches("^[a-zA-Z0-9_\\-]{1,64}$"));
+        }
+
+        @Test
+        @DisplayName("sanitizeName: purely illegal name falls back to 'agent'")
+        void testSanitizeNamePurelyIllegal() {
+            assertEquals("agent", OpenAIMessageConverter.sanitizeName("!!!"));
+            assertEquals("agent", OpenAIMessageConverter.sanitizeName("你好"));
+        }
+
+        @Test
+        @DisplayName(
+                "sanitizeName: assistant message with space in name is sanitized before API call")
+        void testAssistantMessageNameWithSpaceIsSanitized() {
+            Msg msg =
+                    Msg.builder()
+                            .role(MsgRole.ASSISTANT)
+                            .name("My Agent")
+                            .content(List.of(TextBlock.builder().text("Hi").build()))
+                            .build();
+
+            OpenAIMessage result = converter.convertToMessage(msg, false);
+
+            assertNotNull(result);
+            assertEquals("My_Agent", result.getName());
+        }
+
+        @Test
+        @DisplayName(
+                "sanitizeName: user message with space in name is sanitized before API call")
+        void testUserMessageNameWithSpaceIsSanitized() {
+            Msg msg =
+                    Msg.builder()
+                            .role(MsgRole.USER)
+                            .name("Hello World")
+                            .content(List.of(TextBlock.builder().text("Hi").build()))
+                            .build();
+
+            OpenAIMessage result = converter.convertToMessage(msg, false);
+
+            assertNotNull(result);
+            assertEquals("Hello_World", result.getName());
+        }
+
+        @Test
+        @DisplayName(
+                "sanitizeName: assistant message with Chinese name is sanitized before API call")
+        void testAssistantMessageChineseNameIsSanitized() {
+            Msg msg =
+                    Msg.builder()
+                            .role(MsgRole.ASSISTANT)
+                            .name("智能助手")
+                            .content(List.of(TextBlock.builder().text("你好").build()))
+                            .build();
+
+            OpenAIMessage result = converter.convertToMessage(msg, false);
+
+            assertNotNull(result);
+            assertNotNull(result.getName());
+            assertTrue(
+                    result.getName().matches("^[a-zA-Z0-9_\\-]{1,64}$"),
+                    "Sanitized name must satisfy OpenAI constraint but was: " + result.getName());
         }
     }
 

--- a/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-openai/src/test/java/io/agentscope/extensions/model/openai/formatter/OpenAIMessageConverterTest.java
+++ b/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-openai/src/test/java/io/agentscope/extensions/model/openai/formatter/OpenAIMessageConverterTest.java
@@ -772,7 +772,8 @@ class OpenAIMessageConverterTest {
         @DisplayName("sanitizeName: non-ASCII characters are replaced with underscores")
         void testSanitizeNameNonAscii() {
             String result = OpenAIMessageConverter.sanitizeName("智能助手");
-            // all Chinese chars become '_', consecutive collapse, leading/trailing stripped → "agent"
+            // all Chinese chars become '_', consecutive collapse, leading/trailing stripped →
+            // "agent"
             assertTrue(
                     result.matches("^[a-zA-Z0-9_\\-]{1,64}$"),
                     "Result must satisfy OpenAI constraint but was: " + result);
@@ -821,8 +822,7 @@ class OpenAIMessageConverterTest {
         }
 
         @Test
-        @DisplayName(
-                "sanitizeName: user message with space in name is sanitized before API call")
+        @DisplayName("sanitizeName: user message with space in name is sanitized before API call")
         void testUserMessageNameWithSpaceIsSanitized() {
             Msg msg =
                     Msg.builder()

--- a/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-openai/src/test/java/io/agentscope/extensions/model/openai/formatter/OpenAIMessageConverterTest.java
+++ b/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-openai/src/test/java/io/agentscope/extensions/model/openai/formatter/OpenAIMessageConverterTest.java
@@ -43,6 +43,8 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
 /**
  * Unit tests for OpenAIMessageConverter.
@@ -751,110 +753,51 @@ class OpenAIMessageConverterTest {
             assertNull(result.getName());
         }
 
-        // --- sanitizeName unit tests (package-private method via same-package test) ---
-
-        @Test
-        @DisplayName("sanitizeName: valid ASCII name passes through unchanged")
-        void testSanitizeNameValid() {
-            assertEquals("My_Agent", OpenAIMessageConverter.sanitizeName("My_Agent"));
-            assertEquals("agent-1", OpenAIMessageConverter.sanitizeName("agent-1"));
-            assertEquals("Alice", OpenAIMessageConverter.sanitizeName("Alice"));
+        @ParameterizedTest
+        @CsvSource(
+                value = {
+                    "My_Agent|My_Agent",
+                    "agent-1|agent-1",
+                    "My Agent|My_Agent",
+                    "hello/world|hello_world",
+                    "!!!|___",
+                    "''|agent"
+                },
+                delimiter = '|')
+        @DisplayName("sanitizeName should replace illegal characters and preserve valid names")
+        void testSanitizeName(String rawName, String expectedName) {
+            assertEquals(expectedName, OpenAIMessageConverter.sanitizeName(rawName));
         }
 
         @Test
-        @DisplayName("sanitizeName: spaces are replaced with underscores")
-        void testSanitizeNameWithSpaces() {
-            assertEquals("My_Agent", OpenAIMessageConverter.sanitizeName("My Agent"));
-            assertEquals("hello_world", OpenAIMessageConverter.sanitizeName("hello world"));
-        }
-
-        @Test
-        @DisplayName("sanitizeName: non-ASCII characters are replaced with underscores")
+        @DisplayName("sanitizeName should replace non-ASCII characters")
         void testSanitizeNameNonAscii() {
-            String result = OpenAIMessageConverter.sanitizeName("智能助手");
-            // all Chinese chars become '_', consecutive collapse, leading/trailing stripped →
-            // "agent"
-            assertTrue(
-                    result.matches("^[a-zA-Z0-9_\\-]{1,64}$"),
-                    "Result must satisfy OpenAI constraint but was: " + result);
+            assertEquals("____", OpenAIMessageConverter.sanitizeName("\u667a\u80fd\u52a9\u624b"));
         }
 
         @Test
-        @DisplayName("sanitizeName: mixed name with spaces and Chinese collapses correctly")
-        void testSanitizeNameMixed() {
-            String result = OpenAIMessageConverter.sanitizeName("My Agent 你好");
-            // "My_Agent___" → collapse → "My_Agent"
-            assertEquals("My_Agent", result);
-            assertTrue(result.matches("^[a-zA-Z0-9_\\-]{1,64}$"));
-        }
-
-        @Test
-        @DisplayName("sanitizeName: name exceeding 64 chars is truncated")
+        @DisplayName("sanitizeName should truncate names exceeding 64 characters")
         void testSanitizeNameTooLong() {
-            String longName = "a".repeat(80);
-            String result = OpenAIMessageConverter.sanitizeName(longName);
-            assertTrue(result.length() <= 64, "Result must be at most 64 chars");
-            assertTrue(result.matches("^[a-zA-Z0-9_\\-]{1,64}$"));
+            assertEquals("a".repeat(64), OpenAIMessageConverter.sanitizeName("a".repeat(80)));
         }
 
-        @Test
-        @DisplayName("sanitizeName: purely illegal name falls back to 'agent'")
-        void testSanitizeNamePurelyIllegal() {
-            assertEquals("agent", OpenAIMessageConverter.sanitizeName("!!!"));
-            assertEquals("agent", OpenAIMessageConverter.sanitizeName("你好"));
-        }
-
-        @Test
-        @DisplayName(
-                "sanitizeName: assistant message with space in name is sanitized before API call")
-        void testAssistantMessageNameWithSpaceIsSanitized() {
+        @ParameterizedTest
+        @CsvSource(
+                value = {"USER|Hello World|Hello_World", "ASSISTANT|My Agent|My_Agent"},
+                delimiter = '|')
+        @DisplayName("Should sanitize name before converting user and assistant messages")
+        void testMessageNameIsSanitized(MsgRole role, String rawName, String expectedName) {
             Msg msg =
                     Msg.builder()
-                            .role(MsgRole.ASSISTANT)
-                            .name("My Agent")
+                            .role(role)
+                            .name(rawName)
                             .content(List.of(TextBlock.builder().text("Hi").build()))
                             .build();
 
             OpenAIMessage result = converter.convertToMessage(msg, false);
 
             assertNotNull(result);
-            assertEquals("My_Agent", result.getName());
-        }
-
-        @Test
-        @DisplayName("sanitizeName: user message with space in name is sanitized before API call")
-        void testUserMessageNameWithSpaceIsSanitized() {
-            Msg msg =
-                    Msg.builder()
-                            .role(MsgRole.USER)
-                            .name("Hello World")
-                            .content(List.of(TextBlock.builder().text("Hi").build()))
-                            .build();
-
-            OpenAIMessage result = converter.convertToMessage(msg, false);
-
-            assertNotNull(result);
-            assertEquals("Hello_World", result.getName());
-        }
-
-        @Test
-        @DisplayName(
-                "sanitizeName: assistant message with Chinese name is sanitized before API call")
-        void testAssistantMessageChineseNameIsSanitized() {
-            Msg msg =
-                    Msg.builder()
-                            .role(MsgRole.ASSISTANT)
-                            .name("智能助手")
-                            .content(List.of(TextBlock.builder().text("你好").build()))
-                            .build();
-
-            OpenAIMessage result = converter.convertToMessage(msg, false);
-
-            assertNotNull(result);
-            assertNotNull(result.getName());
-            assertTrue(
-                    result.getName().matches("^[a-zA-Z0-9_\\-]{1,64}$"),
-                    "Sanitized name must satisfy OpenAI constraint but was: " + result.getName());
+            assertEquals(expectedName, result.getName());
         }
     }
 


### PR DESCRIPTION
… (#2345 )

## AgentScope-Java Version

[The version of AgentScope-Java you are working on, e.g. 2.0.1, check your pom.xml dependency version or run `mvn dependency:tree | grep agentscope-parent:pom`(only mac/linux)]

## Description
Example:
```java
 /** Logical name used to register and resolve the model via {@link ModelRegistry}. */
    private static final String MODEL_ALIAS = "my-gpt5";

    public static void main(String[] args) throws Exception {
        // ----------------------------------------------------------------
        // 1. Resolve API key and optional custom base URL
        //    Override via env vars so the binary contains no secrets.
        // ----------------------------------------------------------------
        String apiKey = System.getenv("OPENAI_API_KEY");
        
        // Custom base URL for compatible providers (leave null to use OpenAI's default).
        // Example: "https://api.ciyuanshen.top/v1"
        String baseUrl = System.getenv("OPENAI_BASE_URL");

        // ----------------------------------------------------------------
        // 2. Build OpenAIChatModel
        //    Use GenerateOptions to apply call-level defaults (temperature,
        //    maxTokens, etc.) without changing the model's core configuration.
        // ----------------------------------------------------------------
        OpenAIChatModel.Builder modelBuilder =
                OpenAIChatModel.builder()
                        .apiKey(apiKey)
                        .modelName("gpt-5.4")
                        .stream(true)
                        .generateOptions(
                                GenerateOptions.builder()
                                        .temperature(0.2)
                                        .maxCompletionTokens(2048)
                                        .build());

        if (baseUrl != null && !baseUrl.isBlank()) {
            modelBuilder.baseUrl(baseUrl);
        }

        // ----------------------------------------------------------------
        // 3. Register the model under a logical alias so HarnessAgent (and
        //    any other component) can resolve it by name via ModelRegistry.
        // ----------------------------------------------------------------
        ModelRegistry.register(MODEL_ALIAS, modelBuilder.build());

        // ----------------------------------------------------------------
        // 4. Prepare workspace directory
        // ----------------------------------------------------------------
        Path workspace = Paths.get(".agentscope/openai-chat");
        initWorkspaceIfAbsent(workspace);

        // ----------------------------------------------------------------
        // 5. Build HarnessAgent — references the model by its registered name
        // ----------------------------------------------------------------
        HarnessAgent agent =
                HarnessAgent.builder()
                        .name("demo")
                        .sysPrompt(
                                "You are a helpful AI assistant. Be friendly, accurate and"
                                        + " concise.")
                        .model(MODEL_ALIAS)
                        .workspace(workspace)
                        .stateStore(new InMemoryAgentStateStore())
                        .build();

        // ----------------------------------------------------------------
        // 6. Single RuntimeContext for the entire session so multi-turn
        //    history is preserved across invocations.
        // ----------------------------------------------------------------
        RuntimeContext ctx =
                RuntimeContext.builder()
                        .sessionId("openai-chat-session")
                        .userId("user-1")
                        .build();

        // ----------------------------------------------------------------
        // 7. Interactive chat loop with streaming output
        // ----------------------------------------------------------------
        System.out.println("\n" + "=".repeat(60));
        System.out.println("OpenAI Chat Example  (model: gpt-5.5)");
        System.out.println("=".repeat(60));
        System.out.println("Type your message and press Enter. Type 'exit' to quit.\n");

        BufferedReader reader = new BufferedReader(new InputStreamReader(System.in));

        while (true) {
            System.out.print("You: ");
            String input = reader.readLine();

            if (input == null || input.trim().equalsIgnoreCase("exit")) {
                System.out.println("\nGoodbye!");
                break;
            }
            if (input.isBlank()) {
                continue;
            }

            System.out.print("\nAssistant: ");

            agent.streamEvents(new UserMessage("test name",input.trim()), ctx)
                    .doOnNext(
                            event -> {
                                if (event instanceof TextBlockDeltaEvent e) {
                                    System.out.print(e.getDelta());
                                }
                            })
                    .blockLast();
            System.out.println("\n");
        }
    }

    private static void initWorkspaceIfAbsent(Path workspace) throws Exception {
        Files.createDirectories(workspace);
        Path agentsMd = workspace.resolve("AGENTS.md");
        if (Files.exists(agentsMd)) return;
        Files.writeString(
                agentsMd,
                """
                # OpenAI Chat Assistant

                You are a general-purpose assistant powered by GPT.

                ## Behavior Guidelines
                - Answer questions clearly and concisely
                - If you are unsure, say so rather than guessing
                - Use bullet lists for multi-step answers when helpful
                """);
    }
```

## Checklist

Please check the following items before code is ready to be reviewed.

- [X ]  Code has been formatted with `mvn spotless:apply`
- [X]  All tests are passing (`mvn test`)
- [X]  Javadoc comments are complete and follow project conventions
- [X]  Related documentation has been updated (e.g. links, examples, etc.)
- [X]  Code is ready for review
