### PR TITLE
fix: default project root to workspace instead of user.dir in LocalFilesystemSpec

### DIFF
--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/filesystem/spec/LocalFilesystemSpec.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/filesystem/spec/LocalFilesystemSpec.java
@@ -26,7 +26,6 @@ import io.agentscope.harness.agent.filesystem.sandbox.AbstractSandboxFilesystem;
 import io.agentscope.harness.agent.workspace.LocalFsMode;
 import io.agentscope.harness.agent.workspace.PathPolicy;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.LinkedHashMap;
@@ -69,7 +68,7 @@ public class LocalFilesystemSpec {
      * the shell {@code pwd} for {@code execute()} so command output matches user expectation.
      *
      * <p>{@code null} until {@link #project(Path)} is called; defaults to
-     * {@link System#getProperty(String) System.getProperty("user.dir")} at
+     * the agent {@code workspace} directory at
      * {@link #toFilesystem} time.
      */
     private Path project;
@@ -249,7 +248,7 @@ public class LocalFilesystemSpec {
      * etc. fall back to this directory when the agent {@code workspace} does not contain them;
      * shell {@code execute()} runs with {@code pwd} set to this directory.
      *
-     * <p>Defaults to {@code System.getProperty("user.dir")} when not set.
+     * <p>Defaults to the agent {@code workspace} directory when not set.
      *
      * @param project project root path
      * @return this spec
@@ -270,7 +269,7 @@ public class LocalFilesystemSpec {
      * @param localNamespaceFactory optional namespace factory for per-user/session folder scoping
      * @return an {@link OverlayFilesystem} wired with the options in this spec
      */
-    /** Project root explicitly configured, or {@code null} to fall back to {@code ${user.dir}}. */
+    /** Project root explicitly configured, or {@code null} to fall back to the agent workspace. */
     public Path getProject() {
         return project;
     }
@@ -287,7 +286,7 @@ public class LocalFilesystemSpec {
 
     public AbstractFilesystem toFilesystem(Path workspace, NamespaceFactory localNamespaceFactory) {
         Path effectiveProject =
-                project != null ? project : Paths.get(System.getProperty("user.dir"));
+                project != null ? project : workspace;
         List<Path> policyRoots = new ArrayList<>();
         policyRoots.add(effectiveProject);
         policyRoots.add(workspace);


### PR DESCRIPTION
Fixes #2065

## Problem

`LocalFilesystemSpec.toFilesystem()` falls back to `System.getProperty("user.dir")` when `project` is not explicitly set. In non-CLI scenarios (web applications, embedded agents), this exposes the JVM's working directory as the read-only lower layer of the OverlayFilesystem, allowing the agent to read source code, config files, and other sensitive files it should not have access to.

## Root cause

`Paths.get(System.getProperty("user.dir"))` in `toFilesystem()` — the JVM working directory is unrelated to the agent's intended workspace in non-CLI deployments.

## Fix

- Default `effectiveProject` to `workspace` (the agent workspace root, same as the upper layer) instead of `System.getProperty("user.dir")` when `project` is null
- Remove unused `import java.nio.file.Paths`
- Update all Javadoc references to reflect the new default

CLI users who need their project directory as the lower layer should continue to call `.project(Path)` explicitly.
