### PR TITLE
fix(core): preserve AgentEventEmitter context for subagent streaming

### DIFF
--- a/agentscope-core/src/main/java/io/agentscope/core/ReActAgent.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/ReActAgent.java
@@ -148,6 +148,7 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.FluxSink;
 import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Schedulers;
+import reactor.util.context.Context;
 
 /**
  * ReAct (Reasoning and Acting) Agent implementation.
@@ -2635,9 +2636,39 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
                                                 Disposable toolCallsDisposable =
                                                         executeToolCalls(approved)
                                                                 .contextWrite(
-                                                                        ctx ->
-                                                                                ctx.putAll(
-                                                                                        parentCtx))
+                                                                        ctx -> {
+                                                                            Context merged =
+                                                                                    ctx.putAll(
+                                                                                            parentCtx);
+                                                                            if (!merged.hasKey(
+                                                                                            SubagentEventBus
+                                                                                                    .CONTEXT_KEY)
+                                                                                    && !merged
+                                                                                            .hasKey(
+                                                                                                    AgentEventEmitter
+                                                                                                            .CONTEXT_KEY)) {
+                                                                                if (eventSink
+                                                                                        != null) {
+                                                                                    merged =
+                                                                                            merged
+                                                                                                    .put(
+                                                                                                            AgentEventEmitter
+                                                                                                                    .CONTEXT_KEY,
+                                                                                                            (AgentEventEmitter)
+                                                                                                                    eventSink
+                                                                                                                            ::next);
+                                                                                } else if (externalEventEmitter
+                                                                                        != null) {
+                                                                                    merged =
+                                                                                            merged
+                                                                                                    .put(
+                                                                                                            AgentEventEmitter
+                                                                                                                    .CONTEXT_KEY,
+                                                                                                            externalEventEmitter);
+                                                                                }
+                                                                            }
+                                                                            return merged;
+                                                                        })
                                                                 .subscribe(
                                                                         results -> {
                                                                             List<

--- a/agentscope-core/src/test/java/io/agentscope/core/agent/ReActAgentNewLoopE2ETest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/agent/ReActAgentNewLoopE2ETest.java
@@ -22,6 +22,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import io.agentscope.core.ReActAgent;
 import io.agentscope.core.event.AgentEndEvent;
 import io.agentscope.core.event.AgentEvent;
+import io.agentscope.core.event.AgentEventEmitter;
 import io.agentscope.core.event.AgentStartEvent;
 import io.agentscope.core.event.ModelCallEndEvent;
 import io.agentscope.core.event.ToolCallEndEvent;
@@ -50,6 +51,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -160,6 +162,39 @@ class ReActAgentNewLoopE2ETest {
         }
     }
 
+    private static final class ContextProbeTool extends ToolBase {
+        private final AtomicBoolean emitterPresent;
+
+        ContextProbeTool(String name, AtomicBoolean emitterPresent) {
+            super(
+                    name,
+                    "checks the Reactor Context",
+                    AlwaysAllowTool.schema(),
+                    true,
+                    true,
+                    false,
+                    null,
+                    false,
+                    false);
+            this.emitterPresent = emitterPresent;
+        }
+
+        @Override
+        public Mono<PermissionDecision> checkPermissions(
+                Map<String, Object> input, PermissionContextState ctx) {
+            return Mono.just(PermissionDecision.allow("ok"));
+        }
+
+        @Override
+        public Mono<ToolResultBlock> callAsync(ToolCallParam param) {
+            return Mono.deferContextual(
+                    ctx -> {
+                        emitterPresent.set(AgentEventEmitter.fromContext(ctx).isPresent());
+                        return Mono.just(ToolResultBlock.text("context checked"));
+                    });
+        }
+    }
+
     private static final class RecordingMiddleware implements MiddlewareBase {
         final List<String> trace = new ArrayList<>();
 
@@ -181,6 +216,18 @@ class ReActAgentNewLoopE2ETest {
                 Function<ActingInput, Flux<AgentEvent>> next) {
             trace.add("acting:enter");
             return next.apply(input).doOnComplete(() -> trace.add("acting:exit"));
+        }
+    }
+
+    private static final class RemoveAgentEventEmitterContextMiddleware implements MiddlewareBase {
+        @Override
+        public Flux<AgentEvent> onActing(
+                Agent agent,
+                RuntimeContext ctx,
+                ActingInput input,
+                Function<ActingInput, Flux<AgentEvent>> next) {
+            return next.apply(input)
+                    .contextWrite(context -> context.delete(AgentEventEmitter.CONTEXT_KEY));
         }
     }
 
@@ -291,5 +338,83 @@ class ReActAgentNewLoopE2ETest {
                         .findFirst()
                         .orElseThrow();
         assertEquals(ToolResultState.ERROR, end.getState());
+    }
+
+    @Test
+    void streamEventsToolExecutionReceivesAgentEventEmitterFromEventSinkFallback() {
+        AtomicBoolean emitterPresent = new AtomicBoolean();
+        ScriptedModel model =
+                new ScriptedModel(
+                        List.of(
+                                () -> Flux.just(toolUseResponse("c1", "probe", "event-sink")),
+                                () -> Flux.just(textResponse("done"))));
+        Toolkit tk = new Toolkit();
+        tk.registerAgentTool(new ContextProbeTool("probe", emitterPresent));
+
+        ReActAgent agent =
+                ReActAgent.builder()
+                        .name("asst")
+                        .sysPrompt("you are helpful")
+                        .model(model)
+                        .toolkit(tk)
+                        .middleware(new RemoveAgentEventEmitterContextMiddleware())
+                        .build();
+
+        List<AgentEvent> events =
+                agent.streamEvents(
+                                List.of(
+                                        Msg.builder()
+                                                .role(MsgRole.USER)
+                                                .textContent("check context")
+                                                .build()))
+                        .collectList()
+                        .block();
+
+        assertNotNull(events);
+        assertTrue(
+                emitterPresent.get(),
+                "tool execution should receive AgentEventEmitter from the event sink fallback");
+    }
+
+    @Test
+    void forwardedCallToolExecutionReceivesAgentEventEmitterFromExternalEmitterFallback() {
+        AtomicBoolean emitterPresent = new AtomicBoolean();
+        ScriptedModel model =
+                new ScriptedModel(
+                        List.of(
+                                () -> Flux.just(toolUseResponse("c1", "probe", "forwarded")),
+                                () -> Flux.just(textResponse("done"))));
+        Toolkit tk = new Toolkit();
+        tk.registerAgentTool(new ContextProbeTool("probe", emitterPresent));
+
+        ReActAgent agent =
+                ReActAgent.builder()
+                        .name("asst")
+                        .sysPrompt("you are helpful")
+                        .model(model)
+                        .toolkit(tk)
+                        .middleware(new RemoveAgentEventEmitterContextMiddleware())
+                        .build();
+        AgentEventEmitter forwardingEmitter = event -> {};
+
+        Msg result =
+                agent.call(
+                                List.of(
+                                        Msg.builder()
+                                                .role(MsgRole.USER)
+                                                .textContent("check forwarded context")
+                                                .build()))
+                        .contextWrite(
+                                ctx ->
+                                        ctx.put(
+                                                AgentEventEmitter.FORWARDING_CONTEXT_KEY,
+                                                forwardingEmitter))
+                        .block();
+
+        assertNotNull(result);
+        assertTrue(
+                emitterPresent.get(),
+                "tool execution should receive AgentEventEmitter from the external emitter"
+                        + " fallback");
     }
 }


### PR DESCRIPTION
## AgentScope-Java Version

2.0.1-SNAPSHOT

## Description

### Background

`streamEvents()` did not consistently forward local synchronous subagent events to the parent agent event stream.

For a parent `HarnessAgent.streamEvents(...)` call, `ReActAgent#buildAgentStream` installs an `AgentEventEmitter` in the Reactor Context so tools such as `agent_spawn` can forward child agent events into the parent `Flux<AgentEvent>`.

However, during the acting phase, `CallExecution#runToolBatch` bridges tool execution through an internal `Flux.create(...)` and manually subscribes to `executeToolCalls(...)`. In that path, the Reactor Context available to tool execution may no longer contain `AgentEventEmitter.CONTEXT_KEY`.

As a result, `AgentSpawnTool#execLocalSync` cannot enter its `streamEvents()` forwarding path:

```java
AgentEventEmitter.fromContext(ctxView)
```
and falls back to non-forwarding local execution. The subagent still runs and produces its own internal events, but those events are not tagged with the subagent source path and are not emitted into the parent agent's event stream.
This breaks real-time subagent streaming for local synchronous subagents spawned from a parent `streamEvents()` run.

## Changes
* Preserved the parent `AgentEventEmitter` when dispatching approved tool calls from `CallExecution#runToolBatch`.
* Added a context fallback so tool execution receives `AgentEventEmitter.CONTEXT_KEY` when:
  * the current Reactor Context does not already contain an `AgentEventEmitter`
  * the deprecated `SubagentEventBus` path is not active
  * the current call scope already has `eventSink` or `externalEventEmitter`
* Kept the deprecated `stream()` / `SubagentEventBus` behavior unchanged by avoiding forced `AgentEventEmitter` injection when `SubagentEventBus.CONTEXT_KEY` is present.
* Ensured `AgentSpawnTool#execLocalSync` can enter the `streamEvents()` forwarding path and emit child events into the parent stream with source tagging.

## Expected Behavior
* A parent `HarnessAgent.streamEvents(...)` call can spawn a local synchronous subagent via `agent_spawn`.
* The spawned subagent's `AgentEvents` are forwarded into the parent `Flux<AgentEvent>`.
* Forwarded subagent events include the source path produced by `AgentSpawnTool`.
* Clients consuming the parent stream can render subagent output incrementally instead of waiting for the final `agent_spawn` tool result.
* Existing deprecated `stream()` / `SubagentEventBus` behavior remains unchanged.