### PR TITLE
fix(ollama): honor ModelCreationContext.stream flag in OllamaChatMode…

### DIFF
--- a/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-ollama/src/main/java/io/agentscope/extensions/model/ollama/OllamaChatModel.java
+++ b/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-ollama/src/main/java/io/agentscope/extensions/model/ollama/OllamaChatModel.java
@@ -64,21 +64,10 @@ public class OllamaChatModel extends ChatModelBase {
     private static final Logger log = LoggerFactory.getLogger(OllamaChatModel.class);
 
     private final String modelName;
+    private final boolean stream;
     private final OllamaHttpClient httpClient;
     private final OllamaOptions defaultOptions;
     private final Formatter<OllamaMessage, OllamaResponse, OllamaRequest> formatter;
-
-    /**
-     * Whether {@link #doStream} should use Ollama's streaming API (chunked) or the non-streaming
-     * API (single complete response). Defaults to {@code true} to preserve historical behavior.
-     *
-     * <p>The {@code Model.stream} entry point is final and always dispatches to {@code doStream};
-     * this flag therefore controls whether callers that do {@code model.stream(...).blockLast()}
-     * (e.g. single-turn bots, ReActAgent reasoning) receive one aggregated response or only the
-     * last (often empty) streaming chunk. Setting it to {@code false} makes {@code blockLast()}
-     * return the full reply.
-     */
-    private final boolean stream;
 
     /**
      * Creates a new OllamaChatModel.
@@ -100,10 +89,6 @@ public class OllamaChatModel extends ChatModelBase {
 
     /**
      * Creates a new OllamaChatModel with an explicit streaming mode.
-     *
-     * @param stream {@code true} to use Ollama's streaming API in {@link #doStream}; {@code false}
-     *     to use the non-streaming API (single complete response), so that {@code
-     *     model.stream(...).blockLast()} returns the full reply instead of the last chunk.
      */
     public OllamaChatModel(
             String modelName,
@@ -148,13 +133,6 @@ public class OllamaChatModel extends ChatModelBase {
         return this.modelName;
     }
 
-    /**
-     * Whether {@link #doStream} uses Ollama's streaming API (chunked). When {@code false}, the
-     * non-streaming API is used so that {@code model.stream(...).blockLast()} returns the full
-     * reply. Exposed for configuration/diagnostic introspection.
-     *
-     * @return {@code true} if streaming, {@code false} if non-streaming
-     */
     public boolean isStreaming() {
         return this.stream;
     }
@@ -186,12 +164,14 @@ public class OllamaChatModel extends ChatModelBase {
     @Override
     protected Flux<ChatResponse> doStream(
             List<Msg> messages, List<ToolSchema> tools, GenerateOptions options) {
+        boolean effectiveStream =
+                options != null && options.getStream() != null ? options.getStream() : this.stream;
         return streamWithHttpClient(
                 messages,
                 tools,
                 options != null ? options.getToolChoice() : null,
                 OllamaOptions.fromGenerateOptions(options),
-                this.stream);
+                effectiveStream);
     }
 
     /**
@@ -303,6 +283,15 @@ public class OllamaChatModel extends ChatModelBase {
             return this;
         }
 
+        /**
+         * Sets whether streaming should be enabled.
+         * <p>Default is {@code true}
+         */
+        public Builder stream(boolean stream) {
+            this.stream = stream;
+            return this;
+        }
+
         public Builder defaultOptions(OllamaOptions defaultOptions) {
             this.defaultOptions = defaultOptions;
             return this;
@@ -372,23 +361,6 @@ public class OllamaChatModel extends ChatModelBase {
 
         public Builder contextWindowSize(int contextWindowSize) {
             this.contextWindowSize = contextWindowSize;
-            return this;
-        }
-
-        /**
-         * Sets whether {@link OllamaChatModel#doStream} should use Ollama's streaming API (chunked)
-         * or the non-streaming API (single complete response).
-         *
-         * <p>Default is {@code true} (streaming) for backward compatibility. Set to {@code false}
-         * when callers consume the model via {@code model.stream(...).blockLast()} and expect the
-         * full reply — with streaming, {@code blockLast()} returns only the last (often empty)
-         * chunk; with non-streaming, it returns the single aggregated response.
-         *
-         * @param stream {@code true} for streaming, {@code false} for non-streaming
-         * @return this builder instance
-         */
-        public Builder stream(boolean stream) {
-            this.stream = stream;
             return this;
         }
 

--- a/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-ollama/src/main/java/io/agentscope/extensions/model/ollama/OllamaChatModel.java
+++ b/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-ollama/src/main/java/io/agentscope/extensions/model/ollama/OllamaChatModel.java
@@ -69,10 +69,22 @@ public class OllamaChatModel extends ChatModelBase {
     private final Formatter<OllamaMessage, OllamaResponse, OllamaRequest> formatter;
 
     /**
+     * Whether {@link #doStream} should use Ollama's streaming API (chunked) or the non-streaming
+     * API (single complete response). Defaults to {@code true} to preserve historical behavior.
+     *
+     * <p>The {@code Model.stream} entry point is final and always dispatches to {@code doStream};
+     * this flag therefore controls whether callers that do {@code model.stream(...).blockLast()}
+     * (e.g. single-turn bots, ReActAgent reasoning) receive one aggregated response or only the
+     * last (often empty) streaming chunk. Setting it to {@code false} makes {@code blockLast()}
+     * return the full reply.
+     */
+    private final boolean stream;
+
+    /**
      * Creates a new OllamaChatModel.
      *
      * @param modelName The name of the model to use (e.g., "llama2", "mistral").
-     * @param baseUrl The base URL of the Ollama server (e.g., "http://localhost:11434").
+     * @param baseUrl The base URL of the Ollama server (e.g. "http://localhost:11434").
      * @param defaultOptions Default configuration options.
      * @param formatter The message formatter to use.
      * @param httpTransport The HTTP transport to use.
@@ -83,10 +95,28 @@ public class OllamaChatModel extends ChatModelBase {
             OllamaOptions defaultOptions,
             Formatter<OllamaMessage, OllamaResponse, OllamaRequest> formatter,
             HttpTransport httpTransport) {
+        this(modelName, baseUrl, defaultOptions, formatter, httpTransport, true);
+    }
+
+    /**
+     * Creates a new OllamaChatModel with an explicit streaming mode.
+     *
+     * @param stream {@code true} to use Ollama's streaming API in {@link #doStream}; {@code false}
+     *     to use the non-streaming API (single complete response), so that {@code
+     *     model.stream(...).blockLast()} returns the full reply instead of the last chunk.
+     */
+    public OllamaChatModel(
+            String modelName,
+            String baseUrl,
+            OllamaOptions defaultOptions,
+            Formatter<OllamaMessage, OllamaResponse, OllamaRequest> formatter,
+            HttpTransport httpTransport,
+            boolean stream) {
         this.modelName = modelName;
         this.defaultOptions =
                 defaultOptions != null ? defaultOptions : OllamaOptions.builder().build();
         this.formatter = formatter != null ? formatter : new OllamaChatFormatter();
+        this.stream = stream;
 
         HttpTransport transport =
                 httpTransport != null ? httpTransport : HttpTransportFactory.getDefault();
@@ -116,6 +146,17 @@ public class OllamaChatModel extends ChatModelBase {
     @Override
     public String getModelName() {
         return this.modelName;
+    }
+
+    /**
+     * Whether {@link #doStream} uses Ollama's streaming API (chunked). When {@code false}, the
+     * non-streaming API is used so that {@code model.stream(...).blockLast()} returns the full
+     * reply. Exposed for configuration/diagnostic introspection.
+     *
+     * @return {@code true} if streaming, {@code false} if non-streaming
+     */
+    public boolean isStreaming() {
+        return this.stream;
     }
 
     /**
@@ -150,7 +191,7 @@ public class OllamaChatModel extends ChatModelBase {
                 tools,
                 options != null ? options.getToolChoice() : null,
                 OllamaOptions.fromGenerateOptions(options),
-                true);
+                this.stream);
     }
 
     /**
@@ -250,6 +291,7 @@ public class OllamaChatModel extends ChatModelBase {
         private HttpTransport httpTransport;
         private ProxyConfig proxyConfig;
         private int contextWindowSize = -1;
+        private boolean stream = true;
 
         public Builder modelName(String modelName) {
             this.modelName = modelName;
@@ -333,6 +375,23 @@ public class OllamaChatModel extends ChatModelBase {
             return this;
         }
 
+        /**
+         * Sets whether {@link OllamaChatModel#doStream} should use Ollama's streaming API (chunked)
+         * or the non-streaming API (single complete response).
+         *
+         * <p>Default is {@code true} (streaming) for backward compatibility. Set to {@code false}
+         * when callers consume the model via {@code model.stream(...).blockLast()} and expect the
+         * full reply — with streaming, {@code blockLast()} returns only the last (often empty)
+         * chunk; with non-streaming, it returns the single aggregated response.
+         *
+         * @param stream {@code true} for streaming, {@code false} for non-streaming
+         * @return this builder instance
+         */
+        public Builder stream(boolean stream) {
+            this.stream = stream;
+            return this;
+        }
+
         public OllamaChatModel build() {
             OllamaOptions finalOptions =
                     defaultOptions != null
@@ -348,7 +407,8 @@ public class OllamaChatModel extends ChatModelBase {
             HttpTransport transport = resolveTransport();
 
             OllamaChatModel model =
-                    new OllamaChatModel(modelName, baseUrl, finalOptions, formatter, transport);
+                    new OllamaChatModel(
+                            modelName, baseUrl, finalOptions, formatter, transport, stream);
             if (contextWindowSize >= 0) {
                 model.setContextWindowSize(contextWindowSize);
             }

--- a/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-ollama/src/main/java/io/agentscope/extensions/model/ollama/OllamaModelProvider.java
+++ b/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-ollama/src/main/java/io/agentscope/extensions/model/ollama/OllamaModelProvider.java
@@ -61,6 +61,13 @@ public final class OllamaModelProvider implements ModelProvider {
         }
         OllamaChatModel.Builder builder =
                 OllamaChatModel.builder().modelName(modelName).baseUrl(baseUrl);
+        // Honor ModelCreationContext.stream: when a caller sets stream=false (e.g. a single-turn
+        // bot that does model.stream(...).blockLast()), route doStream to Ollama's non-streaming
+        // API so blockLast() returns the full reply instead of the last (empty) chunk. Default
+        // remains streaming when the flag is null.
+        if (context.getStream() != null) {
+            builder.stream(context.getStream());
+        }
         applyAdvancedOptions(builder, context);
         return builder.build();
     }

--- a/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-ollama/src/main/java/io/agentscope/extensions/model/ollama/OllamaModelProvider.java
+++ b/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-ollama/src/main/java/io/agentscope/extensions/model/ollama/OllamaModelProvider.java
@@ -61,10 +61,6 @@ public final class OllamaModelProvider implements ModelProvider {
         }
         OllamaChatModel.Builder builder =
                 OllamaChatModel.builder().modelName(modelName).baseUrl(baseUrl);
-        // Honor ModelCreationContext.stream: when a caller sets stream=false (e.g. a single-turn
-        // bot that does model.stream(...).blockLast()), route doStream to Ollama's non-streaming
-        // API so blockLast() returns the full reply instead of the last (empty) chunk. Default
-        // remains streaming when the flag is null.
         if (context.getStream() != null) {
             builder.stream(context.getStream());
         }

--- a/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-ollama/src/test/java/io/agentscope/extensions/model/ollama/OllamaChatModelTest.java
+++ b/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-ollama/src/test/java/io/agentscope/extensions/model/ollama/OllamaChatModelTest.java
@@ -1206,4 +1206,102 @@ class OllamaChatModelTest {
 
         assertNotNull(model);
     }
+
+    // ========== stream flag routing (fix: doStream used to hardcode streaming) ==========
+
+    /**
+     * Regression test for the bug where {@code doStream} ignored the stream flag and always used
+     * Ollama's streaming API. With streaming, {@code model.stream(...).blockLast()} returns only
+     * the last chunk (an empty {@code done:true} marker), so single-turn callers got an empty
+     * reply. With {@code stream(false)}, {@code blockLast()} must return the full reply via the
+     * non-streaming {@code transport.execute()} path.
+     */
+    @Test
+    @DisplayName(
+            "stream(false) should use non-streaming transport and return full reply on blockLast")
+    void testStreamFalseRoutesToNonStreamingAndReturnsFullReply() throws Exception {
+        // Non-streaming response: a single complete JSON with content "Hello World"
+        String nonStreamingJson =
+                "{\"model\":\""
+                        + TEST_MODEL_NAME
+                        + "\",\"message\":{\"role\":\"assistant\",\"content\":\"Hello World\"},"
+                        + "\"done\":true,\"eval_count\":2}";
+
+        HttpResponse mockResponse =
+                HttpResponse.builder().statusCode(200).body(nonStreamingJson).build();
+        when(httpTransport.execute(any(HttpRequest.class))).thenReturn(mockResponse);
+
+        OllamaChatModel nonStreamingModel =
+                OllamaChatModel.builder()
+                        .modelName(TEST_MODEL_NAME)
+                        .baseUrl("http://localhost:11434")
+                        .httpTransport(httpTransport)
+                        .stream(false)
+                        .build();
+
+        GenerateOptions genOptions = OllamaOptions.builder().build().toGenerateOptions();
+        ChatResponse resp =
+                nonStreamingModel.stream(
+                                List.of(Msg.builder().role(MsgRole.USER).textContent("Hi").build()),
+                                null,
+                                genOptions)
+                        .blockLast();
+
+        // Must have gone through the non-streaming execute() path
+        verify(httpTransport).execute(any(HttpRequest.class));
+        // And blockLast() must carry the full reply content (not an empty trailing chunk)
+        assertNotNull(resp);
+        assertNotNull(resp.getContent());
+        assertFalse(resp.getContent().isEmpty(), "blockLast() content must not be empty");
+        ContentBlock block = resp.getContent().get(0);
+        assertTrue(block instanceof TextBlock);
+        assertEquals("Hello World", ((TextBlock) block).getText());
+    }
+
+    /**
+     * Confirms the default (stream=true) still routes through the streaming path, preserving
+     * backward compatibility for callers that consume the full Flux.
+     */
+    @Test
+    @DisplayName("default (stream=true) should still use streaming transport")
+    void testDefaultStreamTrueStillUsesStreamingTransport() {
+        // Streaming responses: two content chunks + an empty done marker
+        String chunk1 =
+                "{\"model\":\""
+                        + TEST_MODEL_NAME
+                        + "\",\"message\":{\"role\":\"assistant\",\"content\":\"Hello\"},"
+                        + "\"done\":false}";
+        String chunk2 =
+                "{\"model\":\""
+                        + TEST_MODEL_NAME
+                        + "\",\"message\":{\"role\":\"assistant\",\"content\":\" World\"},"
+                        + "\"done\":false}";
+        String doneMarker =
+                "{\"model\":\"" + TEST_MODEL_NAME + "\",\"done\":true,\"eval_count\":2}";
+
+        when(httpTransport.stream(any(HttpRequest.class)))
+                .thenReturn(Flux.just(chunk1, chunk2, doneMarker));
+
+        // Default builder — no stream() call — must remain streaming
+        OllamaChatModel streamingModel =
+                OllamaChatModel.builder()
+                        .modelName(TEST_MODEL_NAME)
+                        .baseUrl("http://localhost:11434")
+                        .httpTransport(httpTransport)
+                        .build();
+
+        GenerateOptions genOptions = OllamaOptions.builder().build().toGenerateOptions();
+        List<ChatResponse> responses =
+                streamingModel.stream(
+                                List.of(Msg.builder().role(MsgRole.USER).textContent("Hi").build()),
+                                null,
+                                genOptions)
+                        .collectList()
+                        .block();
+
+        // Streaming path must be used
+        verify(httpTransport).stream(any(HttpRequest.class));
+        assertNotNull(responses);
+        assertEquals(3, responses.size(), "streaming should emit one response per chunk");
+    }
 }

--- a/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-ollama/src/test/java/io/agentscope/extensions/model/ollama/OllamaChatModelTest.java
+++ b/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-ollama/src/test/java/io/agentscope/extensions/model/ollama/OllamaChatModelTest.java
@@ -1208,14 +1208,6 @@ class OllamaChatModelTest {
     }
 
     // ========== stream flag routing (fix: doStream used to hardcode streaming) ==========
-
-    /**
-     * Regression test for the bug where {@code doStream} ignored the stream flag and always used
-     * Ollama's streaming API. With streaming, {@code model.stream(...).blockLast()} returns only
-     * the last chunk (an empty {@code done:true} marker), so single-turn callers got an empty
-     * reply. With {@code stream(false)}, {@code blockLast()} must return the full reply via the
-     * non-streaming {@code transport.execute()} path.
-     */
     @Test
     @DisplayName(
             "stream(false) should use non-streaming transport and return full reply on blockLast")
@@ -1303,6 +1295,41 @@ class OllamaChatModelTest {
         verify(httpTransport).stream(any(HttpRequest.class));
         assertNotNull(responses);
         assertEquals(3, responses.size(), "streaming should emit one response per chunk");
+    }
+
+    @Test
+    @DisplayName("GenerateOptions.stream(false) should override the model's streaming default")
+    void testGenerateOptionsStreamFalseOverridesDefaultStreaming() throws Exception {
+        String nonStreamingJson =
+                "{\"model\":\""
+                        + TEST_MODEL_NAME
+                        + "\",\"message\":{\"role\":\"assistant\",\"content\":\"Hello World\"},"
+                        + "\"done\":true,\"eval_count\":2}";
+
+        HttpResponse mockResponse =
+                HttpResponse.builder().statusCode(200).body(nonStreamingJson).build();
+        when(httpTransport.execute(any(HttpRequest.class))).thenReturn(mockResponse);
+
+        OllamaChatModel streamingByDefault =
+                OllamaChatModel.builder()
+                        .modelName(TEST_MODEL_NAME)
+                        .baseUrl("http://localhost:11434")
+                        .httpTransport(httpTransport)
+                        .build();
+
+        GenerateOptions requestOptions = GenerateOptions.builder().stream(false).build();
+        ChatResponse resp =
+                streamingByDefault.stream(
+                                List.of(Msg.builder().role(MsgRole.USER).textContent("Hi").build()),
+                                null,
+                                requestOptions)
+                        .blockLast();
+
+        ArgumentCaptor<HttpRequest> requestCaptor = ArgumentCaptor.forClass(HttpRequest.class);
+        verify(httpTransport).execute(requestCaptor.capture());
+        assertTrue(requestCaptor.getValue().getBody().contains("\"stream\":false"));
+        assertNotNull(resp);
+        assertEquals("Hello World", ((TextBlock) resp.getContent().get(0)).getText());
     }
 
     /**

--- a/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-ollama/src/test/java/io/agentscope/extensions/model/ollama/OllamaChatModelTest.java
+++ b/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-ollama/src/test/java/io/agentscope/extensions/model/ollama/OllamaChatModelTest.java
@@ -1304,4 +1304,49 @@ class OllamaChatModelTest {
         assertNotNull(responses);
         assertEquals(3, responses.size(), "streaming should emit one response per chunk");
     }
+
+    /**
+     * The legacy 5-arg constructor (kept for backward compatibility) must delegate to the 6-arg one
+     * with {@code stream=true}. Without this test, the delegation line is uncovered.
+     */
+    @Test
+    @DisplayName("5-arg constructor defaults to streaming (backward compatible delegation)")
+    void testLegacyConstructorDefaultsToStreaming() {
+        OllamaChatModel model =
+                new OllamaChatModel(
+                        TEST_MODEL_NAME,
+                        "http://localhost:11434",
+                        OllamaOptions.builder().build(),
+                        new OllamaChatFormatter(),
+                        null);
+        assertTrue(model.isStreaming(), "5-arg constructor must default to streaming");
+    }
+
+    /**
+     * The 6-arg constructor with {@code stream=false} must expose non-streaming mode via {@link
+     * OllamaChatModel#isStreaming()}. Covers the explicit-stream-flag constructor overload.
+     */
+    @Test
+    @DisplayName("6-arg constructor with stream=false exposes non-streaming mode")
+    void testExplicitConstructorHonorsStreamFlag() {
+        OllamaChatModel streaming =
+                new OllamaChatModel(
+                        TEST_MODEL_NAME,
+                        "http://localhost:11434",
+                        OllamaOptions.builder().build(),
+                        new OllamaChatFormatter(),
+                        null,
+                        true);
+        assertTrue(streaming.isStreaming());
+
+        OllamaChatModel nonStreaming =
+                new OllamaChatModel(
+                        TEST_MODEL_NAME,
+                        "http://localhost:11434",
+                        OllamaOptions.builder().build(),
+                        new OllamaChatFormatter(),
+                        null,
+                        false);
+        assertFalse(nonStreaming.isStreaming());
+    }
 }

--- a/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-ollama/src/test/java/io/agentscope/extensions/model/ollama/OllamaModelProviderTest.java
+++ b/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-ollama/src/test/java/io/agentscope/extensions/model/ollama/OllamaModelProviderTest.java
@@ -72,6 +72,39 @@ class OllamaModelProviderTest {
         assertEquals(128000, model.getContextWindowSize());
     }
 
+    /**
+     * Verifies the provider honors {@link ModelCreationContext#getStream()}: when set to {@code
+     * false}, the created model must be in non-streaming mode (so {@code
+     * model.stream(...).blockLast()} returns the full reply). When unset, the default remains
+     * streaming.
+     */
+    @Test
+    void createHonorsStreamFlagFromContext() {
+        OllamaModelProvider provider = new OllamaModelProvider();
+
+        // stream=false → non-streaming model
+        ModelCreationContext nonStreamingCtx =
+                ModelCreationContext.builder().baseUrl("http://ollama.example.com").stream(false)
+                        .build();
+        Model nonStreaming = provider.create("ollama:llama3", nonStreamingCtx);
+        assertTrue(nonStreaming instanceof OllamaChatModel);
+        assertFalse(((OllamaChatModel) nonStreaming).isStreaming());
+
+        // stream=true → streaming model
+        ModelCreationContext streamingCtx =
+                ModelCreationContext.builder().baseUrl("http://ollama.example.com").stream(true)
+                        .build();
+        Model streaming = provider.create("ollama:llama3", streamingCtx);
+        assertTrue(streaming instanceof OllamaChatModel);
+        assertTrue(((OllamaChatModel) streaming).isStreaming());
+
+        // unset → default streaming (backward compatible)
+        ModelCreationContext defaultCtx =
+                ModelCreationContext.builder().baseUrl("http://ollama.example.com").build();
+        Model defaultModel = provider.create("ollama:llama3", defaultCtx);
+        assertTrue(((OllamaChatModel) defaultModel).isStreaming());
+    }
+
     @Test
     void modelRegistryFindsOllamaProviderFromServiceLoader() {
         assertTrue(ModelRegistry.canResolve("ollama:llama3"));


### PR DESCRIPTION
Closes #2414
…l.doStream

OllamaChatModel.doStream hardcoded the streaming branch (streamWithHttpClient ..., true), ignoring the ModelCreationContext.stream flag that the framework defines as a provider-neutral contract. As a result, callers that consume the model via model.stream(...).blockLast() — e.g. single-turn bots and ReActAgent reasoning — received only the last streaming chunk (an empty done:true marker) instead of the full reply, producing empty responses with no error.

OpenAIChatModel already honors this flag: when stream=false it returns a single aggregated ChatResponse via the non-streaming path. OllamaChatModel's non-streaming branch already existed (streamWithHttpClient ..., false) but was unreachable from doStream.

This change:
- adds a `stream` field to OllamaChatModel (default true, backward compatible)
- threads it through a new constructor overload and a Builder.stream(boolean)
- makes doStream dispatch on this.stream instead of the hardcoded literal
- reads context.getStream() in OllamaModelProvider.create and forwards it to the builder, completing the ModelCreationContext -> provider -> model chain
- exposes isStreaming() for testability

With stream=false, model.stream(...).blockLast() now returns the full reply.

Tests:
- OllamaChatModelTest: stream(false) routes to transport.execute() and blockLast() returns the full content; default stream=true still routes to transport.stream() (backward compatible)
- OllamaModelProviderTest: create() honors context.getStream() (false/true/null)


## Description

[Please describe the background, purpose, changes made, and how to test this PR]

## Checklist

Please check the following items before code is ready to be reviewed.

- [x]  Code has been formatted with `mvn spotless:apply`
- [x]  All tests are passing (`mvn test`)
- [x]  Javadoc comments are complete and follow project conventions
- [x]  Related documentation has been updated (e.g. links, examples, etc.)
- [x]  Code is ready for review
