### PR TITLE
fix(#2509): add per-session interrupt overloads to HarnessAgent

### DIFF
--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/HarnessAgent.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/HarnessAgent.java
@@ -487,6 +487,52 @@ public class HarnessAgent implements Agent, AutoCloseable {
         delegate.interrupt(msg);
     }
 
+    /**
+     * Interrupts the in-flight call identified by the given {@link RuntimeContext}.
+     * Delegates to {@link ReActAgent#interrupt(RuntimeContext)}.
+     *
+     * @param ctx the runtime context identifying the session to interrupt
+     */
+    public void interrupt(RuntimeContext ctx) {
+        delegate.interrupt(ctx);
+    }
+
+    /**
+     * Interrupts the in-flight call identified by the given {@link RuntimeContext}
+     * with an associated user message.
+     * Delegates to {@link ReActAgent#interrupt(RuntimeContext, Msg)}.
+     *
+     * @param ctx the runtime context identifying the session to interrupt
+     * @param msg optional user message to attach to the interrupt signal
+     */
+    public void interrupt(RuntimeContext ctx, Msg msg) {
+        delegate.interrupt(ctx, msg);
+    }
+
+    /**
+     * Interrupts the in-flight call for a specific {@code (userId, sessionId)} session.
+     * Delegates to {@link ReActAgent#interrupt(String, String)}.
+     *
+     * @param userId    the user id ({@code null} = anonymous / single-tenant)
+     * @param sessionId the session id
+     */
+    public void interrupt(String userId, String sessionId) {
+        delegate.interrupt(userId, sessionId);
+    }
+
+    /**
+     * Interrupts the in-flight call for a specific {@code (userId, sessionId)} session
+     * with an associated user message.
+     * Delegates to {@link ReActAgent#interrupt(String, String, Msg)}.
+     *
+     * @param userId    the user id ({@code null} = anonymous / single-tenant)
+     * @param sessionId the session id
+     * @param msg       optional user message to attach to the interrupt signal
+     */
+    public void interrupt(String userId, String sessionId, Msg msg) {
+        delegate.interrupt(userId, sessionId, msg);
+    }
+
     // -----------------------------------------------------------------
     //  Channel / Gateway
     // -----------------------------------------------------------------


### PR DESCRIPTION
## Summary

Adds , , , and  methods to  that delegate to the underlying .

## Problem

 already supports per-session interruption via  and , but  only exposed the deprecated no-arg and -only variants. External callers had no way to interrupt a specific  session through the  API.

## Changes

- Added  — delegates to 
- Added  — delegates to 
- Added  — delegates to 
- Added  — delegates to 

## Testing

This is a pure delegation change — no logic was added. The underlying  methods are already tested for correctness.

Closes #2509