### PR TITLE
feat(core): add middleware execution ordering

### DIFF
--- a/agentscope-core/src/main/java/io/agentscope/core/ReActAgent.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/ReActAgent.java
@@ -127,6 +127,7 @@ import io.agentscope.core.util.JsonUtils;
 import io.agentscope.core.util.MessageUtils;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
@@ -4697,6 +4698,9 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
                                 skillCodeExecutionEnabled,
                                 skillWorkDir));
             }
+
+            // List.sort is stable: middlewares with equal order retain their registration order.
+            middlewares.sort(Comparator.comparingInt(MiddlewareBase::order).reversed());
 
             ReActAgent agent = new ReActAgent(this, agentToolkit);
             selfRef.set(agent);

--- a/agentscope-core/src/main/java/io/agentscope/core/middleware/MiddlewareBase.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/middleware/MiddlewareBase.java
@@ -59,6 +59,20 @@ import reactor.core.publisher.Mono;
 public interface MiddlewareBase {
 
     /**
+     * Returns this middleware's execution order.
+     *
+     * <p>A larger number means a higher priority and places the middleware closer to the outside
+     * of the onion chain: for example, {@code 2} runs before {@code 1}, and {@code 0} runs after
+     * {@code 1}. Middlewares with the same order retain their builder registration order. The
+     * default value keeps custom middlewares outside framework-provided middlewares.
+     *
+     * @return the execution order; higher values execute first before delegating to {@code next}
+     */
+    default int order() {
+        return 1;
+    }
+
+    /**
      * Intercept the entire agent invocation.
      *
      * @param agent the agent instance

--- a/agentscope-core/src/main/java/io/agentscope/core/middleware/MiddlewareBase.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/middleware/MiddlewareBase.java
@@ -64,7 +64,7 @@ public interface MiddlewareBase {
      * <p>A larger number means a higher priority and places the middleware closer to the outside
      * of the onion chain: for example, {@code 2} runs before {@code 1}, and {@code 0} runs after
      * {@code 1}. Middlewares with the same order retain their builder registration order. The
-     * default value keeps custom middlewares outside framework-provided middlewares.
+     * default value is {@code 1}.
      *
      * @return the execution order; higher values execute first before delegating to {@code next}
      */

--- a/agentscope-core/src/test/java/io/agentscope/core/agent/ReActAgentNewLoopBuilderTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/agent/ReActAgentNewLoopBuilderTest.java
@@ -111,7 +111,7 @@ class ReActAgentNewLoopBuilderTest {
     }
 
     @Test
-    void middlewareOrderIsDescendingAndStableForTies() {
+    void builderMiddlewaresAreSortedDescendingAndStableForTies() {
         MiddlewareBase firstDefault = new OrderedMiddleware(1);
         MiddlewareBase lowerPriority = new OrderedMiddleware(-1);
         MiddlewareBase higherPriority = new OrderedMiddleware(2);

--- a/agentscope-core/src/test/java/io/agentscope/core/agent/ReActAgentNewLoopBuilderTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/agent/ReActAgentNewLoopBuilderTest.java
@@ -111,6 +111,34 @@ class ReActAgentNewLoopBuilderTest {
     }
 
     @Test
+    void middlewareOrderIsDescendingAndStableForTies() {
+        MiddlewareBase firstDefault = new OrderedMiddleware(1);
+        MiddlewareBase lowerPriority = new OrderedMiddleware(-1);
+        MiddlewareBase higherPriority = new OrderedMiddleware(2);
+        MiddlewareBase secondDefault = new OrderedMiddleware(1);
+
+        ReActAgent agent =
+                ReActAgent.builder()
+                        .name("ordered")
+                        .model(newFakeModel())
+                        .toolkit(new Toolkit())
+                        .middleware(firstDefault)
+                        .middleware(lowerPriority)
+                        .middleware(higherPriority)
+                        .middleware(secondDefault)
+                        .build();
+
+        List<MiddlewareBase> middlewares = agent.getMiddlewares();
+        assertTrue(middlewares.get(0) instanceof GracefulShutdownMiddleware);
+        assertSame(higherPriority, middlewares.get(1));
+        assertSame(firstDefault, middlewares.get(2));
+        assertSame(secondDefault, middlewares.get(3));
+        assertSame(lowerPriority, middlewares.get(4));
+    }
+
+    private record OrderedMiddleware(int order) implements MiddlewareBase {}
+
+    @Test
     void fromAgentCopiesModelResilienceConfig() {
         ChatModelBase model = newFakeModel();
         ChatModelBase fallback = newFakeModel();

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/HarnessMiddlewareOrderTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/HarnessMiddlewareOrderTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.harness.agent;
+
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.agentscope.core.message.Msg;
+import io.agentscope.core.middleware.MiddlewareBase;
+import io.agentscope.core.model.ChatResponse;
+import io.agentscope.core.model.GenerateOptions;
+import io.agentscope.core.model.Model;
+import io.agentscope.core.model.ToolSchema;
+import io.agentscope.harness.agent.filesystem.local.LocalFilesystem;
+import io.agentscope.harness.agent.middleware.InboxMiddleware;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import reactor.core.publisher.Flux;
+
+class HarnessMiddlewareOrderTest {
+
+    @TempDir Path workspace;
+
+    @Test
+    void lowerPriorityCustomMiddlewareRunsAfterDefaultOrderHarnessMiddlewares() throws Exception {
+        Files.createDirectories(workspace);
+        MiddlewareBase lowerPriority =
+                new MiddlewareBase() {
+                    @Override
+                    public int order() {
+                        return 0;
+                    }
+                };
+
+        HarnessAgent agent =
+                HarnessAgent.builder()
+                        .name("ordered")
+                        .model(new TestModel())
+                        .workspace(workspace)
+                        .abstractFilesystem(new LocalFilesystem(workspace))
+                        .middleware(lowerPriority)
+                        .build();
+
+        List<MiddlewareBase> middlewares = agent.getDelegate().getMiddlewares();
+        assertTrue(
+                indexOfType(middlewares, InboxMiddleware.class)
+                        < middlewares.indexOf(lowerPriority));
+        assertSame(lowerPriority, middlewares.get(middlewares.size() - 1));
+    }
+
+    private static int indexOfType(List<MiddlewareBase> middlewares, Class<?> type) {
+        for (int i = 0; i < middlewares.size(); i++) {
+            if (type.isInstance(middlewares.get(i))) {
+                return i;
+            }
+        }
+        throw new AssertionError("Middleware not found: " + type.getSimpleName());
+    }
+
+    private static final class TestModel implements Model {
+
+        @Override
+        public Flux<ChatResponse> stream(
+                List<Msg> messages, List<ToolSchema> tools, GenerateOptions options) {
+            return Flux.empty();
+        }
+
+        @Override
+        public String getModelName() {
+            return "test-model";
+        }
+    }
+}

--- a/docs/v2/en/docs/building-blocks/middleware.md
+++ b/docs/v2/en/docs/building-blocks/middleware.md
@@ -57,7 +57,7 @@ ReActAgent agent =
                 .build();
 ```
 
-`middleware(...)` (singular) appends one; `middlewares(...)` accepts `List<? extends MiddlewareBase>`. Hooks not implemented by a middleware are skipped at zero cost.
+`middleware(...)` (singular) adds one; `middlewares(...)` accepts `List<? extends MiddlewareBase>`. Hooks not implemented by a middleware are skipped at zero cost.
 
 ## Built-in middlewares
 
@@ -218,12 +218,23 @@ Things to keep in mind:
 
 ### Execution order
 
-Onion hooks (`onAgent`, `onReasoning`, `onActing`, `onModelCall`) — **the first middleware in the list is outermost**:
+Onion hooks (`onAgent`, `onReasoning`, `onActing`, `onModelCall`) are ordered by `MiddlewareBase.order()` — **higher values are outermost**. The default order is `1`; middlewares with the same order retain their builder registration order:
 
 ```
-middlewares = [mw1, mw2]
+middlewares = [mw1(order=2), mw2(order=1)]
 // Order:
 // mw1 pre → mw2 pre → inner → mw2 post → mw1 post
+```
+
+Override `order()` to move a custom middleware relative to the default order. For example, an order of `0` runs inside middleware that keeps the default order of `1`:
+
+```java
+MiddlewareBase lowerPriority = new MiddlewareBase() {
+    @Override
+    public int order() {
+        return 0;
+    }
+};
 ```
 
 For streaming / event-emitting hooks, the inner middleware sees each emitted event first:

--- a/docs/v2/zh/docs/building-blocks/middleware.md
+++ b/docs/v2/zh/docs/building-blocks/middleware.md
@@ -57,7 +57,7 @@ ReActAgent agent =
                 .build();
 ```
 
-`middleware(...)`（单数）也可单独追加一个；`middlewares(...)` 接受 `List<? extends MiddlewareBase>`，未实现的位置自动跳过，不产生任何调用开销。
+`middleware(...)`（单数）也可单独添加一个；`middlewares(...)` 接受 `List<? extends MiddlewareBase>`，未实现的位置自动跳过，不产生任何调用开销。
 
 ## 内置 Middleware
 
@@ -218,12 +218,23 @@ public class RequestContextMiddleware implements MiddlewareBase {
 
 ### 执行顺序
 
-Onion 类 hook（`onAgent`、`onReasoning`、`onActing`、`onModelCall`）—— **列表中第一个 middleware 处于最外层**：
+Onion 类 hook（`onAgent`、`onReasoning`、`onActing`、`onModelCall`）按 `MiddlewareBase.order()` 排序——**数值越大越处于最外层**。默认值是 `1`；相同 order 的 middleware 保持其 Builder 注册顺序：
 
 ```
-middlewares = [mw1, mw2]
+middlewares = [mw1(order=2), mw2(order=1)]
 // 调用顺序：
 // mw1 前 → mw2 前 → 内部逻辑 → mw2 后 → mw1 后
+```
+
+自定义 middleware 可覆写 `order()`，改变其相对默认优先级的位置。例如 order 为 `0` 时，会进入所有仍保持默认 order `1` 的 middleware 内层：
+
+```java
+MiddlewareBase lowerPriority = new MiddlewareBase() {
+    @Override
+    public int order() {
+        return 0;
+    }
+};
 ```
 
 对于流式 / 产出事件的 hook，内层 middleware 先看到每一个 emit 出的事件：


### PR DESCRIPTION
## AgentScope-Java Version

2.0.1-SNAPSHOT

## Description

Closes #2449

Adds `MiddlewareBase.order()` with a default priority of `1`.

`ReActAgent.Builder.build()` now performs one stable descending sort after all user and automatic middleware registrations. Higher numeric values are outermost; equal priorities retain registration order.

Also adds core/Harness coverage and updates Chinese and English middleware documentation.

Validation:

```bash
mvn -pl agentscope-core,agentscope-harness -am \
  -Dtest=ReActAgentNewLoopBuilderTest,HarnessMiddlewareOrderTest \
  -Dsurefire.failIfNoSpecifiedTests=false test
```

## Checklist

Please check the following items before code is ready to be reviewed.

- [x]  Code has been formatted with `mvn spotless:apply`
- [x]  All tests are passing (`mvn test`)
- [x]  Javadoc comments are complete and follow project conventions
- [x]  Related documentation has been updated (e.g. links, examples, etc.)
- [x]  Code is ready for review
