### PR TITLE
fix(skill): give each agent its own SkillBox copy

### DIFF
--- a/agentscope-core/src/main/java/io/agentscope/core/ReActAgent.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/ReActAgent.java
@@ -4714,12 +4714,16 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
          */
         @SuppressWarnings("deprecation")
         private void configureSkillBox(Toolkit agentToolkit) {
-            skillBox.bindToolkit(agentToolkit);
-            skillBox.registerSkillLoadTool();
-            if (skillBox.isAutoUploadSkill()) {
-                skillBox.uploadSkillFiles();
+            // Copy per agent, mirroring the Toolkit.copy() at the top of build(). A SkillBox
+            // holds a mutable reference to the toolkit it serves, so binding the builder's box
+            // to this agent's toolkit repoints any previously built agent's SkillHook at the
+            // wrong toolkit, and two concurrent build() calls race on that field.
+            SkillBox agentSkillBox = skillBox.copy(agentToolkit);
+            agentSkillBox.registerSkillLoadTool();
+            if (agentSkillBox.isAutoUploadSkill()) {
+                agentSkillBox.uploadSkillFiles();
             }
-            hooks.add(new io.agentscope.core.skill.SkillHook(skillBox));
+            hooks.add(new io.agentscope.core.skill.SkillHook(agentSkillBox));
         }
 
         /**

--- a/agentscope-core/src/main/java/io/agentscope/core/skill/SkillBox.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/skill/SkillBox.java
@@ -53,6 +53,8 @@ public class SkillBox {
     private Path uploadDir;
     private SkillFileFilter fileFilter;
     private boolean autoUploadSkill = true;
+    private final String instruction;
+    private boolean exposeAllSkillMetadata = true;
 
     private static final ConcurrentHashMap<String, Object> FILE_LOCKS = new ConcurrentHashMap<>();
 
@@ -70,6 +72,34 @@ public class SkillBox {
         this.skillPromptProvider = new AgentSkillPromptProvider(skillRegistry, instruction);
         this.skillToolFactory = new SkillToolFactory(skillRegistry, toolkit);
         this.toolkit = toolkit;
+        this.instruction = instruction;
+    }
+
+    /**
+     * Creates a copy of this SkillBox bound to {@code toolkit}, mirroring {@link Toolkit#copy()}.
+     *
+     * <p>A SkillBox holds a mutable reference to the toolkit it serves, so a single instance
+     * cannot back two agents: binding it to a second agent's toolkit silently repoints the first
+     * agent's {@link SkillHook} at the wrong toolkit. Copying per agent keeps each agent's skill
+     * state isolated while sharing the (immutable) skills themselves.
+     *
+     * <p>The registered skills and configuration are carried over; {@code uploadDir} is left
+     * unset so it is recomputed lazily against the copy's {@code workDir}.
+     *
+     * @param toolkit The toolkit the copy should be bound to (must not be null)
+     * @return A new SkillBox carrying this box's skills and configuration
+     */
+    public SkillBox copy(Toolkit toolkit) {
+        if (toolkit == null) {
+            throw new IllegalArgumentException("Toolkit cannot be null");
+        }
+        SkillBox copy = new SkillBox(toolkit, this.instruction);
+        this.skillRegistry.copyTo(copy.skillRegistry);
+        copy.workDir = this.workDir;
+        copy.fileFilter = this.fileFilter;
+        copy.autoUploadSkill = this.autoUploadSkill;
+        copy.setExposeAllSkillMetadata(this.exposeAllSkillMetadata);
+        return copy;
     }
 
     /**
@@ -104,6 +134,7 @@ public class SkillBox {
      *                          the core fields
      */
     public void setExposeAllSkillMetadata(boolean exposeAllMetadata) {
+        this.exposeAllSkillMetadata = exposeAllMetadata;
         skillPromptProvider.setExposeAllMetadata(exposeAllMetadata);
     }
 

--- a/agentscope-core/src/main/java/io/agentscope/core/skill/SkillRegistry.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/skill/SkillRegistry.java
@@ -130,6 +130,20 @@ class SkillRegistry {
         return new ConcurrentHashMap<>(registeredSkills);
     }
 
+    /**
+     * Copies every registered skill into {@code target}.
+     *
+     * <p>Skill instances are shared rather than cloned: {@link AgentSkill} implementations are
+     * immutable and safe to register in more than one agent. Only the registry's own maps are
+     * duplicated, so later registrations on either side stay independent.
+     *
+     * @param target The registry to copy into (must not be null)
+     */
+    void copyTo(SkillRegistry target) {
+        target.skills.putAll(this.skills);
+        target.registeredSkills.putAll(this.registeredSkills);
+    }
+
     // ==================== Removal Operations ====================
 
     /**

--- a/agentscope-core/src/test/java/io/agentscope/core/agent/ReActAgentSkillBoxIsolationTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/agent/ReActAgentSkillBoxIsolationTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.core.agent;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+
+import io.agentscope.core.ReActAgent;
+import io.agentscope.core.agent.test.MockModel;
+import io.agentscope.core.skill.AgentSkill;
+import io.agentscope.core.skill.SkillBox;
+import io.agentscope.core.tool.Toolkit;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests that {@link ReActAgent.Builder#build()} does not hijack the builder's {@link SkillBox}.
+ *
+ * <p>{@code configureSkillBox} used to call {@code bindToolkit} on the builder's own box, which
+ * repointed it — and therefore every previously built agent's {@code SkillHook} — at the newest
+ * agent's toolkit. Building now takes a per-agent copy instead. See issue #979.
+ */
+@DisplayName("ReActAgent SkillBox isolation")
+class ReActAgentSkillBoxIsolationTest {
+
+    private static final String SKILL_TOOL_GROUP = "skill-build-in-tools";
+
+    private static ReActAgent.Builder builderWith(SkillBox box) {
+        return ReActAgent.builder()
+                .name("skillbox-agent")
+                .sysPrompt("test")
+                .model(new MockModel("ok"))
+                .skillBox(box);
+    }
+
+    private static SkillBox boxOn(Toolkit toolkit) {
+        SkillBox box = new SkillBox(toolkit);
+        box.setAutoUploadSkill(false); // keep the test off the filesystem
+        box.registerSkill(new AgentSkill("demo_skill", "demo", "# Content", null));
+        return box;
+    }
+
+    @Test
+    @DisplayName("build() leaves the builder's SkillBox bound to its original toolkit")
+    void buildDoesNotRebindTheBuildersSkillBox() {
+        Toolkit ownToolkit = new Toolkit();
+        SkillBox box = boxOn(ownToolkit);
+
+        ReActAgent agent = builderWith(box).build();
+        assertNotNull(agent);
+
+        // If build() had rebound the shared box to the agent's toolkit copy, this would register
+        // the skill-load tool over there instead, and ownToolkit would never see the group.
+        box.registerSkillLoadTool();
+        assertNotNull(
+                ownToolkit.getToolGroup(SKILL_TOOL_GROUP),
+                "builder's SkillBox must still serve the toolkit it was created with");
+    }
+
+    @Test
+    @DisplayName("two agents from one builder do not share skill state")
+    void repeatedBuildsKeepSkillStateIsolated() {
+        Toolkit ownToolkit = new Toolkit();
+        SkillBox box = boxOn(ownToolkit);
+
+        ReActAgent.Builder builder = builderWith(box);
+        ReActAgent first = builder.build();
+        ReActAgent second = builder.build();
+
+        assertNotSame(first, second, "each build() must produce a distinct agent");
+
+        // Still bound to its own toolkit after two builds, not to either agent's copy.
+        box.registerSkillLoadTool();
+        assertNotNull(
+                ownToolkit.getToolGroup(SKILL_TOOL_GROUP),
+                "a second build() must not repoint the builder's SkillBox either");
+    }
+}

--- a/agentscope-core/src/test/java/io/agentscope/core/skill/SkillBoxCopyTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/skill/SkillBoxCopyTest.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.core.skill;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.agentscope.core.tool.Toolkit;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests {@link SkillBox#copy(Toolkit)}.
+ *
+ * <p>A SkillBox holds a mutable reference to the toolkit it serves, so one instance cannot back
+ * two agents. {@code copy} gives each agent its own box while sharing the (immutable) skills.
+ */
+@DisplayName("SkillBox copy")
+class SkillBoxCopyTest {
+
+    private static AgentSkill skill(String id) {
+        return new AgentSkill(id, "desc for " + id, "# Content", null);
+    }
+
+    @Test
+    @DisplayName("copy carries registered skills without sharing the registry")
+    void copyCarriesSkillsIndependently() {
+        Toolkit original = new Toolkit();
+        SkillBox box = new SkillBox(original);
+        AgentSkill alpha = skill("alpha");
+        box.registerSkill(alpha);
+
+        SkillBox copy = box.copy(new Toolkit());
+
+        assertNotSame(box, copy, "copy must be a distinct instance");
+        assertTrue(
+                copy.exists(alpha.getSkillId()),
+                "copy should carry skills registered before the copy");
+
+        // Registrations after the copy must not bleed in either direction.
+        AgentSkill lateOnOriginal = skill("late-original");
+        AgentSkill lateOnCopy = skill("late-copy");
+        box.registerSkill(lateOnOriginal);
+        copy.registerSkill(lateOnCopy);
+
+        assertFalse(
+                copy.exists(lateOnOriginal.getSkillId()),
+                "copy must not see skills registered on the original after the copy");
+        assertFalse(
+                box.exists(lateOnCopy.getSkillId()),
+                "original must not see skills registered on the copy");
+    }
+
+    @Test
+    @DisplayName("copy leaves the source box bound to its own toolkit")
+    void copyDoesNotRebindSource() {
+        Toolkit sourceToolkit = new Toolkit();
+        Toolkit agentToolkit = new Toolkit();
+        SkillBox box = new SkillBox(sourceToolkit);
+        box.registerSkill(skill("alpha"));
+
+        SkillBox copy = box.copy(agentToolkit);
+        copy.registerSkillLoadTool();
+
+        // The load tool belongs to the copy's toolkit only. Before per-agent copying, the shared
+        // box was rebound to the agent's toolkit, so the source lost its binding entirely.
+        assertTrue(
+                agentToolkit.getToolNames().stream().anyMatch(n -> n.contains("skill")),
+                "copy's toolkit should have received the skill-load tool, got "
+                        + agentToolkit.getToolNames());
+        assertTrue(
+                sourceToolkit.getToolNames().stream().noneMatch(n -> n.contains("skill")),
+                "source toolkit must be untouched by the copy, got "
+                        + sourceToolkit.getToolNames());
+    }
+
+    @Test
+    @DisplayName("copy carries configuration flags")
+    void copyCarriesConfiguration() {
+        SkillBox box = new SkillBox(new Toolkit());
+        box.setAutoUploadSkill(false);
+
+        SkillBox copy = box.copy(new Toolkit());
+
+        assertEquals(
+                box.isAutoUploadSkill(),
+                copy.isAutoUploadSkill(),
+                "autoUploadSkill must carry over to the copy");
+    }
+
+    @Test
+    @DisplayName("copy rejects a null toolkit")
+    void copyRejectsNullToolkit() {
+        SkillBox box = new SkillBox(new Toolkit());
+        assertThrows(IllegalArgumentException.class, () -> box.copy(null));
+    }
+}


### PR DESCRIPTION
### Problem

`SkillBox` holds a mutable reference to the `Toolkit` it serves (`SkillBox.java:146` — `bindToolkit` sets `this.toolkit`), but `Builder.configureSkillBox()` called `bindToolkit()` on the **builder's** box on every `build()`:

```java
private void configureSkillBox(Toolkit agentToolkit) {
    skillBox.bindToolkit(agentToolkit);   // mutates the shared builder field
    ...
    hooks.add(new SkillHook(skillBox));   // every agent gets the SAME instance
}
```

`SkillHook` keeps that instance (`SkillHook.java:46`, `private final SkillBox skillBox`), so building a second agent from one builder silently repoints the **first** agent's hook at the **second** agent's toolkit:

- build #1 → `skillBox.toolkit` = agent 1's toolkit copy
- build #2 → `skillBox.toolkit` = agent 2's toolkit copy

`setSkillActive()` uses that field at runtime (`SkillBox.java:343-354`, `this.toolkit.updateToolGroups(...)`), so activating a skill on agent 1 mutates agent 2's tool groups. Two concurrent `build()` calls also race on the same write — the configuration the A2A server uses, where one builder bean serves every request.

This is the remaining half of the shared-builder problem: #2542 fixes the `hooks` / `middlewares` collections; this fixes the shared `SkillBox` object. The two are independent — this PR does not touch the collections and applies cleanly before or after #2542.

### Fix

`build()` already does `this.toolkit.copy()` per agent. Mirror that for the SkillBox.

`SkillBox.copy(Toolkit)` returns a box bound to the agent's own toolkit, carrying the registered skills and configuration (`workDir`, `fileFilter`, `autoUploadSkill`, instruction, metadata exposure). `uploadDir` is deliberately left unset so it is recomputed lazily against the copy's `workDir`, matching `setWorkDir()`'s existing behaviour. Skills are shared rather than cloned — `AgentSkill` is immutable and, as noted in #979, safe to register in multiple agents.

`configureSkillBox()` now copies instead of rebinding, so the builder's box is never mutated.

This is the approach @fang-tech described in #979 ("I will simplify the setup here by using the same automatic copying method as the toolkit"), and it removes the workaround given there — *"you need to create a new skillBox for each reactagent"*.

### Tests

`SkillBoxCopyTest` — skill carry-over, registry independence in both directions after the copy, config carry-over, null rejection, and that copying leaves the source box bound to its own toolkit (the actual regression).

Verified locally with Maven 3.9.16 / JDK 17 target: `SkillBoxCopyTest` 4/4 green, and `Skill*Test`, `ReActAgent*Test`, `Hook*Test` — 57 test classes — pass with no failures or errors. `spotless:check` clean.
