### PR TITLE
fix(harness): restore shared static asset fallback

### DIFF
--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/filesystem/spec/LocalFilesystemSpec.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/filesystem/spec/LocalFilesystemSpec.java
@@ -17,6 +17,7 @@ package io.agentscope.harness.agent.filesystem.spec;
 
 import io.agentscope.harness.agent.IsolationScope;
 import io.agentscope.harness.agent.filesystem.AbstractFilesystem;
+import io.agentscope.harness.agent.filesystem.CompositeFilesystem;
 import io.agentscope.harness.agent.filesystem.OverlayFilesystem;
 import io.agentscope.harness.agent.filesystem.ProjectAwareOverlay;
 import io.agentscope.harness.agent.filesystem.local.LocalFilesystem;
@@ -259,17 +260,6 @@ public class LocalFilesystemSpec {
         return this;
     }
 
-    /**
-     * Builds the effective filesystem as an {@link OverlayFilesystem} with the agent
-     * {@code workspace} as the upper (read-write, shell host) layer and the user
-     * {@link #project(Path)} as the read-only lower layer. Writes always land in
-     * {@code workspace}; reads check {@code workspace} first then fall back to {@code project},
-     * giving copy-on-write semantics for files that originate in the project tree.
-     *
-     * @param workspace agent workspace root (becomes overlay upper)
-     * @param localNamespaceFactory optional namespace factory for per-user/session folder scoping
-     * @return an {@link OverlayFilesystem} wired with the options in this spec
-     */
     /** Project root explicitly configured, or {@code null} to fall back to {@code ${user.dir}}. */
     public Path getProject() {
         return project;
@@ -285,6 +275,20 @@ public class LocalFilesystemSpec {
         return List.copyOf(additionalRoots);
     }
 
+    /**
+     * Builds the effective filesystem as an {@link OverlayFilesystem}. Namespaced workspace
+     * content is the upper layer. Shared static workspace assets ({@code AGENTS.md},
+     * {@code tools.json}, {@code knowledge/}, {@code skills/}, and {@code subagents/}) form the
+     * next layer, followed by project-authored content. Runtime data does not use the shared layer
+     * and therefore remains isolated by the supplied namespace factory.
+     *
+     * <p>Writes land in the namespaced workspace unless project-writable mode is enabled. Reads
+     * prefer user-specific content, then shared static workspace assets, then project content.
+     *
+     * @param workspace agent workspace root (becomes overlay upper)
+     * @param localNamespaceFactory optional namespace factory for per-user/session folder scoping
+     * @return an {@link OverlayFilesystem} wired with the options in this spec
+     */
     public AbstractFilesystem toFilesystem(Path workspace, NamespaceFactory localNamespaceFactory) {
         Path effectiveProject =
                 project != null ? project : Paths.get(System.getProperty("user.dir"));
@@ -304,7 +308,7 @@ public class LocalFilesystemSpec {
                         inheritEnv,
                         localNamespaceFactory,
                         effectiveProject);
-        LocalFilesystem lower = new LocalFilesystem(effectiveProject, true, 10, null);
+        AbstractFilesystem lower = staticAssetFallback(workspace, effectiveProject);
         if (projectWritable) {
             LocalFilesystem projectFs =
                     new LocalFilesystem(
@@ -313,5 +317,27 @@ public class LocalFilesystemSpec {
                     (AbstractSandboxFilesystem) upper, lower, projectFs, workspace);
         }
         return OverlayFilesystem.of(upper, lower);
+    }
+
+    private static AbstractFilesystem staticAssetFallback(Path workspace, Path project) {
+        LocalFilesystem projectRoot = new LocalFilesystem(project, true, 10, null);
+        LocalFilesystem workspaceRoot = new LocalFilesystem(workspace, true, 10, null);
+
+        Map<String, AbstractFilesystem> routes = new LinkedHashMap<>();
+        AbstractFilesystem sharedRootFallback = OverlayFilesystem.of(workspaceRoot, projectRoot);
+        routes.put("AGENTS.md", sharedRootFallback);
+        routes.put("tools.json", sharedRootFallback);
+        routes.put("knowledge/", staticDirectoryFallback(workspace, project, "knowledge"));
+        routes.put("skills/", staticDirectoryFallback(workspace, project, "skills"));
+        routes.put("subagents/", staticDirectoryFallback(workspace, project, "subagents"));
+        return new CompositeFilesystem(projectRoot, routes);
+    }
+
+    private static AbstractFilesystem staticDirectoryFallback(
+            Path workspace, Path project, String directory) {
+        LocalFilesystem shared = new LocalFilesystem(workspace.resolve(directory), true, 10, null);
+        LocalFilesystem projectDefault =
+                new LocalFilesystem(project.resolve(directory), true, 10, null);
+        return OverlayFilesystem.of(shared, projectDefault);
     }
 }

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/filesystem/LocalFilesystemSpecTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/filesystem/LocalFilesystemSpecTest.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.harness.agent.filesystem;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.agentscope.core.agent.RuntimeContext;
+import io.agentscope.harness.agent.filesystem.model.LsResult;
+import io.agentscope.harness.agent.filesystem.model.ReadResult;
+import io.agentscope.harness.agent.filesystem.remote.store.NamespaceFactory;
+import io.agentscope.harness.agent.filesystem.spec.LocalFilesystemSpec;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class LocalFilesystemSpecTest {
+
+    private static final RuntimeContext USER_CONTEXT =
+            RuntimeContext.builder().userId("user-1").build();
+
+    private static final NamespaceFactory USER_NAMESPACE =
+            rc -> rc != null && rc.getUserId() != null ? List.of(rc.getUserId()) : List.of();
+
+    @Test
+    void sharedKnowledgeIsReadableFromUserNamespace(@TempDir Path workspace, @TempDir Path project)
+            throws IOException {
+        Path knowledge = workspace.resolve("knowledge");
+        Files.createDirectories(knowledge);
+        Files.writeString(
+                knowledge.resolve("shared.md"), "shared knowledge", StandardCharsets.UTF_8);
+
+        AbstractFilesystem filesystem =
+                new LocalFilesystemSpec().project(project).toFilesystem(workspace, USER_NAMESPACE);
+
+        ReadResult result = filesystem.read(USER_CONTEXT, "knowledge/shared.md", 0, 0);
+
+        assertTrue(result.isSuccess(), () -> "expected shared fallback, got: " + result.error());
+        assertEquals("shared knowledge", result.fileData().content());
+    }
+
+    @Test
+    void userKnowledgeOverridesSharedAndDirectoryEntriesAreMerged(
+            @TempDir Path workspace, @TempDir Path project) throws IOException {
+        Path sharedKnowledge = workspace.resolve("knowledge");
+        Path userKnowledge = workspace.resolve("user-1").resolve("knowledge");
+        Files.createDirectories(sharedKnowledge);
+        Files.createDirectories(userKnowledge);
+        Files.writeString(
+                sharedKnowledge.resolve("same.md"), "shared version", StandardCharsets.UTF_8);
+        Files.writeString(
+                sharedKnowledge.resolve("shared-only.md"), "shared only", StandardCharsets.UTF_8);
+        Files.writeString(userKnowledge.resolve("same.md"), "user version", StandardCharsets.UTF_8);
+        Files.writeString(
+                userKnowledge.resolve("user-only.md"), "user only", StandardCharsets.UTF_8);
+
+        AbstractFilesystem filesystem =
+                new LocalFilesystemSpec().project(project).toFilesystem(workspace, USER_NAMESPACE);
+
+        ReadResult result = filesystem.read(USER_CONTEXT, "knowledge/same.md", 0, 0);
+        LsResult listing = filesystem.ls(USER_CONTEXT, "knowledge");
+
+        assertTrue(result.isSuccess());
+        assertEquals("user version", result.fileData().content());
+        assertTrue(listing.isSuccess());
+        assertEquals(3, listing.entries().size());
+        assertEquals(
+                List.of("knowledge/same.md", "knowledge/shared-only.md", "knowledge/user-only.md"),
+                listing.entries().stream().map(info -> info.path()).sorted().toList());
+    }
+
+    @Test
+    void runtimeDataDoesNotFallBackToSharedWorkspace(@TempDir Path workspace, @TempDir Path project)
+            throws IOException {
+        Path memory = workspace.resolve("memory");
+        Files.createDirectories(memory);
+        Files.writeString(memory.resolve("private.md"), "shared secret", StandardCharsets.UTF_8);
+
+        AbstractFilesystem filesystem =
+                new LocalFilesystemSpec().project(project).toFilesystem(workspace, USER_NAMESPACE);
+
+        ReadResult result = filesystem.read(USER_CONTEXT, "memory/private.md", 0, 0);
+
+        assertFalse(result.isSuccess(), "runtime data must remain isolated by namespace");
+    }
+
+    @Test
+    void staticAssetsPreferSharedWorkspaceAndRetainProjectFallback(
+            @TempDir Path workspace, @TempDir Path project) throws IOException {
+        Files.writeString(workspace.resolve("AGENTS.md"), "shared agents", StandardCharsets.UTF_8);
+        Files.writeString(project.resolve("AGENTS.md"), "project agents", StandardCharsets.UTF_8);
+        Files.writeString(project.resolve("tools.json"), "project tools", StandardCharsets.UTF_8);
+        Path projectKnowledge = project.resolve("knowledge");
+        Files.createDirectories(projectKnowledge);
+        Files.writeString(
+                projectKnowledge.resolve("default.md"),
+                "project knowledge",
+                StandardCharsets.UTF_8);
+
+        AbstractFilesystem filesystem =
+                new LocalFilesystemSpec().project(project).toFilesystem(workspace, USER_NAMESPACE);
+
+        ReadResult agents = filesystem.read(USER_CONTEXT, "AGENTS.md", 0, 0);
+        ReadResult tools = filesystem.read(USER_CONTEXT, "tools.json", 0, 0);
+        ReadResult knowledge = filesystem.read(USER_CONTEXT, "knowledge/default.md", 0, 0);
+
+        assertTrue(agents.isSuccess());
+        assertTrue(tools.isSuccess());
+        assertTrue(knowledge.isSuccess());
+        assertEquals("shared agents", agents.fileData().content());
+        assertEquals("project tools", tools.fileData().content());
+        assertEquals("project knowledge", knowledge.fileData().content());
+    }
+}


### PR DESCRIPTION
## Summary

- add a selective shared workspace fallback for static assets in local filesystem mode
- preserve user-specific override precedence and project defaults
- keep runtime data isolated by namespace

## Tests

- `mvn -pl agentscope-harness -am -Dtest=LocalFilesystemSpecTest,LocalFilesystemModeTest,LocalFilesystemWithShellTest,ProjectAwareOverlayTest,WorkspaceContextMiddlewarePathBoundsTest -Dsurefire.failIfNoSpecifiedTests=false test`
- 46 tests passed

Closes #2501