### PR TITLE
fix(#2414): honor ModelCreationContext.stream in OllamaChatModel [FaaFyfxR9WAQrL7FcAgEHJvztd8cVMxvjHRS55rw1nwH]

### DIFF
--- a/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-ollama/src/main/java/io/agentscope/extensions/model/ollama/OllamaChatModel.java
+++ b/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-ollama/src/main/java/io/agentscope/extensions/model/ollama/OllamaChatModel.java
@@ -68,6 +68,8 @@ public class OllamaChatModel extends ChatModelBase {
     private final OllamaOptions defaultOptions;
     private final Formatter<OllamaMessage, OllamaResponse, OllamaRequest> formatter;
 
+    private boolean stream = true;
+
     /**
      * Creates a new OllamaChatModel.
      *
@@ -119,6 +121,29 @@ public class OllamaChatModel extends ChatModelBase {
     }
 
     /**
+     * Sets whether streaming responses should be used.
+     *
+     * <p>When {@code stream} is {@code false}, {@link #doStream(List, List, GenerateOptions)}
+     * dispatches to a non-streaming HTTP call and returns a single complete
+     * {@link ChatResponse} (suitable for consumption via {@code blockLast()}).
+     * When {@code true} (the default), responses are streamed incrementally.
+     *
+     * @param stream {@code true} to stream, {@code false} to use a single non-streaming call
+     */
+    public void setStream(boolean stream) {
+        this.stream = stream;
+    }
+
+    /**
+     * Returns whether streaming responses are enabled.
+     *
+     * @return the current streaming flag
+     */
+    public boolean isStream() {
+        return stream;
+    }
+
+    /**
      * Chat with the model using Ollama-specific options.
      * <p>
      * This method uses Ollama-specific options directly without conversion.
@@ -145,12 +170,16 @@ public class OllamaChatModel extends ChatModelBase {
     @Override
     protected Flux<ChatResponse> doStream(
             List<Msg> messages, List<ToolSchema> tools, GenerateOptions options) {
+        boolean effectiveStream = stream;
+        if (options != null && options.getStream() != null) {
+            effectiveStream = options.getStream();
+        }
         return streamWithHttpClient(
                 messages,
                 tools,
                 options != null ? options.getToolChoice() : null,
                 OllamaOptions.fromGenerateOptions(options),
-                true);
+                effectiveStream);
     }
 
     /**
@@ -250,6 +279,7 @@ public class OllamaChatModel extends ChatModelBase {
         private HttpTransport httpTransport;
         private ProxyConfig proxyConfig;
         private int contextWindowSize = -1;
+        private boolean stream = true;
 
         public Builder modelName(String modelName) {
             this.modelName = modelName;
@@ -333,6 +363,22 @@ public class OllamaChatModel extends ChatModelBase {
             return this;
         }
 
+        /**
+         * Sets whether streaming responses should be used.
+         *
+         * <p>When {@code stream} is {@code false}, {@link #doStream(List, List, GenerateOptions)}
+         * dispatches to a non-streaming HTTP call and returns a single complete
+         * response. When {@code true} (the default), responses are streamed
+         * incrementally.
+         *
+         * @param stream {@code true} to stream, {@code false} to use a non-streaming call
+         * @return this builder instance
+         */
+        public Builder stream(boolean stream) {
+            this.stream = stream;
+            return this;
+        }
+
         public OllamaChatModel build() {
             OllamaOptions finalOptions =
                     defaultOptions != null
@@ -349,6 +395,7 @@ public class OllamaChatModel extends ChatModelBase {
 
             OllamaChatModel model =
                     new OllamaChatModel(modelName, baseUrl, finalOptions, formatter, transport);
+            model.setStream(stream);
             if (contextWindowSize >= 0) {
                 model.setContextWindowSize(contextWindowSize);
             }

--- a/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-ollama/src/main/java/io/agentscope/extensions/model/ollama/OllamaModelProvider.java
+++ b/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-ollama/src/main/java/io/agentscope/extensions/model/ollama/OllamaModelProvider.java
@@ -90,6 +90,10 @@ public final class OllamaModelProvider implements ModelProvider {
         if (contextWindowSize != null) {
             builder.contextWindowSize(contextWindowSize);
         }
+        Boolean stream = context.getStream();
+        if (stream != null) {
+            builder.stream(stream);
+        }
     }
 
     private static String firstNonBlank(String preferred, String fallback) {


### PR DESCRIPTION
## What
OllamaChatModel.doStream() previously ignored the streaming setting and always passed `true` to `streamWithHttpClient()`. When a caller creates the model with `stream=false` (via `ModelCreationContext.stream`) and consumes the result with `blockLast()`, they received empty content — the Ollama done marker carries no `message.content`.

## Why it matters
- `ModelCreationContext.stream` is never consulted, so the per-call streaming preference is lost.
- Calling `` ollama:xxx`` with `stream=false` and `blockLast()` yields an empty response body.
- Behavior is inconsistent with the reference implementation (OpenAIChatModel) which honors the flag end-to-end.

## Changes (4 touch points)
`OllamaChatModel.java`:
- Added instance field `private boolean stream = true` to preserve existing streaming default (backward compatible).
- Added `setStream(boolean)` setter (and `isStream()` getter) on the model.
- Added `private boolean stream = true` field to `Builder` plus a public `Builder stream(boolean)` method.
- `Builder.build()` now passes the flag to the model via `model.setStream(stream)`.
- `doStream(...)` now dispatches on the effective stream value (instance field, overridable per-call via `GenerateOptions.stream`) instead of the hardcoded `true`.

`OllamaModelProvider.java`:
- `applyAdvancedOptions(...)` now reads `context.getStream()` and forwards it to `builder.stream(...)` when present.

## Verification
- Existing streaming behavior is preserved (default is `true`).
- `streamWithHttpClient(..., boolean stream)` already handles both paths correctly; this fix only passes the correct boolean.
- Mirrors the approach used in OpenAIChatModel.

Closes #2414