### PR TITLE
fix(harness): enforce plan mode for subagents

### DIFF
--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/HarnessAgentBuilderSupport.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/HarnessAgentBuilderSupport.java
@@ -295,6 +295,9 @@ final class HarnessAgentBuilderSupport {
         final boolean capturedDisableMemoryHooks = b.disableMemoryHooks;
         final boolean capturedDisableSessionPersistence = b.disableSessionPersistence;
         final boolean capturedDisableWorkspaceContext = b.disableWorkspaceContext;
+        final boolean capturedPlanModeEnabled = b.planModeEnabled;
+        final boolean capturedPlanModeAllowShell = b.planModeAllowShell;
+        final String capturedPlanFileDir = b.planFileDir;
         final CompactionConfig capturedCompactionConfig = b.compactionConfig;
         final boolean capturedDisableCompaction = b.disableCompaction;
         final ToolResultEvictionConfig capturedToolResultEvictionConfig =
@@ -336,6 +339,8 @@ final class HarnessAgentBuilderSupport {
             if (capturedDisableMemoryHooks) sub.disableMemoryHooks();
             if (capturedDisableSessionPersistence) sub.disableSessionPersistence();
             if (capturedDisableWorkspaceContext) sub.disableWorkspaceContext();
+            configurePlanMode(
+                    sub, capturedPlanModeEnabled, capturedPlanModeAllowShell, capturedPlanFileDir);
 
             if (!capturedSkillRepos.isEmpty()) sub.skillRepositories(capturedSkillRepos);
             if (capturedProjectGlobalSkillsDir != null) {
@@ -384,6 +389,9 @@ final class HarnessAgentBuilderSupport {
         final boolean capturedDisableMemoryTools = b.disableMemoryTools;
         final boolean capturedDisableMemoryHooks = b.disableMemoryHooks;
         final boolean capturedDisableSessionPersistence = b.disableSessionPersistence;
+        final boolean capturedPlanModeEnabled = b.planModeEnabled;
+        final boolean capturedPlanModeAllowShell = b.planModeAllowShell;
+        final String capturedPlanFileDir = b.planFileDir;
         final GenerateOptions capturedGenOpts = b.generateOptions;
         // See buildGeneralPurposeFactory: propagate the parent's model/tool execution configs so
         // declared subagents honor the parent's timeouts. Without this they fall back to
@@ -475,6 +483,8 @@ final class HarnessAgentBuilderSupport {
             if (capturedDisableMemoryTools) sub.disableMemoryTools();
             if (capturedDisableMemoryHooks) sub.disableMemoryHooks();
             if (capturedDisableSessionPersistence) sub.disableSessionPersistence();
+            configurePlanMode(
+                    sub, capturedPlanModeEnabled, capturedPlanModeAllowShell, capturedPlanFileDir);
 
             if (!capturedSkillRepos.isEmpty()) sub.skillRepositories(capturedSkillRepos);
             if (capturedProjectGlobalSkillsDir != null) {
@@ -489,6 +499,28 @@ final class HarnessAgentBuilderSupport {
             sub.middlewares(capturedMiddlewares);
             return sub.build();
         };
+    }
+
+    /**
+     * Propagates build-time plan-mode capabilities to an automatically constructed subagent.
+     *
+     * <p>Copying the parent's explicit middleware list is not sufficient: {@code
+     * PlanModeMiddleware} and {@code PlanModeManager} are installed dynamically by {@link
+     * HarnessAgent.Builder#build()}. The child must therefore receive the builder configuration
+     * before it is built; setting only {@code AgentState.planActive} later would expose the state
+     * without installing the write-operation guard.
+     */
+    private static void configurePlanMode(
+            HarnessAgent.Builder sub,
+            boolean planModeEnabled,
+            boolean planModeAllowShell,
+            String planFileDir) {
+        if (!planModeEnabled) {
+            return;
+        }
+        sub.enablePlanMode()
+                .planFileDirectory(planFileDir)
+                .allowShellInPlanMode(planModeAllowShell);
     }
 
     /**

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/tool/AgentSpawnTool.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/tool/AgentSpawnTool.java
@@ -268,6 +268,8 @@ public class AgentSpawnTool {
             // Reuse existing agent if same deterministic key was already spawned.
             SpawnedAgent existing = agentsByKey.get(key);
             if (existing != null) {
+                propagatePlanMode(
+                        parentState, currentUserId, existing.sessionId(), existing.agent());
                 String spawnInfo = formatSpawnInfo(key, agentId, sessionId, null);
                 boolean hasTask = task != null && !task.isBlank();
                 if (!hasTask) {
@@ -295,11 +297,7 @@ public class AgentSpawnTool {
         persistSpawnEntry(parentState, key, agentId, sessionId, canonLabel, nextDepth);
 
         // Propagate plan mode: if parent is in plan mode, force child into read-only mode too.
-        if (parentState != null
-                && parentState.getPlanModeContext().isPlanActive()
-                && agent instanceof HarnessAgent ha) {
-            ha.enterPlanMode(currentUserId, sessionId);
-        }
+        propagatePlanMode(parentState, currentUserId, sessionId, agent);
 
         // Propagate DENY permission rules from parent to child (security boundary inheritance).
         boolean inherit = declOpt.map(SubagentDeclaration::isInheritParentPermissions).orElse(true);
@@ -501,6 +499,7 @@ public class AgentSpawnTool {
         long timeoutMs = resolveTimeoutMs(timeoutSeconds, DEFAULT_TIMEOUT_SECONDS);
         String currentUserId = runtimeContext != null ? runtimeContext.getUserId() : null;
         String parentSessionId = runtimeContext != null ? runtimeContext.getSessionId() : null;
+        propagatePlanMode(parentState, currentUserId, spawned.sessionId(), spawned.agent());
         var declOpt = agentManager.getDeclaration(spawned.agentId());
         boolean remote = declOpt.map(SubagentDeclaration::isRemote).orElse(false);
 
@@ -591,6 +590,22 @@ public class AgentSpawnTool {
     // -----------------------------------------------------------------
     //  Helpers
     // -----------------------------------------------------------------
+
+    /**
+     * Activates plan mode on a local child immediately before it can be invoked.
+     *
+     * <p>This must run for both newly-created and reused children. In particular, a persistent
+     * child may have been created while its parent was in build mode and then reused after the
+     * parent entered plan mode.
+     */
+    private static void propagatePlanMode(
+            AgentState parentState, String userId, String sessionId, Agent child) {
+        if (parentState != null
+                && parentState.getPlanModeContext().isPlanActive()
+                && child instanceof HarnessAgent harnessChild) {
+            harnessChild.enterPlanMode(userId, sessionId);
+        }
+    }
 
     /**
      * Returns a {@link Mono} that invokes the local subagent.

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/PlanModeSubagentPropagationTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/PlanModeSubagentPropagationTest.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.harness.agent;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.agentscope.core.agent.RuntimeContext;
+import io.agentscope.core.agent.test.MockModel;
+import io.agentscope.core.message.ToolUseBlock;
+import io.agentscope.core.middleware.ActingInput;
+import io.agentscope.core.model.ToolSchema;
+import io.agentscope.core.state.InMemoryAgentStateStore;
+import io.agentscope.core.util.JsonUtils;
+import io.agentscope.harness.agent.filesystem.local.LocalFilesystem;
+import io.agentscope.harness.agent.middleware.PlanModeMiddleware;
+import io.agentscope.harness.agent.middleware.SubagentEntry;
+import io.agentscope.harness.agent.subagent.SubagentDeclaration;
+import io.agentscope.harness.agent.subagent.WorkspaceMode;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import reactor.core.publisher.Flux;
+
+/** Regression coverage for plan-mode capabilities inherited by automatic subagent factories. */
+class PlanModeSubagentPropagationTest {
+
+    private static final String PLAN_DIR = "review-plans";
+
+    @TempDir Path workspace;
+
+    @Test
+    void declaredSubagent_inheritsPlanModeManagerMiddlewareAndConfiguration() throws Exception {
+        SubagentDeclaration declaration =
+                SubagentDeclaration.builder()
+                        .name("reviewer")
+                        .description("Reviews code")
+                        .inlineAgentsBody("Review without modifying files.")
+                        .workspaceMode(WorkspaceMode.SHARED)
+                        .build();
+
+        SubagentEntry entry =
+                HarnessAgent.builder()
+                        .model(new MockModel("unused"))
+                        .workspace(workspace)
+                        .abstractFilesystem(new LocalFilesystem(workspace))
+                        .stateStore(new InMemoryAgentStateStore())
+                        .enablePlanMode()
+                        .planFileDirectory(PLAN_DIR)
+                        .allowShellInPlanMode()
+                        .subagent(declaration)
+                        .buildSubagentEntries(workspace)
+                        .stream()
+                        .filter(e -> declaration.getName().equals(e.name()))
+                        .findFirst()
+                        .orElseThrow();
+
+        assertPlanModeEnforced(entry);
+    }
+
+    @Test
+    void generalPurposeSubagent_inheritsPlanModeManagerMiddlewareAndConfiguration()
+            throws Exception {
+        SubagentEntry entry =
+                HarnessAgent.builder()
+                        .model(new MockModel("unused"))
+                        .workspace(workspace)
+                        .abstractFilesystem(new LocalFilesystem(workspace))
+                        .stateStore(new InMemoryAgentStateStore())
+                        .enablePlanMode()
+                        .planFileDirectory(PLAN_DIR)
+                        .allowShellInPlanMode()
+                        .buildSubagentEntries(workspace)
+                        .stream()
+                        .filter(e -> "general-purpose".equals(e.name()))
+                        .findFirst()
+                        .orElseThrow();
+
+        assertPlanModeEnforced(entry);
+    }
+
+    private void assertPlanModeEnforced(SubagentEntry entry) throws Exception {
+        RuntimeContext context =
+                RuntimeContext.builder().userId("user").sessionId("child-session").build();
+
+        try (HarnessAgent child = (HarnessAgent) entry.factory().create(context)) {
+            List<String> toolNames =
+                    child.getToolkit().getToolSchemas().stream().map(ToolSchema::getName).toList();
+            assertTrue(toolNames.contains("plan_enter"));
+            assertTrue(toolNames.contains("plan_write"));
+            assertTrue(toolNames.contains("plan_exit"));
+
+            PlanModeMiddleware middleware =
+                    child.getDelegate().getMiddlewares().stream()
+                            .filter(PlanModeMiddleware.class::isInstance)
+                            .map(PlanModeMiddleware.class::cast)
+                            .findFirst()
+                            .orElseThrow();
+
+            child.enterPlanMode(context);
+            var childState =
+                    child.getDelegate().getAgentState(context.getUserId(), context.getSessionId());
+            assertTrue(childState.getPlanModeContext().isPlanActive());
+            assertEquals(
+                    PLAN_DIR + "/PLAN.md", childState.getPlanModeContext().getCurrentPlanFile());
+
+            context.setAgentState(childState);
+            String prompt = middleware.onSystemPrompt(child, context, "base prompt").block();
+            assertTrue(prompt.contains("PLAN MODE is active"));
+            assertTrue(prompt.contains(PLAN_DIR + "/PLAN.md"));
+            assertTrue(prompt.contains("execute"), "allowShellInPlanMode must be inherited");
+
+            Map<String, Object> input =
+                    Map.of("path", "must-not-be-written.txt", "content", "must-not-be-written");
+            ToolUseBlock writeCall =
+                    ToolUseBlock.builder()
+                            .id("write-call")
+                            .name("write_file")
+                            .input(input)
+                            .content(JsonUtils.getJsonCodec().toJson(input))
+                            .build();
+            AtomicBoolean coreActingInvoked = new AtomicBoolean();
+            var events =
+                    middleware
+                            .onActing(
+                                    child,
+                                    context,
+                                    new ActingInput(List.of(writeCall)),
+                                    ignored -> {
+                                        coreActingInvoked.set(true);
+                                        return Flux.empty();
+                                    })
+                            .collectList()
+                            .block();
+
+            assertFalse(
+                    coreActingInvoked.get(),
+                    "a denied child write must not reach core tool execution");
+            assertEquals(3, events.size(), "denial emits start, delta, and end events");
+            assertFalse(
+                    Files.exists(workspace.resolve("must-not-be-written.txt")),
+                    "PlanModeMiddleware must deny the child write before filesystem execution");
+        }
+    }
+}

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/tool/AgentSpawnToolPlanModeTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/tool/AgentSpawnToolPlanModeTest.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.harness.agent.tool;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.agentscope.core.agent.RuntimeContext;
+import io.agentscope.core.agent.test.MockModel;
+import io.agentscope.core.state.AgentState;
+import io.agentscope.core.state.InMemoryAgentStateStore;
+import io.agentscope.harness.agent.HarnessAgent;
+import io.agentscope.harness.agent.middleware.SubagentEntry;
+import io.agentscope.harness.agent.subagent.DefaultAgentManager;
+import io.agentscope.harness.agent.subagent.SubagentDeclaration;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/** Verifies that reused subagents cannot retain build-mode privileges under a plan-mode parent. */
+class AgentSpawnToolPlanModeTest {
+
+    @TempDir Path workspace;
+
+    private final List<HarnessAgent> createdAgents = new ArrayList<>();
+
+    @AfterEach
+    void closeAgents() {
+        createdAgents.forEach(HarnessAgent::close);
+        createdAgents.clear();
+    }
+
+    @Test
+    void persistentSpawnReuse_reappliesParentPlanModeBeforeReturningOrInvoking() {
+        Fixture fixture = fixture();
+
+        fixture.tool()
+                .agentSpawn(
+                        fixture.context(),
+                        fixture.parentState(),
+                        "worker",
+                        null,
+                        "persistent-worker",
+                        null,
+                        null)
+                .block();
+        HarnessAgent reused = createdAgents.get(0);
+        String childSessionId =
+                "sub-"
+                        + AgentSpawnTool.deterministicHash(
+                                fixture.context().getSessionId(), "worker", "persistent-worker");
+        assertFalse(reused.isPlanModeActive(fixture.context().getUserId(), childSessionId));
+
+        fixture.parentState().getPlanModeContext().setPlanActive(true);
+        fixture.tool()
+                .agentSpawn(
+                        fixture.context(),
+                        fixture.parentState(),
+                        "worker",
+                        null,
+                        "persistent-worker",
+                        null,
+                        null)
+                .block();
+
+        assertTrue(
+                reused.isPlanModeActive(fixture.context().getUserId(), childSessionId),
+                "the existing persistent child must enter plan mode on reuse");
+    }
+
+    @Test
+    void agentSend_reappliesParentPlanModeBeforeInvokingExistingChild() {
+        Fixture fixture = fixture();
+
+        String spawnResult =
+                fixture.tool()
+                        .agentSpawn(
+                                fixture.context(),
+                                fixture.parentState(),
+                                "worker",
+                                null,
+                                "persistent-worker",
+                                null,
+                                null)
+                        .block();
+        HarnessAgent reused = createdAgents.get(0);
+        String key = firstLineValue(spawnResult, "agent_key: ");
+        String childSessionId = firstLineValue(spawnResult, "session_id: ");
+        assertFalse(reused.isPlanModeActive(fixture.context().getUserId(), childSessionId));
+
+        fixture.parentState().getPlanModeContext().setPlanActive(true);
+        fixture.tool()
+                .agentSend(
+                        fixture.context(),
+                        fixture.parentState(),
+                        key,
+                        null,
+                        "Continue with read-only research.",
+                        null)
+                .block();
+
+        assertTrue(
+                reused.isPlanModeActive(fixture.context().getUserId(), childSessionId),
+                "agent_send must synchronize plan mode before invoking an existing child");
+    }
+
+    private Fixture fixture() {
+        SubagentDeclaration declaration =
+                SubagentDeclaration.builder()
+                        .name("worker")
+                        .description("Persistent worker")
+                        .inlineAgentsBody("Work on delegated tasks.")
+                        .persistSession(true)
+                        .build();
+        SubagentEntry entry =
+                new SubagentEntry(
+                        "worker",
+                        "Persistent worker",
+                        ignored -> {
+                            HarnessAgent child =
+                                    HarnessAgent.builder()
+                                            .name("worker")
+                                            .model(new MockModel("done"))
+                                            .workspace(workspace)
+                                            .stateStore(new InMemoryAgentStateStore())
+                                            .enablePlanMode()
+                                            .build();
+                            createdAgents.add(child);
+                            return child;
+                        },
+                        declaration);
+        DefaultAgentManager manager = new DefaultAgentManager(List.of(entry), null);
+        AgentSpawnTool tool = new AgentSpawnTool(manager, null, 0);
+        RuntimeContext context =
+                RuntimeContext.builder().userId("user").sessionId("parent-session").build();
+        AgentState parentState =
+                AgentState.builder().userId("user").sessionId("parent-session").build();
+        return new Fixture(tool, context, parentState);
+    }
+
+    private static String firstLineValue(String result, String prefix) {
+        return result.lines()
+                .filter(line -> line.startsWith(prefix))
+                .map(line -> line.substring(prefix.length()))
+                .findFirst()
+                .orElseThrow();
+    }
+
+    private record Fixture(AgentSpawnTool tool, RuntimeContext context, AgentState parentState) {}
+}


### PR DESCRIPTION
## Summary

- Install Plan Mode enforcement for automatically built general-purpose and declared subagents.
- Propagate the parent's Plan Mode configuration, including shell access and the plan file directory.
- Resynchronize Plan Mode state before spawning, reusing, or messaging persistent subagents.
- Add regression tests covering Plan Mode propagation and write-tool restrictions.

## Motivation

Plan Mode enforcement is provided by `PlanModeMiddleware`, rather than by the shared `planActive` state alone.

Previously, automatically built subagents inherited the parent's Plan Mode state but did not install the corresponding manager and middleware. As a result, tools such as `write_file` and `edit_file` could bypass the read-only boundary while the parent agent was in Plan Mode.

The parent agent was unaffected because its Plan Mode middleware was installed during its own build process.

## Testing

```bash
mvn -nsu -pl agentscope-harness -am \
  -DskipITs \
  -Dtest=PlanModeSubagentPropagationTest,AgentSpawnToolPlanModeTest \
  -Dsurefire.failIfNoSpecifiedTests=false \
  test