### PR TITLE
fix(daytona): omit resource fields when creating sandbox from snapshot

### DIFF
--- a/agentscope-extensions/agentscope-extensions-sandbox/agentscope-extensions-sandbox-daytona/pom.xml
+++ b/agentscope-extensions/agentscope-extensions-sandbox/agentscope-extensions-sandbox-daytona/pom.xml
@@ -36,5 +36,17 @@
             <artifactId>agentscope-harness</artifactId>
             <scope>provided</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.squareup.okhttp3</groupId>
+            <artifactId>mockwebserver</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/agentscope-extensions/agentscope-extensions-sandbox/agentscope-extensions-sandbox-daytona/src/main/java/io/agentscope/extensions/sandbox/daytona/DaytonaHttp.java
+++ b/agentscope-extensions/agentscope-extensions-sandbox/agentscope-extensions-sandbox-daytona/src/main/java/io/agentscope/extensions/sandbox/daytona/DaytonaHttp.java
@@ -54,19 +54,24 @@ final class DaytonaHttp {
 
     String createSandbox() throws IOException {
         ObjectNode body = json.createObjectNode();
-        if (opt.getSnapshotId() != null && !opt.getSnapshotId().isBlank()) {
+        boolean useSnapshot = opt.getSnapshotId() != null && !opt.getSnapshotId().isBlank();
+        if (useSnapshot) {
             body.put("snapshot", opt.getSnapshotId());
         } else {
             body.put("image", opt.getImage());
         }
-        if (opt.getCpu() != null) {
-            body.put("cpu", opt.getCpu());
-        }
-        if (opt.getMemory() != null) {
-            body.put("memory", opt.getMemory());
-        }
-        if (opt.getDisk() != null) {
-            body.put("disk", opt.getDisk());
+        // Daytona API rejects resource fields (cpu/memory/disk) when using a
+        // snapshot, so only include them for image-based sandbox creation.
+        if (!useSnapshot) {
+            if (opt.getCpu() != null) {
+                body.put("cpu", opt.getCpu());
+            }
+            if (opt.getMemory() != null) {
+                body.put("memory", opt.getMemory());
+            }
+            if (opt.getDisk() != null) {
+                body.put("disk", opt.getDisk());
+            }
         }
         JsonNode root =
                 DaytonaRetry.withRetries(

--- a/agentscope-extensions/agentscope-extensions-sandbox/agentscope-extensions-sandbox-daytona/src/test/java/io/agentscope/extensions/sandbox/daytona/DaytonaHttpCreateSandboxTest.java
+++ b/agentscope-extensions/agentscope-extensions-sandbox/agentscope-extensions-sandbox-daytona/src/test/java/io/agentscope/extensions/sandbox/daytona/DaytonaHttpCreateSandboxTest.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.extensions.sandbox.daytona;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import okhttp3.OkHttpClient;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Regression tests for {@link DaytonaHttp#createSandbox()} ensuring that
+ * resource fields (cpu/memory/disk) are omitted when a snapshot is used, since
+ * the Daytona API rejects them in snapshot mode.
+ */
+class DaytonaHttpCreateSandboxTest {
+
+    private final ObjectMapper json = new ObjectMapper();
+    private MockWebServer server;
+
+    @BeforeEach
+    void startServer() throws Exception {
+        server = new MockWebServer();
+        server.start();
+    }
+
+    @AfterEach
+    void shutdownServer() throws Exception {
+        server.shutdown();
+    }
+
+    @Test
+    void createSandbox_withSnapshot_omitsCpuMemoryDisk() throws Exception {
+        DaytonaSandboxClientOptions opt = baseOptions();
+        opt.setSnapshotId("snap-123");
+        // defaults: cpu=1, memory=1, disk=3 — must NOT be sent
+
+        enqueueCreateResponse();
+        new DaytonaHttp(opt).createSandbox();
+
+        RecordedRequest req = server.takeRequest();
+        JsonNode body = json.readTree(req.getBody().readUtf8());
+
+        assertTrue(body.has("snapshot"), "snapshot field should be present");
+        assertFalse(body.has("cpu"), "cpu must not be sent in snapshot mode");
+        assertFalse(body.has("memory"), "memory must not be sent in snapshot mode");
+        assertFalse(body.has("disk"), "disk must not be sent in snapshot mode");
+        assertFalse(body.has("image"), "image must not be sent in snapshot mode");
+    }
+
+    @Test
+    void createSandbox_withImage_includesCpuMemoryDisk() throws Exception {
+        DaytonaSandboxClientOptions opt = baseOptions();
+        // no snapshot — image-based creation
+
+        enqueueCreateResponse();
+        new DaytonaHttp(opt).createSandbox();
+
+        RecordedRequest req = server.takeRequest();
+        JsonNode body = json.readTree(req.getBody().readUtf8());
+
+        assertTrue(body.has("image"), "image field should be present");
+        assertTrue(body.has("cpu"), "cpu should be sent in image mode");
+        assertTrue(body.has("memory"), "memory should be sent in image mode");
+        assertTrue(body.has("disk"), "disk should be sent in image mode");
+        assertFalse(body.has("snapshot"), "snapshot must not be sent in image mode");
+    }
+
+    private DaytonaSandboxClientOptions baseOptions() {
+        DaytonaSandboxClientOptions opt = new DaytonaSandboxClientOptions();
+        opt.setApiKey("test-key");
+        opt.setHttpClient(new OkHttpClient());
+        opt.setControlPlaneBaseUrl(server.url("/").toString().replaceAll("/$", ""));
+        opt.setMaxRetries(1);
+        return opt;
+    }
+
+    private void enqueueCreateResponse() {
+        server.enqueue(
+                new MockResponse()
+                        .setHeader("Content-Type", "application/json")
+                        .setBody("{\"id\":\"sandbox-abc\"}"));
+    }
+}


### PR DESCRIPTION
## Bug Description

`DaytonaHttp#createSandbox` always includes `cpu`, `memory`, and `disk` in the request body because `DaytonaSandboxClientOptions` initializes them to non-null defaults (`1`, `1`, `3`). When a `snapshot` is specified, the Daytona API rejects these resource parameters:

```
Cannot specify Sandbox resources when using a snapshot
```

Fixes #2421

## Root Cause

`DaytonaSandboxClientOptions` defines:
```java
private Integer cpu = 1;
private Integer memory = 1;
private Integer disk = 3;
```

`DaytonaHttp#createSandbox` only skips each field when it is `null`. Since the defaults are non-null, they are always serialized — even in snapshot mode, where the Daytona API does not allow resource parameters.

## Fix

Guard `cpu`/`memory`/`disk` behind `!useSnapshot` so they are only included for image-based sandbox creation. The non-snapshot path is unchanged.

```java
boolean useSnapshot = opt.getSnapshotId() != null && !opt.getSnapshotId().isBlank();
// ...
if (!useSnapshot) {
    if (opt.getCpu() != null) body.put("cpu", opt.getCpu());
    if (opt.getMemory() != null) body.put("memory", opt.getMemory());
    if (opt.getDisk() != null) body.put("disk", opt.getDisk());
}
```

This corresponds to Option A from the issue.

## How to Verify

1. `mvn test -pl agentscope-extensions/agentscope-extensions-sandbox/agentscope-extensions-sandbox-daytona -Dtest=DaytonaHttpCreateSandboxTest`
2. Both tests pass — `createSandbox_withSnapshot_omitsCpuMemoryDisk` and `createSandbox_withImage_includesCpuMemoryDisk`

## Test Plan

- [x] Added regression test for this bug (`DaytonaHttpCreateSandboxTest`)
- [x] Existing tests still pass (`mvn spotless:check` + `mvn test` for the module)
- [x] Manual verification of the fix (MockWebServer asserts the request body shape for both snapshot and image modes)

## Risk Assessment

Low — the change only removes fields from the request body in snapshot mode. The image-based path is byte-for-byte identical to before. No public API changes.