### PR TITLE
fix(harness): emit subagent end before parent completion

### DIFF
--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/tool/AgentSpawnTool.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/tool/AgentSpawnTool.java
@@ -56,6 +56,7 @@ import java.util.concurrent.CompletionException;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import reactor.core.Disposable;
@@ -673,20 +674,33 @@ public class AgentSpawnTool {
                                 new AgentStartEvent(spawned.sessionId(), null, spawned.agentId())
                                         .withSource(sourcePath));
 
+                        AtomicBoolean endEmitted = new AtomicBoolean();
+                        Runnable emitEnd =
+                                () -> {
+                                    if (endEmitted.compareAndSet(false, true)) {
+                                        parentEmitter.emit(
+                                                new AgentEndEvent(null).withSource(sourcePath));
+                                    }
+                                };
+
                         return manager.invokeAgent(agent, sessionId, userId, prompt, parentCtx)
                                 .contextWrite(
                                         c ->
                                                 c.put(
                                                         AgentEventEmitter.FORWARDING_CONTEXT_KEY,
                                                         taggedEmitter))
-                                // doFinally, not doOnTerminate: the latter skips cancel, so a
-                                // parent cancel would leave the AgentStartEvent above unmatched
-                                // and consumers would render this subagent as running forever.
+                                // Emit before success or error reaches the parent, which may
+                                // otherwise complete its event sink before doFinally runs.
+                                .doOnSuccess(ignored -> emitEnd.run())
+                                .doOnError(ignored -> emitEnd.run())
+                                // Preserve best-effort cancellation signaling without emitting a
+                                // duplicate if cancellation races with normal termination.
                                 .doFinally(
-                                        signal ->
-                                                parentEmitter.emit(
-                                                        new AgentEndEvent(null)
-                                                                .withSource(sourcePath)));
+                                        signal -> {
+                                            if (signal == SignalType.CANCEL) {
+                                                emitEnd.run();
+                                            }
+                                        });
                     }
 
                     // ── Path 2: stream() (deprecated) — SubagentEventBus forwarding ──

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/HarnessAgentSubagentStreamEventsTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/HarnessAgentSubagentStreamEventsTest.java
@@ -325,6 +325,20 @@ class HarnessAgentSubagentStreamEventsTest {
         assertTrue(
                 firstChildIdx < events.size() - 1,
                 "child events should appear before parent AGENT_END");
+
+        int childEndIdx =
+                events.stream()
+                        .filter(
+                                e ->
+                                        e.getType() == AgentEventType.AGENT_END
+                                                && e.getSource() != null)
+                        .mapToInt(events::indexOf)
+                        .findFirst()
+                        .orElse(-1);
+        assertTrue(childEndIdx > firstChildIdx, "child AGENT_END should follow child events");
+        assertTrue(
+                childEndIdx < events.size() - 1,
+                "child AGENT_END should appear before parent AGENT_END");
     }
 
     // -----------------------------------------------------------------


### PR DESCRIPTION
## AgentScope-Java Version

2.0.1-SNAPSHOT

## Description

### Background

The Harness stream-event tests can intermittently miss the sourced child `AGENT_END` event. The child end event was emitted from `doFinally`, which runs after the terminal signal has propagated downstream. For a quickly completing child agent, the parent can therefore complete and close its event sink before the child end event is forwarded.

This race was exposed by the CI runs of #2532, but it is independent of that middleware-ordering change.

### Changes

- Emit the child `AGENT_END` before success or error is propagated to the parent.
- Retain best-effort end signaling for cancellation.
- Guard emission with `AtomicBoolean` so completion and cancellation races cannot produce duplicate child end events.
- Strengthen the ordering test to require the sourced child `AGENT_END` before the parent `AGENT_END`.

The resulting order is:

```text
parent AGENT_START
child  AGENT_START / events / AGENT_END
parent AGENT_END
```

### Test

```bash
mvn -pl agentscope-harness -am \
  -Dtest=HarnessAgentSubagentStreamEventsTest \
  -Dsurefire.failIfNoSpecifiedTests=false \
  -Djacoco.skip=true \
  -DargLine=-javaagent:$HOME/.m2/repository/net/bytebuddy/byte-buddy-agent/1.17.7/byte-buddy-agent-1.17.7.jar \
  test
```

Result: 4 tests passed, 0 failures.

## Checklist

- [x] Code has been formatted with `mvn spotless:apply`
- [x] All tests are passing (`mvn test`)
- [x] Javadoc comments are complete and follow project conventions
- [x] Related documentation has been updated (not applicable: no public API or documentation change)
- [x] Code is ready for review
