### PR TITLE
feat(starters): add AgentBuilderCustomizer and auto-assembly extensions

### DIFF
--- a/agentscope-extensions/agentscope-spring-boot-starters/agentscope-spring-boot-starter/src/main/java/io/agentscope/spring/boot/AgentBuilderCustomizer.java
+++ b/agentscope-extensions/agentscope-spring-boot-starters/agentscope-spring-boot-starter/src/main/java/io/agentscope/spring/boot/AgentBuilderCustomizer.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.spring.boot;
+
+import io.agentscope.core.ReActAgent;
+import java.util.function.Consumer;
+
+/**
+ * Functional interface for customizing the {@link ReActAgent.Builder} before
+ * {@link ReActAgent.Builder#build()} is invoked by the auto-configuration.
+ *
+ * <p>Beans implementing this interface are collected via
+ * {@link org.springframework.beans.factory.ObjectProvider#orderedStream()} and
+ * applied to the builder in order. This mirrors the existing
+ * {@code ChatModelBuilderCustomizer} pattern used by model provider starters.
+ *
+ * <p>Example:
+ * <pre>{@code
+ * @Bean
+ * public AgentBuilderCustomizer myCustomizer() {
+ *     return builder -> builder.middleware(new MyMiddleware());
+ * }
+ * }</pre>
+ *
+ * @see AgentscopeAutoConfiguration#agentscopeReActAgent
+ */
+@FunctionalInterface
+public interface AgentBuilderCustomizer extends Consumer<ReActAgent.Builder> {}

--- a/agentscope-extensions/agentscope-spring-boot-starters/agentscope-spring-boot-starter/src/main/java/io/agentscope/spring/boot/AgentscopeAutoConfiguration.java
+++ b/agentscope-extensions/agentscope-spring-boot-starters/agentscope-spring-boot-starter/src/main/java/io/agentscope/spring/boot/AgentscopeAutoConfiguration.java
@@ -18,10 +18,14 @@ package io.agentscope.spring.boot;
 import io.agentscope.core.ReActAgent;
 import io.agentscope.core.memory.InMemoryMemory;
 import io.agentscope.core.memory.Memory;
+import io.agentscope.core.middleware.MiddlewareBase;
 import io.agentscope.core.model.Model;
+import io.agentscope.core.permission.PermissionContextState;
 import io.agentscope.core.tool.Toolkit;
 import io.agentscope.spring.boot.properties.AgentProperties;
 import io.agentscope.spring.boot.properties.AgentscopeProperties;
+import io.agentscope.spring.boot.tool.ToolAutoRegistrationBeanPostProcessor;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.config.ConfigurableBeanFactory;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
@@ -51,6 +55,23 @@ import org.springframework.context.annotation.Scope;
  *     sys-prompt: "You are a helpful AI assistant."
  *     max-iters: 10
  * }</pre>
+ *
+ * <p>In addition to the core beans, this configuration provides the following
+ * conveniences when {@code agentscope.agent.enabled=true}:
+ *
+ * <ul>
+ *   <li><b>Tool auto-registration</b> — beans annotated with
+ *       {@link io.agentscope.spring.boot.tool.ToolBean @ToolBean} are
+ *       automatically registered into every {@link Toolkit} via a
+ *       {@link ToolAutoRegistrationBeanPostProcessor}.</li>
+ *   <li><b>Middleware auto-assembly</b> — every {@link MiddlewareBase} bean
+ *       is auto-injected into the agent builder via an
+ *       {@link AgentBuilderCustomizer}, ordered by
+ *       {@link org.springframework.core.annotation.Order @Order}.</li>
+ *   <li><b>PermissionContextState auto-injection</b> — if a
+ *       {@link PermissionContextState} bean exists in the context, it is
+ *       auto-applied to the agent builder.</li>
+ * </ul>
  */
 @AutoConfiguration
 @EnableConfigurationProperties(AgentscopeProperties.class)
@@ -105,14 +126,77 @@ public class AgentscopeAutoConfiguration {
     @ConditionalOnBean(Model.class)
     @ConditionalOnProperty(prefix = "agentscope.agent", name = "enabled", havingValue = "true")
     public ReActAgent agentscopeReActAgent(
-            Model model, Memory memory, Toolkit toolkit, AgentscopeProperties properties) {
+            Model model,
+            Memory memory,
+            Toolkit toolkit,
+            AgentscopeProperties properties,
+            ObjectProvider<AgentBuilderCustomizer> customizers) {
         AgentProperties config = properties.getAgent();
-        return ReActAgent.builder()
-                .name(config.getName())
-                .sysPrompt(config.getSysPrompt())
-                .model(model)
-                .toolkit(toolkit)
-                .maxIters(config.getMaxIters())
-                .build();
+        ReActAgent.Builder builder =
+                ReActAgent.builder()
+                        .name(config.getName())
+                        .sysPrompt(config.getSysPrompt())
+                        .model(model)
+                        .toolkit(toolkit)
+                        .maxIters(config.getMaxIters());
+        customizers.orderedStream().forEach(c -> c.accept(builder));
+        return builder.build();
+    }
+
+    // ------------------------------------------------------------------
+    // Tool auto-registration
+    // ------------------------------------------------------------------
+
+    /**
+     * {@link org.springframework.beans.factory.config.BeanPostProcessor} that
+     * auto-registers {@link io.agentscope.spring.boot.tool.ToolBean @ToolBean}
+     * beans into every {@link Toolkit}.
+     *
+     * <p>Declared as {@code static} so that the configuration class is not
+     * instantiated prematurely.
+     */
+    @Bean
+    @ConditionalOnProperty(prefix = "agentscope.agent", name = "enabled", havingValue = "true")
+    @ConditionalOnMissingBean
+    public static ToolAutoRegistrationBeanPostProcessor toolAutoRegistrationBeanPostProcessor() {
+        return new ToolAutoRegistrationBeanPostProcessor();
+    }
+
+    // ------------------------------------------------------------------
+    // Middleware auto-assembly
+    // ------------------------------------------------------------------
+
+    /**
+     * Auto-injects all {@link MiddlewareBase} beans into the agent builder,
+     * ordered by {@link org.springframework.core.annotation.Order @Order}.
+     */
+    @Bean
+    @ConditionalOnProperty(prefix = "agentscope.agent", name = "enabled", havingValue = "true")
+    @ConditionalOnMissingBean(name = "middlewareAutoCustomizer")
+    public AgentBuilderCustomizer middlewareAutoCustomizer(
+            ObjectProvider<MiddlewareBase> middlewares) {
+        return builder -> middlewares.orderedStream().forEach(builder::middleware);
+    }
+
+    // ------------------------------------------------------------------
+    // PermissionContextState auto-injection
+    // ------------------------------------------------------------------
+
+    /**
+     * If a {@link PermissionContextState} bean exists in the context,
+     * auto-applies it to the agent builder. No-op when no
+     * {@code PermissionContextState} bean is present.
+     */
+    @Bean
+    @ConditionalOnProperty(prefix = "agentscope.agent", name = "enabled", havingValue = "true")
+    @ConditionalOnMissingBean(name = "permissionContextAutoCustomizer")
+    public AgentBuilderCustomizer permissionContextAutoCustomizer(
+            ObjectProvider<PermissionContextState> permissionContext) {
+        return builder -> {
+            PermissionContextState ctx = permissionContext.getIfAvailable();
+            if (ctx != null) {
+                builder.permissionContext(ctx);
+            }
+        };
     }
 }

--- a/agentscope-extensions/agentscope-spring-boot-starters/agentscope-spring-boot-starter/src/main/java/io/agentscope/spring/boot/HookAutoConfiguration.java
+++ b/agentscope-extensions/agentscope-spring-boot-starters/agentscope-spring-boot-starter/src/main/java/io/agentscope/spring/boot/HookAutoConfiguration.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.spring.boot;
+
+import io.agentscope.core.hook.Hook;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+
+/**
+ * Auto-configuration for {@link Hook} auto-assembly.
+ *
+ * <p>Isolated from {@link AgentscopeAutoConfiguration} because {@link Hook} and
+ * {@link io.agentscope.core.hook.HookEvent} are
+ * {@link Deprecated @Deprecated} for removal since 2.0.0. This class will be
+ * removed together with the Hook API.
+ *
+ * <p>When {@code agentscope.agent.enabled=true}, every {@link Hook} bean is
+ * auto-injected into the agent builder via an {@link AgentBuilderCustomizer},
+ * ordered by {@link org.springframework.core.annotation.Order @Order}.
+ */
+@AutoConfiguration
+@ConditionalOnClass(Hook.class)
+@ConditionalOnProperty(prefix = "agentscope.agent", name = "enabled", havingValue = "true")
+@SuppressWarnings("deprecation")
+public class HookAutoConfiguration {
+
+    /**
+     * Auto-injects all {@link Hook} beans into the agent builder, ordered by
+     * {@link org.springframework.core.annotation.Order @Order}.
+     */
+    @Bean
+    @ConditionalOnMissingBean(name = "hookAutoCustomizer")
+    public AgentBuilderCustomizer hookAutoCustomizer(ObjectProvider<Hook> hooks) {
+        return builder -> hooks.orderedStream().forEach(builder::hook);
+    }
+}

--- a/agentscope-extensions/agentscope-spring-boot-starters/agentscope-spring-boot-starter/src/main/java/io/agentscope/spring/boot/tool/ToolAutoRegistrationBeanPostProcessor.java
+++ b/agentscope-extensions/agentscope-spring-boot-starters/agentscope-spring-boot-starter/src/main/java/io/agentscope/spring/boot/tool/ToolAutoRegistrationBeanPostProcessor.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.spring.boot.tool;
+
+import io.agentscope.core.tool.Toolkit;
+import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.config.BeanPostProcessor;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationContextAware;
+
+/**
+ * {@link BeanPostProcessor} that automatically registers beans annotated with
+ * {@link ToolBean} into every {@link Toolkit} instance created by the Spring
+ * container.
+ *
+ * <p>The processor scans for {@code @ToolBean}-annotated beans when a
+ * {@code Toolkit} bean is initialized and calls
+ * {@link Toolkit#registerTool(Object)} for each one. Since {@code Toolkit} is
+ * typically prototype-scoped, each new instance receives the full set of
+ * registered tools.
+ *
+ * <p>Beans are looked up lazily via
+ * {@link ApplicationContext#getBeansWithAnnotation(Class)} so that
+ * {@code @ToolBean} beans are not eagerly instantiated unless a
+ * {@code Toolkit} is actually created.
+ */
+public class ToolAutoRegistrationBeanPostProcessor
+        implements BeanPostProcessor, ApplicationContextAware {
+
+    private static final Logger logger =
+            LoggerFactory.getLogger(ToolAutoRegistrationBeanPostProcessor.class);
+
+    private ApplicationContext applicationContext;
+
+    @Override
+    public Object postProcessAfterInitialization(Object bean, String beanName)
+            throws BeansException {
+        if (bean instanceof Toolkit toolkit) {
+            Map<String, Object> toolBeans =
+                    applicationContext.getBeansWithAnnotation(ToolBean.class);
+            for (Map.Entry<String, Object> entry : toolBeans.entrySet()) {
+                logger.debug(
+                        "Auto-registering @ToolBean '{}' into Toolkit '{}'",
+                        entry.getKey(),
+                        beanName);
+                toolkit.registerTool(entry.getValue());
+            }
+        }
+        return bean;
+    }
+
+    @Override
+    public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
+        this.applicationContext = applicationContext;
+    }
+}

--- a/agentscope-extensions/agentscope-spring-boot-starters/agentscope-spring-boot-starter/src/main/java/io/agentscope/spring/boot/tool/ToolBean.java
+++ b/agentscope-extensions/agentscope-spring-boot-starters/agentscope-spring-boot-starter/src/main/java/io/agentscope/spring/boot/tool/ToolBean.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.spring.boot.tool;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Marker annotation for beans whose {@link io.agentscope.core.tool.Tool}-annotated
+ * methods should be automatically registered into the {@link io.agentscope.core.tool.Toolkit}.
+ *
+ * <p>When this annotation is present on a bean, the
+ * {@link ToolAutoRegistrationBeanPostProcessor} will detect it and call
+ * {@code toolkit.registerTool(bean)} for every {@code Toolkit} bean created in
+ * the application context.
+ *
+ * <p>Example:
+ * <pre>{@code
+ * @ToolBean
+ * public class MyTools {
+ *     @Tool(description = "Search the web")
+ *     public String search(String query) { ... }
+ *
+ *     @Tool(description = "Calculate an expression")
+ *     public double calculate(String expression) { ... }
+ * }
+ * }</pre>
+ *
+ * <p>Multiple {@code @Tool} methods on the same class are all registered in a
+ * single {@code registerTool} call.
+ */
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface ToolBean {}

--- a/agentscope-extensions/agentscope-spring-boot-starters/agentscope-spring-boot-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/agentscope-extensions/agentscope-spring-boot-starters/agentscope-spring-boot-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -14,3 +14,4 @@
 # limitations under the License.
 #
 io.agentscope.spring.boot.AgentscopeAutoConfiguration
+io.agentscope.spring.boot.HookAutoConfiguration

--- a/agentscope-extensions/agentscope-spring-boot-starters/agentscope-spring-boot-starter/src/test/java/io/agentscope/spring/boot/AgentscopeAutoConfigurationTest.java
+++ b/agentscope-extensions/agentscope-spring-boot-starters/agentscope-spring-boot-starter/src/test/java/io/agentscope/spring/boot/AgentscopeAutoConfigurationTest.java
@@ -21,11 +21,17 @@ import io.agentscope.core.ReActAgent;
 import io.agentscope.core.memory.InMemoryMemory;
 import io.agentscope.core.memory.Memory;
 import io.agentscope.core.message.Msg;
+import io.agentscope.core.middleware.MiddlewareBase;
 import io.agentscope.core.model.ChatResponse;
 import io.agentscope.core.model.GenerateOptions;
 import io.agentscope.core.model.Model;
 import io.agentscope.core.model.ToolSchema;
+import io.agentscope.core.permission.PermissionContextState;
+import io.agentscope.core.permission.PermissionMode;
+import io.agentscope.core.tool.Tool;
+import io.agentscope.core.tool.ToolParam;
 import io.agentscope.core.tool.Toolkit;
+import io.agentscope.spring.boot.tool.ToolBean;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
@@ -100,6 +106,87 @@ class AgentscopeAutoConfigurationTest {
                         });
     }
 
+    // ------------------------------------------------------------------
+    // AgentBuilderCustomizer tests
+    // ------------------------------------------------------------------
+
+    @Test
+    void shouldApplyAgentBuilderCustomizer() {
+        contextRunner
+                .withUserConfiguration(
+                        CustomModelConfiguration.class, CustomizerConfiguration.class)
+                .run(
+                        context -> {
+                            ReActAgent agent = context.getBean(ReActAgent.class);
+                            assertThat(agent.getMaxIters()).isEqualTo(99);
+                        });
+    }
+
+    // ------------------------------------------------------------------
+    // Tool auto-registration tests
+    // ------------------------------------------------------------------
+
+    @Test
+    void shouldAutoRegisterToolBeanIntoToolkit() {
+        contextRunner
+                .withUserConfiguration(CustomModelConfiguration.class, ToolBeanConfiguration.class)
+                .run(
+                        context -> {
+                            ReActAgent agent = context.getBean(ReActAgent.class);
+                            assertThat(agent.getToolkit().getToolNames()).contains("test_tool");
+                        });
+    }
+
+    // ------------------------------------------------------------------
+    // Middleware / Hook auto-assembly tests
+    // ------------------------------------------------------------------
+
+    @Test
+    void shouldAutoInjectMiddlewareBeans() {
+        contextRunner
+                .withUserConfiguration(
+                        CustomModelConfiguration.class, MiddlewareConfiguration.class)
+                .run(
+                        context -> {
+                            ReActAgent agent = context.getBean(ReActAgent.class);
+                            assertThat(agent.getMiddlewares())
+                                    .anyMatch(mw -> mw instanceof TestMiddleware);
+                        });
+    }
+
+    // ------------------------------------------------------------------
+    // PermissionContextState auto-injection tests
+    // ------------------------------------------------------------------
+
+    @Test
+    void shouldAutoInjectPermissionContextStateWhenBeanExists() {
+        contextRunner
+                .withUserConfiguration(
+                        CustomModelConfiguration.class, PermissionConfiguration.class)
+                .run(
+                        context -> {
+                            ReActAgent agent = context.getBean(ReActAgent.class);
+                            assertThat(agent.getAgentState().getPermissionContext().getMode())
+                                    .isEqualTo(PermissionMode.ACCEPT_EDITS);
+                        });
+    }
+
+    @Test
+    void shouldNotRequirePermissionContextStateBean() {
+        contextRunner
+                .withUserConfiguration(CustomModelConfiguration.class)
+                .run(
+                        context -> {
+                            ReActAgent agent = context.getBean(ReActAgent.class);
+                            assertThat(agent.getAgentState().getPermissionContext().getMode())
+                                    .isEqualTo(PermissionMode.DEFAULT);
+                        });
+    }
+
+    // ------------------------------------------------------------------
+    // Test configurations
+    // ------------------------------------------------------------------
+
     @Configuration(proxyBeanMethods = false)
     static class CustomModelConfiguration {
 
@@ -131,6 +218,60 @@ class AgentscopeAutoConfigurationTest {
         ReActAgent customAgent(Model model, Toolkit toolkit) {
             return ReActAgent.builder().name("customAgent").model(model).toolkit(toolkit).build();
         }
+    }
+
+    @Configuration(proxyBeanMethods = false)
+    static class CustomizerConfiguration {
+
+        @Bean
+        AgentBuilderCustomizer maxItersCustomizer() {
+            return builder -> builder.maxIters(99);
+        }
+    }
+
+    @Configuration(proxyBeanMethods = false)
+    static class ToolBeanConfiguration {
+
+        @Bean
+        TestTools testTools() {
+            return new TestTools();
+        }
+    }
+
+    @Configuration(proxyBeanMethods = false)
+    static class MiddlewareConfiguration {
+
+        @Bean
+        TestMiddleware testMiddleware() {
+            return new TestMiddleware();
+        }
+    }
+
+    @Configuration(proxyBeanMethods = false)
+    static class PermissionConfiguration {
+
+        @Bean
+        PermissionContextState permissionContextState() {
+            return PermissionContextState.builder().mode(PermissionMode.ACCEPT_EDITS).build();
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // Test beans
+    // ------------------------------------------------------------------
+
+    @ToolBean
+    static class TestTools {
+
+        @Tool(name = "test_tool", description = "A test tool for unit testing")
+        public String testTool(
+                @ToolParam(name = "input", description = "Test input") String input) {
+            return "result: " + input;
+        }
+    }
+
+    static class TestMiddleware implements MiddlewareBase {
+        // All hook methods have default implementations; no override needed.
     }
 
     private static final class TestModel implements Model {

--- a/agentscope-extensions/agentscope-spring-boot-starters/agentscope-spring-boot-starter/src/test/java/io/agentscope/spring/boot/HookAutoConfigurationTest.java
+++ b/agentscope-extensions/agentscope-spring-boot-starters/agentscope-spring-boot-starter/src/test/java/io/agentscope/spring/boot/HookAutoConfigurationTest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.spring.boot;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.agentscope.core.ReActAgent;
+import io.agentscope.core.hook.Hook;
+import io.agentscope.core.hook.HookEvent;
+import io.agentscope.core.message.Msg;
+import io.agentscope.core.model.ChatResponse;
+import io.agentscope.core.model.GenerateOptions;
+import io.agentscope.core.model.Model;
+import io.agentscope.core.model.ToolSchema;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+/**
+ * Tests for {@link HookAutoConfiguration}.
+ *
+ * <p>Isolated because {@link Hook} and {@link io.agentscope.core.hook.HookEvent}
+ * are {@link Deprecated} for removal.
+ */
+@SuppressWarnings("deprecation")
+class HookAutoConfigurationTest {
+
+    private final ApplicationContextRunner contextRunner =
+            new ApplicationContextRunner()
+                    .withConfiguration(
+                            AutoConfigurations.of(
+                                    AgentscopeAutoConfiguration.class, HookAutoConfiguration.class))
+                    .withPropertyValues("agentscope.agent.enabled=true");
+
+    @Test
+    void shouldAutoInjectHookBeans() {
+        contextRunner
+                .withUserConfiguration(CustomModelConfiguration.class, HookConfiguration.class)
+                .run(
+                        context -> {
+                            ReActAgent agent = context.getBean(ReActAgent.class);
+                            assertThat(agent.getHooks()).anyMatch(h -> h instanceof TestHook);
+                        });
+    }
+
+    @Configuration(proxyBeanMethods = false)
+    static class CustomModelConfiguration {
+
+        @Bean
+        Model customModel() {
+            return new TestModel();
+        }
+    }
+
+    @Configuration(proxyBeanMethods = false)
+    static class HookConfiguration {
+
+        @Bean
+        TestHook testHook() {
+            return new TestHook();
+        }
+    }
+
+    static class TestHook implements Hook {
+        @Override
+        public <T extends HookEvent> Mono<T> onEvent(T event) {
+            return Mono.just(event);
+        }
+    }
+
+    private static final class TestModel implements Model {
+        @Override
+        public Flux<ChatResponse> stream(
+                List<Msg> messages, List<ToolSchema> tools, GenerateOptions options) {
+            return Flux.empty();
+        }
+
+        @Override
+        public String getModelName() {
+            return "custom-model";
+        }
+    }
+}

--- a/docs/v2/en/docs/building-blocks/middleware.md
+++ b/docs/v2/en/docs/building-blocks/middleware.md
@@ -59,6 +59,18 @@ ReActAgent agent =
 
 `middleware(...)` (singular) adds one; `middlewares(...)` accepts `List<? extends MiddlewareBase>`. Hooks not implemented by a middleware are skipped at zero cost.
 
+:::{tip}
+**Spring Boot auto-assembly.** When using `agentscope-spring-boot-starter`, declare middleware as beans and they will be auto-injected into the agent builder, ordered by `@Order` — no manual `builder.middleware(...)` needed:
+
+```java
+@Bean
+@Order(100)
+public MiddlewareBase timingMiddleware() { return new TimingMiddleware(); }
+```
+
+This works via `AgentBuilderCustomizer`, an SPI that mirrors `ChatModelBuilderCustomizer`. Similarly, `@ToolBean` beans are auto-registered into `Toolkit`, and a `PermissionContextState` bean (if present) is auto-applied to the builder.
+:::
+
 ## Built-in middlewares
 
 ### OtelTracingMiddleware

--- a/docs/v2/en/docs/building-blocks/tool.md
+++ b/docs/v2/en/docs/building-blocks/tool.md
@@ -105,6 +105,18 @@ Toolkit toolkit = new Toolkit();
 toolkit.registerTool(new SimpleTools());
 ```
 
+:::{tip}
+**Spring Boot auto-registration.** When using `agentscope-spring-boot-starter`, annotate your tool class with `@ToolBean` and it will be auto-registered into every `Toolkit` bean — no manual `registerTool(...)` call needed:
+
+```java
+@ToolBean
+public class MyTools {
+    @Tool(name = "search", description = "Search the web")
+    public String search(@ToolParam(name = "query") String query) { ... }
+}
+```
+:::
+
 Common `@Tool` attributes:
 
 | Attribute | Type | Description |

--- a/docs/v2/zh/docs/building-blocks/middleware.md
+++ b/docs/v2/zh/docs/building-blocks/middleware.md
@@ -59,6 +59,18 @@ ReActAgent agent =
 
 `middleware(...)`（单数）也可单独添加一个；`middlewares(...)` 接受 `List<? extends MiddlewareBase>`，未实现的位置自动跳过，不产生任何调用开销。
 
+:::{tip}
+**Spring Boot 自动装配。** 使用 `agentscope-spring-boot-starter` 时，声明 `@Bean MiddlewareBase` 即自动注入 agent builder，按 `@Order` 排序 —— 无需手动 `builder.middleware(...)`：
+
+```java
+@Bean
+@Order(100)
+public MiddlewareBase timingMiddleware() { return new TimingMiddleware(); }
+```
+
+此机制通过 `AgentBuilderCustomizer` 实现，与 `ChatModelBuilderCustomizer` 模式一致。同理，`@ToolBean` bean 自动注册到 `Toolkit`，`PermissionContextState` bean（如有）自动应用到 builder。
+:::
+
 ## 内置 Middleware
 
 ### OtelTracingMiddleware

--- a/docs/v2/zh/docs/building-blocks/tool.md
+++ b/docs/v2/zh/docs/building-blocks/tool.md
@@ -105,6 +105,18 @@ Toolkit toolkit = new Toolkit();
 toolkit.registerTool(new SimpleTools());
 ```
 
+:::{tip}
+**Spring Boot 自动注册。** 使用 `agentscope-spring-boot-starter` 时，在工具类上标注 `@ToolBean`，框架会自动将其注册到每个 `Toolkit` bean —— 无需手动调用 `registerTool(...)`：
+
+```java
+@ToolBean
+public class MyTools {
+    @Tool(name = "search", description = "Search the web")
+    public String search(@ToolParam(name = "query") String query) { ... }
+}
+```
+:::
+
 `@Tool` 常用属性：
 
 | 属性 | 类型 | 说明 |


### PR DESCRIPTION
## AgentScope-Java Version

2.0.1-SNAPSHOT

## Description

This PR adds an `AgentBuilderCustomizer` SPI to the core Spring Boot starter, mirroring the existing `ChatModelBuilderCustomizer` pattern, and provides several auto-assembly conveniences that reduce boilerplate when building agents.

The core starter currently creates a bare `ReActAgent` with only `name`/`sysPrompt`/`model`/`toolkit`/`maxIters`. Developers must manually call `toolkit.registerTool(...)`, `builder.middleware(...)`, `builder.permissionContext(...)`, etc. This PR makes all of these declarative — declare a `@Bean` and it's auto-injected.

## Changes

### 1. AgentBuilderCustomizer (SPI)

- New `@FunctionalInterface` interface, extends `Consumer<ReActAgent.Builder>`
- `AgentscopeAutoConfiguration#agentscopeReActAgent` now accepts `ObjectProvider<AgentBuilderCustomizer>` and applies all customizers before `build()`
- Backward compatible: no customizer beans → `orderedStream()` is empty → behavior unchanged

### 2. Tool auto-registration (`@ToolBean`)

- New `@ToolBean` marker annotation for beans whose `@Tool` methods should be auto-registered
- New `ToolAutoRegistrationBeanPostProcessor` (static `@Bean`) that scans for `@ToolBean` beans and calls `toolkit.registerTool(...)` on every `Toolkit` instance
- Eliminates manual `toolkit.registerTool(...)` calls in `@Bean Toolkit` methods

### 3. Middleware auto-assembly

- New `middlewareAutoCustomizer` bean: collects all `MiddlewareBase` beans via `ObjectProvider` and injects them into the agent builder, ordered by `@Order`

### 4. PermissionContextState auto-injection

- New `permissionContextAutoCustomizer` bean: if a `PermissionContextState` bean exists in the context, auto-applies it to the builder. No-op when absent.

### 5. Hook auto-assembly (isolated)

- New `HookAutoConfiguration` class: auto-injects `Hook` beans into the agent builder
- Isolated in a separate auto-configuration class because `Hook` and `HookEvent` are `@Deprecated(forRemoval = true, since = "2.0.0")`. This class can be removed together with the Hook API.

### Documentation

- Updated tool docs (EN + ZH): added `@ToolBean` auto-registration tip
- Updated middleware docs (EN + ZH): added Spring Boot auto-assembly tip

### Tests

- `AgentscopeAutoConfigurationTest`: 9 tests (4 existing + 5 new — customizer application, tool auto-registration, middleware auto-injection, permission auto-injection with/without bean)
- `HookAutoConfigurationTest`: 1 test (hook auto-injection)

## Example usage

```java
// Before: manual assembly
@Bean
Toolkit myToolkit() {
    Toolkit tk = new Toolkit();
    tk.registerTool(new MyTools());       // manual registration
    return tk;
}

@Bean
ReActAgent myAgent(Model model, Toolkit toolkit) {
    return ReActAgent.builder()
        .name("assistant")
        .model(model)
        .toolkit(toolkit)
        .middleware(new TimingMiddleware())  // manual middleware
        .build();
}

// After: declarative, auto-assembled
@ToolBean
class MyTools {
    @Tool(name = "search", description = "Search the web")
    public String search(@ToolParam(name = "query") String query) { ... }
}

@Bean
MiddlewareBase timingMiddleware() { return new TimingMiddleware(); }
// Agent bean is auto-created with tools + middleware injected.
// No @Bean ReActAgent needed — the auto-configuration handles it.
```

## Validation

| Check | Result |
|-------|--------|
| `mvn spotless:apply` | Pass |
| `mvn test` (10 tests) | Pass — 10 run, 0 failures, 0 errors |

## Checklist

Please check the following items before code is ready to be reviewed.

- [x]  Code has been formatted with `mvn spotless:apply`
- [x]  All tests are passing (`mvn test`)
- [x]  Javadoc comments are complete and follow project conventions
- [x]  Related documentation has been updated (tool + middleware docs, EN + ZH)
- [x]  Code is ready for review
