### PR TITLE
fix(#2409): reconcile dangling ToolUseBlock on agent interrupt [FaaFyfxR9WAQrL7FcAgEHJvztd8cVMxvjHRS55rw1nwH]

### DIFF
--- a/agentscope-core/src/main/java/io/agentscope/core/ReActAgent.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/ReActAgent.java
@@ -3562,6 +3562,29 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
                         shutdownManager.saveOnInterruptObserved(requestId);
                         return Mono.error(new AgentShuttingDownException());
                     }
+                    // Reconcile any pending ToolUseBlocks before persisting the recovery
+                    // message. An interrupt that fires after reasoning writes a ToolUseBlock
+                    // to the last assistant message but before acting skips tool execution,
+                    // leaving a dangling tool_call with no matching tool result. Models may
+                    // reject such an inconsistent context on the next resumed run, so we
+                    // remove the unfulfilled ToolUseBlocks in-place.
+                    Msg assistantBeforeInterrupt = findLastAssistantMsg();
+                    if (assistantBeforeInterrupt != null) {
+                        List<ContentBlock> blocks =
+                                new ArrayList<>(assistantBeforeInterrupt.getContent());
+                        Set<String> pending = getPendingToolUseIds();
+                        blocks.removeIf(
+                                b ->
+                                        b instanceof ToolUseBlock t
+                                                && pending.contains(t.getId()));
+                        if (!blocks.equals(assistantBeforeInterrupt.getContent())) {
+                            scope.state.contextMutable()
+                                    .set(
+                                            assistantBeforeInterrupt.getIndex(),
+                                            assistantBeforeInterrupt.withContent(blocks));
+                        }
+                    }
+
                     String recoveryText =
                             "I noticed that you have interrupted me. What can I do for you?";
                     Msg recoveryMsg =


### PR DESCRIPTION
## Summary

Fixes a context-consistency bug that corrupts `AgentState` after a mid-cycle interrupt.

## Problem

When an interrupt fires between the **reasoning** step (model emitted `ToolUseBlock`s) and the **acting** step (tool execution), `ReActAgent.handleInterrupt` appends its recovery message but does **not** reconcile the trailing assistant message that already contains the unfulfilled `ToolUseBlock`. The persisted context becomes:

```
..., user, assistant(ToolUseBlock), assistant("I noticed that you have interrupted me...")
                     ^^^^^^^^^^^^^^^^^^^^^^^^  ^^^^^^^^^ no matching ToolResultBlock
```

On the next resumed run the LLM provider receives an assistant `tool_call` with no matching tool result and may return an empty completion (observed with MiniMax-M3) or a 4xx — the agent silently stops responding.

**Root cause:** the `checkInterrupted()` checkpoint at `runPostReasoningPipeline` sits **after** the reasoning result is written to context but **before** `acting`. An interrupt therefore cannot prevent the `ToolUseBlock` from being persisted, and `handleInterrupt` does not reconcile it.

## Fix

Before appending the recovery message, `handleInterrupt` now inspects the last assistant message and removes any pending `ToolUseBlock`s that have no corresponding `ToolResultBlock` in the context. Reuses existing helpers (`findLastAssistantMsg`, `getPendingToolUseIds`) so the fix is contained in a single method.

After this reconciliation the persisted context is self-consistent, and a resumed run proceeds normally.

## Why this location

The alternative — moving the `checkInterrupted` checkpoint above the reasoning-result write — changes "what gets persisted on interrupt" semantics for all interrupt sources and is riskier. Patching `handleInterrupt` is the most contained fix and covers every interrupt path.

---

Fixes #2409
