### PR TITLE
fix: preserve message id, timestamp, and usage in extractResponseData (#500) [FaaFyfxR9WAQrL7FcAgEHJvztd8cVMxvjHRS55rw1nwH]

### DIFF
--- a/agentscope-core/src/main/java/io/agentscope/core/ReActAgent.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/ReActAgent.java
@@ -1380,9 +1380,12 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
             metadata.put(MessageMetadataKeys.STRUCTURED_OUTPUT, responseData);
             metadata.remove("response");
             return Msg.builderForRole(responseMsg.getRole())
+                    .id(responseMsg.getId())
                     .name(responseMsg.getName())
                     .content(responseMsg.getContent())
                     .metadata(metadata)
+                    .timestamp(responseMsg.getTimestamp())
+                    .usage(responseMsg.getUsage())
                     .build();
         }
         return responseMsg;


### PR DESCRIPTION
## Summary

Fixes metadata loss in the structured output flow. When `StructuredOutputCapableAgent.extractResponseData()` rebuilt the message with structured output metadata, it was discarding three fields from the original `responseMsg`:

1. **`id`** — message ID was regenerated, breaking identity tracking
2. **`timestamp`** — creation timestamp was regenerated
3. **`usage`** — LLM token usage (`ChatUsage` / `_chat_usage`) was lost

## Root Cause

In `extractResponseData()`, the `Msg.builderForRole().build()` call did not propagate `.id()`, `.timestamp()`, or `.usage()` from the original `responseMsg`. While the metadata map *content* was already preserved (via `new HashMap<>(responseMsg.getMetadata())`), the message-level fields were silently dropped.

## Changes

- `ReActAgent.java`: Added `.id(responseMsg.getId())`, `.timestamp(responseMsg.getTimestamp())`, and `.usage(responseMsg.getUsage())` to the builder chain in `extractResponseData()`

## Related

Closes #500