### PR TITLE
fix(harness): make ls() report errors instead of silently returning empty results

### DIFF
--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/filesystem/local/LocalFilesystem.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/filesystem/local/LocalFilesystem.java
@@ -237,8 +237,11 @@ public class LocalFilesystem implements AbstractFilesystem {
     @Override
     public LsResult ls(RuntimeContext runtimeContext, String path) {
         Path dirPath = resolvePath(runtimeContext, path);
-        if (!Files.exists(dirPath) || !Files.isDirectory(dirPath)) {
-            return LsResult.success(List.of());
+        if (!Files.exists(dirPath)) {
+            return LsResult.fail("Path does not exist: " + path);
+        }
+        if (!Files.isDirectory(dirPath)) {
+            return LsResult.fail("Not a directory: " + path);
         }
 
         List<FileInfo> results = new ArrayList<>();

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/filesystem/sandbox/BaseSandboxFilesystem.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/filesystem/sandbox/BaseSandboxFilesystem.java
@@ -73,7 +73,13 @@ public abstract class BaseSandboxFilesystem implements AbstractSandboxFilesystem
     public LsResult ls(RuntimeContext runtimeContext, String path) {
         String escapedPath = FilesystemUtils.shellQuote(path);
         String cmd =
-                "for f in "
+                "if [ ! -e "
+                        + escapedPath
+                        + " ]; then echo '__NOT_EXISTS__'; "
+                        + "elif [ ! -d "
+                        + escapedPath
+                        + " ]; then echo '__NOT_A_DIR__'; "
+                        + "else for f in "
                         + escapedPath
                         + "/*; do "
                         + "  if [ -d \"$f\" ]; then "
@@ -84,13 +90,22 @@ public abstract class BaseSandboxFilesystem implements AbstractSandboxFilesystem
                         + "    mtime=$(stat -c '%Y' \"$f\" 2>/dev/null || echo 0); "
                         + "    printf 'FILE:%s\\t%s\\t%s\\n' \"$f\" \"$size\" \"$mtime\"; "
                         + "  fi; "
-                        + "done 2>/dev/null";
+                        + "done; fi";
 
         ExecuteResponse result = execute(runtimeContext, cmd, null);
+        String output = result.output() != null ? result.output().strip() : "";
+
+        if ("__NOT_EXISTS__".equals(output)) {
+            return LsResult.fail("Path does not exist: " + path);
+        }
+        if ("__NOT_A_DIR__".equals(output)) {
+            return LsResult.fail("Not a directory: " + path);
+        }
+
         List<FileInfo> entries = new ArrayList<>();
 
-        if (result.output() != null && !result.output().isBlank()) {
-            for (String line : result.output().strip().split("\n")) {
+        if (!output.isBlank()) {
+            for (String line : output.split("\n")) {
                 if (line.startsWith("DIR:")) {
                     String payload = line.substring(4);
                     String[] parts = payload.split("\t", 2);

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/tool/FilesystemTool.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/tool/FilesystemTool.java
@@ -181,7 +181,7 @@ public class FilesystemTool {
         }
         List<FileInfo> infos = r.entries();
         if (infos == null || infos.isEmpty()) {
-            return "Empty or not a directory: " + path;
+            return "Empty directory: " + path;
         }
         return infos.stream()
                 .map(

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/filesystem/LocalFilesystemModeTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/filesystem/LocalFilesystemModeTest.java
@@ -289,4 +289,22 @@ class LocalFilesystemModeTest {
                 SecurityException.class,
                 () -> fs.read(RuntimeContext.empty(), "/../etc/passwd", 0, 0));
     }
+
+    // ==================== Bug reproduction: ls silently swallows errors ====================
+
+    @Test
+    void ls_nonExistentPath_shouldReturnFail(@TempDir Path workspace) {
+        LocalFilesystem fs = new LocalFilesystem(workspace);
+        LsResult r = fs.ls(RuntimeContext.empty(), "/this/path/does/not/exist");
+        assertFalse(r.isSuccess(), "ls on non-existent path should fail");
+    }
+
+    @Test
+    void ls_filePath_shouldReturnFail(@TempDir Path workspace) throws IOException {
+        Path file = workspace.resolve("foo.txt");
+        Files.writeString(file, "content");
+        LocalFilesystem fs = new LocalFilesystem(workspace);
+        LsResult r = fs.ls(RuntimeContext.empty(), file.toAbsolutePath().toString());
+        assertFalse(r.isSuccess(), "ls on a file path should fail");
+    }
 }

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/filesystem/sandbox/BaseSandboxFilesystemTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/filesystem/sandbox/BaseSandboxFilesystemTest.java
@@ -206,6 +206,24 @@ class BaseSandboxFilesystemTest {
             assertTrue(result.isSuccess());
             assertTrue(result.matches().isEmpty());
         }
+
+        // ==================== Bug reproduction: ls shell swallows errors ====================
+
+        @Test
+        void ls_nonExistentPath_shouldReturnFail() {
+            LocalShellSandboxFilesystem fs = new LocalShellSandboxFilesystem();
+            LsResult r = fs.ls(RT, "/this/path/does/not/exist/at/all");
+            assertFalse(r.isSuccess(), "ls on non-existent path should fail");
+        }
+
+        @Test
+        void ls_filePath_shouldReturnFail() throws IOException {
+            Path file = tmpDir.resolve("file.txt");
+            Files.writeString(file, "content");
+            LocalShellSandboxFilesystem fs = new LocalShellSandboxFilesystem();
+            LsResult r = fs.ls(RT, file.toAbsolutePath().toString());
+            assertFalse(r.isSuccess(), "ls on a file path should fail");
+        }
     }
 
     // ================================================================
@@ -225,7 +243,7 @@ class BaseSandboxFilesystemTest {
         public ExecuteResponse execute(
                 RuntimeContext runtimeContext, String command, Integer timeoutSeconds) {
             lastCommand = command;
-            if (command.startsWith("for f in ") && command.contains("stat -c")) {
+            if (command.startsWith("if [ ! -e ") && command.contains("stat -c")) {
                 return new ExecuteResponse(
                         "DIR:/workspace/docs\t1719300000\n"
                                 + "FILE:/workspace/readme.txt\t12\t1719300000\n",

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/tool/FilesystemToolTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/tool/FilesystemToolTest.java
@@ -89,6 +89,39 @@ class FilesystemToolTest {
         verify(filesystem).ls(RT, "memory");
     }
 
+    // ==================== Bug reproduction: listFiles ambiguous error message ====================
+
+    @Test
+    void listFiles_nonExistentPath_returnsError() {
+        when(filesystem.ls(RT, "/nonexistent"))
+                .thenReturn(LsResult.fail("Path does not exist: /nonexistent"));
+
+        String result = tool.listFiles(RT, "/nonexistent");
+
+        assertTrue(result.startsWith("Error:"), "should report error for non-existent path");
+        assertTrue(result.contains("does not exist"), "error should mention 'does not exist'");
+    }
+
+    @Test
+    void listFiles_filePath_returnsError() {
+        when(filesystem.ls(RT, "/path/to/file.txt"))
+                .thenReturn(LsResult.fail("Not a directory: /path/to/file.txt"));
+
+        String result = tool.listFiles(RT, "/path/to/file.txt");
+
+        assertTrue(result.startsWith("Error:"), "should report error for file path");
+        assertTrue(result.contains("Not a directory"), "error should mention 'Not a directory'");
+    }
+
+    @Test
+    void listFiles_emptyDirectory_returnsEmptyDirMessage() {
+        when(filesystem.ls(RT, "/empty/dir")).thenReturn(LsResult.success(List.of()));
+
+        String result = tool.listFiles(RT, "/empty/dir");
+
+        assertEquals("Empty directory: /empty/dir", result);
+    }
+
     @Test
     void readFile_omittedOffsetAndLimit_defaultToZero() {
         when(filesystem.read(eq(RT), eq("f.txt"), eq(0), eq(0)))


### PR DESCRIPTION
Fixes #2411

## Summary

Three-layer cascade: `LocalFilesystem.ls()` and `BaseSandboxFilesystem.ls()` silently return `success(empty list)` when a path does not exist or is a file (not a directory). This makes `FilesystemTool.listFiles()` unable to distinguish "not found", "not a directory", and "empty directory" — it returns the same misleading `"Empty or not a directory: ..."` message for all three.

## Changes

### `LocalFilesystem.ls()`
Split the single `||` check into two separate conditions:
- `!Files.exists(dirPath)` → `LsResult.fail("Path does not exist: ...")`
- `!Files.isDirectory(dirPath)` → `LsResult.fail("Not a directory: ...")`

### `BaseSandboxFilesystem.ls()`
Added shell-level path existence/directory checks before the glob loop:
```bash
if [ ! -e path ]; then echo '\''__NOT_EXISTS__'\''
elif [ ! -d path ]; then echo '\''__NOT_A_DIR__'\''
else for f in path/*; do ... done
fi
```
Java parses the sentinel values and returns `LsResult.fail(...)` accordingly.
Also updated `FakeSandboxFilesystem.execute()` command matching to match the new command prefix.

### `FilesystemTool.listFiles()`
Changed the empty-entries message from `"Empty or not a directory"` to `"Empty directory"` — since the other two cases are now caught at the filesystem layer as errors.

## Tests
Added 7 reproduction/regression tests across all three layers (previously `@Disabled`, now active). All 36 tests pass with 0 failures.