### PR TITLE
fix(#2475): store userId/sessionId directly on CallExecution instead of parsing slotKey

### DIFF
--- a/agentscope-core/src/main/java/io/agentscope/core/ReActAgent.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/ReActAgent.java
@@ -349,15 +349,7 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
         return (userId == null || userId.isBlank() ? "__anon__" : userId) + "/" + sessionId;
     }
 
-    /** Reverse of {@link #slotKey}: the parsed {@code (userId, sessionId)} pair. */
-    private record SlotRef(String userId, String sessionId) {
-        static SlotRef parse(String slotKey) {
-            int slash = slotKey.lastIndexOf('/');
-            String u = slotKey.substring(0, slash);
-            String s = slotKey.substring(slash + 1);
-            return new SlotRef("__anon__".equals(u) ? null : u, s);
-        }
-    }
+
 
     /**
      * Initial agent-state load for a specific {@code (userId, sessionId)} slot. Tries (in order):
@@ -431,10 +423,9 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
             return Mono.empty();
         }
         syncToolkitToState(scope.state);
-        SlotRef ref = SlotRef.parse(scope.slotKey);
         AgentState toSave = scope.state;
         return Mono.<Void>fromRunnable(
-                        () -> stateStore.save(ref.userId, ref.sessionId, "agent_state", toSave))
+                        () -> stateStore.save(scope.userId, scope.sessionId, "agent_state", toSave))
                 .subscribeOn(Schedulers.boundedElastic());
     }
 
@@ -493,7 +484,7 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
                     permissionEngineCache.computeIfAbsent(
                             slot, k -> new PermissionEngine(loaded.getPermissionContext()));
         }
-        CallExecution scope = new CallExecution(loaded, loadedEngine, slot);
+        CallExecution scope = new CallExecution(loaded, loadedEngine, slot, uid, sid);
         if (toolkit != null) {
             toolkit.setActiveGroups(loaded.getToolContext().getActivatedGroups());
         }
@@ -1438,6 +1429,12 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
         PermissionEngine permissionEngine;
         String slotKey;
 
+        /** Original userId (null if anonymous), stored directly so saveStateToSession does not need to round-trip through the concatenated slot key. */
+        String userId;
+
+        /** Original sessionId, stored directly. */
+        String sessionId;
+
         /**
          * Per-call system message, propagated across PreCallEvent → PreReasoningEvent /
          * PreSummaryEvent. Owned by a single logical execution: seeded to {@code null} at call
@@ -1486,10 +1483,12 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
         /** Native structured-output format set on the per-call scope for native-path calls. */
         ResponseFormat nativeResponseFormat;
 
-        CallExecution(AgentState state, PermissionEngine permissionEngine, String slotKey) {
+        CallExecution(AgentState state, PermissionEngine permissionEngine, String slotKey, String userId, String sessionId) {
             this.state = state;
             this.permissionEngine = permissionEngine;
             this.slotKey = slotKey;
+            this.userId = userId;
+            this.sessionId = sessionId;
         }
 
         /**


### PR DESCRIPTION
## Fixes #2475

### Problem
When `RuntimeContext.sessionId` contains a `/` character (e.g., DingTalk `openConversationId` values like `cidLcMOzfRs62haqnq1NO8SxeYdmc/lO8bWyidOisoKAzM=`), `ReActAgent` persists the `AgentState` under a **corrupted `(userId, sessionId)` pair** because `SlotRef.parse()` splits the concatenated slot key at the last `/`.

### Root Cause
`SlotRef.parse()` uses `lastIndexOf('/')` to split the concatenated key, but this is ambiguous when sessionId itself contains `/`:

```
slotKey = "u1/cidLcMOzfRs62haqnq1NO8SxeYdmc/lO8bWyidOisoKAzM="
// parsed as: userId="u1/cidLcMOzfRs62haqnq1NO8SxeYdmc", sessionId="lO8bWyidOisoKAzM="
// CORRECT: userId="u1", sessionId="cidLcMOzfRs62haqnq1NO8SxeYdmc/lO8bWyidOisoKAzM="
```

### Fix
1. **Store `userId` and `sessionId` directly on `CallExecution`** — the original values are now carried through the per-call scope instead of being reconstructed from the concatenated slot key.
2. **Update `saveStateToSession()`** to use `scope.userId` / `scope.sessionId` directly.
3. **Remove `SlotRef.parse()`** — no longer needed.

### Impact
- Conversation history replay via `getAgentState(userId, sessionId)` now works correctly for any session whose id contains `/`.
- State-store rows no longer accumulate under corrupted `user_id` values.
- Per-user queries like `listSessionIds(userId)` return correct results.

### Testing
A regression test should verify: run a call with a sessionId containing `/` and assert the state is retrievable from the store under the untouched pair, with no sibling slot appearing under a polluted userId.