### PR TITLE
fix(harness): preserve RuntimeContext during skill promotion

### DIFF
--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/HarnessAgent.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/HarnessAgent.java
@@ -287,13 +287,25 @@ public class HarnessAgent implements Agent, AutoCloseable {
      * configured {@link SkillPromotionGate}.
      */
     public Mono<SkillPromoter.PromotionResult> promoteSkill(String name, String reviewerId) {
+        return promoteSkill(name, reviewerId, getRuntimeContext());
+    }
+
+    /**
+     * Promote a draft skill for the explicitly supplied request context.
+     *
+     * <p>Callers promoting skills outside an active {@code call(...)} must use this overload when
+     * the workspace is user- or session-scoped so the draft is resolved and moved within the
+     * correct namespace.
+     */
+    public Mono<SkillPromoter.PromotionResult> promoteSkill(
+            String name, String reviewerId, RuntimeContext ctx) {
         if (skillPromoter == null) {
             return Mono.just(
                     SkillPromoter.PromotionResult.invalid(
                             "skill promoter not configured; call"
                                     + " enableSkillManageTool(...) on the builder"));
         }
-        return skillPromoter.promote(name, reviewerId, getRuntimeContext());
+        return skillPromoter.promote(name, reviewerId, ctx);
     }
 
     /**

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/skill/RuntimeContextSkillRepository.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/skill/RuntimeContextSkillRepository.java
@@ -25,4 +25,17 @@ public interface RuntimeContextSkillRepository extends AgentSkillRepository {
 
     /** Returns the skills visible to exactly the supplied request context. */
     List<AgentSkill> getAllSkills(RuntimeContext context);
+
+    /** Returns the named skill visible to exactly the supplied request context. */
+    default AgentSkill getSkill(String name, RuntimeContext context) {
+        if (name == null || name.isBlank()) {
+            return null;
+        }
+        for (AgentSkill skill : getAllSkills(context)) {
+            if (name.equals(skill.getName())) {
+                return skill;
+            }
+        }
+        return null;
+    }
 }

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/skill/curator/SkillPromoter.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/skill/curator/SkillPromoter.java
@@ -88,9 +88,10 @@ public class SkillPromoter {
         if (name == null || name.isBlank()) {
             return Mono.just(PromotionResult.invalid("name is required"));
         }
+        RuntimeContext effectiveCtx = ctx != null ? ctx : RuntimeContext.empty();
         AgentSkill draft;
         try {
-            draft = draftsRepo.getSkill(name);
+            draft = draftsRepo.getSkill(name, effectiveCtx);
         } catch (Exception e) {
             return Mono.just(PromotionResult.invalid("failed to load draft: " + e.getMessage()));
         }
@@ -101,7 +102,7 @@ public class SkillPromoter {
         // 1. Security scan (always — even when SkillManageTool already scanned, this is the
         //    last gate before going live). Pull resources off disk because the repository's
         //    {@code getSkill(name)} only loads SKILL.md.
-        java.util.Map<String, String> resources = loadDraftResources(name);
+        java.util.Map<String, String> resources = loadDraftResources(name, effectiveCtx);
         SkillSecurityScanner.ScanResult scan =
                 SkillSecurityScanner.scan(name, mdOf(draft), resources);
         if (!SkillSecurityScanner.shouldAllow(
@@ -113,15 +114,16 @@ public class SkillPromoter {
 
         // 2. Build candidate package and call the gate.
         SkillCandidate candidate = buildCandidate(draft, scan);
-        return gate.review(candidate, ctx)
-                .map(decision -> applyDecision(name, reviewerId, decision, scan));
+        return gate.review(candidate, effectiveCtx)
+                .map(decision -> applyDecision(name, reviewerId, decision, scan, effectiveCtx));
     }
 
     private PromotionResult applyDecision(
             String name,
             String reviewerId,
             SkillPromotionGate.PromotionDecision decision,
-            SkillSecurityScanner.ScanResult scan) {
+            SkillSecurityScanner.ScanResult scan,
+            RuntimeContext ctx) {
         if (decision instanceof SkillPromotionGate.PromotionDecision.Reject reject) {
             return PromotionResult.rejected(
                     "gate rejected: " + reject.reason() + " (by " + reject.reviewerId() + ")",
@@ -140,7 +142,7 @@ public class SkillPromoter {
         if (workspaceManager == null) {
             return PromotionResult.invalid("workspaceManager is null; cannot move directory");
         }
-        boolean moved = workspaceManager.moveSkill(RuntimeContext.empty(), src, dst);
+        boolean moved = workspaceManager.moveSkill(ctx, src, dst);
         if (!moved) {
             return PromotionResult.invalid("failed to move draft directory");
         }
@@ -232,7 +234,7 @@ public class SkillPromoter {
      * assets/) so the security scanner sees the full payload — the repository's
      * {@code getSkill} only deserialises SKILL.md.
      */
-    private java.util.Map<String, String> loadDraftResources(String skillName) {
+    private java.util.Map<String, String> loadDraftResources(String skillName, RuntimeContext ctx) {
         java.util.Map<String, String> out = new java.util.LinkedHashMap<>();
         for (String sub : new String[] {"scripts", "references", "templates", "assets"}) {
             // Read each known support directory under <draftsDir>/<name>/<sub>/.
@@ -240,10 +242,7 @@ public class SkillPromoter {
             // filesystem for a glob match scoped to that subdirectory.
             String relDir = draftsDir + "/" + skillName + "/" + sub;
             try {
-                var glob =
-                        draftsRepo
-                                .filesystem()
-                                .glob(io.agentscope.core.agent.RuntimeContext.empty(), "*", relDir);
+                var glob = draftsRepo.filesystem().glob(ctx, "*", relDir);
                 if (!glob.isSuccess() || glob.matches() == null) {
                     continue;
                 }
@@ -256,14 +255,7 @@ public class SkillPromoter {
                     int idx = pathSlash.indexOf("/" + sub + "/");
                     if (idx < 0) continue;
                     String relPath = pathSlash.substring(idx + 1);
-                    var rr =
-                            draftsRepo
-                                    .filesystem()
-                                    .read(
-                                            io.agentscope.core.agent.RuntimeContext.empty(),
-                                            path,
-                                            0,
-                                            0);
+                    var rr = draftsRepo.filesystem().read(ctx, path, 0, 0);
                     if (rr.isSuccess() && rr.fileData() != null) {
                         out.put(relPath, rr.fileData().content());
                     }

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/skill/curator/SkillPromoterTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/skill/curator/SkillPromoterTest.java
@@ -21,6 +21,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.agentscope.core.agent.RuntimeContext;
+import io.agentscope.harness.agent.IsolationScope;
 import io.agentscope.harness.agent.filesystem.AbstractFilesystem;
 import io.agentscope.harness.agent.filesystem.local.LocalFilesystem;
 import io.agentscope.harness.agent.skill.WorkspaceSkillRepository;
@@ -30,6 +31,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Instant;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -208,5 +210,114 @@ class SkillPromoterTest {
                         "skills");
         PromotionResult result = promoter.promote("ghost", "alice", RuntimeContext.empty()).block();
         assertEquals(PromotionResult.Status.INVALID, result.status());
+    }
+
+    @Test
+    void explicitContext_promotesOnlyTheOwningUsersDraft() throws Exception {
+        LocalFilesystem userFs =
+                new LocalFilesystem(workspace, false, 64, IsolationScope.USER.toNamespaceFactory());
+        WorkspaceSkillRepository userDrafts =
+                new WorkspaceSkillRepository(
+                        userFs, "skills/_drafts", RuntimeContext::empty, "drafts");
+        WorkspaceSkillRepository userMain =
+                new WorkspaceSkillRepository(userFs, "skills", RuntimeContext::empty, "main");
+        WorkspaceManager userWorkspaceManager = new WorkspaceManager(workspace, userFs);
+        RuntimeContext alice =
+                RuntimeContext.builder().userId("alice").sessionId("session-a").build();
+        RuntimeContext bob = RuntimeContext.builder().userId("bob").sessionId("session-b").build();
+
+        Path aliceDraft = workspace.resolve("alice/skills/_drafts/private-skill");
+        Files.createDirectories(aliceDraft.resolve("scripts"));
+        Files.writeString(
+                aliceDraft.resolve("SKILL.md"),
+                validSkillMd("private-skill", "Alice's private skill."));
+        Files.writeString(aliceDraft.resolve("scripts/run.sh"), "echo safe\n");
+
+        AtomicBoolean gateCalled = new AtomicBoolean();
+        SkillPromotionGate approveGate =
+                (candidate, ctx) -> {
+                    gateCalled.set(true);
+                    assertEquals("alice", ctx.getUserId());
+                    return Mono.just(
+                            new SkillPromotionGate.PromotionDecision.Approve(
+                                    "reviewer", List.of("prod"), Instant.now()));
+                };
+        SkillPromoter promoter =
+                new SkillPromoter(
+                        userDrafts,
+                        userMain,
+                        userWorkspaceManager,
+                        null,
+                        approveGate,
+                        "skills/_drafts",
+                        "skills");
+
+        try {
+            PromotionResult bobResult = promoter.promote("private-skill", "reviewer", bob).block();
+            assertNotNull(bobResult);
+            assertEquals(PromotionResult.Status.INVALID, bobResult.status());
+            assertTrue(Files.exists(aliceDraft.resolve("SKILL.md")));
+            assertTrue(!gateCalled.get());
+
+            PromotionResult aliceResult =
+                    promoter.promote("private-skill", "reviewer", alice).block();
+            assertNotNull(aliceResult);
+            assertEquals(PromotionResult.Status.APPROVED, aliceResult.status());
+            assertTrue(gateCalled.get());
+            assertTrue(
+                    Files.exists(workspace.resolve("alice/skills/private-skill/scripts/run.sh")));
+            assertTrue(!Files.exists(aliceDraft));
+            assertTrue(!Files.exists(workspace.resolve("bob/skills/private-skill")));
+        } finally {
+            userWorkspaceManager.close();
+        }
+    }
+
+    @Test
+    void explicitContext_scansResourcesInTheOwningUsersNamespace() throws Exception {
+        LocalFilesystem userFs =
+                new LocalFilesystem(workspace, false, 64, IsolationScope.USER.toNamespaceFactory());
+        WorkspaceSkillRepository userDrafts =
+                new WorkspaceSkillRepository(
+                        userFs, "skills/_drafts", RuntimeContext::empty, "drafts");
+        WorkspaceSkillRepository userMain =
+                new WorkspaceSkillRepository(userFs, "skills", RuntimeContext::empty, "main");
+        WorkspaceManager userWorkspaceManager = new WorkspaceManager(workspace, userFs);
+        RuntimeContext alice = RuntimeContext.builder().userId("alice").build();
+
+        Path aliceDraft = workspace.resolve("alice/skills/_drafts/dangerous-skill");
+        Files.createDirectories(aliceDraft.resolve("scripts"));
+        Files.writeString(
+                aliceDraft.resolve("SKILL.md"),
+                validSkillMd("dangerous-skill", "Skill with a dangerous resource."));
+        Files.writeString(aliceDraft.resolve("scripts/run.sh"), "rm -rf /\n");
+
+        AtomicBoolean gateCalled = new AtomicBoolean();
+        SkillPromotionGate approveGate =
+                (candidate, ctx) -> {
+                    gateCalled.set(true);
+                    return Mono.just(
+                            new SkillPromotionGate.PromotionDecision.Approve(
+                                    "reviewer", List.of("prod"), Instant.now()));
+                };
+        SkillPromoter promoter =
+                new SkillPromoter(
+                        userDrafts,
+                        userMain,
+                        userWorkspaceManager,
+                        null,
+                        approveGate,
+                        "skills/_drafts",
+                        "skills");
+
+        try {
+            PromotionResult result = promoter.promote("dangerous-skill", "reviewer", alice).block();
+            assertNotNull(result);
+            assertEquals(PromotionResult.Status.REJECTED, result.status());
+            assertTrue(!gateCalled.get());
+            assertTrue(Files.exists(aliceDraft.resolve("SKILL.md")));
+        } finally {
+            userWorkspaceManager.close();
+        }
     }
 }


### PR DESCRIPTION
## AgentScope-Java Version

2.0.1-SNAPSHOT

## Description

### Background

Skill promotion did not consistently preserve the caller's `RuntimeContext`.

For USER- or SESSION-scoped workspaces, the context determines which filesystem namespace contains the draft skill. Although `SkillPromoter.promote(...)` accepted a context, the following operations still used the default context or `RuntimeContext.empty()`:

- Draft skill lookup
- Supporting resource discovery and reading
- Moving the approved skill into the live directory

This could cause a user-scoped draft to appear missing or make promotion operate on the wrong namespace.

### Changes

- Added `HarnessAgent.promoteSkill(name, reviewerId, RuntimeContext)` for explicit context propagation.
- Kept the existing overload backward-compatible by delegating with the agent's current context.
- Added context-aware skill lookup to `RuntimeContextSkillRepository`.
- Propagated the same effective context through:
  - Draft lookup
  - Resource loading and security scanning
  - Promotion gate review
  - Filesystem move
- Added regression tests for USER-scoped skill isolation.

### Expected Behavior

- A user can promote a draft from their own namespace.
- Another user cannot see or promote that draft.
- Supporting files are scanned in the owning user's namespace.
- Dangerous resources are rejected before invoking the promotion gate.