### PR TITLE
fix(#2329): apply namespace scope to shellCwd in resolveExecuteCwd [FaaFyfxR9WAQrL7FcAgEHJvztd8cVMxvjHRS55rw1nwH]

### DIFF
--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/filesystem/local/LocalFilesystemWithShell.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/filesystem/local/LocalFilesystemWithShell.java
@@ -409,18 +409,16 @@ public class LocalFilesystemWithShell extends LocalFilesystem implements Abstrac
     }
 
     private Path resolveExecuteCwd(RuntimeContext rc) {
-        if (shellCwd != null) {
-            return shellCwd;
-        }
+        Path base = (shellCwd != null) ? shellCwd : getCwd();
         NamespaceFactory nsf = getNamespaceFactory();
         if (nsf == null) {
-            return getCwd();
+            return base;
         }
         List<String> ns = nsf.getNamespace(rc);
         if (ns == null || ns.isEmpty()) {
-            return getCwd();
+            return base;
         }
-        Path namespaced = getCwd();
+        Path namespaced = base;
         for (String segment : ns) {
             namespaced = namespaced.resolve(segment);
         }


### PR DESCRIPTION
## Description
Fixes #2329

When `IsolationScope.SESSION` or `IsolationScope.USER` is configured, the `execute_shell_command` tool should automatically resolve the working directory to the isolated path (e.g., `workspace/<session_id>/`). However, when `shellCwd` is explicitly set (to the project root) in `LocalFilesystemWithShell`, the `resolveExecuteCwd` method returns it directly without applying the namespace scope.

## Root Cause
In `LocalFilesystemWithShell.resolveExecuteCwd()`, the early return for non-null `shellCwd` bypasses the namespace factory entirely:
```java
if (shellCwd != null) {
    return shellCwd;  // ignores namespace/scope
}
```

## Fix
The namespace prefix is now applied to `shellCwd` when it is set, just as it is applied to `getCwd()` when `shellCwd` is null. This ensures that shell commands run in the isolated directory matching the session/user scope.

## Testing
- Existing tests pass (no regression)
- When `IsolationScope.SESSION` is configured, `execute_shell_command` now resolves to `<shellCwd>/<sessionId>/` instead of just `<shellCwd>`
- When `shellCwd` is null, behavior is unchanged (namespace still applied to `getCwd()`)

Wallet: FaaFyfxR9WAQrL7FcAgEHJvztd8cVMxvjHRS55rw1nwH