### PR TITLE
fix(core): add PendingToolRecoveryHook per agent instance instead of mutating shared builder hooks

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.java text eol=lf

--- a/.licenserc.yaml
+++ b/.licenserc.yaml
@@ -61,6 +61,7 @@ header:
     - '.github/**'
     - '**/.gitignore'
     - '**/.helmignore'
+    - '**/.gitattributes'
     - '.repository/'
     - 'compiler/**'
     - '.gitmodules'

--- a/agentscope-core/src/main/java/io/agentscope/core/ReActAgent.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/ReActAgent.java
@@ -174,7 +174,7 @@ public class ReActAgent extends StructuredOutputCapableAgent {
                 builder.name,
                 builder.description,
                 builder.checkRunning,
-                new ArrayList<>(builder.hooks),
+                perInstanceHooks(builder),
                 agentToolkit,
                 builder.structuredOutputReminder);
 
@@ -191,6 +191,22 @@ public class ReActAgent extends StructuredOutputCapableAgent {
                 builder.statePersistence != null
                         ? builder.statePersistence
                         : StatePersistence.all();
+    }
+
+    /**
+     * Builds the per-instance hook list, adding {@link PendingToolRecoveryHook} when enabled.
+     *
+     * <p>The hook is added here (per agent instance) rather than in {@code Builder.build()} so that
+     * {@code build()} stays read-only on the builder's state — concurrent {@code build()} calls on a
+     * shared builder (as the A2A server reuses a single builder bean) are then safe, and each agent
+     * gets exactly one recovery hook instead of accumulating one per build on the shared hooks set.
+     */
+    private static List<Hook> perInstanceHooks(Builder builder) {
+        List<Hook> hooks = new ArrayList<>(builder.hooks);
+        if (builder.enablePendingToolRecovery) {
+            hooks.add(new PendingToolRecoveryHook());
+        }
+        return hooks;
     }
 
     // ==================== RuntimeContext ====================
@@ -1701,10 +1717,10 @@ public class ReActAgent extends StructuredOutputCapableAgent {
                 agentToolkit.registerMetaTool();
             }
 
-            // Register PendingToolRecoveryHook if enabled
-            if (enablePendingToolRecovery) {
-                hooks.add(new PendingToolRecoveryHook());
-            }
+            // NOTE: PendingToolRecoveryHook is no longer added to `hooks` here. build() must stay
+            // read-only on the builder's state so concurrent build() on a shared builder is safe
+            // (the hooks set is a plain, non-thread-safe HashSet). The hook is added per agent
+            // instance in ReActAgent.<init> instead.
 
             // Configure long-term memory if provided
             if (longTermMemory != null) {

--- a/agentscope-core/src/test/java/io/agentscope/core/agent/ReActAgentPendingToolRecoveryTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/agent/ReActAgentPendingToolRecoveryTest.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.core.agent;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import io.agentscope.core.ReActAgent;
+import io.agentscope.core.agent.test.MockModel;
+import io.agentscope.core.agent.test.TestConstants;
+import io.agentscope.core.hook.PendingToolRecoveryHook;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Regression tests for the shared-builder concurrency bug (issue #2539).
+ *
+ * <p>Before the fix, {@code Builder.build()} mutated the shared builder's {@code hooks} set
+ * ({@code this.hooks.add(new PendingToolRecoveryHook())}) when {@code enablePendingToolRecovery}
+ * was enabled. When the same builder was reused across concurrent builds — as the A2A server does
+ * with a shared builder bean — this raced on the non-thread-safe set, failing agent construction
+ * with {@code ArrayIndexOutOfBoundsException} / {@code NullPointerException}, and also leaked one
+ * hook instance into the shared set per build. After the fix, the hook is added per agent instance
+ * in the constructor and {@code build()} is read-only on the builder's state.
+ */
+@DisplayName("ReActAgent PendingToolRecoveryHook shared-builder regression (issue #2539)")
+class ReActAgentPendingToolRecoveryTest {
+
+    private static ReActAgent.Builder sharedBuilderWithRecovery() {
+        return ReActAgent.builder()
+                .name(TestConstants.TEST_REACT_AGENT_NAME)
+                .sysPrompt(TestConstants.DEFAULT_SYS_PROMPT)
+                .model(new MockModel(TestConstants.MOCK_MODEL_SIMPLE_RESPONSE))
+                .enablePendingToolRecovery(true);
+    }
+
+    @Test
+    @DisplayName("Each agent built from a shared builder gets exactly one PendingToolRecoveryHook")
+    void perAgentHookNotAccumulatedOnSharedBuilder() {
+        ReActAgent.Builder shared = sharedBuilderWithRecovery();
+
+        // Reuse one shared builder like the A2A server does. Before the fix, each build added a
+        // hook to the shared set, so later agents carried 2/3 recovery hooks; now each gets one.
+        for (int i = 0; i < 3; i++) {
+            ReActAgent agent = shared.build();
+            assertEquals(
+                    1,
+                    countPendingToolRecoveryHooks(agent),
+                    "each agent must have exactly one PendingToolRecoveryHook");
+        }
+    }
+
+    @Test
+    @DisplayName("Concurrent build() on a shared builder is safe (no race, no hook leak)")
+    void concurrentBuildOnSharedBuilderIsSafe() throws Exception {
+        ReActAgent.Builder shared = sharedBuilderWithRecovery();
+
+        int threads = 8;
+        int perThread = 25;
+        ExecutorService pool = Executors.newFixedThreadPool(threads);
+        try {
+            List<Future<?>> futures = new ArrayList<>();
+            for (int t = 0; t < threads; t++) {
+                futures.add(
+                        pool.submit(
+                                () -> {
+                                    for (int i = 0; i < perThread; i++) {
+                                        // Before the fix, this could throw AIOOBE/NPE (racing on
+                                        // the shared hooks set) or yield agents with growing hooks.
+                                        ReActAgent agent = shared.build();
+                                        assertEquals(1, countPendingToolRecoveryHooks(agent));
+                                    }
+                                    return null;
+                                }));
+            }
+            for (Future<?> f : futures) {
+                f.get(30, TimeUnit.SECONDS);
+            }
+        } finally {
+            pool.shutdown();
+        }
+    }
+
+    private static long countPendingToolRecoveryHooks(ReActAgent agent) {
+        return agent.getSortedHooks().stream()
+                .filter(h -> h instanceof PendingToolRecoveryHook)
+                .count();
+    }
+}


### PR DESCRIPTION
Closes #2539

### Problem

When `ReActAgent.Builder.enablePendingToolRecovery(true)` is set, `Builder.build()` executes `this.hooks.add(new PendingToolRecoveryHook())`, mutating the (possibly shared) builder's hooks set. The A2A server reuses a single builder bean across requests, so concurrent `build()` calls race on the non-thread-safe `HashSet`, failing agent construction with `ArrayIndexOutOfBoundsException` / `NullPointerException`, and leak one hook into the shared set per build.

### Fix

Move the hook from `Builder.build()` into `ReActAgent.<init>`, applied to the per-instance `new ArrayList<>(builder.hooks)` copy. `build()` is now read-only on the builder's state.

### Tests

`ReActAgentPendingToolRecoveryTest`: sequential and concurrent (8 threads × 25) builds from one shared builder each yield exactly one `PendingToolRecoveryHook`, with no exception. All existing `ReActAgent*` tests pass.
