### PR TITLE
perf(tool): stream ranged file reads

### DIFF
--- a/agentscope-core/src/main/java/io/agentscope/core/tool/file/ReadFileTool.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/tool/file/ReadFileTool.java
@@ -18,6 +18,8 @@ package io.agentscope.core.tool.file;
 import io.agentscope.core.message.ToolResultBlock;
 import io.agentscope.core.tool.Tool;
 import io.agentscope.core.tool.ToolParam;
+import java.io.BufferedReader;
+import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -134,20 +136,17 @@ public class ReadFileTool {
                                         String.format("The path %s is not a file.", filePath));
                             }
 
-                            // Read all lines
-                            List<String> lines = Files.readAllLines(path, StandardCharsets.UTF_8);
-                            logger.debug("Read {} lines from file: {}", lines.size(), filePath);
-
                             // Parse ranges if provided
                             if (ranges == null || ranges.trim().isEmpty()) {
                                 // Return entire file content
+                                ReadResult result = readLines(path, 1, Integer.MAX_VALUE);
                                 logger.debug(
-                                        "Returning entire file content ({} lines)", lines.size());
-                                String content = formatLinesWithNumbers(lines, 1, lines.size());
+                                        "Returning entire file content ({} lines)",
+                                        result.linesRead);
                                 return ToolResultBlock.text(
                                         String.format(
                                                 "The content of %s:\n```\n%s```",
-                                                filePath, content));
+                                                filePath, result.content));
                             }
 
                             // Parse the range
@@ -165,26 +164,26 @@ public class ReadFileTool {
                             int end = rangeArray[1];
 
                             // Handle negative indices (count from the end)
-                            if (start < 0) {
-                                start = lines.size() + start + 1;
-                            }
-                            if (end < 0) {
-                                end = lines.size() + end + 1;
+                            int totalLines = -1;
+                            if (start < 0 || end < 0) {
+                                totalLines = countLines(path);
+                                if (start < 0) {
+                                    start = totalLines + start + 1;
+                                }
+                                if (end < 0) {
+                                    end = totalLines + end + 1;
+                                }
                             }
 
                             // Validate range
                             if (start < 1) {
                                 start = 1;
                             }
-                            if (end > lines.size()) {
-                                end = lines.size();
+                            if (totalLines >= 0 && end > totalLines) {
+                                end = totalLines;
                             }
                             if (start > end) {
-                                logger.warn(
-                                        "Invalid range: start {} > end {} for file with {} lines",
-                                        start,
-                                        end,
-                                        lines.size());
+                                logger.warn("Invalid range: start {} > end {}", start, end);
                                 return ToolResultBlock.error(
                                         String.format(
                                                 "Invalid range: start line %d is greater than end"
@@ -194,13 +193,27 @@ public class ReadFileTool {
 
                             logger.debug("Viewing lines {}-{} from file: {}", start, end, filePath);
 
-                            // Extract the specified range
-                            String content = formatLinesWithNumbers(lines, start, end);
+                            ReadResult result = readLines(path, start, end);
+                            if (totalLines < 0 && result.linesRead < end) {
+                                end = result.linesRead;
+                            }
+                            if (start > end) {
+                                logger.warn(
+                                        "Invalid range: start {} > end {} for file with {} lines",
+                                        start,
+                                        end,
+                                        result.linesRead);
+                                return ToolResultBlock.error(
+                                        String.format(
+                                                "Invalid range: start line %d is greater than end"
+                                                        + " line %d.",
+                                                start, end));
+                            }
 
                             return ToolResultBlock.text(
                                     String.format(
                                             "The content of %s in lines [%d, %d]:\n```\n%s```",
-                                            filePath, start, end, content));
+                                            filePath, start, end, result.content));
                         })
                 .onErrorResume(
                         e -> {
@@ -332,25 +345,43 @@ public class ReadFileTool {
                         });
     }
 
-    /**
-     * Format lines with line numbers for display.
-     *
-     * @param lines All lines from the file
-     * @param start Start line number (1-based, inclusive)
-     * @param end End line number (1-based, inclusive)
-     * @return Formatted string with line numbers
-     */
-    private String formatLinesWithNumbers(List<String> lines, int start, int end) {
-        StringBuilder result = new StringBuilder();
+    private ReadResult readLines(Path path, int start, int end) throws IOException {
+        StringBuilder content = new StringBuilder();
+        int lineNumber = 0;
 
-        // Adjust to 0-based index
-        int startIdx = start - 1;
-        int endIdx = end - 1;
-
-        for (int i = startIdx; i <= endIdx && i < lines.size(); i++) {
-            result.append(String.format("%d: %s\n", i + 1, lines.get(i)));
+        try (BufferedReader reader = Files.newBufferedReader(path, StandardCharsets.UTF_8)) {
+            String line;
+            while ((line = reader.readLine()) != null) {
+                lineNumber++;
+                if (lineNumber >= start) {
+                    content.append(lineNumber).append(": ").append(line).append('\n');
+                }
+                if (lineNumber >= end) {
+                    break;
+                }
+            }
         }
 
-        return result.toString();
+        return new ReadResult(content.toString(), lineNumber);
+    }
+
+    private int countLines(Path path) throws IOException {
+        int count = 0;
+        try (BufferedReader reader = Files.newBufferedReader(path, StandardCharsets.UTF_8)) {
+            while (reader.readLine() != null) {
+                count++;
+            }
+        }
+        return count;
+    }
+
+    private static final class ReadResult {
+        private final String content;
+        private final int linesRead;
+
+        private ReadResult(String content, int linesRead) {
+            this.content = content;
+            this.linesRead = linesRead;
+        }
     }
 }

--- a/agentscope-core/src/test/java/io/agentscope/core/tool/file/ReadFileToolTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/tool/file/ReadFileToolTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.core.tool.file;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import io.agentscope.core.message.TextBlock;
+import io.agentscope.core.message.ToolResultBlock;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class ReadFileToolTest {
+
+    @TempDir Path tempDir;
+
+    private ReadFileTool tool;
+    private Path file;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        tool = new ReadFileTool(tempDir.toString());
+        file = tempDir.resolve("sample.txt");
+        Files.writeString(file, "one\ntwo\nthree\nfour\nfive\n", StandardCharsets.UTF_8);
+    }
+
+    @Test
+    void readsPositiveRange() {
+        assertEquals(
+                expected("The content of %s in lines [2, 3]:\n```\n2: two\n3: three\n```"),
+                resultText(tool.viewTextFile(file.toString(), "2,3").block()));
+    }
+
+    @Test
+    void clampsPositiveRangeToEndOfFile() {
+        assertEquals(
+                expected("The content of %s in lines [4, 5]:\n```\n4: four\n5: five\n```"),
+                resultText(tool.viewTextFile(file.toString(), "4,20").block()));
+    }
+
+    @Test
+    void readsRangeRelativeToEndOfFile() {
+        assertEquals(
+                expected(
+                        "The content of %s in lines [3, 5]:\n```\n3: three\n4: four\n5: five\n```"),
+                resultText(tool.viewTextFile(file.toString(), "-3,-1").block()));
+    }
+
+    @Test
+    void readsEntireFileWithoutRange() {
+        assertEquals(
+                expected(
+                        "The content of %s:\n```\n1: one\n2: two\n3: three\n4: four\n5: five\n```"),
+                resultText(tool.viewTextFile(file.toString(), null).block()));
+    }
+
+    @Test
+    void reportsRangeStartingAfterEndOfFile() {
+        assertEquals(
+                "Error: Invalid range: start line 10 is greater than end line 5.",
+                resultText(tool.viewTextFile(file.toString(), "10,20").block()));
+    }
+
+    private String expected(String template) {
+        return String.format(template, file);
+    }
+
+    private String resultText(ToolResultBlock result) {
+        return ((TextBlock) result.getOutput().get(0)).getText();
+    }
+}


### PR DESCRIPTION
## AgentScope-Java Version

2.0.1-SNAPSHOT

## Description

`ReadFileTool` previously loaded every line into memory before applying the requested range. This caused unnecessary memory usage and file I/O for small ranges on large files.

This change:

- reads positive line ranges incrementally and stops at the requested end line;
- preserves negative-index behavior by counting lines before resolving the range;
- reads full-file requests incrementally without retaining a duplicate `List<String>`;
- adds unit coverage for full reads, positive ranges, negative ranges, end-of-file clamping, and out-of-range requests.

Validation:

- `mvn -pl agentscope-core spotless:check` passed.
- `mvn -pl agentscope-core -Dtest=ReadFileToolTest -DforkCount=0 test` passed (5 tests).
- The full `agentscope-core` suite ran 2,217 tests. It reported 1 failure and 7 errors in existing Windows-dependent tests involving file URI handling, the Spring nested filesystem provider, and symbolic-link privileges. The new `ReadFileToolTest` tests passed.

## Checklist

Please check the following items before code is ready to be reviewed.

- [x] Code has been formatted with `mvn spotless:apply`
- [ ] All tests are passing (`mvn test`)
- [x] Javadoc comments are complete and follow project conventions
- [x] Related documentation has been updated (not applicable; public behavior is unchanged)
- [x] Code is ready for review