### PR TITLE
fix(openai): sanitize message names for API requests

### DIFF
--- a/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-openai/src/main/java/io/agentscope/extensions/model/openai/formatter/OpenAIMessageConverter.java
+++ b/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-openai/src/main/java/io/agentscope/extensions/model/openai/formatter/OpenAIMessageConverter.java
@@ -41,6 +41,7 @@ import io.agentscope.extensions.model.openai.dto.OpenAIToolCall;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Function;
+import java.util.regex.Pattern;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -53,6 +54,9 @@ import org.slf4j.LoggerFactory;
 public class OpenAIMessageConverter {
 
     private static final Logger log = LoggerFactory.getLogger(OpenAIMessageConverter.class);
+
+    private static final Pattern INVALID_MESSAGE_NAME_CHARACTERS =
+            Pattern.compile("[^a-zA-Z0-9_-]");
 
     private final Function<Msg, String> textExtractor;
     private final Function<List<ContentBlock>, String> toolResultConverter;
@@ -123,7 +127,7 @@ public class OpenAIMessageConverter {
         OpenAIMessage.Builder builder = OpenAIMessage.builder().role("user");
 
         if (msg.getName() != null) {
-            builder.name(msg.getName());
+            builder.name(sanitizeMessageName(msg.getName()));
         }
 
         List<ContentBlock> blocks = msg.getContent();
@@ -350,7 +354,7 @@ public class OpenAIMessageConverter {
         }
 
         if (msg.getName() != null) {
-            builder.name(msg.getName());
+            builder.name(sanitizeMessageName(msg.getName()));
         }
 
         // Handle tool calls
@@ -429,6 +433,17 @@ public class OpenAIMessageConverter {
         }
 
         return builder.build();
+    }
+
+    /**
+     * Sanitize a message name according to the OpenAI API's allowed character set.
+     *
+     * <p>AgentScope permits human-readable agent names, including spaces, while OpenAI only
+     * accepts ASCII letters, digits, underscores, and hyphens in the message {@code name} field.
+     * Keep the original name inside AgentScope and normalize it only at the API boundary.
+     */
+    private String sanitizeMessageName(String name) {
+        return INVALID_MESSAGE_NAME_CHARACTERS.matcher(name).replaceAll("_");
     }
 
     /**

--- a/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-openai/src/test/java/io/agentscope/extensions/model/openai/formatter/OpenAIMessageConverterTest.java
+++ b/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-openai/src/test/java/io/agentscope/extensions/model/openai/formatter/OpenAIMessageConverterTest.java
@@ -736,6 +736,38 @@ class OpenAIMessageConverterTest {
         }
 
         @Test
+        @DisplayName("Should sanitize invalid characters in user message name")
+        void testUserMessageWithInvalidNameCharacters() {
+            Msg msg =
+                    Msg.builder()
+                            .role(MsgRole.USER)
+                            .name("Alice Smith@example.com")
+                            .content(List.of(TextBlock.builder().text("Hello").build()))
+                            .build();
+
+            OpenAIMessage result = converter.convertToMessage(msg, false);
+
+            assertNotNull(result);
+            assertEquals("Alice_Smith_example_com", result.getName());
+        }
+
+        @Test
+        @DisplayName("Should sanitize invalid characters in assistant message name")
+        void testAssistantMessageWithInvalidNameCharacters() {
+            Msg msg =
+                    Msg.builder()
+                            .role(MsgRole.ASSISTANT)
+                            .name("Research Agent (East)")
+                            .content(List.of(TextBlock.builder().text("Hi").build()))
+                            .build();
+
+            OpenAIMessage result = converter.convertToMessage(msg, false);
+
+            assertNotNull(result);
+            assertEquals("Research_Agent__East_", result.getName());
+        }
+
+        @Test
         @DisplayName("Should handle null name")
         void testMessageWithNullName() {
             Msg msg =


### PR DESCRIPTION
## AgentScope-Java Version

2.0.1-SNAPSHOT

## Description

OpenAI-compatible APIs only allow letters, digits, underscores, and hyphens in the message `name` field.

This change sanitizes unsupported characters when converting user and assistant messages, while preserving the original agent name inside AgentScope.

Fixes #2345

## Checklist

- [x] Code has been formatted with `mvn spotless:apply`
- [x] All relevant tests are passing
- [x] Javadoc comments are complete and follow project conventions
- [ ] Related documentation has been updated
- [x] Code is ready for review