### PR TITLE
fix(core): 用户中断 reasoning 时丢弃未执行的工具调用

### DIFF
--- a/agentscope-core/src/main/java/io/agentscope/core/ReActAgent.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/ReActAgent.java
@@ -2034,19 +2034,7 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
                     .onErrorResume(
                             InterruptedException.class,
                             error -> {
-                                Msg msg = context.buildFinalMessage();
-                                if (msg != null) {
-                                    boolean discard =
-                                            state.interruptControl().getSource()
-                                                            == InterruptSource.SYSTEM
-                                                    && shutdownManager
-                                                                    .getConfig()
-                                                                    .partialReasoningPolicy()
-                                                            == PartialReasoningPolicy.DISCARD;
-                                    if (!discard) {
-                                        state.contextMutable().add(msg);
-                                    }
-                                }
+                                persistInterruptedReasoningMessage(context.buildFinalMessage());
                                 return Mono.error(error);
                             })
                     .flatMap(
@@ -2072,15 +2060,13 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
                     .flatMap(
                             event -> {
                                 Msg eventMsg = event.getReasoningMessage();
-                                if (eventMsg != null) {
-                                    state.contextMutable().add(eventMsg);
-                                }
 
                                 // HITL stop
                                 if (event.isStopRequested()) {
                                     if (eventMsg == null) {
                                         return Mono.empty();
                                     }
+                                    state.contextMutable().add(eventMsg);
                                     return Mono.just(
                                             eventMsg.withGenerateReason(
                                                     GenerateReason.REASONING_STOP_REQUESTED));
@@ -2088,6 +2074,9 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
 
                                 // gotoReasoning requested (e.g., by a PostReasoning hook)
                                 if (event.isGotoReasoningRequested()) {
+                                    if (eventMsg != null) {
+                                        state.contextMutable().add(eventMsg);
+                                    }
                                     List<Msg> gotoMsgs = event.getGotoReasoningMsgs();
                                     if (gotoMsgs != null) {
                                         state.contextMutable().addAll(gotoMsgs);
@@ -2097,11 +2086,26 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
 
                                 // Check finish conditions
                                 if (isFinished(eventMsg)) {
+                                    if (eventMsg != null) {
+                                        state.contextMutable().add(eventMsg);
+                                    }
                                     return Mono.justOrEmpty(eventMsg);
                                 }
 
                                 // Continue to acting
-                                return checkInterrupted().then(acting(iter));
+                                return checkInterrupted()
+                                        .onErrorResume(
+                                                InterruptedException.class,
+                                                error -> {
+                                                    persistInterruptedReasoningMessage(eventMsg);
+                                                    return Mono.error(error);
+                                                })
+                                        .then(
+                                                Mono.defer(
+                                                        () -> {
+                                                            state.contextMutable().add(eventMsg);
+                                                            return acting(iter);
+                                                        }));
                             })
                     .switchIfEmpty(
                             Mono.defer(
@@ -2109,6 +2113,43 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
                                         // No message was produced
                                         return Mono.justOrEmpty((Msg) null);
                                     }));
+        }
+
+        /**
+         * Persist partial reasoning after an interrupt without leaving user-aborted tool calls in
+         * the conversation. Acting has not started at either call site, so retaining those calls
+         * would create orphaned tool uses with no possible result. System interrupts keep their
+         * existing resume policy.
+         */
+        private void persistInterruptedReasoningMessage(Msg msg) {
+            if (msg == null) {
+                return;
+            }
+
+            InterruptSource source = state.interruptControl().getSource();
+            boolean discard =
+                    source == InterruptSource.SYSTEM
+                            && shutdownManager.getConfig().partialReasoningPolicy()
+                                    == PartialReasoningPolicy.DISCARD;
+            if (discard) {
+                return;
+            }
+
+            Msg interruptedMsg = source == InterruptSource.USER ? withoutToolUseBlocks(msg) : msg;
+            if (interruptedMsg != null) {
+                state.contextMutable().add(interruptedMsg);
+            }
+        }
+
+        private static Msg withoutToolUseBlocks(Msg msg) {
+            if (!msg.hasContentBlocks(ToolUseBlock.class)) {
+                return msg;
+            }
+            List<ContentBlock> retained =
+                    msg.getContent().stream()
+                            .filter(block -> !(block instanceof ToolUseBlock))
+                            .toList();
+            return retained.isEmpty() ? null : msg.withContent(retained);
         }
 
         /**

--- a/agentscope-core/src/test/java/io/agentscope/core/agent/ReActAgentPerSessionStateTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/agent/ReActAgentPerSessionStateTest.java
@@ -17,14 +17,19 @@ package io.agentscope.core.agent;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.agentscope.core.ReActAgent;
 import io.agentscope.core.event.AgentEndEvent;
 import io.agentscope.core.event.AgentEvent;
 import io.agentscope.core.event.AgentStartEvent;
+import io.agentscope.core.hook.Hook;
+import io.agentscope.core.hook.HookEvent;
+import io.agentscope.core.hook.PostReasoningEvent;
 import io.agentscope.core.message.ContentBlock;
 import io.agentscope.core.message.GenerateReason;
 import io.agentscope.core.message.Msg;
@@ -42,6 +47,10 @@ import io.agentscope.core.permission.PermissionBehavior;
 import io.agentscope.core.permission.PermissionContextState;
 import io.agentscope.core.permission.PermissionMode;
 import io.agentscope.core.permission.PermissionRule;
+import io.agentscope.core.shutdown.AgentShuttingDownException;
+import io.agentscope.core.shutdown.GracefulShutdownConfig;
+import io.agentscope.core.shutdown.GracefulShutdownManager;
+import io.agentscope.core.shutdown.PartialReasoningPolicy;
 import io.agentscope.core.state.AgentState;
 import io.agentscope.core.state.InMemoryAgentStateStore;
 import io.agentscope.core.state.legacy.ToolkitState;
@@ -54,7 +63,9 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -269,7 +280,15 @@ class ReActAgentPerSessionStateTest {
     @DisplayName("user interrupt drops a partial streaming tool call from persisted reasoning")
     void userInterruptDropsPartialStreamingToolCall() throws Exception {
         InMemoryAgentStateStore store = new InMemoryAgentStateStore();
-        GatedStreamingToolModel model = new GatedStreamingToolModel();
+        GatedReasoningModel model =
+                new GatedReasoningModel(
+                        List.of(
+                                TextBlock.builder().text("partial response").build(),
+                                ToolUseBlock.builder()
+                                        .id("call-streaming")
+                                        .name("echo")
+                                        .content("{\"value\":")
+                                        .build()));
         RuntimeContext ctx = RuntimeContext.builder().userId("u1").sessionId("streaming").build();
         ReActAgent first =
                 ReActAgent.builder()
@@ -284,7 +303,7 @@ class ReActAgentPerSessionStateTest {
                         .subscribeOn(Schedulers.parallel())
                         .toFuture();
         assertTrue(
-                model.afterToolChunk.await(5, TimeUnit.SECONDS),
+                model.afterInitialChunks.await(5, TimeUnit.SECONDS),
                 "partial tool call should be consumed before interrupt");
 
         first.interrupt(ctx);
@@ -347,6 +366,175 @@ class ReActAgentPerSessionStateTest {
         assertTrue(allText(restoredState).contains("completed response"));
     }
 
+    @Test
+    @DisplayName("user interrupt preserves partial reasoning when no tool call was generated")
+    void userInterruptPreservesPartialTextWithoutToolCall() throws Exception {
+        InMemoryAgentStateStore store = new InMemoryAgentStateStore();
+        GatedReasoningModel model =
+                new GatedReasoningModel(
+                        List.of(TextBlock.builder().text("text before interrupt").build()));
+        RuntimeContext ctx = RuntimeContext.builder().userId("u1").sessionId("text-only").build();
+        ReActAgent first =
+                ReActAgent.builder()
+                        .name("asst")
+                        .sysPrompt("hi")
+                        .model(model)
+                        .stateStore(store)
+                        .build();
+
+        CompletableFuture<Msg> future =
+                first.call(List.of(userMsg("hello")), ctx)
+                        .subscribeOn(Schedulers.parallel())
+                        .toFuture();
+        assertTrue(
+                model.afterInitialChunks.await(5, TimeUnit.SECONDS),
+                "partial text should be consumed before interrupt");
+
+        first.interrupt(ctx);
+        model.release.tryEmitEmpty();
+
+        assertEquals(
+                GenerateReason.INTERRUPTED, future.get(5, TimeUnit.SECONDS).getGenerateReason());
+        assertTrue(
+                allText(first.getAgentState("u1", "text-only")).contains("text before interrupt"));
+    }
+
+    @Test
+    @DisplayName("user interrupt does not persist a reasoning message containing only a tool call")
+    void userInterruptDropsToolOnlyReasoningMessage() throws Exception {
+        InMemoryAgentStateStore store = new InMemoryAgentStateStore();
+        GatedReasoningModel model =
+                new GatedReasoningModel(
+                        List.of(
+                                ToolUseBlock.builder()
+                                        .id("call-only")
+                                        .name("echo")
+                                        .input(Map.of("value", "pending"))
+                                        .build()));
+        RuntimeContext ctx = RuntimeContext.builder().userId("u1").sessionId("tool-only").build();
+        ReActAgent first =
+                ReActAgent.builder()
+                        .name("asst")
+                        .sysPrompt("hi")
+                        .model(model)
+                        .stateStore(store)
+                        .build();
+
+        CompletableFuture<Msg> future =
+                first.call(List.of(userMsg("hello")), ctx)
+                        .subscribeOn(Schedulers.parallel())
+                        .toFuture();
+        assertTrue(
+                model.afterInitialChunks.await(5, TimeUnit.SECONDS),
+                "tool call should be consumed before interrupt");
+
+        first.interrupt(ctx);
+        model.release.tryEmitEmpty();
+
+        assertEquals(
+                GenerateReason.INTERRUPTED, future.get(5, TimeUnit.SECONDS).getGenerateReason());
+        assertFalse(hasToolUse(first.getAgentState("u1", "tool-only"), "call-only"));
+    }
+
+    @Test
+    @DisplayName("system interrupt saves partial reasoning under the SAVE policy")
+    void systemInterruptSavesPartialReasoning() throws Exception {
+        AgentState state =
+                runSystemInterruptDuringReasoning(PartialReasoningPolicy.SAVE, "system-save");
+
+        assertTrue(hasToolUse(state, "call-complete"));
+        assertTrue(allText(state).contains("completed response"));
+    }
+
+    @Test
+    @DisplayName("system interrupt discards partial reasoning under the DISCARD policy")
+    void systemInterruptDiscardsPartialReasoning() throws Exception {
+        AgentState state =
+                runSystemInterruptDuringReasoning(PartialReasoningPolicy.DISCARD, "system-discard");
+
+        assertFalse(hasToolUse(state, "call-complete"));
+        assertFalse(allText(state).contains("completed response"));
+    }
+
+    @Test
+    @DisplayName("gotoReasoning persists only non-null reasoning messages")
+    @SuppressWarnings("removal")
+    void gotoReasoningPersistsOnlyNonNullReasoningMessages() {
+        AtomicInteger reasoningRound = new AtomicInteger();
+        Hook gotoHook =
+                new Hook() {
+                    @Override
+                    public <T extends HookEvent> Mono<T> onEvent(T event) {
+                        if (event instanceof PostReasoningEvent reasoningEvent) {
+                            int round = reasoningRound.getAndIncrement();
+                            if (round == 0) {
+                                reasoningEvent.gotoReasoning();
+                            } else if (round == 1) {
+                                reasoningEvent.setReasoningMessage(null);
+                                reasoningEvent.gotoReasoning();
+                            }
+                        }
+                        return Mono.just(event);
+                    }
+                };
+        ReActAgent agent =
+                ReActAgent.builder()
+                        .name("asst")
+                        .sysPrompt("hi")
+                        .model(new SequentialTextModel("first response", "discarded", "final"))
+                        .hook(gotoHook)
+                        .build();
+
+        Msg result = agent.call(userMsg("hello")).block(Duration.ofSeconds(5));
+
+        assertEquals("final", result.getTextContent());
+        List<String> texts = allText(agent.getAgentState());
+        assertTrue(texts.contains("first response"));
+        assertFalse(texts.contains("discarded"));
+        assertTrue(texts.contains("final"));
+    }
+
+    private AgentState runSystemInterruptDuringReasoning(
+            PartialReasoningPolicy policy, String sessionId) throws Exception {
+        GracefulShutdownManager manager = GracefulShutdownManager.getInstance();
+        manager.resetForTesting();
+        manager.setConfig(new GracefulShutdownConfig(Duration.ofSeconds(30), policy));
+
+        InMemoryAgentStateStore store = new InMemoryAgentStateStore();
+        GateReasoningCompletionMiddleware gate = new GateReasoningCompletionMiddleware();
+        RuntimeContext ctx = RuntimeContext.builder().userId("u1").sessionId(sessionId).build();
+        ReActAgent agent =
+                ReActAgent.builder()
+                        .name("asst")
+                        .sysPrompt("hi")
+                        .model(new CompletedToolCallModel())
+                        .stateStore(store)
+                        .middleware(gate)
+                        .build();
+        try {
+            CompletableFuture<Msg> future =
+                    agent.call(List.of(userMsg("hello")), ctx)
+                            .subscribeOn(Schedulers.parallel())
+                            .toFuture();
+            assertTrue(
+                    gate.reasoningCompleted.await(5, TimeUnit.SECONDS),
+                    "model reasoning should complete before shutdown");
+
+            assertTrue(manager.performGracefulShutdown());
+            gate.release.tryEmitEmpty();
+
+            ExecutionException error =
+                    assertThrows(ExecutionException.class, () -> future.get(5, TimeUnit.SECONDS));
+            assertInstanceOf(AgentShuttingDownException.class, error.getCause());
+            return agent.getAgentState("u1", sessionId);
+        } finally {
+            gate.release.tryEmitEmpty();
+            agent.close();
+            manager.resetForTesting();
+            manager.setConfig(GracefulShutdownConfig.DEFAULT);
+        }
+    }
+
     private static final class DelayedFirstChunkModel extends ChatModelBase {
         private final CountDownLatch subscribed;
 
@@ -378,31 +566,28 @@ class ReActAgentPerSessionStateTest {
         }
     }
 
-    private static final class GatedStreamingToolModel extends ChatModelBase {
-        private final CountDownLatch afterToolChunk = new CountDownLatch(1);
+    private static final class GatedReasoningModel extends ChatModelBase {
+        private final List<ContentBlock> initialBlocks;
+        private final CountDownLatch afterInitialChunks = new CountDownLatch(1);
         private final Sinks.One<Void> release = Sinks.one();
+
+        private GatedReasoningModel(List<ContentBlock> initialBlocks) {
+            this.initialBlocks = List.copyOf(initialBlocks);
+        }
 
         @Override
         public String getModelName() {
-            return "gated-streaming-tool";
+            return "gated-reasoning";
         }
 
         @Override
         protected Flux<ChatResponse> doStream(
                 List<Msg> messages, List<ToolSchema> tools, GenerateOptions options) {
-            ToolUseBlock partialToolCall =
-                    ToolUseBlock.builder()
-                            .id("call-streaming")
-                            .name("echo")
-                            .content("{\"value\":")
-                            .build();
             return Flux.concat(
-                    Flux.just(
-                            response(TextBlock.builder().text("partial response").build()),
-                            response(partialToolCall)),
+                    Flux.fromIterable(initialBlocks).map(ReActAgentPerSessionStateTest::response),
                     Flux.defer(
                             () -> {
-                                afterToolChunk.countDown();
+                                afterInitialChunks.countDown();
                                 return release.asMono()
                                         .thenReturn(
                                                 response(
@@ -410,6 +595,30 @@ class ReActAgentPerSessionStateTest {
                                                                 .text("not consumed")
                                                                 .build()));
                             }));
+        }
+    }
+
+    private static final class SequentialTextModel extends ChatModelBase {
+        private final List<String> responses;
+        private final AtomicInteger index = new AtomicInteger();
+
+        private SequentialTextModel(String... responses) {
+            this.responses = List.of(responses);
+        }
+
+        @Override
+        public String getModelName() {
+            return "sequential-text";
+        }
+
+        @Override
+        protected Flux<ChatResponse> doStream(
+                List<Msg> messages, List<ToolSchema> tools, GenerateOptions options) {
+            return Flux.just(
+                    response(
+                            TextBlock.builder()
+                                    .text(responses.get(index.getAndIncrement()))
+                                    .build()));
         }
     }
 

--- a/agentscope-core/src/test/java/io/agentscope/core/agent/ReActAgentPerSessionStateTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/agent/ReActAgentPerSessionStateTest.java
@@ -30,6 +30,10 @@ import io.agentscope.core.message.GenerateReason;
 import io.agentscope.core.message.Msg;
 import io.agentscope.core.message.MsgRole;
 import io.agentscope.core.message.TextBlock;
+import io.agentscope.core.message.ToolResultBlock;
+import io.agentscope.core.message.ToolUseBlock;
+import io.agentscope.core.middleware.MiddlewareBase;
+import io.agentscope.core.middleware.ReasoningInput;
 import io.agentscope.core.model.ChatModelBase;
 import io.agentscope.core.model.ChatResponse;
 import io.agentscope.core.model.GenerateOptions;
@@ -44,16 +48,21 @@ import io.agentscope.core.state.legacy.ToolkitState;
 import io.agentscope.core.tool.Toolkit;
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
+import reactor.core.publisher.Sinks;
 import reactor.core.scheduler.Schedulers;
 
 /** Per-(userId, sessionId) state access / persistence API on {@link ReActAgent}. */
@@ -256,6 +265,88 @@ class ReActAgentPerSessionStateTest {
         assertEquals(GenerateReason.INTERRUPTED, restoredRecovery.getGenerateReason());
     }
 
+    @Test
+    @DisplayName("user interrupt drops a partial streaming tool call from persisted reasoning")
+    void userInterruptDropsPartialStreamingToolCall() throws Exception {
+        InMemoryAgentStateStore store = new InMemoryAgentStateStore();
+        GatedStreamingToolModel model = new GatedStreamingToolModel();
+        RuntimeContext ctx = RuntimeContext.builder().userId("u1").sessionId("streaming").build();
+        ReActAgent first =
+                ReActAgent.builder()
+                        .name("asst")
+                        .sysPrompt("hi")
+                        .model(model)
+                        .stateStore(store)
+                        .build();
+
+        CompletableFuture<Msg> future =
+                first.call(List.of(userMsg("hello")), ctx)
+                        .subscribeOn(Schedulers.parallel())
+                        .toFuture();
+        assertTrue(
+                model.afterToolChunk.await(5, TimeUnit.SECONDS),
+                "partial tool call should be consumed before interrupt");
+
+        first.interrupt(ctx);
+        model.release.tryEmitEmpty();
+
+        Msg reply = future.get(5, TimeUnit.SECONDS);
+        assertEquals(GenerateReason.INTERRUPTED, reply.getGenerateReason());
+
+        StrictHistoryModel strictModel = new StrictHistoryModel();
+        ReActAgent restored =
+                ReActAgent.builder()
+                        .name("asst")
+                        .sysPrompt("hi")
+                        .model(strictModel)
+                        .stateStore(store)
+                        .enablePendingToolRecovery(true)
+                        .build();
+        AgentState restoredState = restored.getAgentState("u1", "streaming");
+        assertFalse(hasToolUse(restoredState, "call-streaming"));
+        assertTrue(allText(restoredState).contains("partial response"));
+
+        Msg continued =
+                restored.call(List.of(userMsg("continue")), ctx).block(Duration.ofSeconds(5));
+        assertEquals("continued", continued.getTextContent());
+        assertTrue(strictModel.unresolvedIds.isEmpty());
+    }
+
+    @Test
+    @DisplayName(
+            "user interrupt before acting drops a completed tool call from persisted reasoning")
+    void userInterruptBeforeActingDropsCompletedToolCall() throws Exception {
+        InMemoryAgentStateStore store = new InMemoryAgentStateStore();
+        GateReasoningCompletionMiddleware gate = new GateReasoningCompletionMiddleware();
+        RuntimeContext ctx = RuntimeContext.builder().userId("u1").sessionId("pre-acting").build();
+        ReActAgent first =
+                ReActAgent.builder()
+                        .name("asst")
+                        .sysPrompt("hi")
+                        .model(new CompletedToolCallModel())
+                        .stateStore(store)
+                        .middleware(gate)
+                        .build();
+
+        CompletableFuture<Msg> future =
+                first.call(List.of(userMsg("hello")), ctx)
+                        .subscribeOn(Schedulers.parallel())
+                        .toFuture();
+        assertTrue(
+                gate.reasoningCompleted.await(5, TimeUnit.SECONDS),
+                "model reasoning should complete before interrupt");
+
+        first.interrupt(ctx);
+        gate.release.tryEmitEmpty();
+
+        Msg reply = future.get(5, TimeUnit.SECONDS);
+        assertEquals(GenerateReason.INTERRUPTED, reply.getGenerateReason());
+
+        AgentState restoredState = agent(store).getAgentState("u1", "pre-acting");
+        assertFalse(hasToolUse(restoredState, "call-complete"));
+        assertTrue(allText(restoredState).contains("completed response"));
+    }
+
     private static final class DelayedFirstChunkModel extends ChatModelBase {
         private final CountDownLatch subscribed;
 
@@ -287,12 +378,132 @@ class ReActAgentPerSessionStateTest {
         }
     }
 
+    private static final class GatedStreamingToolModel extends ChatModelBase {
+        private final CountDownLatch afterToolChunk = new CountDownLatch(1);
+        private final Sinks.One<Void> release = Sinks.one();
+
+        @Override
+        public String getModelName() {
+            return "gated-streaming-tool";
+        }
+
+        @Override
+        protected Flux<ChatResponse> doStream(
+                List<Msg> messages, List<ToolSchema> tools, GenerateOptions options) {
+            ToolUseBlock partialToolCall =
+                    ToolUseBlock.builder()
+                            .id("call-streaming")
+                            .name("echo")
+                            .content("{\"value\":")
+                            .build();
+            return Flux.concat(
+                    Flux.just(
+                            response(TextBlock.builder().text("partial response").build()),
+                            response(partialToolCall)),
+                    Flux.defer(
+                            () -> {
+                                afterToolChunk.countDown();
+                                return release.asMono()
+                                        .thenReturn(
+                                                response(
+                                                        TextBlock.builder()
+                                                                .text("not consumed")
+                                                                .build()));
+                            }));
+        }
+    }
+
+    private static final class CompletedToolCallModel extends ChatModelBase {
+        @Override
+        public String getModelName() {
+            return "completed-tool-call";
+        }
+
+        @Override
+        protected Flux<ChatResponse> doStream(
+                List<Msg> messages, List<ToolSchema> tools, GenerateOptions options) {
+            ToolUseBlock toolCall =
+                    ToolUseBlock.builder()
+                            .id("call-complete")
+                            .name("echo")
+                            .input(Map.of("value", "done"))
+                            .build();
+            return Flux.just(
+                    ChatResponse.builder()
+                            .content(
+                                    List.of(
+                                            TextBlock.builder().text("completed response").build(),
+                                            toolCall))
+                            .build());
+        }
+    }
+
+    private static final class GateReasoningCompletionMiddleware implements MiddlewareBase {
+        private final CountDownLatch reasoningCompleted = new CountDownLatch(1);
+        private final Sinks.One<Void> release = Sinks.one();
+
+        @Override
+        public Flux<AgentEvent> onReasoning(
+                Agent agent,
+                RuntimeContext ctx,
+                ReasoningInput input,
+                Function<ReasoningInput, Flux<AgentEvent>> next) {
+            return next.apply(input)
+                    .concatWith(
+                            Flux.defer(
+                                    () -> {
+                                        reasoningCompleted.countDown();
+                                        return release.asMono().thenMany(Flux.empty());
+                                    }));
+        }
+    }
+
+    private static final class StrictHistoryModel extends ChatModelBase {
+        private volatile Set<String> unresolvedIds = Set.of();
+
+        @Override
+        public String getModelName() {
+            return "strict-history";
+        }
+
+        @Override
+        protected Flux<ChatResponse> doStream(
+                List<Msg> messages, List<ToolSchema> tools, GenerateOptions options) {
+            Set<String> toolUseIds = new HashSet<>();
+            Set<String> toolResultIds = new HashSet<>();
+            for (Msg message : messages) {
+                message.getContentBlocks(ToolUseBlock.class)
+                        .forEach(block -> toolUseIds.add(block.getId()));
+                message.getContentBlocks(ToolResultBlock.class)
+                        .forEach(block -> toolResultIds.add(block.getId()));
+            }
+            toolUseIds.removeAll(toolResultIds);
+            unresolvedIds = Set.copyOf(toolUseIds);
+            if (!unresolvedIds.isEmpty()) {
+                return Flux.error(
+                        new IllegalStateException(
+                                "Unresolved tool calls in model history: " + unresolvedIds));
+            }
+            return Flux.just(response(TextBlock.builder().text("continued").build()));
+        }
+    }
+
+    private static ChatResponse response(ContentBlock block) {
+        return ChatResponse.builder().content(List.of(block)).build();
+    }
+
     private static Msg userMsg(String text) {
         return Msg.builder()
                 .name("user")
                 .role(MsgRole.USER)
                 .content(TextBlock.builder().text(text).build())
                 .build();
+    }
+
+    private static boolean hasToolUse(AgentState state, String id) {
+        return state.getContext().stream()
+                .flatMap(msg -> msg.getContentBlocks(ToolUseBlock.class).stream())
+                .anyMatch(block -> id.equals(block.getId()));
     }
 
     private static List<String> allText(AgentState state) {


### PR DESCRIPTION
fix: #2470

## AgentScope-Java Version

2.0.1-SNAPSHOT

## Description

### 修改概述

修复用户中断 ReActAgent 的 reasoning 阶段时，尚未执行的工具调用被写入 memory，导致后续请求携带孤立 `tool_use`、会话上下文无法恢复的问题。

### 问题原因

reasoning 产生的消息会在工具执行前写入 memory。用户中断恰好发生在工具调用流式生成期间，或 reasoning 已完成但 acting 尚未开始时，当前实现仍会保留其中的 `ToolUseBlock`。由于对应工具没有执行，memory 中不会产生配对的工具结果；重建 Agent 或发起下一轮模型请求时，严格校验消息历史的模型会拒绝这段上下文。

### 修复方案

- 用户中断 reasoning 时，仅持久化已经生成的文本和 thinking 内容，丢弃所有尚未执行的 `ToolUseBlock`。
- 将正常 reasoning 消息的完整持久化延后到 acting 前的中断检查之后，覆盖“工具调用已生成、但 acting 尚未开始”的窗口。
- 保持系统中断以及 `PartialReasoningPolicy` 的既有语义不变。

### 测试覆盖

- reasoning 流式生成部分工具参数时发生用户中断。
- reasoning 已生成完整工具调用、acting 开始前发生用户中断。
- 用户中断纯文本 reasoning 时保留已生成文本。
- 用户中断仅包含工具调用的 reasoning 时不持久化空消息。
- 系统中断分别使用 `PartialReasoningPolicy.SAVE` 和 `DISCARD`。
- `gotoReasoning` 时分别处理非空和空 reasoning 消息。
- 基于中断后的 memory 重建 Agent，并在严格历史校验下继续对话。
- 本地 JaCoCo 报告中，本 PR 修改的所有可执行行和条件分支均已覆盖。
- 完整执行 `agentscope-core` 测试：2228 tests，0 failures，0 errors，8 skipped。

## Checklist

Please check the following items before code is ready to be reviewed.

- [x] Code has been formatted with `mvn spotless:apply`
- [x] All tests are passing (`mvn -pl agentscope-core test`)
- [x] Javadoc comments are complete and follow project conventions
- [x] Related documentation has been updated (not applicable; this fix does not change the public API)
- [x] Code is ready for review
