### PR TITLE
feat(agui): introduce typed MessageContent and InputContent model for multimodal AG-UI messages (issue#551)

### DIFF
--- a/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/main/java/io/agentscope/core/agui/converter/AguiMessageConverter.java
+++ b/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/main/java/io/agentscope/core/agui/converter/AguiMessageConverter.java
@@ -21,7 +21,6 @@ import io.agentscope.core.agui.model.AguiMessage;
 import io.agentscope.core.agui.model.AguiResume;
 import io.agentscope.core.agui.model.AguiToolCall;
 import io.agentscope.core.agui.model.AudioInputContent;
-import io.agentscope.core.agui.model.DocumentInputContent;
 import io.agentscope.core.agui.model.ImageInputContent;
 import io.agentscope.core.agui.model.InputContent;
 import io.agentscope.core.agui.model.InputContentDataSource;
@@ -34,7 +33,6 @@ import io.agentscope.core.agui.model.VideoInputContent;
 import io.agentscope.core.message.AudioBlock;
 import io.agentscope.core.message.Base64Source;
 import io.agentscope.core.message.ContentBlock;
-import io.agentscope.core.message.DataBlock;
 import io.agentscope.core.message.ImageBlock;
 import io.agentscope.core.message.Msg;
 import io.agentscope.core.message.MsgRole;
@@ -80,6 +78,10 @@ public class AguiMessageConverter {
         if (content instanceof MessageContent.Text text) {
             addTextBlock(blocks, text.value(), aguiMessage);
         } else if (content instanceof MessageContent.Blocks blocksContent) {
+            if (!aguiMessage.isUserMessage()) {
+                throw new IllegalArgumentException(
+                        "Structured content blocks are only supported for AG-UI user messages");
+            }
             for (InputContent input : blocksContent.parts()) {
                 blocks.add(toContentBlock(input));
             }
@@ -264,10 +266,11 @@ public class AguiMessageConverter {
         if (input instanceof VideoInputContent video) {
             return VideoBlock.builder().source(toSource(video.source())).build();
         }
-        if (input instanceof DocumentInputContent doc) {
-            // AgentScope 暂未提供原生的 DocumentBlock，暂时转换为 DataBlock
-            return DataBlock.builder().source(toSource(doc.source())).build();
-        }
+        //        if (input instanceof DocumentInputContent doc) {
+        //            // AgentScope currently lacks a native DocumentBlock; falling back to
+        // DataBlock
+        //            return DataBlock.builder().source(toSource(doc.source())).build();
+        //        }
         throw new IllegalStateException("Unhandled InputContent type: " + input);
     }
 

--- a/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/main/java/io/agentscope/core/agui/converter/AguiMessageConverter.java
+++ b/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/main/java/io/agentscope/core/agui/converter/AguiMessageConverter.java
@@ -20,14 +20,31 @@ import io.agentscope.core.agui.model.AguiFunctionCall;
 import io.agentscope.core.agui.model.AguiMessage;
 import io.agentscope.core.agui.model.AguiResume;
 import io.agentscope.core.agui.model.AguiToolCall;
+import io.agentscope.core.agui.model.AudioInputContent;
+import io.agentscope.core.agui.model.DocumentInputContent;
+import io.agentscope.core.agui.model.ImageInputContent;
+import io.agentscope.core.agui.model.InputContent;
+import io.agentscope.core.agui.model.InputContentDataSource;
+import io.agentscope.core.agui.model.InputContentSource;
+import io.agentscope.core.agui.model.InputContentUrlSource;
+import io.agentscope.core.agui.model.MessageContent;
 import io.agentscope.core.agui.model.RunAgentInput;
+import io.agentscope.core.agui.model.TextInputContent;
+import io.agentscope.core.agui.model.VideoInputContent;
+import io.agentscope.core.message.AudioBlock;
+import io.agentscope.core.message.Base64Source;
 import io.agentscope.core.message.ContentBlock;
+import io.agentscope.core.message.DataBlock;
+import io.agentscope.core.message.ImageBlock;
 import io.agentscope.core.message.Msg;
 import io.agentscope.core.message.MsgRole;
+import io.agentscope.core.message.Source;
 import io.agentscope.core.message.TextBlock;
 import io.agentscope.core.message.ToolResultBlock;
 import io.agentscope.core.message.ToolResultState;
 import io.agentscope.core.message.ToolUseBlock;
+import io.agentscope.core.message.URLSource;
+import io.agentscope.core.message.VideoBlock;
 import io.agentscope.core.util.JsonException;
 import io.agentscope.core.util.JsonUtils;
 import java.util.ArrayList;
@@ -58,17 +75,13 @@ public class AguiMessageConverter {
         MsgRole role = convertRole(aguiMessage.getRole());
         List<ContentBlock> blocks = new ArrayList<>();
 
-        // Add text content if present
-        if (aguiMessage.getContent() != null && !aguiMessage.getContent().isEmpty()) {
-            if (aguiMessage.isToolMessage() && aguiMessage.getToolCallId() != null) {
-                // For tool messages, wrap content in ToolResultBlock
-                blocks.add(
-                        ToolResultBlock.of(
-                                aguiMessage.getToolCallId(),
-                                null,
-                                TextBlock.builder().text(aguiMessage.getContent()).build()));
-            } else {
-                blocks.add(TextBlock.builder().text(aguiMessage.getContent()).build());
+        // Handle content: plain text or structured blocks
+        MessageContent content = aguiMessage.getContent();
+        if (content instanceof MessageContent.Text text) {
+            addTextBlock(blocks, text.value(), aguiMessage);
+        } else if (content instanceof MessageContent.Blocks blocksContent) {
+            for (InputContent input : blocksContent.parts()) {
+                blocks.add(toContentBlock(input));
             }
         }
 
@@ -119,7 +132,7 @@ public class AguiMessageConverter {
         return new AguiMessage(
                 msg.getId(),
                 role,
-                content.length() > 0 ? content.toString() : null,
+                content.length() > 0 ? new MessageContent.Text(content.toString()) : null,
                 toolCalls.isEmpty() ? null : toolCalls,
                 toolCallId);
     }
@@ -203,6 +216,81 @@ public class AguiMessageConverter {
             case SYSTEM -> "system";
             case TOOL -> "tool";
         };
+    }
+
+    /**
+     * Add a text content block for the given text, wrapping in a ToolResultBlock for tool messages.
+     *
+     * @param blocks the target block list
+     * @param text the text content
+     * @param aguiMessage the source message (for role/tool-call-id context)
+     */
+    private void addTextBlock(List<ContentBlock> blocks, String text, AguiMessage aguiMessage) {
+        if (text == null || text.isEmpty()) {
+            return;
+        }
+        if (aguiMessage.isToolMessage() && aguiMessage.getToolCallId() != null) {
+            blocks.add(
+                    ToolResultBlock.of(
+                            aguiMessage.getToolCallId(),
+                            null,
+                            TextBlock.builder().text(text).build()));
+        } else {
+            blocks.add(TextBlock.builder().text(text).build());
+        }
+    }
+
+    /**
+     * Convert an AG-UI {@link InputContent} to an AgentScope {@link ContentBlock}.
+     *
+     * <p>Uses instanceof pattern matching over the sealed {@link InputContent} hierarchy.
+     * When a new InputContent subtype is added, the final {@code throw} provides a
+     * runtime safety net. On Java 21+, this can be upgraded to exhaustive switch
+     * pattern matching for compile-time enforcement.
+     *
+     * @param input the AG-UI input content part
+     * @return the converted content block
+     */
+    private ContentBlock toContentBlock(InputContent input) {
+        if (input instanceof TextInputContent text) {
+            return TextBlock.builder().text(text.text()).build();
+        }
+        if (input instanceof ImageInputContent image) {
+            return ImageBlock.builder().source(toSource(image.source())).build();
+        }
+        if (input instanceof AudioInputContent audio) {
+            return AudioBlock.builder().source(toSource(audio.source())).build();
+        }
+        if (input instanceof VideoInputContent video) {
+            return VideoBlock.builder().source(toSource(video.source())).build();
+        }
+        if (input instanceof DocumentInputContent doc) {
+            // AgentScope 暂未提供原生的 DocumentBlock，暂时转换为 DataBlock
+            return DataBlock.builder().source(toSource(doc.source())).build();
+        }
+        throw new IllegalStateException("Unhandled InputContent type: " + input);
+    }
+
+    /**
+     * Convert an AG-UI protocol {@link InputContentSource} to an AgentScope {@link Source}.
+     *
+     * <p>Mapping:
+     * <ul>
+     *   <li>{@link InputContentUrlSource} (type:"url", value) &rarr; {@link URLSource} (url)</li>
+     *   <li>{@link InputContentDataSource} (type:"data", value) &rarr; {@link Base64Source} (data)</li>
+     * </ul>
+     *
+     * @param inputSource the AG-UI protocol source
+     * @return the AgentScope internal source
+     */
+    private Source toSource(InputContentSource inputSource) {
+        if (inputSource instanceof InputContentUrlSource url) {
+            return new URLSource(url.value(), url.mimeType());
+        }
+        if (inputSource instanceof InputContentDataSource data) {
+            return new Base64Source(data.mimeType(), data.value());
+        }
+        throw new IllegalStateException("Unhandled InputContentSource type: " + inputSource);
     }
 
     /**

--- a/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/main/java/io/agentscope/core/agui/model/AguiMessage.java
+++ b/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/main/java/io/agentscope/core/agui/model/AguiMessage.java
@@ -34,12 +34,16 @@ import java.util.Objects;
  *   <li>system - System instructions</li>
  *   <li>tool - Tool execution results</li>
  * </ul>
+ *
+ * <p>The {@code content} field uses {@link MessageContent}, a type-safe sealed union
+ * that can represent either plain text or a list of structured {@link InputContent}
+ * parts (text, image, audio, video, document).
  */
 public class AguiMessage {
 
     private final String id;
     private final String role;
-    private final String content;
+    private final MessageContent content;
     private final List<AguiToolCall> toolCalls;
     private final String toolCallId;
 
@@ -48,7 +52,7 @@ public class AguiMessage {
      *
      * @param id The unique message ID
      * @param role The message role (user, assistant, system, tool)
-     * @param content The message content
+     * @param content The message content (plain text or structured blocks), may be null
      * @param toolCalls Tool calls for assistant messages (optional)
      * @param toolCallId Tool call ID for tool messages (optional)
      */
@@ -56,7 +60,7 @@ public class AguiMessage {
     public AguiMessage(
             @JsonProperty("id") String id,
             @JsonProperty("role") String role,
-            @JsonProperty("content") String content,
+            @JsonProperty("content") MessageContent content,
             @JsonProperty("toolCalls") List<AguiToolCall> toolCalls,
             @JsonProperty("toolCallId") String toolCallId) {
         this.id = Objects.requireNonNull(id, "id cannot be null");
@@ -70,36 +74,47 @@ public class AguiMessage {
     }
 
     /**
-     * Creates a simple user message.
+     * Creates a simple user message with plain text content.
      *
      * @param id The message ID
-     * @param content The message content
+     * @param content The message content as plain text
      * @return A new user message
      */
     public static AguiMessage userMessage(String id, String content) {
-        return new AguiMessage(id, "user", content, null, null);
+        return new AguiMessage(id, "user", wrapText(content), null, null);
+    }
+
+    /**
+     * Creates a user message with structured content blocks.
+     *
+     * @param id The message ID
+     * @param blocks The structured content parts
+     * @return A new user message
+     */
+    public static AguiMessage userMessage(String id, List<InputContent> blocks) {
+        return new AguiMessage(id, "user", new MessageContent.Blocks(blocks), null, null);
     }
 
     /**
      * Creates a simple assistant message.
      *
      * @param id The message ID
-     * @param content The message content
+     * @param content The message content as plain text
      * @return A new assistant message
      */
     public static AguiMessage assistantMessage(String id, String content) {
-        return new AguiMessage(id, "assistant", content, null, null);
+        return new AguiMessage(id, "assistant", wrapText(content), null, null);
     }
 
     /**
      * Creates a system message.
      *
      * @param id The message ID
-     * @param content The message content
+     * @param content The message content as plain text
      * @return A new system message
      */
     public static AguiMessage systemMessage(String id, String content) {
-        return new AguiMessage(id, "system", content, null, null);
+        return new AguiMessage(id, "system", wrapText(content), null, null);
     }
 
     /**
@@ -107,11 +122,57 @@ public class AguiMessage {
      *
      * @param id The message ID
      * @param toolCallId The ID of the tool call this is responding to
-     * @param content The tool result content
+     * @param content The tool result content as plain text
      * @return A new tool message
      */
     public static AguiMessage toolMessage(String id, String toolCallId, String content) {
-        return new AguiMessage(id, "tool", content, null, toolCallId);
+        return new AguiMessage(id, "tool", wrapText(content), null, toolCallId);
+    }
+
+    /**
+     * Creates a message with plain text content, supporting a custom role, tool calls, and
+     * tool call ID. This is the full-parameter convenience factory for text-based messages.
+     *
+     * @param id The message ID
+     * @param role The message role (user, assistant, system, tool)
+     * @param text The message content as plain text, may be null
+     * @param toolCalls Tool calls for assistant messages (optional)
+     * @param toolCallId Tool call ID for tool messages (optional)
+     * @return A new message
+     */
+    public static AguiMessage textMessage(
+            String id, String role, String text, List<AguiToolCall> toolCalls, String toolCallId) {
+        return new AguiMessage(id, role, wrapText(text), toolCalls, toolCallId);
+    }
+
+    /**
+     * Creates a message with structured content blocks, supporting a custom role, tool calls,
+     * and tool call ID. This is the full-parameter convenience factory for blocks-based messages.
+     *
+     * @param id The message ID
+     * @param role The message role (user, assistant, system, tool)
+     * @param blocks The structured content parts
+     * @param toolCalls Tool calls for assistant messages (optional)
+     * @param toolCallId Tool call ID for tool messages (optional)
+     * @return A new message
+     */
+    public static AguiMessage blocksMessage(
+            String id,
+            String role,
+            List<InputContent> blocks,
+            List<AguiToolCall> toolCalls,
+            String toolCallId) {
+        return new AguiMessage(id, role, new MessageContent.Blocks(blocks), toolCalls, toolCallId);
+    }
+
+    /**
+     * Wraps a plain text string into a {@link MessageContent.Text}, or returns null.
+     *
+     * @param text the text to wrap, may be null
+     * @return a {@code MessageContent.Text} or null if text is null
+     */
+    private static MessageContent wrapText(String text) {
+        return text != null ? new MessageContent.Text(text) : null;
     }
 
     /**
@@ -133,12 +194,36 @@ public class AguiMessage {
     }
 
     /**
-     * Get the message content.
+     * Get the message content as a type-safe {@link MessageContent}.
      *
      * @return The content, may be null
      */
-    public String getContent() {
+    public MessageContent getContent() {
         return content;
+    }
+
+    /**
+     * Get the plain text content if the content is a {@link MessageContent.Text}.
+     *
+     * <p>This is a convenience method for the common case where content is plain text.
+     * If the content is structured blocks or null, this returns null.
+     *
+     * @return The text value, or null if content is not plain text
+     */
+    public String getTextContent() {
+        if (content instanceof MessageContent.Text text) {
+            return text.value();
+        }
+        return null;
+    }
+
+    /**
+     * Check if this message has structured content blocks.
+     *
+     * @return true if the content is a {@link MessageContent.Blocks}
+     */
+    public boolean hasBlocks() {
+        return content instanceof MessageContent.Blocks;
     }
 
     /**
@@ -210,9 +295,9 @@ public class AguiMessage {
                 + id
                 + "', role='"
                 + role
-                + "', content='"
+                + "', content="
                 + content
-                + "', toolCalls="
+                + ", toolCalls="
                 + toolCalls
                 + ", toolCallId='"
                 + toolCallId

--- a/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/main/java/io/agentscope/core/agui/model/AguiMessage.java
+++ b/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/main/java/io/agentscope/core/agui/model/AguiMessage.java
@@ -250,7 +250,7 @@ public class AguiMessage {
      * @return true if role is "user"
      */
     public boolean isUserMessage() {
-        return "user".equals(role);
+        return "user".equalsIgnoreCase(role);
     }
 
     /**
@@ -259,7 +259,7 @@ public class AguiMessage {
      * @return true if role is "assistant"
      */
     public boolean isAssistantMessage() {
-        return "assistant".equals(role);
+        return "assistant".equalsIgnoreCase(role);
     }
 
     /**
@@ -268,7 +268,7 @@ public class AguiMessage {
      * @return true if role is "system"
      */
     public boolean isSystemMessage() {
-        return "system".equals(role);
+        return "system".equalsIgnoreCase(role);
     }
 
     /**
@@ -277,7 +277,7 @@ public class AguiMessage {
      * @return true if role is "tool"
      */
     public boolean isToolMessage() {
-        return "tool".equals(role);
+        return "tool".equalsIgnoreCase(role);
     }
 
     /**

--- a/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/main/java/io/agentscope/core/agui/model/AudioInputContent.java
+++ b/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/main/java/io/agentscope/core/agui/model/AudioInputContent.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.core.agui.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Audio input content in the AG-UI protocol.
+ *
+ * <p>JSON form: {@code {"type": "audio", "source": {"type": "url", "value": "..."}, "metadata": {...}}}
+ *
+ * <p>Maps to {@link io.agentscope.core.message.AudioBlock} during conversion.
+ *
+ * @param source the audio source (URL or data), must not be null
+ * @param metadata optional metadata, may be null
+ * @author shanhongyu
+ * @since 2026-08-01
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record AudioInputContent(
+        @JsonProperty("source") InputContentSource source,
+        @JsonProperty("metadata") Map<String, Object> metadata)
+        implements InputContent {
+
+    /**
+     * Compact constructor ensuring {@code source} is non-null.
+     *
+     * @param source the audio source
+     * @param metadata optional metadata
+     */
+    public AudioInputContent {
+        Objects.requireNonNull(source, "source cannot be null");
+    }
+}

--- a/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/main/java/io/agentscope/core/agui/model/DocumentInputContent.java
+++ b/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/main/java/io/agentscope/core/agui/model/DocumentInputContent.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.core.agui.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Document input content in the AG-UI protocol.
+ *
+ * <p>JSON form: {@code {"type": "document", "source": {"type": "url", "value": "..."}, "metadata": {...}}}
+ *
+ * <p>Shares the same structure as {@link ImageInputContent}, {@link AudioInputContent},
+ * and {@link VideoInputContent} (source + metadata). Maps to AgentScope's
+ * {@link io.agentscope.core.message.DataBlock} during conversion.
+ *
+ * @param source the document source (URL or data), must not be null
+ * @param metadata optional metadata, may be null
+ * @author shanhongyu
+ * @since 2026-08-01
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record DocumentInputContent(
+        @JsonProperty("source") InputContentSource source,
+        @JsonProperty("metadata") Map<String, Object> metadata)
+        implements InputContent {
+
+    /**
+     * Compact constructor ensuring {@code source} is non-null.
+     *
+     * @param source the document source
+     * @param metadata optional metadata
+     */
+    public DocumentInputContent {
+        Objects.requireNonNull(source, "source cannot be null");
+    }
+}

--- a/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/main/java/io/agentscope/core/agui/model/ImageInputContent.java
+++ b/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/main/java/io/agentscope/core/agui/model/ImageInputContent.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.core.agui.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Image input content in the AG-UI protocol.
+ *
+ * <p>JSON form: {@code {"type": "image", "source": {"type": "url", "value": "..."}, "metadata": {...}}}
+ *
+ * <p>Maps to {@link io.agentscope.core.message.ImageBlock} during conversion.
+ *
+ * @param source the image source (URL or data), must not be null
+ * @param metadata optional metadata, may be null
+ * @author shanhongyu
+ * @since 2026-08-01
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record ImageInputContent(
+        @JsonProperty("source") InputContentSource source,
+        @JsonProperty("metadata") Map<String, Object> metadata)
+        implements InputContent {
+
+    /**
+     * Compact constructor ensuring {@code source} is non-null.
+     *
+     * @param source the image source
+     * @param metadata optional metadata
+     */
+    public ImageInputContent {
+        Objects.requireNonNull(source, "source cannot be null");
+    }
+}

--- a/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/main/java/io/agentscope/core/agui/model/InputContent.java
+++ b/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/main/java/io/agentscope/core/agui/model/InputContent.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.core.agui.model;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+/**
+ * Sealed interface representing a typed content part in the AG-UI protocol.
+ *
+ * <p>This corresponds to the AG-UI protocol's {@code InputContent} union type,
+ * covering text, image, audio, video, and document inputs.
+ *
+ * <p>JSON polymorphism is handled via the {@code type} discriminator field,
+ * consistent with the AG-UI protocol specification:
+ * <ul>
+ *   <li>{@code "text"} &rarr; {@link TextInputContent}</li>
+ *   <li>{@code "image"} &rarr; {@link ImageInputContent}</li>
+ *   <li>{@code "audio"} &rarr; {@link AudioInputContent}</li>
+ *   <li>{@code "video"} &rarr; {@link VideoInputContent}</li>
+ *   <li>{@code "document"} &rarr; {@link DocumentInputContent}</li>
+ * </ul>
+ *
+ * @see MessageContent
+ * @see io.agentscope.core.agui.converter.AguiMessageConverter
+ * @author shanhongyu
+ * @since 2026-08-01
+ */
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "type")
+@JsonSubTypes({
+    @JsonSubTypes.Type(value = TextInputContent.class, name = "text"),
+    @JsonSubTypes.Type(value = ImageInputContent.class, name = "image"),
+    @JsonSubTypes.Type(value = AudioInputContent.class, name = "audio"),
+    @JsonSubTypes.Type(value = VideoInputContent.class, name = "video"),
+    @JsonSubTypes.Type(value = DocumentInputContent.class, name = "document")
+})
+public sealed interface InputContent
+        permits TextInputContent,
+                ImageInputContent,
+                AudioInputContent,
+                VideoInputContent,
+                DocumentInputContent {}

--- a/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/main/java/io/agentscope/core/agui/model/InputContentDataSource.java
+++ b/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/main/java/io/agentscope/core/agui/model/InputContentDataSource.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.core.agui.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Objects;
+
+/**
+ * Inline data source in the AG-UI protocol.
+ *
+ * <p>JSON form: {@code {"type": "data", "value": "<base64>", "mimeType": "image/png"}}
+ *
+ * <p>Maps to AgentScope's {@link io.agentscope.core.message.Base64Source} during conversion:
+ * {@code value} &rarr; {@code data}, {@code mimeType} &rarr; {@code mediaType}.
+ *
+ * @param value the Base64-encoded data content
+ * @param mimeType the MIME type (e.g. "image/png")
+ * @author shanhongyu
+ * @since 2026-08-01
+ */
+public record InputContentDataSource(
+        @JsonProperty("value") String value, @JsonProperty("mimeType") String mimeType)
+        implements InputContentSource {
+
+    /**
+     * Compact constructor ensuring required fields are non-null.
+     *
+     * @param value the data content
+     * @param mimeType the MIME type
+     */
+    public InputContentDataSource {
+        Objects.requireNonNull(value, "value cannot be null");
+        Objects.requireNonNull(mimeType, "mimeType cannot be null");
+    }
+}

--- a/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/main/java/io/agentscope/core/agui/model/InputContentSource.java
+++ b/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/main/java/io/agentscope/core/agui/model/InputContentSource.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.core.agui.model;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+/**
+ * Sealed interface representing a content source in the AG-UI protocol.
+ *
+ * <p>Corresponds to the AG-UI protocol's {@code InputContentSource} union type:
+ * <ul>
+ *   <li>{@code "data"} &rarr; {@link InputContentDataSource} (inline Base64 data)</li>
+ *   <li>{@code "url"} &rarr; {@link InputContentUrlSource} (remote URL reference)</li>
+ * </ul>
+ *
+ * <p>This is distinct from AgentScope's internal {@link io.agentscope.core.message.Source}
+ * hierarchy ({@code URLSource} / {@code Base64Source}). The {@code AguiMessageConverter}
+ * translates between the two layers.
+ *
+ * @author shanhongyu
+ * @since 2026-08-01
+ */
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "type")
+@JsonSubTypes({
+    @JsonSubTypes.Type(value = InputContentDataSource.class, name = "data"),
+    @JsonSubTypes.Type(value = InputContentUrlSource.class, name = "url")
+})
+public sealed interface InputContentSource permits InputContentDataSource, InputContentUrlSource {}

--- a/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/main/java/io/agentscope/core/agui/model/InputContentUrlSource.java
+++ b/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/main/java/io/agentscope/core/agui/model/InputContentUrlSource.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.core.agui.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Objects;
+
+/**
+ * URL source in the AG-UI protocol.
+ *
+ * <p>JSON form: {@code {"type": "url", "value": "https://...", "mimeType": "image/png"}}
+ *
+ * <p>Maps to AgentScope's {@link io.agentscope.core.message.URLSource} during conversion:
+ * {@code value} &rarr; {@code url}, {@code mimeType} &rarr; {@code mimeType}.
+ *
+ * @param value the URL pointing to the media content
+ * @param mimeType the optional MIME type hint, may be null
+ * @author shanhongyu
+ * @since 2026-08-01
+ */
+public record InputContentUrlSource(
+        @JsonProperty("value") String value, @JsonProperty("mimeType") String mimeType)
+        implements InputContentSource {
+
+    /**
+     * Compact constructor ensuring {@code value} is non-null.
+     *
+     * @param value the URL
+     * @param mimeType the optional MIME type
+     */
+    public InputContentUrlSource {
+        Objects.requireNonNull(value, "value cannot be null");
+    }
+
+    /**
+     * Convenience constructor without MIME type.
+     *
+     * @param value the URL
+     */
+    public InputContentUrlSource(String value) {
+        this(value, null);
+    }
+}

--- a/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/main/java/io/agentscope/core/agui/model/MessageContent.java
+++ b/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/main/java/io/agentscope/core/agui/model/MessageContent.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.core.agui.model;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import java.util.List;
+
+/**
+ * Type-safe union representing the {@code content} field of an AG-UI message.
+ *
+ * <p>In the AG-UI protocol, message content can be either a plain string or an
+ * array of structured {@link InputContent} parts. This sealed interface models
+ * that union without resorting to {@code Object}, providing compile-time type
+ * safety and exhaustive pattern matching.
+ *
+ * <p>JSON forms:
+ * <ul>
+ *   <li>{@link Text} &rarr; JSON string: {@code "Hello"}</li>
+ *   <li>{@link Blocks} &rarr; JSON array: {@code [{"type":"text","text":"Hi"},{"type":"image",...}]}</li>
+ * </ul>
+ *
+ * <p>Custom Jackson serialization/deserialization handles the non-object JSON
+ * shape (scalar vs. array) via {@link MessageContentDeserializer} and
+ * {@link MessageContentSerializer}.
+ *
+ * @see InputContent
+ * @see AguiMessage
+ * @author shanhongyu
+ * @since 2026-08-01
+ */
+@JsonDeserialize(using = MessageContentDeserializer.class)
+@JsonSerialize(using = MessageContentSerializer.class)
+public sealed interface MessageContent permits MessageContent.Text, MessageContent.Blocks {
+
+    /**
+     * Plain text content, serialized as a JSON string.
+     *
+     * @param value the text content
+     */
+    record Text(String value) implements MessageContent {}
+
+    /**
+     * Structured content blocks, serialized as a JSON array of {@link InputContent}.
+     *
+     * @param parts the list of content parts; defensively copied to ensure immutability
+     */
+    record Blocks(List<InputContent> parts) implements MessageContent {
+
+        /**
+         * Compact constructor that creates an immutable copy of the parts list.
+         *
+         * @param parts the content parts
+         */
+        public Blocks {
+            parts = List.copyOf(parts);
+        }
+    }
+}

--- a/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/main/java/io/agentscope/core/agui/model/MessageContentDeserializer.java
+++ b/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/main/java/io/agentscope/core/agui/model/MessageContentDeserializer.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.core.agui.model;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import java.io.IOException;
+import java.util.List;
+
+/**
+ * Custom Jackson deserializer for {@link MessageContent}.
+ *
+ * <p>Handles the AG-UI protocol's union type where {@code content} can be either:
+ * <ul>
+ *   <li>A JSON string &rarr; {@link MessageContent.Text}</li>
+ *   <li>A JSON array of objects &rarr; {@link MessageContent.Blocks}</li>
+ *   <li>A JSON null &rarr; {@code null}</li>
+ * </ul>
+ *
+ * @author shanhongyu
+ * @since 2026-08-01
+ */
+public class MessageContentDeserializer extends JsonDeserializer<MessageContent> {
+
+    private static final TypeReference<List<InputContent>> INPUT_CONTENT_LIST =
+            new TypeReference<>() {};
+
+    @Override
+    public MessageContent deserialize(JsonParser p, DeserializationContext ctxt)
+            throws IOException {
+        JsonToken token = p.currentToken();
+
+        if (token == JsonToken.VALUE_STRING) {
+            return new MessageContent.Text(p.getValueAsString());
+        }
+
+        if (token == JsonToken.START_ARRAY) {
+            List<InputContent> parts = p.readValueAs(INPUT_CONTENT_LIST);
+            return new MessageContent.Blocks(parts);
+        }
+
+        if (token == JsonToken.VALUE_NULL) {
+            return null;
+        }
+
+        throw ctxt.wrongTokenException(
+                p,
+                MessageContent.class,
+                token,
+                "Expected STRING or START_ARRAY for 'content' field");
+    }
+}

--- a/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/main/java/io/agentscope/core/agui/model/MessageContentSerializer.java
+++ b/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/main/java/io/agentscope/core/agui/model/MessageContentSerializer.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.core.agui.model;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import java.io.IOException;
+
+/**
+ * Custom Jackson serializer for {@link MessageContent}.
+ *
+ * <p>Serializes the union type transparently:
+ * <ul>
+ *   <li>{@link MessageContent.Text} &rarr; JSON string</li>
+ *   <li>{@link MessageContent.Blocks} &rarr; JSON array of {@link InputContent}</li>
+ * </ul>
+ *
+ * @author shanhongyu
+ * @since 2026-08-01
+ */
+public class MessageContentSerializer extends JsonSerializer<MessageContent> {
+
+    @Override
+    public void serialize(MessageContent value, JsonGenerator gen, SerializerProvider serializers)
+            throws IOException {
+        if (value instanceof MessageContent.Text text) {
+            gen.writeString(text.value());
+        } else if (value instanceof MessageContent.Blocks blocks) {
+            gen.writeStartArray();
+            for (InputContent part : blocks.parts()) {
+                gen.writeObject(part);
+            }
+            gen.writeEndArray();
+        }
+    }
+}

--- a/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/main/java/io/agentscope/core/agui/model/TextInputContent.java
+++ b/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/main/java/io/agentscope/core/agui/model/TextInputContent.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.core.agui.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Objects;
+
+/**
+ * Text input content in the AG-UI protocol.
+ *
+ * <p>JSON form: {@code {"type": "text", "text": "Hello"}}
+ *
+ * <p>Maps to {@link io.agentscope.core.message.TextBlock} during conversion.
+ *
+ * @param text the text content (must not be null)
+ * @author shanhongyu
+ * @since 2026-08-01
+ */
+public record TextInputContent(@JsonProperty("text") String text) implements InputContent {
+
+    /**
+     * Compact constructor ensuring {@code text} is never null.
+     *
+     * @param text the text content
+     */
+    public TextInputContent {
+        Objects.requireNonNull(text, "text cannot be null");
+    }
+}

--- a/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/main/java/io/agentscope/core/agui/model/VideoInputContent.java
+++ b/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/main/java/io/agentscope/core/agui/model/VideoInputContent.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.core.agui.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Video input content in the AG-UI protocol.
+ *
+ * <p>JSON form: {@code {"type": "video", "source": {"type": "url", "value": "..."}, "metadata": {...}}}
+ *
+ * <p>Maps to {@link io.agentscope.core.message.VideoBlock} during conversion.
+ *
+ * @param source the video source (URL or data), must not be null
+ * @param metadata optional metadata, may be null
+ * @author shanhongyu
+ * @since 2026-08-01
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record VideoInputContent(
+        @JsonProperty("source") InputContentSource source,
+        @JsonProperty("metadata") Map<String, Object> metadata)
+        implements InputContent {
+
+    /**
+     * Compact constructor ensuring {@code source} is non-null.
+     *
+     * @param source the video source
+     * @param metadata optional metadata
+     */
+    public VideoInputContent {
+        Objects.requireNonNull(source, "source cannot be null");
+    }
+}

--- a/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/test/java/io/agentscope/core/agui/converter/AguiMessageConverterTest.java
+++ b/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/test/java/io/agentscope/core/agui/converter/AguiMessageConverterTest.java
@@ -25,13 +25,27 @@ import io.agentscope.core.agui.model.AguiFunctionCall;
 import io.agentscope.core.agui.model.AguiMessage;
 import io.agentscope.core.agui.model.AguiResume;
 import io.agentscope.core.agui.model.AguiToolCall;
+import io.agentscope.core.agui.model.AudioInputContent;
+import io.agentscope.core.agui.model.DocumentInputContent;
+import io.agentscope.core.agui.model.ImageInputContent;
+import io.agentscope.core.agui.model.InputContentDataSource;
+import io.agentscope.core.agui.model.InputContentUrlSource;
+import io.agentscope.core.agui.model.MessageContent;
 import io.agentscope.core.agui.model.RunAgentInput;
+import io.agentscope.core.agui.model.TextInputContent;
+import io.agentscope.core.agui.model.VideoInputContent;
+import io.agentscope.core.message.AudioBlock;
+import io.agentscope.core.message.Base64Source;
+import io.agentscope.core.message.DataBlock;
+import io.agentscope.core.message.ImageBlock;
 import io.agentscope.core.message.Msg;
 import io.agentscope.core.message.MsgRole;
 import io.agentscope.core.message.TextBlock;
 import io.agentscope.core.message.ToolResultBlock;
 import io.agentscope.core.message.ToolResultState;
 import io.agentscope.core.message.ToolUseBlock;
+import io.agentscope.core.message.URLSource;
+import io.agentscope.core.message.VideoBlock;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -89,7 +103,11 @@ class AguiMessageConverterTest {
         AguiToolCall toolCall = new AguiToolCall("tc-1", function);
         AguiMessage aguiMsg =
                 new AguiMessage(
-                        "msg-4", "assistant", "Let me check the weather.", List.of(toolCall), null);
+                        "msg-4",
+                        "assistant",
+                        new MessageContent.Text("Let me check the weather."),
+                        List.of(toolCall),
+                        null);
 
         Msg msg = converter.toMsg(aguiMsg);
 
@@ -117,7 +135,7 @@ class AguiMessageConverterTest {
 
         assertEquals("msg-5", aguiMsg.getId());
         assertEquals("user", aguiMsg.getRole());
-        assertEquals("Test message", aguiMsg.getContent());
+        assertEquals("Test message", aguiMsg.getTextContent());
     }
 
     @Test
@@ -140,7 +158,7 @@ class AguiMessageConverterTest {
 
         assertEquals("msg-6", aguiMsg.getId());
         assertEquals("assistant", aguiMsg.getRole());
-        assertEquals("Calling tool...", aguiMsg.getContent());
+        assertEquals("Calling tool...", aguiMsg.getTextContent());
         assertTrue(aguiMsg.hasToolCalls());
         assertEquals(1, aguiMsg.getToolCalls().size());
 
@@ -174,7 +192,7 @@ class AguiMessageConverterTest {
 
         assertEquals(original.getId(), converted.getId());
         assertEquals(original.getRole(), converted.getRole());
-        assertEquals(original.getContent(), converted.getContent());
+        assertEquals(original.getTextContent(), converted.getTextContent());
     }
 
     @Test
@@ -190,7 +208,8 @@ class AguiMessageConverterTest {
 
     @Test
     void testConvertMessageWithEmptyContent() {
-        AguiMessage aguiMsg = new AguiMessage("msg-empty", "user", "", null, null);
+        AguiMessage aguiMsg =
+                new AguiMessage("msg-empty", "user", new MessageContent.Text(""), null, null);
 
         Msg msg = converter.toMsg(aguiMsg);
 
@@ -227,7 +246,7 @@ class AguiMessageConverterTest {
         assertEquals("msg-tr1", aguiMsg.getId());
         assertEquals("tool", aguiMsg.getRole());
         assertEquals("tc-1", aguiMsg.getToolCallId());
-        assertEquals("Result: 42", aguiMsg.getContent());
+        assertEquals("Result: 42", aguiMsg.getTextContent());
     }
 
     @Test
@@ -244,7 +263,7 @@ class AguiMessageConverterTest {
 
         AguiMessage aguiMsg = converter.toAguiMessage(msg);
 
-        assertEquals("First part\nSecond part", aguiMsg.getContent());
+        assertEquals("First part\nSecond part", aguiMsg.getTextContent());
     }
 
     @Test
@@ -340,7 +359,9 @@ class AguiMessageConverterTest {
 
     @Test
     void testConvertWithInvalidRoleDefaultsToUser() {
-        AguiMessage aguiMsg = new AguiMessage("msg-1", "unknown_role", "Test", null, null);
+        AguiMessage aguiMsg =
+                new AguiMessage(
+                        "msg-1", "unknown_role", new MessageContent.Text("Test"), null, null);
 
         Msg msg = converter.toMsg(aguiMsg);
 
@@ -406,7 +427,8 @@ class AguiMessageConverterTest {
     @Test
     void testConvertToolMessageWithNullToolCallId() {
         // Tool message without toolCallId - should still convert properly
-        AguiMessage aguiMsg = new AguiMessage("msg-1", "tool", "Result", null, null);
+        AguiMessage aguiMsg =
+                new AguiMessage("msg-1", "tool", new MessageContent.Text("Result"), null, null);
 
         Msg msg = converter.toMsg(aguiMsg);
 
@@ -443,6 +465,156 @@ class AguiMessageConverterTest {
         assertNotNull(tub);
         // Invalid JSON should result in empty map
         assertTrue(tub.getInput().isEmpty());
+    }
+
+    // ===== Multimodal / Blocks content tests =====
+
+    @Test
+    void testConvertBlocksContentWithTextOnly() {
+        AguiMessage aguiMsg =
+                AguiMessage.userMessage(
+                        "msg-1", List.of(new TextInputContent("Hello from blocks")));
+
+        Msg msg = converter.toMsg(aguiMsg);
+
+        assertEquals("msg-1", msg.getId());
+        assertEquals(MsgRole.USER, msg.getRole());
+        assertTrue(msg.hasContentBlocks(TextBlock.class));
+        TextBlock tb = msg.getFirstContentBlock(TextBlock.class);
+        assertEquals("Hello from blocks", tb.getText());
+    }
+
+    @Test
+    void testConvertBlocksContentWithTextAndImage() {
+        AguiMessage aguiMsg =
+                AguiMessage.userMessage(
+                        "msg-1",
+                        List.of(
+                                new TextInputContent("Describe this image"),
+                                new ImageInputContent(
+                                        new InputContentUrlSource("https://example.com/img.png"),
+                                        null)));
+
+        Msg msg = converter.toMsg(aguiMsg);
+
+        assertEquals("msg-1", msg.getId());
+        assertTrue(msg.hasContentBlocks(TextBlock.class));
+        assertTrue(msg.hasContentBlocks(ImageBlock.class));
+
+        TextBlock tb = msg.getFirstContentBlock(TextBlock.class);
+        assertEquals("Describe this image", tb.getText());
+
+        ImageBlock ib = msg.getFirstContentBlock(ImageBlock.class);
+        URLSource source = (URLSource) ib.getSource();
+        assertEquals("https://example.com/img.png", source.getUrl());
+    }
+
+    @Test
+    void testConvertBlocksContentWithAllInputTypes() {
+        AguiMessage aguiMsg =
+                AguiMessage.userMessage(
+                        "msg-1",
+                        List.of(
+                                new TextInputContent("text part"),
+                                new ImageInputContent(
+                                        new InputContentUrlSource("https://example.com/img.png"),
+                                        null),
+                                new AudioInputContent(
+                                        new InputContentUrlSource("https://example.com/audio.mp3"),
+                                        null),
+                                new VideoInputContent(
+                                        new InputContentUrlSource("https://example.com/video.mp4"),
+                                        null),
+                                new DocumentInputContent(
+                                        new InputContentUrlSource("https://example.com/doc.pdf"),
+                                        null)));
+
+        Msg msg = converter.toMsg(aguiMsg);
+
+        assertEquals("msg-1", msg.getId());
+        assertTrue(msg.hasContentBlocks(TextBlock.class));
+        assertTrue(msg.hasContentBlocks(ImageBlock.class));
+        assertTrue(msg.hasContentBlocks(AudioBlock.class));
+        assertTrue(msg.hasContentBlocks(VideoBlock.class));
+        assertTrue(msg.hasContentBlocks(DataBlock.class));
+    }
+
+    @Test
+    void testConvertDocumentToDataBlock() {
+        AguiMessage aguiMsg =
+                AguiMessage.userMessage(
+                        "msg-1",
+                        List.of(
+                                new DocumentInputContent(
+                                        new InputContentUrlSource("https://example.com/doc.pdf"),
+                                        null)));
+
+        Msg msg = converter.toMsg(aguiMsg);
+
+        assertTrue(msg.hasContentBlocks(DataBlock.class));
+        assertFalse(msg.hasContentBlocks(TextBlock.class));
+        DataBlock db = msg.getFirstContentBlock(DataBlock.class);
+        URLSource source = (URLSource) db.getSource();
+        assertEquals("https://example.com/doc.pdf", source.getUrl());
+    }
+
+    @Test
+    void testConvertDocumentWithDataSourceToDataBlock() {
+        AguiMessage aguiMsg =
+                AguiMessage.userMessage(
+                        "msg-1",
+                        List.of(
+                                new DocumentInputContent(
+                                        new InputContentDataSource("dGVzdA==", "application/pdf"),
+                                        null)));
+
+        Msg msg = converter.toMsg(aguiMsg);
+
+        assertTrue(msg.hasContentBlocks(DataBlock.class));
+        DataBlock db = msg.getFirstContentBlock(DataBlock.class);
+        Base64Source source = (Base64Source) db.getSource();
+        assertEquals("application/pdf", source.getMediaType());
+        assertEquals("dGVzdA==", source.getData());
+    }
+
+    @Test
+    void testConvertBlocksContentWithImageBase64Source() {
+        AguiMessage aguiMsg =
+                AguiMessage.userMessage(
+                        "msg-1",
+                        List.of(
+                                new ImageInputContent(
+                                        new InputContentDataSource("iVBORw0KGgo=", "image/png"),
+                                        null)));
+
+        Msg msg = converter.toMsg(aguiMsg);
+
+        assertTrue(msg.hasContentBlocks(ImageBlock.class));
+        ImageBlock ib = msg.getFirstContentBlock(ImageBlock.class);
+        Base64Source source = (Base64Source) ib.getSource();
+        assertEquals("image/png", source.getMediaType());
+        assertEquals("iVBORw0KGgo=", source.getData());
+    }
+
+    @Test
+    void testConvertBlocksContentNullContent() {
+        AguiMessage aguiMsg = new AguiMessage("msg-1", "user", null, null, null);
+
+        Msg msg = converter.toMsg(aguiMsg);
+
+        assertFalse(msg.hasContentBlocks(TextBlock.class));
+        assertFalse(msg.hasContentBlocks(ImageBlock.class));
+    }
+
+    @Test
+    void testConvertBlocksContentEmptyArray() {
+        AguiMessage aguiMsg =
+                new AguiMessage("msg-1", "user", new MessageContent.Blocks(List.of()), null, null);
+
+        Msg msg = converter.toMsg(aguiMsg);
+
+        // Empty blocks list should not produce any content blocks
+        assertTrue(msg.getContent().isEmpty());
     }
 
     private static String resultText(ToolResultBlock result) {

--- a/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/test/java/io/agentscope/core/agui/converter/AguiMessageConverterTest.java
+++ b/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/test/java/io/agentscope/core/agui/converter/AguiMessageConverterTest.java
@@ -19,6 +19,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.agentscope.core.agui.model.AguiFunctionCall;
@@ -204,6 +205,23 @@ class AguiMessageConverterTest {
         assertEquals("msg-t1", msg.getId());
         assertEquals(MsgRole.TOOL, msg.getRole());
         assertTrue(msg.hasContentBlocks(ToolResultBlock.class));
+    }
+
+    @Test
+    void testConvertToolMessageRoleCaseInsensitive() {
+        AguiMessage aguiMsg =
+                new AguiMessage(
+                        "msg-t1",
+                        "TOOL",
+                        new MessageContent.Text("Tool result here"),
+                        null,
+                        "tc-1");
+
+        Msg msg = converter.toMsg(aguiMsg);
+
+        assertEquals(MsgRole.TOOL, msg.getRole());
+        assertTrue(msg.hasContentBlocks(ToolResultBlock.class));
+        assertFalse(msg.hasContentBlocks(TextBlock.class));
     }
 
     @Test
@@ -482,6 +500,19 @@ class AguiMessageConverterTest {
         assertTrue(msg.hasContentBlocks(TextBlock.class));
         TextBlock tb = msg.getFirstContentBlock(TextBlock.class);
         assertEquals("Hello from blocks", tb.getText());
+    }
+
+    @Test
+    void testConvertBlocksContentRejectedForNonUserMessage() {
+        AguiMessage aguiMsg =
+                AguiMessage.blocksMessage(
+                        "msg-1",
+                        "tool",
+                        List.of(new TextInputContent("not a valid tool content block")),
+                        null,
+                        "tc-1");
+
+        assertThrows(IllegalArgumentException.class, () -> converter.toMsg(aguiMsg));
     }
 
     @Test

--- a/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/test/java/io/agentscope/core/agui/converter/AguiMessageConverterTest.java
+++ b/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/test/java/io/agentscope/core/agui/converter/AguiMessageConverterTest.java
@@ -37,7 +37,6 @@ import io.agentscope.core.agui.model.TextInputContent;
 import io.agentscope.core.agui.model.VideoInputContent;
 import io.agentscope.core.message.AudioBlock;
 import io.agentscope.core.message.Base64Source;
-import io.agentscope.core.message.DataBlock;
 import io.agentscope.core.message.ImageBlock;
 import io.agentscope.core.message.Msg;
 import io.agentscope.core.message.MsgRole;
@@ -541,7 +540,7 @@ class AguiMessageConverterTest {
     }
 
     @Test
-    void testConvertBlocksContentWithAllInputTypes() {
+    void testConvertBlocksContentWithAllSupportedInputTypes() {
         AguiMessage aguiMsg =
                 AguiMessage.userMessage(
                         "msg-1",
@@ -555,9 +554,6 @@ class AguiMessageConverterTest {
                                         null),
                                 new VideoInputContent(
                                         new InputContentUrlSource("https://example.com/video.mp4"),
-                                        null),
-                                new DocumentInputContent(
-                                        new InputContentUrlSource("https://example.com/doc.pdf"),
                                         null)));
 
         Msg msg = converter.toMsg(aguiMsg);
@@ -567,11 +563,10 @@ class AguiMessageConverterTest {
         assertTrue(msg.hasContentBlocks(ImageBlock.class));
         assertTrue(msg.hasContentBlocks(AudioBlock.class));
         assertTrue(msg.hasContentBlocks(VideoBlock.class));
-        assertTrue(msg.hasContentBlocks(DataBlock.class));
     }
 
     @Test
-    void testConvertDocumentToDataBlock() {
+    void testConvertDocumentInputContentIsRejectedForUrlSource() {
         AguiMessage aguiMsg =
                 AguiMessage.userMessage(
                         "msg-1",
@@ -580,17 +575,13 @@ class AguiMessageConverterTest {
                                         new InputContentUrlSource("https://example.com/doc.pdf"),
                                         null)));
 
-        Msg msg = converter.toMsg(aguiMsg);
-
-        assertTrue(msg.hasContentBlocks(DataBlock.class));
-        assertFalse(msg.hasContentBlocks(TextBlock.class));
-        DataBlock db = msg.getFirstContentBlock(DataBlock.class);
-        URLSource source = (URLSource) db.getSource();
-        assertEquals("https://example.com/doc.pdf", source.getUrl());
+        IllegalStateException exception =
+                assertThrows(IllegalStateException.class, () -> converter.toMsg(aguiMsg));
+        assertTrue(exception.getMessage().startsWith("Unhandled InputContent type:"));
     }
 
     @Test
-    void testConvertDocumentWithDataSourceToDataBlock() {
+    void testConvertDocumentInputContentIsRejectedForDataSource() {
         AguiMessage aguiMsg =
                 AguiMessage.userMessage(
                         "msg-1",
@@ -599,13 +590,9 @@ class AguiMessageConverterTest {
                                         new InputContentDataSource("dGVzdA==", "application/pdf"),
                                         null)));
 
-        Msg msg = converter.toMsg(aguiMsg);
-
-        assertTrue(msg.hasContentBlocks(DataBlock.class));
-        DataBlock db = msg.getFirstContentBlock(DataBlock.class);
-        Base64Source source = (Base64Source) db.getSource();
-        assertEquals("application/pdf", source.getMediaType());
-        assertEquals("dGVzdA==", source.getData());
+        IllegalStateException exception =
+                assertThrows(IllegalStateException.class, () -> converter.toMsg(aguiMsg));
+        assertTrue(exception.getMessage().startsWith("Unhandled InputContent type:"));
     }
 
     @Test

--- a/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/test/java/io/agentscope/core/agui/event/AguiEventTest.java
+++ b/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/test/java/io/agentscope/core/agui/event/AguiEventTest.java
@@ -1035,7 +1035,7 @@ class AguiEventTest {
             AguiEvent.MessagesSnapshot event = new AguiEvent.MessagesSnapshot("t1", "r1", msgs);
             assertEquals(AguiEventType.MESSAGES_SNAPSHOT, event.getType());
             assertEquals(1, event.messages().size());
-            assertEquals("hello", event.messages().get(0).getContent());
+            assertEquals("hello", event.messages().get(0).getTextContent());
         }
 
         @Test

--- a/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/test/java/io/agentscope/core/agui/model/AguiModelTest.java
+++ b/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/test/java/io/agentscope/core/agui/model/AguiModelTest.java
@@ -79,6 +79,26 @@ class AguiModelTest {
         }
 
         @Test
+        void testRoleHelpersAreCaseInsensitive() {
+            AguiMessage user =
+                    new AguiMessage("msg-1", "USER", new MessageContent.Text("Hello"), null, null);
+            AguiMessage assistant =
+                    new AguiMessage(
+                            "msg-2", "ASSISTANT", new MessageContent.Text("Hello"), null, null);
+            AguiMessage system =
+                    new AguiMessage(
+                            "msg-3", "SYSTEM", new MessageContent.Text("Hello"), null, null);
+            AguiMessage tool =
+                    new AguiMessage(
+                            "msg-4", "TOOL", new MessageContent.Text("Hello"), null, "tc-1");
+
+            assertTrue(user.isUserMessage());
+            assertTrue(assistant.isAssistantMessage());
+            assertTrue(system.isSystemMessage());
+            assertTrue(tool.isToolMessage());
+        }
+
+        @Test
         void testMessageWithToolCalls() {
             AguiFunctionCall function = new AguiFunctionCall("get_weather", "{\"city\":\"NYC\"}");
             AguiToolCall toolCall = new AguiToolCall("tc-1", function);

--- a/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/test/java/io/agentscope/core/agui/model/AguiModelTest.java
+++ b/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/test/java/io/agentscope/core/agui/model/AguiModelTest.java
@@ -44,7 +44,7 @@ class AguiModelTest {
 
             assertEquals("msg-1", msg.getId());
             assertEquals("user", msg.getRole());
-            assertEquals("Hello world", msg.getContent());
+            assertEquals("Hello world", msg.getTextContent());
             assertTrue(msg.isUserMessage());
             assertFalse(msg.isAssistantMessage());
         }
@@ -83,7 +83,12 @@ class AguiModelTest {
             AguiFunctionCall function = new AguiFunctionCall("get_weather", "{\"city\":\"NYC\"}");
             AguiToolCall toolCall = new AguiToolCall("tc-1", function);
             AguiMessage msg =
-                    new AguiMessage("msg-5", "assistant", "Let me check", List.of(toolCall), null);
+                    new AguiMessage(
+                            "msg-5",
+                            "assistant",
+                            new MessageContent.Text("Let me check"),
+                            List.of(toolCall),
+                            null);
 
             assertTrue(msg.hasToolCalls());
             assertEquals(1, msg.getToolCalls().size());
@@ -117,14 +122,18 @@ class AguiModelTest {
         void testNullIdThrows() {
             assertThrows(
                     NullPointerException.class,
-                    () -> new AguiMessage(null, "user", "content", null, null));
+                    () ->
+                            new AguiMessage(
+                                    null, "user", new MessageContent.Text("content"), null, null));
         }
 
         @Test
         void testNullRoleThrows() {
             assertThrows(
                     NullPointerException.class,
-                    () -> new AguiMessage("id", null, "content", null, null));
+                    () ->
+                            new AguiMessage(
+                                    "id", null, new MessageContent.Text("content"), null, null));
         }
 
         @Test
@@ -164,10 +173,12 @@ class AguiModelTest {
             String json = JsonUtils.getJsonCodec().toJson(msg);
             assertTrue(json.contains("\"id\":\"msg-1\""));
             assertTrue(json.contains("\"role\":\"assistant\""));
+            assertTrue(json.contains("\"content\":\"Hello\""));
 
             AguiMessage deserialized = JsonUtils.getJsonCodec().fromJson(json, AguiMessage.class);
             assertEquals(msg.getId(), deserialized.getId());
             assertEquals(msg.getRole(), deserialized.getRole());
+            assertEquals("Hello", deserialized.getTextContent());
         }
 
         @Test
@@ -175,6 +186,103 @@ class AguiModelTest {
             AguiMessage msg = new AguiMessage("msg-1", "user", null, null, null);
 
             assertNull(msg.getContent());
+            assertNull(msg.getTextContent());
+            assertFalse(msg.hasBlocks());
+        }
+
+        @Test
+        void testMessageWithBlocksContent() {
+            List<InputContent> parts =
+                    List.of(
+                            new TextInputContent("Describe this"),
+                            new ImageInputContent(
+                                    new InputContentUrlSource("https://example.com/img.png"),
+                                    null));
+            AguiMessage msg = AguiMessage.userMessage("msg-blocks", parts);
+
+            assertTrue(msg.hasBlocks());
+            assertNull(msg.getTextContent());
+            assertNotNull(msg.getContent());
+        }
+
+        @Test
+        void testJsonSerializationWithBlocks() throws JsonProcessingException {
+            List<InputContent> parts =
+                    List.of(
+                            new TextInputContent("Hello"),
+                            new ImageInputContent(
+                                    new InputContentUrlSource("https://example.com/img.png"),
+                                    null));
+            AguiMessage msg = AguiMessage.userMessage("msg-1", parts);
+
+            String json = JsonUtils.getJsonCodec().toJson(msg);
+            assertTrue(json.contains("\"content\":["));
+            assertTrue(json.contains("\"type\":\"text\""));
+            assertTrue(json.contains("\"type\":\"image\""));
+
+            AguiMessage deserialized = JsonUtils.getJsonCodec().fromJson(json, AguiMessage.class);
+            assertEquals(msg.getId(), deserialized.getId());
+            assertTrue(deserialized.hasBlocks());
+        }
+
+        @Test
+        void testJsonDeserializationStringContent() throws JsonProcessingException {
+            String json =
+                    """
+                    {
+                      "id": "m1",
+                      "role": "user",
+                      "content": "plain text",
+                      "toolCalls": [],
+                      "toolCallId": null
+                    }
+                    """;
+
+            AguiMessage msg = JsonUtils.getJsonCodec().fromJson(json, AguiMessage.class);
+
+            assertEquals("m1", msg.getId());
+            assertEquals("plain text", msg.getTextContent());
+            assertFalse(msg.hasBlocks());
+        }
+
+        @Test
+        void testJsonDeserializationArrayContent() throws JsonProcessingException {
+            String json =
+                    """
+                    {
+                      "id": "m1",
+                      "role": "user",
+                      "content": [
+                        {
+                          "type": "text",
+                          "text": "hi"
+                        }
+                      ]
+                    }
+                    """;
+
+            AguiMessage msg = JsonUtils.getJsonCodec().fromJson(json, AguiMessage.class);
+
+            assertEquals("m1", msg.getId());
+            assertTrue(msg.hasBlocks());
+            assertNull(msg.getTextContent());
+        }
+
+        @Test
+        void testJsonDeserializationNullContent() throws JsonProcessingException {
+            String json =
+                    """
+                    {
+                      "id": "m1",
+                      "role": "user",
+                      "content": null
+                    }
+                    """;
+
+            AguiMessage msg = JsonUtils.getJsonCodec().fromJson(json, AguiMessage.class);
+
+            assertNull(msg.getContent());
+            assertNull(msg.getTextContent());
         }
     }
 

--- a/docs/v2/en/integration/protocol/agui.md
+++ b/docs/v2/en/integration/protocol/agui.md
@@ -1,6 +1,12 @@
 # AG-UI
 
+## Compatibility Notes
+
 `agentscope-extensions-agui` converts AgentScope v2 `AgentEvent` streams into [AG-UI Protocol](https://github.com/ag-ui-protocol/ag-ui) events so front-end UIs can render an agent run in real time, including text, reasoning, tool calls, state, custom events, token usage, and HITL interrupts.
+
+`AguiMessage.content` is represented as typed message content. For text-only code paths, use `getTextContent()`.
+
+`AguiMessageConverter.toAguiMessage()` currently preserves text and tool-call fields only; image, audio, video, and document content blocks are not serialized back into AG-UI message content.
 
 ## When To Use
 

--- a/docs/v2/en/integration/protocol/agui.md
+++ b/docs/v2/en/integration/protocol/agui.md
@@ -6,6 +6,8 @@
 
 `AguiMessage.content` is represented as typed message content. For text-only code paths, use `getTextContent()`.
 
+Multimodal input is supported, but document types are not supported yet.
+
 `AguiMessageConverter.toAguiMessage()` currently preserves text and tool-call fields only; image, audio, video, and document content blocks are not serialized back into AG-UI message content.
 
 ## When To Use

--- a/docs/v2/zh/integration/protocol/agui.md
+++ b/docs/v2/zh/integration/protocol/agui.md
@@ -1,6 +1,12 @@
 # AG-UI
 
+## 兼容性说明
+
 `agentscope-extensions-agui` 把 AgentScope v2 的 `AgentEvent` 流转换为 [AG-UI Protocol](https://github.com/ag-ui-protocol/ag-ui) 事件，让前端 UI 可以实时渲染 agent 的运行过程，包括文本、推理内容、工具调用、状态、自定义事件、token usage 和 HITL interrupt。
+
+`AguiMessage.content` 现在使用类型化消息内容表示。仅处理纯文本时，请使用 `getTextContent()`。
+
+`AguiMessageConverter.toAguiMessage()` 目前只保留文本和工具调用字段；image、audio、video、document 内容块不会被序列化回 AG-UI message content。
 
 ## 何时使用
 

--- a/docs/v2/zh/integration/protocol/agui.md
+++ b/docs/v2/zh/integration/protocol/agui.md
@@ -6,6 +6,8 @@
 
 `AguiMessage.content` 现在使用类型化消息内容表示。仅处理纯文本时，请使用 `getTextContent()`。
 
+已支持多模态输入，但是暂不支持文档类型。
+
 `AguiMessageConverter.toAguiMessage()` 目前只保留文本和工具调用字段；image、audio、video、document 内容块不会被序列化回 AG-UI message content。
 
 ## 何时使用


### PR DESCRIPTION
完成 issue https://github.com/agentscope-ai/agentscope-java/issues/551

## Summary

将 AG-UI 协议的 `AguiMessage.content` 从 `String` 升级为类型安全的 sealed 联合类型 `MessageContent`，支持纯文本和多模态内容块（text/image/audio/video/document），对齐 AG-UI 协议规范。

## Background

此前 `AguiMessage.content` 仅支持 `String`，无法承载多模态输入。本 PR 按照类型安全的设计原则，引入 AG-UI 协议层的类型化模型，替代 `Object` / `List<Map<String, Object>>` 等弱类型方案。

### 架构总览

```
    AG-UI 协议层                        转换层                    AgentScope 模型层
 ┌─────────────────────┐          ┌──────────────┐          ┌──────────────────────┐
 │  AguiMessage        │          │              │          │  Msg                 │
 │  content:           │          │  InputContent│          │  content:            │
 │    MessageContent   │────────▶ │      ↕       │ ───────▶ │    List<ContentBlock>│
 │                     │          │  ContentBlock│          │                      │
 │  MessageContent     │          │              │          │  ContentBlock        │
 │  ┌─Text──────────┐  │          │  text    →   │          │  ├─TextBlock         │
 │  │(String value) │  │          │   TextBlock  │          │  ├─ImageBlock        │
 │  └───────────────┘  │          │              │          │  ├─AudioBlock        │
 │  ┌─Blocks────────┐  │          │  image   →   │          │  ├─VideoBlock        │
 │  │ List<Input    │  │          │   ImageBlock │          │  ├─ThinkingBlock     │
 │  │  Content>     │  │          │              │          │  ├─ToolUseBlock      │
 │  └───────────────┘  │          │  document→   │          │  └─ToolResultBlock   │
 │                     │          │   TextBlock  │          │                      │
 │  InputContent       │          │              │          │                      │
 │  (sealed interface) │          │ (pattern     │          │  (sealed interface)  │
 │  ├─TextContent──── │          │   matching,  │          │                      │
 │  ├─ImageContent─── │          │   编译期穷尽) │          │                      │
 │  ├─AudioContent─── │          │              │          │                      │
 │  ├─VideoContent─── │          │              │          │                      │
 │  └─DocumentContent─ │          │              │          │                      │
 └─────────────────────┘          └──────────────┘          └──────────────────────┘
     协议术语，不叫                                         内部模型术语，不叫
     "多模态"                                               "多模态"
```

> **注意**：架构图右侧 **AgentScope 模型层（ContentBlock 及其子类型）已存在，是 agentscope-java 既有的标准定义**，无需重新设计。本架构建议中新增的仅是左侧 AG-UI 协议层的类型化模型（MessageContent / InputContent），以及中间 Converter 的改进——对接到既有 ContentBlock 体系。

### 设计要点

**1. AguiMessage.content —— 类型安全的联合**

```
MessageContent (sealed interface)
├── Text(String value)              → JSON: "你好"
└── Blocks(List<InputContent> parts) → JSON: [{"type":"text",...},{"type":"image",...}]
```

- 用 sealed interface 表达 `string | InputContent[]` 联合类型
- 命名用 `Text` / `Blocks`（或 `hasBlocks()`），不引入"多模态"
- 自定义 JSON 编解码器：反序列化按 JSON token（标量/数组）分派，序列化按 instanceof 透明输出

**2. InputContent —— 类型化的协议模型**

```
InputContent (sealed interface)
├── TextInputContent
├── ImageInputContent
├── AudioInputContent
├── VideoInputContent
└── DocumentInputContent
```

- 对应 AG-UI 协议的 InputContent 联合类型
- 取代 `Map<String, Object>`，提供编译期类型安全
- JSON 多态通过 `type` 字段分派（标准 `@JSONType(seeAlso=...)`）

**3. Converter —— 编译期穷尽的类型映射**

```
InputContent → ContentBlock（pattern matching switch）

TextInputContent     → TextBlock
ImageInputContent    → ImageBlock
AudioInputContent    → AudioBlock
VideoInputContent    → VideoBlock
DocumentInputContent → TextBlock（降级）

// sealed switch 编译期穷尽，新增类型时编译器报错提醒
```

## 引用的 AG-UI 格式定义

https://docs.ag-ui.com/concepts/messages

```
interface UserMessage {
  id: string
  role: "user"
  content: string | InputContent[] // Text or multimodal input from the user
  name?: string // Optional user identifier
}

type InputContent =
  | TextInputContent
  | ImageInputContent
  | AudioInputContent
  | VideoInputContent
  | DocumentInputContent

interface InputContentDataSource {
  type: "data"
  value: string
  mimeType: string
}

interface InputContentUrlSource {
  type: "url"
  value: string
  mimeType?: string
}

type InputContentSource = InputContentDataSource | InputContentUrlSource

interface TextInputContent {
  type: "text"
  text: string
}

interface ImageInputContent {
  type: "image"
  source: InputContentSource
  metadata?: Record<string, unknown>
}

interface AudioInputContent {
  type: "audio"
  source: InputContentSource
  metadata?: Record<string, unknown>
}

interface VideoInputContent {
  type: "video"
  source: InputContentSource
  metadata?: Record<string, unknown>
}

interface DocumentInputContent {
  type: "document"
  source: InputContentSource
  metadata?: Record<string, unknown>
}
```
