### PR TITLE
fix(core): repair null streaming tool args from complete raw JSON

### DIFF
--- a/agentscope-core/src/main/java/io/agentscope/core/agent/accumulator/ToolCallsAccumulator.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/agent/accumulator/ToolCallsAccumulator.java
@@ -67,9 +67,16 @@ public class ToolCallsAccumulator implements ContentAccumulator<ToolUseBlock> {
                 this.name = block.getName();
             }
 
-            // Merge parameters
+            // Merge parameters. Skip null values so a partial/null map from an early
+            // stream chunk cannot wipe previously accumulated non-null arguments.
             if (block.getInput() != null) {
-                this.args.putAll(block.getInput());
+                for (Map.Entry<String, Object> entry : block.getInput().entrySet()) {
+                    if (entry.getValue() != null) {
+                        this.args.put(entry.getKey(), entry.getValue());
+                    } else if (!this.args.containsKey(entry.getKey())) {
+                        this.args.put(entry.getKey(), null);
+                    }
+                }
             }
 
             // Accumulate raw content (for parsing complete JSON)
@@ -87,17 +94,27 @@ public class ToolCallsAccumulator implements ContentAccumulator<ToolUseBlock> {
             Map<String, Object> finalArgs = new HashMap<>(args);
             String rawContentStr = this.rawContent.toString();
 
-            // If no parsed arguments but has raw JSON content, try to parse
-            if (finalArgs.isEmpty() && rawContentStr.length() > 0) {
+            // Always attempt to parse the fully accumulated raw JSON. Early stream chunks may
+            // look like complete objects ({...}) but still contain null/incomplete values;
+            // the final raw content is the source of truth for missing or null keys.
+            if (!rawContentStr.isEmpty()) {
                 try {
                     @SuppressWarnings("unchecked")
                     Map<String, Object> parsed =
                             JsonUtils.getJsonCodec().fromJson(rawContentStr, Map.class);
                     if (parsed != null) {
-                        finalArgs.putAll(parsed);
+                        for (Map.Entry<String, Object> entry : parsed.entrySet()) {
+                            if (entry.getValue() == null) {
+                                continue;
+                            }
+                            Object existing = finalArgs.get(entry.getKey());
+                            if (existing == null || !finalArgs.containsKey(entry.getKey())) {
+                                finalArgs.put(entry.getKey(), entry.getValue());
+                            }
+                        }
                     }
                 } catch (Exception ignored) {
-                    // Parsing failed, keep empty args
+                    // Parsing failed, keep previously merged args
                 }
             }
 

--- a/agentscope-core/src/test/java/io/agentscope/core/agent/accumulator/ToolCallsAccumulatorTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/agent/accumulator/ToolCallsAccumulatorTest.java
@@ -412,4 +412,65 @@ class ToolCallsAccumulatorTest {
         assertEquals("{\"city\": \"Tokyo\"}", toolCall.getContent());
         assertEquals("Tokyo", toolCall.getInput().get("city"));
     }
+
+    @Test
+    @DisplayName(
+            "Should repair null input values from complete raw JSON (#768 HTML streaming case)")
+    void testRepairNullInputValuesFromCompleteRawContent() {
+        // Early chunk: keys present but values null (partial/early parse of incomplete JSON)
+        Map<String, Object> partialArgs = new HashMap<>();
+        partialArgs.put("file_path", null);
+        partialArgs.put("content", null);
+
+        String html =
+                "<html>\n  <body class=\"main\">\n    <p>Hello \"world\"</p>\n  </body>\n</html>";
+        String completeJson =
+                "{\"file_path\":\"index.html\",\"content\":"
+                        + io.agentscope.core.util.JsonUtils.getJsonCodec().toJson(html)
+                        + "}";
+
+        ToolUseBlock chunk1 =
+                ToolUseBlock.builder()
+                        .id("call_html")
+                        .name("write_text_file")
+                        .input(partialArgs)
+                        .content(completeJson)
+                        .build();
+
+        accumulator.add(chunk1);
+
+        List<ToolUseBlock> result = accumulator.buildAllToolCalls();
+        assertEquals(1, result.size());
+        ToolUseBlock toolCall = result.get(0);
+
+        assertEquals("index.html", toolCall.getInput().get("file_path"));
+        assertEquals(html, toolCall.getInput().get("content"));
+    }
+
+    @Test
+    @DisplayName("Should not let null input from later chunks overwrite earlier non-null values")
+    void testNullInputDoesNotOverwriteNonNullArgs() {
+        Map<String, Object> goodArgs = new HashMap<>();
+        goodArgs.put("file_path", "a.md");
+        goodArgs.put("content", "hello");
+
+        Map<String, Object> nullArgs = new HashMap<>();
+        nullArgs.put("file_path", null);
+        nullArgs.put("content", null);
+
+        accumulator.add(
+                ToolUseBlock.builder()
+                        .id("call_1")
+                        .name("write_text_file")
+                        .input(goodArgs)
+                        .content("{\"file_path\":\"a.md\",\"content\":\"hello\"}")
+                        .build());
+        accumulator.add(
+                ToolUseBlock.builder().id("call_1").name("__fragment__").input(nullArgs).build());
+
+        List<ToolUseBlock> result = accumulator.buildAllToolCalls();
+        assertEquals(1, result.size());
+        assertEquals("a.md", result.get(0).getInput().get("file_path"));
+        assertEquals("hello", result.get(0).getInput().get("content"));
+    }
 }


### PR DESCRIPTION
## Summary

- Repair `ToolCallsAccumulator` so complete raw tool-call JSON fills missing/null input values after streaming.
- Prevent later null input maps from overwriting previously accumulated non-null arguments.
- Add regression tests for HTML-like multi-line content and null-overwrite protection.

Closes #768

## Description

When streaming tool-call arguments for complex multi-line content (e.g. HTML), early chunks can leave `ToolUseBlock.input` with keys present but null values. Because `build()` previously only parsed raw content when `finalArgs` was empty, those nulls were never repaired even though `content` held valid complete JSON.

## Checklist

- [x] Code has been formatted with `mvn spotless:apply`
- [x] Targeted tests pass (`ToolCallsAccumulatorTest`, 15 tests)
- [x] Related documentation has been updated (N/A)
- [x] Code is ready for review

## Testing

```bash
JAVA_HOME=/path/to/jdk21 mvn -pl agentscope-core -am \
  -Dspotless.check.skip=true \
  -Dtest=ToolCallsAccumulatorTest \
  -Dsurefire.failIfNoSpecifiedTests=false \
  test
```