### PR TITLE
fix(core): release shutdown state saver on close

### DIFF
--- a/agentscope-core/src/main/java/io/agentscope/core/ReActAgent.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/ReActAgent.java
@@ -324,6 +324,7 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
         this.hookDispatcher = new LegacyHookDispatcher(this);
 
         if (this.stateStore != null) {
+            AgentStateStore capturedStateStore = this.stateStore;
             shutdownManager.bindStateSaver(
                     this,
                     // The saver receives the precise per-(userId, sessionId) AgentState bound to
@@ -331,7 +332,7 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
                     // interrupted request, so persist that session directly rather than the
                     // instance "last-active" CallExecution (which is wrong under concurrency).
                     agentState ->
-                            stateStore.save(
+                            capturedStateStore.save(
                                     agentState.getUserId(),
                                     agentState.getSessionId(),
                                     "agent_state",
@@ -3841,8 +3842,7 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
 
     @Override
     public void close() {
-        // No-op for the core ReActAgent. Subclasses / wrappers (HarnessAgent) may release
-        // additional resources here.
+        shutdownManager.unbindStateSaver(this);
     }
 
     // ==================== Builder ====================

--- a/agentscope-core/src/main/java/io/agentscope/core/shutdown/GracefulShutdownManager.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/shutdown/GracefulShutdownManager.java
@@ -116,6 +116,19 @@ public final class GracefulShutdownManager {
     }
 
     /**
+     * Unregister the {@link ShutdownStateSaver} for the given agent.
+     *
+     * <p>Agents must call this when they are closed so the process-wide shutdown manager does not
+     * retain short-lived agent instances through their saver callbacks.
+     */
+    public void unbindStateSaver(Agent agent) {
+        if (agent == null) {
+            return;
+        }
+        stateSavers.remove(agent.getAgentId());
+    }
+
+    /**
      * Check whether the agent was previously interrupted by shutdown, and clear the flag.
      *
      * <p>Called from {@link GracefulShutdownMiddleware} on each {@code onAgent} to detect

--- a/agentscope-core/src/test/java/io/agentscope/core/shutdown/GracefulShutdownTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/shutdown/GracefulShutdownTest.java
@@ -27,7 +27,9 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 
+import io.agentscope.core.ReActAgent;
 import io.agentscope.core.agent.AgentBase;
+import io.agentscope.core.agent.test.MockModel;
 import io.agentscope.core.interruption.InterruptContext;
 import io.agentscope.core.message.Msg;
 import io.agentscope.core.message.MsgRole;
@@ -354,6 +356,49 @@ class GracefulShutdownTest {
 
             assertDoesNotThrow(() -> manager.bindStateSaver(null, s -> {}));
             assertDoesNotThrow(() -> manager.bindStateSaver(agent, null));
+        }
+
+        @Test
+        @DisplayName("unbindStateSaver removes the agent saver")
+        void unbindStateSaverRemovesSaver() {
+            TestableAgent agent = createTestAgent("agent-1");
+            AtomicReference<AgentState> savedState = new AtomicReference<>();
+            manager.bindStateSaver(agent, savedState::set);
+
+            manager.unbindStateSaver(agent);
+            String requestId = manager.registerRequest(agent);
+            manager.saveOnInterruptObserved(requestId);
+
+            assertNull(savedState.get());
+        }
+
+        @Test
+        @DisplayName("unbindStateSaver is idempotent and accepts null")
+        void unbindStateSaverIsIdempotent() {
+            TestableAgent agent = createTestAgent("agent-1");
+            manager.bindStateSaver(agent, state -> {});
+
+            assertDoesNotThrow(() -> manager.unbindStateSaver(agent));
+            assertDoesNotThrow(() -> manager.unbindStateSaver(agent));
+            assertDoesNotThrow(() -> manager.unbindStateSaver(null));
+        }
+
+        @Test
+        @DisplayName("closing ReActAgent unregisters its state saver")
+        void closingReActAgentUnregistersStateSaver() {
+            ReActAgent agent =
+                    ReActAgent.builder()
+                            .name("short-lived")
+                            .sysPrompt("test")
+                            .model(new MockModel("ok"))
+                            .stateStore(new InMemoryAgentStateStore())
+                            .build();
+
+            agent.close();
+            String requestId = manager.registerRequest(agent);
+            manager.saveOnInterruptObserved(requestId);
+
+            assertFalse(agent.getAgentState().isShutdownInterrupted());
         }
 
         @Test


### PR DESCRIPTION
## Summary

Fixes #2321.

`GracefulShutdownManager` registered one state saver per stateful Agent but never removed it. Because the saver callback captured the `ReActAgent` instance, closing short-lived Agents still left their full object graphs reachable from the process-wide singleton.

This change:

- adds a symmetric, null-safe `unbindStateSaver(Agent)` lifecycle API;
- unregisters the saver from `ReActAgent.close()`, which also covers `HarnessAgent.close()` through its delegate;
- captures the `AgentStateStore` local in the saver callback instead of the enclosing Agent;
- adds regression coverage for removal, idempotence, null handling, and the real `ReActAgent.close()` path.

## User impact

Applications that create and close a fresh stateful Agent per request no longer accumulate saver entries or retain closed Agent instances through the shutdown manager.

## Tests

- `mvn -pl agentscope-core -Dtest=GracefulShutdownTest test` (49 tests passed)
- `mvn -pl agentscope-core test` (2221 tests passed, 9 skipped)
- Spotless check passed as part of both Maven builds.

## Compatibility and risk

The new manager API is additive and `close()` remains idempotent. Active request contexts keep the saver snapshot captured at request registration, so closing an Agent does not mutate already registered request objects. Normal long-lived Agent shutdown behavior is unchanged until the Agent is explicitly closed.