### PR TITLE
fix(harness): enforce parent DENY rules for spawned subagents

### DIFF
--- a/agentscope-core/src/main/java/io/agentscope/core/ReActAgent.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/ReActAgent.java
@@ -2534,7 +2534,7 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
             for (ToolUseBlock tc : toolCalls) {
                 if (deniedIds.contains(tc.getId())) {
                     ToolResultBlock denied =
-                            ToolResultBlock.text("Permission denied by user")
+                            ToolResultBlock.text("Permission denied by rules")
                                     .withIdAndName(tc.getId(), tc.getName())
                                     .withState(ToolResultState.DENIED);
                     deniedEntries.add(Map.entry(tc, denied));
@@ -2555,7 +2555,7 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
                                                         replyId,
                                                         use.getId(),
                                                         use.getName(),
-                                                        "Permission denied by user"),
+                                                        "Permission denied by rules"),
                                                 new ToolResultEndEvent(
                                                         replyId,
                                                         use.getId(),
@@ -3695,11 +3695,38 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
     public void setPermissionMode(String userId, String sessionId, PermissionMode mode) {
         Objects.requireNonNull(mode, "mode must not be null");
         String sid = (sessionId == null || sessionId.isBlank()) ? defaultSessionId : sessionId;
-        String slot = slotKey(userId, sid);
-        AgentState s = getAgentState(userId, sid);
-        s.setPermissionContext(s.getPermissionContext().withMode(mode));
-        permissionEngineCache.put(slot, new PermissionEngine(s.getPermissionContext()));
-        saveAgentState(userId, sid);
+        AgentState state = getAgentState(userId, sid);
+        installPermissionContext(userId, sid, state, state.getPermissionContext().withMode(mode));
+    }
+
+    /**
+     * Replaces the permission context for one {@code (userId, sessionId)} slot, rebuilds that
+     * slot's permission engine, and persists the updated state.
+     *
+     * <p>An in-flight call keeps the call-scoped engine it started with. The replacement applies
+     * to subsequent calls on this slot and does not affect any other user or session.
+     *
+     * @param userId user identity for the slot (may be {@code null})
+     * @param sessionId session identity (falls back to the default session id when {@code null})
+     * @param permissionContext complete replacement context
+     */
+    public void replacePermissionContext(
+            String userId, String sessionId, PermissionContextState permissionContext) {
+        Objects.requireNonNull(permissionContext, "permissionContext must not be null");
+        String sid = (sessionId == null || sessionId.isBlank()) ? defaultSessionId : sessionId;
+        AgentState state = getAgentState(userId, sid);
+        installPermissionContext(userId, sid, state, permissionContext);
+    }
+
+    private void installPermissionContext(
+            String userId,
+            String sessionId,
+            AgentState state,
+            PermissionContextState permissionContext) {
+        state.setPermissionContext(permissionContext);
+        permissionEngineCache.put(
+                slotKey(userId, sessionId), new PermissionEngine(permissionContext));
+        saveAgentState(userId, sessionId);
     }
 
     /**

--- a/agentscope-core/src/test/java/io/agentscope/core/agent/ReActAgentPerSessionStateTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/agent/ReActAgentPerSessionStateTest.java
@@ -34,6 +34,10 @@ import io.agentscope.core.model.ChatModelBase;
 import io.agentscope.core.model.ChatResponse;
 import io.agentscope.core.model.GenerateOptions;
 import io.agentscope.core.model.ToolSchema;
+import io.agentscope.core.permission.PermissionBehavior;
+import io.agentscope.core.permission.PermissionContextState;
+import io.agentscope.core.permission.PermissionMode;
+import io.agentscope.core.permission.PermissionRule;
 import io.agentscope.core.state.AgentState;
 import io.agentscope.core.state.InMemoryAgentStateStore;
 import io.agentscope.core.state.legacy.ToolkitState;
@@ -177,6 +181,33 @@ class ReActAgentPerSessionStateTest {
         AgentState other = reborn.getAgentState("u1", "other");
         assertFalse(other.getPlanModeContext().isPlanActive());
         assertEquals("", other.getSummary());
+    }
+
+    @Test
+    @DisplayName("replacePermissionContext updates and persists only the targeted slot")
+    void replacePermissionContextUpdatesOnlyTargetSlot() {
+        InMemoryAgentStateStore store = new InMemoryAgentStateStore();
+        ReActAgent agent = agent(store);
+        PermissionRule denyRule =
+                new PermissionRule("blocked_tool", null, PermissionBehavior.DENY, "parent-policy");
+        PermissionContextState replacement =
+                PermissionContextState.builder()
+                        .mode(PermissionMode.BYPASS)
+                        .addDenyRule("blocked_tool", denyRule)
+                        .build();
+
+        agent.replacePermissionContext("u1", "sessA", replacement);
+
+        assertEquals(replacement, agent.getAgentState("u1", "sessA").getPermissionContext());
+        assertTrue(
+                agent.getAgentState("u1", "sessB").getPermissionContext().isTrivial(),
+                "replacing one slot must not alter another slot");
+
+        ReActAgent reborn = agent(store);
+        assertEquals(
+                replacement,
+                reborn.getAgentState("u1", "sessA").getPermissionContext(),
+                "the replacement must survive state-store reload");
     }
 
     @Test

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/tool/AgentSpawnTool.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/tool/AgentSpawnTool.java
@@ -29,6 +29,7 @@ import io.agentscope.core.event.AgentStartEvent;
 import io.agentscope.core.event.SubagentExposedEvent;
 import io.agentscope.core.message.Msg;
 import io.agentscope.core.permission.PermissionContextState;
+import io.agentscope.core.permission.PermissionMode;
 import io.agentscope.core.permission.PermissionRule;
 import io.agentscope.core.state.AgentState;
 import io.agentscope.core.tool.Tool;
@@ -43,6 +44,8 @@ import io.agentscope.harness.agent.subagent.task.BackgroundTask;
 import io.agentscope.harness.agent.subagent.task.TaskRepository;
 import io.agentscope.harness.agent.subagent.task.TaskRunSpec;
 import io.agentscope.harness.agent.subagent.task.TaskStatus;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -279,6 +282,12 @@ public class AgentSpawnTool {
             if (existing != null) {
                 propagatePlanMode(
                         parentState, currentUserId, existing.sessionId(), existing.agent());
+                propagateParentDenyRules(
+                        parentState,
+                        currentUserId,
+                        existing.sessionId(),
+                        existing.agent(),
+                        declOpt);
                 String spawnInfo = formatSpawnInfo(key, agentId, sessionId, null);
                 boolean hasTask = task != null && !task.isBlank();
                 if (!hasTask) {
@@ -309,10 +318,7 @@ public class AgentSpawnTool {
         propagatePlanMode(parentState, currentUserId, sessionId, agent);
 
         // Propagate DENY permission rules from parent to child (security boundary inheritance).
-        boolean inherit = declOpt.map(SubagentDeclaration::isInheritParentPermissions).orElse(true);
-        if (inherit && parentState != null && agent instanceof ReActAgent ra) {
-            propagateDenyRules(parentState, ra);
-        }
+        propagateParentDenyRules(parentState, currentUserId, sessionId, agent, declOpt);
 
         // Expose subagent to user via gateway bridge if requested. The effective decision combines
         // (in priority order) a per-call RuntimeContext override, the declaration policy, and the
@@ -510,6 +516,8 @@ public class AgentSpawnTool {
         DefaultAgentManager manager = managerFor(runtimeContext);
         propagatePlanMode(parentState, currentUserId, spawned.sessionId(), spawned.agent());
         var declOpt = manager.getDeclaration(spawned.agentId());
+        propagateParentDenyRules(
+                parentState, currentUserId, spawned.sessionId(), spawned.agent(), declOpt);
         boolean remote = declOpt.map(SubagentDeclaration::isRemote).orElse(false);
 
         if (timeoutMs == 0) {
@@ -1233,25 +1241,86 @@ public class AgentSpawnTool {
                 : SessionIdUtils.deterministicHash(parent, agentId);
     }
 
+    private static void propagateParentDenyRules(
+            AgentState parentState,
+            String userId,
+            String childSessionId,
+            Agent childAgent,
+            Optional<SubagentDeclaration> declaration) {
+        boolean inherit =
+                declaration.map(SubagentDeclaration::isInheritParentPermissions).orElse(true);
+        if (!inherit || parentState == null) {
+            return;
+        }
+
+        PermissionContextState parentPermissions = parentState.getPermissionContext();
+        if (parentPermissions == null || parentPermissions.getDenyRules().isEmpty()) {
+            return;
+        }
+
+        if (childAgent instanceof HarnessAgent harnessAgent) {
+            mergeParentDenyRulesIntoSlot(
+                    userId, childSessionId, harnessAgent.getDelegate(), parentPermissions);
+        } else if (childAgent instanceof ReActAgent reactAgent) {
+            mergeParentDenyRulesIntoSlot(userId, childSessionId, reactAgent, parentPermissions);
+        }
+    }
+
+    private static void mergeParentDenyRulesIntoSlot(
+            String userId,
+            String childSessionId,
+            ReActAgent child,
+            PermissionContextState parentPermissions) {
+        PermissionContextState childPermissions =
+                child.getAgentState(userId, childSessionId).getPermissionContext();
+        PermissionContextState merged = mergeParentDenyRules(childPermissions, parentPermissions);
+        if (!merged.equals(childPermissions)) {
+            child.replacePermissionContext(userId, childSessionId, merged);
+        }
+    }
+
     /**
-     * Copies all DENY rules from the parent's permission context into the child's permission
-     * engine. This enforces the security boundary: anything the parent is explicitly denied, the
-     * child is also denied.
+     * Adds parent DENY rules without widening the child's configured permissions.
+     *
+     * <p>A trivial child uses the legacy lightweight permission path, where a tool-level
+     * {@code PASSTHROUGH} is allowed. Adding the first DENY rule makes the context non-trivial and
+     * activates the full engine; {@link PermissionMode#BYPASS} preserves that prior fallback while
+     * explicit DENY rules still take precedence.
      */
-    private static void propagateDenyRules(AgentState parentState, ReActAgent child) {
-        PermissionContextState parentPerms = parentState.getPermissionContext();
-        if (parentPerms == null || parentPerms.getDenyRules().isEmpty()) {
-            return;
-        }
-        var childEngine = child.getPermissionEngine();
-        if (childEngine == null) {
-            return;
-        }
-        for (Map.Entry<String, List<PermissionRule>> entry :
-                parentPerms.getDenyRules().entrySet()) {
-            for (PermissionRule rule : entry.getValue()) {
-                childEngine.addRule(rule);
-            }
-        }
+    private static PermissionContextState mergeParentDenyRules(
+            PermissionContextState child, PermissionContextState parent) {
+        PermissionContextState.Builder merged =
+                PermissionContextState.builder()
+                        .mode(child.isTrivial() ? PermissionMode.BYPASS : child.getMode());
+
+        child.getWorkingDirectories().forEach(merged::addWorkingDirectory);
+        child.getAllowRules()
+                .forEach(
+                        (toolName, rules) ->
+                                rules.forEach(rule -> merged.addAllowRule(toolName, rule)));
+
+        Map<String, List<PermissionRule>> denyRules = new LinkedHashMap<>();
+        child.getDenyRules()
+                .forEach((toolName, rules) -> denyRules.put(toolName, new ArrayList<>(rules)));
+        parent.getDenyRules()
+                .forEach(
+                        (toolName, rules) -> {
+                            List<PermissionRule> targetRules =
+                                    denyRules.computeIfAbsent(
+                                            toolName, ignored -> new ArrayList<>());
+                            for (PermissionRule rule : rules) {
+                                if (!targetRules.contains(rule)) {
+                                    targetRules.add(rule);
+                                }
+                            }
+                        });
+        denyRules.forEach(
+                (toolName, rules) -> rules.forEach(rule -> merged.addDenyRule(toolName, rule)));
+
+        child.getAskRules()
+                .forEach(
+                        (toolName, rules) ->
+                                rules.forEach(rule -> merged.addAskRule(toolName, rule)));
+        return merged.build();
     }
 }

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/tool/AgentSpawnToolPermissionTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/tool/AgentSpawnToolPermissionTest.java
@@ -1,0 +1,385 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.harness.agent.tool;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.agentscope.core.ReActAgent;
+import io.agentscope.core.agent.Agent;
+import io.agentscope.core.agent.RuntimeContext;
+import io.agentscope.core.agent.test.MockModel;
+import io.agentscope.core.permission.AdditionalWorkingDirectory;
+import io.agentscope.core.permission.PermissionBehavior;
+import io.agentscope.core.permission.PermissionContextState;
+import io.agentscope.core.permission.PermissionEngine;
+import io.agentscope.core.permission.PermissionMode;
+import io.agentscope.core.permission.PermissionRule;
+import io.agentscope.core.state.AgentState;
+import io.agentscope.core.state.InMemoryAgentStateStore;
+import io.agentscope.core.tool.ToolBase;
+import io.agentscope.harness.agent.HarnessAgent;
+import io.agentscope.harness.agent.middleware.SubagentEntry;
+import io.agentscope.harness.agent.subagent.DefaultAgentManager;
+import io.agentscope.harness.agent.subagent.SubagentDeclaration;
+import io.agentscope.harness.agent.subagent.SubagentFactory;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class AgentSpawnToolPermissionTest {
+
+    private static final String USER_ID = "user-a";
+    private static final String PARENT_SESSION_ID = "parent-a";
+
+    @TempDir Path workspace;
+
+    private final List<AutoCloseable> createdAgents = new ArrayList<>();
+
+    @AfterEach
+    void closeAgents() throws Exception {
+        for (AutoCloseable agent : createdAgents) {
+            agent.close();
+        }
+        createdAgents.clear();
+    }
+
+    @Test
+    void harnessChildReceivesParentDenyInActualExecutionSlot() {
+        PermissionRule parentDeny = denyRule("blocked_probe", "parent-policy");
+        AtomicReference<Agent> childRef = new AtomicReference<>();
+        AgentSpawnTool tool =
+                tool(
+                        declaration(true, false),
+                        ignored -> {
+                            HarnessAgent child =
+                                    HarnessAgent.builder()
+                                            .name("worker")
+                                            .model(new MockModel("done"))
+                                            .workspace(workspace)
+                                            .stateStore(new InMemoryAgentStateStore())
+                                            .disableMemoryTools()
+                                            .disableMemoryHooks()
+                                            .disableWorkspaceContext()
+                                            .build();
+                            createdAgents.add(child);
+                            childRef.set(child);
+                            return child;
+                        });
+
+        String spawnResult =
+                tool.agentSpawn(
+                                parentContext(),
+                                parentState(
+                                        PermissionContextState.builder()
+                                                .mode(PermissionMode.BYPASS)
+                                                .addDenyRule("blocked_probe", parentDeny)
+                                                .build()),
+                                "worker",
+                                null,
+                                null,
+                                null,
+                                null)
+                        .block();
+
+        String childSessionId = firstLineValue(spawnResult, "session_id: ");
+        HarnessAgent child = (HarnessAgent) childRef.get();
+        PermissionContextState actual =
+                child.getDelegate().getAgentState(USER_ID, childSessionId).getPermissionContext();
+
+        assertEquals(PermissionMode.BYPASS, actual.getMode());
+        assertEquals(List.of(parentDeny), actual.getDenyRules().get("blocked_probe"));
+
+        PermissionEngine engine = new PermissionEngine(actual);
+        assertEquals(
+                PermissionBehavior.ALLOW,
+                engine.checkPermission(new ProbeTool("identity_probe"), Map.of())
+                        .block()
+                        .getBehavior(),
+                "a formerly-trivial child must keep allowing unmatched PASSTHROUGH tools");
+        assertEquals(
+                PermissionBehavior.DENY,
+                engine.checkPermission(new ProbeTool("blocked_probe"), Map.of())
+                        .block()
+                        .getBehavior(),
+                "the inherited parent rule must deny the blocked tool");
+    }
+
+    @Test
+    void directReactChildKeepsItsOwnPermissionContextAndAddsOnlyParentDeny() {
+        PermissionRule childAllow =
+                new PermissionRule(
+                        "read_file", "docs/**", PermissionBehavior.ALLOW, "child-policy");
+        PermissionRule childDeny = denyRule("delete_file", "child-policy");
+        PermissionRule childAsk =
+                new PermissionRule("write_file", "docs/**", PermissionBehavior.ASK, "child-policy");
+        PermissionContextState childPermissions =
+                PermissionContextState.builder()
+                        .mode(PermissionMode.ACCEPT_EDITS)
+                        .addWorkingDirectory(
+                                "child", new AdditionalWorkingDirectory("/child", "child-policy"))
+                        .addAllowRule("read_file", childAllow)
+                        .addDenyRule("delete_file", childDeny)
+                        .addAskRule("write_file", childAsk)
+                        .build();
+        PermissionRule parentDeny = denyRule("blocked_probe", "parent-policy");
+        PermissionContextState parentPermissions =
+                PermissionContextState.builder()
+                        .mode(PermissionMode.DONT_ASK)
+                        .addWorkingDirectory(
+                                "parent",
+                                new AdditionalWorkingDirectory("/parent", "parent-policy"))
+                        .addAllowRule(
+                                "parent_read",
+                                new PermissionRule(
+                                        "parent_read",
+                                        null,
+                                        PermissionBehavior.ALLOW,
+                                        "parent-policy"))
+                        .addDenyRule("blocked_probe", parentDeny)
+                        .addAskRule(
+                                "parent_write",
+                                new PermissionRule(
+                                        "parent_write",
+                                        null,
+                                        PermissionBehavior.ASK,
+                                        "parent-policy"))
+                        .build();
+        AtomicReference<Agent> childRef = new AtomicReference<>();
+        AgentSpawnTool tool =
+                tool(
+                        declaration(true, false),
+                        ignored -> {
+                            ReActAgent child =
+                                    ReActAgent.builder()
+                                            .name("worker")
+                                            .model(new MockModel("done"))
+                                            .permissionContext(childPermissions)
+                                            .build();
+                            createdAgents.add(child);
+                            childRef.set(child);
+                            return child;
+                        });
+
+        String spawnResult =
+                tool.agentSpawn(
+                                parentContext(),
+                                parentState(parentPermissions),
+                                "worker",
+                                null,
+                                null,
+                                null,
+                                null)
+                        .block();
+
+        String childSessionId = firstLineValue(spawnResult, "session_id: ");
+        PermissionContextState actual =
+                ((ReActAgent) childRef.get())
+                        .getAgentState(USER_ID, childSessionId)
+                        .getPermissionContext();
+
+        assertEquals(PermissionMode.ACCEPT_EDITS, actual.getMode());
+        assertEquals(
+                Map.of("child", childPermissions.getWorkingDirectories().get("child")),
+                actual.getWorkingDirectories());
+        assertEquals(Map.of("read_file", List.of(childAllow)), actual.getAllowRules());
+        assertEquals(
+                Map.of(
+                        "delete_file", List.of(childDeny),
+                        "blocked_probe", List.of(parentDeny)),
+                actual.getDenyRules());
+        assertEquals(Map.of("write_file", List.of(childAsk)), actual.getAskRules());
+    }
+
+    @Test
+    void declarationCanDisableParentDenyInheritance() {
+        AtomicReference<Agent> childRef = new AtomicReference<>();
+        AgentSpawnTool tool =
+                tool(
+                        declaration(false, false),
+                        ignored -> {
+                            ReActAgent child =
+                                    ReActAgent.builder()
+                                            .name("worker")
+                                            .model(new MockModel("done"))
+                                            .build();
+                            createdAgents.add(child);
+                            childRef.set(child);
+                            return child;
+                        });
+
+        String spawnResult =
+                tool.agentSpawn(
+                                parentContext(),
+                                parentState(
+                                        PermissionContextState.builder()
+                                                .addDenyRule(
+                                                        "blocked_probe",
+                                                        denyRule("blocked_probe", "parent-policy"))
+                                                .build()),
+                                "worker",
+                                null,
+                                null,
+                                null,
+                                null)
+                        .block();
+
+        String childSessionId = firstLineValue(spawnResult, "session_id: ");
+        PermissionContextState actual =
+                ((ReActAgent) childRef.get())
+                        .getAgentState(USER_ID, childSessionId)
+                        .getPermissionContext();
+        assertTrue(actual.isTrivial());
+        assertFalse(actual.getDenyRules().containsKey("blocked_probe"));
+    }
+
+    @Test
+    void persistentReuseAndAgentSendAddCurrentParentDenyWithoutDuplicates() {
+        List<HarnessAgent> children = new ArrayList<>();
+        AgentSpawnTool tool =
+                tool(
+                        declaration(true, true),
+                        ignored -> {
+                            HarnessAgent child =
+                                    HarnessAgent.builder()
+                                            .name("worker")
+                                            .model(new MockModel("done"))
+                                            .workspace(workspace)
+                                            .disableMemoryTools()
+                                            .disableMemoryHooks()
+                                            .disableWorkspaceContext()
+                                            .build();
+                            children.add(child);
+                            createdAgents.add(child);
+                            return child;
+                        });
+        AgentState parentState =
+                parentState(
+                        PermissionContextState.builder()
+                                .addDenyRule("blocked_v1", denyRule("blocked_v1", "parent-v1"))
+                                .build());
+
+        String spawnResult =
+                tool.agentSpawn(
+                                parentContext(),
+                                parentState,
+                                "worker",
+                                null,
+                                "persistent-worker",
+                                null,
+                                null)
+                        .block();
+        String key = firstLineValue(spawnResult, "agent_key: ");
+        String childSessionId = firstLineValue(spawnResult, "session_id: ");
+        HarnessAgent persistentChild = children.get(0);
+
+        parentState.setPermissionContext(
+                PermissionContextState.builder()
+                        .addDenyRule("blocked_v2", denyRule("blocked_v2", "parent-v2"))
+                        .build());
+        tool.agentSpawn(
+                        parentContext(),
+                        parentState,
+                        "worker",
+                        null,
+                        "persistent-worker",
+                        null,
+                        null)
+                .block();
+        tool.agentSpawn(
+                        parentContext(),
+                        parentState,
+                        "worker",
+                        null,
+                        "persistent-worker",
+                        null,
+                        null)
+                .block();
+
+        parentState.setPermissionContext(
+                PermissionContextState.builder()
+                        .addDenyRule("blocked_v3", denyRule("blocked_v3", "parent-v3"))
+                        .build());
+        tool.agentSend(parentContext(), parentState, key, null, "continue", null).block();
+
+        PermissionContextState actual =
+                persistentChild
+                        .getDelegate()
+                        .getAgentState(USER_ID, childSessionId)
+                        .getPermissionContext();
+        assertEquals(1, actual.getDenyRules().get("blocked_v1").size());
+        assertEquals(1, actual.getDenyRules().get("blocked_v2").size());
+        assertEquals(1, actual.getDenyRules().get("blocked_v3").size());
+    }
+
+    private AgentSpawnTool tool(SubagentDeclaration declaration, SubagentFactory factory) {
+        SubagentEntry entry =
+                new SubagentEntry("worker", "permission worker", factory, declaration);
+        return new AgentSpawnTool(new DefaultAgentManager(List.of(entry), null), null, 0);
+    }
+
+    private static SubagentDeclaration declaration(boolean inherit, boolean persist) {
+        return SubagentDeclaration.builder()
+                .name("worker")
+                .description("permission worker")
+                .inlineAgentsBody("Review permissions")
+                .persistSession(persist)
+                .inheritParentPermissions(inherit)
+                .build();
+    }
+
+    private static RuntimeContext parentContext() {
+        return RuntimeContext.builder().userId(USER_ID).sessionId(PARENT_SESSION_ID).build();
+    }
+
+    private static AgentState parentState(PermissionContextState permissions) {
+        return AgentState.builder()
+                .userId(USER_ID)
+                .sessionId(PARENT_SESSION_ID)
+                .permissionContext(permissions)
+                .build();
+    }
+
+    private static PermissionRule denyRule(String toolName, String source) {
+        return new PermissionRule(toolName, null, PermissionBehavior.DENY, source);
+    }
+
+    private static String firstLineValue(String result, String prefix) {
+        return result.lines()
+                .filter(line -> line.startsWith(prefix))
+                .map(line -> line.substring(prefix.length()))
+                .findFirst()
+                .orElseThrow();
+    }
+
+    private static final class ProbeTool extends ToolBase {
+        private ProbeTool(String name) {
+            super(
+                    ToolBase.builder()
+                            .name(name)
+                            .description("permission probe")
+                            .inputSchema(Map.of("type", "object", "properties", Map.of()))
+                            .readOnly(true)
+                            .concurrencySafe(true));
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Ensure spawned subagents cannot execute tools explicitly denied by their parent agent.

## Problem

`SubagentDeclaration.inheritParentPermissions` defaults to `true`, but parent DENY rules were not effective for automatically created `HarnessAgent` subagents.

There were three causes:

1. `HarnessAgent` wraps a `ReActAgent` delegate but is not itself a `ReActAgent`, so the existing type check skipped propagation.
2. The previous logic updated the default permission engine instead of the child’s actual `(userId, sessionId)` slot.
3. Updating only `PermissionEngine` left `AgentState.permissionContext` unchanged, allowing the runtime to treat the context as trivial and bypass the engine.

As a result, a subagent could execute a tool explicitly denied by its parent.

## Changes

- Resolve both direct `ReActAgent` children and `HarnessAgent` delegates.
- Merge parent DENY rules into the child’s actual execution slot.
- Keep `AgentState`, the permission engine cache, and persisted state synchronized.
- Reapply current parent restrictions when:
  - spawning a new child;
  - reusing a persistent child;
  - sending a message to an existing child.
- Preserve the child’s existing:
  - permission mode;
  - ALLOW rules;
  - ASK rules;
  - working directories;
  - local DENY rules.
- Respect `inheritParentPermissions=false`.
- Avoid adding duplicate DENY rules.
- Report automatic rule rejection as `Permission denied by rules`.

Only parent DENY rules are inherited. This change does not inherit parent ALLOW rules, ASK rules, or working directories.

For an initially trivial child context, BYPASS mode preserves the previous behavior for unmatched `PASSTHROUGH` tools, while explicit DENY rules still take precedence.

## Tests

Added coverage for:

- DENY propagation through a `HarnessAgent` delegate.
- Direct `ReActAgent` children.
- Real `(userId, childSessionId)` slot updates.
- Preservation of the child’s existing permission context.
- Disabled inheritance.
- Persistent child reuse.
- `agent_send` synchronization.
- Rule deduplication.
- State-store persistence and session isolation.
