### PR TITLE
fix: apply isolation namespace to shell execute cwd (#2329) [FaaFyfxR9WAQrL7FcAgEHJvztd8cVMxvjHRS55rw1nwH]

### DIFF
--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/filesystem/local/LocalFilesystemWithShell.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/filesystem/local/LocalFilesystemWithShell.java
@@ -409,18 +409,17 @@ public class LocalFilesystemWithShell extends LocalFilesystem implements Abstrac
     }
 
     private Path resolveExecuteCwd(RuntimeContext rc) {
-        if (shellCwd != null) {
-            return shellCwd;
-        }
+        Path base = shellCwd != null ? shellCwd : getCwd();
+
         NamespaceFactory nsf = getNamespaceFactory();
         if (nsf == null) {
-            return getCwd();
+            return base;
         }
         List<String> ns = nsf.getNamespace(rc);
         if (ns == null || ns.isEmpty()) {
-            return getCwd();
+            return base;
         }
-        Path namespaced = getCwd();
+        Path namespaced = base;
         for (String segment : ns) {
             namespaced = namespaced.resolve(segment);
         }


### PR DESCRIPTION
## Description

When `IsolationScope.SESSION` or `IsolationScope.USER` is configured, the `LocalFilesystemWithShell` correctly creates a namespace-aware working directory (e.g., `<workspace>/<sessionId>/`). However, the `resolveExecuteCwd()` method short-circuits when `shellCwd` is set (the project root), returning `shellCwd` directly without applying the namespace prefix. This causes shell commands to run in the project root instead of the isolated session directory, leading to failures when the agent tries to execute scripts that were generated in the isolated workspace.

## Root Cause

In `LocalFilesystemWithShell.resolveExecuteCwd()`:

```java
if (shellCwd != null) {
    return shellCwd;  // ← BUG: skips namespace resolution entirely
}
```

When `shellCwd` is set (to the project root), the method returns immediately without checking the `NamespaceFactory`, so the shell always runs in the project root regardless of the configured isolation scope.

## Fix

Use `shellCwd` (or `getCwd()` as fallback) as the base path, then apply namespace resolution on top of it:

```java
Path base = shellCwd != null ? shellCwd : getCwd();
// ... then apply namespace on top of base
```

This ensures that when isolation scope is configured, the shell's working directory becomes `<projectRoot>/<sessionId>/` (or `<workspace>/<sessionId>/`) instead of `<projectRoot>/`.

## Testing

- The existing `LocalFilesystemUserIsolationExampleTest` and `SandboxFilesystemIsolationScopeExampleTest` should pass with this fix
- Commands executed via `execute_shell_command` will now correctly resolve to the isolated namespace directory

Fixes #2329