### PR TITLE
fix(#2312): prevent nested workspace directory in SANDBOXED mode when project is subdirectory of workspace [FaaFyfxR9WAQrL7FcAgEHJvztd8cVMxvjHRS55rw1nwH]

### DIFF
--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/filesystem/spec/LocalFilesystemSpec.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/filesystem/spec/LocalFilesystemSpec.java
@@ -285,11 +285,28 @@ public class LocalFilesystemSpec {
         return List.copyOf(additionalRoots);
     }
 
+    /**
+     * Checks whether {@code sub} is a subdirectory of {@code parent} (including same path).
+     * Both paths are normalized before comparison.
+     */
+    private static boolean isSubdirectoryOf(Path sub, Path parent) {
+        Path normalizedSub = sub.toAbsolutePath().normalize();
+        Path normalizedParent = parent.toAbsolutePath().normalize();
+        return normalizedSub.equals(normalizedParent) || normalizedSub.startsWith(normalizedParent);
+    }
+
     public AbstractFilesystem toFilesystem(Path workspace, NamespaceFactory localNamespaceFactory) {
         Path effectiveProject =
                 project != null ? project : Paths.get(System.getProperty("user.dir"));
         List<Path> policyRoots = new ArrayList<>();
-        policyRoots.add(effectiveProject);
+        // Avoid adding the project as a separate policy root when it is a subdirectory of
+        // the workspace — the workspace root already covers it. Without this guard, the
+        // overlay's lower layer (project) being inside the upper layer (workspace) creates
+        // a circular dependency that manifests as a nested working directory in SANDBOXED
+        // mode (see #2312).
+        if (!isSubdirectoryOf(effectiveProject, workspace)) {
+            policyRoots.add(effectiveProject);
+        }
         policyRoots.add(workspace);
         policyRoots.addAll(additionalRoots);
         PathPolicy pathPolicy = PathPolicy.of(policyRoots);
@@ -304,6 +321,14 @@ public class LocalFilesystemSpec {
                         inheritEnv,
                         localNamespaceFactory,
                         effectiveProject);
+        // When the project is a subdirectory of the workspace, the overlay would create a
+        // circular dependency: the lower layer (project) is inside the upper layer (workspace).
+        // In this case, skip the overlay and use the workspace directly. The project directory
+        // will be created as a regular subdirectory of the workspace when the agent first
+        // accesses it. See #2312.
+        if (isSubdirectoryOf(effectiveProject, workspace)) {
+            return upper;
+        }
         LocalFilesystem lower = new LocalFilesystem(effectiveProject, true, 10, null);
         if (projectWritable) {
             LocalFilesystem projectFs =


### PR DESCRIPTION
## Summary

When `LocalFilesystemSpec` is configured with `LocalFsMode.SANDBOXED` and the `project` directory is a subdirectory of the `workspace` (e.g., `project=agentRoot/workspace`, `workspace=agentRoot`), the `OverlayFilesystem` creates a circular dependency: the lower layer (project) is inside the upper layer (workspace).

This manifests as a **nested working directory** being created inside the user's workspace in SANDBOXED mode, while the same configuration works correctly in local mode.

## Root Cause

In `LocalFilesystemSpec.toFilesystem()`, the overlay always creates two layers:
- Upper layer: `LocalFilesystemWithShell(workspace, ...)`
- Lower layer: `LocalFilesystem(project, ...)`

When `project` is a subdirectory of `workspace`, the lower layer is inside the upper layer's file tree, causing the overlay to create a nested directory structure.

## Fix

1. Added an `isSubdirectoryOf()` helper that checks whether one path is a subdirectory of another (both normalized).
2. In `toFilesystem()`, detect when the project is a subdirectory of the workspace. When this is the case:
   - Skip adding the project to `policyRoots` (workspace already covers it)
   - Skip creating the overlay — use the workspace directly
   - The project directory will be created as a regular subdirectory when the agent first accesses it

## Testing

- Existing tests should continue to pass since the overlay path is only skipped when the project is explicitly a subdirectory of the workspace, which is a rare edge case
- Manual verification: configure `LocalFilesystemSpec` with `mode=LocalFsMode.SANDBOXED`, `project=agentRoot/workspace`, `workspace=agentRoot` — no nested directory should be created

Closes #2312
