### PR TITLE
fix(harness): preserve wakeups during active turns

### DIFF
--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/gateway/HarnessGateway.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/gateway/HarnessGateway.java
@@ -450,8 +450,9 @@ public final class HarnessGateway implements Gateway, WakeupDispatcher.WakeupTar
 
     /**
      * Returns {@code true} when the given session is currently inside a gated turn (a run is in
-     * progress). Used by {@link WakeupDispatcher} to skip sessions that will naturally drain their
-     * inbox on the current reasoning step.
+     * progress). {@link WakeupDispatcher} uses this for diagnostics; wakeup runs are still
+     * submitted and wait on the same gate so a late inbox entry is not left without a follow-up
+     * turn.
      */
     public boolean isSessionRunning(String sessionId) {
         String gateKey = sessionToGateKey.get(sessionId);

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/gateway/SessionTurnGate.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/gateway/SessionTurnGate.java
@@ -39,8 +39,8 @@ public final class SessionTurnGate {
 
     /**
      * Non-blocking check: returns {@code true} when a turn is currently held for the given key
-     * (i.e. a run is in progress). Used by {@link WakeupDispatcher} to skip sessions that are
-     * already active — their current run will drain the inbox naturally.
+     * (i.e. a run is in progress). Used by {@link WakeupDispatcher} for diagnostics before it
+     * submits a wakeup that will wait on this gate.
      */
     public boolean isRunning(String key) {
         Semaphore s = gates.get(key);

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/gateway/WakeupDispatcher.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/gateway/WakeupDispatcher.java
@@ -26,11 +26,12 @@ import reactor.core.Disposable;
 import reactor.core.publisher.Mono;
 
 /**
- * Per-process dispatcher that wakes idle sessions when background work completes.
+ * Per-process dispatcher that schedules session wakeups when background work completes.
  *
  * <p>Subscribes to the shared wakeup signal channel on {@link MessageBus#subscribeWakeup()} and
- * drains the durable wakeup queue on each signal. For each queued entry whose target session is
- * idle, triggers a new reasoning round via {@link WakeupTarget#runWakeup(String)}.
+ * drains the durable wakeup queue on each signal. Each queued entry triggers a new reasoning round
+ * via {@link WakeupTarget#runWakeup(String)}. The target serializes wakeup rounds behind an active
+ * session turn so entries drained while the session is running are not discarded.
  *
  * It serves as the universal activator for all cross-session communication:
  *
@@ -76,7 +77,8 @@ public class WakeupDispatcher implements AutoCloseable {
         Mono<Msg> runWakeup(String sessionId);
 
         /**
-         * Triggers a wakeup run for an idle session, carrying the owning user id when present.
+         * Triggers a wakeup run, carrying the owning user id when present. Implementations must
+         * serialize the run behind any active turn for the same session.
          *
          * <p>Called by {@link WakeupDispatcher} when a background task completes or a team message
          * arrives. Implementations should set the user id on the agent runtime context when
@@ -155,14 +157,13 @@ public class WakeupDispatcher implements AutoCloseable {
 
         if (target.isSessionRunning(sessionId)) {
             log.debug(
-                    "WakeupDispatcher: session {} is running, skipping (current run will drain"
-                            + " inbox)",
+                    "WakeupDispatcher: session {} is running; wakeup will wait behind the current"
+                            + " turn",
                     sessionId);
-            return;
         }
 
         log.info(
-                "WakeupDispatcher: waking idle session {}, userId={}, agentId={}",
+                "WakeupDispatcher: dispatching wakeup for session {}, userId={}, agentId={}",
                 sessionId,
                 userId,
                 agentId);

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/gateway/WakeupDispatcherTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/gateway/WakeupDispatcherTest.java
@@ -70,16 +70,24 @@ class WakeupDispatcherTest {
     }
 
     @Test
-    @DisplayName("Running session is skipped by dispatcher")
-    void runningSession_skipped() throws Exception {
+    @DisplayName("Wakeup for a running session is delegated instead of discarded")
+    void runningSession_wakeupIsNotDiscarded() throws Exception {
         target.addKnown("sess-running");
         target.markRunning("sess-running");
+        messageBus
+                .queuePush(
+                        "agentscope:wakeups",
+                        Map.of(
+                                "userId", "user-1",
+                                "sessionId", "sess-running",
+                                "agentId", "agent-main"))
+                .block();
+
         dispatcher.start();
-
-        messageBus.enqueueWakeup("user-1", "sess-running", "agent-main").block();
-
-        Thread.sleep(500);
-        assertTrue(target.wokenSessions.isEmpty(), "Running session should not be woken");
+        assertTrue(
+                target.awaitWakeup(1, 3, TimeUnit.SECONDS),
+                "Wakeup must reach the target, which serializes it behind the active turn");
+        assertEquals("sess-running", target.wokenSessions.get(0));
     }
 
     @Test


### PR DESCRIPTION
## Summary

- prevent drained wakeup entries from being discarded while a session turn is active
- submit follow-up wakeup runs through the existing fair session gate
- add a regression test for wakeups drained during an active turn

## Tests

- `mvn -pl agentscope-harness -am -Dtest=WakeupDispatcherTest,WorkspaceMessageBusTest,HarnessGatewaySessionIdTest,SubagentDeliveryTest -Dsurefire.failIfNoSpecifiedTests=false test`
- 36 tests passed

Fixes #2506