### PR TITLE
feat(harness): allow disabling general-purpose subagent

### DIFF
--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/HarnessAgent.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/HarnessAgent.java
@@ -1096,6 +1096,7 @@ public class HarnessAgent implements Agent, AutoCloseable {
         boolean disableWorkspaceContext = false;
         boolean disableAtPathExpansion = false;
         boolean disableSubagents = false;
+        boolean disableGeneralPurposeSubagent = false;
         boolean disableDynamicSkills = false;
         boolean disableDefaultWorkspaceSkills = false;
         boolean disableDynamicSubagents = false;
@@ -1934,6 +1935,17 @@ public class HarnessAgent implements Agent, AutoCloseable {
 
         public Builder disableSubagents() {
             this.disableSubagents = true;
+            return this;
+        }
+
+        /**
+         * Disables the built-in {@code general-purpose} subagent while keeping declared and custom
+         * subagents available.
+         *
+         * @return this builder
+         */
+        public Builder disableGeneralPurposeSubagent() {
+            this.disableGeneralPurposeSubagent = true;
             return this;
         }
 

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/HarnessAgentBuilderSupport.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/HarnessAgentBuilderSupport.java
@@ -197,13 +197,15 @@ final class HarnessAgentBuilderSupport {
 
         List<SubagentEntry> entries = new ArrayList<>();
 
-        entries.add(
-                new SubagentEntry(
-                        "general-purpose",
-                        "General-purpose subagent with same capabilities as the main agent."
-                                + " Use for any isolated task that can be fully delegated.",
-                        buildGeneralPurposeFactory(b, resolvedWorkspace, sandboxFs),
-                        null));
+        if (!b.disableGeneralPurposeSubagent) {
+            entries.add(
+                    new SubagentEntry(
+                            "general-purpose",
+                            "General-purpose subagent with same capabilities as the main agent."
+                                    + " Use for any isolated task that can be fully delegated.",
+                            buildGeneralPurposeFactory(b, resolvedWorkspace, sandboxFs),
+                            null));
+        }
 
         for (SubagentDeclaration decl : allDeclarations) {
             entries.add(
@@ -240,13 +242,15 @@ final class HarnessAgentBuilderSupport {
             HarnessAgent.Builder b, Path resolvedWorkspace, SandboxBackedFilesystem sandboxFs) {
         List<SubagentEntry> entries = new ArrayList<>();
 
-        entries.add(
-                new SubagentEntry(
-                        "general-purpose",
-                        "General-purpose subagent with same capabilities as the main agent."
-                                + " Use for any isolated task that can be fully delegated.",
-                        buildGeneralPurposeFactory(b, resolvedWorkspace, sandboxFs),
-                        null));
+        if (!b.disableGeneralPurposeSubagent) {
+            entries.add(
+                    new SubagentEntry(
+                            "general-purpose",
+                            "General-purpose subagent with same capabilities as the main agent."
+                                    + " Use for any isolated task that can be fully delegated.",
+                            buildGeneralPurposeFactory(b, resolvedWorkspace, sandboxFs),
+                            null));
+        }
 
         for (SubagentDeclaration decl : b.subagentDeclarations) {
             entries.add(

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/HarnessAgentTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/HarnessAgentTest.java
@@ -480,6 +480,53 @@ class HarnessAgentTest {
     }
 
     @Test
+    void disableGeneralPurposeSubagent_keepsDeclaredSubagentsAvailable() throws Exception {
+        Files.createDirectories(workspace);
+        Files.writeString(workspace.resolve(WorkspaceConstants.AGENTS_MD), "# workspace\n");
+        Path subagents = workspace.resolve("subagents");
+        Files.createDirectories(subagents);
+        Files.writeString(
+                subagents.resolve("specialist.md"),
+                """
+                ---
+                description: A custom specialist subagent
+                ---
+                You only reply OK.
+                """);
+
+        Model model = stubModel("done");
+        HarnessAgent.Builder builder =
+                HarnessAgent.builder()
+                        .name("main")
+                        .model(model)
+                        .workspace(workspace)
+                        .abstractFilesystem(new LocalFilesystem(workspace))
+                        .disableGeneralPurposeSubagent();
+
+        List<String> entryNames =
+                builder.buildSubagentEntries(workspace).stream()
+                        .map(SubagentEntry::name)
+                        .collect(Collectors.toList());
+        assertFalse(entryNames.contains("general-purpose"));
+        assertTrue(entryNames.contains("specialist"));
+
+        HarnessAgent agent = builder.build();
+        agent.call(userText("go"), RuntimeContext.builder().sessionId("s2").build()).block();
+
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<List<Msg>> captor = ArgumentCaptor.forClass(List.class);
+        verify(model, atLeast(1)).stream(captor.capture(), any(), any());
+        String combined =
+                captor.getAllValues().stream()
+                        .map(HarnessAgentTest::joinAllText)
+                        .filter(s -> s.contains("## Subagents"))
+                        .findFirst()
+                        .orElse("");
+        assertTrue(combined.contains("`specialist`"));
+        assertFalse(combined.contains("general-purpose"));
+    }
+
+    @Test
     void subagentsDir_loadsMarkdownDeclarations() throws Exception {
         Files.createDirectories(workspace);
         Files.writeString(workspace.resolve(WorkspaceConstants.AGENTS_MD), "# w\n");


### PR DESCRIPTION
## AgentScope-Java Version

2.0.1-SNAPSHOT

## Description

HarnessAgent always registers the built-in `general-purpose` subagent when subagent support is enabled. This can interfere with explicitly declared subagents by allowing the built-in agent to handle tasks intended for them.

This change adds `disableGeneralPurposeSubagent()` to disable only the built-in entry while keeping programmatic, workspace-defined, and custom subagents available. Both static and dynamic subagent registration paths honor the new option.

Fixes #2340

## Checklist

- [x] Code has been formatted with `mvn spotless:apply`
- [x] All relevant tests are passing
- [x] Javadoc comments are complete and follow project conventions
- [ ] Related documentation has been updated
- [x] Code is ready for review