### PR TITLE
fix(openai): drop non-chunk summary event message to avoid content duplication

### DIFF
--- a/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-openai/src/main/java/io/agentscope/extensions/model/openai/OpenAIClient.java
+++ b/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-openai/src/main/java/io/agentscope/extensions/model/openai/OpenAIClient.java
@@ -24,6 +24,7 @@ import io.agentscope.core.model.transport.HttpTransportException;
 import io.agentscope.core.model.transport.HttpTransportFactory;
 import io.agentscope.core.util.JsonException;
 import io.agentscope.core.util.JsonUtils;
+import io.agentscope.extensions.model.openai.dto.OpenAIChoice;
 import io.agentscope.extensions.model.openai.dto.OpenAIRequest;
 import io.agentscope.extensions.model.openai.dto.OpenAIResponse;
 import io.agentscope.extensions.model.openai.exception.OpenAIException;
@@ -423,6 +424,22 @@ public class OpenAIClient {
                                                         errorCode,
                                                         data));
                                         return;
+                                    }
+                                    // Some OpenAI-compatible providers (e.g. MiniMax) emit an
+                                    // extra non-chunk chat.completion summary event at the end
+                                    // of the stream whose message restates the entire message.
+                                    // The incremental deltas have already accumulated the full
+                                    // content, so accumulating the summary message again would
+                                    // double reasoning_content / tool_call arguments (arguments
+                                    // become {...}{...}, invalid JSON), which the model rejects
+                                    // on the next round, halting the agent. Drop the summary
+                                    // message content but keep the choice's finish_reason and
+                                    // usage (real token counts only appear in the summary event).
+                                    if (!response.isChunk()) {
+                                        OpenAIChoice summaryChoice = response.getFirstChoice();
+                                        if (summaryChoice != null) {
+                                            summaryChoice.setMessage(null);
+                                        }
                                     }
                                     sink.next(response);
                                 }

--- a/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-openai/src/main/java/io/agentscope/extensions/model/openai/OpenAIClient.java
+++ b/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-openai/src/main/java/io/agentscope/extensions/model/openai/OpenAIClient.java
@@ -34,6 +34,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.regex.Pattern;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -401,6 +402,7 @@ public class OpenAIClient {
                             .body(requestBody)
                             .build();
 
+            AtomicBoolean seenChunk = new AtomicBoolean(false);
             return transport.stream(httpRequest)
                     // The SSE `[DONE]` sentinel terminates the stream: complete the Flux here
                     // rather than merely filtering it out, otherwise completion is deferred until
@@ -426,16 +428,13 @@ public class OpenAIClient {
                                         return;
                                     }
                                     // Some OpenAI-compatible providers (e.g. MiniMax) emit an
-                                    // extra non-chunk chat.completion summary event at the end
-                                    // of the stream whose message restates the entire message.
-                                    // The incremental deltas have already accumulated the full
-                                    // content, so accumulating the summary message again would
-                                    // double reasoning_content / tool_call arguments (arguments
-                                    // become {...}{...}, invalid JSON), which the model rejects
-                                    // on the next round, halting the agent. Drop the summary
-                                    // message content but keep the choice's finish_reason and
-                                    // usage (real token counts only appear in the summary event).
-                                    if (!response.isChunk()) {
+                                    // extra non-chunk chat.completion summary event after regular
+                                    // chunks. Drop duplicated summary message content, but only
+                                    // after seeing at least one chunk so stream-only full
+                                    // chat.completion events are preserved.
+                                    if (response.isChunk()) {
+                                        seenChunk.set(true);
+                                    } else if (seenChunk.get()) {
                                         OpenAIChoice summaryChoice = response.getFirstChoice();
                                         if (summaryChoice != null) {
                                             summaryChoice.setMessage(null);

--- a/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-openai/src/test/java/io/agentscope/extensions/model/openai/MinimaxDoubledSummaryReplayTest.java
+++ b/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-openai/src/test/java/io/agentscope/extensions/model/openai/MinimaxDoubledSummaryReplayTest.java
@@ -132,12 +132,32 @@ class MinimaxDoubledSummaryReplayTest {
                 "tool args must not be doubled into {...}{...}");
     }
 
+    @Test
+    void chatCompletionOnlyStreamPreservesMessage() {
+        String completionOnlyPayload =
+                "{\"id\":\"chatcmpl-full\",\"object\":\"chat.completion\",\"choices\":[{\"index\":0,\"message\":{\"role\":\"assistant\",\"content\":\"Hello"
+                    + " from a full SSE"
+                    + " completion\"},\"finish_reason\":\"stop\"}],\"usage\":{\"prompt_tokens\":1,\"completion_tokens\":7,\"total_tokens\":8}}";
+
+        List<OpenAIResponse> responses = runStream(completionOnlyPayload);
+
+        assertEquals(1, responses.size());
+        OpenAIChoice choice = responses.get(0).getFirstChoice();
+        assertNotNull(choice);
+        assertNotNull(choice.getMessage(), "full completion messages must be preserved");
+        assertEquals("Hello from a full SSE completion", choice.getMessage().getContentAsString());
+    }
+
     private List<OpenAIResponse> runStream() {
+        return runStream(SSE_PAYLOADS);
+    }
+
+    private List<OpenAIResponse> runStream(String... payloads) {
         HttpTransport transport =
                 new HttpTransport() {
                     @Override
                     public Flux<String> stream(HttpRequest request) {
-                        return Flux.fromArray(SSE_PAYLOADS).concatWith(Flux.just("[DONE]"));
+                        return Flux.fromArray(payloads).concatWith(Flux.just("[DONE]"));
                     }
 
                     @Override

--- a/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-openai/src/test/java/io/agentscope/extensions/model/openai/MinimaxDoubledSummaryReplayTest.java
+++ b/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-openai/src/test/java/io/agentscope/extensions/model/openai/MinimaxDoubledSummaryReplayTest.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.extensions.model.openai;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import io.agentscope.core.agent.accumulator.ReasoningContext;
+import io.agentscope.core.message.Msg;
+import io.agentscope.core.message.ToolUseBlock;
+import io.agentscope.core.model.ChatResponse;
+import io.agentscope.core.model.transport.HttpRequest;
+import io.agentscope.core.model.transport.HttpResponse;
+import io.agentscope.core.model.transport.HttpTransport;
+import io.agentscope.extensions.model.openai.dto.OpenAIChoice;
+import io.agentscope.extensions.model.openai.dto.OpenAIRequest;
+import io.agentscope.extensions.model.openai.dto.OpenAIResponse;
+import io.agentscope.extensions.model.openai.formatter.OpenAIResponseParser;
+import java.time.Instant;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Flux;
+
+// MiniMax-M3 streaming summary event dedup regression
+class MinimaxDoubledSummaryReplayTest {
+
+    // 5 chat.completion.chunk deltas + 1 chat.completion summary, captured from real MiniMax-M3
+    private static final String[] SSE_PAYLOADS = {
+        "{\"id\":\"06b0ebbde818dbb3769e9726ab05cb9f\",\"choices\":[{\"index\":0,\"delta\":{\"role\":\"assistant\",\"name\":\"MiniMax"
+            + " AI\",\"audio_content\":\"\",\"reasoning_content\":\"The\",\"reasoning_details\":[{\"type\":\"reasoning.text\",\"id\":\"reasoning-text-1\",\"format\":\"MiniMax-response-v1\",\"index\":0,\"text\":\"The\"}]}}],\"created\":1784789181,\"model\":\"MiniMax-M3\",\"object\":\"chat.completion.chunk\",\"usage\":{\"total_tokens\":0,\"total_characters\":0},\"input_sensitive\":false,\"output_sensitive\":false,\"input_sensitive_type\":0,\"output_sensitive_type\":0,\"output_sensitive_int\":0,\"service_tier\":\"standard\"}",
+        "{\"id\":\"06b0ebbde818dbb3769e9726ab05cb9f\",\"choices\":[{\"index\":0,\"delta\":{\"role\":\"assistant\",\"name\":\"MiniMax"
+            + " AI\",\"audio_content\":\"\",\"reasoning_content\":\" user wants me to generate a"
+            + " daily AI briefing HTML dashboard using the AIHOT skill. Let me load the skill first"
+            + " to understand how to"
+            + " fetch\",\"reasoning_details\":[{\"type\":\"reasoning.text\",\"id\":\"reasoning-text-1\",\"format\":\"MiniMax-response-v1\",\"index\":0,\"text\":\""
+            + " user wants me to generate a daily AI briefing HTML dashboard using the AIHOT skill."
+            + " Let me load the skill first to understand how to"
+            + " fetch\"}]}}],\"created\":1784789181,\"model\":\"MiniMax-M3\",\"object\":\"chat.completion.chunk\",\"usage\":{\"total_tokens\":0,\"total_characters\":0},\"input_sensitive\":false,\"output_sensitive\":false,\"input_sensitive_type\":0,\"output_sensitive_type\":0,\"output_sensitive_int\":0,\"service_tier\":\"standard\"}",
+        "{\"id\":\"06b0ebbde818dbb3769e9726ab05cb9f\",\"choices\":[{\"index\":0,\"delta\":{\"role\":\"assistant\",\"name\":\"MiniMax"
+            + " AI\",\"audio_content\":\"\",\"reasoning_content\":\" the data, then create the HTML"
+            + " dashboard according to the specifications.\\n"
+            + "\\n"
+            + "Let me start by loading the AIHOT"
+            + " skill.\",\"reasoning_details\":[{\"type\":\"reasoning.text\",\"id\":\"reasoning-text-1\",\"format\":\"MiniMax-response-v1\",\"index\":0,\"text\":\""
+            + " the data, then create the HTML dashboard according to the specifications.\\n"
+            + "\\n"
+            + "Let me start by loading the AIHOT"
+            + " skill.\"}]}}],\"created\":1784789181,\"model\":\"MiniMax-M3\",\"object\":\"chat.completion.chunk\",\"usage\":{\"total_tokens\":0,\"total_characters\":0},\"input_sensitive\":false,\"output_sensitive\":false,\"input_sensitive_type\":0,\"output_sensitive_type\":0,\"output_sensitive_int\":0,\"service_tier\":\"standard\"}",
+        "{\"id\":\"06b0ebbde818dbb3769e9726ab05cb9f\",\"choices\":[{\"index\":0,\"delta\":{\"role\":\"assistant\",\"name\":\"MiniMax"
+            + " AI\",\"tool_calls\":[{\"id\":\"call_function_fo7n64ha38ds_1\",\"type\":\"function\",\"function\":{\"name\":\"load_skill_through_path\",\"arguments\":\"{\\\"skillId\\\":"
+            + " \\\"AIHOT_marketplace\\\", \\\"path\\\":"
+            + " \\\"SKILL.md\\\"\"},\"index\":0}],\"audio_content\":\"\"}}],\"created\":1784789181,\"model\":\"MiniMax-M3\",\"object\":\"chat.completion.chunk\",\"usage\":{\"total_tokens\":0,\"total_characters\":0},\"input_sensitive\":false,\"output_sensitive\":false,\"input_sensitive_type\":0,\"output_sensitive_type\":0,\"output_sensitive_int\":0,\"service_tier\":\"standard\"}",
+        "{\"id\":\"06b0ebbde818dbb3769e9726ab05cb9f\",\"choices\":[{\"finish_reason\":\"tool_calls\",\"index\":0,\"delta\":{\"role\":\"assistant\",\"name\":\"MiniMax"
+            + " AI\",\"tool_calls\":[{\"function\":{\"arguments\":\"}\"},\"index\":0}],\"audio_content\":\"\"}}],\"created\":1784789181,\"model\":\"MiniMax-M3\",\"object\":\"chat.completion.chunk\",\"usage\":{\"total_tokens\":0,\"total_characters\":0},\"input_sensitive\":false,\"output_sensitive\":false,\"input_sensitive_type\":0,\"output_sensitive_type\":0,\"output_sensitive_int\":0,\"service_tier\":\"standard\"}",
+        "{\"id\":\"06b0ebbde818dbb3769e9726ab05cb9f\",\"choices\":[{\"finish_reason\":\"tool_calls\",\"index\":0,\"message\":{\"role\":\"assistant\",\"name\":\"MiniMax"
+            + " AI\",\"tool_calls\":[{\"id\":\"call_function_fo7n64ha38ds_1\",\"type\":\"function\",\"function\":{\"name\":\"load_skill_through_path\",\"arguments\":\"{\\\"skillId\\\":"
+            + " \\\"AIHOT_marketplace\\\", \\\"path\\\":"
+            + " \\\"SKILL.md\\\"}\"},\"index\":0}],\"audio_content\":\"\",\"reasoning_content\":\"The"
+            + " user wants me to generate a daily AI briefing HTML dashboard using the AIHOT skill."
+            + " Let me load the skill first to understand how to fetch the data, then create the"
+            + " HTML dashboard according to the specifications.\\n"
+            + "\\n"
+            + "Let me start by loading the AIHOT"
+            + " skill.\",\"reasoning_details\":[{\"type\":\"reasoning.text\",\"id\":\"reasoning-text-1\",\"format\":\"MiniMax-response-v1\",\"index\":0,\"text\":\"The"
+            + " user wants me to generate a daily AI briefing HTML dashboard using the AIHOT skill."
+            + " Let me load the skill first to understand how to fetch the data, then create the"
+            + " HTML dashboard according to the specifications.\\n"
+            + "\\n"
+            + "Let me start by loading the AIHOT"
+            + " skill.\"}]}}],\"created\":1784789181,\"model\":\"MiniMax-M3\",\"object\":\"chat.completion\",\"usage\":{\"total_tokens\":12078,\"total_characters\":0,\"prompt_tokens\":11977,\"completion_tokens\":101,\"prompt_tokens_details\":{\"cached_tokens\":114}},\"input_sensitive\":false,\"output_sensitive\":false,\"input_sensitive_type\":0,\"output_sensitive_type\":0,\"output_sensitive_int\":0,\"service_tier\":\"standard\",\"base_resp\":{\"status_code\":0,\"status_msg\":\"\"}}"
+    };
+
+    // Fix point: transport layer clears the non-chunk summary message, keeps finishReason
+    @Test
+    void summaryEventMessageClearedByTransportLayer() {
+        List<OpenAIResponse> responses = runStream();
+        assertEquals(6, responses.size());
+        OpenAIResponse summary = responses.get(5);
+        assertFalse(summary.isChunk());
+        assertEquals("chat.completion", summary.getObject());
+        OpenAIChoice choice = summary.getFirstChoice();
+        assertNotNull(choice);
+        assertNull(choice.getMessage(), "summary message must be cleared by transport layer");
+        assertEquals("tool_calls", choice.getFinishReason(), "finishReason must be preserved");
+    }
+
+    // End-to-end: once the summary message is cleared, ReasoningContext accumulates single-copy
+    // reasoning and tool args instead of doubled ones
+    @Test
+    void reasoningAndToolArgsNotDoubled() {
+        List<OpenAIResponse> responses = runStream();
+        OpenAIResponseParser parser = new OpenAIResponseParser();
+        Instant start = Instant.now();
+        ReasoningContext ctx = new ReasoningContext("test");
+        for (OpenAIResponse r : responses) {
+            ChatResponse cr = parser.parseResponse(r, start);
+            if (cr != null) {
+                ctx.processChunk(cr);
+            }
+        }
+        Msg finalMsg = ctx.buildFinalMessage();
+        assertNotNull(finalMsg);
+        // deltas already accumulated the full reasoning; the summary must not append it again
+        assertEquals(
+                1,
+                countMatches(ctx.getAccumulatedThinking(), "Let me start by loading"),
+                "reasoning must not be doubled by the summary event");
+        // tool args must stay a single valid JSON object -> skillId appears once
+        String allArgs =
+                ctx.getAllAccumulatedToolCalls().stream()
+                        .map(ToolUseBlock::getContent)
+                        .collect(Collectors.joining());
+        assertEquals(
+                1,
+                countMatches(allArgs, "AIHOT_marketplace"),
+                "tool args must not be doubled into {...}{...}");
+    }
+
+    private List<OpenAIResponse> runStream() {
+        HttpTransport transport =
+                new HttpTransport() {
+                    @Override
+                    public Flux<String> stream(HttpRequest request) {
+                        return Flux.fromArray(SSE_PAYLOADS).concatWith(Flux.just("[DONE]"));
+                    }
+
+                    @Override
+                    public HttpResponse execute(HttpRequest request) {
+                        throw new UnsupportedOperationException("execute not used");
+                    }
+
+                    @Override
+                    public void close() {}
+                };
+        OpenAIClient client = new OpenAIClient(transport);
+        OpenAIRequest request = new OpenAIRequest();
+        request.setStream(true);
+        return client.stream("test-key", "http://localhost/v1", request, null)
+                .collectList()
+                .block();
+    }
+
+    private static int countMatches(String haystack, String needle) {
+        int count = 0;
+        int idx = 0;
+        while ((idx = haystack.indexOf(needle, idx)) != -1) {
+            count++;
+            idx += needle.length();
+        }
+        return count;
+    }
+}


### PR DESCRIPTION
## AgentScope-Java Version

2.0.1-SNAPSHOT

## Description

Fixes #2366.

Some OpenAI-compatible providers (confirmed with MiniMax-M3) terminate a streaming response with an extra non-chunk `chat.completion` **summary** event whose `message` restates the full message (reasoning text + complete tool-call arguments) that the incremental `delta` chunks already delivered.

`OpenAIResponse.isChunk()` returns `false` for this summary, so `OpenAIResponseParser.parseResponse` routes it to `parseCompletionResponse`, extracting the full `message` into `ContentBlock`s identical to what the deltas already produced. `ReasoningContext` then accumulates them on top of the existing content:

- `reasoning_content` is doubled (delta-accumulated full text + summary full text)
- `tool_call.arguments` are concatenated into `{...}{...}` (invalid JSON), which survives loose JSON validation, is sent back on the next round, and the model rejects it (returns empty `choices:[]`), halting the agent.

### Changes

`OpenAIClient.stream()`: after the error check and before emitting, if the response is not a chunk (i.e. a summary event), clear its `choice.message` while keeping the `choice` (so `finish_reason` is preserved) and `usage` (real token counts only appear in the summary event). Provider-agnostic, lives at the protocol-normalization layer alongside the existing `[DONE]` filtering and error detection.

### How to test

Regression test `MinimaxDoubledSummaryReplayTest` replays a 6-event SSE trace captured from a real MiniMax-M3 stream (5 incremental `chat.completion.chunk` deltas + 1 non-chunk `chat.completion` summary) through the real `OpenAIClient.stream()` (driven by a stub `HttpTransport`), then feeds the parsed `OpenAIResponse`s through `OpenAIResponseParser` and `ReasoningContext`:

1. `summaryEventMessageClearedByTransportLayer` — asserts the summary event's `choice.message` is cleared while `finish_reason` is preserved (the fix point).
2. `reasoningAndToolArgsNotDoubled` — asserts accumulated reasoning contains `Let me start by loading` once (not twice) and tool args contain `AIHOT_marketplace` once (not `{...}{...}`).

Both tests fail without the fix (message non-null; reasoning/args counted twice) and pass with it.

## Checklist

- [x] Code has been formatted with `mvn spotless:apply`
- [x] All tests are passing (`mvn test`)
- [x] Javadoc comments are complete and follow project conventions
- [x] Related documentation has been updated (e.g. links, examples, etc.)
- [x] Code is ready for review