### PR TITLE
fix(anthropic): preserve thinking signatures

### DIFF
--- a/agentscope-core/src/main/java/io/agentscope/core/agent/accumulator/ThinkingAccumulator.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/agent/accumulator/ThinkingAccumulator.java
@@ -17,6 +17,8 @@ package io.agentscope.core.agent.accumulator;
 
 import io.agentscope.core.message.ContentBlock;
 import io.agentscope.core.message.ThinkingBlock;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * Thinking content accumulator for accumulating streaming thinking chunks.
@@ -28,14 +30,21 @@ import io.agentscope.core.message.ThinkingBlock;
 public class ThinkingAccumulator implements ContentAccumulator<ThinkingBlock> {
 
     private final StringBuilder accumulated = new StringBuilder();
+    private final Map<String, Object> metadata = new HashMap<>();
 
     /**
      * @hidden
      */
     @Override
     public void add(ThinkingBlock block) {
-        if (block != null && block.getThinking() != null) {
+        if (block == null) {
+            return;
+        }
+        if (block.getThinking() != null) {
             accumulated.append(block.getThinking());
+        }
+        if (block.getMetadata() != null) {
+            metadata.putAll(block.getMetadata());
         }
     }
 
@@ -55,7 +64,10 @@ public class ThinkingAccumulator implements ContentAccumulator<ThinkingBlock> {
         if (!hasContent()) {
             return null;
         }
-        return ThinkingBlock.builder().thinking(accumulated.toString()).build();
+        return ThinkingBlock.builder()
+                .thinking(accumulated.toString())
+                .metadata(metadata.isEmpty() ? null : metadata)
+                .build();
     }
 
     /**
@@ -64,6 +76,7 @@ public class ThinkingAccumulator implements ContentAccumulator<ThinkingBlock> {
     @Override
     public void reset() {
         accumulated.setLength(0);
+        metadata.clear();
     }
 
     /**

--- a/agentscope-core/src/main/java/io/agentscope/core/message/ThinkingBlock.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/message/ThinkingBlock.java
@@ -39,6 +39,9 @@ public final class ThinkingBlock extends ContentBlock {
     /** Metadata key for storing OpenRouter/Gemini reasoning details list. */
     public static final String METADATA_REASONING_DETAILS = "reasoningDetails";
 
+    /** Metadata key for storing the signature of an Anthropic extended-thinking block. */
+    public static final String METADATA_ANTHROPIC_SIGNATURE = "anthropicSignature";
+
     private final String thinking;
     private final Map<String, Object> metadata;
 
@@ -73,6 +76,8 @@ public final class ThinkingBlock extends ContentBlock {
      * <ul>
      *   <li>{@link #METADATA_REASONING_DETAILS} - List of OpenAIReasoningDetail objects from
      *       OpenRouter/Gemini
+     *   <li>{@link #METADATA_ANTHROPIC_SIGNATURE} - Signature of an Anthropic extended-thinking
+     *       block
      * </ul>
      *
      * @return The metadata map, or null if no metadata is set

--- a/agentscope-core/src/test/java/io/agentscope/core/agent/accumulator/ReasoningContextTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/agent/accumulator/ReasoningContextTest.java
@@ -22,10 +22,12 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.agentscope.core.message.Msg;
 import io.agentscope.core.message.TextBlock;
+import io.agentscope.core.message.ThinkingBlock;
 import io.agentscope.core.message.ToolUseBlock;
 import io.agentscope.core.model.ChatResponse;
 import io.agentscope.core.model.ChatUsage;
 import java.util.List;
+import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -167,6 +169,41 @@ class ReasoningContextTest {
         assertNotNull(msg);
         ChatUsage resultUsage = msg.getChatUsage();
         assertNull(resultUsage);
+    }
+
+    @Test
+    @DisplayName("Should preserve thinking metadata across streaming chunks")
+    void testThinkingMetadataAccumulation() {
+        ChatResponse thinkingChunk =
+                ChatResponse.builder()
+                        .id("msg-1")
+                        .content(List.of(ThinkingBlock.builder().thinking("Reasoning").build()))
+                        .build();
+        ChatResponse signatureChunk =
+                ChatResponse.builder()
+                        .id("msg-1")
+                        .content(
+                                List.of(
+                                        ThinkingBlock.builder()
+                                                .metadata(
+                                                        Map.of(
+                                                                ThinkingBlock
+                                                                        .METADATA_ANTHROPIC_SIGNATURE,
+                                                                "stream-signature"))
+                                                .build()))
+                        .build();
+
+        context.processChunk(thinkingChunk);
+        context.processChunk(signatureChunk);
+
+        ThinkingBlock aggregated =
+                context.buildFinalMessage().getFirstContentBlock(ThinkingBlock.class);
+        assertNotNull(aggregated);
+        assertEquals("Reasoning", aggregated.getThinking());
+        assertNotNull(aggregated.getMetadata());
+        assertEquals(
+                "stream-signature",
+                aggregated.getMetadata().get(ThinkingBlock.METADATA_ANTHROPIC_SIGNATURE));
     }
 
     @Test

--- a/agentscope-core/src/test/java/io/agentscope/core/agent/accumulator/ThinkingAccumulatorTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/agent/accumulator/ThinkingAccumulatorTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.core.agent.accumulator;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.agentscope.core.message.ThinkingBlock;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class ThinkingAccumulatorTest {
+
+    @Test
+    void shouldHandleNullBlocksAndClearMetadataOnReset() {
+        ThinkingAccumulator accumulator = new ThinkingAccumulator();
+
+        accumulator.add(null);
+        assertFalse(accumulator.hasContent());
+        assertNull(accumulator.buildAggregated());
+
+        accumulator.add(ThinkingBlock.builder().thinking("Reasoning").build());
+        accumulator.add(
+                ThinkingBlock.builder()
+                        .metadata(
+                                Map.of(
+                                        ThinkingBlock.METADATA_ANTHROPIC_SIGNATURE,
+                                        "stream-signature"))
+                        .build());
+
+        ThinkingBlock aggregated = (ThinkingBlock) accumulator.buildAggregated();
+        assertNotNull(aggregated);
+        assertEquals("Reasoning", aggregated.getThinking());
+        assertNotNull(aggregated.getMetadata());
+        assertEquals(
+                "stream-signature",
+                aggregated.getMetadata().get(ThinkingBlock.METADATA_ANTHROPIC_SIGNATURE));
+
+        accumulator.reset();
+
+        assertFalse(accumulator.hasContent());
+        assertNull(accumulator.buildAggregated());
+        assertTrue(accumulator.getAccumulated().isEmpty());
+    }
+}

--- a/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-anthropic/src/main/java/io/agentscope/extensions/model/anthropic/formatter/AnthropicMessageConverter.java
+++ b/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-anthropic/src/main/java/io/agentscope/extensions/model/anthropic/formatter/AnthropicMessageConverter.java
@@ -21,6 +21,7 @@ import com.anthropic.models.messages.ImageBlockParam;
 import com.anthropic.models.messages.MessageParam;
 import com.anthropic.models.messages.MessageParam.Role;
 import com.anthropic.models.messages.TextBlockParam;
+import com.anthropic.models.messages.ThinkingBlockParam;
 import com.anthropic.models.messages.ToolResultBlockParam;
 import com.anthropic.models.messages.ToolUseBlockParam;
 import io.agentscope.core.message.ContentBlock;
@@ -257,12 +258,22 @@ public class AnthropicMessageConverter {
                         ContentBlockParam.ofText(
                                 TextBlockParam.builder().text(hb.getHint()).build()));
             } else if (block instanceof ThinkingBlock thinkingBlock) {
-                // Anthropic supports thinking blocks natively
-                contentBlocks.add(
-                        ContentBlockParam.ofText(
-                                TextBlockParam.builder()
-                                        .text(thinkingBlock.getThinking())
-                                        .build()));
+                Object signature =
+                        thinkingBlock.getMetadata() != null
+                                ? thinkingBlock
+                                        .getMetadata()
+                                        .get(ThinkingBlock.METADATA_ANTHROPIC_SIGNATURE)
+                                : null;
+                if (signature instanceof String signatureText && !signatureText.isBlank()) {
+                    contentBlocks.add(
+                            ContentBlockParam.ofThinking(
+                                    ThinkingBlockParam.builder()
+                                            .thinking(thinkingBlock.getThinking())
+                                            .signature(signatureText)
+                                            .build()));
+                } else {
+                    log.debug("Skipping unsigned ThinkingBlock when formatting Anthropic history.");
+                }
             } else if (block instanceof ImageBlock ib) {
                 try {
                     ImageBlockParam imageParam = mediaConverter.convertImageBlock(ib);

--- a/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-anthropic/src/main/java/io/agentscope/extensions/model/anthropic/formatter/AnthropicResponseParser.java
+++ b/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-anthropic/src/main/java/io/agentscope/extensions/model/anthropic/formatter/AnthropicResponseParser.java
@@ -83,6 +83,11 @@ public class AnthropicResponseParser {
                                     contentBlocks.add(
                                             ThinkingBlock.builder()
                                                     .thinking(thinking.thinking())
+                                                    .metadata(
+                                                            Map.of(
+                                                                    ThinkingBlock
+                                                                            .METADATA_ANTHROPIC_SIGNATURE,
+                                                                    thinking.signature()))
                                                     .build()));
         }
 
@@ -148,6 +153,20 @@ public class AnthropicResponseParser {
                                     contentBlocks.add(
                                             ThinkingBlock.builder()
                                                     .thinking(thinkingDelta.thinking())
+                                                    .build()));
+
+            deltaEvent
+                    .delta()
+                    .signature()
+                    .ifPresent(
+                            signatureDelta ->
+                                    contentBlocks.add(
+                                            ThinkingBlock.builder()
+                                                    .metadata(
+                                                            Map.of(
+                                                                    ThinkingBlock
+                                                                            .METADATA_ANTHROPIC_SIGNATURE,
+                                                                    signatureDelta.signature()))
                                                     .build()));
 
             // Input JSON delta (tool calling)

--- a/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-anthropic/src/test/java/io/agentscope/extensions/model/anthropic/formatter/AnthropicMessageConverterTest.java
+++ b/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-anthropic/src/test/java/io/agentscope/extensions/model/anthropic/formatter/AnthropicMessageConverterTest.java
@@ -191,6 +191,11 @@ class AnthropicMessageConverterTest extends AnthropicFormatterTestBase {
                                 List.of(
                                         ThinkingBlock.builder()
                                                 .thinking("Let me think...")
+                                                .metadata(
+                                                        Map.of(
+                                                                ThinkingBlock
+                                                                        .METADATA_ANTHROPIC_SIGNATURE,
+                                                                "signature-123"))
                                                 .build()))
                         .build();
 
@@ -199,8 +204,32 @@ class AnthropicMessageConverterTest extends AnthropicFormatterTestBase {
         assertEquals(1, result.size());
         List<ContentBlockParam> blocks = result.get(0).content().asBlockParams();
         assertEquals(1, blocks.size());
+        assertTrue(blocks.get(0).isThinking());
+        assertEquals("Let me think...", blocks.get(0).asThinking().thinking());
+        assertEquals("signature-123", blocks.get(0).asThinking().signature());
+    }
+
+    @Test
+    void testConvertUnsignedThinkingBlockSkipsIt() {
+        Msg msg =
+                Msg.builder()
+                        .name("Assistant")
+                        .role(MsgRole.ASSISTANT)
+                        .content(
+                                List.of(
+                                        ThinkingBlock.builder()
+                                                .thinking("Unsigned thinking")
+                                                .build(),
+                                        TextBlock.builder().text("Visible answer").build()))
+                        .build();
+
+        List<MessageParam> result = converter.convert(List.of(msg));
+
+        assertEquals(1, result.size());
+        List<ContentBlockParam> blocks = result.get(0).content().asBlockParams();
+        assertEquals(1, blocks.size());
         assertTrue(blocks.get(0).isText());
-        assertEquals("Let me think...", blocks.get(0).asText().text());
+        assertEquals("Visible answer", blocks.get(0).asText().text());
     }
 
     @Test

--- a/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-anthropic/src/test/java/io/agentscope/extensions/model/anthropic/formatter/AnthropicMessageConverterTest.java
+++ b/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-anthropic/src/test/java/io/agentscope/extensions/model/anthropic/formatter/AnthropicMessageConverterTest.java
@@ -220,6 +220,14 @@ class AnthropicMessageConverterTest extends AnthropicFormatterTestBase {
                                         ThinkingBlock.builder()
                                                 .thinking("Unsigned thinking")
                                                 .build(),
+                                        ThinkingBlock.builder()
+                                                .thinking("Blank signature thinking")
+                                                .metadata(
+                                                        Map.of(
+                                                                ThinkingBlock
+                                                                        .METADATA_ANTHROPIC_SIGNATURE,
+                                                                "   "))
+                                                .build(),
                                         TextBlock.builder().text("Visible answer").build()))
                         .build();
 

--- a/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-anthropic/src/test/java/io/agentscope/extensions/model/anthropic/formatter/AnthropicResponseParserTest.java
+++ b/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-anthropic/src/test/java/io/agentscope/extensions/model/anthropic/formatter/AnthropicResponseParserTest.java
@@ -161,6 +161,7 @@ class AnthropicResponseParserTest extends AnthropicFormatterTestBase {
         when(contentBlock.toolUse()).thenReturn(Optional.empty());
         when(contentBlock.thinking()).thenReturn(Optional.of(thinkingBlock));
         when(thinkingBlock.thinking()).thenReturn("Let me think about this...");
+        when(thinkingBlock.signature()).thenReturn("signature-123");
 
         Instant startTime = Instant.now();
         ChatResponse response = AnthropicResponseParser.parseMessage(message, startTime);
@@ -171,6 +172,10 @@ class AnthropicResponseParserTest extends AnthropicFormatterTestBase {
         ThinkingBlock parsedThinking =
                 assertInstanceOf(ThinkingBlock.class, response.getContent().get(0));
         assertEquals("Let me think about this...", parsedThinking.getThinking());
+        assertNotNull(parsedThinking.getMetadata());
+        assertEquals(
+                "signature-123",
+                parsedThinking.getMetadata().get(ThinkingBlock.METADATA_ANTHROPIC_SIGNATURE));
     }
 
     @Test
@@ -335,6 +340,27 @@ class AnthropicResponseParserTest extends AnthropicFormatterTestBase {
                 assertInstanceOf(ThinkingBlock.class, response.getContent().get(0));
         assertEquals("Let me reason through this.", parsedThinking.getThinking());
         assertNull(response.getUsage());
+    }
+
+    @Test
+    void testParseStreamEventSignatureDelta() throws Exception {
+        RawContentBlockDeltaEvent deltaEvent =
+                RawContentBlockDeltaEvent.builder()
+                        .index(0)
+                        .signatureDelta("stream-signature")
+                        .build();
+        RawMessageStreamEvent event = RawMessageStreamEvent.ofContentBlockDelta(deltaEvent);
+
+        ChatResponse response = invokeParseStreamEvent(event, Instant.now());
+
+        assertEquals(1, response.getContent().size());
+        ThinkingBlock parsedThinking =
+                assertInstanceOf(ThinkingBlock.class, response.getContent().get(0));
+        assertEquals("", parsedThinking.getThinking());
+        assertNotNull(parsedThinking.getMetadata());
+        assertEquals(
+                "stream-signature",
+                parsedThinking.getMetadata().get(ThinkingBlock.METADATA_ANTHROPIC_SIGNATURE));
     }
 
     @Test


### PR DESCRIPTION
## Summary

- preserve extended-thinking signatures in non-streaming and streaming responses
- accumulate signature metadata with streamed thinking text
- send signed thinking blocks back with the native Anthropic content type
- skip unsigned thinking blocks instead of exposing them as ordinary text

## Testing

- `mvn -pl agentscope-core -Dtest=ReasoningContextTest test`
- `mvn -pl agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-anthropic test`
- `mvn spotless:apply`

Fixes #2400