### PR TITLE
fix(#2407): make full constructors public in MysqlSkillRepository and PostgresSkillRepository [FaaFyfxR9WAQrL7FcAgEHJvztd8cVMxvjHRS55rw1nwH]

### DIFF
--- a/agentscope-extensions/agentscope-extensions-skills/agentscope-extensions-skill-mysql-repository/src/main/java/io/agentscope/core/skill/repository/mysql/MysqlSkillRepository.java
+++ b/agentscope-extensions/agentscope-extensions-skills/agentscope-extensions-skill-mysql-repository/src/main/java/io/agentscope/core/skill/repository/mysql/MysqlSkillRepository.java
@@ -193,8 +193,8 @@ public class MysqlSkillRepository implements AgentSkillRepository {
      * auto-migrated to add {@code metadata_json}.
      *
      * <p>
-     * This constructor is private. Use {@link #builder(DataSource)} to create instances
-     * with custom configuration.
+     * Users may call this constructor directly to pass custom database and table names without
+     * using the builder, or continue to use {@link #builder(DataSource)} for a fluent API.
      *
      * @param dataSource         DataSource for database connections
      * @param databaseName       Custom database name (uses default if null or
@@ -212,7 +212,7 @@ public class MysqlSkillRepository implements AgentSkillRepository {
      * @throws IllegalStateException    if createIfNotExist is false and
      *                                  database/tables do not exist
      */
-    private MysqlSkillRepository(
+    public MysqlSkillRepository(
             DataSource dataSource,
             String databaseName,
             String skillsTableName,

--- a/agentscope-extensions/agentscope-extensions-skills/agentscope-extensions-skill-postgresql-repository/src/main/java/io/agentscope/core/skill/repository/postgresql/PostgresSkillRepository.java
+++ b/agentscope-extensions/agentscope-extensions-skills/agentscope-extensions-skill-postgresql-repository/src/main/java/io/agentscope/core/skill/repository/postgresql/PostgresSkillRepository.java
@@ -204,11 +204,11 @@ public class PostgresSkillRepository implements AgentSkillRepository {
      * auto-migrated to add {@code metadata_json}.
      *
      * <p>
-     * This constructor is private. Use {@link #builder(DataSource)} to create instances
-     * with custom configuration.
+     * Users may call this constructor directly to pass custom schema and table names without
+     * using the builder, or continue to use {@link #builder(DataSource)} for a fluent API.
      *
      * @param dataSource         DataSource for database connections
-     * @param schemaName       Custom schema name (uses default if null or
+     * @param schemaName         Custom schema name (uses default if null or
      *                           empty)
      * @param skillsTableName    Custom skills table name (uses default if null or
      *                           empty)
@@ -223,7 +223,7 @@ public class PostgresSkillRepository implements AgentSkillRepository {
      * @throws IllegalStateException    if createIfNotExist is false and
      *                                  schema/tables do not exist
      */
-    private PostgresSkillRepository(
+    public PostgresSkillRepository(
             DataSource dataSource,
             String schemaName,
             String skillsTableName,


### PR DESCRIPTION
Fixes #2407

## Problem

The full constructor in both `MysqlSkillRepository` and `PostgresSkillRepository` that accepts custom database/schema name and table names is declared `private`, so users cannot construct an instance with custom names without going through the builder.

## Fix

- Changed the visibility of the 6-parameter constructor from `private` to `public` in both repositories.
- Updated the Javadoc: removed "This constructor is private" and added a note that users may call this constructor directly or continue to use the builder.

Both repositories now allow either path:
```java
// direct constructor (now public)
MysqlSkillRepository repo = new MysqlSkillRepository(dataSource, "my_db", "my_skills", "my_resources", true, true);

// builder (unchanged)
MysqlSkillRepository repo = MysqlSkillRepository.builder(dataSource)
        .databaseName("my_db")
        .skillsTableName("my_skills")
        .resourcesTableName("my_resources")
        .build();
```

No functional or behavior changes — the constructor body and builder are untouched.
