### PR TITLE
fix(agent): checkpoint state on stream cancellation

### DIFF
--- a/agentscope-core/src/main/java/io/agentscope/core/ReActAgent.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/ReActAgent.java
@@ -624,6 +624,21 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
         unbindRuntimeContextFromHooks();
     }
 
+    @Override
+    protected Mono<Void> onAgentExecutionCancelled(Object callScope) {
+        if (!(callScope instanceof CallExecution scope)) {
+            return Mono.empty();
+        }
+        return saveStateToSession(scope)
+                .onErrorResume(
+                        error -> {
+                            log.warn(
+                                    "Failed to checkpoint AgentState after call cancellation",
+                                    error);
+                            return Mono.empty();
+                        });
+    }
+
     private RuntimeContext buildMergedRuntimeContext(RuntimeContext run) {
         if (run == null) {
             if (toolExecutionContext != null) {

--- a/agentscope-core/src/main/java/io/agentscope/core/agent/AgentBase.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/agent/AgentBase.java
@@ -36,12 +36,17 @@ import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 import java.util.function.Supplier;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import reactor.core.Disposable;
+import reactor.core.Exceptions;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.FluxSink;
 import reactor.core.publisher.Mono;
+import reactor.core.publisher.SignalType;
 import reactor.core.publisher.Sinks;
 import reactor.core.scheduler.Schedulers;
 
@@ -92,6 +97,8 @@ import reactor.core.scheduler.Schedulers;
 @SuppressWarnings("deprecation")
 public abstract class AgentBase implements Agent {
 
+    private static final Logger log = LoggerFactory.getLogger(AgentBase.class);
+
     private final String agentId;
     private final String name;
     private final String description;
@@ -108,7 +115,7 @@ public abstract class AgentBase implements Agent {
      * Per-key call serialization tails. Each entry holds the completion signal of the most recently
      * enqueued call for that key; the next call for the same key chains after it, so calls sharing a
      * key run one-at-a-time (FIFO) while different keys run concurrently. See {@link
-     * #callSerializationKey(RuntimeContext)} and {@link #serializeOnKey(Object, Mono)}.
+     * #callSerializationKey(RuntimeContext)} and {@link #serializeOnKey(Object, Mono, Supplier)}.
      */
     private final ConcurrentHashMap<Object, Mono<Void>> callGates = new ConcurrentHashMap<>();
 
@@ -272,15 +279,28 @@ public abstract class AgentBase implements Agent {
                                     // serialization gate (if any) admits this call:
                                     // beforeAgentExecution resolves/loads the session slot and must
                                     // not race a concurrent same-session call.
+                                    AtomicReference<Object> callScope = new AtomicReference<>();
                                     Mono<Msg> lifecycle =
                                             Mono.defer(
                                                     () ->
                                                             runLifecycleBody(
-                                                                    msgs, rc, doCallFn, requestId));
+                                                                    msgs, rc, doCallFn, requestId,
+                                                                    callScope));
+                                    Supplier<Mono<Void>> cancellationFinalizer =
+                                            () -> {
+                                                Object scope = callScope.get();
+                                                return scope == null
+                                                        ? Mono.empty()
+                                                        : onAgentExecutionCancelled(scope);
+                                            };
                                     Mono<Msg> gated =
                                             gateKey == null
-                                                    ? lifecycle
-                                                    : serializeOnKey(gateKey, lifecycle);
+                                                    ? finalizeCancellation(
+                                                            lifecycle, cancellationFinalizer)
+                                                    : serializeOnKey(
+                                                            gateKey,
+                                                            lifecycle,
+                                                            cancellationFinalizer);
                                     return gated.contextWrite(
                                                     c ->
                                                             requestId == null || requestId.isEmpty()
@@ -301,8 +321,10 @@ public abstract class AgentBase implements Agent {
             List<Msg> msgs,
             RuntimeContext rc,
             Function<List<Msg>, Mono<Msg>> doCallFn,
-            String requestId) {
+            String requestId,
+            AtomicReference<Object> callScope) {
         Object scope = beforeAgentExecution(msgs, rc);
+        callScope.set(scope);
         // Bind this call's resolved per-session state to the tracked shutdown request so graceful
         // shutdown interrupts / saves the exact (userId, sessionId) session rather than the agent's
         // no-arg "most-recently-active" accessors.
@@ -339,10 +361,12 @@ public abstract class AgentBase implements Agent {
     /**
      * Serializes {@code action} against other actions sharing {@code key}: this call waits for the
      * previously-enqueued call with the same key to terminate before running, then becomes the tail
-     * the next same-key call waits on. Releases its slot on any terminal signal (complete, error, or
-     * cancel) so a failed/cancelled call never blocks the queue.
+     * the next same-key call waits on. Complete and error release the slot immediately. Cancellation
+     * starts {@code cancellationFinalizer} and releases the slot when that publisher terminates, so
+     * a subsequent same-key call cannot overtake cancellation persistence.
      */
-    private <T> Mono<T> serializeOnKey(Object key, Mono<T> action) {
+    private <T> Mono<T> serializeOnKey(
+            Object key, Mono<T> action, Supplier<Mono<Void>> cancellationFinalizer) {
         return Mono.defer(
                 () -> {
                     Sinks.Empty<Void> release = Sinks.empty();
@@ -355,14 +379,67 @@ public abstract class AgentBase implements Agent {
                                 prev[0] = tail == null ? Mono.empty() : tail;
                                 return releaseMono;
                             });
+                    Runnable releaseGate =
+                            () -> {
+                                release.tryEmitEmpty();
+                                callGates.remove(key, releaseMono);
+                            };
                     return prev[0].onErrorComplete()
                             .then(action)
                             .doFinally(
                                     sig -> {
-                                        release.tryEmitEmpty();
-                                        callGates.remove(key, releaseMono);
+                                        if (sig == SignalType.CANCEL) {
+                                            runCancellationFinalizer(
+                                                    cancellationFinalizer, releaseGate);
+                                        } else {
+                                            releaseGate.run();
+                                        }
                                     });
                 });
+    }
+
+    private <T> Mono<T> finalizeCancellation(
+            Mono<T> action, Supplier<Mono<Void>> cancellationFinalizer) {
+        return action.doFinally(
+                sig -> {
+                    if (sig == SignalType.CANCEL) {
+                        runCancellationFinalizer(cancellationFinalizer, () -> {});
+                    }
+                });
+    }
+
+    private void runCancellationFinalizer(
+            Supplier<Mono<Void>> cancellationFinalizer, Runnable afterFinalizer) {
+        Mono<Void> finalizer;
+        try {
+            finalizer = cancellationFinalizer.get();
+        } catch (Throwable error) {
+            afterFinalizer.run();
+            Exceptions.throwIfFatal(error);
+            log.warn("Cancellation finalizer failed for agent {}", getName(), error);
+            return;
+        }
+        if (finalizer == null) {
+            afterFinalizer.run();
+            return;
+        }
+        try {
+            finalizer
+                    .onErrorResume(
+                            error -> {
+                                log.warn(
+                                        "Cancellation finalizer failed for agent {}",
+                                        getName(),
+                                        error);
+                                return Mono.empty();
+                            })
+                    .doFinally(ignored -> afterFinalizer.run())
+                    .subscribe();
+        } catch (Throwable error) {
+            afterFinalizer.run();
+            Exceptions.throwIfFatal(error);
+            log.warn("Cancellation finalizer failed for agent {}", getName(), error);
+        }
     }
 
     /**
@@ -594,6 +671,22 @@ public abstract class AgentBase implements Agent {
      * #beforeAgentExecution(List, RuntimeContext)}. The default is a no-op.
      */
     protected void afterAgentExecution() {}
+
+    /**
+     * Returns best-effort asynchronous finalization for a call cancelled after its per-call scope
+     * has been established.
+     *
+     * <p>For serialized calls, the next call sharing the same key is admitted only after the
+     * returned publisher terminates. Lifecycle cleanup itself is not delayed. Implementations must
+     * keep this publisher non-blocking on the caller thread; synchronous I/O should be scheduled on
+     * an appropriate worker.
+     *
+     * @param callScope the scope returned by {@link #beforeAgentExecution(List, RuntimeContext)}
+     * @return completion of the cancellation finalizer; empty by default
+     */
+    protected Mono<Void> onAgentExecutionCancelled(Object callScope) {
+        return Mono.empty();
+    }
 
     /**
      * Pushes {@code ctx} to all {@link RuntimeContextAware} hooks registered for this agent. The

--- a/agentscope-core/src/test/java/io/agentscope/core/agent/ReActAgentCancellationCheckpointTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/agent/ReActAgentCancellationCheckpointTest.java
@@ -1,0 +1,416 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.core.agent;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.agentscope.core.ReActAgent;
+import io.agentscope.core.event.AgentEvent;
+import io.agentscope.core.message.ContentBlock;
+import io.agentscope.core.message.Msg;
+import io.agentscope.core.message.TextBlock;
+import io.agentscope.core.message.UserMessage;
+import io.agentscope.core.model.ChatModelBase;
+import io.agentscope.core.model.ChatResponse;
+import io.agentscope.core.model.GenerateOptions;
+import io.agentscope.core.model.ToolSchema;
+import io.agentscope.core.shutdown.GracefulShutdownManager;
+import io.agentscope.core.state.AgentState;
+import io.agentscope.core.state.InMemoryAgentStateStore;
+import io.agentscope.core.state.State;
+import io.agentscope.core.state.Task;
+import io.agentscope.core.state.ToolContextState;
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import reactor.core.Disposable;
+import reactor.core.publisher.Flux;
+import reactor.core.scheduler.Schedulers;
+
+@DisplayName("ReActAgent cancellation checkpoints")
+class ReActAgentCancellationCheckpointTest {
+
+    private static final String USER_ID = "checkpoint-user";
+    private static final String SESSION_ID = "checkpoint-session";
+    private static final String AGENT_STATE_KEY = "agent_state";
+
+    @Test
+    @DisplayName("cancellation persists a reloadable snapshot of the call-scoped state")
+    void cancellationPersistsReloadableCallScopedState() throws Exception {
+        SnapshotStore store = new SnapshotStore();
+        NeverModel model = new NeverModel();
+        RuntimeContext runtimeContext = context(SESSION_ID);
+
+        try (ReActAgent agent = agent(model, store)) {
+            Disposable call =
+                    agent.streamEvents(List.of(message("keep this turn")), runtimeContext)
+                            .subscribe();
+            try {
+                await(model.subscribed, "model call did not start");
+                AgentState live = runtimeContext.getAgentState();
+                assertNotNull(live);
+
+                live.setSummary("checkpoint summary");
+                live.getPlanModeContext().setPlanActive(true);
+                live.getPlanModeContext().setCurrentPlanFile("plans/recovery.md");
+                live.getTasksContext()
+                        .tasksMutable()
+                        .add(
+                                Task.builder()
+                                        .id("checkpoint-task")
+                                        .subject("Resume interrupted work")
+                                        .description("State must survive downstream cancellation")
+                                        .createdAt("2026-07-28T00:00:00Z")
+                                        .build());
+                ToolContextState.SpawnEntry spawn =
+                        new ToolContextState.SpawnEntry(
+                                "agent:worker:checkpoint",
+                                "worker",
+                                "child-checkpoint-session",
+                                "Worker",
+                                1);
+                live.getToolContext().putSpawnEntry(spawn.key(), spawn);
+
+                call.dispose();
+                await(store.saved, "cancellation checkpoint did not finish");
+
+                AgentState restored =
+                        store.get(USER_ID, SESSION_ID, AGENT_STATE_KEY, AgentState.class)
+                                .orElseThrow();
+                assertEquals(1, store.saveCount.get());
+                assertEquals(USER_ID, restored.getUserId());
+                assertEquals(SESSION_ID, restored.getSessionId());
+                assertEquals("checkpoint summary", restored.getSummary());
+                assertTrue(restored.getPlanModeContext().isPlanActive());
+                assertEquals(
+                        "plans/recovery.md", restored.getPlanModeContext().getCurrentPlanFile());
+                assertEquals(
+                        "Resume interrupted work",
+                        restored.getTasksContext().getTasks().get(0).getSubject());
+                assertEquals(spawn, restored.getToolContext().getSpawnRegistry().get(spawn.key()));
+                assertTrue(texts(restored).contains("keep this turn"));
+            } finally {
+                call.dispose();
+            }
+        }
+    }
+
+    @Test
+    @DisplayName("normal completion keeps exactly one state save")
+    void normalCompletionDoesNotAddCancellationSave() {
+        SnapshotStore store = new SnapshotStore();
+
+        try (ReActAgent agent = agent(new FixedModel(), store)) {
+            agent.streamEvents(List.of(message("complete")), context(SESSION_ID))
+                    .blockLast(Duration.ofSeconds(5));
+
+            assertEquals(1, store.saveCount.get());
+        }
+    }
+
+    @Test
+    @DisplayName("cancellation without a state store is a safe no-op")
+    void cancellationWithoutStoreIsSafe() throws Exception {
+        NeverModel model = new NeverModel();
+
+        try (ReActAgent agent = agent(model, null)) {
+            Disposable call =
+                    agent.streamEvents(List.of(message("no persistence")), context(SESSION_ID))
+                            .subscribe();
+            await(model.subscribed, "model call did not start");
+
+            call.dispose();
+
+            assertTrue(call.isDisposed());
+            assertEquals(0, GracefulShutdownManager.getInstance().getActiveRequestCount());
+        }
+    }
+
+    @Test
+    @DisplayName("a failed cancellation save does not prevent lifecycle or gate cleanup")
+    void failedCheckpointStillCleansUpAndReleasesSession() throws Exception {
+        FailingOnceStore store = new FailingOnceStore();
+        FirstCallNeverModel model = new FirstCallNeverModel();
+        RuntimeContext runtimeContext = context(SESSION_ID);
+
+        try (ReActAgent agent = agent(model, store)) {
+            Disposable cancelled =
+                    agent.streamEvents(List.of(message("cancel first")), runtimeContext)
+                            .subscribe();
+            await(model.firstSubscribed, "first model call did not start");
+
+            cancelled.dispose();
+            await(store.failedSaveAttempted, "failing checkpoint was not attempted");
+            assertEquals(0, GracefulShutdownManager.getInstance().getActiveRequestCount());
+
+            AgentEvent last =
+                    agent.streamEvents(List.of(message("run second")), context(SESSION_ID))
+                            .blockLast(Duration.ofSeconds(5));
+
+            assertNotNull(last, "same-session call should proceed after checkpoint failure");
+            assertEquals(2, model.subscriptions.get());
+            assertEquals(0, GracefulShutdownManager.getInstance().getActiveRequestCount());
+        }
+    }
+
+    @Test
+    @DisplayName("the session gate orders cancellation saves without blocking other sessions")
+    void cancellationCheckpointIsOrderedPerSessionAndIsolatedAcrossSessions() throws Exception {
+        BlockingFirstSaveStore store = new BlockingFirstSaveStore(SESSION_ID);
+        RoutingModel model = new RoutingModel();
+
+        try (ReActAgent agent = agent(model, store)) {
+            Disposable cancelled =
+                    agent.streamEvents(List.of(message("cancelled input")), context(SESSION_ID))
+                            .subscribe();
+            try {
+                await(model.cancelledSubscribed, "cancelled model call did not start");
+                cancelled.dispose();
+                await(store.blockingSaveStarted, "cancellation save did not start");
+
+                CompletableFuture<List<AgentEvent>> sameSession =
+                        agent.streamEvents(
+                                        List.of(message("same session follow-up")),
+                                        context(SESSION_ID))
+                                .subscribeOn(Schedulers.parallel())
+                                .collectList()
+                                .toFuture();
+                assertFalse(
+                        model.sameSessionSubscribed.await(200, TimeUnit.MILLISECONDS),
+                        "same-session call must wait for the cancellation checkpoint");
+
+                CompletableFuture<List<AgentEvent>> otherSession =
+                        agent.streamEvents(
+                                        List.of(message("other session input")),
+                                        context("independent-session"))
+                                .subscribeOn(Schedulers.parallel())
+                                .collectList()
+                                .toFuture();
+                await(
+                        model.otherSessionSubscribed,
+                        "an independent session should not wait for the blocked checkpoint");
+                assertFalse(otherSession.get(5, TimeUnit.SECONDS).isEmpty());
+
+                store.allowBlockingSave.countDown();
+                await(
+                        model.sameSessionSubscribed,
+                        "same-session call did not resume after checkpoint completion");
+                assertFalse(sameSession.get(5, TimeUnit.SECONDS).isEmpty());
+
+                AgentState same =
+                        store.get(USER_ID, SESSION_ID, AGENT_STATE_KEY, AgentState.class)
+                                .orElseThrow();
+                AgentState other =
+                        store.get(USER_ID, "independent-session", AGENT_STATE_KEY, AgentState.class)
+                                .orElseThrow();
+                assertTrue(texts(same).contains("cancelled input"));
+                assertTrue(texts(same).contains("same session follow-up"));
+                assertFalse(texts(other).contains("cancelled input"));
+                assertTrue(texts(other).contains("other session input"));
+            } finally {
+                store.allowBlockingSave.countDown();
+                cancelled.dispose();
+            }
+        }
+    }
+
+    private static ReActAgent agent(ChatModelBase model, InMemoryAgentStateStore store) {
+        ReActAgent.Builder builder =
+                ReActAgent.builder()
+                        .name("cancellation-checkpoint-agent")
+                        .sysPrompt("Test cancellation persistence.")
+                        .model(model);
+        if (store != null) {
+            builder.stateStore(store);
+        }
+        return builder.build();
+    }
+
+    private static RuntimeContext context(String sessionId) {
+        return RuntimeContext.builder().userId(USER_ID).sessionId(sessionId).build();
+    }
+
+    private static Msg message(String text) {
+        return new UserMessage(text);
+    }
+
+    private static List<String> texts(AgentState state) {
+        return state.getContext().stream().map(Msg::getTextContent).toList();
+    }
+
+    private static void await(CountDownLatch latch, String message) throws InterruptedException {
+        assertTrue(latch.await(5, TimeUnit.SECONDS), message);
+    }
+
+    private static ChatResponse response() {
+        return ChatResponse.builder()
+                .content(List.<ContentBlock>of(TextBlock.builder().text("done").build()))
+                .build();
+    }
+
+    private static final class NeverModel extends ChatModelBase {
+        private final CountDownLatch subscribed = new CountDownLatch(1);
+
+        @Override
+        public String getModelName() {
+            return "never";
+        }
+
+        @Override
+        protected Flux<ChatResponse> doStream(
+                List<Msg> messages, List<ToolSchema> tools, GenerateOptions options) {
+            return Flux.defer(
+                    () -> {
+                        subscribed.countDown();
+                        return Flux.never();
+                    });
+        }
+    }
+
+    private static final class FixedModel extends ChatModelBase {
+        @Override
+        public String getModelName() {
+            return "fixed";
+        }
+
+        @Override
+        protected Flux<ChatResponse> doStream(
+                List<Msg> messages, List<ToolSchema> tools, GenerateOptions options) {
+            return Flux.just(response());
+        }
+    }
+
+    private static final class FirstCallNeverModel extends ChatModelBase {
+        private final CountDownLatch firstSubscribed = new CountDownLatch(1);
+        private final AtomicInteger subscriptions = new AtomicInteger();
+
+        @Override
+        public String getModelName() {
+            return "first-never";
+        }
+
+        @Override
+        protected Flux<ChatResponse> doStream(
+                List<Msg> messages, List<ToolSchema> tools, GenerateOptions options) {
+            return Flux.defer(
+                    () -> {
+                        if (subscriptions.incrementAndGet() == 1) {
+                            firstSubscribed.countDown();
+                            return Flux.never();
+                        }
+                        return Flux.just(response());
+                    });
+        }
+    }
+
+    private static final class RoutingModel extends ChatModelBase {
+        private final CountDownLatch cancelledSubscribed = new CountDownLatch(1);
+        private final CountDownLatch sameSessionSubscribed = new CountDownLatch(1);
+        private final CountDownLatch otherSessionSubscribed = new CountDownLatch(1);
+
+        @Override
+        public String getModelName() {
+            return "routing";
+        }
+
+        @Override
+        protected Flux<ChatResponse> doStream(
+                List<Msg> messages, List<ToolSchema> tools, GenerateOptions options) {
+            return Flux.defer(
+                    () -> {
+                        String latest = messages.get(messages.size() - 1).getTextContent();
+                        if ("cancelled input".equals(latest)) {
+                            cancelledSubscribed.countDown();
+                            return Flux.never();
+                        }
+                        if ("same session follow-up".equals(latest)) {
+                            sameSessionSubscribed.countDown();
+                        } else if ("other session input".equals(latest)) {
+                            otherSessionSubscribed.countDown();
+                        }
+                        return Flux.just(response());
+                    });
+        }
+    }
+
+    private static class SnapshotStore extends InMemoryAgentStateStore {
+        private final CountDownLatch saved = new CountDownLatch(1);
+        private final AtomicInteger saveCount = new AtomicInteger();
+
+        @Override
+        public void save(String userId, String sessionId, String key, State value) {
+            if (AGENT_STATE_KEY.equals(key) && value instanceof AgentState state) {
+                saveCount.incrementAndGet();
+                super.save(userId, sessionId, key, AgentState.fromJsonString(state.toJson()));
+                saved.countDown();
+                return;
+            }
+            super.save(userId, sessionId, key, value);
+        }
+    }
+
+    private static final class FailingOnceStore extends SnapshotStore {
+        private final CountDownLatch failedSaveAttempted = new CountDownLatch(1);
+        private final AtomicBoolean failNextSave = new AtomicBoolean(true);
+
+        @Override
+        public void save(String userId, String sessionId, String key, State value) {
+            if (AGENT_STATE_KEY.equals(key) && failNextSave.compareAndSet(true, false)) {
+                failedSaveAttempted.countDown();
+                throw new IllegalStateException("simulated checkpoint failure");
+            }
+            super.save(userId, sessionId, key, value);
+        }
+    }
+
+    private static final class BlockingFirstSaveStore extends SnapshotStore {
+        private final String blockedSessionId;
+        private final AtomicBoolean blockNextSave = new AtomicBoolean(true);
+        private final CountDownLatch blockingSaveStarted = new CountDownLatch(1);
+        private final CountDownLatch allowBlockingSave = new CountDownLatch(1);
+
+        private BlockingFirstSaveStore(String blockedSessionId) {
+            this.blockedSessionId = blockedSessionId;
+        }
+
+        @Override
+        public void save(String userId, String sessionId, String key, State value) {
+            if (AGENT_STATE_KEY.equals(key)
+                    && blockedSessionId.equals(sessionId)
+                    && blockNextSave.compareAndSet(true, false)) {
+                blockingSaveStarted.countDown();
+                try {
+                    if (!allowBlockingSave.await(5, TimeUnit.SECONDS)) {
+                        throw new IllegalStateException("timed out waiting to release test save");
+                    }
+                } catch (InterruptedException error) {
+                    Thread.currentThread().interrupt();
+                    throw new IllegalStateException("test save interrupted", error);
+                }
+            }
+            super.save(userId, sessionId, key, value);
+        }
+    }
+}

--- a/docs/v2/en/docs/building-blocks/context.md
+++ b/docs/v2/en/docs/building-blocks/context.md
@@ -49,6 +49,8 @@ An [`AgentStateStore`](../../integration/session/index.md) persists an **`AgentS
 
 At the end of each `call()`, the framework writes the entire `AgentState` to the state store under the key `agent_state`, addressed by the call's `(userId, sessionId)`. The next `call()` with the same `(userId, sessionId)` loads it back automatically. **Provided the state store is distributed (e.g. Redis), agent instances on different processes — even different physical machines — see identical state.**
 
+If a downstream subscriber cancels `streamEvents()` after the call scope has been established — for example, when an SSE client disconnects — the framework starts one best-effort checkpoint of that call's live `AgentState`. The per-session gate admits the next call for the same `(userId, sessionId)` only after this checkpoint succeeds or fails, preventing a stale reload or an older delayed save from overwriting newer state. Other sessions remain independent. A storage failure is logged but does not prevent lifecycle cleanup; without an `AgentStateStore`, cancellation persistence is a no-op.
+
 ### The auto-persistence and recovery flow
 
 ```
@@ -75,7 +77,7 @@ call(msgs, RuntimeContext(userId, sessionId))
 
 This wiring lives in `ReActAgent` itself; `HarnessAgent` inherits it for free. The agent instance holds no fixed session — each call reads / writes the slot named by its `RuntimeContext` (falling back to the builder-time `defaultSessionId`).
 
-> Mid-`call()` state changes happen against the in-memory `AgentState`. **The state store is written once per call (and on shutdown), not on every message** — so the throughput pressure on your store stays low.
+> Mid-`call()` state changes happen against the in-memory `AgentState`. **The state store is written once on normal completion or downstream cancellation (and on shutdown), not on every message** — so the throughput pressure on your store stays low.
 
 ### Built-in and extension implementations
 

--- a/docs/v2/zh/docs/building-blocks/context.md
+++ b/docs/v2/zh/docs/building-blocks/context.md
@@ -49,6 +49,8 @@ description: "无状态 Agent 引擎、AgentState 生命周期、状态持久化
 
 一次 `call()` 结束,框架自动把整份 `AgentState` 以 `agent_state` 这个键写进状态存储,按该次调用的 `(userId, sessionId)` 寻址。下次同 `(userId, sessionId)` 的 `call()` 会自动从存储读回——**只要状态存储是分布式的(例如 Redis),不同进程、不同物理机上的 agent 实例都能拿到完全一致的状态**。
 
+如果 `streamEvents()` 在 call-scope 建立后被下游取消——例如 SSE 客户端断连——框架会对该次调用的 live `AgentState` 发起一次 best-effort checkpoint。同一 `(userId, sessionId)` 的下一次调用会等到该 checkpoint 成功或失败后才通过 per-session gate,避免读到陈旧状态,也避免旧调用的延迟保存覆盖新状态;其他 session 不受影响。存储失败只记录日志,不会阻止生命周期清理;未配置 `AgentStateStore` 时取消保存是安全的 no-op。
+
 ### 自动持久化与恢复链路
 
 ```
@@ -75,7 +77,7 @@ call(msgs, RuntimeContext(userId, sessionId))
 
 这套机制是 **`ReActAgent` 自带**的,`HarnessAgent` 直接继承,无需额外配置。Agent 实例不绑定固定 session——每次调用读写的是其 `RuntimeContext` 指定的槽位(缺省回退到 builder 上的 `defaultSessionId`)。
 
-> 单次 `call()` 期间的中间状态变更靠的是内存里的 `AgentState` 对象。**状态存储不在每条消息后落盘,而是在 call 结束 / shutdown 时整体写入**——所以对后端的吞吐压力很低。
+> 单次 `call()` 期间的中间状态变更靠的是内存里的 `AgentState` 对象。**状态存储不在每条消息后落盘,而是在 call 正常完成、下游取消或 shutdown 时整体写入**——所以对后端的吞吐压力很低。
 
 ### 内置与扩展实现
 


### PR DESCRIPTION
## AgentScope-Java Version

2.0.1-SNAPSHOT

## Description

Fixes #1997.

### Background

When a `streamEvents(...)` subscription is cancelled, such as after an SSE
disconnect, the normal completion-based persistence path is not reached. The
live per-call `AgentState` may therefore be cleaned up without a timely
checkpoint, making intermediate context, summary, task, plan, tool, and
subagent state unrecoverable.

### Changes

- Capture the exact per-call scope after it has been established.
- Trigger a best-effort checkpoint when the call receives a downstream
  cancellation signal.
- Reuse the existing `CallExecution` and session persistence path so the
  correct `(userId, sessionId, agent_state)` is saved.
- Keep the same-session serialization gate closed until cancellation
  persistence terminates, preventing a newer call from loading stale state or
  being overwritten by an older delayed save.
- Preserve concurrency between different sessions.
- Keep lifecycle cleanup, sandbox release, shutdown unregister, and session
  gate release safe when persistence fails.
- Keep cancellation safe when no `AgentStateStore` is configured.
- Avoid duplicate persistence on normal completion.
- Add unit tests covering cancellation persistence, complete state recovery,
  normal completion, missing stores, persistence failures, same-session
  ordering, and cross-session isolation.
- Document cancellation checkpoint behavior in the English and Chinese
  context documentation.

### Testing

- `ReActAgentCancellationCheckpointTest`: 5/5 passed.
- `DangerousPathBypassTest`: 9/9 passed when rerun with the required Windows
  symbolic-link privilege.
- `GracefulShutdownTest`: 46/46 passed in isolation.
- Project-wide `clean verify` completed successfully across all 82 reactor
  modules, with the Windows privilege-dependent and shared-state
  order-sensitive test classes verified separately as listed above.
- Spotless validation passed.
- Javadoc generation and doclint validation passed.

## Checklist

Please check the following items before code is ready to be reviewed.

- [x] Code formatting passes the project Spotless checks
- [x] All tests are passing (`mvn test`)
- [x] Javadoc comments are complete and follow project conventions
- [x] Related documentation has been updated (e.g. links, examples, etc.)
- [x] Code is ready for review