### PR TITLE
fix(harness): 连续会话压缩时会过滤上一轮摘要，导致原始用户意图丢失

### DIFF
--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/memory/MemoryFlushManager.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/memory/MemoryFlushManager.java
@@ -24,6 +24,7 @@ import io.agentscope.core.message.ToolResultBlock;
 import io.agentscope.core.message.ToolUseBlock;
 import io.agentscope.core.model.Model;
 import io.agentscope.core.util.JsonUtils;
+import io.agentscope.harness.agent.memory.compaction.ConversationCompactor;
 import io.agentscope.harness.agent.memory.session.SessionEntry;
 import io.agentscope.harness.agent.memory.session.SessionTree;
 import io.agentscope.harness.agent.workspace.WorkspaceConstants;
@@ -346,16 +347,24 @@ public class MemoryFlushManager {
      * Serializes all messages into a textual representation for the memory extraction model.
      * Includes USER, ASSISTANT, and TOOL messages. Assistant tool-call blocks and tool-result
      * blocks are rendered as concise text so the model can extract memories from tool interactions.
-     * The injected {@code <session_context>} user message is skipped as it contains only
-     * environment metadata, not real conversation content.
+     * Internal context messages are skipped because they are generated from existing context,
+     * not new user/assistant/tool facts.
      */
     private String serializeMessages(List<Msg> messages) {
         return messages.stream()
                 .filter(m -> m.getRole() != null && m.getRole() != MsgRole.SYSTEM)
-                .filter(m -> !isSessionContextMessage(m))
+                .filter(m -> !isInternalContextMessage(m))
                 .map(this::renderMessage)
                 .filter(s -> s != null && !s.isBlank())
                 .collect(Collectors.joining("\n"));
+    }
+
+    private static boolean isInternalContextMessage(Msg msg) {
+        return isSessionContextMessage(msg) || isCompactionSummaryMessage(msg);
+    }
+
+    private static boolean isCompactionSummaryMessage(Msg msg) {
+        return msg != null && ConversationCompactor.SUMMARY_MSG_NAME.equals(msg.getName());
     }
 
     private static boolean isSessionContextMessage(Msg msg) {

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/memory/compaction/ConversationCompactor.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/memory/compaction/ConversationCompactor.java
@@ -26,12 +26,14 @@ import io.agentscope.core.model.Model;
 import io.agentscope.harness.agent.memory.MemoryFlushManager;
 import io.agentscope.harness.agent.memory.compaction.CompactionConfig.TruncateArgsConfig;
 import io.agentscope.harness.agent.middleware.CompactionMiddleware;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.UUID;
 import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -436,8 +438,8 @@ public class ConversationCompactor {
      * conversation history was offloaded.
      * When null, falls back to the simple "summary to date" format.
      *
-     * <p>The message name is set to {@link #SUMMARY_MSG_NAME} so hooks can identify and
-     * skip summary messages during future flush/offload cycles.
+     * <p>The message name is set to {@link #SUMMARY_MSG_NAME} so hooks can identify generated
+     * summaries, and the stable content-based ID keeps repeated session offloads idempotent.
      */
     private static Msg buildSummaryMessage(String summary, String filePath) {
         String content;
@@ -455,10 +457,16 @@ public class ConversationCompactor {
             content = "Here is a summary of the conversation to date:\n\n" + summary;
         }
         return Msg.builder()
+                .id(buildSummaryMessageId(content))
                 .role(MsgRole.USER)
                 .name(SUMMARY_MSG_NAME)
                 .content(TextBlock.builder().text(content).build())
                 .build();
+    }
+
+    private static String buildSummaryMessageId(String content) {
+        UUID stableId = UUID.nameUUIDFromBytes(content.getBytes(StandardCharsets.UTF_8));
+        return SUMMARY_MSG_NAME + ":" + stableId;
     }
 
     // -------------------------------------------------------------------------

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/memory/compaction/ConversationCompactor.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/memory/compaction/ConversationCompactor.java
@@ -115,9 +115,10 @@ public class ConversationCompactor {
             return Mono.just(Optional.empty());
         }
 
-        // Filter previous summary messages from the prefix before offloading to avoid
-        // re-storing already-archived summaries.
-        List<Msg> prefix = filterSummaryMessages(new ArrayList<>(messages.subList(0, cutoff)));
+        // Keep prior summaries in the summarization input so each compaction builds on the
+        // previous one, but exclude them from memory flushing to avoid duplicate extraction.
+        List<Msg> summaryInput = new ArrayList<>(messages.subList(0, cutoff));
+        List<Msg> flushInput = filterSummaryMessages(summaryInput);
         List<Msg> tail = new ArrayList<>(messages.subList(cutoff, messages.size()));
 
         log.info(
@@ -127,11 +128,11 @@ public class ConversationCompactor {
                 cutoff,
                 tail.size());
 
-        // Step 2: Flush long-term memories from the prefix (best-effort).
+        // Step 2: Flush long-term memories only from newly compacted raw messages (best-effort).
         Mono<Void> flushStep =
                 config.isFlushBeforeCompact()
                         ? flushManager
-                                .flushMemories(rc, prefix)
+                                .flushMemories(rc, flushInput)
                                 .doOnSuccess(v -> log.debug("Memory flush before compaction done"))
                                 .onErrorResume(
                                         e -> {
@@ -172,12 +173,12 @@ public class ConversationCompactor {
             offloadStep = Mono.just("");
         }
 
-        // Step 4: LLM summarization of the prefix, combined with the offload result.
+        // Step 4: LLM summarization of prior summaries plus the newly compacted prefix.
         return flushStep
                 .then(offloadStep)
                 .flatMap(
                         offloadPath ->
-                                summarizePrefix(prefix, config)
+                                summarizePrefix(summaryInput, config)
                                         .map(
                                                 summary -> {
                                                     String filePath =
@@ -467,13 +468,12 @@ public class ConversationCompactor {
     /**
      * Removes previously injected summary messages from a list.
      *
-     * <p>During chained summarization the working memory may already contain a summary USER
-     * message from a prior compaction round. We filter these out before offloading to the
-     * backend so the original messages (already stored there) are not duplicated.
+     * <p>Prior summaries remain part of the next summarization input, but memory flushing must
+     * only process the newly compacted raw messages to avoid duplicate extraction.
      */
     static List<Msg> filterSummaryMessages(List<Msg> messages) {
         return messages.stream()
-                .filter(m -> !SUMMARY_MSG_NAME.equals(m.getName()))
+                .filter(message -> !SUMMARY_MSG_NAME.equals(message.getName()))
                 .collect(Collectors.toList());
     }
 

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/memory/MemoryFlushManagerOffloadTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/memory/MemoryFlushManagerOffloadTest.java
@@ -21,6 +21,7 @@ import io.agentscope.core.agent.RuntimeContext;
 import io.agentscope.core.message.Msg;
 import io.agentscope.core.message.MsgRole;
 import io.agentscope.core.message.TextBlock;
+import io.agentscope.harness.agent.memory.compaction.ConversationCompactor;
 import io.agentscope.harness.agent.memory.session.SessionEntry;
 import io.agentscope.harness.agent.memory.session.SessionTree;
 import io.agentscope.harness.agent.workspace.WorkspaceManager;
@@ -123,10 +124,46 @@ class MemoryFlushManagerOffloadTest {
                         .count());
     }
 
+    @Test
+    void offloadMessages_persistsCompactionSummariesAndDedupesStableIds() throws Exception {
+        RuntimeContext rc = RuntimeContext.builder().sessionId("session-1").build();
+
+        try (WorkspaceManager workspaceManager = new WorkspaceManager(workspace)) {
+            MemoryFlushManager flushManager = new MemoryFlushManager(workspaceManager, null);
+
+            List<Msg> batch =
+                    List.of(
+                            compactionSummary("summary-id", "summary should stay recoverable"),
+                            message("m1", MsgRole.USER, "real follow-up"));
+            flushManager.offloadMessages(rc, batch, "agent-a", "session-1");
+            flushManager.offloadMessages(rc, batch, "agent-a", "session-1");
+        }
+
+        Path context = workspace.resolve("agents/agent-a/sessions/session-1.jsonl");
+        SessionTree tree = new SessionTree(context, workspace, null);
+        tree.load();
+
+        List<SessionEntry.MessageEntry> entries = tree.getMessageEntries();
+        assertEquals(2, entries.size());
+        assertEquals(
+                List.of("summary-id", "m1"), entries.stream().map(SessionEntry::getId).toList());
+        assertEquals("summary should stay recoverable", entries.get(0).getContent());
+        assertEquals("real follow-up", entries.get(1).getContent());
+    }
+
     private static Msg message(String id, MsgRole role, String text) {
         return Msg.builder()
                 .id(id)
                 .role(role)
+                .content(TextBlock.builder().text(text).build())
+                .build();
+    }
+
+    private static Msg compactionSummary(String id, String text) {
+        return Msg.builder()
+                .id(id)
+                .role(MsgRole.USER)
+                .name(ConversationCompactor.SUMMARY_MSG_NAME)
                 .content(TextBlock.builder().text(text).build())
                 .build();
     }

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/memory/MemoryFlushManagerTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/memory/MemoryFlushManagerTest.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.harness.agent.memory;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.agentscope.core.agent.RuntimeContext;
+import io.agentscope.core.message.Msg;
+import io.agentscope.core.message.MsgRole;
+import io.agentscope.core.message.TextBlock;
+import io.agentscope.core.model.ChatResponse;
+import io.agentscope.core.model.GenerateOptions;
+import io.agentscope.core.model.Model;
+import io.agentscope.core.model.ToolSchema;
+import io.agentscope.harness.agent.memory.compaction.ConversationCompactor;
+import io.agentscope.harness.agent.workspace.WorkspaceManager;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import reactor.core.publisher.Flux;
+
+class MemoryFlushManagerTest {
+
+    @TempDir Path workspace;
+
+    @Test
+    void flushMemories_skipsCompactionSummariesWhenRealMessagesRemain() {
+        RecordingModel model = new RecordingModel();
+        RuntimeContext rc = RuntimeContext.builder().sessionId("session-1").build();
+
+        try (WorkspaceManager workspaceManager = new WorkspaceManager(workspace)) {
+            MemoryFlushManager flushManager = new MemoryFlushManager(workspaceManager, model);
+
+            flushManager
+                    .flushMemories(
+                            rc,
+                            List.of(
+                                    compactionSummary("internal summary should not be flushed"),
+                                    message(MsgRole.USER, "real follow-up")))
+                    .block();
+        }
+
+        String userPrompt = model.userPrompt(0);
+        assertFalse(userPrompt.contains("internal summary should not be flushed"));
+        assertTrue(userPrompt.contains("real follow-up"));
+    }
+
+    @Test
+    void flushMemories_summaryOnlyInputDoesNotCallModel() {
+        RecordingModel model = new RecordingModel();
+        RuntimeContext rc = RuntimeContext.builder().sessionId("session-1").build();
+
+        try (WorkspaceManager workspaceManager = new WorkspaceManager(workspace)) {
+            MemoryFlushManager flushManager = new MemoryFlushManager(workspaceManager, model);
+
+            flushManager.flushMemories(rc, List.of(compactionSummary("internal only"))).block();
+        }
+
+        assertTrue(model.inputs.isEmpty());
+    }
+
+    private static Msg message(MsgRole role, String text) {
+        return Msg.builder().role(role).content(TextBlock.builder().text(text).build()).build();
+    }
+
+    private static Msg compactionSummary(String text) {
+        return Msg.builder()
+                .role(MsgRole.USER)
+                .name(ConversationCompactor.SUMMARY_MSG_NAME)
+                .content(TextBlock.builder().text(text).build())
+                .build();
+    }
+
+    private static String text(Msg message) {
+        return ((TextBlock) message.getContent().get(0)).getText();
+    }
+
+    private static final class RecordingModel implements Model {
+
+        private final List<List<Msg>> inputs = new ArrayList<>();
+
+        @Override
+        public Flux<ChatResponse> stream(
+                List<Msg> messages, List<ToolSchema> tools, GenerateOptions options) {
+            inputs.add(List.copyOf(messages));
+            return Flux.just(
+                    ChatResponse.builder()
+                            .id("flush-response")
+                            .content(List.of(TextBlock.builder().text("NO_REPLY").build()))
+                            .build());
+        }
+
+        @Override
+        public String getModelName() {
+            return "recording-model";
+        }
+
+        private String userPrompt(int index) {
+            assertEquals(2, inputs.get(index).size());
+            return text(inputs.get(index).get(1));
+        }
+    }
+}

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/memory/compaction/ConversationCompactorTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/memory/compaction/ConversationCompactorTest.java
@@ -1,0 +1,252 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.harness.agent.memory.compaction;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.agentscope.core.agent.RuntimeContext;
+import io.agentscope.core.message.Msg;
+import io.agentscope.core.message.MsgRole;
+import io.agentscope.core.message.TextBlock;
+import io.agentscope.core.model.ChatResponse;
+import io.agentscope.core.model.GenerateOptions;
+import io.agentscope.core.model.Model;
+import io.agentscope.core.model.ToolSchema;
+import io.agentscope.harness.agent.memory.MemoryFlushManager;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+/** Tests message routing between summarization, memory flushing, and the preserved tail. */
+class ConversationCompactorTest {
+
+    /** Verifies that a prior summary is summarized again but is neither flushed nor retained. */
+    @Test
+    void compactIfNeeded_routesPriorSummaryToSummaryInputButNotFlushOrTail() {
+        Fixture fixture = new Fixture();
+
+        List<Msg> compacted =
+                fixture.compact(
+                        List.of(
+                                summary("S1"),
+                                message("M2"),
+                                message("TAIL_1"),
+                                message("TAIL_2")));
+
+        assertTrue(fixture.model.prompt(0).contains("S1"));
+        assertTrue(fixture.model.prompt(0).contains("M2"));
+        assertEquals(List.of("M2"), texts(fixture.flushInputs.get(0)));
+        assertEquals(3, compacted.size());
+        assertEquals(ConversationCompactor.SUMMARY_MSG_NAME, compacted.get(0).getName());
+        assertEquals(List.of("TAIL_1", "TAIL_2"), texts(compacted.subList(1, compacted.size())));
+    }
+
+    /** Verifies that multiple prior summaries in the prefix are replaced by one new summary. */
+    @Test
+    void compactIfNeeded_mergesMultiplePriorSummariesIntoOneReplacement() {
+        Fixture fixture = new Fixture();
+
+        List<Msg> compacted =
+                fixture.compact(
+                        List.of(
+                                summary("S0"),
+                                message("M1"),
+                                summary("S1"),
+                                message("M2"),
+                                message("TAIL_1"),
+                                message("TAIL_2")));
+
+        String prompt = fixture.model.prompt(0);
+        assertTrue(prompt.contains("S0"));
+        assertTrue(prompt.contains("S1"));
+        assertEquals(List.of("M1", "M2"), texts(fixture.flushInputs.get(0)));
+        assertEquals(
+                1,
+                compacted.stream()
+                        .filter(msg -> ConversationCompactor.SUMMARY_MSG_NAME.equals(msg.getName()))
+                        .count());
+    }
+
+    /** Verifies that a summary-only prefix is not treated as empty conversation history. */
+    @Test
+    void compactIfNeeded_summaryOnlyPrefixDoesNotBecomeEmptyHistory() {
+        Fixture fixture = new Fixture();
+
+        List<Msg> compacted =
+                fixture.compact(
+                        List.of(summary("ONLY_OLD_SUMMARY"), message("TAIL_1"), message("TAIL_2")));
+
+        assertTrue(fixture.model.prompt(0).contains("ONLY_OLD_SUMMARY"));
+        assertTrue(fixture.flushInputs.get(0).isEmpty());
+        assertTrue(text(compacted.get(0)).contains("ROUND_1"));
+        assertFalse(text(compacted.get(0)).contains("No previous conversation history."));
+    }
+
+    /** Verifies that chained compaction summarizes the prior summary with the new prefix. */
+    @Test
+    void compactIfNeeded_chainedCompactionUsesPreviousSummaryAndNewPrefix() {
+        Fixture fixture = new Fixture();
+        List<Msg> first =
+                fixture.compact(
+                        List.of(
+                                summary("S1"),
+                                message("M2"),
+                                message("TAIL_1"),
+                                message("TAIL_2")));
+        List<Msg> secondInput = new ArrayList<>(first);
+        secondInput.add(message("M3"));
+        secondInput.add(message("TAIL_3"));
+        secondInput.add(message("TAIL_4"));
+
+        List<Msg> second = fixture.compact(secondInput);
+
+        assertTrue(fixture.model.prompt(1).contains("ROUND_1"));
+        assertTrue(fixture.model.prompt(1).contains("M3"));
+        assertFalse(text(second.get(0)).contains("ROUND_1"));
+        assertTrue(text(second.get(0)).contains("ROUND_2"));
+        assertEquals(List.of("TAIL_1", "TAIL_2", "M3"), texts(fixture.flushInputs.get(1)));
+    }
+
+    /** Verifies that disabling memory flush does not remove the prior summary from summarization. */
+    @Test
+    void compactIfNeeded_skipsFlushWhenDisabledAndStillUsesPriorSummary() {
+        Fixture fixture = new Fixture(false);
+
+        fixture.compact(
+                List.of(summary("S1"), message("M2"), message("TAIL_1"), message("TAIL_2")));
+
+        assertTrue(fixture.model.prompt(0).contains("S1"));
+        assertTrue(fixture.model.prompt(0).contains("M2"));
+        assertTrue(fixture.flushInputs.isEmpty());
+    }
+
+    /** Creates a regular user message. */
+    private static Msg message(String text) {
+        return Msg.builder()
+                .role(MsgRole.USER)
+                .content(TextBlock.builder().text(text).build())
+                .build();
+    }
+
+    /** Creates a summary message injected by the compactor. */
+    private static Msg summary(String text) {
+        return Msg.builder()
+                .role(MsgRole.USER)
+                .name(ConversationCompactor.SUMMARY_MSG_NAME)
+                .content(TextBlock.builder().text(text).build())
+                .build();
+    }
+
+    /** Returns the text from the first content block of a message. */
+    private static String text(Msg message) {
+        return ((TextBlock) message.getContent().get(0)).getText();
+    }
+
+    /** Returns message texts for concise routing assertions. */
+    private static List<String> texts(List<Msg> messages) {
+        return messages.stream().map(ConversationCompactorTest::text).toList();
+    }
+
+    /** Holds isolated compactor dependencies and invocation records for each test. */
+    private static final class Fixture {
+
+        private final RecordingModel model = new RecordingModel();
+        private final MemoryFlushManager flushManager = mock(MemoryFlushManager.class);
+        private final RuntimeContext runtimeContext = mock(RuntimeContext.class);
+        private final List<List<Msg>> flushInputs = new ArrayList<>();
+        private final ConversationCompactor compactor;
+        private final CompactionConfig config;
+
+        /** Creates a fixture with memory flushing enabled. */
+        private Fixture() {
+            this(true);
+        }
+
+        /** Creates a fixture with the requested memory-flush setting. */
+        private Fixture(boolean flushBeforeCompact) {
+            when(flushManager.flushMemories(any(RuntimeContext.class), anyList()))
+                    .thenAnswer(
+                            invocation -> {
+                                List<Msg> input = invocation.getArgument(1);
+                                flushInputs.add(List.copyOf(input));
+                                return Mono.empty();
+                            });
+            compactor = new ConversationCompactor(model, flushManager);
+            config =
+                    CompactionConfig.builder()
+                            .triggerMessages(3)
+                            .triggerTokens(0)
+                            .keepMessages(2)
+                            .keepTokens(0)
+                            .summaryPrompt("SUMMARY_INPUT:\n{messages}")
+                            .flushBeforeCompact(flushBeforeCompact)
+                            .offloadBeforeCompact(false)
+                            .truncateArgs(null)
+                            .prune(null)
+                            .build();
+        }
+
+        /** Runs compaction and requires the supplied input to trigger it. */
+        private List<Msg> compact(List<Msg> messages) {
+            Optional<List<Msg>> result =
+                    compactor
+                            .compactIfNeeded(
+                                    runtimeContext, messages, config, "agent-id", "session-id")
+                            .block();
+            assertTrue(result.isPresent());
+            return result.orElseThrow();
+        }
+    }
+
+    /** Records summarization prompts and returns a distinct fixed summary for each invocation. */
+    private static final class RecordingModel implements Model {
+
+        private final List<List<Msg>> inputs = new ArrayList<>();
+
+        /** Records the model input and emits a fixed text response for the current invocation. */
+        @Override
+        public Flux<ChatResponse> stream(
+                List<Msg> messages, List<ToolSchema> tools, GenerateOptions options) {
+            inputs.add(List.copyOf(messages));
+            String summary = "ROUND_" + inputs.size();
+            return Flux.just(
+                    ChatResponse.builder()
+                            .id("summary-" + inputs.size())
+                            .content(List.of(TextBlock.builder().text(summary).build()))
+                            .build());
+        }
+
+        /** Returns the test model name. */
+        @Override
+        public String getModelName() {
+            return "recording-model";
+        }
+
+        /** Returns the summarization prompt for the specified invocation. */
+        private String prompt(int index) {
+            return text(inputs.get(index).get(0));
+        }
+    }
+}

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/memory/compaction/ConversationCompactorTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/memory/compaction/ConversationCompactorTest.java
@@ -59,6 +59,7 @@ class ConversationCompactorTest {
         assertTrue(fixture.model.prompt(0).contains("M2"));
         assertEquals(List.of("M2"), texts(fixture.flushInputs.get(0)));
         assertEquals(3, compacted.size());
+        assertTrue(compacted.get(0).getId().startsWith(ConversationCompactor.SUMMARY_MSG_NAME));
         assertEquals(ConversationCompactor.SUMMARY_MSG_NAME, compacted.get(0).getName());
         assertEquals(List.of("TAIL_1", "TAIL_2"), texts(compacted.subList(1, compacted.size())));
     }


### PR DESCRIPTION
fix: #2359 
```markdown
## 修改概述

修复 `ConversationCompactor` 在连续执行会话压缩时过滤上一轮摘要，导致后续摘要无法继承原始会话上下文的问题。

该问题已确认影响 AgentScope Java v2.0.0，当前 `main` 分支的
`2.0.1-SNAPSHOT` 中也存在相同实现。

## 问题原因

当前实现会先从待压缩前缀中过滤
`__compaction_summary__`：

```java
List<Msg> prefix =
        filterSummaryMessages(
                new ArrayList<>(messages.subList(0, cutoff)));
```

过滤后的 `prefix` 随后同时用于：

- 生成下一轮压缩摘要；
- 提取长期记忆。

这导致第二次及后续压缩无法看到上一轮摘要，实际行为变成：

```text
S2 = summarize(M2)
S3 = summarize(M3)
```

而不是：

```text
S2 = summarize(S1 + M2)
S3 = summarize(S2 + M3)
```

如果待压缩前缀只包含上一轮摘要，过滤后的前缀会变成空列表，
最终生成：

```text
No previous conversation history.
```

此时上一轮摘要中保留的会话目标、关键决策和后续计划会从模型上下文中丢失。

## 修复方案

根据用途分别构造摘要输入和长期记忆输入：

```java
List<Msg> summaryInput =
        new ArrayList<>(messages.subList(0, cutoff));

List<Msg> flushInput =
        filterSummaryMessages(summaryInput);

List<Msg> tail =
        new ArrayList<>(messages.subList(cutoff, messages.size()));
```

其中：

- `summaryInput` 保留上一轮摘要，用于生成累计摘要；
- `flushInput` 过滤上一轮摘要，避免重复提取长期记忆；
- `tail` 保持原有行为，继续保留未压缩的近期消息。

修复后满足：

```text
新摘要 = summarize(上一轮摘要 + 本轮待压缩消息)
压缩后上下文 = 新摘要 + 未压缩的近期消息
```

`offloadMessages()` 的行为保持不变。该方法原本接收的就是完整
`messages`，而不是过滤后的 prefix：

```java
flushManager.offloadMessages(
        rc, messages, agentId, sessionId);
```

因此本次修复只调整摘要生成和 memory flush 的输入，不改变会话归档语义。

## 测试覆盖

新增 `ConversationCompactorTest`，覆盖：

- 上一轮摘要进入下一轮摘要模型输入；
- 上一轮摘要不进入 memory flush；
- 连续执行两轮压缩时，第二轮摘要模型输入包含第一轮生成的摘要；
- 待压缩前缀只包含旧摘要时，不生成
  `No previous conversation history.`；
- 前缀中存在多个旧摘要时，压缩后只保留一个新摘要；
- 禁用 memory flush 时，旧摘要仍进入下一轮摘要模型输入。