### PR TITLE
fix(gemini): apply model execution config

### DIFF
--- a/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-gemini/src/main/java/io/agentscope/extensions/model/gemini/GeminiChatModel.java
+++ b/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-gemini/src/main/java/io/agentscope/extensions/model/gemini/GeminiChatModel.java
@@ -31,6 +31,7 @@ import io.agentscope.core.model.ChatResponse;
 import io.agentscope.core.model.GenerateOptions;
 import io.agentscope.core.model.ModelContextWindows;
 import io.agentscope.core.model.ModelException;
+import io.agentscope.core.model.ModelUtils;
 import io.agentscope.core.model.ToolSchema;
 import io.agentscope.core.model.transport.ProxyConfig;
 import io.agentscope.extensions.model.gemini.formatter.GeminiChatFormatter;
@@ -231,6 +232,17 @@ public class GeminiChatModel extends ChatModelBase {
      */
     @Override
     protected Flux<ChatResponse> doStream(
+            List<Msg> messages, List<ToolSchema> tools, GenerateOptions options) {
+        return applyExecutionConfig(doStream0(messages, tools, options), options);
+    }
+
+    private Flux<ChatResponse> applyExecutionConfig(
+            Flux<ChatResponse> responseFlux, GenerateOptions options) {
+        return ModelUtils.applyTimeoutAndRetry(
+                responseFlux, options, defaultOptions, modelName, "gemini");
+    }
+
+    protected Flux<ChatResponse> doStream0(
             List<Msg> messages, List<ToolSchema> tools, GenerateOptions options) {
         Instant startTime = Instant.now();
         log.debug(

--- a/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-gemini/src/main/java/io/agentscope/extensions/model/gemini/GeminiChatModel.java
+++ b/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-gemini/src/main/java/io/agentscope/extensions/model/gemini/GeminiChatModel.java
@@ -233,13 +233,8 @@ public class GeminiChatModel extends ChatModelBase {
     @Override
     protected Flux<ChatResponse> doStream(
             List<Msg> messages, List<ToolSchema> tools, GenerateOptions options) {
-        return applyExecutionConfig(doStream0(messages, tools, options), options);
-    }
-
-    private Flux<ChatResponse> applyExecutionConfig(
-            Flux<ChatResponse> responseFlux, GenerateOptions options) {
         return ModelUtils.applyTimeoutAndRetry(
-                responseFlux, options, defaultOptions, modelName, "gemini");
+                doStream0(messages, tools, options), options, defaultOptions, modelName, "gemini");
     }
 
     protected Flux<ChatResponse> doStream0(
@@ -579,7 +574,7 @@ public class GeminiChatModel extends ChatModelBase {
                             httpOptions,
                             credentials,
                             resolvedClientOptions,
-                            defaultOptions,
+                            ModelUtils.ensureDefaultExecutionConfig(defaultOptions),
                             formatter);
             model.setContextWindowSize(
                     contextWindowSize >= 0

--- a/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-gemini/src/test/java/io/agentscope/extensions/model/gemini/GeminiChatModelTest.java
+++ b/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-gemini/src/test/java/io/agentscope/extensions/model/gemini/GeminiChatModelTest.java
@@ -24,6 +24,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import com.google.genai.types.ClientOptions;
 import com.google.genai.types.HttpOptions;
 import com.google.genai.types.ProxyOptions;
+import io.agentscope.core.message.Msg;
 import io.agentscope.core.model.ChatResponse;
 import io.agentscope.core.model.ExecutionConfig;
 import io.agentscope.core.model.GenerateOptions;
@@ -83,7 +84,8 @@ class GeminiChatModelTest {
                         ModelException.class,
                         () ->
                                 new TestGeminiChatModel(Flux.never())
-                                        .stream(List.of(), List.of(), options).blockLast());
+                                        .stream(List.of(), List.of(), options)
+                                                .blockLast(Duration.ofSeconds(1)));
 
         assertTrue(error.getMessage().contains("timeout"));
     }
@@ -701,9 +703,7 @@ class GeminiChatModelTest {
 
         @Override
         protected Flux<ChatResponse> doStream0(
-                List<io.agentscope.core.message.Msg> messages,
-                List<ToolSchema> tools,
-                GenerateOptions options) {
+                List<Msg> messages, List<ToolSchema> tools, GenerateOptions options) {
             return response;
         }
     }

--- a/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-gemini/src/test/java/io/agentscope/extensions/model/gemini/GeminiChatModelTest.java
+++ b/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-gemini/src/test/java/io/agentscope/extensions/model/gemini/GeminiChatModelTest.java
@@ -18,11 +18,16 @@ package io.agentscope.extensions.model.gemini;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.google.genai.types.ClientOptions;
 import com.google.genai.types.HttpOptions;
 import com.google.genai.types.ProxyOptions;
+import io.agentscope.core.model.ChatResponse;
+import io.agentscope.core.model.ExecutionConfig;
 import io.agentscope.core.model.GenerateOptions;
+import io.agentscope.core.model.ModelException;
 import io.agentscope.core.model.ToolChoice;
 import io.agentscope.core.model.ToolSchema;
 import io.agentscope.core.model.test.ModelTestUtils;
@@ -30,11 +35,14 @@ import io.agentscope.core.model.transport.ProxyConfig;
 import io.agentscope.extensions.model.gemini.formatter.GeminiChatFormatter;
 import io.agentscope.extensions.model.gemini.formatter.GeminiMultiAgentFormatter;
 import java.lang.reflect.Field;
+import java.time.Duration;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Flux;
 
 /**
  * Unit tests for GeminiChatModel.
@@ -56,6 +64,58 @@ class GeminiChatModelTest {
     @BeforeEach
     void setUp() {
         mockApiKey = ModelTestUtils.createMockApiKey();
+    }
+
+    @Test
+    @DisplayName("Should apply request timeout to Gemini response streams")
+    void testAppliesRequestTimeout() {
+        GenerateOptions options =
+                GenerateOptions.builder()
+                        .executionConfig(
+                                ExecutionConfig.builder()
+                                        .timeout(Duration.ofMillis(10))
+                                        .maxAttempts(1)
+                                        .build())
+                        .build();
+
+        ModelException error =
+                assertThrows(
+                        ModelException.class,
+                        () ->
+                                new TestGeminiChatModel(Flux.never())
+                                        .stream(List.of(), List.of(), options).blockLast());
+
+        assertTrue(error.getMessage().contains("timeout"));
+    }
+
+    @Test
+    @DisplayName("Should retry Gemini response streams according to execution config")
+    void testRetriesRequestThroughStreamEntryPoint() {
+        AtomicInteger attempts = new AtomicInteger();
+        GenerateOptions options =
+                GenerateOptions.builder()
+                        .executionConfig(
+                                ExecutionConfig.builder()
+                                        .maxAttempts(2)
+                                        .initialBackoff(Duration.ofMillis(1))
+                                        .maxBackoff(Duration.ofMillis(1))
+                                        .retryOn(error -> true)
+                                        .build())
+                        .build();
+
+        assertThrows(
+                RuntimeException.class,
+                () ->
+                        new TestGeminiChatModel(
+                                        Flux.defer(
+                                                () -> {
+                                                    attempts.incrementAndGet();
+                                                    return Flux.error(
+                                                            new IllegalStateException("failed"));
+                                                }))
+                                .stream(List.of(), List.of(), options).blockLast());
+
+        assertEquals(2, attempts.get());
     }
 
     @Test
@@ -628,5 +688,23 @@ class GeminiChatModelTest {
         Field httpOptionsField = GeminiChatModel.class.getDeclaredField("httpOptions");
         httpOptionsField.setAccessible(true);
         return (HttpOptions) httpOptionsField.get(model);
+    }
+
+    private static final class TestGeminiChatModel extends GeminiChatModel {
+
+        private final Flux<ChatResponse> response;
+
+        private TestGeminiChatModel(Flux<ChatResponse> response) {
+            super("test-key", "gemini-test", true, null, null, null, null, null, null, null, null);
+            this.response = response;
+        }
+
+        @Override
+        protected Flux<ChatResponse> doStream0(
+                List<io.agentscope.core.message.Msg> messages,
+                List<ToolSchema> tools,
+                GenerateOptions options) {
+            return response;
+        }
     }
 }


### PR DESCRIPTION
## AgentScope-Java Version

Current main branch.

## Description

### Background

`GeminiChatModel` returned its SDK stream directly, so configured request timeout and retry settings were ignored even though other providers apply the shared execution wrapper.

### Changes

- Apply `ModelUtils.applyTimeoutAndRetry` to Gemini response streams.
- Add timeout and retry coverage through the public `stream()` entry point.

### Validation

- `mvn -q -pl agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-gemini -am -Dtest=GeminiChatModelTest test`
- `mvn -q -T1 -pl agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-gemini -am verify`

The full repository `verify` ran through its Java test phase, but the unrelated `agentscope-builder` step could not download npm 10.9.2 because the npm registry TLS handshake was terminated.

## Checklist

- [x] Code has been formatted with `mvn spotless:apply` rules
- [x] Relevant tests are passing
- [x] Javadoc follows existing conventions
- [ ] Documentation update is not needed
- [x] Code is ready for review