### PR TITLE
fix(skill): bind ALL agent tools when multiple are registered on one skill

### DIFF
--- a/agentscope-core/src/main/java/io/agentscope/core/skill/SkillBox.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/skill/SkillBox.java
@@ -383,7 +383,7 @@ public class SkillBox {
         private Toolkit toolkit;
         private AgentSkill skill;
         private Object toolObject;
-        private AgentTool agentTool;
+        private final List<AgentTool> agentTools = new ArrayList<>();
         private McpClientWrapper mcpClientWrapper;
         private SubAgentProvider<?> subAgentProvider;
         private SubAgentConfig subAgentConfig;
@@ -424,13 +424,15 @@ public class SkillBox {
         }
 
         /**
-         * Set the AgentTool instance to register.
+         * Add an AgentTool instance to register. May be called multiple times to bind several
+         * tools to the same skill — every tool is bound into the skill's gated tool group
+         * (previously each call overwrote the previous one, so only the last tool was bound).
          *
          * @param agentTool The AgentTool instance
          * @return This builder for chaining
          */
         public SkillRegistration agentTool(AgentTool agentTool) {
-            this.agentTool = agentTool;
+            this.agentTools.add(agentTool);
             return this;
         }
 
@@ -511,7 +513,7 @@ public class SkillBox {
          */
         public SkillRegistration subAgent(SubAgentProvider<?> provider, SubAgentConfig config) {
             if (this.toolObject != null
-                    || this.agentTool != null
+                    || !this.agentTools.isEmpty()
                     || this.mcpClientWrapper != null) {
                 throw new IllegalStateException(
                         "Cannot set multiple registration types. Use only one of: tool(),"
@@ -593,7 +595,7 @@ public class SkillBox {
             skillBox.registerSkill(skill);
 
             if (toolObject != null
-                    || agentTool != null
+                    || !agentTools.isEmpty()
                     || mcpClientWrapper != null
                     || subAgentProvider != null) {
                 if (toolkit == null && (toolkit = skillBox.toolkit) == null) {
@@ -604,17 +606,48 @@ public class SkillBox {
                 if (toolkit.getToolGroup(skillToolGroup) == null) {
                     toolkit.createToolGroup(skillToolGroup, skillToolGroup, false);
                 }
-                toolkit.registration()
-                        .group(skillToolGroup)
-                        .presetParameters(presetParameters)
-                        .extendedModel(extendedModel)
-                        .enableTools(enableTools)
-                        .disableTools(disableTools)
-                        .agentTool(agentTool)
-                        .tool(toolObject)
-                        .mcpClient(mcpClientWrapper)
-                        .subAgent(subAgentProvider, subAgentConfig)
-                        .apply();
+                // Toolkit.ToolRegistration 每次只能注册一个工具（exactly-one 校验），
+                // 多 tool 的 skill 必须逐个独立注册，否则只有最后一个生效
+                for (AgentTool tool : agentTools) {
+                    toolkit.registration()
+                            .group(skillToolGroup)
+                            .presetParameters(presetParameters)
+                            .extendedModel(extendedModel)
+                            .enableTools(enableTools)
+                            .disableTools(disableTools)
+                            .agentTool(tool)
+                            .apply();
+                }
+                if (toolObject != null) {
+                    toolkit.registration()
+                            .group(skillToolGroup)
+                            .presetParameters(presetParameters)
+                            .extendedModel(extendedModel)
+                            .enableTools(enableTools)
+                            .disableTools(disableTools)
+                            .tool(toolObject)
+                            .apply();
+                }
+                if (mcpClientWrapper != null) {
+                    toolkit.registration()
+                            .group(skillToolGroup)
+                            .presetParameters(presetParameters)
+                            .extendedModel(extendedModel)
+                            .enableTools(enableTools)
+                            .disableTools(disableTools)
+                            .mcpClient(mcpClientWrapper)
+                            .apply();
+                }
+                if (subAgentProvider != null) {
+                    toolkit.registration()
+                            .group(skillToolGroup)
+                            .presetParameters(presetParameters)
+                            .extendedModel(extendedModel)
+                            .enableTools(enableTools)
+                            .disableTools(disableTools)
+                            .subAgent(subAgentProvider, subAgentConfig)
+                            .apply();
+                }
             }
         }
     }

--- a/agentscope-core/src/main/java/io/agentscope/core/skill/SkillBox.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/skill/SkillBox.java
@@ -428,11 +428,15 @@ public class SkillBox {
          * tools to the same skill — every tool is bound into the skill's gated tool group
          * (previously each call overwrote the previous one, so only the last tool was bound).
          *
-         * @param agentTool The AgentTool instance
+         * <p>A {@code null} argument is ignored, mirroring {@code Toolkit.ToolRegistration}.
+         *
+         * @param agentTool The AgentTool instance; ignored when {@code null}
          * @return This builder for chaining
          */
         public SkillRegistration agentTool(AgentTool agentTool) {
-            this.agentTools.add(agentTool);
+            if (agentTool != null) {
+                this.agentTools.add(agentTool);
+            }
             return this;
         }
 
@@ -606,8 +610,28 @@ public class SkillBox {
                 if (toolkit.getToolGroup(skillToolGroup) == null) {
                     toolkit.createToolGroup(skillToolGroup, skillToolGroup, false);
                 }
-                // Toolkit.ToolRegistration 每次只能注册一个工具（exactly-one 校验），
-                // 多 tool 的 skill 必须逐个独立注册，否则只有最后一个生效
+                // A SkillRegistration still binds exactly one registration kind. Previously all
+                // four values were handed to a single Toolkit.ToolRegistration, whose exactly-one
+                // check rejected mixtures. Registering each agent tool separately (needed so that
+                // several tools can share one skill) bypasses that check, so the invariant is
+                // enforced here instead — with an error naming the kinds that were combined.
+                int registrationKinds =
+                        (agentTools.isEmpty() ? 0 : 1)
+                                + (toolObject != null ? 1 : 0)
+                                + (mcpClientWrapper != null ? 1 : 0)
+                                + (subAgentProvider != null ? 1 : 0);
+                if (registrationKinds > 1) {
+                    throw new IllegalStateException(
+                            "A skill registration must bind exactly one of agentTool(), tool(),"
+                                    + " mcpClient() or subAgent(), but got: "
+                                    + (agentTools.isEmpty() ? "" : "agentTool ")
+                                    + (toolObject != null ? "tool " : "")
+                                    + (mcpClientWrapper != null ? "mcpClient " : "")
+                                    + (subAgentProvider != null ? "subAgent" : "").trim());
+                }
+                // Toolkit.ToolRegistration binds a single tool per call (exactly-one check), so a
+                // skill carrying several agent tools must register them one at a time — otherwise
+                // only the last one takes effect.
                 for (AgentTool tool : agentTools) {
                     toolkit.registration()
                             .group(skillToolGroup)

--- a/agentscope-core/src/test/java/io/agentscope/core/skill/SkillBoxTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/skill/SkillBoxTest.java
@@ -188,6 +188,35 @@ class SkillBoxTest {
         }
 
         @Test
+        @DisplayName("Should bind ALL agent tools when multiple are registered on one skill")
+        void testMultipleAgentToolsAllBoundToSkillGroup() {
+            AgentTool first = createTestTool("multi_tool_first");
+            AgentTool second = createTestTool("multi_tool_second");
+            AgentSkill skill =
+                    new AgentSkill(
+                            "Multi Tool Skill", "Skill with two agent tools", "# Multi", null);
+
+            // 连续两次 agentTool()：此前第二次会覆盖第一次，导致只有 second 被绑进门控组
+            skillBox.registration().skill(skill).agentTool(first).agentTool(second).apply();
+
+            String groupName = skill.getSkillId() + "_skill_tools";
+            assertNotNull(toolkit.getToolGroup(groupName), "skill tool group should exist");
+            assertTrue(
+                    toolkit.getToolGroup(groupName).getTools().contains("multi_tool_first"),
+                    "first tool must also be bound into the skill group (regression: was"
+                            + " overwritten)");
+            assertTrue(
+                    toolkit.getToolGroup(groupName).getTools().contains("multi_tool_second"),
+                    "second tool must be bound into the skill group");
+            assertFalse(
+                    toolkit.getToolGroup(groupName).isActive(),
+                    "skill tool group must start inactive (gated until skill is loaded)");
+
+            assertNotNull(toolkit.getTool("multi_tool_first"));
+            assertNotNull(toolkit.getTool("multi_tool_second"));
+        }
+
+        @Test
         @DisplayName("Should successfully register when only mcp client is provided")
         void testSuccessfullyRegisterWhenOnlyMcpClientProvided() {
             McpClientWrapper mcpClient = mock(McpClientWrapper.class);

--- a/agentscope-core/src/test/java/io/agentscope/core/skill/SkillBoxTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/skill/SkillBoxTest.java
@@ -196,7 +196,8 @@ class SkillBoxTest {
                     new AgentSkill(
                             "Multi Tool Skill", "Skill with two agent tools", "# Multi", null);
 
-            // 连续两次 agentTool()：此前第二次会覆盖第一次，导致只有 second 被绑进门控组
+            // Two consecutive agentTool() calls: the second used to overwrite the first, so only
+            // "second" ended up bound into the gated group.
             skillBox.registration().skill(skill).agentTool(first).agentTool(second).apply();
 
             String groupName = skill.getSkillId() + "_skill_tools";
@@ -214,6 +215,52 @@ class SkillBoxTest {
 
             assertNotNull(toolkit.getTool("multi_tool_first"));
             assertNotNull(toolkit.getTool("multi_tool_second"));
+        }
+
+        @Test
+        @DisplayName("Should ignore a null agent tool instead of failing the registration")
+        void testNullAgentToolIsIgnored() {
+            AgentTool real = createTestTool("null_guard_tool");
+            AgentSkill skill =
+                    new AgentSkill("Null Guard Skill", "Skill with a null tool", "# Null", null);
+
+            // A null must not be appended to the tool list — otherwise apply() would hand null to
+            // Toolkit.registration().agentTool(null) and fail the whole skill registration.
+            assertDoesNotThrow(
+                    () ->
+                            skillBox.registration()
+                                    .skill(skill)
+                                    .agentTool(null)
+                                    .agentTool(real)
+                                    .apply());
+
+            String groupName = skill.getSkillId() + "_skill_tools";
+            assertNotNull(toolkit.getToolGroup(groupName), "skill tool group should exist");
+            assertTrue(
+                    toolkit.getToolGroup(groupName).getTools().contains("null_guard_tool"),
+                    "the non-null tool must still be bound");
+        }
+
+        @Test
+        @DisplayName("Should reject mixing two registration kinds on one skill registration")
+        void testMixingRegistrationKindsIsRejected() {
+            AgentTool agentTool = createTestTool("mixed_agent_tool");
+            AgentSkill skill = new AgentSkill("Mixed Skill", "Skill mixing kinds", "# Mixed", null);
+
+            // Registering each agent tool separately bypasses Toolkit.ToolRegistration's
+            // exactly-one check, so SkillRegistration enforces the invariant itself.
+            IllegalStateException error =
+                    assertThrows(
+                            IllegalStateException.class,
+                            () ->
+                                    skillBox.registration()
+                                            .skill(skill)
+                                            .agentTool(agentTool)
+                                            .tool(new Object())
+                                            .apply());
+            assertTrue(
+                    error.getMessage().contains("agentTool") && error.getMessage().contains("tool"),
+                    "error should name the combined kinds, got: " + error.getMessage());
         }
 
         @Test


### PR DESCRIPTION
## Summary

`SkillBox.SkillRegistration.agentTool()` was a **single-slot field**. Calling it twice on one registration (e.g. a skill that declares two tools) overwrote the first tool, so **only the last `AgentTool` was bound into the skill's gated tool group** (`{skillId}_skill_tools`).

Impact on users: any skill declaring multiple tools silently loses all but the last one — those tools are neither gated (invisible before the skill is loaded) nor unlockable via `load_skill_through_path`. We hit this in production with skills whose `tools` list has more than one entry.

## Root cause

- `SkillRegistration.agentTool` was `private AgentTool agentTool;` — each call overwrote the previous value.
- `apply()` bound only that one surviving field into the group.
- `Toolkit.ToolRegistration` enforces exactly-one-tool-per-registration, so chaining multiple tools on one registration can't work anyway — each tool needs its own registration.

## Fix

- `agentTools` is now a `List<AgentTool>`; the singular `agentTool()` method appends (backward compatible).
- `apply()` binds each accumulated tool with its own `Toolkit.registration()` into the skill group.
- The other tool kinds (`toolObject` / `mcpClient` / `subAgent`) also get their own registrations instead of sharing one chain (which violated the exactly-one rule whenever more than one kind was set).

## Tests

New regression test `SkillBoxTest#testMultipleAgentToolsAllBoundToSkillGroup`:
- **Fails on the v2.0.0 tag** with `first tool must also be bound into the skill group (regression: was overwritten) ==> expected: <true> but was: <false>`
- **Passes with this fix**; full `SkillBoxTest` suite green (16/16)

Also verified: group still starts inactive (gating semantics unchanged), single-tool registration unchanged.