### PR TITLE
fix(core): custom HITL deny reason and tool result events on ASK deny

### DIFF
--- a/agentscope-core/src/main/java/io/agentscope/core/ReActAgent.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/ReActAgent.java
@@ -1750,13 +1750,15 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
          *       modified) one from the result, set state to {@link ToolCallState#ALLOWED}, and
          *       register any attached {@link PermissionRule}s with the engine.</li>
          *   <li>{@code confirmed == false}: write a DENIED {@link ToolResultBlock} to context so
-         *       the tool will no longer be pending on resume.</li>
+         *       the tool will no longer be pending on resume, and emit the same
+         *       {@link ToolResultStartEvent} / {@link ToolResultTextDeltaEvent} /
+         *       {@link ToolResultEndEvent} sequence used for auto-denied tools.</li>
          * </ul>
          */
         private void applyConfirmResults(List<ConfirmResult> results) {
             // Replace ASKING ToolUseBlocks with possibly-modified ones from the user, and
             // promote them to ALLOWED. Collect denied ones for separate handling.
-            List<ToolUseBlock> deniedToolCalls = new ArrayList<>();
+            List<Map.Entry<ToolUseBlock, String>> deniedEntries = new ArrayList<>();
             Map<String, ToolUseBlock> replacements = new HashMap<>();
             Map<String, ToolCallState> stateUpdates = new HashMap<>();
             for (ConfirmResult r : results) {
@@ -1775,20 +1777,47 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
                         }
                     }
                 } else {
-                    deniedToolCalls.add(target);
+                    deniedEntries.add(Map.entry(target, resolveUserDenyMessage(r)));
                 }
             }
             applyToolUseBlockReplacements(replacements);
-            for (ToolUseBlock denied : deniedToolCalls) {
+            if (deniedEntries.isEmpty()) {
+                return;
+            }
+            // Correlate all deny tool-result events for this resume with one reply id, matching
+            // the auto-deny path in runToolBatch.
+            String replyId = UUID.randomUUID().toString().replace("-", "");
+            for (Map.Entry<ToolUseBlock, String> entry : deniedEntries) {
+                ToolUseBlock denied = entry.getKey();
+                String denyMessage = entry.getValue();
                 ToolResultBlock deniedResult =
-                        ToolResultBlock.text("Permission denied by user")
+                        ToolResultBlock.text(denyMessage)
                                 .withIdAndName(denied.getId(), denied.getName())
                                 .withState(ToolResultState.DENIED);
                 Msg deniedMsg =
                         ToolResultMessageBuilder.buildToolResultMsg(
                                 deniedResult, denied, getName());
                 state.contextMutable().add(deniedMsg);
+                publishEvent(new ToolResultStartEvent(replyId, denied.getId(), denied.getName()));
+                publishEvent(
+                        new ToolResultTextDeltaEvent(
+                                replyId, denied.getId(), denied.getName(), denyMessage));
+                publishEvent(
+                        new ToolResultEndEvent(
+                                replyId, denied.getId(), denied.getName(), ToolResultState.DENIED));
             }
+        }
+
+        /**
+         * Resolve the tool-result text for a user deny. Prefer {@link ConfirmResult#getMessage()}
+         * when present; otherwise keep the historical default.
+         */
+        private static String resolveUserDenyMessage(ConfirmResult result) {
+            String message = result.getMessage();
+            if (message != null && !message.isBlank()) {
+                return message;
+            }
+            return "Permission denied by user";
         }
 
         /**

--- a/agentscope-core/src/main/java/io/agentscope/core/event/ConfirmResult.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/event/ConfirmResult.java
@@ -29,7 +29,9 @@ import java.util.List;
  * future calls — e.g. "always allow this command going forward".
  *
  * <p>When denied ({@code confirmed == false}), an optional {@link #message} can override the
- * default tool-result text ({@code "Permission denied by user"}).
+ * default tool-result text ({@code "Permission denied by user"}). Prefer {@link #withMessage} or
+ * the 4-arg constructor — there is no 3-arg {@code (confirmed, toolCall, message)} overload so
+ * {@code new ConfirmResult(c, t, null)} stays unambiguous against the rules overload.
  */
 public class ConfirmResult {
 
@@ -61,12 +63,19 @@ public class ConfirmResult {
     }
 
     /**
-     * Convenience constructor with a custom deny message and no rules.
+     * Factory for a confirm result with a custom deny message and no rules.
      *
-     * <p>Useful when the user rejects a tool call and wants the model to see a specific reason.
+     * <p>Use this (or the 4-arg constructor) instead of a 3-arg message overload so that {@code
+     * new ConfirmResult(confirmed, toolCall, null)} remains unambiguously the rules constructor.
+     *
+     * @param confirmed whether the user approved the tool call
+     * @param toolCall the (possibly modified) tool call being decided
+     * @param message custom tool-result text when denying; blank/null falls back to the default
+     * @return a new {@link ConfirmResult}
      */
-    public ConfirmResult(boolean confirmed, ToolUseBlock toolCall, String message) {
-        this(confirmed, toolCall, null, message);
+    public static ConfirmResult withMessage(
+            boolean confirmed, ToolUseBlock toolCall, String message) {
+        return new ConfirmResult(confirmed, toolCall, null, message);
     }
 
     public boolean isConfirmed() {

--- a/agentscope-core/src/main/java/io/agentscope/core/event/ConfirmResult.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/event/ConfirmResult.java
@@ -27,26 +27,46 @@ import java.util.List;
  * <p>When confirmed, the caller may supply a modified {@link #toolCall} (allowing the user to
  * tweak input) and/or new {@link #rules} that the {@code PermissionEngine} should remember for
  * future calls — e.g. "always allow this command going forward".
+ *
+ * <p>When denied ({@code confirmed == false}), an optional {@link #message} can override the
+ * default tool-result text ({@code "Permission denied by user"}).
  */
 public class ConfirmResult {
 
     private final boolean confirmed;
     private final ToolUseBlock toolCall;
     private final List<PermissionRule> rules;
+    private final String message;
 
     @JsonCreator
     public ConfirmResult(
             @JsonProperty("confirmed") boolean confirmed,
             @JsonProperty("toolCall") ToolUseBlock toolCall,
-            @JsonProperty("rules") List<PermissionRule> rules) {
+            @JsonProperty("rules") List<PermissionRule> rules,
+            @JsonProperty("message") String message) {
         this.confirmed = confirmed;
         this.toolCall = toolCall;
         this.rules = rules;
+        this.message = message;
     }
 
-    /** Convenience constructor without rules. */
+    /** Convenience constructor without a custom deny message. */
+    public ConfirmResult(boolean confirmed, ToolUseBlock toolCall, List<PermissionRule> rules) {
+        this(confirmed, toolCall, rules, null);
+    }
+
+    /** Convenience constructor without rules or a custom deny message. */
     public ConfirmResult(boolean confirmed, ToolUseBlock toolCall) {
-        this(confirmed, toolCall, null);
+        this(confirmed, toolCall, null, null);
+    }
+
+    /**
+     * Convenience constructor with a custom deny message and no rules.
+     *
+     * <p>Useful when the user rejects a tool call and wants the model to see a specific reason.
+     */
+    public ConfirmResult(boolean confirmed, ToolUseBlock toolCall, String message) {
+        this(confirmed, toolCall, null, message);
     }
 
     public boolean isConfirmed() {
@@ -65,5 +85,16 @@ public class ConfirmResult {
      */
     public List<PermissionRule> getRules() {
         return rules;
+    }
+
+    /**
+     * Optional text used as the denied tool-result content when {@link #confirmed} is false.
+     *
+     * <p>When null or blank, the agent falls back to {@code "Permission denied by user"}.
+     *
+     * @return custom deny message, or null
+     */
+    public String getMessage() {
+        return message;
     }
 }

--- a/agentscope-core/src/test/java/io/agentscope/core/agent/ReActAgentHitlTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/agent/ReActAgentHitlTest.java
@@ -26,6 +26,8 @@ import io.agentscope.core.event.ConfirmResult;
 import io.agentscope.core.event.RequestStopEvent;
 import io.agentscope.core.event.RequireUserConfirmEvent;
 import io.agentscope.core.event.ToolResultEndEvent;
+import io.agentscope.core.event.ToolResultStartEvent;
+import io.agentscope.core.event.ToolResultTextDeltaEvent;
 import io.agentscope.core.event.UserConfirmResultEvent;
 import io.agentscope.core.message.ContentBlock;
 import io.agentscope.core.message.GenerateReason;
@@ -215,7 +217,11 @@ class ReActAgentHitlTest {
     }
 
     private static Msg confirmMsg(boolean confirmed, ToolUseBlock toolCall) {
-        return confirmMsg(List.of(new ConfirmResult(confirmed, toolCall, null)));
+        return confirmMsg(new ConfirmResult(confirmed, toolCall));
+    }
+
+    private static Msg confirmMsg(ConfirmResult result) {
+        return confirmMsg(List.of(result));
     }
 
     private static Msg confirmMsg(List<ConfirmResult> confirmResults) {
@@ -227,6 +233,23 @@ class ReActAgentHitlTest {
                 .textContent("[confirm]")
                 .metadata(meta)
                 .build();
+    }
+
+    private static ToolUseBlock pendingAskingTool(ReActAgent agent) {
+        for (int i = agent.getAgentState().getContext().size() - 1; i >= 0; i--) {
+            Msg m = agent.getAgentState().getContext().get(i);
+            if (m.getRole() == MsgRole.ASSISTANT) {
+                return m.getContentBlocks(ToolUseBlock.class).get(0);
+            }
+        }
+        throw new AssertionError("expected an assistant message with a pending tool call");
+    }
+
+    private static String toolResultText(ToolResultBlock block) {
+        return block.getOutput().stream()
+                .filter(b -> b instanceof TextBlock)
+                .map(b -> ((TextBlock) b).getText())
+                .reduce("", String::concat);
     }
 
     @Test
@@ -383,29 +406,96 @@ class ReActAgentHitlTest {
         assertNotNull(first);
         assertEquals(GenerateReason.PERMISSION_ASKING, first.getGenerateReason());
 
-        Msg lastAssistant = null;
-        for (int i = agent.getAgentState().getContext().size() - 1; i >= 0; i--) {
-            Msg m = agent.getAgentState().getContext().get(i);
-            if (m.getRole() == MsgRole.ASSISTANT) {
-                lastAssistant = m;
-                break;
-            }
-        }
-        ToolUseBlock pending = lastAssistant.getContentBlocks(ToolUseBlock.class).get(0);
+        ToolUseBlock pending = pendingAskingTool(agent);
 
         // Second call → deny
         Msg second = agent.call(List.of(confirmMsg(false, pending))).block();
         assertNotNull(second);
 
-        // Context should contain a DENIED ToolResultBlock for tc1
-        boolean foundDenied =
+        // Context should contain a DENIED ToolResultBlock for tc1 with the default message
+        ToolResultBlock denied =
                 agent.getAgentState().getContext().stream()
                         .flatMap(m -> m.getContentBlocks(ToolResultBlock.class).stream())
-                        .anyMatch(
-                                tr ->
-                                        "tc1".equals(tr.getId())
-                                                && tr.getState() == ToolResultState.DENIED);
-        assertTrue(foundDenied, "expected a DENIED ToolResultBlock for the rejected tool");
+                        .filter(tr -> "tc1".equals(tr.getId()))
+                        .findFirst()
+                        .orElse(null);
+        assertNotNull(denied, "expected a DENIED ToolResultBlock for the rejected tool");
+        assertEquals(ToolResultState.DENIED, denied.getState());
+        assertEquals("Permission denied by user", toolResultText(denied));
+    }
+
+    @Test
+    void askingToolResumeWithCustomDenyMessageUsesConfirmResultMessage() {
+        ChatModelBase model =
+                new ScriptedModel(
+                        List.of(
+                                () -> Flux.just(toolUseResponse("tc1", "ask", "x")),
+                                () -> Flux.just(textResponse("done"))));
+        ReActAgent agent = buildAgent(model, toolkitWith(new AskingTool("ask")));
+
+        Msg first = agent.call(List.of()).block();
+        assertNotNull(first);
+        assertEquals(GenerateReason.PERMISSION_ASKING, first.getGenerateReason());
+
+        ToolUseBlock pending = pendingAskingTool(agent);
+        String reason = "User rejected: do not delete production data";
+        Msg second =
+                agent.call(List.of(confirmMsg(new ConfirmResult(false, pending, reason)))).block();
+        assertNotNull(second);
+
+        ToolResultBlock denied =
+                agent.getAgentState().getContext().stream()
+                        .flatMap(m -> m.getContentBlocks(ToolResultBlock.class).stream())
+                        .filter(tr -> "tc1".equals(tr.getId()))
+                        .findFirst()
+                        .orElse(null);
+        assertNotNull(denied);
+        assertEquals(ToolResultState.DENIED, denied.getState());
+        assertEquals(reason, toolResultText(denied));
+    }
+
+    @Test
+    void askingToolResumeWithDenyEmitsToolResultEvents() {
+        ChatModelBase model =
+                new ScriptedModel(
+                        List.of(
+                                () -> Flux.just(toolUseResponse("tc1", "ask", "x")),
+                                () -> Flux.just(textResponse("done"))));
+        ReActAgent agent = buildAgent(model, toolkitWith(new AskingTool("ask")));
+
+        // First stream: pause on ASK
+        List<AgentEvent> firstEvents = agent.streamEvents(List.of()).collectList().block();
+        assertNotNull(firstEvents);
+        assertTrue(indexOf(firstEvents, RequireUserConfirmEvent.class) >= 0);
+
+        ToolUseBlock pending = pendingAskingTool(agent);
+        String reason = "blocked by policy";
+
+        // Second stream: deny — should surface the same Start/Delta/End sequence as auto-deny
+        List<AgentEvent> resumeEvents =
+                agent.streamEvents(List.of(confirmMsg(new ConfirmResult(false, pending, reason))))
+                        .collectList()
+                        .block();
+        assertNotNull(resumeEvents);
+
+        int iStart = indexOf(resumeEvents, ToolResultStartEvent.class);
+        int iDelta = indexOf(resumeEvents, ToolResultTextDeltaEvent.class);
+        int iEnd = indexOf(resumeEvents, ToolResultEndEvent.class);
+        assertTrue(iStart >= 0, "ToolResultStartEvent must be emitted on manual deny");
+        assertTrue(iDelta > iStart, "ToolResultTextDeltaEvent must follow Start");
+        assertTrue(iEnd > iDelta, "ToolResultEndEvent must follow TextDelta");
+
+        ToolResultStartEvent start = (ToolResultStartEvent) resumeEvents.get(iStart);
+        assertEquals("tc1", start.getToolCallId());
+        assertEquals("ask", start.getToolCallName());
+
+        ToolResultTextDeltaEvent delta = (ToolResultTextDeltaEvent) resumeEvents.get(iDelta);
+        assertEquals("tc1", delta.getToolCallId());
+        assertEquals(reason, delta.getDelta());
+
+        ToolResultEndEvent end = (ToolResultEndEvent) resumeEvents.get(iEnd);
+        assertEquals("tc1", end.getToolCallId());
+        assertEquals(ToolResultState.DENIED, end.getState());
     }
 
     @Test

--- a/agentscope-core/src/test/java/io/agentscope/core/agent/ReActAgentHitlTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/agent/ReActAgentHitlTest.java
@@ -440,7 +440,8 @@ class ReActAgentHitlTest {
         ToolUseBlock pending = pendingAskingTool(agent);
         String reason = "User rejected: do not delete production data";
         Msg second =
-                agent.call(List.of(confirmMsg(new ConfirmResult(false, pending, reason)))).block();
+                agent.call(List.of(confirmMsg(ConfirmResult.withMessage(false, pending, reason))))
+                        .block();
         assertNotNull(second);
 
         ToolResultBlock denied =
@@ -452,6 +453,36 @@ class ReActAgentHitlTest {
         assertNotNull(denied);
         assertEquals(ToolResultState.DENIED, denied.getState());
         assertEquals(reason, toolResultText(denied));
+    }
+
+    @Test
+    void askingToolResumeWithBlankDenyMessageFallsBackToDefault() {
+        ChatModelBase model =
+                new ScriptedModel(
+                        List.of(
+                                () -> Flux.just(toolUseResponse("tc1", "ask", "x")),
+                                () -> Flux.just(textResponse("done"))));
+        ReActAgent agent = buildAgent(model, toolkitWith(new AskingTool("ask")));
+
+        Msg first = agent.call(List.of()).block();
+        assertNotNull(first);
+        assertEquals(GenerateReason.PERMISSION_ASKING, first.getGenerateReason());
+
+        ToolUseBlock pending = pendingAskingTool(agent);
+        Msg second =
+                agent.call(List.of(confirmMsg(ConfirmResult.withMessage(false, pending, "   "))))
+                        .block();
+        assertNotNull(second);
+
+        ToolResultBlock denied =
+                agent.getAgentState().getContext().stream()
+                        .flatMap(m -> m.getContentBlocks(ToolResultBlock.class).stream())
+                        .filter(tr -> "tc1".equals(tr.getId()))
+                        .findFirst()
+                        .orElse(null);
+        assertNotNull(denied);
+        assertEquals(ToolResultState.DENIED, denied.getState());
+        assertEquals("Permission denied by user", toolResultText(denied));
     }
 
     @Test
@@ -473,7 +504,10 @@ class ReActAgentHitlTest {
 
         // Second stream: deny — should surface the same Start/Delta/End sequence as auto-deny
         List<AgentEvent> resumeEvents =
-                agent.streamEvents(List.of(confirmMsg(new ConfirmResult(false, pending, reason))))
+                agent.streamEvents(
+                                List.of(
+                                        confirmMsg(
+                                                ConfirmResult.withMessage(false, pending, reason))))
                         .collectList()
                         .block();
         assertNotNull(resumeEvents);

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/tool/AgentSpawnTool.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/tool/AgentSpawnTool.java
@@ -711,8 +711,13 @@ public class AgentSpawnTool {
                                 new AgentStartEvent(spawned.sessionId(), null, spawned.agentId())
                                         .withSource(sourcePath));
 
-                        AtomicBoolean endEmitted = new AtomicBoolean();
-                        Runnable emitEnd =
+                        // Emit AGENT_END at most once. Prefer the success path (flatMap) so the
+                        // bookend is delivered *before* the Mono value reaches
+                        // execWithTimeoutPromotion's CompletableFuture bridge — otherwise
+                        // whenComplete can advance the parent and complete the streamEvents sink
+                        // before doFinally runs, dropping the child AGENT_END under load (CI).
+                        AtomicBoolean endEmitted = new AtomicBoolean(false);
+                        Runnable emitChildEnd =
                                 () -> {
                                     if (endEmitted.compareAndSet(false, true)) {
                                         parentEmitter.emit(
@@ -726,16 +731,18 @@ public class AgentSpawnTool {
                                                 c.put(
                                                         AgentEventEmitter.FORWARDING_CONTEXT_KEY,
                                                         taggedEmitter))
-                                // Emit before success or error reaches the parent, which may
-                                // otherwise complete its event sink before doFinally runs.
-                                .doOnSuccess(ignored -> emitEnd.run())
-                                .doOnError(ignored -> emitEnd.run())
-                                // Preserve best-effort cancellation signaling without emitting a
-                                // duplicate if cancellation races with normal termination.
+                                .flatMap(
+                                        msg -> {
+                                            emitChildEnd.run();
+                                            return Mono.just(msg);
+                                        })
+                                .doOnError(err -> emitChildEnd.run())
+                                // Cancel: flatMap/doOnError do not run; still need the bookend so
+                                // consumers do not render the subagent as running forever.
                                 .doFinally(
                                         signal -> {
                                             if (signal == SignalType.CANCEL) {
-                                                emitEnd.run();
+                                                emitChildEnd.run();
                                             }
                                         });
                     }

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/HarnessAgentSubagentStreamEventsTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/HarnessAgentSubagentStreamEventsTest.java
@@ -257,7 +257,12 @@ class HarnessAgentSubagentStreamEventsTest {
                                         e.getType() == AgentEventType.AGENT_END
                                                 && e.getSource() != null)
                         .collect(Collectors.toList());
-        assertFalse(childEnds.isEmpty(), "expected child AGENT_END with source");
+        assertFalse(
+                childEnds.isEmpty(),
+                "expected child AGENT_END with source; events="
+                        + events.stream()
+                                .map(e -> e.getType() + "(src=" + e.getSource() + ")")
+                                .collect(Collectors.joining(", ")));
         assertTrue(childEnds.get(0).getSource().contains(childId));
     }
 

--- a/docs/v2/en/docs/building-blocks/permission-system.md
+++ b/docs/v2/en/docs/building-blocks/permission-system.md
@@ -314,7 +314,10 @@ if (result != null && result.getGenerateReason() == GenerateReason.PERMISSION_AS
     // Show pending operations to the user
     askingTools.forEach(t -> System.out.println("Pending: " + t.getName() + " " + t.getInput()));
 
-    // 4. Collect the user's decision, build ConfirmResult, and resume
+    // 4. Collect the user's decision, build ConfirmResult, and resume.
+    // Deny with a custom tool-result reason via ConfirmResult.withMessage(...), or the
+    // 4-arg constructor (confirmed, toolCall, rules, message). Blank/null message keeps
+    // the default "Permission denied by user".
     boolean approved = askUser();
     List<ConfirmResult> confirmResults =
             askingTools.stream()

--- a/docs/v2/zh/docs/building-blocks/permission-system.md
+++ b/docs/v2/zh/docs/building-blocks/permission-system.md
@@ -314,7 +314,10 @@ if (result != null && result.getGenerateReason() == GenerateReason.PERMISSION_AS
     // 向用户展示
     askingTools.forEach(t -> System.out.println("Pending: " + t.getName() + " " + t.getInput()));
 
-    // 4. 收集用户决策，构建 ConfirmResult 恢复 agent
+    // 4. 收集用户决策，构建 ConfirmResult 恢复 agent。
+    // 拒绝时可自定义 tool-result 文案：ConfirmResult.withMessage(...) 或 4 参构造
+    // (confirmed, toolCall, rules, message)。message 为 null/空白时回退为
+    // "Permission denied by user"。
     boolean approved = askUser();
     List<ConfirmResult> confirmResults =
             askingTools.stream()


### PR DESCRIPTION
## AgentScope-Java Version

2.0.1-SNAPSHOT (`main`)

## Description

Fixes #2492.

When permission HITL is in ASK and the user rejects a tool call:

1. **Custom deny reason** — `ConfirmResult` now has an optional `message` field. If set (non-blank), that text is written into the denied `ToolResultBlock` instead of the fixed `"Permission denied by user"`. Existing callers keep the old default.
2. **Tool result events** — manual deny now emits `ToolResultStartEvent` → `ToolResultTextDeltaEvent` → `ToolResultEndEvent` (state `DENIED`), matching the auto-deny path in `runToolBatch`. Previously only context was updated, so stream consumers never saw tool_result events for user denials.

### Usage

```java
// Prefer factory (no ambiguous 3-arg overload with List rules):
ConfirmResult.withMessage(false, toolCall, "User rejected: do not delete production data");
// or full form:
new ConfirmResult(false, toolCall, /* rules */ null, "custom reason");
// blank/null message → "Permission denied by user"
```

### How tested

```bash
mvn -pl agentscope-core -am test -Dtest=ReActAgentHitlTest
# Tests run: 9, Failures: 0, Errors: 0
```

New coverage in `ReActAgentHitlTest`:
- custom deny message appears in the denied tool result
- blank/whitespace deny message falls back to `"Permission denied by user"`
- resume-with-deny stream emits Start / TextDelta / End with `DENIED` state

## Checklist

Please check the following items before code is ready to be reviewed.

- [x]  Code has been formatted with `mvn spotless:apply`
- [x]  All tests are passing (`mvn test` — `ReActAgentHitlTest`)
- [x]  Javadoc comments are complete and follow project conventions
- [x]  Related documentation has been updated (e.g. links, examples, etc.)
- [x]  Code is ready for review