### PR TITLE
docs(multi-agent): remove dead multiagent-patterns example links

### DIFF
--- a/docs/v1/en/docs/multi-agent/handoffs.md
+++ b/docs/v1/en/docs/multi-agent/handoffs.md
@@ -1,5 +1,7 @@
 # Handoffs
 
+> **Note:** The former Spring Boot example module `agentscope-examples/multiagent-patterns/` was removed during the 2.0 package refactor. Use the code snippets on this page as the reference implementation. For other runnable samples, see `agentscope-examples/documentation/`.
+
 In the **handoffs** pattern, behavior changes dynamically based on state. Tools update a state variable (e.g. `active_agent`) that persists across turns; the graph reads this variable to route to different agents. This pattern is well-suited to customer support and sales flows where control transfers between specialized agents (e.g. sales vs. support) via tool calls.
 
 The term **handoffs** is commonly used for using tool calls (such as `transfer_to_sales_agent` or `transfer_to_support`) to transfer control between agents or states (see e.g. [OpenAI Agents](https://openai.github.io/openai-agents-python/handoffs/).
@@ -240,17 +242,11 @@ Any key you update via `getStateForUpdate` must be declared in the graph’s key
 
 ## Example project
 
-The full handoffs example (sales + support with handoff tools) is in the repository:
+The handoffs pattern (sales + support with handoff tools) is illustrated by the snippets below:
 
-- **Location**: `agentscope-examples/multiagent-patterns/handoffs/`
 - **Highlights**: `AgentScopeHandoffsConfig` (graph, agents, routing), `TransferToSalesTool`, `TransferToSupportTool`, `RouteInitialAction`, `RouteAfterSalesAction`, `RouteAfterSupportAction`, and `AgentScopeHandoffsService` to invoke the graph.
 
 Build and run (from repo root):
-
-```bash
-./mvnw -pl agentscope-examples/multiagent-patterns/handoffs -am -B package -DskipTests
-./mvnw -pl agentscope-examples/multiagent-patterns/handoffs spring-boot:run
-```
 
 Set `agentscope.runner.enabled=true` in `application.yml` to run the demo on startup. Default port is 8089.
 

--- a/docs/v1/en/docs/multi-agent/pipeline.md
+++ b/docs/v1/en/docs/multi-agent/pipeline.md
@@ -1,8 +1,8 @@
 # Pipeline
 
-The pipeline example uses **Spring AI Alibaba** flow agents (**SequentialAgent**, **ParallelAgent**, **LoopAgent**) with **AgentScopeAgent** sub-agents and AgentScope **DashScopeChatModel** (`Model`). Each pipeline is built from ReActAgent-based AgentScopeAgents and invoked via `PipelineService`.
+> **Note:** The former Spring Boot example module `agentscope-examples/multiagent-patterns/` was removed during the 2.0 package refactor. Use the code snippets on this page as the reference implementation. For other runnable samples, see `agentscope-examples/documentation/`.
 
-**Location**: `agentscope-examples/multiagent-patterns/pipeline/`
+The pipeline example uses **Spring AI Alibaba** flow agents (**SequentialAgent**, **ParallelAgent**, **LoopAgent**) with **AgentScopeAgent** sub-agents and AgentScope **DashScopeChatModel** (`Model`). Each pipeline is built from ReActAgent-based AgentScopeAgents and invoked via `PipelineService`.
 
 ## Prerequisites
 
@@ -320,53 +320,12 @@ public class PipelineCommandRunner implements ApplicationRunner {
 }
 ```
 
-## Build and run
-
-From the repo root:
-
-```bash
-./mvnw -pl agentscope-examples/multiagent-patterns/pipeline -am -B package -DskipTests
-./mvnw -pl agentscope-examples/multiagent-patterns/pipeline spring-boot:run
-```
-
-**With demo runner:**
-
-```bash
-export pipeline.runner.enabled=true
-./mvnw -pl agentscope-examples/multiagent-patterns/pipeline spring-boot:run
-```
-
-Or in `application.yml`: `pipeline.runner.enabled: true`.
-
 ## Configuration
 
 | Property | Default | Description |
 |----------|---------|-------------|
 | `spring.ai.dashscope.api-key` | (env `AI_DASHSCOPE_API_KEY`) | DashScope API key for the model |
 | `pipeline.runner.enabled` | `false` | If `true`, run Sequential, Parallel, and Loop demos on startup |
-
-## Project layout
-
-```
-agentscope-examples/multiagent-patterns/pipeline/
-├── README.md
-├── pom.xml
-└── src/main/
-    ├── java/.../pipeline/
-    │   ├── PipelineApplication.java
-    │   ├── PipelineModelConfig.java        # Model (DashScopeChatModel) bean
-    │   ├── PipelineService.java            # runSequential, runParallel, runLoop
-    │   ├── PipelineCommandRunner.java      # optional demo (pipeline.runner.enabled)
-    │   ├── PipelineRunnerConfig.java       # PipelineService bean
-    │   ├── sequential/
-    │   │   └── SequentialPipelineConfig.java
-    │   ├── parallel/
-    │   │   └── ParallelPipelineConfig.java
-    │   └── loop/
-    │       └── LoopPipelineConfig.java
-    └── resources/
-        └── application.yml
-```
 
 ## Related Documentation
 

--- a/docs/v1/en/docs/multi-agent/routing.md
+++ b/docs/v1/en/docs/multi-agent/routing.md
@@ -1,5 +1,7 @@
 # Routing
 
+> **Note:** The former Spring Boot example module `agentscope-examples/multiagent-patterns/` was removed during the 2.0 package refactor. Use the code snippets on this page as the reference implementation. For other runnable samples, see `agentscope-examples/documentation/`.
+
 In the **router** pattern, a routing step classifies the input and directs it to specialized agents. Zero or more specialists can be invoked (e.g. in parallel), and results are synthesized into a single response. This is useful when you have distinct **verticals**—separate knowledge domains that each have their own agent (e.g. GitHub, Notion, Slack).
 
 The router decomposes the query, specialist agents are invoked (single or parallel), and a combined answer is produced.
@@ -107,31 +109,8 @@ The AgentScope example provides two variants: **Simple** (single routing agent +
 
 ## Example project
 
-**Location**: `agentscope-examples/multiagent-patterns/routing/`
-
 - **Simple**: Entry is `RouterService.run(query)`; flow is classify → parallel specialists → (framework merge) → optional RouterService synthesis. Set `routing.runner.enabled=true` to run the Simple demo on startup (see **RoutingRunner**).
 - **Graph**: Entry is `RoutingGraphService.run(query)`; flow is preprocess → routing subgraph → postprocess. Set `routing-graph.runner.enabled=true` to run the Graph demo on startup (see **RoutingGraphRunner**).
-
-**Build and run** (from repo root):
-
-```bash
-./mvnw -pl agentscope-examples/multiagent-patterns/routing -am -B package -DskipTests
-./mvnw -pl agentscope-examples/multiagent-patterns/routing spring-boot:run
-```
-
-**Run Simple demo only**:
-
-```bash
-./mvnw -pl agentscope-examples/multiagent-patterns/routing spring-boot:run \
-  -Dspring-boot.run.arguments="--routing.runner.enabled=true"
-```
-
-**Run Graph demo only**:
-
-```bash
-./mvnw -pl agentscope-examples/multiagent-patterns/routing spring-boot:run \
-  -Dspring-boot.run.arguments="--routing-graph.runner.enabled=true"
-```
 
 **Configuration**: Set `AI_DASHSCOPE_API_KEY` (or `spring.ai.dashscope.api-key`) for DashScope model and specialist calls.
 

--- a/docs/v1/en/docs/multi-agent/skills.md
+++ b/docs/v1/en/docs/multi-agent/skills.md
@@ -1,5 +1,7 @@
 # Skills (Progressive Disclosure)
 
+> **Note:** The former Spring Boot example module `agentscope-examples/multiagent-patterns/` was removed during the 2.0 package refactor. Use the code snippets on this page as the reference implementation. For other runnable samples, see `agentscope-examples/documentation/`.
+
 In the **skills** pattern, specialized capabilities are packaged as invokable "skills" that augment an agent’s behavior. Skills are primarily **prompt-driven**: the agent sees skill metadata (e.g. name and description) first and loads full skill content **on demand** via a tool (e.g. `read_skill`). This keeps the initial context small and avoids loading all skill text upfront.
 
 AgentScope implements this with **SkillBox**, **SkillRepository** (e.g. `ClasspathSkillRepository`), and skill tools. The core feature is documented in [Agent Skill](../task/agent-skill.md); this page focuses on the **multi-agent example** that uses the same mechanism for a SQL assistant.
@@ -39,16 +41,8 @@ In the example:
 
 The **SQL assistant** example uses two skills: **sales_analytics** (customers, orders, revenue) and **inventory_management** (products, warehouses, stock). The user asks in natural language; the agent calls **read_skill("sales_analytics")** or **read_skill("inventory_management")** when needed, then generates SQL.
 
-- **Location**: `agentscope-examples/multiagent-patterns/skills/`
 - **Key classes**: `SkillsConfig` (ClasspathSkillRepository, SkillBox, ReActAgent), `SkillsRunner` (optional demo).
 - **Run**: Set `skills.runner.enabled=true` to run a single-query demo on startup (e.g. “Write a SQL query to find all customers who made orders over $1000 in the last month”).
-
-**Build and run** (from repo root):
-
-```bash
-./mvnw -pl agentscope-examples/multiagent-patterns/skills -am -B package -DskipTests
-./mvnw -pl agentscope-examples/multiagent-patterns/skills spring-boot:run
-```
 
 **Use in your code**: Inject the ReActAgent (e.g. `sqlAssistantAgent`) and call it with a user `Msg`; get text from the response with `getTextContent()`. The agent will use skill descriptions to decide when to call **read_skill** and then generate the SQL.
 

--- a/docs/v1/en/docs/multi-agent/subagent.md
+++ b/docs/v1/en/docs/multi-agent/subagent.md
@@ -1,5 +1,7 @@
 # Subagents
 
+> **Note:** The former Spring Boot example module `agentscope-examples/multiagent-patterns/` was removed during the 2.0 package refactor. Use the code snippets on this page as the reference implementation. For other runnable samples, see `agentscope-examples/documentation/`.
+
 Subagents are **specialized agents** that a main **orchestrator** delegates work to. The orchestrator does not execute the work itself; it calls a **Task** tool with a sub-agent type and a task description. The system runs the chosen sub-agent in an **isolated context** (its own system prompt and tools), then returns the result to the orchestrator. This keeps the main conversation focused and avoids context bloat, while still allowing multiple domains (e.g. codebase exploration, web research, dependency analysis) to be handled by dedicated agents.
 
 This pattern is sometimes called a **dispatcher–worker** or **hierarchical** model: one “manager” agent that delegates to “specialist” sub-agents on demand.
@@ -122,13 +124,6 @@ The AgentScope example implements a **Tech Due Diligence Assistant**: one orches
 - **Orchestrator** system prompt describes when to use each sub-agent and when to use direct tools. It has Task, TaskOutput, glob_search, grep_search, web_fetch.
 - **Markdown specs** live in `src/main/resources/agents/*.md` and are loaded with `TaskToolsBuilder.addAgentResource(res)`.
 - **dependency-analyzer** is built as a ReActAgent and registered with `TaskToolsBuilder.subAgent("dependency-analyzer", dependencyAnalyzerReAct)`.
-
-**Run interactively**:
-
-```bash
-./mvnw -pl agentscope-examples/multiagent-patterns/subagent spring-boot:run \
-  -Dspring-boot.run.arguments="--subagent.run-interactive=true"
-```
 
 **Use in code**: Inject **OrchestratorService** and call `run(userMessage)`; the service invokes the graph that runs the orchestrator with the given input.
 

--- a/docs/v1/en/docs/multi-agent/supervisor.md
+++ b/docs/v1/en/docs/multi-agent/supervisor.md
@@ -1,5 +1,7 @@
 # Supervisor
 
+> **Note:** The former Spring Boot example module `agentscope-examples/multiagent-patterns/` was removed during the 2.0 package refactor. Use the code snippets on this page as the reference implementation. For other runnable samples, see `agentscope-examples/documentation/`.
+
 In the **supervisor** pattern, a central **supervisor** (main agent) coordinates specialized agents by calling them as **tools**. The supervisor receives user requests, decides which specialist(s) to call (e.g. calendar, email), and synthesizes their results into one reply. Specialized agents are **stateless** from the user’s perspective; the supervisor keeps the conversation and delegates one-off tasks. This pattern is implemented in AgentScope via **Agent as Tool** ([agent-as-tool.md](../task/agent-as-tool.md)): `Toolkit.registration().subAgent()`.
 
 ## Overview
@@ -37,16 +39,8 @@ In the example, calendar and email “APIs” are **stubbed** (`CalendarStubTool
 
 ## Example Project
 
-- **Location**: `agentscope-examples/multiagent-patterns/supervisor/`
 - **Key classes**: `SupervisorConfig` (model, calendarAgent, emailAgent, supervisorAgent), `CalendarStubTools`, `EmailStubTools`, `SupervisorRunner` (optional demo).
 - **Demo**: Set `supervisor.run-examples=true` to run two scenarios on startup: (1) single-domain: “Schedule a team standup for tomorrow at 9am”; (2) multi-domain: “Schedule a meeting with the design team next Tuesday at 2pm for 1 hour, and send them an email reminder about reviewing the new mockups.”
-
-**Build and run** (from repo root):
-
-```bash
-./mvnw -pl agentscope-examples/multiagent-patterns/supervisor -am -B package -DskipTests
-./mvnw -pl agentscope-examples/multiagent-patterns/supervisor spring-boot:run
-```
 
 **Use in your code**: Inject the supervisor ReActAgent (e.g. `@Qualifier("supervisorAgent")`) and call it with a user `Msg`; get text from the response with `getTextContent()`.
 

--- a/docs/v1/en/docs/multi-agent/workflow.md
+++ b/docs/v1/en/docs/multi-agent/workflow.md
@@ -1,5 +1,7 @@
 # Custom Workflow
 
+> **Note:** The former Spring Boot example module `agentscope-examples/multiagent-patterns/` was removed during the 2.0 package refactor. Use the code snippets on this page as the reference implementation. For other runnable samples, see `agentscope-examples/documentation/`.
+
 In the **custom workflow** pattern, you define your own execution flow using **Spring AI Alibaba StateGraph**. You have full control over the graph structure—sequential steps, conditional branches, loops, and parallel execution. Nodes can be **deterministic** (e.g. vector search, DB query), **LLM-based** (e.g. rewrite, classify), or **agentic** (an agent with tools). State is passed between nodes via a shared state map with configurable strategies (replace, append).
 
 This pattern is useful when standard patterns (Pipeline, Routing, Subagents, etc.) do not fit, when you need to mix deterministic logic with agentic behavior, or when your use case requires multi-stage processing with explicit control over the flow.
@@ -54,32 +56,10 @@ START → list_tables → call_get_schema → get_schema → generate_query → 
 
 ## Example project
 
-**Location**: `agentscope-examples/multiagent-patterns/workflow/`
-
 | Package   | Flow | Description |
 |-----------|------|-------------|
 | **ragagent** | Query → Rewrite → Retrieve → Prepare → Agent → Response | RAG: rewrite query, vector retrieve, then ReActAgent with context and `get_latest_news` tool. Uses AgentScope Model, Knowledge (embedding + store), and AgentScopeAgent. |
 | **sqlagent** | START → list_tables → get_schema → generate_query → END | SQL: list tables, get schema for relevant tables, then ReActAgent with SQL tools (list_tables, schema, query). Uses H2 in-memory and AgentScopeAgent. |
-
-**Build and run** (from repo root):
-
-```bash
-./mvnw -pl agentscope-examples/multiagent-patterns/workflow -am -B package -DskipTests
-```
-
-**Run RAG workflow** (with optional demo on startup):
-
-```bash
-./mvnw -pl agentscope-examples/multiagent-patterns/workflow spring-boot:run \
-  -Dspring-boot.run.arguments="--workflow.rag.enabled=true --workflow.runner.enabled=true"
-```
-
-**Run SQL workflow** (with optional demo on startup):
-
-```bash
-./mvnw -pl agentscope-examples/multiagent-patterns/workflow spring-boot:run \
-  -Dspring-boot.run.arguments="--workflow.sql.enabled=true --workflow.runner.enabled=true"
-```
 
 **Configuration**:
 
@@ -94,7 +74,7 @@ START → list_tables → call_get_schema → get_schema → generate_query → 
 - **Routing**: Routing is classify → specialist(s) → merge, often with a single router node. In a custom workflow you could implement the same with your own graph (e.g. router node → branch → specialists → merge node).
 - **Handoffs**: Handoffs use state (e.g. `active_agent`) to route between agent nodes. Custom workflow can do the same with conditional edges and state; Handoffs is a dedicated pattern for “who owns the conversation” transitions.
 
-For implementation details and code, see the workflow example (`agentscope-examples/multiagent-patterns/workflow/`) and the RAG/SQL config classes (`RagAgentConfig`, `SqlAgentConfig`).
+For implementation details, use the snippets on this page and the RAG/SQL config classes (`RagAgentConfig`, `SqlAgentConfig`).
 
 ## Related Documentation
 

--- a/docs/v1/zh/docs/multi-agent/handoffs.md
+++ b/docs/v1/zh/docs/multi-agent/handoffs.md
@@ -1,5 +1,7 @@
 # Handoffs（交接）
 
+> **说明：** 原先的 Spring Boot 示例模块 `agentscope-examples/multiagent-patterns/` 已在 2.0 包重构中移除。请以本文中的代码片段作为参考实现。其他可运行示例见 `agentscope-examples/documentation/`。
+
 在 **Handoffs** 模式中，行为根据状态动态变化。工具会更新一个在轮次间持久存在的状态变量（如 `active_agent`），图根据该变量将请求路由到不同智能体。该模式适合客服、销售等场景：通过工具调用在专职智能体（如销售与支持）之间转移控制权。
 
 **Handoffs** 一词常用来描述通过工具调用（如 `transfer_to_sales_agent`、`transfer_to_support`）在智能体或状态之间转移控制（可参考 [OpenAI Agents](https://openai.github.io/openai-agents-python/handoffs/)）。
@@ -239,15 +241,9 @@ resultOpt.ifPresent(state -> {
 
 完整的 Handoffs 示例（销售 + 支持与交接工具）位于仓库中：
 
-- **路径**：`agentscope-examples/multiagent-patterns/handoffs/`
 - **要点**：`AgentScopeHandoffsConfig`（图、智能体、路由），`TransferToSalesTool`、`TransferToSupportTool`，`RouteInitialAction`、`RouteAfterSalesAction`、`RouteAfterSupportAction`，以及用于调用图的 `AgentScopeHandoffsService`。
 
 在仓库根目录构建并运行：
-
-```bash
-./mvnw -pl agentscope-examples/multiagent-patterns/handoffs -am -B package -DskipTests
-./mvnw -pl agentscope-examples/multiagent-patterns/handoffs spring-boot:run
-```
 
 在 `application.yml` 中设置 `agentscope.runner.enabled=true` 可在启动时运行演示。默认端口为 8089。
 

--- a/docs/v1/zh/docs/multi-agent/overview.md
+++ b/docs/v1/zh/docs/multi-agent/overview.md
@@ -30,7 +30,6 @@ AgentScope 支持以下多智能体模式，每种都有独立页面说明实现
 
 ## 如何选型
 
-
 ### 工作流（workflow）vs 对话（conversational）
 从整体上，多智能体模式可分为 **工作流（workflow）** 与 **对话（conversational）** 两类：
 

--- a/docs/v1/zh/docs/multi-agent/pipeline.md
+++ b/docs/v1/zh/docs/multi-agent/pipeline.md
@@ -1,5 +1,7 @@
 # Pipeline（管道）
 
+> **说明：** 原先的 Spring Boot 示例模块 `agentscope-examples/multiagent-patterns/` 已在 2.0 包重构中移除。请以本文中的代码片段作为参考实现。其他可运行示例见 `agentscope-examples/documentation/`。
+
 本示例使用 **Spring AI Alibaba** 的流式智能体（**SequentialAgent**、**ParallelAgent**、**LoopAgent**）与 **AgentScopeAgent** 子智能体及 AgentScope 的 **DashScopeChatModel**（`Model`）。各管道由基于 ReActAgent 的 AgentScopeAgent 构建，并通过 `PipelineService` 调用。
 
 ## 前置条件
@@ -318,53 +320,12 @@ public class PipelineCommandRunner implements ApplicationRunner {
 }
 ```
 
-## 构建与运行
-
-在仓库根目录执行：
-
-```bash
-./mvnw -pl agentscope-examples/multiagent-patterns/pipeline -am -B package -DskipTests
-./mvnw -pl agentscope-examples/multiagent-patterns/pipeline spring-boot:run
-```
-
-**启用演示运行器：**
-
-```bash
-export pipeline.runner.enabled=true
-./mvnw -pl agentscope-examples/multiagent-patterns/pipeline spring-boot:run
-```
-
-或在 `application.yml` 中设置：`pipeline.runner.enabled: true`。
-
 ## 配置
 
 | 配置项 | 默认值 | 说明 |
 |--------|--------|------|
 | `spring.ai.dashscope.api-key` | 环境变量 `AI_DASHSCOPE_API_KEY` | 模型使用的 DashScope API Key |
 | `pipeline.runner.enabled` | `false` | 为 `true` 时，启动时运行顺序、并行、循环三个演示 |
-
-## 项目结构
-
-```
-agentscope-examples/multiagent-patterns/pipeline/
-├── README.md
-├── pom.xml
-└── src/main/
-    ├── java/.../pipeline/
-    │   ├── PipelineApplication.java
-    │   ├── PipelineModelConfig.java        # Model (DashScopeChatModel) Bean
-    │   ├── PipelineService.java            # runSequential, runParallel, runLoop
-    │   ├── PipelineCommandRunner.java      # 可选演示（pipeline.runner.enabled）
-    │   ├── PipelineRunnerConfig.java       # PipelineService Bean
-    │   ├── sequential/
-    │   │   └── SequentialPipelineConfig.java
-    │   ├── parallel/
-    │   │   └── ParallelPipelineConfig.java
-    │   └── loop/
-    │       └── LoopPipelineConfig.java
-    └── resources/
-        └── application.yml
-```
 
 ## 相关文档
 

--- a/docs/v1/zh/docs/multi-agent/routing.md
+++ b/docs/v1/zh/docs/multi-agent/routing.md
@@ -1,5 +1,7 @@
 # Routing（路由）
 
+> **说明：** 原先的 Spring Boot 示例模块 `agentscope-examples/multiagent-patterns/` 已在 2.0 包重构中移除。请以本文中的代码片段作为参考实现。其他可运行示例见 `agentscope-examples/documentation/`。
+
 在 **Router** 模式中，路由步骤对输入进行分类并分发给专职智能体。可以调用零个或多个专家（例如并行），再将结果合成为一个回答。适用于存在多个**垂直领域**的场景——每个领域有独立的知识与对应智能体（如 GitHub、Notion、Slack）。
 
 在 Routing 模式中，路由器对查询进行分解，专家智能体被调用（单个或并行），最后得到组合答案。
@@ -107,31 +109,8 @@
 
 ## 示例项目
 
-**路径**：`agentscope-examples/multiagent-patterns/routing/`
-
 - **Simple**：入口为 `RouterService.run(query)`；流程为分类 → 并行专家 →（框架 merge）→ 可选 RouterService 合成。设置 `routing.runner.enabled=true` 可在启动时运行 Simple 演示（见 **RoutingRunner**）。
 - **Graph**：入口为 `RoutingGraphService.run(query)`；流程为预处理 → 路由子图 → 后处理。设置 `routing-graph.runner.enabled=true` 可在启动时运行 Graph 演示（见 **RoutingGraphRunner**）。
-
-**构建与运行**（在仓库根目录）：
-
-```bash
-./mvnw -pl agentscope-examples/multiagent-patterns/routing -am -B package -DskipTests
-./mvnw -pl agentscope-examples/multiagent-patterns/routing spring-boot:run
-```
-
-**仅运行 Simple 演示**：
-
-```bash
-./mvnw -pl agentscope-examples/multiagent-patterns/routing spring-boot:run \
-  -Dspring-boot.run.arguments="--routing.runner.enabled=true"
-```
-
-**仅运行 Graph 演示**：
-
-```bash
-./mvnw -pl agentscope-examples/multiagent-patterns/routing spring-boot:run \
-  -Dspring-boot.run.arguments="--routing-graph.runner.enabled=true"
-```
 
 **配置**：需设置 `AI_DASHSCOPE_API_KEY`（或 `spring.ai.dashscope.api-key`）供 DashScope 模型与专家调用。
 

--- a/docs/v1/zh/docs/multi-agent/skills.md
+++ b/docs/v1/zh/docs/multi-agent/skills.md
@@ -1,5 +1,7 @@
 # Skills（渐进式披露）
 
+> **说明：** 原先的 Spring Boot 示例模块 `agentscope-examples/multiagent-patterns/` 已在 2.0 包重构中移除。请以本文中的代码片段作为参考实现。其他可运行示例见 `agentscope-examples/documentation/`。
+
 在 **Skills** 模式中，专项能力被打包成可调用的「技能」，用于增强智能体行为。技能主要是**提示驱动**的：智能体先看到技能元数据（如名称、描述），再通过工具（如 `read_skill`）**按需**加载完整技能内容，从而控制初始上下文大小，避免一次性加载所有技能文本。
 
 AgentScope 通过 **SkillBox**、**SkillRepository**（如 `ClasspathSkillRepository`）和技能工具实现该机制。核心能力在 [智能体技能](../task/agent-skill.md) 中说明；本文侧重使用同一机制的 **多智能体示例**（SQL 助手）。
@@ -39,16 +41,8 @@ AgentScope 通过 **SkillBox**、**SkillRepository**（如 `ClasspathSkillReposi
 
 **SQL 助手**示例包含两个技能：**sales_analytics**（客户、订单、收入）和 **inventory_management**（产品、仓库、库存）。用户用自然语言提问；智能体在需要时调用 **read_skill("sales_analytics")** 或 **read_skill("inventory_management")**，再生成 SQL。
 
-- **路径**：`agentscope-examples/multiagent-patterns/skills/`
 - **主要类**：`SkillsConfig`（ClasspathSkillRepository、SkillBox、ReActAgent），`SkillsRunner`（可选演示）。
 - **运行**：设置 `skills.runner.enabled=true` 可在启动时运行单次查询演示（如「写出查询过去一个月内订单金额超过 1000 的所有客户的 SQL」）。
-
-**构建与运行**（在仓库根目录）：
-
-```bash
-./mvnw -pl agentscope-examples/multiagent-patterns/skills -am -B package -DskipTests
-./mvnw -pl agentscope-examples/multiagent-patterns/skills spring-boot:run
-```
 
 **在代码中使用**：注入 ReActAgent（如 `sqlAssistantAgent`），传入用户 `Msg` 调用；用 `getTextContent()` 取回复文本。智能体会根据技能描述决定何时调用 **read_skill** 并生成 SQL。
 

--- a/docs/v1/zh/docs/multi-agent/subagent.md
+++ b/docs/v1/zh/docs/multi-agent/subagent.md
@@ -1,5 +1,7 @@
 # Subagents（子智能体）
 
+> **说明：** 原先的 Spring Boot 示例模块 `agentscope-examples/multiagent-patterns/` 已在 2.0 包重构中移除。请以本文中的代码片段作为参考实现。其他可运行示例见 `agentscope-examples/documentation/`。
+
 **子智能体**是主编排智能体（orchestrator）委托工作的**专职智能体**。编排智能体不亲自执行这些工作，而是通过 **Task** 工具传入子智能体类型和任务描述来调用。系统在**独立上下文**（各自的系统提示与工具）中运行选定的子智能体，再将结果返回给编排智能体。这样主对话保持聚焦、避免上下文膨胀，同时仍可由不同专职智能体处理多类任务（如代码库探索、网络调研、依赖分析）。
 
 该模式常被称为**分发–工作者**或**分层**模型：一个“管理”智能体按需将任务分发给“专家”子智能体。
@@ -124,11 +126,6 @@ AgentScope 示例实现了一个**技术尽调助手**：一个编排智能体�
 - **dependency-analyzer** 以 ReActAgent 构建，通过 `TaskToolsBuilder.subAgent("dependency-analyzer", dependencyAnalyzerReAct)` 注册。
 
 **交互运行**：
-
-```bash
-./mvnw -pl agentscope-examples/multiagent-patterns/subagent spring-boot:run \
-  -Dspring-boot.run.arguments="--subagent.run-interactive=true"
-```
 
 **代码调用**：注入 **OrchestratorService**，调用 `run(userMessage)`；服务会执行调用编排智能体的图。
 

--- a/docs/v1/zh/docs/multi-agent/supervisor.md
+++ b/docs/v1/zh/docs/multi-agent/supervisor.md
@@ -1,5 +1,7 @@
 # Supervisor（监督者）
 
+> **说明：** 原先的 Spring Boot 示例模块 `agentscope-examples/multiagent-patterns/` 已在 2.0 包重构中移除。请以本文中的代码片段作为参考实现。其他可运行示例见 `agentscope-examples/documentation/`。
+
 在 **Supervisor** 模式中，一个中心**监督者**（主智能体）通过**工具**调用专职智能体进行协调。监督者接收用户请求，决定调用哪些专家（如日历、邮件），并将结果综合成一条回复。专职智能体从用户视角看是**无状态**的；监督者维护对话，将一次性任务委托给专家。在 AgentScope 中通过 **Agent as Tool**（[agent-as-tool.md](../task/agent-as-tool.md)）实现：`Toolkit.registration().subAgent()`。
 
 ## 概述
@@ -37,16 +39,8 @@
 
 ## 示例项目
 
-- **路径**：`agentscope-examples/multiagent-patterns/supervisor/`
 - **主要类**：`SupervisorConfig`（model、calendarAgent、emailAgent、supervisorAgent），`CalendarStubTools`，`EmailStubTools`，`SupervisorRunner`（可选演示）。
 - **演示**：设置 `supervisor.run-examples=true` 可在启动时运行两个场景：(1) 单领域：「明天上午 9 点安排团队站会」；(2) 多领域：「下周二下午 2 点与设计团队开 1 小时会，并给他们发邮件提醒查看新原型」。
-
-**构建与运行**（在仓库根目录）：
-
-```bash
-./mvnw -pl agentscope-examples/multiagent-patterns/supervisor -am -B package -DskipTests
-./mvnw -pl agentscope-examples/multiagent-patterns/supervisor spring-boot:run
-```
 
 **在代码中使用**：注入监督者 ReActAgent（如 `@Qualifier("supervisorAgent")`），传入用户 `Msg` 调用；用 `getTextContent()` 获取回复文本。
 

--- a/docs/v1/zh/docs/multi-agent/workflow.md
+++ b/docs/v1/zh/docs/multi-agent/workflow.md
@@ -1,5 +1,7 @@
 # 自定义工作流（Custom Workflow）
 
+> **说明：** 原先的 Spring Boot 示例模块 `agentscope-examples/multiagent-patterns/` 已在 2.0 包重构中移除。请以本文中的代码片段作为参考实现。其他可运行示例见 `agentscope-examples/documentation/`。
+
 在**自定义工作流**模式中，你使用 **Spring AI Alibaba StateGraph** 定义自己的执行流程。你可以完全控制图结构——顺序步骤、条件分支、循环与并行执行。节点可以是**确定性**的（如向量检索、数据库查询）、**基于 LLM** 的（如改写、分类）或**智能体**（带工具的 Agent）。节点之间通过共享状态 Map 传递数据，并可为每个 key 配置策略（覆盖或追加）。
 
 当标准模式（Pipeline、Routing、Subagents 等）不适用、需要将确定性逻辑与智能体行为混合、或流程需要多阶段且对执行顺序有明确要求时，适合采用该模式。
@@ -54,32 +56,10 @@ START → list_tables → call_get_schema → get_schema → generate_query → 
 
 ## 示例项目
 
-**路径**：`agentscope-examples/multiagent-patterns/workflow/`
-
 | 包名       | 流程 | 说明 |
 |------------|------|------|
 | **ragagent** | Query → Rewrite → Retrieve → Prepare → Agent → Response | RAG：改写查询、向量检索，再由 ReActAgent 结合上下文与 `get_latest_news` 工具回答。使用 AgentScope Model、Knowledge（embedding + store）与 AgentScopeAgent。 |
 | **sqlagent** | START → list_tables → get_schema → generate_query → END | SQL：列出表、获取相关表 schema，再由 ReActAgent 使用 SQL 工具（list_tables、schema、query）生成并执行查询。使用 H2 内存库与 AgentScopeAgent。 |
-
-**构建与运行**（在仓库根目录）：
-
-```bash
-./mvnw -pl agentscope-examples/multiagent-patterns/workflow -am -B package -DskipTests
-```
-
-**运行 RAG 工作流**（可选启动时跑一次演示）：
-
-```bash
-./mvnw -pl agentscope-examples/multiagent-patterns/workflow spring-boot:run \
-  -Dspring-boot.run.arguments="--workflow.rag.enabled=true --workflow.runner.enabled=true"
-```
-
-**运行 SQL 工作流**（可选启动时跑一次演示）：
-
-```bash
-./mvnw -pl agentscope-examples/multiagent-patterns/workflow spring-boot:run \
-  -Dspring-boot.run.arguments="--workflow.sql.enabled=true --workflow.runner.enabled=true"
-```
 
 **配置**：
 
@@ -94,7 +74,7 @@ START → list_tables → call_get_schema → get_schema → generate_query → 
 - **Routing**：Routing 为“分类 → 专家 → 合并”。在自定义工作流中可用自己的图实现（如 router 节点 → 分支 → 专家 → 合并节点）。
 - **Handoffs**：Handoffs 通过状态（如 `active_agent`）在智能体节点间路由。自定义工作流也可用条件边与状态实现；Handoffs 是专门表达“谁负责当前对话”的交接模式。
 
-实现细节与代码见示例目录 `agentscope-examples/multiagent-patterns/workflow/` 及 RAG/SQL 配置类（`RagAgentConfig`、`SqlAgentConfig`）。
+实现细节见本文代码片段及 RAG/SQL 配置类说明（`RagAgentConfig`、`SqlAgentConfig`）。
 
 ## 相关文档
 


### PR DESCRIPTION
## AgentScope-Java Version

2.0.1-SNAPSHOT

## Description

Fixes #1676.

V1 multi-agent docs still pointed at `agentscope-examples/multiagent-patterns/*` (e.g. pipeline) for Location and `mvnw -pl ... spring-boot:run` instructions. That example tree was removed in the 2.0 package refactor, so the links 404.

**Changes:**
- Add a short note at the top of affected zh/en multi-agent pages that the Spring Boot example modules were removed
- Remove dead Location / project-tree / `mvnw -pl agentscope-examples/multiagent-patterns/...` run commands
- Keep the inline pattern code snippets as the reference implementation
- Point readers to `agentscope-examples/documentation/` for other runnable samples

**How to verify:**
1. Before: `ls agentscope-examples/multiagent-patterns/pipeline` fails; `rg 'agentscope-examples/multiagent-patterns/[a-z]+/' docs/v1 --glob '*.md'` shows many Location/run refs
2. After: the same `rg` for Location/run module paths returns no matches; each affected page has the removal note and still contains the educational code snippets

## Checklist

- [x] Code has been formatted with `mvn spotless:apply` — N/A (docs only)
- [x] All tests are passing (`mvn test`) — N/A (docs only)
- [x] Javadoc comments are complete and follow project conventions — N/A
- [x] Related documentation has been updated (e.g. links, examples, etc.)
- [x] Code is ready for review
