### PR TITLE
feat(HITL): Emit UserConfirmResultEvent when resuming permission HITL

### DIFF
--- a/agentscope-core/src/main/java/io/agentscope/core/ReActAgent.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/ReActAgent.java
@@ -1538,39 +1538,8 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
             // ConfirmResults (via Msg.METADATA_CONFIRM_RESULTS) before we can proceed.
             List<ToolUseBlock> asking = askingToolCalls();
             if (!asking.isEmpty()) {
-                List<ConfirmResult> confirmResults = extractConfirmResults(msgs);
-                if (confirmResults.isEmpty()) {
-                    String pendingSummary =
-                            asking.stream()
-                                    .map(t -> t.getName() + " (id=" + t.getId() + ")")
-                                    .collect(Collectors.joining(", "));
-                    throw new IllegalStateException(
-                            "Agent is paused for human-in-the-loop confirmation: the following"
-                                    + " tool call(s) are in ASKING state and need your approval"
-                                    + " before the agent can continue: ["
-                                    + pendingSummary
-                                    + "]. This call supplied no confirmation, so it cannot"
-                                    + " proceed.\n"
-                                    + "To resume, send a follow-up message that carries a"
-                                    + " List<ConfirmResult> under the metadata key \""
-                                    + Msg.METADATA_CONFIRM_RESULTS
-                                    + "\", e.g.:\n"
-                                    + "    UserMessage.builder()\n"
-                                    + "        .metadata(Map.of(Msg.METADATA_CONFIRM_RESULTS,\n"
-                                    + "            List.of(new ConfirmResult(true, toolCall))))\n"
-                                    + "        .build();\n"
-                                    + "Tip: capture the ToolUseBlocks from the"
-                                    + " RequireUserConfirmEvent emitted when the agent paused.\n"
-                                    + "If you did NOT expect a pending confirmation here, a"
-                                    + " previous run most likely paused on one of these tool calls"
-                                    + " and persisted that state under the same (agentId,"
-                                    + " sessionId); start a fresh session, clear the persisted"
-                                    + " state, or use an in-memory state store to begin clean.");
-                }
                 List<ConfirmResult> normalizedResults =
-                        validateAndNormalizeConfirmResults(confirmResults, asking);
-                // Surface the accepted confirmation payload before mutating context or executing
-                // tools, so stream consumers can close the RequireUserConfirmEvent loop.
+                        validateAndNormalizeConfirmResults(msgs, asking);
                 publishEvent(
                         new UserConfirmResultEvent(
                                 resolvePendingConfirmRequestReplyId(), normalizedResults));
@@ -1633,22 +1602,49 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
         /**
          * Validate the user-provided confirmation payload against the currently ASKING tool calls.
          *
-         * <p>Permission HITL resumes as a batch: every ASKING tool call must be covered exactly
-         * once, and no result may reference a stale or unrelated tool call. Returning a copied list
-         * gives downstream event emission and state mutation the same trusted payload.
+         * <p>Permission HITL resumes with one or more confirmations for currently ASKING tool
+         * calls. Confirmations may cover a subset of ASKING calls, but no result may reference a
+         * stale or unrelated tool call. Returning a copied list gives downstream event emission and
+         * state mutation the same trusted payload.
          */
         private List<ConfirmResult> validateAndNormalizeConfirmResults(
-                List<ConfirmResult> results, List<ToolUseBlock> asking) {
+                List<Msg> msgs, List<ToolUseBlock> asking) {
+            List<ConfirmResult> results = extractConfirmResults(msgs);
+            if (results.isEmpty()) {
+                String pendingSummary =
+                        asking.stream()
+                                .map(t -> t.getName() + " (id=" + t.getId() + ")")
+                                .collect(Collectors.joining(", "));
+                throw new IllegalStateException(
+                        "Agent is paused for human-in-the-loop confirmation: the following"
+                                + " tool call(s) are in ASKING state and need your approval"
+                                + " before the agent can continue: ["
+                                + pendingSummary
+                                + "]. This call supplied no confirmation, so it cannot"
+                                + " proceed.\n"
+                                + "To resume, send a follow-up message that carries a"
+                                + " List<ConfirmResult> under the metadata key \""
+                                + Msg.METADATA_CONFIRM_RESULTS
+                                + "\", e.g.:\n"
+                                + "    UserMessage.builder()\n"
+                                + "        .metadata(Map.of(Msg.METADATA_CONFIRM_RESULTS,\n"
+                                + "            List.of(new ConfirmResult(true, toolCall))))\n"
+                                + "        .build();\n"
+                                + "Tip: capture the ToolUseBlocks from the"
+                                + " RequireUserConfirmEvent emitted when the agent paused.\n"
+                                + "If you did NOT expect a pending confirmation here, a"
+                                + " previous run most likely paused on one of these tool calls"
+                                + " and persisted that state under the same (agentId,"
+                                + " sessionId); start a fresh session, clear the persisted"
+                                + " state, or use an in-memory state store to begin clean.");
+            }
+
             Set<String> expectedIds =
                     asking.stream()
                             .map(ToolUseBlock::getId)
                             .filter(Objects::nonNull)
                             .collect(Collectors.toCollection(LinkedHashSet::new));
 
-            Map<String, ToolUseBlock> askingById =
-                    asking.stream()
-                            .filter(t -> t.getId() != null)
-                            .collect(Collectors.toMap(ToolUseBlock::getId, Function.identity()));
             Set<String> providedIds = new LinkedHashSet<>();
             List<ConfirmResult> normalized = new ArrayList<>();
 
@@ -1675,19 +1671,6 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
                 }
                 normalized.add(result);
             }
-
-            if (!providedIds.equals(expectedIds)) {
-                Set<String> missing = new LinkedHashSet<>(expectedIds);
-                missing.removeAll(providedIds);
-                Set<String> unexpected = new LinkedHashSet<>(providedIds);
-                unexpected.removeAll(expectedIds);
-                throw new IllegalStateException(
-                        "ConfirmResults must cover all ASKING tool calls exactly once. Missing: "
-                                + missing
-                                + ", Unexpected: "
-                                + unexpected);
-            }
-
             return List.copyOf(normalized);
         }
 

--- a/agentscope-core/src/main/java/io/agentscope/core/ReActAgent.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/ReActAgent.java
@@ -1538,8 +1538,7 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
             // ConfirmResults (via Msg.METADATA_CONFIRM_RESULTS) before we can proceed.
             List<ToolUseBlock> asking = askingToolCalls();
             if (!asking.isEmpty()) {
-                List<ConfirmResult> confirmResults =
-                        extractAndValidateConfirmResults(msgs, asking);
+                List<ConfirmResult> confirmResults = extractAndValidateConfirmResults(msgs, asking);
                 publishEvent(
                         new UserConfirmResultEvent(
                                 resolvePendingConfirmRequestReplyId(), confirmResults));

--- a/agentscope-core/src/main/java/io/agentscope/core/ReActAgent.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/ReActAgent.java
@@ -1538,12 +1538,12 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
             // ConfirmResults (via Msg.METADATA_CONFIRM_RESULTS) before we can proceed.
             List<ToolUseBlock> asking = askingToolCalls();
             if (!asking.isEmpty()) {
-                List<ConfirmResult> normalizedResults =
-                        validateAndNormalizeConfirmResults(msgs, asking);
+                List<ConfirmResult> confirmResults =
+                        extractAndValidateConfirmResults(msgs, asking);
                 publishEvent(
                         new UserConfirmResultEvent(
-                                resolvePendingConfirmRequestReplyId(), normalizedResults));
-                applyConfirmResults(normalizedResults);
+                                resolvePendingConfirmRequestReplyId(), confirmResults));
+                applyConfirmResults(confirmResults);
                 clearPendingConfirmRequest();
                 return resumeAgent();
             }
@@ -1607,7 +1607,7 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
          * stale or unrelated tool call. Returning a copied list gives downstream event emission and
          * state mutation the same trusted payload.
          */
-        private List<ConfirmResult> validateAndNormalizeConfirmResults(
+        private List<ConfirmResult> extractAndValidateConfirmResults(
                 List<Msg> msgs, List<ToolUseBlock> asking) {
             List<ConfirmResult> results = extractConfirmResults(msgs);
             if (results.isEmpty()) {
@@ -1671,7 +1671,7 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
                 }
                 normalized.add(result);
             }
-            return List.copyOf(normalized);
+            return normalized;
         }
 
         /**

--- a/agentscope-core/src/main/java/io/agentscope/core/ReActAgent.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/ReActAgent.java
@@ -50,6 +50,7 @@ import io.agentscope.core.event.ToolResultDataDeltaEvent;
 import io.agentscope.core.event.ToolResultEndEvent;
 import io.agentscope.core.event.ToolResultStartEvent;
 import io.agentscope.core.event.ToolResultTextDeltaEvent;
+import io.agentscope.core.event.UserConfirmResultEvent;
 import io.agentscope.core.formatter.JsonSchema;
 import io.agentscope.core.formatter.ResponseFormat;
 import io.agentscope.core.hook.Hook;
@@ -1566,7 +1567,15 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
                                     + " sessionId); start a fresh session, clear the persisted"
                                     + " state, or use an in-memory state store to begin clean.");
                 }
-                applyConfirmResults(confirmResults);
+                List<ConfirmResult> normalizedResults =
+                        validateAndNormalizeConfirmResults(confirmResults, asking);
+                // Surface the accepted confirmation payload before mutating context or executing
+                // tools, so stream consumers can close the RequireUserConfirmEvent loop.
+                publishEvent(
+                        new UserConfirmResultEvent(
+                                resolvePendingConfirmRequestReplyId(), normalizedResults));
+                applyConfirmResults(normalizedResults);
+                clearPendingConfirmRequest();
                 return resumeAgent();
             }
 
@@ -1619,6 +1628,128 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
                 }
             }
             return collected;
+        }
+
+        /**
+         * Validate the user-provided confirmation payload against the currently ASKING tool calls.
+         *
+         * <p>Permission HITL resumes as a batch: every ASKING tool call must be covered exactly
+         * once, and no result may reference a stale or unrelated tool call. Returning a copied list
+         * gives downstream event emission and state mutation the same trusted payload.
+         */
+        private List<ConfirmResult> validateAndNormalizeConfirmResults(
+                List<ConfirmResult> results, List<ToolUseBlock> asking) {
+            Set<String> expectedIds =
+                    asking.stream()
+                            .map(ToolUseBlock::getId)
+                            .filter(Objects::nonNull)
+                            .collect(Collectors.toCollection(LinkedHashSet::new));
+
+            Map<String, ToolUseBlock> askingById =
+                    asking.stream()
+                            .filter(t -> t.getId() != null)
+                            .collect(Collectors.toMap(ToolUseBlock::getId, Function.identity()));
+            Set<String> providedIds = new LinkedHashSet<>();
+            List<ConfirmResult> normalized = new ArrayList<>();
+
+            for (ConfirmResult result : results) {
+                if (result == null || result.getToolCall() == null) {
+                    throw new IllegalStateException(
+                            "ConfirmResult and ConfirmResult.toolCall must not be null.");
+                }
+                ToolUseBlock toolCall = result.getToolCall();
+                String toolCallId = toolCall.getId();
+                if (toolCallId == null || toolCallId.isEmpty()) {
+                    throw new IllegalStateException("ConfirmResult.toolCall.id must not be empty.");
+                }
+                if (!providedIds.add(toolCallId)) {
+                    throw new IllegalStateException(
+                            "Duplicate ConfirmResult for tool call ID: " + toolCallId);
+                }
+                if (!expectedIds.contains(toolCallId)) {
+                    throw new IllegalStateException(
+                            "ConfirmResult references non-ASKING tool call ID: "
+                                    + toolCallId
+                                    + ". Expected: "
+                                    + expectedIds);
+                }
+                normalized.add(result);
+            }
+
+            if (!providedIds.equals(expectedIds)) {
+                Set<String> missing = new LinkedHashSet<>(expectedIds);
+                missing.removeAll(providedIds);
+                Set<String> unexpected = new LinkedHashSet<>(providedIds);
+                unexpected.removeAll(expectedIds);
+                throw new IllegalStateException(
+                        "ConfirmResults must cover all ASKING tool calls exactly once. Missing: "
+                                + missing
+                                + ", Unexpected: "
+                                + unexpected);
+            }
+
+            return List.copyOf(normalized);
+        }
+
+        /**
+         * Resolve the reply id from the assistant message that originally paused for confirmation.
+         *
+         * <p>This keeps {@link UserConfirmResultEvent} correlated with the prior
+         * {@link RequireUserConfirmEvent}, even though the confirmation arrives in a later
+         * {@code agent.call(...)} invocation.
+         */
+        private String resolvePendingConfirmRequestReplyId() {
+            Msg confirmRequestMsg = findLastAssistantMsg();
+            if (confirmRequestMsg == null || confirmRequestMsg.getMetadata() == null) {
+                return "";
+            }
+            Object raw = confirmRequestMsg.getMetadata().get(Msg.METADATA_CONFIRM_REQUEST_REPLY_ID);
+            return raw instanceof String s ? s : "";
+        }
+
+        /**
+         * Persist the reply id for the pending confirmation request on the live assistant message.
+         *
+         * <p>The assistant message already owns the ASKING {@link ToolUseBlock}s, so storing the
+         * correlation metadata there lets the next call recover it from session state.
+         */
+        private void persistPendingConfirmRequest(String replyId) {
+            Msg lastAssistant = findLastAssistantMsg();
+            if (lastAssistant == null) {
+                return;
+            }
+            Map<String, Object> metadata = new HashMap<>(lastAssistant.getMetadata());
+            metadata.put(Msg.METADATA_CONFIRM_REQUEST_REPLY_ID, replyId);
+            replaceLastAssistantMsg(lastAssistant.withMetadata(metadata));
+        }
+
+        /**
+         * Remove confirmation-request correlation metadata after the resume payload is accepted.
+         *
+         * <p>Leaving it behind would make later agent turns appear to belong to an already-closed
+         * HITL request.
+         */
+        private void clearPendingConfirmRequest() {
+            Msg lastAssistant = findLastAssistantMsg();
+            if (lastAssistant == null || lastAssistant.getMetadata() == null) {
+                return;
+            }
+            if (!lastAssistant.getMetadata().containsKey(Msg.METADATA_CONFIRM_REQUEST_REPLY_ID)) {
+                return;
+            }
+            Map<String, Object> metadata = new HashMap<>(lastAssistant.getMetadata());
+            metadata.remove(Msg.METADATA_CONFIRM_REQUEST_REPLY_ID);
+            replaceLastAssistantMsg(lastAssistant.withMetadata(metadata));
+        }
+
+        private void replaceLastAssistantMsg(Msg replacement) {
+            List<Msg> ctx = state.contextMutable();
+            for (int i = ctx.size() - 1; i >= 0; i--) {
+                if (ctx.get(i).getRole() == MsgRole.ASSISTANT) {
+                    ctx.set(i, replacement);
+                    return;
+                }
+            }
         }
 
         /**
@@ -2507,6 +2638,7 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
                                 // completion;
                                 // initialise it to empty since no successful execution happened.
                                 resultHolder.set(List.of());
+                                persistPendingConfirmRequest(replyId);
                                 return Flux.<AgentEvent>just(
                                         new RequireUserConfirmEvent(replyId, pending),
                                         new RequestStopEvent(

--- a/agentscope-core/src/main/java/io/agentscope/core/message/Msg.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/message/Msg.java
@@ -77,6 +77,13 @@ public class Msg implements State {
     public static final String METADATA_CONFIRM_RESULTS = "agentscope_confirm_results";
 
     /**
+     * Metadata key storing the {@code replyId} of the {@code RequireUserConfirmEvent} that paused
+     * this assistant turn. Used to correlate the later {@code UserConfirmResultEvent}.
+     */
+    public static final String METADATA_CONFIRM_REQUEST_REPLY_ID =
+            "agentscope_confirm_request_reply_id";
+
+    /**
      * Metadata key (boolean) marking a message as <em>synthetic</em>: framework-injected rather
      * than authored by the user, the model, or a tool. Synthetic messages (e.g. the per-turn todo
      * reminder produced by {@code TaskReminderMiddleware}) are appended transiently to the
@@ -667,6 +674,23 @@ public class Msg implements State {
                 this.role,
                 newContent,
                 this.metadata,
+                this.timestamp,
+                this.usage);
+    }
+
+    /**
+     * Returns a copy of this message with the given metadata.
+     *
+     * @param newMetadata the replacement metadata
+     * @return a new Msg with identical content but replaced metadata
+     */
+    public Msg withMetadata(Map<String, Object> newMetadata) {
+        return new Msg(
+                this.id,
+                this.name,
+                this.role,
+                this.content,
+                newMetadata,
                 this.timestamp,
                 this.usage);
     }

--- a/agentscope-core/src/test/java/io/agentscope/core/agent/ReActAgentHitlTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/agent/ReActAgentHitlTest.java
@@ -26,6 +26,7 @@ import io.agentscope.core.event.ConfirmResult;
 import io.agentscope.core.event.RequestStopEvent;
 import io.agentscope.core.event.RequireUserConfirmEvent;
 import io.agentscope.core.event.ToolResultEndEvent;
+import io.agentscope.core.event.UserConfirmResultEvent;
 import io.agentscope.core.message.ContentBlock;
 import io.agentscope.core.message.GenerateReason;
 import io.agentscope.core.message.Msg;
@@ -108,6 +109,10 @@ class ReActAgentHitlTest {
                                         .input(input)
                                         .build()))
                 .build();
+    }
+
+    private static ChatResponse toolUseResponse(List<ToolUseBlock> toolUses) {
+        return ChatResponse.builder().content(List.copyOf(toolUses)).build();
     }
 
     private static final class AskingTool extends ToolBase {
@@ -279,6 +284,72 @@ class ReActAgentHitlTest {
 
         RequestStopEvent stop = (RequestStopEvent) events.get(iStop);
         assertEquals(GenerateReason.PERMISSION_ASKING, stop.getGenerateReason());
+    }
+
+    @Test
+    void confirmedResumeEmitsUserConfirmResultEventCorrelatedToRequireEvent() {
+        ChatModelBase model =
+                new ScriptedModel(
+                        List.of(
+                                () -> Flux.just(toolUseResponse("tc1", "ask", "x")),
+                                () -> Flux.just(textResponse("done"))));
+        ReActAgent agent = buildAgent(model, toolkitWith(new AskingTool("ask")));
+
+        List<AgentEvent> pauseEvents = agent.streamEvents(List.of()).collectList().block();
+        assertNotNull(pauseEvents);
+        RequireUserConfirmEvent req =
+                (RequireUserConfirmEvent)
+                        pauseEvents.get(indexOf(pauseEvents, RequireUserConfirmEvent.class));
+
+        List<AgentEvent> resumeEvents =
+                agent.streamEvents(List.of(confirmMsg(true, req.getToolCalls().get(0))))
+                        .collectList()
+                        .block();
+        assertNotNull(resumeEvents);
+
+        int iConfirm = indexOf(resumeEvents, UserConfirmResultEvent.class);
+        int iToolEnd = indexOf(resumeEvents, ToolResultEndEvent.class);
+        assertTrue(iConfirm >= 0, "UserConfirmResultEvent must be emitted on confirmed resume");
+        assertTrue(iToolEnd > iConfirm, "tool execution must follow the confirm-result event");
+
+        UserConfirmResultEvent confirm = (UserConfirmResultEvent) resumeEvents.get(iConfirm);
+        assertEquals(req.getReplyId(), confirm.getReplyId());
+        assertEquals(1, confirm.getConfirmResults().size());
+        assertEquals("tc1", confirm.getConfirmResults().get(0).getToolCall().getId());
+    }
+
+    @Test
+    void confirmResultsMustCoverEveryAskingToolCall() {
+        ChatModelBase model =
+                new ScriptedModel(
+                        List.of(
+                                () ->
+                                        Flux.just(
+                                                toolUseResponse(
+                                                        List.of(
+                                                                ToolUseBlock.builder()
+                                                                        .id("tc1")
+                                                                        .name("ask1")
+                                                                        .input(Map.of("query", "x"))
+                                                                        .build(),
+                                                                ToolUseBlock.builder()
+                                                                        .id("tc2")
+                                                                        .name("ask2")
+                                                                        .input(Map.of("query", "y"))
+                                                                        .build())))));
+        ReActAgent agent =
+                buildAgent(model, toolkitWith(new AskingTool("ask1"), new AskingTool("ask2")));
+
+        Msg first = agent.call(List.of()).block();
+        assertNotNull(first);
+        List<ToolUseBlock> pending = first.getContentBlocks(ToolUseBlock.class);
+        assertEquals(2, pending.size());
+
+        IllegalStateException error =
+                assertThrows(
+                        IllegalStateException.class,
+                        () -> agent.call(List.of(confirmMsg(true, pending.get(0)))).block());
+        assertTrue(error.getMessage().contains("cover all ASKING tool calls"));
     }
 
     @Test

--- a/agentscope-core/src/test/java/io/agentscope/core/agent/ReActAgentHitlTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/agent/ReActAgentHitlTest.java
@@ -319,7 +319,7 @@ class ReActAgentHitlTest {
     }
 
     @Test
-    void confirmResultsMustCoverEveryAskingToolCall() {
+    void confirmResultsMayCoverSomeAskingToolCalls() {
         ChatModelBase model =
                 new ScriptedModel(
                         List.of(
@@ -345,11 +345,16 @@ class ReActAgentHitlTest {
         List<ToolUseBlock> pending = first.getContentBlocks(ToolUseBlock.class);
         assertEquals(2, pending.size());
 
-        IllegalStateException error =
-                assertThrows(
-                        IllegalStateException.class,
-                        () -> agent.call(List.of(confirmMsg(true, pending.get(0)))).block());
-        assertTrue(error.getMessage().contains("cover all ASKING tool calls"));
+        Msg resumed = agent.call(List.of(confirmMsg(true, pending.get(0)))).block();
+        assertNotNull(resumed);
+        assertEquals(GenerateReason.PERMISSION_ASKING, resumed.getGenerateReason());
+
+        List<ToolUseBlock> remaining =
+                resumed.getContentBlocks(ToolUseBlock.class).stream()
+                        .filter(t -> t.getState() == ToolCallState.ASKING)
+                        .toList();
+        assertEquals(1, remaining.size());
+        assertEquals("tc2", remaining.get(0).getId());
     }
 
     @Test

--- a/docs/v2/en/docs/building-blocks/message-and-event.md
+++ b/docs/v2/en/docs/building-blocks/message-and-event.md
@@ -296,7 +296,13 @@ Events are grouped below; unless noted otherwise, every event also carries `getR
 
     **RequireExternalExecutionEvent** — agent pauses for external execution.
 
-    **UserConfirmResultEvent** — user provides confirmation results (input event); carries `List<ConfirmResult>`.
+    **UserConfirmResultEvent** — emitted when a later `call()` resumes a paused permission HITL request.
+    It carries one or more `ConfirmResult`s, and its `replyId` matches the earlier `RequireUserConfirmEvent`.
+
+    | Method | Type | Description |
+    |--------|------|-------------|
+    | `getReplyId()` | `String` | Reply ID of the correlated `RequireUserConfirmEvent` |
+    | `getConfirmResults()` | `List<ConfirmResult>` | Confirmation results accepted for this resume |
 
     **ExternalExecutionResultEvent** — external system returns execution results (input event); carries `List<ToolResultBlock>`.
 

--- a/docs/v2/en/docs/building-blocks/permission-system.md
+++ b/docs/v2/en/docs/building-blocks/permission-system.md
@@ -388,6 +388,11 @@ Msg resumeMsg =
 agent.call(List.of(resumeMsg)).block();
 ```
 
+If the resume is sent with `streamEvents(List.of(resumeMsg))`, the stream includes a
+`UserConfirmResultEvent` before the resumed tool execution. Use its `replyId` to associate
+the accepted results with the earlier `RequireUserConfirmEvent`; the event contains only
+the confirmations included in that resume call.
+
 Comparison of the two modes:
 
 | | Blocking `call()` | Streaming `streamEvents()` |

--- a/docs/v2/zh/docs/building-blocks/message-and-event.md
+++ b/docs/v2/zh/docs/building-blocks/message-and-event.md
@@ -296,7 +296,13 @@ sequenceDiagram
 
     **RequireExternalExecutionEvent** — 智能体暂停等待外部执行。
 
-    **UserConfirmResultEvent** — 用户提供确认结果（输入事件）。携带 `List<ConfirmResult>`。
+    **UserConfirmResultEvent** — 用户提供确认结果。携带 `List<ConfirmResult>`。
+     `replyId` 与最初暂停智能体的 `RequireUserConfirmEvent` 相同。
+
+    | 方法 | 类型 | 描述 |
+    |------|------|------|
+    | `getReplyId()` | `String` | 关联的 `RequireUserConfirmEvent` 的回复 ID |
+    | `getConfirmResults()` | `List<ConfirmResult>` | 本次恢复接受的确认结果 |
 
     **ExternalExecutionResultEvent** — 外部系统提供执行结果（输入事件）。携带 `List<ToolResultBlock>`。
 

--- a/docs/v2/zh/docs/building-blocks/permission-system.md
+++ b/docs/v2/zh/docs/building-blocks/permission-system.md
@@ -389,6 +389,10 @@ Msg resumeMsg =
 agent.call(List.of(resumeMsg)).block();
 ```
 
+如果使用 `streamEvents(List.of(resumeMsg))` 发起恢复，事件流会在恢复执行工具之前包含
+`UserConfirmResultEvent`。使用它的 `replyId` 将本次接受的确认结果关联到之前的
+`RequireUserConfirmEvent`；该事件只包含本次恢复消息携带的确认结果。
+
 两种模式的区别：
 
 | | Blocking `call()` | Streaming `streamEvents()` |


### PR DESCRIPTION
## Summary

- Emit `UserConfirmResultEvent` when `ReActAgent` accepts `ConfirmResult` payloads while resuming permission HITL.
- Persist the pending confirmation request `replyId` on the live assistant message so the result event can correlate with the earlier `RequireUserConfirmEvent`.
- Validate that resume `ConfirmResult`s fully cover all current `ASKING` tool calls before emitting the event or mutating context.
- Update HITL tests and event docs for the new resume-event behavior.

## Checklist

Please check the following items before code is ready to be reviewed.

- [ ]  Code has been formatted with `mvn spotless:apply`
- [ ]  All tests are passing (`mvn test`)
- [ ]  Javadoc comments are complete and follow project conventions
- [ ]  Related documentation has been updated (e.g. links, examples, etc.)
- [ ]  Code is ready for review
