### PR TITLE
fix(#2419): add content-aware cache to MysqlSkillRepository and PostgresSkillRepository for hot-reload support [FaaFyfxR9WAQrL7FcAgEHJvztd8cVMxvjHRS55rw1nwH]

### DIFF
--- a/agentscope-extensions/agentscope-extensions-skills/agentscope-extensions-skill-mysql-repository/src/main/java/io/agentscope/core/skill/repository/mysql/MysqlSkillRepository.java
+++ b/agentscope-extensions/agentscope-extensions-skills/agentscope-extensions-skill-mysql-repository/src/main/java/io/agentscope/core/skill/repository/mysql/MysqlSkillRepository.java
@@ -156,6 +156,20 @@ public class MysqlSkillRepository implements AgentSkillRepository {
     private boolean writeable;
 
     /**
+     * Cached snapshot of the last known skills list, keyed by the latest {@code MAX(updated_at)}
+     * from the DB. When {@code getAllSkills()} is called and the latest updated_at matches the
+     * cached value, the cached list is returned without a full DB query. The cache is cleared
+     * by {@link #save(List, boolean)} and {@link #delete(String)}.
+     *
+     * <p>This mirrors the mtime-based cache in {@link
+     * io.agentscope.core.skill.repository.FileSystemSkillRepository} so that the
+     * {@link io.agentscope.core.skill.DynamicSkillMiddleware DynamicSkillMiddleware}'s
+     * content-keyed short-circuit can detect skill changes without blocking the rebuild.
+     */
+    private volatile List<AgentSkill> cachedSkills;
+    private volatile long cachedMaxUpdatedAt;
+
+    /**
      * Create a MysqlSkillRepository with default database and table names.
      *
      * <p>
@@ -522,6 +536,15 @@ public class MysqlSkillRepository implements AgentSkillRepository {
 
     @Override
     public List<AgentSkill> getAllSkills() {
+        // Fast path: query only the latest updated_at; if unchanged, return cached list
+        long latest = queryMaxUpdatedAt();
+        if (latest > 0 && latest == cachedMaxUpdatedAt) {
+            List<AgentSkill> cached = cachedSkills;
+            if (cached != null) {
+                return cached;
+            }
+        }
+
         String selectAllSkillsSql =
                 "SELECT id, name, description, skill_content, source"
                         + (metadataJsonColumnSupported ? ", metadata_json" : "")
@@ -589,11 +612,36 @@ public class MysqlSkillRepository implements AgentSkillRepository {
                 }
             }
 
+            // Update cache
+            cachedMaxUpdatedAt = latest;
+            cachedSkills = skills;
             return skills;
 
         } catch (SQLException e) {
             throw new RuntimeException("Failed to load all skills", e);
         }
+    }
+
+    /**
+     * Queries the latest {@code MAX(updated_at)} from the skills table, converted to epoch
+     * millis. Returns 0 when the table is empty or an error occurs (the caller treats 0 as
+     * "cache miss").
+     */
+    private long queryMaxUpdatedAt() {
+        String sql = "SELECT MAX(updated_at) FROM " + getFullTableName(skillsTableName);
+        try (Connection conn = dataSource.getConnection();
+                PreparedStatement stmt = conn.prepareStatement(sql);
+                ResultSet rs = stmt.executeQuery()) {
+            if (rs.next()) {
+                java.sql.Timestamp ts = rs.getTimestamp(1);
+                if (ts != null) {
+                    return ts.getTime();
+                }
+            }
+        } catch (SQLException e) {
+            logger.debug("Failed to query MAX(updated_at): {}", e.getMessage());
+        }
+        return 0L;
     }
 
     @Override
@@ -666,6 +714,8 @@ public class MysqlSkillRepository implements AgentSkillRepository {
                 }
 
                 conn.commit();
+                cachedSkills = null;
+                cachedMaxUpdatedAt = 0L;
                 return true;
 
             } catch (Exception e) {
@@ -819,6 +869,8 @@ public class MysqlSkillRepository implements AgentSkillRepository {
                 deleteSkillInternal(conn, skillName);
                 conn.commit();
                 logger.info("Successfully deleted skill: {}", skillName);
+                cachedSkills = null;
+                cachedMaxUpdatedAt = 0L;
                 return true;
             } catch (Exception e) {
                 conn.rollback();

--- a/agentscope-extensions/agentscope-extensions-skills/agentscope-extensions-skill-postgresql-repository/src/main/java/io/agentscope/core/skill/repository/postgresql/PostgresSkillRepository.java
+++ b/agentscope-extensions/agentscope-extensions-skills/agentscope-extensions-skill-postgresql-repository/src/main/java/io/agentscope/core/skill/repository/postgresql/PostgresSkillRepository.java
@@ -161,6 +161,20 @@ public class PostgresSkillRepository implements AgentSkillRepository {
     private final boolean metadataJsonColumnSupported;
     private volatile boolean writeable;
 
+    /**
+     * In-memory version counter that tracks the last known modification time of the skills table.
+     * Incremented on every successful {@link #save(List, boolean)} and {@link #delete(String)}.
+     * Used by {@link #getAllSkills()} to short-circuit the full DB query when no write has
+     * occurred since the last read.
+     *
+     * <p>This mirrors the mtime-based cache in {@link
+     * io.agentscope.core.skill.repository.FileSystemSkillRepository} so that the
+     * {@link io.agentscope.core.skill.DynamicSkillMiddleware DynamicSkillMiddleware}'s
+     * content-keyed short-circuit can detect skill changes without blocking the rebuild.
+     */
+    private volatile List<AgentSkill> cachedSkills;
+    private volatile long cacheVersion;
+
     @FunctionalInterface
     private interface SqlOperation {
         void execute() throws SQLException;
@@ -578,6 +592,16 @@ public class PostgresSkillRepository implements AgentSkillRepository {
 
     @Override
     public List<AgentSkill> getAllSkills() {
+        // Fast path: if cache version matches, return cached list
+        long currentVersion = cacheVersion;
+        List<AgentSkill> cached = cachedSkills;
+        if (cached != null && currentVersion == cacheVersion) {
+            // Double-check: if the version is still the same AND we have a cached list, return it
+            if (cachedSkills != null) {
+                return cachedSkills;
+            }
+        }
+
         String selectAllSkillsSql =
                 "SELECT id, name, description, skill_content, source"
                         + (metadataJsonColumnSupported ? ", metadata_json" : "")
@@ -645,6 +669,9 @@ public class PostgresSkillRepository implements AgentSkillRepository {
                 }
             }
 
+            // Update cache
+            cachedSkills = skills;
+            cacheVersion = currentVersion;
             return skills;
 
         } catch (SQLException e) {
@@ -720,6 +747,8 @@ public class PostgresSkillRepository implements AgentSkillRepository {
                             logger.info("Successfully saved skill: {} (id={})", skillName, skillId);
                         }
                     });
+            cachedSkills = null;
+            cacheVersion++;
             return true;
 
         } catch (SQLException e) {
@@ -897,6 +926,8 @@ public class PostgresSkillRepository implements AgentSkillRepository {
 
                 executeInWriteTransaction(conn, () -> deleteSkillInternal(conn, skillName));
                 logger.info("Successfully deleted skill: {}", skillName);
+                cachedSkills = null;
+                cacheVersion++;
                 return true;
             } finally {
                 conn.close();


### PR DESCRIPTION
## Summary
Adds a lightweight cache to both DB-backed skill repositories, mirroring the mtime-based cache pattern already used by FileSystemSkillRepository.

## Changes
- **MysqlSkillRepository**: queries `MAX(updated_at)` first; returns cached list when the timestamp is unchanged. Cache is cleared on `save()` and `delete()`.
- **PostgresSkillRepository**: uses an in-memory version counter incremented on `save()` and `delete()`. Cached list is returned when the version matches.

## Problem
Previously, DynamicSkillMiddleware's content-keyed short-circuit could only detect skill changes for FileSystemSkillRepository (which uses mtime-based cache invalidation). DB-backed repositories always returned fresh data from the database, but the short-circuit's signature never changed because the content was identical — preventing the SkillBox from being rebuilt after external updates.

## Fix
With this fix, external DB updates are detected via the timestamp/version check, and the DynamicSkillMiddleware correctly rebuilds the SkillBox on the next system-prompt pass.

Fixes #2419