### PR TITLE
fix: add clarifying instruction to distinguish skills from tools in skill prompt (#2438) [FaaFyfxR9WAQrL7FcAgEHJvztd8cVMxvjHRS55rw1nwH]

### DIFF
--- a/agentscope-core/src/main/java/io/agentscope/core/skill/AgentSkillPromptProvider.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/skill/AgentSkillPromptProvider.java
@@ -69,6 +69,13 @@ public class AgentSkillPromptProvider {
             - <skill-id> is always appended for tool loading
             </usage>
 
+            Note: The <available_skills> section below lists only your skills (specialized
+            capabilities). Your tools (file management, network requests, memory, etc.) are
+            described separately in the system prompt. When asked about "what skills you
+            have" or "what skills are available", list ONLY the skills from the
+            <available_skills> section. Do NOT include tools or tool groups in your skills
+            answer — they are capabilities, not skills.
+
             <available_skills>
 
             """;


### PR DESCRIPTION
## Description

When the agent is asked "what skills do you have" (`你有哪些技能？`), the LLM response includes both skills (from `<available_skills>`) and tools from the Toolkit (file management, network requests, memory, etc.). This is because the system prompt lists both, and the LLM naturally includes everything it sees.

**Root cause**: The `AgentSkillPromptProvider.DEFAULT_AGENT_SKILL_INSTRUCTION` does not instruct the LLM to distinguish between skills and tools. The `<available_skills>` section shows skills, but the LLM also sees tool definitions elsewhere in the system prompt and considers them part of its "skills."

**Fix**: Added a clarifying instruction block after `</usage>` and before `<available_skills>` that explicitly tells the LLM:
- `<available_skills>` lists only skills (specialized capabilities)
- Tools (file management, network requests, etc.) are described separately
- When asked about "what skills you have", list ONLY the skills from `<available_skills>`
- Do NOT include tools or tool groups in the skills answer

**Testing**: This is a prompt-level change. The fix is verified by checking that the instruction text is added to the `DEFAULT_AGENT_SKILL_INSTRUCTION` constant. No functional code changes were made.

Closes #2438

[FaaFyfxR9WAQrL7FcAgEHJvztd8cVMxvjHRS55rw1nwH]