### PR TITLE
fix(#2405): prefix MCP tool names with mcp__{server}__ for proper tool filtering [FaaFyfxR9WAQrL7FcAgEHJvztd8cVMxvjHRS55rw1nwH]

### DIFF
--- a/agentscope-core/src/main/java/io/agentscope/core/tool/McpClientManager.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/tool/McpClientManager.java
@@ -174,7 +174,7 @@ class McpClientManager {
 
                             McpTool agentTool =
                                     new McpTool(
-                                            mcpTool.name(),
+                                            "mcp__" + mcpClientWrapper.getName() + "__" + mcpTool.name(),
                                             mcpTool.description() != null
                                                     ? mcpTool.description()
                                                     : "",


### PR DESCRIPTION
Closes agentscope-ai/agentscope-java#2405

## Summary

When registering custom MCP servers, the tools inside them were not renamed to `mcp__{server_name}__{tool_name}` format as documented in https://java.agentscope.io/v2/zh/docs/building-blocks/tool.html#mcp. This caused the `ToolsConfig.allow` filter to be unable to properly include MCP server tools.

## Root Cause

In `McpClientManager.registerMcpClient()`, the `McpTool` was created with the original tool name from the MCP server (e.g., `getTime`, `listHoliday`), without the `mcp__{server_name}__` prefix that the documentation specifies.

## Fix

Changed `McpClientManager.java` line 177 to prefix the tool name with `"mcp__" + mcpClientWrapper.getName() + "__"`:

```java
// Before:
new McpTool(mcpTool.name(), ...)

// After:
new McpTool("mcp__" + mcpClientWrapper.getName() + "__" + mcpTool.name(), ...)
```

The `enableTools` filtering in `McpServerConfig` still works correctly because it filters by the original MCP tool name (before prefixing), and the `ToolFilter` reads the final prefixed tool name from the toolkit.

## Testing

- `enableTools` from `McpServerConfig` still filters by original tool names correctly
- `ToolsConfig.allow`/`deny` now works with the prefixed names
- Existing unit tests in `McpClientManagerTest` remain unaffected (they don't assert tool names directly)
