### PR TITLE
fix(harness): reject empty old string in file edits

### DIFF
--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/filesystem/util/FilesystemUtils.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/filesystem/util/FilesystemUtils.java
@@ -55,6 +55,10 @@ public final class FilesystemUtils {
      */
     public static Object[] performStringReplacement(
             String content, String oldString, String newString, boolean replaceAll) {
+        if (oldString == null || oldString.isEmpty()) {
+            return new Object[] {"Error: old_string must not be empty"};
+        }
+
         int occurrences = countOccurrences(content, oldString);
 
         if (occurrences == 0) {

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/filesystem/util/FilesystemUtilsTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/filesystem/util/FilesystemUtilsTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.harness.agent.filesystem.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
+
+import java.time.Duration;
+import org.junit.jupiter.api.Test;
+
+class FilesystemUtilsTest {
+
+    @Test
+    void performStringReplacement_emptyOldString_returnsErrorWithoutHanging() {
+        Object[] result =
+                assertTimeoutPreemptively(
+                        Duration.ofSeconds(1),
+                        () ->
+                                FilesystemUtils.performStringReplacement(
+                                        "content", "", "replacement", false));
+
+        assertEquals(1, result.length);
+        assertEquals("Error: old_string must not be empty", result[0]);
+    }
+
+    @Test
+    void performStringReplacement_nullOldString_returnsError() {
+        Object[] result =
+                FilesystemUtils.performStringReplacement("content", null, "replacement", false);
+
+        assertEquals(1, result.length);
+        assertEquals("Error: old_string must not be empty", result[0]);
+    }
+}


### PR DESCRIPTION
## Summary
- reject null or empty `old_string` before counting occurrences
- prevent `edit_file` from hanging indefinitely
- add regression tests for empty and null values

## Testing
- `mvn -q -pl agentscope-harness -am test`

Fixes #2446