### PR TITLE
fix(core): apply transformed model-call text deltas

### DIFF
--- a/agentscope-core/src/main/java/io/agentscope/core/ReActAgent.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/ReActAgent.java
@@ -2133,13 +2133,31 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
             Function<ModelCallInput, Flux<AgentEvent>> modelCallCore =
                     mci -> modelCallStream(context, mci, true);
 
+            StringBuilder transformedText = new StringBuilder();
+            AtomicBoolean sawTransformedTextDelta = new AtomicBoolean(false);
             return MiddlewareChain.build(
                             middlewares,
                             ReActAgent.this,
                             rc,
                             MiddlewareBase::onModelCall,
                             modelCallCore)
-                    .apply(new ModelCallInput(messages, tools, options, modelForCall()));
+                    .apply(new ModelCallInput(messages, tools, options, modelForCall()))
+                    .doOnNext(
+                            event -> {
+                                if (event instanceof TextBlockDeltaEvent textDelta) {
+                                    sawTransformedTextDelta.set(true);
+                                    if (textDelta.getDelta() != null) {
+                                        transformedText.append(textDelta.getDelta());
+                                    }
+                                }
+                            })
+                    .doOnComplete(
+                            () -> {
+                                if (sawTransformedTextDelta.get()
+                                        || !context.getAccumulatedText().isEmpty()) {
+                                    context.replaceAccumulatedText(transformedText.toString());
+                                }
+                            });
         }
 
         private Flux<AgentEvent> modelCallStream(

--- a/agentscope-core/src/main/java/io/agentscope/core/ReActAgent.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/ReActAgent.java
@@ -2151,7 +2151,7 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
                                     }
                                 }
                             })
-                    .doOnComplete(
+                    .doOnTerminate(
                             () -> {
                                 if (sawTransformedTextDelta.get()
                                         || !context.getAccumulatedText().isEmpty()) {

--- a/agentscope-core/src/main/java/io/agentscope/core/agent/accumulator/ReasoningContext.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/agent/accumulator/ReasoningContext.java
@@ -240,6 +240,16 @@ public class ReasoningContext {
     }
 
     /**
+     * Replace accumulated text after {@code onModelCall} middleware transforms text delta events.
+     *
+     * @hidden
+     * @param text text reconstructed from the transformed event stream
+     */
+    public void replaceAccumulatedText(String text) {
+        textAcc.replace(text);
+    }
+
+    /**
      * Get the accumulated thinking content.
      *
      * @hidden

--- a/agentscope-core/src/main/java/io/agentscope/core/agent/accumulator/TextAccumulator.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/agent/accumulator/TextAccumulator.java
@@ -74,4 +74,16 @@ public class TextAccumulator implements ContentAccumulator<TextBlock> {
     public String getAccumulated() {
         return accumulated.toString();
     }
+
+    /**
+     * Replace the accumulated text with content reconstructed from the model-call event stream.
+     *
+     * @hidden
+     */
+    public void replace(String text) {
+        accumulated.setLength(0);
+        if (text != null) {
+            accumulated.append(text);
+        }
+    }
 }

--- a/agentscope-core/src/main/java/io/agentscope/core/middleware/MiddlewareBase.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/middleware/MiddlewareBase.java
@@ -112,6 +112,10 @@ public interface MiddlewareBase {
     /**
      * Intercept the raw model API call.
      *
+     * <p>Transformations to {@link io.agentscope.core.event.TextBlockDeltaEvent} instances in the
+     * returned stream are reflected in the final response message. This allows middleware to
+     * normalize model text before consumers, including native structured-output parsing, use it.
+     *
      * @param agent the agent instance
      * @param ctx   per-call runtime context (session, user, attributes)
      * @param input model-call input (messages, tools, options, model)

--- a/agentscope-core/src/test/java/io/agentscope/core/agent/ReActAgentMiddlewareIntegrationTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/agent/ReActAgentMiddlewareIntegrationTest.java
@@ -16,7 +16,9 @@
 package io.agentscope.core.agent;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.agentscope.core.ReActAgent;
@@ -25,6 +27,7 @@ import io.agentscope.core.event.AgentEvent;
 import io.agentscope.core.event.AgentStartEvent;
 import io.agentscope.core.event.HintBlockEvent;
 import io.agentscope.core.event.ModelCallStartEvent;
+import io.agentscope.core.event.TextBlockDeltaEvent;
 import io.agentscope.core.message.ContentBlock;
 import io.agentscope.core.message.Msg;
 import io.agentscope.core.message.TextBlock;
@@ -231,6 +234,66 @@ class ReActAgentMiddlewareIntegrationTest {
                 reasoningEnters,
                 modelCallEnters,
                 "reasoning and modelCall enter counts must match");
+    }
+
+    @Test
+    void modelCallMiddlewareCanDropAllTextDeltas() {
+        MiddlewareBase droppingMiddleware =
+                new MiddlewareBase() {
+                    @Override
+                    public Flux<AgentEvent> onModelCall(
+                            Agent agent,
+                            RuntimeContext ctx,
+                            ModelCallInput input,
+                            Function<ModelCallInput, Flux<AgentEvent>> next) {
+                        return next.apply(input)
+                                .filter(event -> !(event instanceof TextBlockDeltaEvent));
+                    }
+                };
+        ReActAgent agent = buildAgent(new FixedTextModel("ok"), List.of(droppingMiddleware));
+
+        List<AgentEvent> events = agent.streamEvents(List.of()).collectList().block();
+
+        assertNotNull(events);
+        assertFalse(events.stream().anyMatch(TextBlockDeltaEvent.class::isInstance));
+        assertTrue(events.get(events.size() - 1) instanceof AgentEndEvent);
+    }
+
+    @Test
+    void modelCallMiddlewareCanReplaceTextDeltaWithNull() {
+        MiddlewareBase nullingMiddleware =
+                new MiddlewareBase() {
+                    @Override
+                    public Flux<AgentEvent> onModelCall(
+                            Agent agent,
+                            RuntimeContext ctx,
+                            ModelCallInput input,
+                            Function<ModelCallInput, Flux<AgentEvent>> next) {
+                        return next.apply(input)
+                                .map(
+                                        event -> {
+                                            if (!(event instanceof TextBlockDeltaEvent textDelta)) {
+                                                return event;
+                                            }
+                                            return new TextBlockDeltaEvent(
+                                                    textDelta.getReplyId(),
+                                                    textDelta.getBlockId(),
+                                                    null);
+                                        });
+                    }
+                };
+        ReActAgent agent = buildAgent(new FixedTextModel("ok"), List.of(nullingMiddleware));
+
+        List<AgentEvent> events = agent.streamEvents(List.of()).collectList().block();
+
+        assertNotNull(events);
+        TextBlockDeltaEvent textDelta =
+                events.stream()
+                        .filter(TextBlockDeltaEvent.class::isInstance)
+                        .map(TextBlockDeltaEvent.class::cast)
+                        .findFirst()
+                        .orElseThrow();
+        assertNull(textDelta.getDelta());
     }
 
     /**

--- a/agentscope-core/src/test/java/io/agentscope/core/agent/ReActAgentMiddlewareIntegrationTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/agent/ReActAgentMiddlewareIntegrationTest.java
@@ -80,6 +80,26 @@ class ReActAgentMiddlewareIntegrationTest {
         }
     }
 
+    private static final class InterruptedAfterTextModel extends ChatModelBase {
+        @Override
+        public String getModelName() {
+            return "interrupted-after-text";
+        }
+
+        @Override
+        protected Flux<ChatResponse> doStream(
+                List<Msg> messages, List<ToolSchema> tools, GenerateOptions options) {
+            return Flux.concat(
+                    Flux.just(
+                            ChatResponse.builder()
+                                    .content(
+                                            List.<ContentBlock>of(
+                                                    TextBlock.builder().text("raw").build()))
+                                    .build()),
+                    Flux.error(new InterruptedException("interrupted after text")));
+        }
+    }
+
     /** Records entry/exit at every middleware hook to a shared trace list. */
     private static final class RecordingMiddleware implements MiddlewareBase {
         private final String tag;
@@ -294,6 +314,42 @@ class ReActAgentMiddlewareIntegrationTest {
                         .findFirst()
                         .orElseThrow();
         assertNull(textDelta.getDelta());
+    }
+
+    @Test
+    void transformedTextIsUsedForPartialMessageWhenModelCallIsInterrupted() {
+        MiddlewareBase replacingMiddleware =
+                new MiddlewareBase() {
+                    @Override
+                    public Flux<AgentEvent> onModelCall(
+                            Agent agent,
+                            RuntimeContext ctx,
+                            ModelCallInput input,
+                            Function<ModelCallInput, Flux<AgentEvent>> next) {
+                        return next.apply(input)
+                                .map(
+                                        event -> {
+                                            if (!(event instanceof TextBlockDeltaEvent textDelta)) {
+                                                return event;
+                                            }
+                                            return new TextBlockDeltaEvent(
+                                                    textDelta.getReplyId(),
+                                                    textDelta.getBlockId(),
+                                                    "transformed");
+                                        });
+                    }
+                };
+        ReActAgent agent =
+                buildAgent(new InterruptedAfterTextModel(), List.of(replacingMiddleware));
+
+        agent.streamEvents(List.of()).onErrorResume(error -> Flux.empty()).blockLast();
+
+        assertTrue(
+                agent.getAgentState().getContext().stream()
+                        .anyMatch(message -> "transformed".equals(message.getTextContent())));
+        assertFalse(
+                agent.getAgentState().getContext().stream()
+                        .anyMatch(message -> "raw".equals(message.getTextContent())));
     }
 
     /**

--- a/agentscope-core/src/test/java/io/agentscope/core/agent/ReActAgentStructuredOutputWithToolsTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/agent/ReActAgentStructuredOutputWithToolsTest.java
@@ -23,10 +23,14 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.agentscope.core.ReActAgent;
 import io.agentscope.core.agent.test.TestConstants;
+import io.agentscope.core.event.AgentEvent;
+import io.agentscope.core.event.TextBlockDeltaEvent;
 import io.agentscope.core.message.Msg;
 import io.agentscope.core.message.MsgRole;
 import io.agentscope.core.message.TextBlock;
 import io.agentscope.core.message.ToolUseBlock;
+import io.agentscope.core.middleware.MiddlewareBase;
+import io.agentscope.core.middleware.ModelCallInput;
 import io.agentscope.core.model.ChatResponse;
 import io.agentscope.core.model.ChatUsage;
 import io.agentscope.core.model.GenerateOptions;
@@ -191,6 +195,55 @@ class ReActAgentStructuredOutputWithToolsTest {
                                 .build());
     }
 
+    private static Function<List<Msg>, List<ChatResponse>> fencedNativeResponder() {
+        return msgs ->
+                List.of(
+                        ChatResponse.builder()
+                                .id("msg_1")
+                                .content(List.of(TextBlock.builder().text("```json\n").build()))
+                                .build(),
+                        ChatResponse.builder()
+                                .id("msg_1")
+                                .content(
+                                        List.of(
+                                                TextBlock.builder()
+                                                        .text(
+                                                                "{\"city\":\"Shanghai\","
+                                                                    + "\"temperature\":\"32°C\"}")
+                                                        .build()))
+                                .build(),
+                        ChatResponse.builder()
+                                .id("msg_1")
+                                .content(List.of(TextBlock.builder().text("\n```").build()))
+                                .build());
+    }
+
+    private static final class MarkdownFenceRemovingMiddleware implements MiddlewareBase {
+
+        @Override
+        public Flux<AgentEvent> onModelCall(
+                Agent agent,
+                RuntimeContext ctx,
+                ModelCallInput input,
+                Function<ModelCallInput, Flux<AgentEvent>> next) {
+            return next.apply(input)
+                    .map(
+                            event -> {
+                                if (!(event instanceof TextBlockDeltaEvent textDelta)) {
+                                    return event;
+                                }
+                                String delta = textDelta.getDelta();
+                                if (delta == null
+                                        || (!delta.startsWith("```json")
+                                                && !delta.endsWith("```"))) {
+                                    return event;
+                                }
+                                return new TextBlockDeltaEvent(
+                                        textDelta.getReplyId(), textDelta.getBlockId(), "");
+                            });
+        }
+    }
+
     private static Msg userMsg() {
         return Msg.builder()
                 .name("user")
@@ -222,6 +275,31 @@ class ReActAgentStructuredOutputWithToolsTest {
         assertFalse(
                 model.toolListContainsGenerateResponse(),
                 "Native path should not inject generate_response tool");
+    }
+
+    @Test
+    @DisplayName("Model-call text delta replacement is used for native structured output")
+    void modelCallTextDeltaReplacement_updatesNativeStructuredOutput() {
+        ConfigurableMockModel model =
+                new ConfigurableMockModel(true, true, fencedNativeResponder());
+        ReActAgent agent =
+                ReActAgent.builder()
+                        .name("test-agent")
+                        .sysPrompt("test")
+                        .model(model)
+                        .middlewares(List.of(new MarkdownFenceRemovingMiddleware()))
+                        .build();
+
+        Msg result =
+                agent.call(userMsg(), WeatherInfo.class)
+                        .block(Duration.ofMillis(TestConstants.DEFAULT_TEST_TIMEOUT_MS));
+
+        assertNotNull(result);
+        assertEquals("{\"city\":\"Shanghai\",\"temperature\":\"32°C\"}", result.getTextContent());
+        assertTrue(result.hasStructuredData());
+        WeatherInfo info = result.getStructuredData(WeatherInfo.class);
+        assertEquals("Shanghai", info.city);
+        assertEquals("32°C", info.temperature);
     }
 
     @Test

--- a/agentscope-core/src/test/java/io/agentscope/core/agent/accumulator/TextAccumulatorTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/agent/accumulator/TextAccumulatorTest.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.core.agent.accumulator;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import io.agentscope.core.message.TextBlock;
+import org.junit.jupiter.api.Test;
+
+class TextAccumulatorTest {
+
+    @Test
+    void replaceNullClearsAccumulatedText() {
+        TextAccumulator accumulator = new TextAccumulator();
+        accumulator.add(TextBlock.builder().text("original").build());
+
+        accumulator.replace(null);
+
+        assertFalse(accumulator.hasContent());
+        assertEquals("", accumulator.getAccumulated());
+    }
+}


### PR DESCRIPTION
## AgentScope-Java Version

2.0.1-SNAPSHOT

## Description

Fixes #2385.

`MiddlewareBase.onModelCall` can transform emitted `TextBlockDeltaEvent`s, but those changes previously affected only the external event stream. The final `Msg` was still built from unmodified model chunks, causing native structured-output parsing to consume stale text.

This change rebuilds accumulated response text from the transformed model-call event stream before producing the final message. As a result, middleware can normalize text—such as removing Markdown JSON fences—before native structured-output parsing.

Added regression coverage for a model that streams fenced JSON across multiple chunks. The middleware removes the fence deltas, and the test verifies the final response contains valid JSON and deserializes into structured data.

Validation:

- `mvn -pl agentscope-core -Dtest=ReActAgentStructuredOutputWithToolsTest,ReActAgentMiddlewareIntegrationTest test`
- 12 tests passed.

## Checklist

- [x] Code has been formatted with `mvn spotless:apply`
- [x] All tests are passing (`mvn test`)
- [x] Javadoc comments are complete and follow project conventions
- [x] Related documentation has been updated
- [x] Code is ready for review