### PR TITLE
fix(models): route qwen3.8-max to multimodal DashScope endpoint

### DIFF
--- a/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-dashscope/src/main/java/io/agentscope/extensions/model/dashscope/DashScopeHttpClient.java
+++ b/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-dashscope/src/main/java/io/agentscope/extensions/model/dashscope/DashScopeHttpClient.java
@@ -330,11 +330,7 @@ public class DashScopeHttpClient {
      *   <li>If endpointType is {@link EndpointType#MULTIMODAL} → multimodal API</li>
      *   <li>If endpointType is {@link EndpointType#AUTO}:
      *     <ul>
-     *       <li>Models starting with "qvq" → multimodal API</li>
-     *       <li>Models containing "-vl" → multimodal API</li>
-     *       <li>Models containing "-asr" → multimodal API</li>
-     *       <li>Models starting with "qwen3.5" → multimodal API</li>
-     *       <li>Models starting with "qwen3.6" → multimodal API</li>
+     *       <li>Models recognized by {@link #isMultimodalModel(String)} → multimodal API</li>
      *       <li>All other models → text generation API</li>
      *     </ul>
      *   </li>
@@ -376,6 +372,7 @@ public class DashScopeHttpClient {
      *   <li>Models starting with "qwen3.5" (e.g., qwen3.5-plus, qwen3.5-flash)</li>
      *   <li>Models starting with "qwen3.6" (e.g., qwen3.6-plus, qwen3.6-flash)</li>
      *   <li>Models starting with "qwen3.7" where not "qwen3.7-max" (e.g., qwen3.7-plus)</li>
+     *   <li>Models starting with "qwen3.8-max" (e.g., qwen3.8-max)</li>
      *   <li>Models containing "kimi-k2.5"/"kimi-k2.6" (e.g., kimi-k2.6, kimi/kimi-k2.5)</li>
      * </ul>
      *
@@ -405,6 +402,7 @@ public class DashScopeHttpClient {
                 || lowerModelName.startsWith("qwen3.5")
                 || lowerModelName.startsWith("qwen3.6")
                 || lowerModelName.startsWith("qwen3.7")
+                || lowerModelName.startsWith("qwen3.8-max")
                 || lowerModelName.contains("kimi-k2.5")
                 || lowerModelName.contains("kimi-k2.6");
     }

--- a/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-dashscope/src/test/java/io/agentscope/extensions/model/dashscope/DashScopeHttpClientTest.java
+++ b/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-dashscope/src/test/java/io/agentscope/extensions/model/dashscope/DashScopeHttpClientTest.java
@@ -175,6 +175,9 @@ class DashScopeHttpClientTest {
                 client.selectEndpoint("qwen3.6-plus", EndpointType.AUTO));
         assertEquals(
                 DashScopeHttpClient.MULTIMODAL_GENERATION_ENDPOINT,
+                client.selectEndpoint("qwen3.8-max", EndpointType.AUTO));
+        assertEquals(
+                DashScopeHttpClient.MULTIMODAL_GENERATION_ENDPOINT,
                 client.selectEndpoint("kimi-k2.5", EndpointType.AUTO));
         assertEquals(
                 DashScopeHttpClient.MULTIMODAL_GENERATION_ENDPOINT,
@@ -198,6 +201,7 @@ class DashScopeHttpClientTest {
         assertTrue(client.requiresMultimodalApi("qwen-vl-plus", EndpointType.AUTO));
         assertTrue(client.requiresMultimodalApi("qwen3.5-plus", EndpointType.AUTO));
         assertTrue(client.requiresMultimodalApi("qwen3.6-plus", EndpointType.AUTO));
+        assertTrue(client.requiresMultimodalApi("qwen3.8-max", EndpointType.AUTO));
     }
 
     @Test
@@ -219,6 +223,14 @@ class DashScopeHttpClientTest {
         assertTrue(DashScopeHttpClient.isMultimodalModel("Qwen3.6-Plus"));
         // qwen-3.6-plus (with hyphen before 3.6) does not match
         assertFalse(DashScopeHttpClient.isMultimodalModel("qwen-3.6-plus"));
+    }
+
+    @Test
+    void testIsMultimodalModelIncludesQwen38MaxFamily() {
+        assertTrue(DashScopeHttpClient.isMultimodalModel("qwen3.8-max"));
+        assertTrue(DashScopeHttpClient.isMultimodalModel("Qwen3.8-Max"));
+        assertTrue(DashScopeHttpClient.isMultimodalModel("qwen3.8-max-2026-08-01"));
+        assertFalse(DashScopeHttpClient.isMultimodalModel("qwen-3.8-max"));
     }
 
     @Test


### PR DESCRIPTION
## AgentScope-Java Version

2.0.1-SNAPSHOT

## Description

DashScope AUTO routing did not recognize the `qwen3.8-max` family as multimodal. As a result, requests used text-only message formatting and the text-generation endpoint, causing calls to fail.

This change:

- recognizes `qwen3.8-max` and versioned variants in `DashScopeHttpClient.isMultimodalModel`
- routes AUTO requests through multimodal formatting and the multimodal-generation endpoint
- keeps endpoint-selection documentation tied to the shared classification predicate
- adds regression coverage for exact, case-insensitive, versioned, and near-name cases

Fixes #2550

### Test Plan

- `mvn -pl agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-dashscope -am -Dtest=DashScopeHttpClientTest -Dsurefire.failIfNoSpecifiedTests=false test`
  - 61 tests passed
- `mvn spotless:check`
- `mvn clean verify`

## Checklist

Please check the following items before code is ready to be reviewed.

- [x] Code has been formatted with `mvn spotless:apply`
- [x] All tests are passing (`mvn test`)
- [x] Javadoc comments are complete and follow project conventions
- [x] Related documentation has been updated (no external documentation changes required)
- [x] Code is ready for review
