### PR TITLE
feat(tool): wait async result with taskId

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ build/
 .vscode/
 .claude/
 .codex
+.cursor
 ### Mac OS ###
 .DS_Store
 

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/middleware/SubagentsMiddleware.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/middleware/SubagentsMiddleware.java
@@ -119,8 +119,13 @@ public class SubagentsMiddleware implements HarnessRuntimeMiddleware {
 
             **`task_output`** — Retrieve the result of a background task by task_id.
             - **You rarely need this.** Completed tasks are pushed back to you automatically as a `<system-reminder>` block before your next reasoning step.
-            - Use `task_output(block=false)` only when you need the full result and the pushed summary was truncated, or to inspect a specific task on demand.
-            - Avoid `block=true`; it serialises the conversation behind the task.
+            - Use `task_output(block=false)` when you need a specific task's latest status/result, the pushed summary was truncated, or you intentionally want to check progress while continuing other reasoning.
+            - Use `task_output(block=true)` only for one specific task you are ready to wait for; for multiple tasks use `wait_async_results`.
+
+            **`wait_async_results`** — Wait for background-task delivery when the next step depends on results.
+            - `wait_async_results(task_ids=...)` waits until the specified async subagent tasks have reached terminal state and their results can be injected.
+            - `wait_async_results(wait_all=true)` waits for all currently tracked non-terminal background tasks in this session. It snapshots the current set; tasks started later are not added to that wait.
+            - With no task ids and no `wait_all`, it keeps the legacy inbox wait behavior for any delivered async result.
 
             **`task_cancel`** — Cancel a running background task by task_id. No effect on already-completed tasks.
 
@@ -128,8 +133,9 @@ public class SubagentsMiddleware implements HarnessRuntimeMiddleware {
 
             ### Background task flow
             1. Spawn with `timeout_seconds=0` to fire-and-forget; the response gives you a task_id.
-            2. **Do not poll.** Continue with other work; when the task finishes you'll see a `<system-reminder>` containing its result.
-            3. If the agent has nothing useful to do, hand control back to the user — they'll prompt again when ready and the next reasoning round will surface any completions.
+            2. Continue with independent work. If you need fresh state, use `task_output(block=false)` for selected tasks.
+            3. If a later step must wait for a known group, call `wait_async_results(task_ids=...)`; if it must wait for every current background task, call `wait_async_results(wait_all=true)`.
+            4. If the agent has nothing useful to do, hand control back to the user — they'll prompt again when ready and the next reasoning round will surface any completions.
 
             ### Timeout promotion
             When a sync spawn/send exceeds its timeout, the task is **not lost** — it is automatically promoted to a background task. You receive `status: timeout_promoted` with a `task_id`. Treat it like any async task: the result will be pushed back to you automatically as a `<system-reminder>`. Do NOT retry the same task — it is already running in the background.
@@ -157,8 +163,10 @@ public class SubagentsMiddleware implements HarnessRuntimeMiddleware {
             4. **Reconcile** → Incorporate or synthesize the result into the main thread
 
             ### Usage patterns
-            - **Parallel execution**: Launch multiple subagents concurrently with timeout_seconds=0 when tasks are independent, then collect results with task_output(block=false) after a delay
-            - **Sync delegation**: Use default timeout for simple one-shot delegation
+            - **Parallel async execution**: Split work by independence/dependency. Launch independent, non-conflicting tasks with `timeout_seconds=0`; continue reasoning, then use `task_output(block=false)` for selective progress checks or `wait_async_results(task_ids=...)` / `wait_async_results(wait_all=true)` when a barrier is required
+            - **Parallel sync delegation**: When the toolkit executes tool calls in parallel, multiple sync `agent_spawn` / `agent_send` calls can run concurrently and the parent waits for those tool results before continuing
+            - **Mixed short/long work**: Wait for short prerequisite tasks first, continue reasoning with those results, and merge long-running async results later through `task_output` or `wait_async_results`
+            - **Sync delegation**: Use default timeout for simple one-shot delegation when one result is needed before the next reasoning step
             - **Persistent session**: Spawn without a task, then use send for multi-turn interaction
             - **Cancel stale work**: Use task_cancel to stop background tasks that are no longer needed
             - Subagent results are NOT visible to the user — always summarize them in your response

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/tool/AgentSpawnTool.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/tool/AgentSpawnTool.java
@@ -129,6 +129,8 @@ public class AgentSpawnTool {
             status: accepted
             task_id: %s
             Use task_output(task_id='%s', block=false) to check status, \
+            wait_async_results(task_ids=...) to wait for a chosen group, \
+            wait_async_results(wait_all=true) to wait for all current background tasks, \
             task_cancel(task_id='%s') to cancel, or task_list() to see all tasks. \
             Do NOT call task_output immediately — the task has just started.\
             """;
@@ -202,7 +204,10 @@ public class AgentSpawnTool {
                     Every response starts with three lines: agent_key (pass this verbatim to \
                     agent_send as agent_key), agent_id (the subagent type name), and session_id \
                     (internal; do not use as agent_key). Sync mode returns the reply below that; \
-                    async (timeout_seconds=0) adds task_id for task_output — task_id is NOT agent_key.\
+                    async (timeout_seconds=0) adds task_id for task_output or wait_async_results; \
+                    task_id is NOT agent_key. Multiple sync tool calls may run in parallel when \
+                    the toolkit enables parallel tool execution; otherwise use async tasks for \
+                    explicit parallelism.\
                     """)
     public Mono<String> agentSpawn(
             RuntimeContext runtimeContext,
@@ -444,7 +449,7 @@ public class AgentSpawnTool {
                     Send a message to an existing subagent. Use the exact string from the \
                     agent_key line of agent_spawn output (starts with agent:), or the label \
                     you set at spawn. Do not pass agent_id, session_id, or task_id here. \
-                    timeout_seconds=0 returns task_id for task_output.\
+                    timeout_seconds=0 returns task_id for task_output or wait_async_results.\
                     """)
     public Mono<String> agentSend(
             RuntimeContext runtimeContext,
@@ -977,6 +982,7 @@ public class AgentSpawnTool {
                 task_id: %s
                 The task exceeded the %ds sync timeout but is still running in the background. \
                 Use task_output(task_id='%s', block=false) to check status, \
+                wait_async_results(task_ids=...) when this task is part of a required barrier, \
                 or wait — completed tasks are pushed back to you automatically. \
                 Do NOT retry the same task.\
                 """,

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/tool/TaskTool.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/tool/TaskTool.java
@@ -55,10 +55,13 @@ public class TaskTool {
             description =
                     "Retrieve the output of a background subagent task. Use when agent_spawn or"
                         + " agent_send was called with timeout_seconds=0. Prefer block=false to"
-                        + " check status without waiting. Only use block=true (the default) when"
-                        + " you are ready to wait for the result. Do NOT call this immediately"
-                        + " after launching a task — the task status in conversation history is"
-                        + " stale; always call task_output or task_list to get the current state.")
+                        + " check status without waiting. Use block=true only for one specific task"
+                        + " you are ready to block on. For several async subagent tasks, prefer"
+                        + " wait_async_results(task_ids=...) or wait_async_results(wait_all=true)"
+                        + " when you need a barrier, otherwise keep reasoning and poll selected"
+                        + " tasks later with block=false. Do NOT call this immediately after"
+                        + " launching a task — the task status in conversation history is stale;"
+                        + " always call task_output or task_list to get the current state.")
     public String taskOutput(
             RuntimeContext runtimeContext,
             @ToolParam(

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/tool/WaitAsyncResultsTool.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/tool/WaitAsyncResultsTool.java
@@ -21,7 +21,9 @@ import io.agentscope.core.tool.ToolParam;
 import io.agentscope.harness.agent.bus.MessageBus;
 import io.agentscope.harness.agent.subagent.task.BackgroundTask;
 import io.agentscope.harness.agent.subagent.task.TaskRepository;
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.slf4j.Logger;
@@ -72,6 +74,9 @@ public class WaitAsyncResultsTool {
                             + "their completion instead of returning to the user. After this tool "
                             + "returns successfully, continue reasoning — the results will be "
                             + "automatically injected into your context. "
+                            + "Use task_ids to wait until specific task IDs are all terminal, "
+                            + "or wait_all=true to wait until all currently running tasks in the "
+                            + "session are terminal. "
                             + "Max timeout is 120 seconds. "
                             + "If you have already waited without results, use task_list or "
                             + "task_output(block=false) to check status instead of waiting again.",
@@ -83,6 +88,23 @@ public class WaitAsyncResultsTool {
                                     "Maximum seconds to wait. Default 60, max 120. "
                                             + "Values above 120 are clamped.")
                     Integer timeoutSeconds,
+            @ToolParam(
+                            name = "task_ids",
+                            description =
+                                    "Optional comma-separated task IDs to wait for. When set, the "
+                                            + "tool returns only after all listed tasks are "
+                                            + "terminal, or timeout.",
+                            required = false)
+                    String taskIds,
+            @ToolParam(
+                            name = "wait_all",
+                            description =
+                                    "Optional barrier mode. When true and task_ids is empty, wait "
+                                            + "for the snapshot of currently non-terminal tasks in "
+                                            + "this session. Tasks created later are not added to "
+                                            + "the wait set.",
+                            required = false)
+                    Boolean waitAll,
             RuntimeContext runtimeContext)
             throws InterruptedException {
 
@@ -94,6 +116,11 @@ public class WaitAsyncResultsTool {
         AtomicInteger emptyWaits =
                 consecutiveEmptyWaitsBySession.computeIfAbsent(
                         sessionId, k -> new AtomicInteger(0));
+        List<String> explicitTaskIds = parseTaskIds(taskIds);
+        if (!explicitTaskIds.isEmpty() || Boolean.TRUE.equals(waitAll)) {
+            return waitForTaskBarrier(
+                    timeoutSeconds, runtimeContext, sessionId, explicitTaskIds, emptyWaits);
+        }
 
         if (emptyWaits.get() >= MAX_CONSECUTIVE_EMPTY_WAITS) {
             Boolean hasMessages = messageBus.inboxHasMessages(sessionId).block();
@@ -185,6 +212,197 @@ public class WaitAsyncResultsTool {
                 + "). "
                 + "Use task_list to check task status, or task_output(block=false) to poll "
                 + "without blocking.";
+    }
+
+    public String waitForResults(Integer timeoutSeconds, RuntimeContext runtimeContext)
+            throws InterruptedException {
+        return waitForResults(timeoutSeconds, null, null, runtimeContext);
+    }
+
+    private String waitForTaskBarrier(
+            Integer timeoutSeconds,
+            RuntimeContext runtimeContext,
+            String sessionId,
+            List<String> explicitTaskIds,
+            AtomicInteger emptyWaits)
+            throws InterruptedException {
+        if (taskRepository == null) {
+            return "Cannot wait for task completion: task repository is unavailable. "
+                    + "Use task_list or task_output(block=false) to check status.";
+        }
+
+        if (!explicitTaskIds.isEmpty()) {
+            List<String> missingTaskIds =
+                    explicitTaskIds.stream()
+                            .filter(
+                                    id ->
+                                            taskRepository.getTask(runtimeContext, sessionId, id)
+                                                    == null)
+                            .toList();
+            if (!missingTaskIds.isEmpty()) {
+                return "Cannot wait: unknown task_ids "
+                        + missingTaskIds
+                        + ". Use task_list to find valid task IDs.";
+            }
+        }
+
+        List<String> waitSet =
+                !explicitTaskIds.isEmpty()
+                        ? explicitTaskIds
+                        : snapshotNonTerminalTaskIds(runtimeContext, sessionId);
+        if (waitSet.isEmpty()) {
+            log.info(
+                    "wait_async_results: wait_all snapshot empty,"
+                            + " returning immediately, session={}",
+                    sessionId);
+            emptyWaits.set(0);
+            return "No running background tasks found at wait start. Continue reasoning, "
+                    + "or use task_list to review existing task status.";
+        }
+
+        String completed = completeTaskBarrierIfReady(runtimeContext, sessionId, waitSet);
+        if (completed != null) {
+            emptyWaits.set(0);
+            return completed;
+        }
+
+        String rejected = rejectIfWaitBudgetExhausted(sessionId, emptyWaits);
+        if (rejected != null) {
+            return rejected;
+        }
+
+        int timeout = normalizeTimeout(timeoutSeconds, sessionId);
+        log.info(
+                "wait_async_results: waiting up to {}s for task barrier, session={}, tasks={}",
+                timeout,
+                sessionId,
+                waitSet);
+
+        long deadlineMs = System.currentTimeMillis() + (timeout * 1000L);
+        while (true) {
+            completed = completeTaskBarrierIfReady(runtimeContext, sessionId, waitSet);
+            if (completed != null) {
+                emptyWaits.set(0);
+                return completed;
+            }
+            long remainingMs = deadlineMs - System.currentTimeMillis();
+            if (remainingMs <= 0) {
+                break;
+            }
+            sleepForPollInterval(remainingMs);
+        }
+
+        int emptyCount = emptyWaits.incrementAndGet();
+        log.info(
+                "wait_async_results: timeout after {}s waiting for tasks {}"
+                        + " (consecutive empty waits: {}), session={}",
+                timeout,
+                waitSet,
+                emptyCount,
+                sessionId);
+        return "Timeout after "
+                + timeout
+                + "s. Requested background tasks are not all terminal yet (empty wait "
+                + emptyCount
+                + "/"
+                + MAX_CONSECUTIVE_EMPTY_WAITS
+                + "). "
+                + "Use task_list to check task status, or task_output(block=false) to poll "
+                + "without blocking.";
+    }
+
+    private String completeTaskBarrierIfReady(
+            RuntimeContext runtimeContext, String sessionId, List<String> waitSet) {
+        for (String taskId : waitSet) {
+            BackgroundTask task = taskRepository.getTask(runtimeContext, sessionId, taskId);
+            if (task == null) {
+                log.info(
+                        "wait_async_results: task barrier missing task {}, session={}",
+                        taskId,
+                        sessionId);
+                return "Cannot wait: task_id "
+                        + taskId
+                        + " is no longer available. Use task_list to refresh task status.";
+            }
+            if (!task.getTaskStatus().isTerminal()) {
+                return null;
+            }
+        }
+        log.info(
+                "wait_async_results: task barrier complete, tasks={}, session={}",
+                waitSet,
+                sessionId);
+        return "All requested background tasks are terminal. Continue reasoning — "
+                + "results will be injected automatically when delivered, or use "
+                + "task_output(task_id) to read a specific result.";
+    }
+
+    private String rejectIfWaitBudgetExhausted(String sessionId, AtomicInteger emptyWaits) {
+        if (emptyWaits.get() < MAX_CONSECUTIVE_EMPTY_WAITS) {
+            return null;
+        }
+        Boolean hasMessages = messageBus.inboxHasMessages(sessionId).block();
+        if (Boolean.TRUE.equals(hasMessages)) {
+            log.info(
+                    "wait_async_results: budget was exhausted but inbox now has messages,"
+                            + " resetting counter, session={}",
+                    sessionId);
+            emptyWaits.set(0);
+            return "Async results have arrived. Continue reasoning — "
+                    + "the results will be injected into your context automatically.";
+        }
+        log.info(
+                "wait_async_results: rejected — {} consecutive empty waits reached, session={}",
+                emptyWaits.get(),
+                sessionId);
+        return "Wait budget exhausted: you have already waited "
+                + emptyWaits.get()
+                + " times without receiving results. "
+                + "Do NOT call wait_async_results again. Instead use task_list to check "
+                + "task status, or task_output(block=false) to poll for results without "
+                + "blocking.";
+    }
+
+    private int normalizeTimeout(Integer timeoutSeconds, String sessionId) {
+        int raw =
+                timeoutSeconds != null && timeoutSeconds > 0
+                        ? timeoutSeconds
+                        : DEFAULT_TIMEOUT_SECONDS;
+        int timeout = Math.min(raw, MAX_TIMEOUT_SECONDS);
+        if (raw > MAX_TIMEOUT_SECONDS) {
+            log.info(
+                    "wait_async_results: clamped timeout from {}s to {}s, session={}",
+                    raw,
+                    timeout,
+                    sessionId);
+        }
+        return timeout;
+    }
+
+    private void sleepForPollInterval(long remainingMs) throws InterruptedException {
+        Thread.sleep(Math.min(POLL_INTERVAL_MS, remainingMs));
+    }
+
+    private List<String> parseTaskIds(String taskIds) {
+        if (taskIds == null || taskIds.isBlank()) {
+            return List.of();
+        }
+        List<String> parsed = new ArrayList<>();
+        for (String raw : taskIds.split(",")) {
+            String id = raw.trim();
+            if (!id.isEmpty()) {
+                parsed.add(id);
+            }
+        }
+        return parsed;
+    }
+
+    private List<String> snapshotNonTerminalTaskIds(RuntimeContext rc, String sessionId) {
+        Collection<BackgroundTask> tasks = taskRepository.listTasks(rc, sessionId, null);
+        return tasks.stream()
+                .filter(t -> !t.getTaskStatus().isTerminal())
+                .map(BackgroundTask::getTaskId)
+                .toList();
     }
 
     private boolean hasNonTerminalTasks(RuntimeContext rc, String sessionId) {

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/tool/WaitAsyncResultsToolTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/tool/WaitAsyncResultsToolTest.java
@@ -25,6 +25,7 @@ import io.agentscope.harness.agent.subagent.task.BackgroundTask;
 import io.agentscope.harness.agent.subagent.task.TaskRepository;
 import io.agentscope.harness.agent.subagent.task.TaskRunSpec;
 import io.agentscope.harness.agent.subagent.task.TaskStatus;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -213,11 +214,141 @@ class WaitAsyncResultsToolTest {
     }
 
     @Test
+    @DisplayName("task_ids waits until all listed tasks are terminal")
+    void taskIdsWaitUntilAllListedTasksTerminal() throws Exception {
+        CompletableFuture<String> t1 = new CompletableFuture<>();
+        CompletableFuture<String> t2 = new CompletableFuture<>();
+        TaskRepository repo =
+                new StubTaskRepository(
+                        List.of(
+                                new BackgroundTask("t1", "agent-1", t1),
+                                new BackgroundTask("t2", "agent-2", t2)));
+        WaitAsyncResultsTool tool = new WaitAsyncResultsTool(emptyBus(), repo);
+
+        Thread completer =
+                new Thread(
+                        () -> {
+                            sleep(150);
+                            t1.complete("one");
+                            sleep(150);
+                            t2.complete("two");
+                        });
+        completer.start();
+
+        String result = tool.waitForResults(2, " t1, t2 ", null, ctx());
+        completer.join();
+
+        assertTrue(
+                result.contains("All requested background tasks are terminal"),
+                "should complete barrier after both tasks finish, got: " + result);
+    }
+
+    @Test
+    @DisplayName("task_ids timeout if any listed task remains running")
+    void taskIdsTimeoutWhenAnyListedTaskStillRunning() throws Exception {
+        CompletableFuture<String> completed = CompletableFuture.completedFuture("done");
+        CompletableFuture<String> running = new CompletableFuture<>();
+        TaskRepository repo =
+                new StubTaskRepository(
+                        List.of(
+                                new BackgroundTask("t1", "agent-1", completed),
+                                new BackgroundTask("t2", "agent-2", running)));
+        WaitAsyncResultsTool tool = new WaitAsyncResultsTool(emptyBus(), repo);
+
+        String result = tool.waitForResults(1, "t1,t2", null, ctx());
+
+        assertTrue(result.contains("Timeout"), "should timeout while t2 is running");
+        assertTrue(
+                result.contains("not all terminal yet"),
+                "should explain barrier condition, got: " + result);
+    }
+
+    @Test
+    @DisplayName("task_ids rejects unknown task ids")
+    void taskIdsRejectsUnknownTaskIds() throws Exception {
+        TaskRepository repo =
+                new StubTaskRepository(
+                        List.of(
+                                new BackgroundTask(
+                                        "t1",
+                                        "agent-1",
+                                        CompletableFuture.completedFuture("done"))));
+        WaitAsyncResultsTool tool = new WaitAsyncResultsTool(emptyBus(), repo);
+
+        long start = System.currentTimeMillis();
+        String result = tool.waitForResults(120, "t1,missing", null, ctx());
+        long elapsed = System.currentTimeMillis() - start;
+
+        assertTrue(result.contains("unknown task_ids"), "got: " + result);
+        assertTrue(result.contains("missing"), "should report the missing id, got: " + result);
+        assertTrue(elapsed < 2_000, "should not wait for unknown ids, took: " + elapsed + "ms");
+    }
+
+    @Test
+    @DisplayName("wait_all=true waits for snapshot of current non-terminal tasks")
+    void waitAllWaitsForCurrentNonTerminalSnapshot() throws Exception {
+        CompletableFuture<String> running = new CompletableFuture<>();
+        MutableTaskRepository repo =
+                new MutableTaskRepository(List.of(new BackgroundTask("t1", "agent-1", running)));
+        WaitAsyncResultsTool tool = new WaitAsyncResultsTool(emptyBus(), repo);
+
+        Thread completer =
+                new Thread(
+                        () -> {
+                            sleep(150);
+                            repo.add(
+                                    new BackgroundTask("t2", "agent-2", new CompletableFuture<>()));
+                            running.complete("done");
+                        });
+        completer.start();
+
+        String result = tool.waitForResults(2, null, true, ctx());
+        completer.join();
+
+        assertTrue(
+                result.contains("All requested background tasks are terminal"),
+                "wait_all should use the initial snapshot and ignore later tasks, got: " + result);
+    }
+
+    @Test
+    @DisplayName("wait_all=true with empty snapshot returns immediately")
+    void waitAllEmptySnapshotReturnsImmediately() throws Exception {
+        WaitAsyncResultsTool tool =
+                new WaitAsyncResultsTool(emptyBus(), new StubTaskRepository(List.of()));
+
+        long start = System.currentTimeMillis();
+        String result = tool.waitForResults(120, null, true, ctx());
+        long elapsed = System.currentTimeMillis() - start;
+
+        assertTrue(result.contains("No running background tasks"), "got: " + result);
+        assertTrue(elapsed < 2_000, "should return immediately, took: " + elapsed + "ms");
+    }
+
+    @Test
+    @DisplayName("barrier mode requires TaskRepository")
+    void barrierModeRequiresTaskRepository() throws Exception {
+        WaitAsyncResultsTool tool = new WaitAsyncResultsTool(emptyBus(), null);
+
+        String result = tool.waitForResults(1, "t1", null, ctx());
+
+        assertTrue(result.contains("task repository is unavailable"), "got: " + result);
+    }
+
+    @Test
     @DisplayName("no TaskRepository (null) → falls through to normal wait")
     void nullTaskRepositoryFallsThrough() throws Exception {
         WaitAsyncResultsTool tool = new WaitAsyncResultsTool(emptyBus(), null);
         String result = tool.waitForResults(1, ctx());
         assertTrue(result.contains("Timeout"), "should proceed to wait and timeout");
+    }
+
+    private static void sleep(long millis) {
+        try {
+            Thread.sleep(millis);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new AssertionError(e);
+        }
     }
 
     private static class StubMessageBus implements MessageBus {
@@ -280,7 +411,7 @@ class WaitAsyncResultsToolTest {
 
     private static class StubTaskRepository implements TaskRepository {
 
-        private final List<BackgroundTask> tasks;
+        protected final List<BackgroundTask> tasks;
 
         StubTaskRepository(List<BackgroundTask> tasks) {
             this.tasks = tasks;
@@ -322,6 +453,17 @@ class WaitAsyncResultsToolTest {
         @Override
         public boolean cancelTask(RuntimeContext rc, String sessionId, String taskId) {
             return false;
+        }
+    }
+
+    private static class MutableTaskRepository extends StubTaskRepository {
+
+        MutableTaskRepository(List<BackgroundTask> tasks) {
+            super(new ArrayList<>(tasks));
+        }
+
+        void add(BackgroundTask task) {
+            tasks.add(task);
         }
     }
 }

--- a/docs/v2/en/docs/harness/subagent.md
+++ b/docs/v2/en/docs/harness/subagent.md
@@ -110,6 +110,10 @@ The parent creates a subagent with `agent_spawn`; the key knob is `timeout_secon
 - `timeout_seconds > 0` (default 30, max 600) — **synchronous** call; the parent blocks on this step, result returns as the tool result.
 - `timeout_seconds = 0` — **background** call; returns a `task_id` immediately, subagent runs in the background.
 
+If a goal can be split into independent subtasks that do not conflict on resources, the parent can issue multiple synchronous subagent calls in the same reasoning turn. When tool execution is configured for parallelism, those synchronous calls can advance in parallel; the parent enters the next reasoning step only after that batch of tool results has returned, forming a synchronous fan-out / fan-in barrier.
+
+Decompose work by independence and dependency graph first: nodes without dependency edges are good candidates for parallel subagents; dependent nodes should wait for upstream results before dispatch or merge. Short or critical-path tasks are good candidates for synchronous waiting or an explicit barrier so the parent can continue reasoning with their results. Long tasks can run in the background while the parent continues other work, then be collected and merged later.
+
 ### Background tasks push back automatically
 
 When a background task finishes, the parent **does not need to poll** — before the parent's next reasoning step, the framework injects completed task results as a system reminder at the end of the conversation:
@@ -134,12 +138,19 @@ Behind the scenes, subagent lifecycle is split across two groups of tools:
 | `agent_send` | Send a follow-up message to an existing subagent |
 | `agent_list` | List active subagent instances |
 | `task_output` | Retrieve the result of a background task by `task_id` (blocking or non-blocking) |
+| `wait_async_results` | Wait for background results; can wait for specific `task_ids` to all finish, or use `wait_all=true` for a snapshot of unfinished tasks in the current session |
 | `task_cancel` | Cancel a running background task |
 | `task_list` | List all background tasks with their current statuses |
 
-`agent_spawn` / `agent_send` manage subagent **instances** (create, reuse, communicate); `task_output` / `task_cancel` / `task_list` manage background **task results** (check status, fetch output, cancel). The bridge between them is the `task_id` — returned by `agent_spawn` or `agent_send` when `timeout_seconds=0`.
+`agent_spawn` / `agent_send` manage subagent **instances** (create, reuse, communicate); `task_output` / `wait_async_results` / `task_cancel` / `task_list` manage background **task results** (check status, fetch output, wait, cancel). The bridge between them is the `task_id` — returned by `agent_spawn` or `agent_send` when `timeout_seconds=0`.
 
-> In most cases the auto push-back mechanism delivers results without any explicit tool call. The task tools are useful as escape hatches: checking progress before push-back fires, cancelling tasks that are no longer needed, or recovering task state after conversation compaction.
+> In most cases the auto push-back mechanism delivers results without any explicit tool call. The task tools are useful as escape hatches: checking progress before push-back fires, waiting for a set of results that must be available together, cancelling tasks that are no longer needed, or recovering task state after conversation compaction.
+
+There are three common ways to collect asynchronous results:
+
+- **Automatic push-back**: the default path. Completed child tasks are injected as a `<system-reminder>` before the next reasoning step, so the parent does not need to poll immediately.
+- **Targeted task check**: call `task_output(task_id, block=false)` to inspect one task's current state or final result. This is useful for taking short-task results early, or recovering results that were compacted or not injected.
+- **Wait barrier**: call `wait_async_results(task_ids="id1,id2")` to wait until all listed tasks are terminal; or call `wait_async_results(wait_all=true)` to wait for the snapshot of unfinished tasks in the current session at the start of the call. `wait_all=true` does not dynamically add tasks created while it is waiting.
 
 ## Send a follow-up to an existing subagent
 

--- a/docs/v2/zh/docs/harness/subagent.md
+++ b/docs/v2/zh/docs/harness/subagent.md
@@ -110,6 +110,10 @@ HarnessAgent.builder()
 - `timeout_seconds > 0`（默认 30，最大 600）—— **同步**调用，主 agent 在这一步 block 等待结果，结果作为工具结果返回。
 - `timeout_seconds = 0` —— **后台**调用，立即返回一个 `task_id`，子 agent 在后台跑。
 
+如果一个目标可以拆成多个互不依赖、资源不冲突的子任务，主 agent 可以在同一轮 reasoning 里发起多个同步子 agent 调用。工具执行层启用并行后，这些同步调用可以并行推进；主 agent 会等这一批工具结果都返回后再进入下一轮推理，相当于一次同步 fan-out / fan-in。
+
+任务拆解时先画清楚独立性和依赖图：没有依赖边的节点适合交给多个子 agent 并行；有依赖关系的节点要等上游结果后再派发或合并。短任务、关键路径任务适合同步等待或先用 barrier 等齐，用于继续推理；长任务可以用后台模式先跑，主 agent 继续处理其他工作，后续再取结果合并。
+
 ### 后台任务自动反向通知
 
 后台任务跑完了，**主 agent 不需要轮询**——下一次推理开始前，框架会把已完成的任务结果作为系统提醒注入对话末尾：
@@ -134,12 +138,19 @@ HarnessAgent.builder()
 | `agent_send` | 向已存在的子 agent 追加消息 |
 | `agent_list` | 列出当前活跃的子 agent 实例 |
 | `task_output` | 通过 `task_id` 获取后台任务结果（阻塞或非阻塞） |
+| `wait_async_results` | 等待后台结果到达；可按 `task_ids` 等指定任务全部完成，或用 `wait_all=true` 等待当前 session 未完成任务快照全部完成 |
 | `task_cancel` | 取消正在运行的后台任务 |
 | `task_list` | 列出所有后台任务及其当前状态 |
 
-`agent_spawn` / `agent_send` 管理子 agent **实例**（创建、复用、通信）；`task_output` / `task_cancel` / `task_list` 管理后台**任务结果**（查状态、取结果、取消）。两者的桥梁是 `task_id`——在 `agent_spawn` 或 `agent_send` 使用 `timeout_seconds=0` 时返回。
+`agent_spawn` / `agent_send` 管理子 agent **实例**（创建、复用、通信）；`task_output` / `wait_async_results` / `task_cancel` / `task_list` 管理后台**任务结果**（查状态、取结果、等待、取消）。两者的桥梁是 `task_id`——在 `agent_spawn` 或 `agent_send` 使用 `timeout_seconds=0` 时返回。
 
-> 大多数情况下自动反向通知机制会把结果推回来，不需要显式调用任务工具。它们主要用作逃生口：在反向通知触发前主动检查进度、取消不再需要的任务、或者在对话压缩后恢复任务状态。
+> 大多数情况下自动反向通知机制会把结果推回来，不需要显式调用任务工具。它们主要用作逃生口：在反向通知触发前主动检查进度、等待一组必须同时拿齐的结果、取消不再需要的任务、或者在对话压缩后恢复任务状态。
+
+异步结果有三种常用收集方式：
+
+- **主动通知**：默认路径。子任务完成后，下一轮 reasoning 前通过 `<system-reminder>` 注入，主 agent 不需要立即轮询。
+- **指定任务检查**：用 `task_output(task_id, block=false)` 主动查看某个任务的当前状态或终态结果，适合先拿短任务结果、补取被压缩或未注入的结果。
+- **等待 barrier**：用 `wait_async_results(task_ids="id1,id2")` 等指定任务集合全部终态；或用 `wait_async_results(wait_all=true)` 等调用开始时当前 session 的未完成任务快照全部终态。`wait_all=true` 不会把等待期间新创建的任务动态加入 wait set。
 
 ## 给已存在的子 agent 补一条消息
 


### PR DESCRIPTION
## Background

The main agent often needs to delegate several independent subtasks to subagents, let them run in parallel, and collect results according to task dependencies. The framework already has `agent_spawn` / `agent_send`, background execution via `timeout_seconds=0`, `task_output`, completion callbacks, and the existing `ToolkitConfig.parallel` tool execution capability. However, async result collection is still too coarse:

- The legacy `wait_async_results` call only waits for any message to arrive in the session inbox. It cannot express “wait until these specific tasks are all done”.
- After launching multiple async subagents, the main agent has to poll each task with `task_output`, with no explicit wait-all barrier.
- The responsibilities of `wait_all`, task-id based waiting, automatic delivery, and explicit polling need to be aligned across tool descriptions, middleware prompts, and docs.
- Wakeup only schedules a future reasoning opportunity. It does not mean the result has already been injected into the model context.

This PR closes the loop for parallel subagent orchestration: launch async work, wait when a dependency barrier is needed, and collect results without breaking the legacy inbox-based wait behavior.

## Main Changes

- Add `wait_async_results(task_ids=...)` to wait until a specific comma-separated task set is terminal.
- Add `wait_async_results(wait_all=true)` to wait for the current snapshot of non-terminal tasks in the session.
- Return fast diagnostics for unknown task ids, empty wait-all snapshots, missing session context, and unavailable `TaskRepository`.
- Keep legacy `wait_async_results(timeout_seconds)` inbox-any behavior when no barrier parameters are provided.
- Keep existing guardrails: timeout clamping, consecutive empty-wait budget, and non-blocking alternatives in timeout messages.
- Clarify `agent_spawn`, `task_output`, and `wait_async_results` tool descriptions for sync, async, polling, and barrier collection.
- Update `SubagentsMiddleware` prompt guidance and English/Chinese docs for task decomposition, parallel spawn, short-first/long-later collection, automatic delivery, and wakeup boundaries.