### PR TITLE
feat(agui): CopilotKit demo and HITL interrupt resume fixes

### DIFF
--- a/agentscope-examples/agentscope-copilotkit/README.md
+++ b/agentscope-examples/agentscope-copilotkit/README.md
@@ -1,0 +1,66 @@
+# AgentScope × CopilotKit
+
+展示 **AgentScope Java + AG-UI + CopilotKit v2** 高级用法的端到端示例：多路由 Runtime、会话线程、共享状态、生成式 UI、前端工具与人机协作（HITL）。
+
+## 能力矩阵
+
+| 能力 | 前端 Hook / 组件 | 后端 |
+|------|------------------|------|
+| 多路由 Runtime | `CopilotKit useSingleEndpoint={false}` | `/agui/run/info` · `threads` · `connect` · `run` |
+| 会话管理 | `useThreads` | `DemoThreadStore` + 事件回放 |
+| 共享状态 | `useAgent` / `useAgentContext` | Agent state 同步 |
+| 前端工具 | `useFrontendTool` | AG-UI 转发前端工具 schema |
+| 生成式 UI | `useRenderTool` / `useComponent` / `useDefaultRenderTool` | 工具结果驱动渲染 |
+| HITL | `useInterrupt` + `useHumanInTheLoop` | schema-only `requestHumanApproval` |
+| 建议 / 附件 | `useSuggestions` / `useAttachments` | Runtime 能力声明 |
+
+## 快速开始
+
+### 1. 环境变量
+
+```bash
+export DASHSCOPE_API_KEY=your_key
+```
+
+### 2. 启动后端
+
+在仓库根目录或本模块执行：
+
+```bash
+mvn -pl agentscope-examples/agentscope-copilotkit -am spring-boot:run
+```
+
+默认端口：`8080`，AG-UI 前缀：`/agui`。
+
+### 3. 启动前端（开发）
+
+```bash
+cd agentscope-examples/agentscope-copilotkit/frontend
+pnpm install
+pnpm dev
+```
+
+打开 [http://localhost:5173](http://localhost:5173)。Vite 会将 `/agui` 代理到后端。
+
+生产构建产物可输出到 `src/main/resources/static/`，由 Spring Boot 直接托管。
+
+## 界面结构
+
+1. **Hero**：品牌与能力预览（暗黑 + 香槟金 + 极光微光）
+2. **Capability Rail**：高级用法矩阵
+3. **Workbench**
+   - 左：会话线程（`useThreads`）
+   - 中：`CopilotChat` + HITL 演示条
+   - 右：共享状态 / Hooks / 可复制指令（Tabs）
+
+## 推荐试玩指令
+
+- 把演示主题改成“订单审核”，优先级设为高。
+- 渲染订单卡片：订单 A1001，金额 199.9，状态待支付。
+- 调用 `confirmDemoAction`，体验前端 HITL。
+- 点击「开始测试」体验后端 interrupt 审批。
+
+## 技术栈
+
+- **Backend**：Spring WebFlux · AgentScope · `agentscope-extensions-agui` · DashScope
+- **Frontend**：React 19 · Vite · CopilotKit v2 · Tailwind CSS 4 · shadcn/ui

--- a/agentscope-examples/agentscope-copilotkit/frontend/components.json
+++ b/agentscope-examples/agentscope-copilotkit/frontend/components.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://ui.shadcn.com/schema.json",
+  "style": "new-york",
+  "rsc": false,
+  "tsx": true,
+  "tailwind": {
+    "config": "",
+    "css": "src/styles.css",
+    "baseColor": "slate",
+    "cssVariables": true,
+    "prefix": ""
+  },
+  "aliases": {
+    "components": "@/components",
+    "utils": "@/lib/utils",
+    "ui": "@/components/ui",
+    "lib": "@/lib",
+    "hooks": "@/hooks"
+  },
+  "iconLibrary": "lucide"
+}

--- a/agentscope-examples/agentscope-copilotkit/frontend/index.html
+++ b/agentscope-examples/agentscope-copilotkit/frontend/index.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="zh-CN" class="dark">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="description"
+      content="AgentScope × CopilotKit 高级能力演示：共享状态、生成式 UI、人机协作与会话管理。"
+    />
+    <title>AgentScope × CopilotKit</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600;700;800&family=Space+Grotesk:wght@500;600;700&display=swap"
+      rel="stylesheet"
+    />
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/agentscope-examples/agentscope-copilotkit/frontend/package-lock.json
+++ b/agentscope-examples/agentscope-copilotkit/frontend/package-lock.json
@@ -1,0 +1,9125 @@
+{
+  "name": "agentscope-copilotkit-frontend",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "agentscope-copilotkit-frontend",
+      "version": "0.1.0",
+      "dependencies": {
+        "@ag-ui/client": "^0.0.57",
+        "@copilotkit/a2ui-renderer": "^1.65.0",
+        "@copilotkit/react-core": "^1.65.0",
+        "@copilotkit/react-ui": "^1.65.0",
+        "@radix-ui/react-scroll-area": "^1.2.18",
+        "@radix-ui/react-separator": "^1.1.15",
+        "@radix-ui/react-slot": "^1.3.3",
+        "@radix-ui/react-tabs": "^1.1.21",
+        "class-variance-authority": "^0.7.1",
+        "clsx": "^2.1.1",
+        "lucide-react": "^1.27.0",
+        "react": "^19.2.8",
+        "react-dom": "^19.2.8",
+        "tailwind-merge": "^3.6.0",
+        "zod": "^4.4.3",
+        "zod3": "npm:zod@3.25.76"
+      },
+      "devDependencies": {
+        "@tailwindcss/vite": "^4.3.3",
+        "@types/node": "^26.1.2",
+        "@types/react": "^19.2.17",
+        "@types/react-dom": "^19.2.3",
+        "@vitejs/plugin-react": "^6.0.4",
+        "tailwindcss": "^4.3.3",
+        "tw-animate-css": "^1.4.0",
+        "typescript": "^7.0.2",
+        "vite": "^8.1.5"
+      }
+    },
+    "node_modules/@0no-co/graphql.web": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmmirror.com/@0no-co/graphql.web/-/graphql.web-1.3.3.tgz",
+      "integrity": "sha512-4gFGBdyaFmQ6n9euhp5JtIGS4ZeivwDr1tCPENUxTvy5wyv532yOtFCr9zzYAJh1s6uibgC+TRXUcay+mxzCoQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0"
+      },
+      "peerDependenciesMeta": {
+        "graphql": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@a2ui/web_core": {
+      "version": "0.10.4",
+      "resolved": "https://registry.npmmirror.com/@a2ui/web_core/-/web_core-0.10.4.tgz",
+      "integrity": "sha512-sahOUSKZIGv9ZtnHjfzWR8o/F1XfSTp4sQAX5/auSenQYBYDRaY0+vrZIkddc/IEzpXJob6cFJT2r5/mLzAvqg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@preact/signals-core": "^1.14.2",
+        "date-fns": "^4.4.0",
+        "zod": "^3.25.76",
+        "zod-to-json-schema": "^3.25.2"
+      }
+    },
+    "node_modules/@a2ui/web_core/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmmirror.com/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/@ag-ui/client": {
+      "version": "0.0.57",
+      "resolved": "https://registry.npmmirror.com/@ag-ui/client/-/client-0.0.57.tgz",
+      "integrity": "sha512-Xap2alG9Z0/j5kb3x4D7oTpe2sw1dfrC9rgJJr2NZu5vKcm8dzIPNd31mF2B4zS3BKqYIu245yxKPhEtT30MHw==",
+      "dependencies": {
+        "@ag-ui/core": "0.0.57",
+        "@ag-ui/encoder": "0.0.57",
+        "@ag-ui/proto": "0.0.57",
+        "@types/uuid": "^10.0.0",
+        "compare-versions": "^6.1.1",
+        "fast-json-patch": "^3.1.1",
+        "rxjs": "7.8.1",
+        "untruncate-json": "^0.0.1",
+        "uuid": "^11.1.0",
+        "zod": "^3.22.4"
+      }
+    },
+    "node_modules/@ag-ui/client/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmmirror.com/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/@ag-ui/core": {
+      "version": "0.0.57",
+      "resolved": "https://registry.npmmirror.com/@ag-ui/core/-/core-0.0.57.tgz",
+      "integrity": "sha512-gho1OWjNE6E3Rl7ZEZ1wr2CEpUHjLFU0FqzCZZk439TicLu+BfLCMkMokB07bMGlRmbJ60hM6LW60iOVauCx+Q==",
+      "dependencies": {
+        "zod": "^3.22.4"
+      }
+    },
+    "node_modules/@ag-ui/core/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmmirror.com/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/@ag-ui/encoder": {
+      "version": "0.0.57",
+      "resolved": "https://registry.npmmirror.com/@ag-ui/encoder/-/encoder-0.0.57.tgz",
+      "integrity": "sha512-ifD9NctR4xyPDR58xF9GK1bj/S8oECFkTeDfuYD8tXdbcOstIJ2TOqU2zhiCKnw7Vw+zR9Qv3TbsM9E7Gi9X3Q==",
+      "dependencies": {
+        "@ag-ui/core": "0.0.57",
+        "@ag-ui/proto": "0.0.57"
+      }
+    },
+    "node_modules/@ag-ui/proto": {
+      "version": "0.0.57",
+      "resolved": "https://registry.npmmirror.com/@ag-ui/proto/-/proto-0.0.57.tgz",
+      "integrity": "sha512-pPENOZt0P6ibH8sCTgq05wLYXi5t3P9B5r/1bWYehXjUxtyOdnukSlWM++SsCIwUXsQdm/b3aBgGjEeTF7RenA==",
+      "dependencies": {
+        "@ag-ui/core": "0.0.57",
+        "@bufbuild/protobuf": "^2.2.5",
+        "@protobuf-ts/protoc": "^2.11.1"
+      }
+    },
+    "node_modules/@antfu/install-pkg": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmmirror.com/@antfu/install-pkg/-/install-pkg-1.1.0.tgz",
+      "integrity": "sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ==",
+      "license": "MIT",
+      "dependencies": {
+        "package-manager-detector": "^1.3.0",
+        "tinyexec": "^1.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmmirror.com/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@braintree/sanitize-url": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmmirror.com/@braintree/sanitize-url/-/sanitize-url-7.1.2.tgz",
+      "integrity": "sha512-jigsZK+sMF/cuiB7sERuo9V7N9jx+dhmHHnQyDSVdpZwVutaBu7WvNYqMDLSgFgfB30n452TP3vjDAvFC973mA==",
+      "license": "MIT"
+    },
+    "node_modules/@bufbuild/protobuf": {
+      "version": "2.13.0",
+      "resolved": "https://registry.npmmirror.com/@bufbuild/protobuf/-/protobuf-2.13.0.tgz",
+      "integrity": "sha512-acq7c49vxfm1ggJ95P70TX7ABDM0vxr1SYD3BB0o0jnBLB4OAqeHyKuN+cD3w80gXEDQ2zxHpR6CUeA+O/aU9g==",
+      "license": "(Apache-2.0 AND BSD-3-Clause)"
+    },
+    "node_modules/@chevrotain/types": {
+      "version": "11.1.2",
+      "resolved": "https://registry.npmmirror.com/@chevrotain/types/-/types-11.1.2.tgz",
+      "integrity": "sha512-U+HFai5+zmJCkK86QsaJtoITlboZHBqrVketcO2ROv865xfCMSFpELQoz1GkX5GzME8pTa+3kbKrZHQtI0gdbw==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@copilotkit/a2ui-renderer": {
+      "version": "1.66.2",
+      "resolved": "https://registry.npmmirror.com/@copilotkit/a2ui-renderer/-/a2ui-renderer-1.66.2.tgz",
+      "integrity": "sha512-XKalmTPIbOs4Y25+wUdqGtPFoWBMaFW9IPUcKOg/VJnde8k5t68GUqtubsS3v7D/Wx6bPyrm7d3iX2u6OnUbsw==",
+      "license": "MIT",
+      "dependencies": {
+        "@a2ui/web_core": "0.10.4",
+        "clsx": "^2.1.1",
+        "lit": "^3.3.2",
+        "zod": "^3.25.75",
+        "zod-to-json-schema": "^3.24.1"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "react-dom": "^18 || ^19 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@copilotkit/a2ui-renderer/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmmirror.com/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/@copilotkit/core": {
+      "version": "1.66.2",
+      "resolved": "https://registry.npmmirror.com/@copilotkit/core/-/core-1.66.2.tgz",
+      "integrity": "sha512-XWxbs72EkmhdCUgK80rRNjt+k3yTmbe0qP82iiU2cV5IWNbKbSvC9jO9ZAsa3Wbilhf2XTD1PSWa4dwN3xulHg==",
+      "dependencies": {
+        "@ag-ui/client": "0.0.57",
+        "@copilotkit/shared": "1.66.2",
+        "@tanstack/pacer": "^0.20.1",
+        "phoenix": "^1.8.4",
+        "rxjs": "7.8.1",
+        "zod-to-json-schema": "^3.24.6"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@copilotkit/license-verifier": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmmirror.com/@copilotkit/license-verifier/-/license-verifier-0.5.0.tgz",
+      "integrity": "sha512-vrwKtIpYwF0FT9ZoYASH8owa2cGV0dhDvJGaCRaRMStwDxpc6DRdydKkhx8cWZXyBRxEYcq/Vygv4JvevhQQdQ==",
+      "license": "MIT"
+    },
+    "node_modules/@copilotkit/react-core": {
+      "version": "1.66.2",
+      "resolved": "https://registry.npmmirror.com/@copilotkit/react-core/-/react-core-1.66.2.tgz",
+      "integrity": "sha512-tq0QvzYQUj5b80/qexXsFg6aVRafdReAmb1rRWhQLUEDvB5bZCLjQcJlEAi8rwtAp6RjtKpIbeFJnJqmr3lREg==",
+      "license": "MIT",
+      "dependencies": {
+        "@ag-ui/client": "0.0.57",
+        "@ag-ui/core": "0.0.57",
+        "@copilotkit/a2ui-renderer": "1.66.2",
+        "@copilotkit/core": "1.66.2",
+        "@copilotkit/runtime-client-gql": "1.66.2",
+        "@copilotkit/shared": "1.66.2",
+        "@copilotkit/web-components": "1.66.2",
+        "@copilotkit/web-inspector": "1.66.2",
+        "@jetbrains/websandbox": "^1.1.3",
+        "@lit-labs/react": "^2.0.2",
+        "@radix-ui/react-dropdown-menu": "^2.1.15",
+        "@radix-ui/react-slot": "^1.2.3",
+        "@radix-ui/react-tooltip": "^1.2.7",
+        "@scarf/scarf": "^1.3.0",
+        "@tanstack/react-virtual": "^3.13.0",
+        "class-variance-authority": "^0.7.1",
+        "clsx": "^2.1.1",
+        "katex": "^0.16.22",
+        "lit": "^3.3.2",
+        "lucide-react": "^0.525.0",
+        "react-markdown": "^8.0.7",
+        "rxjs": "7.8.1",
+        "streamdown": "^1.3.0",
+        "tailwind-merge": "^3.3.1",
+        "tw-animate-css": "^1.3.5",
+        "untruncate-json": "^0.0.1",
+        "use-stick-to-bottom": "^1.1.1",
+        "zod-to-json-schema": "^3.24.5"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "react-dom": "^18 || ^19 || ^19.0.0-rc",
+        "zod": ">=3.0.0"
+      }
+    },
+    "node_modules/@copilotkit/react-core/node_modules/lucide-react": {
+      "version": "0.525.0",
+      "resolved": "https://registry.npmmirror.com/lucide-react/-/lucide-react-0.525.0.tgz",
+      "integrity": "sha512-Tm1txJ2OkymCGkvwoHt33Y2JpN5xucVq1slHcgE6Lk0WjDfjgKWor5CdVER8U6DvcfMwh4M8XxmpTiyzfmfDYQ==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@copilotkit/react-ui": {
+      "version": "1.66.2",
+      "resolved": "https://registry.npmmirror.com/@copilotkit/react-ui/-/react-ui-1.66.2.tgz",
+      "integrity": "sha512-lEbqjJ/2y+/c3XPcze+1mbxSNHhnOIedh/gz65zklcEKXqcBu+x6RXjhwcOPTybXQSxDT7GZrQ5B1VDhoKkWZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@copilotkit/react-core": "1.66.2",
+        "@copilotkit/runtime-client-gql": "1.66.2",
+        "@copilotkit/shared": "1.66.2",
+        "@headlessui/react": "^2.2.9",
+        "react-markdown": "^10.1.0",
+        "react-syntax-highlighter": "^16.1.1",
+        "rehype-raw": "^7.0.0",
+        "rehype-sanitize": "^6.0.0",
+        "remark-gfm": "^4.0.1",
+        "remark-math": "^6.0.0"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19 || ^19.0.0-rc"
+      }
+    },
+    "node_modules/@copilotkit/react-ui/node_modules/@types/hast": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmmirror.com/@types/hast/-/hast-3.0.5.tgz",
+      "integrity": "sha512-rp/ezSWaD1m44dPKICGhiskI13nVr7qTloFwDa/IYkhhf5nzwP+zIQcIJh3WIFSBOy/H1PzB40jPjMDksN4F+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@copilotkit/react-ui/node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmmirror.com/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "license": "MIT"
+    },
+    "node_modules/@copilotkit/react-ui/node_modules/react-markdown": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmmirror.com/react-markdown/-/react-markdown-10.1.0.tgz",
+      "integrity": "sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "hast-util-to-jsx-runtime": "^2.0.0",
+        "html-url-attributes": "^3.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-rehype": "^11.0.0",
+        "unified": "^11.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18",
+        "react": ">=18"
+      }
+    },
+    "node_modules/@copilotkit/react-ui/node_modules/remark-parse": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmmirror.com/remark-parse/-/remark-parse-11.0.0.tgz",
+      "integrity": "sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/@copilotkit/react-ui/node_modules/remark-rehype": {
+      "version": "11.1.2",
+      "resolved": "https://registry.npmmirror.com/remark-rehype/-/remark-rehype-11.1.2.tgz",
+      "integrity": "sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "unified": "^11.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/@copilotkit/react-ui/node_modules/unified": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmmirror.com/unified/-/unified-11.0.5.tgz",
+      "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "bail": "^2.0.0",
+        "devlop": "^1.0.0",
+        "extend": "^3.0.0",
+        "is-plain-obj": "^4.0.0",
+        "trough": "^2.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/@copilotkit/react-ui/node_modules/unist-util-visit": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmmirror.com/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
+      "integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/@copilotkit/react-ui/node_modules/vfile": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmmirror.com/vfile/-/vfile-6.0.3.tgz",
+      "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/@copilotkit/runtime-client-gql": {
+      "version": "1.66.2",
+      "resolved": "https://registry.npmmirror.com/@copilotkit/runtime-client-gql/-/runtime-client-gql-1.66.2.tgz",
+      "integrity": "sha512-Cz2KYXpsGfZT/7cNPrr19LxnbgSoX31rWJ6gYmF4iGPJ3MOXy839TNBknoOsGR9wX9Y7twBvm9enb8WXUj7H8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@copilotkit/shared": "1.66.2",
+        "@urql/core": "^5.0.3",
+        "untruncate-json": "^0.0.1",
+        "urql": "^4.1.0"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19 || ^19.0.0-rc"
+      }
+    },
+    "node_modules/@copilotkit/shared": {
+      "version": "1.66.2",
+      "resolved": "https://registry.npmmirror.com/@copilotkit/shared/-/shared-1.66.2.tgz",
+      "integrity": "sha512-FmLAVm1jvSflxiVulozRbdft5dFPqP5EHyTq7Fl9CVwrxQR2Z2/CO9plifwKBJRkZpxIBsgp05i8NR3u6xUqgA==",
+      "license": "MIT",
+      "dependencies": {
+        "@ag-ui/client": "0.0.57",
+        "@copilotkit/license-verifier": "~0.5.0",
+        "@segment/analytics-node": "^2.1.2",
+        "@standard-schema/spec": "^1.0.0",
+        "chalk": "4.1.2",
+        "graphql": "^16.8.1",
+        "partial-json": "^0.1.7",
+        "uuid": "^11.1.0",
+        "zod": "^3.23.3",
+        "zod-to-json-schema": "^3.23.5"
+      },
+      "peerDependencies": {
+        "@ag-ui/core": ">=0.0.48"
+      }
+    },
+    "node_modules/@copilotkit/shared/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmmirror.com/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/@copilotkit/web-components": {
+      "version": "1.66.2",
+      "resolved": "https://registry.npmmirror.com/@copilotkit/web-components/-/web-components-1.66.2.tgz",
+      "integrity": "sha512-PnmGVJqnpe+FKUcw3b062vorBRUXPEZONM0+N6a8uufvz456PBYVQQeTHlU+sVCW9Jsx7iSDsAUSrDNiso19Gw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "lit": "^3.3.2"
+      }
+    },
+    "node_modules/@copilotkit/web-inspector": {
+      "version": "1.66.2",
+      "resolved": "https://registry.npmmirror.com/@copilotkit/web-inspector/-/web-inspector-1.66.2.tgz",
+      "integrity": "sha512-kXYRfdfkE76gx68Jhqap6aivj6xq8pR5nDn4KPkyX7XCueJ+zZUhrCemSf16xYonOsyng5iq7VYyy+CUge9cJQ==",
+      "dependencies": {
+        "@ag-ui/client": "0.0.57",
+        "@copilotkit/core": "1.66.2",
+        "lit": "^3.2.0",
+        "lucide": "^0.525.0",
+        "marked": "^12.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@floating-ui/core": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmmirror.com/@floating-ui/core/-/core-1.8.0.tgz",
+      "integrity": "sha512-0CIZ5itps/8x7BG8dEIhs53BvCUH2PCoogtakwRTut+Arm58sJooJ0AuZhLw2HJYIR5cMLNPBSS728sPho2khQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/utils": "^0.2.12"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmmirror.com/@floating-ui/dom/-/dom-1.8.0.tgz",
+      "integrity": "sha512-yXSrzeHZBTZadLOlfyhCkJHNeLJnHRnRInwdZ40L7ZiaAtrBwoYlsDrX3v5zB1Utk7CLfzcOVnVVWoXEky7Ceg==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/core": "^1.8.0",
+        "@floating-ui/utils": "^0.2.12"
+      }
+    },
+    "node_modules/@floating-ui/react": {
+      "version": "0.26.28",
+      "resolved": "https://registry.npmmirror.com/@floating-ui/react/-/react-0.26.28.tgz",
+      "integrity": "sha512-yORQuuAtVpiRjpMhdc0wJj06b9JFjrYF4qp96j++v2NBpbi6SEGF7donUJ3TMieerQ6qVkAv1tgr7L4r5roTqw==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/react-dom": "^2.1.2",
+        "@floating-ui/utils": "^0.2.8",
+        "tabbable": "^6.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@floating-ui/react-dom": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmmirror.com/@floating-ui/react-dom/-/react-dom-2.1.9.tgz",
+      "integrity": "sha512-JDjEFGCpImxDCA7JJKviA0M9+RtmJdj0m/NVU5IMgBK+AmZouAQQ7/+2GLH0GXXY0YMw9oXPB8hKdbPYg5QLYg==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/dom": "^1.8.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.2.12",
+      "resolved": "https://registry.npmmirror.com/@floating-ui/utils/-/utils-0.2.12.tgz",
+      "integrity": "sha512-HpCo8tmWzLVad5s2d19EhAz5zqrrQ6s69qd6moPMQvkOuSwDT1YgRfWSVuc4ennqrgv3OHppiOGMQ7oC13yIww==",
+      "license": "MIT"
+    },
+    "node_modules/@headlessui/react": {
+      "version": "2.2.10",
+      "resolved": "https://registry.npmmirror.com/@headlessui/react/-/react-2.2.10.tgz",
+      "integrity": "sha512-5pVLNK9wlpxTUTy9GpgbX/SdcRh+HBnPktjM2wbiLTH4p+2EPHBO1aoSryUCuKUIItdDWO9ITlhUL8UnUN/oIA==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/react": "^0.26.16",
+        "@react-aria/focus": "^3.20.2",
+        "@react-aria/interactions": "^3.25.0",
+        "@tanstack/react-virtual": "^3.13.9",
+        "use-sync-external-store": "^1.5.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "react-dom": "^18 || ^19 || ^19.0.0-rc"
+      }
+    },
+    "node_modules/@iconify/types": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmmirror.com/@iconify/types/-/types-2.0.0.tgz",
+      "integrity": "sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==",
+      "license": "MIT"
+    },
+    "node_modules/@iconify/utils": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmmirror.com/@iconify/utils/-/utils-3.1.4.tgz",
+      "integrity": "sha512-b1S7B1k9ohZ+iNTi2ATxbRYG9fTrJmUT0rc46bvVnNxqNRGW7dyo/vRREwyniI5IRN2RSJHDcm+s3BjWrSAjHw==",
+      "license": "MIT",
+      "dependencies": {
+        "@antfu/install-pkg": "^1.1.0",
+        "@iconify/types": "^2.0.0",
+        "import-meta-resolve": "^4.2.0"
+      }
+    },
+    "node_modules/@internationalized/date": {
+      "version": "3.12.3",
+      "resolved": "https://registry.npmmirror.com/@internationalized/date/-/date-3.12.3.tgz",
+      "integrity": "sha512-fuLX+3ZKLsxI73y8b01EG/WjHb6gE6weCqlfawPO27kBWGMh9G1yH6Csv1uU7/cac9H2GHmOMt6CjmuQ1aia4Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0"
+      }
+    },
+    "node_modules/@internationalized/number": {
+      "version": "3.6.7",
+      "resolved": "https://registry.npmmirror.com/@internationalized/number/-/number-3.6.7.tgz",
+      "integrity": "sha512-3ji1fcrT+FPAK86UqEhB/psHixYo6niWPJtt7+qRaYFynt/BaJG8GhAPimtWUpEiVSTq8ZM8L5psMxGquiB/Vg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0"
+      }
+    },
+    "node_modules/@internationalized/string": {
+      "version": "3.2.10",
+      "resolved": "https://registry.npmmirror.com/@internationalized/string/-/string-3.2.10.tgz",
+      "integrity": "sha512-PDx6//vHSpRnHfxqMqto11zQvhsaU74O3mKv2F/0eicGZcl9NLjQmGlbHz/LsJh5tLKp4A4L7ZVTzN1/MmMTvA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0"
+      }
+    },
+    "node_modules/@jetbrains/websandbox": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmmirror.com/@jetbrains/websandbox/-/websandbox-1.3.1.tgz",
+      "integrity": "sha512-YTl3MJXbAkYDyuRhWqlQoo7eY2jaLGRqUkx4LVRvxr0VnK7s5bu0p2KAGOWZIBf6I3pmuuq+JzBDHw1b0fV0/Q==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmmirror.com/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmmirror.com/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmmirror.com/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmmirror.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmmirror.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@lit-labs/react": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmmirror.com/@lit-labs/react/-/react-2.1.3.tgz",
+      "integrity": "sha512-OD9h2JynerBQUMNzb563jiVpxfvPF0HjQkKY2mx0lpVYvD7F+rtJpOGz6ek+6ufMidV3i+MPT9SX62OKWHFrQg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit/react": "^1.0.3"
+      }
+    },
+    "node_modules/@lit-labs/ssr-dom-shim": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmmirror.com/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.6.0.tgz",
+      "integrity": "sha512-VHb0ALPMTlgKjM6yIxxoQNnpKyUKLD04VzeQdsiXkMqkvYlAHxq9glGLmgbb889/1GsohSOAjvQYoiBppXFqrQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@lit/react": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmmirror.com/@lit/react/-/react-1.0.8.tgz",
+      "integrity": "sha512-p2+YcF+JE67SRX3mMlJ1TKCSTsgyOVdAwd/nxp3NuV1+Cb6MWALbN6nT7Ld4tpmYofcE5kcaSY1YBB9erY+6fw==",
+      "license": "BSD-3-Clause",
+      "peerDependencies": {
+        "@types/react": "17 || 18 || 19"
+      }
+    },
+    "node_modules/@lit/reactive-element": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmmirror.com/@lit/reactive-element/-/reactive-element-2.1.2.tgz",
+      "integrity": "sha512-pbCDiVMnne1lYUIaYNN5wrwQXDtHaYtg7YEFPeW+hws6U47WeFvISGUWekPGKWOP1ygrs0ef0o1VJMk1exos5A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.5.0"
+      }
+    },
+    "node_modules/@lukeed/csprng": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmmirror.com/@lukeed/csprng/-/csprng-1.1.0.tgz",
+      "integrity": "sha512-Z7C/xXCiGWsg0KuKsHTKJxbWhpI3Vs5GwLfOean7MGyVFGqdRgBbAjOCh6u4bbjPc/8MJ2pZmK/0DLdCbivLDA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@lukeed/uuid": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmmirror.com/@lukeed/uuid/-/uuid-2.0.1.tgz",
+      "integrity": "sha512-qC72D4+CDdjGqJvkFMMEAtancHUQ7/d/tAiHf64z8MopFDmcrtbcJuerDtFceuAfQJ2pDSfCKCtbqoGBNnwg0w==",
+      "license": "MIT",
+      "dependencies": {
+        "@lukeed/csprng": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@mermaid-js/parser": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmmirror.com/@mermaid-js/parser/-/parser-1.2.0.tgz",
+      "integrity": "sha512-oYPyv8A4As1yH5Bx+04iQEQxXuIQDe0GKCNSRgao6z8AM9jixXIfP0vsppRLvGf+nKIOb9/LdpWA4YuJiVvESA==",
+      "license": "MIT",
+      "dependencies": {
+        "@chevrotain/types": "~11.1.2"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.142.0",
+      "resolved": "https://registry.npmmirror.com/@oxc-project/types/-/types-0.142.0.tgz",
+      "integrity": "sha512-7W+2q5AKQVU36fkaryontrHn3YDt1RyUYXatw9i5H8ocYe2sPKSFB6eS8WNPeRKiN1qAWWZUPm7gwFzJGrccqQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@preact/signals-core": {
+      "version": "1.14.4",
+      "resolved": "https://registry.npmmirror.com/@preact/signals-core/-/signals-core-1.14.4.tgz",
+      "integrity": "sha512-HNB6HYeYKhQbJ1aKl+YRjrS4+QWHLKX6qKoUsfS/m0vqzsVaEBiZiaKbG/e+NKk2ch5ALQr/ihWaMHxiCuuWHA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      }
+    },
+    "node_modules/@protobuf-ts/protoc": {
+      "version": "2.11.1",
+      "resolved": "https://registry.npmmirror.com/@protobuf-ts/protoc/-/protoc-2.11.1.tgz",
+      "integrity": "sha512-mUZJaV0daGO6HUX90o/atzQ6A7bbN2RSuHtdwo8SSF2Qoe3zHwa4IHyCN1evftTeHfLmdz+45qo47sL+5P8nyg==",
+      "license": "Apache-2.0",
+      "bin": {
+        "protoc": "protoc.js"
+      }
+    },
+    "node_modules/@radix-ui/number": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmmirror.com/@radix-ui/number/-/number-1.1.3.tgz",
+      "integrity": "sha512-Road2bidD0uu/1BGDOWNdPI06g0lIRy6IF9GZcIrDK2KGItfor8IQwQa+yM2ERgHM1MmHxaxpTzk0/Jp42lNfA==",
+      "license": "MIT"
+    },
+    "node_modules/@radix-ui/primitive": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmmirror.com/@radix-ui/primitive/-/primitive-1.1.7.tgz",
+      "integrity": "sha512-rqWnm76nYT8HoNNqEjpgJ7Pw/DrBj5iBTrmEPo6HTX5+VJyBNOqTdv4g89G63HuR5g0AaENoAcH7Is5fF2kZ8Q==",
+      "license": "MIT"
+    },
+    "node_modules/@radix-ui/react-arrow": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmmirror.com/@radix-ui/react-arrow/-/react-arrow-1.1.15.tgz",
+      "integrity": "sha512-v4zggRcjadnI+ClKDuijlQEW4tw3NoaeHc/PwpKnLoLLKNUG4InLegkstooLcRIUWCs+8L22dGURCVuFfOKfnA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-collection": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmmirror.com/@radix-ui/react-collection/-/react-collection-1.1.15.tgz",
+      "integrity": "sha512-9W+B9NPF0NaaPh/1NJd3+KqsnlLqU9H7T2rvww+fp+T/evVXdNAyYcnfRQZFOjkR1ajQp3yORlqnI8soawLvNA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.5",
+        "@radix-ui/react-context": "1.2.2",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-slot": "1.3.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmmirror.com/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.5.tgz",
+      "integrity": "sha512-+48PbAAbq3didjJxa+OaWY2ZwgAKsNiRGyeHKszblZMQ+kcpd9pAaT11cMkGEie0vsOi3QdeTE6d5Fe3Gn61kA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-context": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmmirror.com/@radix-ui/react-context/-/react-context-1.2.2.tgz",
+      "integrity": "sha512-RHCUGwKHDr0hDGg4X7ma4JG4/+12qxw8rkh5QKdDldlCvtja6nUx1Ef/8HVrJze81lEsgLQlqjzjGNHantgnQA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-direction": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmmirror.com/@radix-ui/react-direction/-/react-direction-1.1.4.tgz",
+      "integrity": "sha512-5pzg4FGQNpExhnhT2zlrP1wZFaYCd1K0nYWoFAdcYoYK868IEigqMX3B3f8yIoRlAhAeDWciLI6ZdCKHF9P4Vg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dismissable-layer": {
+      "version": "1.1.19",
+      "resolved": "https://registry.npmmirror.com/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.19.tgz",
+      "integrity": "sha512-8g4pfOL9HoKKLWGiypT+dphVqjFfmcXO5GBnhsG6zI+lxAx/8feQpr+1LSN8Re3hiZ+XkLNS4O9ztK11/LzQ6w==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-use-callback-ref": "1.1.4",
+        "@radix-ui/react-use-effect-event": "0.0.5"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dropdown-menu": {
+      "version": "2.1.24",
+      "resolved": "https://registry.npmmirror.com/@radix-ui/react-dropdown-menu/-/react-dropdown-menu-2.1.24.tgz",
+      "integrity": "sha512-geq8l2rJkxvkXsT9RMgtUE3P8pITFpTsvYpbySi1IH4fZEABD/Gp85myayFgxk0ktljGMJnCbeFkyTusvSvv7g==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.5",
+        "@radix-ui/react-context": "1.2.2",
+        "@radix-ui/react-id": "1.1.4",
+        "@radix-ui/react-menu": "2.1.24",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-use-controllable-state": "1.2.6"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-focus-guards": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmmirror.com/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.6.tgz",
+      "integrity": "sha512-RNOJjfZMTyBM6xYmV3IVGXkPjIhcBAuv48POevAXwrGJhkWZ9p1rFoIS1JFooPuT193AZmRsCPhpoVJxx6OPoQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-focus-scope": {
+      "version": "1.1.16",
+      "resolved": "https://registry.npmmirror.com/@radix-ui/react-focus-scope/-/react-focus-scope-1.1.16.tgz",
+      "integrity": "sha512-wmRZ2WWLvmt6KHy2rNPOdPUjwq5xOHY02+m+udwJTn0aNIox/rkskAvJTyTLGhPK6KgrUjlJUJpgmx/+wFiFIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-use-callback-ref": "1.1.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-id": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmmirror.com/@radix-ui/react-id/-/react-id-1.1.4.tgz",
+      "integrity": "sha512-TMQp2llA+RYn7JcjnrMnz7wN4pcVttPZnRZo52PLQsoLVKzNlVwUeHmfePgTgRluXFvlD3GD5g5MOVVTJCO0qA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-menu": {
+      "version": "2.1.24",
+      "resolved": "https://registry.npmmirror.com/@radix-ui/react-menu/-/react-menu-2.1.24.tgz",
+      "integrity": "sha512-uW7RVuU6Lp/ZtfeY4b3kL32zccgEWvPv1+cf17ubYzHa9cL8AHokmk36cG/XEiH/smbQvumnieXX9j/e9RqJWA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.7",
+        "@radix-ui/react-collection": "1.1.15",
+        "@radix-ui/react-compose-refs": "1.1.5",
+        "@radix-ui/react-context": "1.2.2",
+        "@radix-ui/react-direction": "1.1.4",
+        "@radix-ui/react-dismissable-layer": "1.1.19",
+        "@radix-ui/react-focus-guards": "1.1.6",
+        "@radix-ui/react-focus-scope": "1.1.16",
+        "@radix-ui/react-id": "1.1.4",
+        "@radix-ui/react-popper": "1.3.7",
+        "@radix-ui/react-portal": "1.1.17",
+        "@radix-ui/react-presence": "1.1.10",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-roving-focus": "1.1.19",
+        "@radix-ui/react-slot": "1.3.3",
+        "@radix-ui/react-use-callback-ref": "1.1.4",
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.7.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-popper": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmmirror.com/@radix-ui/react-popper/-/react-popper-1.3.7.tgz",
+      "integrity": "sha512-UsJrrd7w4wuKKTdvd/DNERVlwSlUcyXzjhyDwBk+3aPOsCjOY6ZSbxuw8E6lZTjjfP8Cpd0J8VVkrYUWyGYXyg==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/react-dom": "^2.0.0",
+        "@radix-ui/react-arrow": "1.1.15",
+        "@radix-ui/react-compose-refs": "1.1.5",
+        "@radix-ui/react-context": "1.2.2",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-use-callback-ref": "1.1.4",
+        "@radix-ui/react-use-layout-effect": "1.1.4",
+        "@radix-ui/react-use-rect": "1.1.4",
+        "@radix-ui/react-use-size": "1.1.4",
+        "@radix-ui/rect": "1.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-portal": {
+      "version": "1.1.17",
+      "resolved": "https://registry.npmmirror.com/@radix-ui/react-portal/-/react-portal-1.1.17.tgz",
+      "integrity": "sha512-vKQLcWypUnwZVvfV7UkGahH2g6ySe8M8R+zYBwPrv5byZ9QAW6cQVvNKo7GgmD+p8aYb6D9JBuvy8/WhOno2wQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-use-layout-effect": "1.1.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-presence": {
+      "version": "1.1.10",
+      "resolved": "https://registry.npmmirror.com/@radix-ui/react-presence/-/react-presence-1.1.10.tgz",
+      "integrity": "sha512-3wyzCQ6+ubRA+D4uv9m95JYLXxmOHp05qjrkjeA7uKHHtjpPggQzc6DAb0URl7j67oR0K2foO4ip27TiX037Bw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.10",
+      "resolved": "https://registry.npmmirror.com/@radix-ui/react-primitive/-/react-primitive-2.1.10.tgz",
+      "integrity": "sha512-MucOnzh6hR5mid6VpkbglRAMYMjKLqRnGBbjXkzjK52fuQDd1qbkx78a5P40mkcnVXJdEVxm26E9OPAiUq7nBg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.3.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-roving-focus": {
+      "version": "1.1.19",
+      "resolved": "https://registry.npmmirror.com/@radix-ui/react-roving-focus/-/react-roving-focus-1.1.19.tgz",
+      "integrity": "sha512-V9jI6hDjT7l3jsCQD9bLNvDLM3tH/gdbOTp7Tefp3hbbgCGQoK7tUvrWiRlcoBHIZ809ElXwNQwVo0B98LuTXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.7",
+        "@radix-ui/react-collection": "1.1.15",
+        "@radix-ui/react-compose-refs": "1.1.5",
+        "@radix-ui/react-context": "1.2.2",
+        "@radix-ui/react-direction": "1.1.4",
+        "@radix-ui/react-id": "1.1.4",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-use-callback-ref": "1.1.4",
+        "@radix-ui/react-use-controllable-state": "1.2.6",
+        "@radix-ui/react-use-is-hydrated": "0.1.3",
+        "@radix-ui/react-use-layout-effect": "1.1.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-scroll-area": {
+      "version": "1.2.18",
+      "resolved": "https://registry.npmmirror.com/@radix-ui/react-scroll-area/-/react-scroll-area-1.2.18.tgz",
+      "integrity": "sha512-Zn5Cd171wxsO3Dfg8HaW6RifTb9CYTKQJHs/G4+LN1GfmJpaQMZQyQxMprVPHpaz7QY4l9BxK2JwQuzHsXC8nA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/number": "1.1.3",
+        "@radix-ui/primitive": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.5",
+        "@radix-ui/react-context": "1.2.2",
+        "@radix-ui/react-direction": "1.1.4",
+        "@radix-ui/react-presence": "1.1.10",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-use-callback-ref": "1.1.4",
+        "@radix-ui/react-use-layout-effect": "1.1.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-separator": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmmirror.com/@radix-ui/react-separator/-/react-separator-1.1.15.tgz",
+      "integrity": "sha512-jOLO4lssEzWpoDu7G+Ze4VjwMRUBt291pnZD0gmalREZipnTX3wadQo7Fy48GCTfe14/YRN6rw/rOJqrE85Wxw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-slot": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmmirror.com/@radix-ui/react-slot/-/react-slot-1.3.3.tgz",
+      "integrity": "sha512-qx7oqnYbxnK9kYI9m317qmFmEgo6ywqWvbTogdj7cL9p3/yx4M48p7Rnw5z3H890cL/ow/EeWJsuTykeZVXP5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.5"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tabs": {
+      "version": "1.1.21",
+      "resolved": "https://registry.npmmirror.com/@radix-ui/react-tabs/-/react-tabs-1.1.21.tgz",
+      "integrity": "sha512-UKxJlZid7FVtsk/WTxj4i4uSEgj2Au+KBbS7SQyTlzMhhn+86Cz3tISZdTa87bfEfcuvZezf2ZsxD4xuEKtkog==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.7",
+        "@radix-ui/react-context": "1.2.2",
+        "@radix-ui/react-direction": "1.1.4",
+        "@radix-ui/react-id": "1.1.4",
+        "@radix-ui/react-presence": "1.1.10",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-roving-focus": "1.1.19",
+        "@radix-ui/react-use-controllable-state": "1.2.6"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tooltip": {
+      "version": "1.2.16",
+      "resolved": "https://registry.npmmirror.com/@radix-ui/react-tooltip/-/react-tooltip-1.2.16.tgz",
+      "integrity": "sha512-6EamKFRRnlpdadndbZ6LMwycfwkwPte1B42hs6QA0gYhjaOKqW4PZ4pjaW9UrlDX5eVt/OjncE7BFTPL5nmZhg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.5",
+        "@radix-ui/react-context": "1.2.2",
+        "@radix-ui/react-dismissable-layer": "1.1.19",
+        "@radix-ui/react-id": "1.1.4",
+        "@radix-ui/react-popper": "1.3.7",
+        "@radix-ui/react-portal": "1.1.17",
+        "@radix-ui/react-presence": "1.1.10",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-slot": "1.3.3",
+        "@radix-ui/react-use-controllable-state": "1.2.6",
+        "@radix-ui/react-use-layout-effect": "1.1.4",
+        "@radix-ui/react-visually-hidden": "1.2.11"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-callback-ref": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmmirror.com/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.4.tgz",
+      "integrity": "sha512-R6OUY2e2fA6Yn6s+VSx5KBV6Nx8LQEhu+cz7LCej18rQ1HLyg9PSC9jP/ZNx0o6FAIK9c0F1kHylzSxKsdlkrQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-controllable-state": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmmirror.com/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.6.tgz",
+      "integrity": "sha512-uEQJGT97ZA/TgP/Hydw47lHu+/vQj6z/0jA+WeTbK1o9Rx45GImjpD0tc3W5ad3D6XTSR6e1yEO0FvGq6WQfVQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.7",
+        "@radix-ui/react-use-effect-event": "0.0.5",
+        "@radix-ui/react-use-layout-effect": "1.1.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-effect-event": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmmirror.com/@radix-ui/react-use-effect-event/-/react-use-effect-event-0.0.5.tgz",
+      "integrity": "sha512-7cshFL8HGS/7HEiHH+9kL9HBwp2sa9yX18Knwek6KYWmXwM7pegMgta2AXMQKI+rq3JnfSj9x8wYqFMTdG1Jgg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-is-hydrated": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmmirror.com/@radix-ui/react-use-is-hydrated/-/react-use-is-hydrated-0.1.3.tgz",
+      "integrity": "sha512-umO/aJ+82CpOnhDZUTbILCQf7kU/g0iv+oGs/Q8jw7IkhWBzaEP4sA268PhFAJTFetbwp3ICc6ktpI4TqtxcIw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-layout-effect": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmmirror.com/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.4.tgz",
+      "integrity": "sha512-K20DkRkUwDnxEYMBPcg3Y6voLkEy5p5QQmszZgLngKKiC7dzBR/aEuK3w1qlx2JWDUNH6FluahYdgR3BP+QbYw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-rect": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmmirror.com/@radix-ui/react-use-rect/-/react-use-rect-1.1.4.tgz",
+      "integrity": "sha512-cSOCh6JlkmfjLyNcLiu2nB4v+nm+dkZ+Q5KHWk/soo4U7ZLiEQFKHK9/YmtBHjfCEaU43IBKQOc4/uJmCaiCTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/rect": "1.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-size": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmmirror.com/@radix-ui/react-use-size/-/react-use-size-1.1.4.tgz",
+      "integrity": "sha512-D3anSY15EJoxrihpsXI6SMrmmonnQtR2ni7arO+Lfdg3O95b9hNXxONk8jA5C8ANdF/h5HMAxejgs8PWJ6rlhw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-visually-hidden": {
+      "version": "1.2.11",
+      "resolved": "https://registry.npmmirror.com/@radix-ui/react-visually-hidden/-/react-visually-hidden-1.2.11.tgz",
+      "integrity": "sha512-NFS86RYYZb4/exihaESBGOpMJFz8MGLAfu3mOBSGByVnVPC9JPASfYubxd/8KbkQK0sYAv8lVQDEQukDX/qXvQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/rect": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmmirror.com/@radix-ui/rect/-/rect-1.1.3.tgz",
+      "integrity": "sha512-JtyZR+mqgBibTo8xea3B6ZRmzZiM/YeVBtUkas6zMuXjAlfIFIW2FgqeM9eLyvEaYX66vr6DJMK+4U6LV0KhNw==",
+      "license": "MIT"
+    },
+    "node_modules/@react-aria/focus": {
+      "version": "3.22.1",
+      "resolved": "https://registry.npmmirror.com/@react-aria/focus/-/focus-3.22.1.tgz",
+      "integrity": "sha512-CPxtkyrBi/HYY5P3lE/57sQ6qfa0lN8E55TOm89H0kNGv0lKt+/0zP7lWERzBjRr5IxBVrQX4gFEowBN52LPaA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0",
+        "react-aria": "^3.48.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/interactions": {
+      "version": "3.28.1",
+      "resolved": "https://registry.npmmirror.com/@react-aria/interactions/-/interactions-3.28.1.tgz",
+      "integrity": "sha512-Bqb+HrD5I5MHS2SKBhISYqo2SW8Y2dfzgF/Y1lIJq7xqLxheo9vzxPGEHhz+XzkgGfoqEJx8A6a3C7uiqS3HWA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/shared": "^3.34.0",
+        "@swc/helpers": "^0.5.0",
+        "react-aria": "^3.48.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/shared": {
+      "version": "3.36.1",
+      "resolved": "https://registry.npmmirror.com/@react-types/shared/-/shared-3.36.1.tgz",
+      "integrity": "sha512-AzsuD9OfxTOZMMvTRhlN3oHBwOmFN7tDh27LzqmHt4+uOgPhJT7ZM7/kVs/8/o0WxayMUIk3hBmCFRHv1FUoag==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmmirror.com/@rolldown/binding-android-arm64/-/binding-android-arm64-1.2.2.tgz",
+      "integrity": "sha512-l7x215OGvo1s52JWmR8U/DAVzEDWBCIbTm28aeJV/WDTSHgcKXaZTuBT0hJMs5NggilfJTW3clZVvd24yfKJxA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmmirror.com/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.2.2.tgz",
+      "integrity": "sha512-9u9Xv6c1AJZT0FfwH5vrMG5Jjcwhc1MlyrPu0XfTqkzsmqfks2M6W/o5XwAJgVVN/jHpqqngC1WevHKKTIUtIA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmmirror.com/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.2.2.tgz",
+      "integrity": "sha512-9W1mbGZAfW3oqd85bhBkmpyHCCzL1TeG/zFFP3vg7b0rlly8cxOcre5nXwz+LHazCwac2MNWgPdPCHndABjpWQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmmirror.com/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.2.2.tgz",
+      "integrity": "sha512-0p1lhiCSCyaerFwtrdZQUx7NqGk6LQnaRKWX7tFQqwQgvX0rjM15cIkm3pax1UpEakK14C4mOxx/jSqCBdBRqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmmirror.com/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.2.2.tgz",
+      "integrity": "sha512-e+cOJXrJ2L3zx6YzqPg+f6Wbk3V1cKB8bOhbaYdVYN3DdquzNdRAmrbETz1qnt5yp/c7JNlNjmITiA2cVneQ7w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmmirror.com/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.2.2.tgz",
+      "integrity": "sha512-JsSMsj6sNat/MuhG5fnBD7QgbtpHKVe30x5/bAVirDHdhoQRXJkF6xc0Jqk8O4fiCUQAzMOoH9wZi3m60c8wtg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmmirror.com/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.2.2.tgz",
+      "integrity": "sha512-B5G/zJdHaoJn9vD50eGHWkiWfmq8Uhi3IiLPJTzmZTrAalk1bztUikSXo0qga18ibE0IXboyeMUnhPjhAJ45wQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmmirror.com/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.2.2.tgz",
+      "integrity": "sha512-6mC/awzKka8W6EoekjegpfGkjz8jXWDX63pqu/HYVpyKtZfu65Jsh4QAH3Kej3CAv/c1oGX7psTmFEbr0mDxLA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmmirror.com/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.2.2.tgz",
+      "integrity": "sha512-412MX9fJLdA1IK28EZnc8jYv2HRTleOZgfLQumJ5zy7OeJLZlg/CETwFaXjNmGVxG51cFHpKLqb5LKvBC+HsHA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmmirror.com/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.2.2.tgz",
+      "integrity": "sha512-Q/+HI/ToJafZ1iCqGgVQXUEkIjufHCTF0gBQ2a5o3cg7GJ2h0qyq3nvvSmU+bGda2/7ygXpTY4TM6gO9OhQ0ZA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmmirror.com/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.2.2.tgz",
+      "integrity": "sha512-ZKp/w41n6wCvxzxQHtQSbuphfX3Y4cCvbjkKHusrLx4lh+JWLTU7StSltO/DKARISzbj368d+qUaCjI8K2wzXw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmmirror.com/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.2.2.tgz",
+      "integrity": "sha512-pxE6xD4KS3eAROkKK5yrhB9/3+vhlhVGMvlQLbdpzrBGDbKrnzx3RLwPaHvasLo6jgaiBLn7e04Df9C4tYhjmA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmmirror.com/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.2.2.tgz",
+      "integrity": "sha512-4MqEue5re+xIZzAWsB8sj0P1kqZySWqIuN4t6QaIO/YA6SFwySOLruvWQFzfmqk8LBK2P30KCSJwf6mJCZZ5/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmmirror.com/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.2.2.tgz",
+      "integrity": "sha512-NweNxxD0Nf9t8v7kodun45Ijp3EIwYY+uydPP6qBEYvfBqhIjN6dZMzlQja3tqX/aLs3F3Uz+AxDpKgRhpOZQg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmmirror.com/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@scarf/scarf": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmmirror.com/@scarf/scarf/-/scarf-1.4.0.tgz",
+      "integrity": "sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@segment/analytics-core": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmmirror.com/@segment/analytics-core/-/analytics-core-1.8.2.tgz",
+      "integrity": "sha512-5FDy6l8chpzUfJcNlIcyqYQq4+JTUynlVoCeCUuVz+l+6W0PXg+ljKp34R4yLVCcY5VVZohuW+HH0VLWdwYVAg==",
+      "license": "MIT",
+      "dependencies": {
+        "@lukeed/uuid": "^2.0.0",
+        "@segment/analytics-generic-utils": "1.2.0",
+        "dset": "^3.1.4",
+        "tslib": "^2.4.1"
+      }
+    },
+    "node_modules/@segment/analytics-generic-utils": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmmirror.com/@segment/analytics-generic-utils/-/analytics-generic-utils-1.2.0.tgz",
+      "integrity": "sha512-DfnW6mW3YQOLlDQQdR89k4EqfHb0g/3XvBXkovH1FstUN93eL1kfW9CsDcVQyH3bAC5ZsFyjA/o/1Q2j0QeoWw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.4.1"
+      }
+    },
+    "node_modules/@segment/analytics-node": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmmirror.com/@segment/analytics-node/-/analytics-node-2.3.0.tgz",
+      "integrity": "sha512-fOXLL8uY0uAWw/sTLmezze80hj8YGgXXlAfvSS6TUmivk4D/SP0C0sxnbpFdkUzWg2zT64qWIZj26afEtSnxUA==",
+      "license": "MIT",
+      "dependencies": {
+        "@lukeed/uuid": "^2.0.0",
+        "@segment/analytics-core": "1.8.2",
+        "@segment/analytics-generic-utils": "1.2.0",
+        "buffer": "^6.0.3",
+        "jose": "^5.1.0",
+        "node-fetch": "^2.6.7",
+        "tslib": "^2.4.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/core": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmmirror.com/@shikijs/core/-/core-3.23.0.tgz",
+      "integrity": "sha512-NSWQz0riNb67xthdm5br6lAkvpDJRTgB36fxlo37ZzM2yq0PQFFzbd8psqC2XMPgCzo1fW6cVi18+ArJ44wqgA==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "3.23.0",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4",
+        "hast-util-to-html": "^9.0.5"
+      }
+    },
+    "node_modules/@shikijs/core/node_modules/@types/hast": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmmirror.com/@types/hast/-/hast-3.0.5.tgz",
+      "integrity": "sha512-rp/ezSWaD1m44dPKICGhiskI13nVr7qTloFwDa/IYkhhf5nzwP+zIQcIJh3WIFSBOy/H1PzB40jPjMDksN4F+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@shikijs/engine-javascript": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmmirror.com/@shikijs/engine-javascript/-/engine-javascript-3.23.0.tgz",
+      "integrity": "sha512-aHt9eiGFobmWR5uqJUViySI1bHMqrAgamWE1TYSUoftkAeCCAiGawPMwM+VCadylQtF4V3VNOZ5LmfItH5f3yA==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "3.23.0",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "oniguruma-to-es": "^4.3.4"
+      }
+    },
+    "node_modules/@shikijs/engine-oniguruma": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmmirror.com/@shikijs/engine-oniguruma/-/engine-oniguruma-3.23.0.tgz",
+      "integrity": "sha512-1nWINwKXxKKLqPibT5f4pAFLej9oZzQTsby8942OTlsJzOBZ0MWKiwzMsd+jhzu8YPCHAswGnnN1YtQfirL35g==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "3.23.0",
+        "@shikijs/vscode-textmate": "^10.0.2"
+      }
+    },
+    "node_modules/@shikijs/langs": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmmirror.com/@shikijs/langs/-/langs-3.23.0.tgz",
+      "integrity": "sha512-2Ep4W3Re5aB1/62RSYQInK9mM3HsLeB91cHqznAJMuylqjzNVAVCMnNWRHFtcNHXsoNRayP9z1qj4Sq3nMqYXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "3.23.0"
+      }
+    },
+    "node_modules/@shikijs/themes": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmmirror.com/@shikijs/themes/-/themes-3.23.0.tgz",
+      "integrity": "sha512-5qySYa1ZgAT18HR/ypENL9cUSGOeI2x+4IvYJu4JgVJdizn6kG4ia5Q1jDEOi7gTbN4RbuYtmHh0W3eccOrjMA==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "3.23.0"
+      }
+    },
+    "node_modules/@shikijs/types": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmmirror.com/@shikijs/types/-/types-3.23.0.tgz",
+      "integrity": "sha512-3JZ5HXOZfYjsYSk0yPwBrkupyYSLpAE26Qc0HLghhZNGTZg/SKxXIIgoxOpmmeQP0RRSDJTk1/vPfw9tbw+jSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
+      }
+    },
+    "node_modules/@shikijs/types/node_modules/@types/hast": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmmirror.com/@types/hast/-/hast-3.0.5.tgz",
+      "integrity": "sha512-rp/ezSWaD1m44dPKICGhiskI13nVr7qTloFwDa/IYkhhf5nzwP+zIQcIJh3WIFSBOy/H1PzB40jPjMDksN4F+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@shikijs/vscode-textmate": {
+      "version": "10.0.2",
+      "resolved": "https://registry.npmmirror.com/@shikijs/vscode-textmate/-/vscode-textmate-10.0.2.tgz",
+      "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmmirror.com/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
+    },
+    "node_modules/@swc/helpers": {
+      "version": "0.5.23",
+      "resolved": "https://registry.npmmirror.com/@swc/helpers/-/helpers-0.5.23.tgz",
+      "integrity": "sha512-5lSsMOTXURePglDfvuAQUqkGek9Hg2kksOYay2m0+XR++b2NWYL/4sWyuvVBIs8oKnJaxkdi9whaL/sqN13afw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@tailwindcss/node": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmmirror.com/@tailwindcss/node/-/node-4.3.3.tgz",
+      "integrity": "sha512-/T8IKEsf9VTU6tLjgC7+sv2mOPtQxzE2jMw7u4Tt40Tx+QSZxpzh95/H6cMKoja9XuW7iMdLJYBB0o9G1CaAgg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/remapping": "^2.3.5",
+        "enhanced-resolve": "^5.24.1",
+        "jiti": "^2.7.0",
+        "lightningcss": "1.32.0",
+        "magic-string": "^0.30.21",
+        "source-map-js": "^1.2.1",
+        "tailwindcss": "4.3.3"
+      }
+    },
+    "node_modules/@tailwindcss/oxide": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmmirror.com/@tailwindcss/oxide/-/oxide-4.3.3.tgz",
+      "integrity": "sha512-krXjAikiaFSPaK/FkAQT5UTx3VormQaiZ5hBFlJZ9UFQGB/rwg1MZIhHAG9smMQRTdyJxP6Qt5MwMtdyU5FWrA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20"
+      },
+      "optionalDependencies": {
+        "@tailwindcss/oxide-android-arm64": "4.3.3",
+        "@tailwindcss/oxide-darwin-arm64": "4.3.3",
+        "@tailwindcss/oxide-darwin-x64": "4.3.3",
+        "@tailwindcss/oxide-freebsd-x64": "4.3.3",
+        "@tailwindcss/oxide-linux-arm-gnueabihf": "4.3.3",
+        "@tailwindcss/oxide-linux-arm64-gnu": "4.3.3",
+        "@tailwindcss/oxide-linux-arm64-musl": "4.3.3",
+        "@tailwindcss/oxide-linux-x64-gnu": "4.3.3",
+        "@tailwindcss/oxide-linux-x64-musl": "4.3.3",
+        "@tailwindcss/oxide-wasm32-wasi": "4.3.3",
+        "@tailwindcss/oxide-win32-arm64-msvc": "4.3.3",
+        "@tailwindcss/oxide-win32-x64-msvc": "4.3.3"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-android-arm64": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmmirror.com/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.3.3.tgz",
+      "integrity": "sha512-Y85A2gmPSkl5Ve5qR86GL4HT509cFqQh1aes9p3sSkyTPwt0Pppf3GkwGe4JPACcRYjgJIEhQgM6dBClnr0NYw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-darwin-arm64": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmmirror.com/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.3.3.tgz",
+      "integrity": "sha512-BiaWatpBcERQFDlOjRDpIVXuFK5PJez5SA4JMg6VYZdBYU+qKfV/vqjcIs+IYmtitf1xYQZTwXvU/8y4lfZUGw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-darwin-x64": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmmirror.com/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.3.3.tgz",
+      "integrity": "sha512-fAeUqfV5ndhxRwai8cXGzdLvul9utWOmeTkv69unv4ZXixjn61Z+p9lCWdwOwA3TYboG3BwdVuN/RDjhBRl0mw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-freebsd-x64": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmmirror.com/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.3.3.tgz",
+      "integrity": "sha512-iyf5bV6+wnAlflVeEy7R25dupxTNECZN5QMI0qNT6eT+EgaGdZcKhGkr5SdoaWiLJ3spLqIY9VCeSGrwmtg4kw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm-gnueabihf": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmmirror.com/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.3.3.tgz",
+      "integrity": "sha512-aAYUprJAJQWWbRrPvtjdroZ56Md+JM8pMiopS6xGEwDfLhqj+2ver2p4nU4Mb3CRqcMmNBjo8KkUgcxhkzVQGQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm64-gnu": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmmirror.com/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.3.3.tgz",
+      "integrity": "sha512-nDxldcEENOxZRzC2uu9jrutZdAAQtb+8WWDCSnWL1zvBk1+FN+x6MtDViPB5AJMfttVCUhehGWus3XBPgatM/w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm64-musl": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmmirror.com/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.3.3.tgz",
+      "integrity": "sha512-Md44bD6veX/PC5iyF8cDVnw4HBIANZepRZZ7a8DQOvkfo5WUBwcp6iAuCUz23u+4SUkhJlD3eL7hNdW8ezd/kA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-x64-gnu": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmmirror.com/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.3.3.tgz",
+      "integrity": "sha512-tx7us1muwOKAKWao2v/GaafFeQboE6aj88vC6ziN2NCGcRm8gWUhwjzg+YdVB1e4boAtdtma4L43onunI6NS4w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-x64-musl": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmmirror.com/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.3.3.tgz",
+      "integrity": "sha512-SJxX60smvHgasZoBy11dX6YRjXJFovwWBoedhbQPOBzgFWBHGB+TVPWB9BxzR7TTxU8FQZAI2AyiNCMzFm8Img==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmmirror.com/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.3.3.tgz",
+      "integrity": "sha512-jx1+rPhY/5Ympkktd656HBWEBLxP7dH06losBLjjf5vgCODXvi9KhtftWcMIwTFIDqBr7cRnQkdLnAG+IOlGvQ==",
+      "bundleDependencies": [
+        "@napi-rs/wasm-runtime",
+        "@emnapi/core",
+        "@emnapi/runtime",
+        "@tybys/wasm-util",
+        "@emnapi/wasi-threads",
+        "tslib"
+      ],
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.11.1",
+        "@emnapi/runtime": "^1.11.1",
+        "@emnapi/wasi-threads": "^1.2.2",
+        "@napi-rs/wasm-runtime": "^1.1.4",
+        "@tybys/wasm-util": "^0.10.2",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmmirror.com/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.3.3.tgz",
+      "integrity": "sha512-3rc292Ca2ceK6Ulcc/bAVnTs/3nDtoPhyEKlgPv+yQJQi/JS/AMJlqzxvlDacL1nekbrcf6bTqp/jV4qgnPxNQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-win32-x64-msvc": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmmirror.com/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.3.3.tgz",
+      "integrity": "sha512-yJ0pwIVc/nYeGoV02WtsN8KYyLQv7kyI2wDnkezyJlGGjkd4QLwDGAwl47YpPJeuI0M0ObaXGSPjvWDPeTPggw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/vite": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmmirror.com/@tailwindcss/vite/-/vite-4.3.3.tgz",
+      "integrity": "sha512-yYU8cogLeSh/ms2jh8Fj7jaba/EWa7Ja6GoUqYZaraEuCI5YS6ms6ObZgjjedm+jm6XZjdNRWBpPP6Z86oOxcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@tailwindcss/node": "4.3.3",
+        "@tailwindcss/oxide": "4.3.3",
+        "tailwindcss": "4.3.3"
+      },
+      "peerDependencies": {
+        "vite": "^5.2.0 || ^6 || ^7 || ^8"
+      }
+    },
+    "node_modules/@tanstack/devtools-event-client": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmmirror.com/@tanstack/devtools-event-client/-/devtools-event-client-0.4.4.tgz",
+      "integrity": "sha512-6T5Yop/793YI+H+5J8Hsyj4kCih9sl4t3ElLgKioW5hk3ocn+ZdSJ94tT7vL7uabxSugWYBZlOTMPzEw2puvQw==",
+      "license": "MIT",
+      "bin": {
+        "intent": "bin/intent.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/pacer": {
+      "version": "0.20.1",
+      "resolved": "https://registry.npmmirror.com/@tanstack/pacer/-/pacer-0.20.1.tgz",
+      "integrity": "sha512-ZNQ1bIL6eUXVKdic0tiImvBVkWrg/IoSK6VIacTrO3d3HAGnd70qFJNJagR/YOJIOw4EKGWnodwpYZkN1pWuVQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/devtools-event-client": "^0.4.3",
+        "@tanstack/store": "^0.9.3"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-virtual": {
+      "version": "3.14.9",
+      "resolved": "https://registry.npmmirror.com/@tanstack/react-virtual/-/react-virtual-3.14.9.tgz",
+      "integrity": "sha512-qZyr0FZDP8rDC4WBhsryIZmAd9bveJvFGUJJtskWaew6/0dTRS6wZxnR6VQ5bY2KwL3LjerrHqQLk3a0GKcPXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/virtual-core": "3.17.7"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@tanstack/store": {
+      "version": "0.9.3",
+      "resolved": "https://registry.npmmirror.com/@tanstack/store/-/store-0.9.3.tgz",
+      "integrity": "sha512-8reSzl/qGWGGVKhBoxXPMWzATSbZLZFWhwBAFO9NAyp0TxzfBP0mIrGb8CP8KrQTmvzXlR/vFPPUrHTLBGyFyw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/virtual-core": {
+      "version": "3.17.7",
+      "resolved": "https://registry.npmmirror.com/@tanstack/virtual-core/-/virtual-core-3.17.7.tgz",
+      "integrity": "sha512-bp+v10y65sp2H7WpWfIMyxTNfl8ZVfxFTLRjPIFRryi6FV/J33z4IS53WO4pTk36KlvJ4iLiQz+oaydDC1xbcA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@types/d3": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmmirror.com/@types/d3/-/d3-7.4.3.tgz",
+      "integrity": "sha512-lZXZ9ckh5R8uiFVt8ogUNf+pIrK4EsWrx2Np75WvF/eTpJ0FMHNhjXk8CKEx/+gpHbNQyJWehbFaTvqmHWB3ww==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-array": "*",
+        "@types/d3-axis": "*",
+        "@types/d3-brush": "*",
+        "@types/d3-chord": "*",
+        "@types/d3-color": "*",
+        "@types/d3-contour": "*",
+        "@types/d3-delaunay": "*",
+        "@types/d3-dispatch": "*",
+        "@types/d3-drag": "*",
+        "@types/d3-dsv": "*",
+        "@types/d3-ease": "*",
+        "@types/d3-fetch": "*",
+        "@types/d3-force": "*",
+        "@types/d3-format": "*",
+        "@types/d3-geo": "*",
+        "@types/d3-hierarchy": "*",
+        "@types/d3-interpolate": "*",
+        "@types/d3-path": "*",
+        "@types/d3-polygon": "*",
+        "@types/d3-quadtree": "*",
+        "@types/d3-random": "*",
+        "@types/d3-scale": "*",
+        "@types/d3-scale-chromatic": "*",
+        "@types/d3-selection": "*",
+        "@types/d3-shape": "*",
+        "@types/d3-time": "*",
+        "@types/d3-time-format": "*",
+        "@types/d3-timer": "*",
+        "@types/d3-transition": "*",
+        "@types/d3-zoom": "*"
+      }
+    },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmmirror.com/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-axis": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmmirror.com/@types/d3-axis/-/d3-axis-3.0.6.tgz",
+      "integrity": "sha512-pYeijfZuBd87T0hGn0FO1vQ/cgLk6E1ALJjfkC0oJ8cbwkZl3TpgS8bVBLZN+2jjGgg38epgxb2zmoGtSfvgMw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-brush": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmmirror.com/@types/d3-brush/-/d3-brush-3.0.6.tgz",
+      "integrity": "sha512-nH60IZNNxEcrh6L1ZSMNA28rj27ut/2ZmI3r96Zd+1jrZD++zD3LsMIjWlvg4AYrHn/Pqz4CF3veCxGjtbqt7A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-chord": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmmirror.com/@types/d3-chord/-/d3-chord-3.0.6.tgz",
+      "integrity": "sha512-LFYWWd8nwfwEmTZG9PfQxd17HbNPksHBiJHaKuY1XeqscXacsS2tyoo6OdRsjf+NQYeB6XrNL3a25E3gH69lcg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmmirror.com/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-contour": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmmirror.com/@types/d3-contour/-/d3-contour-3.0.6.tgz",
+      "integrity": "sha512-BjzLgXGnCWjUSYGfH1cpdo41/hgdWETu4YxpezoztawmqsvCeep+8QGfiY6YbDvfgHz/DkjeIkkZVJavB4a3rg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-array": "*",
+        "@types/geojson": "*"
+      }
+    },
+    "node_modules/@types/d3-delaunay": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmmirror.com/@types/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
+      "integrity": "sha512-ZMaSKu4THYCU6sV64Lhg6qjf1orxBthaC161plr5KuPHo3CNm8DTHiLw/5Eq2b6TsNP0W0iJrUOFscY6Q450Hw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-dispatch": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmmirror.com/@types/d3-dispatch/-/d3-dispatch-3.0.7.tgz",
+      "integrity": "sha512-5o9OIAdKkhN1QItV2oqaE5KMIiXAvDWBDPrD85e58Qlz1c1kI/J0NcqbEG88CoTwJrYe7ntUCVfeUl2UJKbWgA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-drag": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmmirror.com/@types/d3-drag/-/d3-drag-3.0.7.tgz",
+      "integrity": "sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-dsv": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmmirror.com/@types/d3-dsv/-/d3-dsv-3.0.7.tgz",
+      "integrity": "sha512-n6QBF9/+XASqcKK6waudgL0pf/S5XHPPI8APyMLLUHd8NqouBGLsU8MgtO7NINGtPBtk9Kko/W4ea0oAspwh9g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmmirror.com/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-fetch": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmmirror.com/@types/d3-fetch/-/d3-fetch-3.0.7.tgz",
+      "integrity": "sha512-fTAfNmxSb9SOWNB9IoG5c8Hg6R+AzUHDRlsXsDZsNp6sxAEOP0tkP3gKkNSO/qmHPoBFTxNrjDprVHDQDvo5aA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-dsv": "*"
+      }
+    },
+    "node_modules/@types/d3-force": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmmirror.com/@types/d3-force/-/d3-force-3.0.10.tgz",
+      "integrity": "sha512-ZYeSaCF3p73RdOKcjj+swRlZfnYpK1EbaDiYICEEp5Q6sUiqFaFQ9qgoshp5CzIyyb/yD09kD9o2zEltCexlgw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-format": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmmirror.com/@types/d3-format/-/d3-format-3.0.4.tgz",
+      "integrity": "sha512-fALi2aI6shfg7vM5KiR1wNJnZ7r6UuggVqtDA+xiEdPZQwy/trcQaHnwShLuLdta2rTymCNpxYTiMZX/e09F4g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-geo": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmmirror.com/@types/d3-geo/-/d3-geo-3.1.1.tgz",
+      "integrity": "sha512-65Emv9fQiQQqphLlRkuQ5ypPsOmWPhtBGCMv61JDPEPMvsx+gzhGf74yw1a78xFKPj6zw4AgQICJoQv0vK9M2w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "*"
+      }
+    },
+    "node_modules/@types/d3-hierarchy": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmmirror.com/@types/d3-hierarchy/-/d3-hierarchy-3.1.7.tgz",
+      "integrity": "sha512-tJFtNoYBtRtkNysX1Xq4sxtjK8YgoWUNpIiUee0/jHGRwqvzYxkq0hGVbbOGSz+JgFxxRu4K8nb3YpG3CMARtg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmmirror.com/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmmirror.com/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-polygon": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmmirror.com/@types/d3-polygon/-/d3-polygon-3.0.2.tgz",
+      "integrity": "sha512-ZuWOtMaHCkN9xoeEMr1ubW2nGWsp4nIql+OPQRstu4ypeZ+zk3YKqQT0CXVe/PYqrKpZAi+J9mTs05TKwjXSRA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-quadtree": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmmirror.com/@types/d3-quadtree/-/d3-quadtree-3.0.6.tgz",
+      "integrity": "sha512-oUzyO1/Zm6rsxKRHA1vH0NEDG58HrT5icx/azi9MF1TWdtttWl0UIUsjEQBBh+SIkrpd21ZjEv7ptxWys1ncsg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-random": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmmirror.com/@types/d3-random/-/d3-random-3.0.4.tgz",
+      "integrity": "sha512-UHYId5WTCx4L4YNel7NU00XUXXgvgpgZOvp10PuvsQENjMDXhh2RyFc0KBjO7B45ne4Ha1yVH7ii0vnzKkuzWA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmmirror.com/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-scale-chromatic": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmmirror.com/@types/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
+      "integrity": "sha512-iWMJgwkK7yTRmWqRB5plb1kadXyQ5Sj8V/zYlFGMUBbIPKQScw+Dku9cAAMgJG+z5GYDoMjWGLVOvjghDEFnKQ==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-selection": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmmirror.com/@types/d3-selection/-/d3-selection-3.0.11.tgz",
+      "integrity": "sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmmirror.com/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmmirror.com/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-time-format": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmmirror.com/@types/d3-time-format/-/d3-time-format-4.0.3.tgz",
+      "integrity": "sha512-5xg9rC+wWL8kdDj153qZcsJ0FWiFt0J5RB6LYUNZjwSnesfblqrI/bJ1wBdJ8OQfncgbJG5+2F+qfqnqyzYxyg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmmirror.com/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-transition": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmmirror.com/@types/d3-transition/-/d3-transition-3.0.9.tgz",
+      "integrity": "sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-zoom": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmmirror.com/@types/d3-zoom/-/d3-zoom-3.0.8.tgz",
+      "integrity": "sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-interpolate": "*",
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/debug": {
+      "version": "4.1.13",
+      "resolved": "https://registry.npmmirror.com/@types/debug/-/debug-4.1.13.tgz",
+      "integrity": "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/ms": "*"
+      }
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmmirror.com/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/estree-jsx": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmmirror.com/@types/estree-jsx/-/estree-jsx-1.0.5.tgz",
+      "integrity": "sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "*"
+      }
+    },
+    "node_modules/@types/geojson": {
+      "version": "7946.0.16",
+      "resolved": "https://registry.npmmirror.com/@types/geojson/-/geojson-7946.0.16.tgz",
+      "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/hast": {
+      "version": "2.3.10",
+      "resolved": "https://registry.npmmirror.com/@types/hast/-/hast-2.3.10.tgz",
+      "integrity": "sha512-McWspRw8xx8J9HurkVBfYj0xKoE25tOFlHGdx4MJ5xORQrMGZNqJhVQWaIbm6Oyla5kYOXtDiopzKRJzEOkwJw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^2"
+      }
+    },
+    "node_modules/@types/katex": {
+      "version": "0.16.8",
+      "resolved": "https://registry.npmmirror.com/@types/katex/-/katex-0.16.8.tgz",
+      "integrity": "sha512-trgaNyfU+Xh2Tc+ABIb44a5AYUpicB3uwirOioeOkNPPbmgRNtcWyDeeFRzjPZENO9Vq8gvVqfhaaXWLlevVwg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/mdast": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmmirror.com/@types/mdast/-/mdast-4.0.4.tgz",
+      "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmmirror.com/@types/ms/-/ms-2.1.0.tgz",
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "26.1.2",
+      "resolved": "https://registry.npmmirror.com/@types/node/-/node-26.1.2.tgz",
+      "integrity": "sha512-Vu4a5UFA9rIIFJ7rB/Vaafh9lrCQszopTCx6KjFboXTGQbPNasehVR5TEiithSDGyd1DEiUByggTZsg8jukeIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~8.3.0"
+      }
+    },
+    "node_modules/@types/prismjs": {
+      "version": "1.26.6",
+      "resolved": "https://registry.npmmirror.com/@types/prismjs/-/prismjs-1.26.6.tgz",
+      "integrity": "sha512-vqlvI7qlMvcCBbVe0AKAb4f97//Hy0EBTaiW8AalRnG/xAN5zOiWWyrNqNXeq8+KAuvRewjCVY1+IPxk4RdNYw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/prop-types": {
+      "version": "15.7.15",
+      "resolved": "https://registry.npmmirror.com/@types/prop-types/-/prop-types-15.7.15.tgz",
+      "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/react": {
+      "version": "19.2.18",
+      "resolved": "https://registry.npmmirror.com/@types/react/-/react-19.2.18.tgz",
+      "integrity": "sha512-AnzbBERsrLKtk2XSfTbYRLjQPdy116Sty4q+T+Bp3IC4l6jNBvreVPAHmpq9qhXQM7CXZPjLVmGMw9sy+hxQ3w==",
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "19.2.4",
+      "resolved": "https://registry.npmmirror.com/@types/react-dom/-/react-dom-19.2.4.tgz",
+      "integrity": "sha512-Bsc+QHgp+P/F02XDzNCY9jnZNCUuLki36KT7VKrTXXLdHf+vHMNZnW1rVu5DNW/rCK+fya3DATySbLM4yhtKUw==",
+      "devOptional": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^19.2.0"
+      }
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmmirror.com/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/unist": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmmirror.com/@types/unist/-/unist-2.0.11.tgz",
+      "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmmirror.com/@types/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==",
+      "license": "MIT"
+    },
+    "node_modules/@typescript/typescript-aix-ppc64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmmirror.com/@typescript/typescript-aix-ppc64/-/typescript-aix-ppc64-7.0.2.tgz",
+      "integrity": "sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-darwin-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmmirror.com/@typescript/typescript-darwin-arm64/-/typescript-darwin-arm64-7.0.2.tgz",
+      "integrity": "sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-darwin-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmmirror.com/@typescript/typescript-darwin-x64/-/typescript-darwin-x64-7.0.2.tgz",
+      "integrity": "sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-freebsd-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmmirror.com/@typescript/typescript-freebsd-arm64/-/typescript-freebsd-arm64-7.0.2.tgz",
+      "integrity": "sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-freebsd-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmmirror.com/@typescript/typescript-freebsd-x64/-/typescript-freebsd-x64-7.0.2.tgz",
+      "integrity": "sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-arm": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmmirror.com/@typescript/typescript-linux-arm/-/typescript-linux-arm-7.0.2.tgz",
+      "integrity": "sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmmirror.com/@typescript/typescript-linux-arm64/-/typescript-linux-arm64-7.0.2.tgz",
+      "integrity": "sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-loong64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmmirror.com/@typescript/typescript-linux-loong64/-/typescript-linux-loong64-7.0.2.tgz",
+      "integrity": "sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-mips64el": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmmirror.com/@typescript/typescript-linux-mips64el/-/typescript-linux-mips64el-7.0.2.tgz",
+      "integrity": "sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-ppc64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmmirror.com/@typescript/typescript-linux-ppc64/-/typescript-linux-ppc64-7.0.2.tgz",
+      "integrity": "sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-riscv64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmmirror.com/@typescript/typescript-linux-riscv64/-/typescript-linux-riscv64-7.0.2.tgz",
+      "integrity": "sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-s390x": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmmirror.com/@typescript/typescript-linux-s390x/-/typescript-linux-s390x-7.0.2.tgz",
+      "integrity": "sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmmirror.com/@typescript/typescript-linux-x64/-/typescript-linux-x64-7.0.2.tgz",
+      "integrity": "sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-netbsd-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmmirror.com/@typescript/typescript-netbsd-arm64/-/typescript-netbsd-arm64-7.0.2.tgz",
+      "integrity": "sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-netbsd-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmmirror.com/@typescript/typescript-netbsd-x64/-/typescript-netbsd-x64-7.0.2.tgz",
+      "integrity": "sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-openbsd-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmmirror.com/@typescript/typescript-openbsd-arm64/-/typescript-openbsd-arm64-7.0.2.tgz",
+      "integrity": "sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-openbsd-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmmirror.com/@typescript/typescript-openbsd-x64/-/typescript-openbsd-x64-7.0.2.tgz",
+      "integrity": "sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-sunos-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmmirror.com/@typescript/typescript-sunos-x64/-/typescript-sunos-x64-7.0.2.tgz",
+      "integrity": "sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-win32-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmmirror.com/@typescript/typescript-win32-arm64/-/typescript-win32-arm64-7.0.2.tgz",
+      "integrity": "sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-win32-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmmirror.com/@typescript/typescript-win32-x64/-/typescript-win32-x64-7.0.2.tgz",
+      "integrity": "sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@ungap/structured-clone": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmmirror.com/@ungap/structured-clone/-/structured-clone-1.3.3.tgz",
+      "integrity": "sha512-60YRaenCQcVjYEKOcG824+DRGGIQ3VKErcBoAEDJZz5bKIs2ZG+X/H9Nk+Q6EVkwJk5QNApxbrc5QtBSwtrXAg==",
+      "license": "ISC"
+    },
+    "node_modules/@upsetjs/venn.js": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmmirror.com/@upsetjs/venn.js/-/venn.js-2.0.0.tgz",
+      "integrity": "sha512-WbBhLrooyePuQ1VZxrJjtLvTc4NVfpOyKx0sKqioq9bX1C1m7Jgykkn8gLrtwumBioXIqam8DLxp88Adbue6Hw==",
+      "license": "MIT",
+      "optionalDependencies": {
+        "d3-selection": "^3.0.0",
+        "d3-transition": "^3.0.1"
+      }
+    },
+    "node_modules/@urql/core": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmmirror.com/@urql/core/-/core-5.2.0.tgz",
+      "integrity": "sha512-/n0ieD0mvvDnVAXEQgX/7qJiVcvYvNkOHeBvkwtylfjydar123caCXcl58PXFY11oU1oquJocVXHxLAbtv4x1A==",
+      "license": "MIT",
+      "dependencies": {
+        "@0no-co/graphql.web": "^1.0.13",
+        "wonka": "^6.3.2"
+      }
+    },
+    "node_modules/@vitejs/plugin-react": {
+      "version": "6.0.5",
+      "resolved": "https://registry.npmmirror.com/@vitejs/plugin-react/-/plugin-react-6.0.5.tgz",
+      "integrity": "sha512-BOVzne/NL162sMdResB25mUv+vWMF5NoAjNf09TeGlE7ZpszZWSD3winycicLJw72yeVsoCn/2kOhEuCvEShMA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rolldown/pluginutils": "^1.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "peerDependencies": {
+        "@rolldown/plugin-babel": "^0.1.7 || ^0.2.0",
+        "babel-plugin-react-compiler": "^1.0.0",
+        "vite": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@rolldown/plugin-babel": {
+          "optional": true
+        },
+        "babel-plugin-react-compiler": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmmirror.com/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/aria-hidden": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmmirror.com/aria-hidden/-/aria-hidden-1.2.6.tgz",
+      "integrity": "sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/bail": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmmirror.com/bail/-/bail-2.0.2.tgz",
+      "integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmmirror.com/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmmirror.com/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/ccount": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmmirror.com/ccount/-/ccount-2.0.1.tgz",
+      "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmmirror.com/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/character-entities": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmmirror.com/character-entities/-/character-entities-2.0.2.tgz",
+      "integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-html4": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmmirror.com/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
+      "integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-legacy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmmirror.com/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
+      "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-reference-invalid": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmmirror.com/character-reference-invalid/-/character-reference-invalid-2.0.1.tgz",
+      "integrity": "sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/class-variance-authority": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmmirror.com/class-variance-authority/-/class-variance-authority-0.7.1.tgz",
+      "integrity": "sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "clsx": "^2.1.1"
+      },
+      "funding": {
+        "url": "https://polar.sh/cva"
+      }
+    },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmmirror.com/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmmirror.com/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmmirror.com/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT"
+    },
+    "node_modules/comma-separated-tokens": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmmirror.com/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
+      "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/commander": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmmirror.com/commander/-/commander-8.3.0.tgz",
+      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/compare-versions": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmmirror.com/compare-versions/-/compare-versions-6.1.1.tgz",
+      "integrity": "sha512-4hm4VPpIecmlg59CHXnRDnqGplJFrbLG4aFEl5vl6cK1u76ws3LLvX7ikFnTDl5vo39sjWD6AaDPYodJp/NNHg==",
+      "license": "MIT"
+    },
+    "node_modules/cose-base": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmmirror.com/cose-base/-/cose-base-1.0.3.tgz",
+      "integrity": "sha512-s9whTXInMSgAp/NVXVNuVxVKzGH2qck3aQlVHxDCdAEPgtMKwc4Wq6/QKhgdEdgbLSi9rBTAcPoRa6JpiG4ksg==",
+      "license": "MIT",
+      "dependencies": {
+        "layout-base": "^1.0.0"
+      }
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmmirror.com/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "license": "MIT"
+    },
+    "node_modules/cytoscape": {
+      "version": "3.34.0",
+      "resolved": "https://registry.npmmirror.com/cytoscape/-/cytoscape-3.34.0.tgz",
+      "integrity": "sha512-62rNSrioXw93uliKFBwjukeQyeWwH2PqDrTac31r2P6464u3AUvTk0xS4LVvT251g7IgkFunrI48ZEZGjywSOg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/cytoscape-cose-bilkent": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmmirror.com/cytoscape-cose-bilkent/-/cytoscape-cose-bilkent-4.1.0.tgz",
+      "integrity": "sha512-wgQlVIUJF13Quxiv5e1gstZ08rnZj2XaLHGoFMYXz7SkNfCDOOteKBE6SYRfA9WxxI/iBc3ajfDoc6hb/MRAHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "cose-base": "^1.0.0"
+      },
+      "peerDependencies": {
+        "cytoscape": "^3.2.0"
+      }
+    },
+    "node_modules/cytoscape-fcose": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmmirror.com/cytoscape-fcose/-/cytoscape-fcose-2.2.0.tgz",
+      "integrity": "sha512-ki1/VuRIHFCzxWNrsshHYPs6L7TvLu3DL+TyIGEsRcvVERmxokbf5Gdk7mFxZnTdiGtnA4cfSmjZJMviqSuZrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "cose-base": "^2.2.0"
+      },
+      "peerDependencies": {
+        "cytoscape": "^3.2.0"
+      }
+    },
+    "node_modules/cytoscape-fcose/node_modules/cose-base": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmmirror.com/cose-base/-/cose-base-2.2.0.tgz",
+      "integrity": "sha512-AzlgcsCbUMymkADOJtQm3wO9S3ltPfYOFD5033keQn9NJzIbtnZj+UdBJe7DYml/8TdbtHJW3j58SOnKhWY/5g==",
+      "license": "MIT",
+      "dependencies": {
+        "layout-base": "^2.0.0"
+      }
+    },
+    "node_modules/cytoscape-fcose/node_modules/layout-base": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmmirror.com/layout-base/-/layout-base-2.0.1.tgz",
+      "integrity": "sha512-dp3s92+uNI1hWIpPGH3jK2kxE2lMjdXdr+DH8ynZHpd6PUlH6x6cbuXnoMmiNumznqaNO31xu9e79F0uuZ0JFg==",
+      "license": "MIT"
+    },
+    "node_modules/d3": {
+      "version": "7.9.0",
+      "resolved": "https://registry.npmmirror.com/d3/-/d3-7.9.0.tgz",
+      "integrity": "sha512-e1U46jVP+w7Iut8Jt8ri1YsPOvFpg46k+K8TpCb0P+zjCkjkPnV7WzfDJzMHy1LnA+wj5pLT1wjO901gLXeEhA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "3",
+        "d3-axis": "3",
+        "d3-brush": "3",
+        "d3-chord": "3",
+        "d3-color": "3",
+        "d3-contour": "4",
+        "d3-delaunay": "6",
+        "d3-dispatch": "3",
+        "d3-drag": "3",
+        "d3-dsv": "3",
+        "d3-ease": "3",
+        "d3-fetch": "3",
+        "d3-force": "3",
+        "d3-format": "3",
+        "d3-geo": "3",
+        "d3-hierarchy": "3",
+        "d3-interpolate": "3",
+        "d3-path": "3",
+        "d3-polygon": "3",
+        "d3-quadtree": "3",
+        "d3-random": "3",
+        "d3-scale": "4",
+        "d3-scale-chromatic": "3",
+        "d3-selection": "3",
+        "d3-shape": "3",
+        "d3-time": "3",
+        "d3-time-format": "4",
+        "d3-timer": "3",
+        "d3-transition": "3",
+        "d3-zoom": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmmirror.com/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-axis": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmmirror.com/d3-axis/-/d3-axis-3.0.0.tgz",
+      "integrity": "sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-brush": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmmirror.com/d3-brush/-/d3-brush-3.0.0.tgz",
+      "integrity": "sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "3",
+        "d3-transition": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-chord": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmmirror.com/d3-chord/-/d3-chord-3.0.1.tgz",
+      "integrity": "sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmmirror.com/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-contour": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmmirror.com/d3-contour/-/d3-contour-4.0.2.tgz",
+      "integrity": "sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-delaunay": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmmirror.com/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
+      "integrity": "sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==",
+      "license": "ISC",
+      "dependencies": {
+        "delaunator": "5"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dispatch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmmirror.com/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
+      "integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-drag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmmirror.com/d3-drag/-/d3-drag-3.0.0.tgz",
+      "integrity": "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-selection": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dsv": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmmirror.com/d3-dsv/-/d3-dsv-3.0.1.tgz",
+      "integrity": "sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q==",
+      "license": "ISC",
+      "dependencies": {
+        "commander": "7",
+        "iconv-lite": "0.6",
+        "rw": "1"
+      },
+      "bin": {
+        "csv2json": "bin/dsv2json.js",
+        "csv2tsv": "bin/dsv2dsv.js",
+        "dsv2dsv": "bin/dsv2dsv.js",
+        "dsv2json": "bin/dsv2json.js",
+        "json2csv": "bin/json2dsv.js",
+        "json2dsv": "bin/json2dsv.js",
+        "json2tsv": "bin/json2dsv.js",
+        "tsv2csv": "bin/dsv2dsv.js",
+        "tsv2json": "bin/dsv2json.js"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dsv/node_modules/commander": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmmirror.com/commander/-/commander-7.2.0.tgz",
+      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmmirror.com/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-fetch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmmirror.com/d3-fetch/-/d3-fetch-3.0.1.tgz",
+      "integrity": "sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dsv": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-force": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmmirror.com/d3-force/-/d3-force-3.0.0.tgz",
+      "integrity": "sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-quadtree": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmmirror.com/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-geo": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmmirror.com/d3-geo/-/d3-geo-3.1.1.tgz",
+      "integrity": "sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.5.0 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-hierarchy": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmmirror.com/d3-hierarchy/-/d3-hierarchy-3.1.2.tgz",
+      "integrity": "sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmmirror.com/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmmirror.com/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-polygon": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmmirror.com/d3-polygon/-/d3-polygon-3.0.1.tgz",
+      "integrity": "sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-quadtree": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmmirror.com/d3-quadtree/-/d3-quadtree-3.0.1.tgz",
+      "integrity": "sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-random": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmmirror.com/d3-random/-/d3-random-3.0.1.tgz",
+      "integrity": "sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-sankey": {
+      "version": "0.12.3",
+      "resolved": "https://registry.npmmirror.com/d3-sankey/-/d3-sankey-0.12.3.tgz",
+      "integrity": "sha512-nQhsBRmM19Ax5xEIPLMY9ZmJ/cDvd1BG3UVvt5h3WRxKg5zGRbvnteTyWAbzeSvlh3tW7ZEmq4VwR5mB3tutmQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-array": "1 - 2",
+        "d3-shape": "^1.2.0"
+      }
+    },
+    "node_modules/d3-sankey/node_modules/d3-array": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmmirror.com/d3-array/-/d3-array-2.12.1.tgz",
+      "integrity": "sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "internmap": "^1.0.0"
+      }
+    },
+    "node_modules/d3-sankey/node_modules/d3-path": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmmirror.com/d3-path/-/d3-path-1.0.9.tgz",
+      "integrity": "sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/d3-sankey/node_modules/d3-shape": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmmirror.com/d3-shape/-/d3-shape-1.3.7.tgz",
+      "integrity": "sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-path": "1"
+      }
+    },
+    "node_modules/d3-sankey/node_modules/internmap": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmmirror.com/internmap/-/internmap-1.0.1.tgz",
+      "integrity": "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw==",
+      "license": "ISC"
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmmirror.com/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale-chromatic": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmmirror.com/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
+      "integrity": "sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-interpolate": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-selection": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmmirror.com/d3-selection/-/d3-selection-3.0.0.tgz",
+      "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmmirror.com/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmmirror.com/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmmirror.com/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmmirror.com/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-transition": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmmirror.com/d3-transition/-/d3-transition-3.0.1.tgz",
+      "integrity": "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-dispatch": "1 - 3",
+        "d3-ease": "1 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "d3-selection": "2 - 3"
+      }
+    },
+    "node_modules/d3-zoom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmmirror.com/d3-zoom/-/d3-zoom-3.0.0.tgz",
+      "integrity": "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "2 - 3",
+        "d3-transition": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/dagre-d3-es": {
+      "version": "7.0.14",
+      "resolved": "https://registry.npmmirror.com/dagre-d3-es/-/dagre-d3-es-7.0.14.tgz",
+      "integrity": "sha512-P4rFMVq9ESWqmOgK+dlXvOtLwYg0i7u0HBGJER0LZDJT2VHIPAMZ/riPxqJceWMStH5+E61QxFra9kIS3AqdMg==",
+      "license": "MIT",
+      "dependencies": {
+        "d3": "^7.9.0",
+        "lodash-es": "^4.17.21"
+      }
+    },
+    "node_modules/date-fns": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmmirror.com/date-fns/-/date-fns-4.4.0.tgz",
+      "integrity": "sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
+      }
+    },
+    "node_modules/dayjs": {
+      "version": "1.11.21",
+      "resolved": "https://registry.npmmirror.com/dayjs/-/dayjs-1.11.21.tgz",
+      "integrity": "sha512-98IT+HOahAisibz/yjKbzuOBwYcjJ7BCLPzARyHiyEBmRz4fatF+KPJszEHXsGYjUG234aH/cOjW1wwTbKUZlA==",
+      "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmmirror.com/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decode-named-character-reference": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmmirror.com/decode-named-character-reference/-/decode-named-character-reference-1.3.0.tgz",
+      "integrity": "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "character-entities": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/delaunator": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmmirror.com/delaunator/-/delaunator-5.1.0.tgz",
+      "integrity": "sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ==",
+      "license": "ISC",
+      "dependencies": {
+        "robust-predicates": "^3.0.2"
+      }
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmmirror.com/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmmirror.com/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/detect-node-es": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmmirror.com/detect-node-es/-/detect-node-es-1.1.0.tgz",
+      "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==",
+      "license": "MIT"
+    },
+    "node_modules/devlop": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmmirror.com/devlop/-/devlop-1.1.0.tgz",
+      "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/diff": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmmirror.com/diff/-/diff-5.2.2.tgz",
+      "integrity": "sha512-vtcDfH3TOjP8UekytvnHH1o1P4FcUdt4eQ1Y+Abap1tk/OB2MWQvcwS2ClCd1zuIhc3JKOx6p3kod8Vfys3E+A==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/dompurify": {
+      "version": "3.4.13",
+      "resolved": "https://registry.npmmirror.com/dompurify/-/dompurify-3.4.13.tgz",
+      "integrity": "sha512-2vmYIoqjze2d+kakP8S/nS5shfsl587kzwEjcGlTdiksUVgFHnFCsLYDVj/JNqJVOQZGSYBTmuycv0PodwmnMQ==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
+      }
+    },
+    "node_modules/dset": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmmirror.com/dset/-/dset-3.1.4.tgz",
+      "integrity": "sha512-2QF/g9/zTaPDc3BjNcVTGoBbXBgYfMTTceLaYcFJ/W9kggFUkhxD/hMEeuLKbugyef9SqAx8cpgwlIP/jinUTA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/enhanced-resolve": {
+      "version": "5.24.5",
+      "resolved": "https://registry.npmmirror.com/enhanced-resolve/-/enhanced-resolve-5.24.5.tgz",
+      "integrity": "sha512-L1l8TNvomm6UVW5B253AGxQagSQr+vGwhMlrrfRS2qmhx46AMpMVJKQYLvWYbysTMY8VoicOvzHzoHMbyzB+4A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.4",
+        "tapable": "^2.3.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmmirror.com/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/es-toolkit": {
+      "version": "1.50.0",
+      "resolved": "https://registry.npmmirror.com/es-toolkit/-/es-toolkit-1.50.0.tgz",
+      "integrity": "sha512-OyZKhUVvEep9ITEiwHn8GKnMRQIVqoSIX7WnRbkWgJkllCujilqP2rD0u979tkl8wqyc8ICwlc1UBVv/Sl1G6w==",
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks",
+        "tests/types"
+      ]
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmmirror.com/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/estree-util-is-identifier-name": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmmirror.com/estree-util-is-identifier-name/-/estree-util-is-identifier-name-3.0.0.tgz",
+      "integrity": "sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmmirror.com/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "license": "MIT"
+    },
+    "node_modules/fast-json-patch": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmmirror.com/fast-json-patch/-/fast-json-patch-3.1.1.tgz",
+      "integrity": "sha512-vf6IHUX2SBcA+5/+4883dsIjpBTqmfBjmYiWK1savxQmFk4JfBMLa7ynTYOs1Rolp/T1betJxHiGD3g1Mn8lUQ==",
+      "license": "MIT"
+    },
+    "node_modules/fault": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmmirror.com/fault/-/fault-1.0.4.tgz",
+      "integrity": "sha512-CJ0HCB5tL5fYTEA7ToAq5+kTwd++Borf1/bifxd9iT70QcXr4MRrO3Llf8Ifs70q+SJcGHFtnIE/Nw6giCtECA==",
+      "license": "MIT",
+      "dependencies": {
+        "format": "^0.2.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmmirror.com/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/format": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmmirror.com/format/-/format-0.2.2.tgz",
+      "integrity": "sha512-wzsgA6WOq+09wrU1tsJ09udeR/YZRaeArL9e1wPbFg3GG2yDnC2ldKpxs4xunpFF9DgqCqOIra3bc1HWrJ37Ww==",
+      "engines": {
+        "node": ">=0.4.x"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmmirror.com/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/get-east-asian-width": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmmirror.com/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+      "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/get-nonce": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmmirror.com/get-nonce/-/get-nonce-1.0.1.tgz",
+      "integrity": "sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmmirror.com/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/graphql": {
+      "version": "16.14.2",
+      "resolved": "https://registry.npmmirror.com/graphql/-/graphql-16.14.2.tgz",
+      "integrity": "sha512-Chq1s4CY7jmh8gO2qvLIJyfCDIN+EHLFW/9iShnp1z8FjBQMoodWP1kDC36VAMXXIvAjj4ARa7ntfAV2BrjsbA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
+      }
+    },
+    "node_modules/hachure-fill": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmmirror.com/hachure-fill/-/hachure-fill-0.5.2.tgz",
+      "integrity": "sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg==",
+      "license": "MIT"
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmmirror.com/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/hast": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmmirror.com/hast/-/hast-1.0.0.tgz",
+      "integrity": "sha512-vFUqlRV5C+xqP76Wwq2SrM0kipnmpxJm7OfvVXpB35Fp+Fn4MV+ozr+JZr5qFvyR1q/U+Foim2x+3P+x9S1PLA==",
+      "deprecated": "Renamed to rehype",
+      "license": "MIT"
+    },
+    "node_modules/hast-util-from-dom": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmmirror.com/hast-util-from-dom/-/hast-util-from-dom-5.0.1.tgz",
+      "integrity": "sha512-N+LqofjR2zuzTjCPzyDUdSshy4Ma6li7p/c3pA78uTwzFgENbgbUrm2ugwsOdcjI1muO+o6Dgzp9p8WHtn/39Q==",
+      "license": "ISC",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hastscript": "^9.0.0",
+        "web-namespaces": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-from-dom/node_modules/@types/hast": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmmirror.com/@types/hast/-/hast-3.0.5.tgz",
+      "integrity": "sha512-rp/ezSWaD1m44dPKICGhiskI13nVr7qTloFwDa/IYkhhf5nzwP+zIQcIJh3WIFSBOy/H1PzB40jPjMDksN4F+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/hast-util-from-html": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmmirror.com/hast-util-from-html/-/hast-util-from-html-2.0.3.tgz",
+      "integrity": "sha512-CUSRHXyKjzHov8yKsQjGOElXy/3EKpyX56ELnkHH34vDVw1N1XSQ1ZcAvTyAPtGqLTuKP/uxM+aLkSPqF/EtMw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "devlop": "^1.1.0",
+        "hast-util-from-parse5": "^8.0.0",
+        "parse5": "^7.0.0",
+        "vfile": "^6.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-from-html-isomorphic": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmmirror.com/hast-util-from-html-isomorphic/-/hast-util-from-html-isomorphic-2.0.0.tgz",
+      "integrity": "sha512-zJfpXq44yff2hmE0XmwEOzdWin5xwH+QIhMLOScpX91e/NSGPsAzNCvLQDIEPyO2TXi+lBmU6hjLIhV8MwP2kw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hast-util-from-dom": "^5.0.0",
+        "hast-util-from-html": "^2.0.0",
+        "unist-util-remove-position": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-from-html-isomorphic/node_modules/@types/hast": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmmirror.com/@types/hast/-/hast-3.0.5.tgz",
+      "integrity": "sha512-rp/ezSWaD1m44dPKICGhiskI13nVr7qTloFwDa/IYkhhf5nzwP+zIQcIJh3WIFSBOy/H1PzB40jPjMDksN4F+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/hast-util-from-html/node_modules/@types/hast": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmmirror.com/@types/hast/-/hast-3.0.5.tgz",
+      "integrity": "sha512-rp/ezSWaD1m44dPKICGhiskI13nVr7qTloFwDa/IYkhhf5nzwP+zIQcIJh3WIFSBOy/H1PzB40jPjMDksN4F+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/hast-util-from-html/node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmmirror.com/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "license": "MIT"
+    },
+    "node_modules/hast-util-from-html/node_modules/vfile": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmmirror.com/vfile/-/vfile-6.0.3.tgz",
+      "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-from-parse5": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmmirror.com/hast-util-from-parse5/-/hast-util-from-parse5-8.0.3.tgz",
+      "integrity": "sha512-3kxEVkEKt0zvcZ3hCRYI8rqrgwtlIOFMWkbclACvjlDw8Li9S2hk/d51OI0nr/gIpdMHNepwgOKqZ/sy0Clpyg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "devlop": "^1.0.0",
+        "hastscript": "^9.0.0",
+        "property-information": "^7.0.0",
+        "vfile": "^6.0.0",
+        "vfile-location": "^5.0.0",
+        "web-namespaces": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-from-parse5/node_modules/@types/hast": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmmirror.com/@types/hast/-/hast-3.0.5.tgz",
+      "integrity": "sha512-rp/ezSWaD1m44dPKICGhiskI13nVr7qTloFwDa/IYkhhf5nzwP+zIQcIJh3WIFSBOy/H1PzB40jPjMDksN4F+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/hast-util-from-parse5/node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmmirror.com/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "license": "MIT"
+    },
+    "node_modules/hast-util-from-parse5/node_modules/property-information": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmmirror.com/property-information/-/property-information-7.2.0.tgz",
+      "integrity": "sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/hast-util-from-parse5/node_modules/vfile": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmmirror.com/vfile/-/vfile-6.0.3.tgz",
+      "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-is-element": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmmirror.com/hast-util-is-element/-/hast-util-is-element-3.0.0.tgz",
+      "integrity": "sha512-Val9mnv2IWpLbNPqc/pUem+a7Ipj2aHacCwgNfTiK0vJKl0LF+4Ba4+v1oPHFpf3bLYmreq0/l3Gud9S5OH42g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-is-element/node_modules/@types/hast": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmmirror.com/@types/hast/-/hast-3.0.5.tgz",
+      "integrity": "sha512-rp/ezSWaD1m44dPKICGhiskI13nVr7qTloFwDa/IYkhhf5nzwP+zIQcIJh3WIFSBOy/H1PzB40jPjMDksN4F+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/hast-util-parse-selector": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmmirror.com/hast-util-parse-selector/-/hast-util-parse-selector-4.0.0.tgz",
+      "integrity": "sha512-wkQCkSYoOGCRKERFWcxMVMOcYE2K1AaNLU8DXS9arxnLOUEWbOXKXiJUNzEpqZ3JOKpnha3jkFrumEjVliDe7A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-parse-selector/node_modules/@types/hast": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmmirror.com/@types/hast/-/hast-3.0.5.tgz",
+      "integrity": "sha512-rp/ezSWaD1m44dPKICGhiskI13nVr7qTloFwDa/IYkhhf5nzwP+zIQcIJh3WIFSBOy/H1PzB40jPjMDksN4F+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/hast-util-raw": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmmirror.com/hast-util-raw/-/hast-util-raw-9.1.0.tgz",
+      "integrity": "sha512-Y8/SBAHkZGoNkpzqqfCldijcuUKh7/su31kEBp67cFY09Wy0mTRgtsLYsiIxMJxlu0f6AA5SUTbDR8K0rxnbUw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "hast-util-from-parse5": "^8.0.0",
+        "hast-util-to-parse5": "^8.0.0",
+        "html-void-elements": "^3.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "parse5": "^7.0.0",
+        "unist-util-position": "^5.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0",
+        "web-namespaces": "^2.0.0",
+        "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-raw/node_modules/@types/hast": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmmirror.com/@types/hast/-/hast-3.0.5.tgz",
+      "integrity": "sha512-rp/ezSWaD1m44dPKICGhiskI13nVr7qTloFwDa/IYkhhf5nzwP+zIQcIJh3WIFSBOy/H1PzB40jPjMDksN4F+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/hast-util-raw/node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmmirror.com/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "license": "MIT"
+    },
+    "node_modules/hast-util-raw/node_modules/unist-util-visit": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmmirror.com/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
+      "integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-raw/node_modules/vfile": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmmirror.com/vfile/-/vfile-6.0.3.tgz",
+      "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-sanitize": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmmirror.com/hast-util-sanitize/-/hast-util-sanitize-5.0.2.tgz",
+      "integrity": "sha512-3yTWghByc50aGS7JlGhk61SPenfE/p1oaFeNwkOOyrscaOkMGrcW9+Cy/QAIOBpZxP1yqDIzFMR0+Np0i0+usg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "unist-util-position": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-sanitize/node_modules/@types/hast": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmmirror.com/@types/hast/-/hast-3.0.5.tgz",
+      "integrity": "sha512-rp/ezSWaD1m44dPKICGhiskI13nVr7qTloFwDa/IYkhhf5nzwP+zIQcIJh3WIFSBOy/H1PzB40jPjMDksN4F+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/hast-util-to-html": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmmirror.com/hast-util-to-html/-/hast-util-to-html-9.0.5.tgz",
+      "integrity": "sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "ccount": "^2.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "html-void-elements": "^3.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "stringify-entities": "^4.0.0",
+        "zwitch": "^2.0.4"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-to-html/node_modules/@types/hast": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmmirror.com/@types/hast/-/hast-3.0.5.tgz",
+      "integrity": "sha512-rp/ezSWaD1m44dPKICGhiskI13nVr7qTloFwDa/IYkhhf5nzwP+zIQcIJh3WIFSBOy/H1PzB40jPjMDksN4F+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/hast-util-to-html/node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmmirror.com/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "license": "MIT"
+    },
+    "node_modules/hast-util-to-html/node_modules/hast-util-whitespace": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmmirror.com/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
+      "integrity": "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-to-html/node_modules/property-information": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmmirror.com/property-information/-/property-information-7.2.0.tgz",
+      "integrity": "sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/hast-util-to-jsx-runtime": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmmirror.com/hast-util-to-jsx-runtime/-/hast-util-to-jsx-runtime-2.3.6.tgz",
+      "integrity": "sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "devlop": "^1.0.0",
+        "estree-util-is-identifier-name": "^3.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "mdast-util-mdx-expression": "^2.0.0",
+        "mdast-util-mdx-jsx": "^3.0.0",
+        "mdast-util-mdxjs-esm": "^2.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "style-to-js": "^1.0.0",
+        "unist-util-position": "^5.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-to-jsx-runtime/node_modules/@types/hast": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmmirror.com/@types/hast/-/hast-3.0.5.tgz",
+      "integrity": "sha512-rp/ezSWaD1m44dPKICGhiskI13nVr7qTloFwDa/IYkhhf5nzwP+zIQcIJh3WIFSBOy/H1PzB40jPjMDksN4F+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/hast-util-to-jsx-runtime/node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmmirror.com/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "license": "MIT"
+    },
+    "node_modules/hast-util-to-jsx-runtime/node_modules/hast-util-whitespace": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmmirror.com/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
+      "integrity": "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-to-jsx-runtime/node_modules/property-information": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmmirror.com/property-information/-/property-information-7.2.0.tgz",
+      "integrity": "sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/hast-util-to-parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmmirror.com/hast-util-to-parse5/-/hast-util-to-parse5-8.0.1.tgz",
+      "integrity": "sha512-MlWT6Pjt4CG9lFCjiz4BH7l9wmrMkfkJYCxFwKQic8+RTZgWPuWxwAfjJElsXkex7DJjfSJsQIt931ilUgmwdA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "devlop": "^1.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "web-namespaces": "^2.0.0",
+        "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-to-parse5/node_modules/@types/hast": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmmirror.com/@types/hast/-/hast-3.0.5.tgz",
+      "integrity": "sha512-rp/ezSWaD1m44dPKICGhiskI13nVr7qTloFwDa/IYkhhf5nzwP+zIQcIJh3WIFSBOy/H1PzB40jPjMDksN4F+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/hast-util-to-parse5/node_modules/property-information": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmmirror.com/property-information/-/property-information-7.2.0.tgz",
+      "integrity": "sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/hast-util-to-text": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmmirror.com/hast-util-to-text/-/hast-util-to-text-4.0.2.tgz",
+      "integrity": "sha512-KK6y/BN8lbaq654j7JgBydev7wuNMcID54lkRav1P0CaE1e47P72AWWPiGKXTJU271ooYzcvTAn/Zt0REnvc7A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "hast-util-is-element": "^3.0.0",
+        "unist-util-find-after": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-to-text/node_modules/@types/hast": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmmirror.com/@types/hast/-/hast-3.0.5.tgz",
+      "integrity": "sha512-rp/ezSWaD1m44dPKICGhiskI13nVr7qTloFwDa/IYkhhf5nzwP+zIQcIJh3WIFSBOy/H1PzB40jPjMDksN4F+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/hast-util-to-text/node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmmirror.com/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "license": "MIT"
+    },
+    "node_modules/hast-util-whitespace": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmmirror.com/hast-util-whitespace/-/hast-util-whitespace-2.0.1.tgz",
+      "integrity": "sha512-nAxA0v8+vXSBDt3AnRUNjyRIQ0rD+ntpbAp4LnPkumc5M9yUbSMa4XDU9Q6etY4f1Wp4bNgvc1yjiZtsTTrSng==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hastscript": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmmirror.com/hastscript/-/hastscript-9.0.1.tgz",
+      "integrity": "sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "hast-util-parse-selector": "^4.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hastscript/node_modules/@types/hast": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmmirror.com/@types/hast/-/hast-3.0.5.tgz",
+      "integrity": "sha512-rp/ezSWaD1m44dPKICGhiskI13nVr7qTloFwDa/IYkhhf5nzwP+zIQcIJh3WIFSBOy/H1PzB40jPjMDksN4F+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/hastscript/node_modules/property-information": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmmirror.com/property-information/-/property-information-7.2.0.tgz",
+      "integrity": "sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/highlight.js": {
+      "version": "10.7.3",
+      "resolved": "https://registry.npmmirror.com/highlight.js/-/highlight.js-10.7.3.tgz",
+      "integrity": "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/highlightjs-vue": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmmirror.com/highlightjs-vue/-/highlightjs-vue-1.0.0.tgz",
+      "integrity": "sha512-PDEfEF102G23vHmPhLyPboFCD+BkMGu+GuJe2d9/eH4FsCwvgBpnc9n0pGE+ffKdph38s6foEZiEjdgHdzp+IA==",
+      "license": "CC0-1.0"
+    },
+    "node_modules/html-url-attributes": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmmirror.com/html-url-attributes/-/html-url-attributes-3.0.1.tgz",
+      "integrity": "sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/html-void-elements": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmmirror.com/html-void-elements/-/html-void-elements-3.0.0.tgz",
+      "integrity": "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmmirror.com/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmmirror.com/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/import-meta-resolve": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmmirror.com/import-meta-resolve/-/import-meta-resolve-4.2.0.tgz",
+      "integrity": "sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/inline-style-parser": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmmirror.com/inline-style-parser/-/inline-style-parser-0.1.1.tgz",
+      "integrity": "sha512-7NXolsK4CAS5+xvdj5OMMbI962hU/wvwoxk+LWR9Ek9bVtyuuYScDN6eS0rUm6TxApFpw7CX1o4uJzcd4AyD3Q==",
+      "license": "MIT"
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmmirror.com/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/is-alphabetical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmmirror.com/is-alphabetical/-/is-alphabetical-2.0.1.tgz",
+      "integrity": "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-alphanumerical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmmirror.com/is-alphanumerical/-/is-alphanumerical-2.0.1.tgz",
+      "integrity": "sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-alphabetical": "^2.0.0",
+        "is-decimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-buffer": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmmirror.com/is-buffer/-/is-buffer-2.0.5.tgz",
+      "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/is-decimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmmirror.com/is-decimal/-/is-decimal-2.0.1.tgz",
+      "integrity": "sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-hexadecimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmmirror.com/is-hexadecimal/-/is-hexadecimal-2.0.1.tgz",
+      "integrity": "sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-plain-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmmirror.com/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/jiti": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmmirror.com/jiti/-/jiti-2.7.0.tgz",
+      "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jiti": "lib/jiti-cli.mjs"
+      }
+    },
+    "node_modules/jose": {
+      "version": "5.10.0",
+      "resolved": "https://registry.npmmirror.com/jose/-/jose-5.10.0.tgz",
+      "integrity": "sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmmirror.com/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "license": "MIT"
+    },
+    "node_modules/katex": {
+      "version": "0.16.47",
+      "resolved": "https://registry.npmmirror.com/katex/-/katex-0.16.47.tgz",
+      "integrity": "sha512-Eeo8Ys1doU1z+x8AZsPpQu+p/QcZBI5PeOo7QGQdy2x2m0MU/hYagBbGOmXwr5KVbEfVuWv9LpnQWeehogurjg==",
+      "funding": [
+        "https://opencollective.com/katex",
+        "https://github.com/sponsors/katex"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^8.3.0"
+      },
+      "bin": {
+        "katex": "cli.js"
+      }
+    },
+    "node_modules/khroma": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmmirror.com/khroma/-/khroma-2.1.0.tgz",
+      "integrity": "sha512-Ls993zuzfayK269Svk9hzpeGUKob/sIgZzyHYdjQoAdQetRKpOLj+k/QQQ/6Qi0Yz65mlROrfd+Ev+1+7dz9Kw=="
+    },
+    "node_modules/kleur": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmmirror.com/kleur/-/kleur-4.1.5.tgz",
+      "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/layout-base": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmmirror.com/layout-base/-/layout-base-1.0.2.tgz",
+      "integrity": "sha512-8h2oVEZNktL4BH2JCOI90iD1yXwL6iNW7KcCKT2QZgQJR2vbqDsldCTPRU9NifTCqHZci57XvQQ15YTu+sTYPg==",
+      "license": "MIT"
+    },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmmirror.com/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmmirror.com/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmmirror.com/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmmirror.com/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmmirror.com/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmmirror.com/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmmirror.com/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmmirror.com/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmmirror.com/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmmirror.com/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmmirror.com/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmmirror.com/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lit": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmmirror.com/lit/-/lit-3.3.3.tgz",
+      "integrity": "sha512-fycuvZg/hkpozL00lm1pEJH5nN/lr9ZXd6mJI2HSN4+Bzc+LDNdEApJ6HFbPkdFNHLvOplIIuJvxkS4XUxqirw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit/reactive-element": "^2.1.0",
+        "lit-element": "^4.2.0",
+        "lit-html": "^3.3.0"
+      }
+    },
+    "node_modules/lit-element": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmmirror.com/lit-element/-/lit-element-4.2.2.tgz",
+      "integrity": "sha512-aFKhNToWxoyhkNDmWZwEva2SlQia+jfG0fjIWV//YeTaWrVnOxD89dPKfigCUspXFmjzOEUQpOkejH5Ly6sG0w==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.5.0",
+        "@lit/reactive-element": "^2.1.0",
+        "lit-html": "^3.3.0"
+      }
+    },
+    "node_modules/lit-html": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmmirror.com/lit-html/-/lit-html-3.3.3.tgz",
+      "integrity": "sha512-el8M6jK2o3RXBnrSHX3ZKrsN8zEV63pSExTO1wYJz7QndGYZ8353e2a5PPX+qHe2aGayfnchQmkAojaWAREOIA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@types/trusted-types": "^2.0.2"
+      }
+    },
+    "node_modules/lodash-es": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmmirror.com/lodash-es/-/lodash-es-4.18.1.tgz",
+      "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
+      "license": "MIT"
+    },
+    "node_modules/longest-streak": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmmirror.com/longest-streak/-/longest-streak-3.1.0.tgz",
+      "integrity": "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmmirror.com/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/lowlight": {
+      "version": "1.20.0",
+      "resolved": "https://registry.npmmirror.com/lowlight/-/lowlight-1.20.0.tgz",
+      "integrity": "sha512-8Ktj+prEb1RoCPkEOrPMYUN/nCggB7qAWe3a7OpMjWQkh3l2RD5wKRQ+o8Q8YuI9RG/xs95waaI/E6ym/7NsTw==",
+      "license": "MIT",
+      "dependencies": {
+        "fault": "^1.0.0",
+        "highlight.js": "~10.7.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/lucide": {
+      "version": "0.525.0",
+      "resolved": "https://registry.npmmirror.com/lucide/-/lucide-0.525.0.tgz",
+      "integrity": "sha512-sfehWlaE/7NVkcEQ4T9JD3eID8RNMIGJBBUq9wF3UFiJIrcMKRbU3g1KGfDk4svcW7yw8BtDLXaXo02scDtUYQ==",
+      "license": "ISC"
+    },
+    "node_modules/lucide-react": {
+      "version": "1.28.0",
+      "resolved": "https://registry.npmmirror.com/lucide-react/-/lucide-react-1.28.0.tgz",
+      "integrity": "sha512-fARAFJULsGuDDydjp6+6blekG/sBIM29TerzLjc9bQUKAcEfrSc4ZQKb25KRz4OMKd87cZTb5dgq0w/T6KufVg==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmmirror.com/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/markdown-table": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmmirror.com/markdown-table/-/markdown-table-3.0.4.tgz",
+      "integrity": "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/marked": {
+      "version": "12.0.2",
+      "resolved": "https://registry.npmmirror.com/marked/-/marked-12.0.2.tgz",
+      "integrity": "sha512-qXUm7e/YKFoqFPYPa3Ukg9xlI5cyAtGmyEIzMfW//m6kXwCy2Ps9DYf5ioijFKQ8qyuscrHoY04iJGctu2Kg0Q==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/mdast-util-definitions": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmmirror.com/mdast-util-definitions/-/mdast-util-definitions-5.1.2.tgz",
+      "integrity": "sha512-8SVPMuHqlPME/z3gqVwWY4zVXn8lqKv/pAhC57FuJ40ImXyBpmO5ukh98zB2v7Blql2FiHjHv9LVztSIqjY+MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^3.0.0",
+        "@types/unist": "^2.0.0",
+        "unist-util-visit": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-definitions/node_modules/@types/mdast": {
+      "version": "3.0.15",
+      "resolved": "https://registry.npmmirror.com/@types/mdast/-/mdast-3.0.15.tgz",
+      "integrity": "sha512-LnwD+mUEfxWMa1QpDraczIn6k0Ee3SMicuYSSzS6ZYl2gKS09EClnJYGd8Du6rfc5r/GZEk5o1mRb8TaTj03sQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^2"
+      }
+    },
+    "node_modules/mdast-util-find-and-replace": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmmirror.com/mdast-util-find-and-replace/-/mdast-util-find-and-replace-3.0.2.tgz",
+      "integrity": "sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "escape-string-regexp": "^5.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-from-markdown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmmirror.com/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.3.tgz",
+      "integrity": "sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark": "^4.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-from-markdown/node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmmirror.com/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "license": "MIT"
+    },
+    "node_modules/mdast-util-gfm": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmmirror.com/mdast-util-gfm/-/mdast-util-gfm-3.1.0.tgz",
+      "integrity": "sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-gfm-autolink-literal": "^2.0.0",
+        "mdast-util-gfm-footnote": "^2.0.0",
+        "mdast-util-gfm-strikethrough": "^2.0.0",
+        "mdast-util-gfm-table": "^2.0.0",
+        "mdast-util-gfm-task-list-item": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-autolink-literal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmmirror.com/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-2.0.1.tgz",
+      "integrity": "sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-find-and-replace": "^3.0.0",
+        "micromark-util-character": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmmirror.com/mdast-util-gfm-footnote/-/mdast-util-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.1.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-strikethrough": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmmirror.com/mdast-util-gfm-strikethrough/-/mdast-util-gfm-strikethrough-2.0.0.tgz",
+      "integrity": "sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-table": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmmirror.com/mdast-util-gfm-table/-/mdast-util-gfm-table-2.0.0.tgz",
+      "integrity": "sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "markdown-table": "^3.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-task-list-item": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmmirror.com/mdast-util-gfm-task-list-item/-/mdast-util-gfm-task-list-item-2.0.0.tgz",
+      "integrity": "sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-math": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmmirror.com/mdast-util-math/-/mdast-util-math-3.0.0.tgz",
+      "integrity": "sha512-Tl9GBNeG/AhJnQM221bJR2HPvLOSnLE/T9cJI9tlc6zwQk2nPk/4f0cHkOdEixQPC/j8UtKDdITswvLAy1OZ1w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "longest-streak": "^3.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.1.0",
+        "unist-util-remove-position": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-math/node_modules/@types/hast": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmmirror.com/@types/hast/-/hast-3.0.5.tgz",
+      "integrity": "sha512-rp/ezSWaD1m44dPKICGhiskI13nVr7qTloFwDa/IYkhhf5nzwP+zIQcIJh3WIFSBOy/H1PzB40jPjMDksN4F+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/mdast-util-mdx-expression": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmmirror.com/mdast-util-mdx-expression/-/mdast-util-mdx-expression-2.0.1.tgz",
+      "integrity": "sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdx-expression/node_modules/@types/hast": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmmirror.com/@types/hast/-/hast-3.0.5.tgz",
+      "integrity": "sha512-rp/ezSWaD1m44dPKICGhiskI13nVr7qTloFwDa/IYkhhf5nzwP+zIQcIJh3WIFSBOy/H1PzB40jPjMDksN4F+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/mdast-util-mdx-jsx": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmmirror.com/mdast-util-mdx-jsx/-/mdast-util-mdx-jsx-3.2.0.tgz",
+      "integrity": "sha512-lj/z8v0r6ZtsN/cGNNtemmmfoLAFZnjMbNyLzBafjzikOM+glrjNHPlf6lQDOTccj9n5b0PPihEBbhneMyGs1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.1.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "parse-entities": "^4.0.0",
+        "stringify-entities": "^4.0.0",
+        "unist-util-stringify-position": "^4.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdx-jsx/node_modules/@types/hast": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmmirror.com/@types/hast/-/hast-3.0.5.tgz",
+      "integrity": "sha512-rp/ezSWaD1m44dPKICGhiskI13nVr7qTloFwDa/IYkhhf5nzwP+zIQcIJh3WIFSBOy/H1PzB40jPjMDksN4F+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/mdast-util-mdx-jsx/node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmmirror.com/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "license": "MIT"
+    },
+    "node_modules/mdast-util-mdxjs-esm": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmmirror.com/mdast-util-mdxjs-esm/-/mdast-util-mdxjs-esm-2.0.1.tgz",
+      "integrity": "sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdxjs-esm/node_modules/@types/hast": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmmirror.com/@types/hast/-/hast-3.0.5.tgz",
+      "integrity": "sha512-rp/ezSWaD1m44dPKICGhiskI13nVr7qTloFwDa/IYkhhf5nzwP+zIQcIJh3WIFSBOy/H1PzB40jPjMDksN4F+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/mdast-util-phrasing": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmmirror.com/mdast-util-phrasing/-/mdast-util-phrasing-4.1.0.tgz",
+      "integrity": "sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-hast": {
+      "version": "13.2.1",
+      "resolved": "https://registry.npmmirror.com/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz",
+      "integrity": "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "trim-lines": "^3.0.0",
+        "unist-util-position": "^5.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-hast/node_modules/@types/hast": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmmirror.com/@types/hast/-/hast-3.0.5.tgz",
+      "integrity": "sha512-rp/ezSWaD1m44dPKICGhiskI13nVr7qTloFwDa/IYkhhf5nzwP+zIQcIJh3WIFSBOy/H1PzB40jPjMDksN4F+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/mdast-util-to-hast/node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmmirror.com/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "license": "MIT"
+    },
+    "node_modules/mdast-util-to-hast/node_modules/unist-util-visit": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmmirror.com/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
+      "integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-hast/node_modules/vfile": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmmirror.com/vfile/-/vfile-6.0.3.tgz",
+      "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-markdown": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmmirror.com/mdast-util-to-markdown/-/mdast-util-to-markdown-2.1.2.tgz",
+      "integrity": "sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "longest-streak": "^3.0.0",
+        "mdast-util-phrasing": "^4.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "unist-util-visit": "^5.0.0",
+        "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-markdown/node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmmirror.com/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "license": "MIT"
+    },
+    "node_modules/mdast-util-to-markdown/node_modules/unist-util-visit": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmmirror.com/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
+      "integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmmirror.com/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz",
+      "integrity": "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mermaid": {
+      "version": "11.16.1",
+      "resolved": "https://registry.npmmirror.com/mermaid/-/mermaid-11.16.1.tgz",
+      "integrity": "sha512-TQsq6u22fAn3rek5VOubrhKPo1g5hwC3FXUN9hiyupTckcYiGuuKGkNQrKYwGJkXUxZdojwRG46gsSCFZMDp4g==",
+      "license": "MIT",
+      "dependencies": {
+        "@braintree/sanitize-url": "^7.1.2",
+        "@iconify/utils": "^3.0.2",
+        "@mermaid-js/parser": "^1.2.0",
+        "@types/d3": "^7.4.3",
+        "@upsetjs/venn.js": "^2.0.0",
+        "cytoscape": "^3.33.3",
+        "cytoscape-cose-bilkent": "^4.1.0",
+        "cytoscape-fcose": "^2.2.0",
+        "d3": "^7.9.0",
+        "d3-sankey": "^0.12.3",
+        "dagre-d3-es": "7.0.14",
+        "dayjs": "^1.11.20",
+        "dompurify": "^3.3.3",
+        "es-toolkit": "^1.45.1",
+        "katex": "^0.16.45",
+        "khroma": "^2.1.0",
+        "marked": "^16.3.0",
+        "roughjs": "^4.6.6",
+        "stylis": "^4.3.6",
+        "ts-dedent": "^2.2.0",
+        "uuid": "^11.1.0 || ^12 || ^13 || ^14.0.0"
+      }
+    },
+    "node_modules/mermaid/node_modules/marked": {
+      "version": "16.4.2",
+      "resolved": "https://registry.npmmirror.com/marked/-/marked-16.4.2.tgz",
+      "integrity": "sha512-TI3V8YYWvkVf3KJe1dRkpnjs68JUPyEa5vjKrp1XEEJUAOaQc+Qj+L1qWbPd0SJuAdQkFU0h73sXXqwDYxsiDA==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/micromark": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmmirror.com/micromark/-/micromark-4.0.2.tgz",
+      "integrity": "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@types/debug": "^4.0.0",
+        "debug": "^4.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-core-commonmark": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmmirror.com/micromark-core-commonmark/-/micromark-core-commonmark-2.0.3.tgz",
+      "integrity": "sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-factory-destination": "^2.0.0",
+        "micromark-factory-label": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-factory-title": "^2.0.0",
+        "micromark-factory-whitespace": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-html-tag-name": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-extension-cjk-friendly": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmmirror.com/micromark-extension-cjk-friendly/-/micromark-extension-cjk-friendly-1.2.3.tgz",
+      "integrity": "sha512-gRzVLUdjXBLX6zNPSnHGDoo+ZTp5zy+MZm0g3sv+3chPXY7l9gW+DnrcHcZh/jiPR6MjPKO4AEJNp4Aw6V9z5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.1.0",
+        "micromark-extension-cjk-friendly-util": "2.1.1",
+        "micromark-util-chunked": "^2.0.1",
+        "micromark-util-resolve-all": "^2.0.1",
+        "micromark-util-symbol": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "micromark": "^4.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "micromark-util-types": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/micromark-extension-cjk-friendly-gfm-strikethrough": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmmirror.com/micromark-extension-cjk-friendly-gfm-strikethrough/-/micromark-extension-cjk-friendly-gfm-strikethrough-1.2.3.tgz",
+      "integrity": "sha512-gSPnxgHDDqXYOBvQRq6lerrq9mjDhdtKn+7XETuXjxWcL62yZEfUdA28Ml1I2vDIPfAOIKLa0h2XDSGkInGHFQ==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.1.0",
+        "get-east-asian-width": "^1.3.0",
+        "micromark-extension-cjk-friendly-util": "2.1.1",
+        "micromark-util-character": "^2.1.1",
+        "micromark-util-chunked": "^2.0.1",
+        "micromark-util-resolve-all": "^2.0.1",
+        "micromark-util-symbol": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "micromark": "^4.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "micromark-util-types": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/micromark-extension-cjk-friendly-util": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmmirror.com/micromark-extension-cjk-friendly-util/-/micromark-extension-cjk-friendly-util-2.1.1.tgz",
+      "integrity": "sha512-egs6+12JU2yutskHY55FyR48ZiEcFOJFyk9rsiyIhcJ6IvWB6ABBqVrBw8IobqJTDZ/wdSr9eoXDPb5S2nW1bg==",
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.3.0",
+        "micromark-util-character": "^2.1.1",
+        "micromark-util-symbol": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependenciesMeta": {
+        "micromark-util-types": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/micromark-extension-gfm": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmmirror.com/micromark-extension-gfm/-/micromark-extension-gfm-3.0.0.tgz",
+      "integrity": "sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-extension-gfm-autolink-literal": "^2.0.0",
+        "micromark-extension-gfm-footnote": "^2.0.0",
+        "micromark-extension-gfm-strikethrough": "^2.0.0",
+        "micromark-extension-gfm-table": "^2.0.0",
+        "micromark-extension-gfm-tagfilter": "^2.0.0",
+        "micromark-extension-gfm-task-list-item": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-autolink-literal": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmmirror.com/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-2.1.0.tgz",
+      "integrity": "sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmmirror.com/micromark-extension-gfm-footnote/-/micromark-extension-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-strikethrough": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmmirror.com/micromark-extension-gfm-strikethrough/-/micromark-extension-gfm-strikethrough-2.1.0.tgz",
+      "integrity": "sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-table": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmmirror.com/micromark-extension-gfm-table/-/micromark-extension-gfm-table-2.1.1.tgz",
+      "integrity": "sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-tagfilter": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmmirror.com/micromark-extension-gfm-tagfilter/-/micromark-extension-gfm-tagfilter-2.0.0.tgz",
+      "integrity": "sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-task-list-item": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmmirror.com/micromark-extension-gfm-task-list-item/-/micromark-extension-gfm-task-list-item-2.1.0.tgz",
+      "integrity": "sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-math": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmmirror.com/micromark-extension-math/-/micromark-extension-math-3.1.0.tgz",
+      "integrity": "sha512-lvEqd+fHjATVs+2v/8kg9i5Q0AP2k85H0WUOwpIVvUML8BapsMvh1XAogmQjOCsLpoKRCVQqEkQBB3NhVBcsOg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/katex": "^0.16.0",
+        "devlop": "^1.0.0",
+        "katex": "^0.16.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-factory-destination": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmmirror.com/micromark-factory-destination/-/micromark-factory-destination-2.0.1.tgz",
+      "integrity": "sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-label": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmmirror.com/micromark-factory-label/-/micromark-factory-label-2.0.1.tgz",
+      "integrity": "sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-space": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmmirror.com/micromark-factory-space/-/micromark-factory-space-2.0.1.tgz",
+      "integrity": "sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-title": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmmirror.com/micromark-factory-title/-/micromark-factory-title-2.0.1.tgz",
+      "integrity": "sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-whitespace": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmmirror.com/micromark-factory-whitespace/-/micromark-factory-whitespace-2.0.1.tgz",
+      "integrity": "sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-character": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmmirror.com/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
+      "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-chunked": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmmirror.com/micromark-util-chunked/-/micromark-util-chunked-2.0.1.tgz",
+      "integrity": "sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-classify-character": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmmirror.com/micromark-util-classify-character/-/micromark-util-classify-character-2.0.1.tgz",
+      "integrity": "sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-combine-extensions": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmmirror.com/micromark-util-combine-extensions/-/micromark-util-combine-extensions-2.0.1.tgz",
+      "integrity": "sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-numeric-character-reference": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmmirror.com/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-2.0.2.tgz",
+      "integrity": "sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-string": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmmirror.com/micromark-util-decode-string/-/micromark-util-decode-string-2.0.1.tgz",
+      "integrity": "sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-encode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmmirror.com/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
+      "integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-html-tag-name": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmmirror.com/micromark-util-html-tag-name/-/micromark-util-html-tag-name-2.0.1.tgz",
+      "integrity": "sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-normalize-identifier": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmmirror.com/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-2.0.1.tgz",
+      "integrity": "sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-resolve-all": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmmirror.com/micromark-util-resolve-all/-/micromark-util-resolve-all-2.0.1.tgz",
+      "integrity": "sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-sanitize-uri": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmmirror.com/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
+      "integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-subtokenize": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmmirror.com/micromark-util-subtokenize/-/micromark-util-subtokenize-2.1.0.tgz",
+      "integrity": "sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-symbol": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmmirror.com/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
+      "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-types": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmmirror.com/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
+      "integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/mri": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmmirror.com/mri/-/mri-1.2.0.tgz",
+      "integrity": "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmmirror.com/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.17",
+      "resolved": "https://registry.npmmirror.com/nanoid/-/nanoid-3.3.17.tgz",
+      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmmirror.com/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmmirror.com/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/oniguruma-parser": {
+      "version": "0.12.2",
+      "resolved": "https://registry.npmmirror.com/oniguruma-parser/-/oniguruma-parser-0.12.2.tgz",
+      "integrity": "sha512-6HVa5oIrgMC6aA6WF6XyyqbhRPJrKR02L20+2+zpDtO5QAzGHAUGw5TKQvwi5vctNnRHkJYmjAhRVQF2EKdTQw==",
+      "license": "MIT"
+    },
+    "node_modules/oniguruma-to-es": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmmirror.com/oniguruma-to-es/-/oniguruma-to-es-4.3.6.tgz",
+      "integrity": "sha512-csuQ9x3Yr0cEIs/Zgx/OEt9iBw9vqIunAPQkx19R/fiMq2oGVTgcMqO/V3Ybqefr1TBvosI6jU539ksaBULJyA==",
+      "license": "MIT",
+      "dependencies": {
+        "oniguruma-parser": "^0.12.2",
+        "regex": "^6.1.0",
+        "regex-recursion": "^6.0.2"
+      }
+    },
+    "node_modules/package-manager-detector": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmmirror.com/package-manager-detector/-/package-manager-detector-1.8.0.tgz",
+      "integrity": "sha512-yQA4H19AmPEoMUeavPMDIe1higySl/gH/yaQrkT/s07Qp+7pp2hYz30N3z2l5BkjVkF9Ow6o0wjJamm2y7Sn0A==",
+      "license": "MIT"
+    },
+    "node_modules/parse-entities": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmmirror.com/parse-entities/-/parse-entities-4.0.2.tgz",
+      "integrity": "sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "character-entities-legacy": "^3.0.0",
+        "character-reference-invalid": "^2.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "is-alphanumerical": "^2.0.0",
+        "is-decimal": "^2.0.0",
+        "is-hexadecimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmmirror.com/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/partial-json": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmmirror.com/partial-json/-/partial-json-0.1.7.tgz",
+      "integrity": "sha512-Njv/59hHaokb/hRUjce3Hdv12wd60MtM9Z5Olmn+nehe0QDAsRtRbJPvJ0Z91TusF0SuZRIvnM+S4l6EIP8leA==",
+      "license": "MIT"
+    },
+    "node_modules/path-data-parser": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmmirror.com/path-data-parser/-/path-data-parser-0.1.0.tgz",
+      "integrity": "sha512-NOnmBpt5Y2RWbuv0LMzsayp3lVylAHLPUTut412ZA3l+C4uw4ZVkQbjShYCQ8TCpUMdPapr4YjUqLYD6v68j+w==",
+      "license": "MIT"
+    },
+    "node_modules/phoenix": {
+      "version": "1.8.9",
+      "resolved": "https://registry.npmmirror.com/phoenix/-/phoenix-1.8.9.tgz",
+      "integrity": "sha512-/2qzAZB3P2s08fFAYaG65lqaNFmVXUSlXdY4/JDdDKIC81y2cFWkPwI8gycy4VLpv197JwZ5PpBf3VhoG32yGA==",
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmmirror.com/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmmirror.com/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/points-on-curve": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmmirror.com/points-on-curve/-/points-on-curve-0.2.0.tgz",
+      "integrity": "sha512-0mYKnYYe9ZcqMCWhUjItv/oHjvgEsfKvnUTg8sAtnHr3GVy7rGkXCb6d5cSyqrWqL4k81b9CPg3urd+T7aop3A==",
+      "license": "MIT"
+    },
+    "node_modules/points-on-path": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmmirror.com/points-on-path/-/points-on-path-0.2.1.tgz",
+      "integrity": "sha512-25ClnWWuw7JbWZcgqY/gJ4FQWadKxGWk+3kR/7kD0tCaDtPPMj7oHu2ToLaVhfpnHrZzYby2w6tUA0eOIuUg8g==",
+      "license": "MIT",
+      "dependencies": {
+        "path-data-parser": "0.1.0",
+        "points-on-curve": "0.2.0"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.25",
+      "resolved": "https://registry.npmmirror.com/postcss/-/postcss-8.5.25.tgz",
+      "integrity": "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.16",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/prismjs": {
+      "version": "1.30.0",
+      "resolved": "https://registry.npmmirror.com/prismjs/-/prismjs-1.30.0.tgz",
+      "integrity": "sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmmirror.com/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
+    "node_modules/prop-types/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmmirror.com/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT"
+    },
+    "node_modules/property-information": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmmirror.com/property-information/-/property-information-6.5.0.tgz",
+      "integrity": "sha512-PgTgs/BlvHxOu8QuEN7wi5A0OmXaBcHpmCSTehcs6Uuu9IkDIEo13Hy7n898RHfrQ49vKCoGeWZSaAK01nwVig==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/react": {
+      "version": "19.2.8",
+      "resolved": "https://registry.npmmirror.com/react/-/react-19.2.8.tgz",
+      "integrity": "sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-aria": {
+      "version": "3.51.0",
+      "resolved": "https://registry.npmmirror.com/react-aria/-/react-aria-3.51.0.tgz",
+      "integrity": "sha512-AyWLw0XR38cFPwBu/ErgGaVrc5dupLEKmRlMXTGvFKOtbaGRQ2+yQJkjVhpdHhoRhU4+G+tJDFeHDTS8tK3bfQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@internationalized/date": "^3.12.3",
+        "@internationalized/number": "^3.6.7",
+        "@internationalized/string": "^3.2.10",
+        "@react-types/shared": "^3.36.1",
+        "@swc/helpers": "^0.5.0",
+        "aria-hidden": "^1.2.3",
+        "clsx": "^2.0.0",
+        "react-stately": "3.49.0",
+        "use-sync-external-store": "^1.6.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "19.2.8",
+      "resolved": "https://registry.npmmirror.com/react-dom/-/react-dom-19.2.8.tgz",
+      "integrity": "sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ==",
+      "license": "MIT",
+      "dependencies": {
+        "scheduler": "^0.27.0"
+      },
+      "peerDependencies": {
+        "react": "^19.2.8"
+      }
+    },
+    "node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmmirror.com/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "license": "MIT"
+    },
+    "node_modules/react-markdown": {
+      "version": "8.0.7",
+      "resolved": "https://registry.npmmirror.com/react-markdown/-/react-markdown-8.0.7.tgz",
+      "integrity": "sha512-bvWbzG4MtOU62XqBx3Xx+zB2raaFFsq4mYiAzfjXJMEz2sixgeAfraA3tvzULF02ZdOMUOKTBFFaZJDDrq+BJQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^2.0.0",
+        "@types/prop-types": "^15.0.0",
+        "@types/unist": "^2.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "hast-util-whitespace": "^2.0.0",
+        "prop-types": "^15.0.0",
+        "property-information": "^6.0.0",
+        "react-is": "^18.0.0",
+        "remark-parse": "^10.0.0",
+        "remark-rehype": "^10.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "style-to-object": "^0.4.0",
+        "unified": "^10.0.0",
+        "unist-util-visit": "^4.0.0",
+        "vfile": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16",
+        "react": ">=16"
+      }
+    },
+    "node_modules/react-remove-scroll": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmmirror.com/react-remove-scroll/-/react-remove-scroll-2.7.2.tgz",
+      "integrity": "sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q==",
+      "license": "MIT",
+      "dependencies": {
+        "react-remove-scroll-bar": "^2.3.7",
+        "react-style-singleton": "^2.2.3",
+        "tslib": "^2.1.0",
+        "use-callback-ref": "^1.3.3",
+        "use-sidecar": "^1.1.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-remove-scroll-bar": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmmirror.com/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.8.tgz",
+      "integrity": "sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==",
+      "license": "MIT",
+      "dependencies": {
+        "react-style-singleton": "^2.2.2",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-stately": {
+      "version": "3.49.0",
+      "resolved": "https://registry.npmmirror.com/react-stately/-/react-stately-3.49.0.tgz",
+      "integrity": "sha512-13iNq2KzBrRAzxRc+n53hgROfIistiYY/sPtIhCw1qUB7/kmo+X1xEU2uiS5zcCIrc55AUPwoHqOIIpKWSwB9A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@internationalized/date": "^3.12.3",
+        "@internationalized/number": "^3.6.7",
+        "@internationalized/string": "^3.2.10",
+        "@react-types/shared": "^3.36.1",
+        "@swc/helpers": "^0.5.0",
+        "use-sync-external-store": "^1.6.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/react-style-singleton": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmmirror.com/react-style-singleton/-/react-style-singleton-2.2.3.tgz",
+      "integrity": "sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "get-nonce": "^1.0.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-syntax-highlighter": {
+      "version": "16.1.1",
+      "resolved": "https://registry.npmmirror.com/react-syntax-highlighter/-/react-syntax-highlighter-16.1.1.tgz",
+      "integrity": "sha512-PjVawBGy80C6YbC5DDZJeUjBmC7skaoEUdvfFQediQHgCL7aKyVHe57SaJGfQsloGDac+gCpTfRdtxzWWKmCXA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.28.4",
+        "highlight.js": "^10.4.1",
+        "highlightjs-vue": "^1.0.0",
+        "lowlight": "^1.17.0",
+        "prismjs": "^1.30.0",
+        "refractor": "^5.0.0"
+      },
+      "engines": {
+        "node": ">= 16.20.2"
+      },
+      "peerDependencies": {
+        "react": ">= 0.14.0"
+      }
+    },
+    "node_modules/refractor": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmmirror.com/refractor/-/refractor-5.0.0.tgz",
+      "integrity": "sha512-QXOrHQF5jOpjjLfiNk5GFnWhRXvxjUVnlFxkeDmewR5sXkr3iM46Zo+CnRR8B+MDVqkULW4EcLVcRBNOPXHosw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/prismjs": "^1.0.0",
+        "hastscript": "^9.0.0",
+        "parse-entities": "^4.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/refractor/node_modules/@types/hast": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmmirror.com/@types/hast/-/hast-3.0.5.tgz",
+      "integrity": "sha512-rp/ezSWaD1m44dPKICGhiskI13nVr7qTloFwDa/IYkhhf5nzwP+zIQcIJh3WIFSBOy/H1PzB40jPjMDksN4F+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/regex": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmmirror.com/regex/-/regex-6.1.0.tgz",
+      "integrity": "sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg==",
+      "license": "MIT",
+      "dependencies": {
+        "regex-utilities": "^2.3.0"
+      }
+    },
+    "node_modules/regex-recursion": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmmirror.com/regex-recursion/-/regex-recursion-6.0.2.tgz",
+      "integrity": "sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg==",
+      "license": "MIT",
+      "dependencies": {
+        "regex-utilities": "^2.3.0"
+      }
+    },
+    "node_modules/regex-utilities": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmmirror.com/regex-utilities/-/regex-utilities-2.3.0.tgz",
+      "integrity": "sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==",
+      "license": "MIT"
+    },
+    "node_modules/rehype-harden": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmmirror.com/rehype-harden/-/rehype-harden-1.1.8.tgz",
+      "integrity": "sha512-Qn7vR1xrf6fZCrkm9TDWi/AB4ylrHy+jqsNm1EHOAmbARYA6gsnVJBq/sdBh6kmT4NEZxH5vgIjrscefJAOXcw==",
+      "license": "MIT",
+      "dependencies": {
+        "unist-util-visit": "^5.0.0"
+      }
+    },
+    "node_modules/rehype-harden/node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmmirror.com/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "license": "MIT"
+    },
+    "node_modules/rehype-harden/node_modules/unist-util-visit": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmmirror.com/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
+      "integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/rehype-katex": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmmirror.com/rehype-katex/-/rehype-katex-7.0.1.tgz",
+      "integrity": "sha512-OiM2wrZ/wuhKkigASodFoo8wimG3H12LWQaH8qSPVJn9apWKFSH3YOCtbKpBorTVw/eI7cuT21XBbvwEswbIOA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/katex": "^0.16.0",
+        "hast-util-from-html-isomorphic": "^2.0.0",
+        "hast-util-to-text": "^4.0.0",
+        "katex": "^0.16.0",
+        "unist-util-visit-parents": "^6.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/rehype-katex/node_modules/@types/hast": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmmirror.com/@types/hast/-/hast-3.0.5.tgz",
+      "integrity": "sha512-rp/ezSWaD1m44dPKICGhiskI13nVr7qTloFwDa/IYkhhf5nzwP+zIQcIJh3WIFSBOy/H1PzB40jPjMDksN4F+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/rehype-katex/node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmmirror.com/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "license": "MIT"
+    },
+    "node_modules/rehype-katex/node_modules/vfile": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmmirror.com/vfile/-/vfile-6.0.3.tgz",
+      "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/rehype-raw": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmmirror.com/rehype-raw/-/rehype-raw-7.0.0.tgz",
+      "integrity": "sha512-/aE8hCfKlQeA8LmyeyQvQF3eBiLRGNlfBJEvWH7ivp9sBqs7TNqBL5X3v157rM4IFETqDnIOO+z5M/biZbo9Ww==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hast-util-raw": "^9.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/rehype-raw/node_modules/@types/hast": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmmirror.com/@types/hast/-/hast-3.0.5.tgz",
+      "integrity": "sha512-rp/ezSWaD1m44dPKICGhiskI13nVr7qTloFwDa/IYkhhf5nzwP+zIQcIJh3WIFSBOy/H1PzB40jPjMDksN4F+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/rehype-raw/node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmmirror.com/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "license": "MIT"
+    },
+    "node_modules/rehype-raw/node_modules/vfile": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmmirror.com/vfile/-/vfile-6.0.3.tgz",
+      "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/rehype-sanitize": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmmirror.com/rehype-sanitize/-/rehype-sanitize-6.0.0.tgz",
+      "integrity": "sha512-CsnhKNsyI8Tub6L4sm5ZFsme4puGfc6pYylvXo1AeqaGbjOYyzNv3qZPwvs0oMJ39eryyeOdmxwUIo94IpEhqg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hast-util-sanitize": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/rehype-sanitize/node_modules/@types/hast": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmmirror.com/@types/hast/-/hast-3.0.5.tgz",
+      "integrity": "sha512-rp/ezSWaD1m44dPKICGhiskI13nVr7qTloFwDa/IYkhhf5nzwP+zIQcIJh3WIFSBOy/H1PzB40jPjMDksN4F+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/remark-gfm": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmmirror.com/remark-gfm/-/remark-gfm-4.0.1.tgz",
+      "integrity": "sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-gfm": "^3.0.0",
+        "micromark-extension-gfm": "^3.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-stringify": "^11.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-gfm/node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmmirror.com/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "license": "MIT"
+    },
+    "node_modules/remark-gfm/node_modules/remark-parse": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmmirror.com/remark-parse/-/remark-parse-11.0.0.tgz",
+      "integrity": "sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-gfm/node_modules/unified": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmmirror.com/unified/-/unified-11.0.5.tgz",
+      "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "bail": "^2.0.0",
+        "devlop": "^1.0.0",
+        "extend": "^3.0.0",
+        "is-plain-obj": "^4.0.0",
+        "trough": "^2.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-gfm/node_modules/vfile": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmmirror.com/vfile/-/vfile-6.0.3.tgz",
+      "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-math": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmmirror.com/remark-math/-/remark-math-6.0.0.tgz",
+      "integrity": "sha512-MMqgnP74Igy+S3WwnhQ7kqGlEerTETXMvJhrUzDikVZ2/uogJCb+WHUg97hK9/jcfc0dkD73s3LN8zU49cTEtA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-math": "^3.0.0",
+        "micromark-extension-math": "^3.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-math/node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmmirror.com/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "license": "MIT"
+    },
+    "node_modules/remark-math/node_modules/unified": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmmirror.com/unified/-/unified-11.0.5.tgz",
+      "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "bail": "^2.0.0",
+        "devlop": "^1.0.0",
+        "extend": "^3.0.0",
+        "is-plain-obj": "^4.0.0",
+        "trough": "^2.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-math/node_modules/vfile": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmmirror.com/vfile/-/vfile-6.0.3.tgz",
+      "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-parse": {
+      "version": "10.0.2",
+      "resolved": "https://registry.npmmirror.com/remark-parse/-/remark-parse-10.0.2.tgz",
+      "integrity": "sha512-3ydxgHa/ZQzG8LvC7jTXccARYDcRld3VfcgIIFs7bI6vbRSxJJmzgLEIIoYKyrfhaY+ujuWaf/PJiMZXoiCXgw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^3.0.0",
+        "mdast-util-from-markdown": "^1.0.0",
+        "unified": "^10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-parse/node_modules/@types/mdast": {
+      "version": "3.0.15",
+      "resolved": "https://registry.npmmirror.com/@types/mdast/-/mdast-3.0.15.tgz",
+      "integrity": "sha512-LnwD+mUEfxWMa1QpDraczIn6k0Ee3SMicuYSSzS6ZYl2gKS09EClnJYGd8Du6rfc5r/GZEk5o1mRb8TaTj03sQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^2"
+      }
+    },
+    "node_modules/remark-parse/node_modules/mdast-util-from-markdown": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmmirror.com/mdast-util-from-markdown/-/mdast-util-from-markdown-1.3.1.tgz",
+      "integrity": "sha512-4xTO/M8c82qBcnQc1tgpNtubGUW/Y1tBQ1B0i5CtSoelOLKFYlElIr3bvgREYYO5iRqbMY1YuqZng0GVOI8Qww==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^3.0.0",
+        "@types/unist": "^2.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "mdast-util-to-string": "^3.1.0",
+        "micromark": "^3.0.0",
+        "micromark-util-decode-numeric-character-reference": "^1.0.0",
+        "micromark-util-decode-string": "^1.0.0",
+        "micromark-util-normalize-identifier": "^1.0.0",
+        "micromark-util-symbol": "^1.0.0",
+        "micromark-util-types": "^1.0.0",
+        "unist-util-stringify-position": "^3.0.0",
+        "uvu": "^0.5.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-parse/node_modules/mdast-util-to-string": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmmirror.com/mdast-util-to-string/-/mdast-util-to-string-3.2.0.tgz",
+      "integrity": "sha512-V4Zn/ncyN1QNSqSBxTrMOLpjr+IKdHl2v3KVLoWmDPscP4r9GcCi71gjgvUV1SFSKh92AjAG4peFuBl2/YgCJg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-parse/node_modules/micromark": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmmirror.com/micromark/-/micromark-3.2.0.tgz",
+      "integrity": "sha512-uD66tJj54JLYq0De10AhWycZWGQNUvDI55xPgk2sQM5kn1JYlhbCMTtEeT27+vAhW2FBQxLlOmS3pmA7/2z4aA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@types/debug": "^4.0.0",
+        "debug": "^4.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "micromark-core-commonmark": "^1.0.1",
+        "micromark-factory-space": "^1.0.0",
+        "micromark-util-character": "^1.0.0",
+        "micromark-util-chunked": "^1.0.0",
+        "micromark-util-combine-extensions": "^1.0.0",
+        "micromark-util-decode-numeric-character-reference": "^1.0.0",
+        "micromark-util-encode": "^1.0.0",
+        "micromark-util-normalize-identifier": "^1.0.0",
+        "micromark-util-resolve-all": "^1.0.0",
+        "micromark-util-sanitize-uri": "^1.0.0",
+        "micromark-util-subtokenize": "^1.0.0",
+        "micromark-util-symbol": "^1.0.0",
+        "micromark-util-types": "^1.0.1",
+        "uvu": "^0.5.0"
+      }
+    },
+    "node_modules/remark-parse/node_modules/micromark-core-commonmark": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmmirror.com/micromark-core-commonmark/-/micromark-core-commonmark-1.1.0.tgz",
+      "integrity": "sha512-BgHO1aRbolh2hcrzL2d1La37V0Aoz73ymF8rAcKnohLy93titmv62E0gP8Hrx9PKcKrqCZ1BbLGbP3bEhoXYlw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "micromark-factory-destination": "^1.0.0",
+        "micromark-factory-label": "^1.0.0",
+        "micromark-factory-space": "^1.0.0",
+        "micromark-factory-title": "^1.0.0",
+        "micromark-factory-whitespace": "^1.0.0",
+        "micromark-util-character": "^1.0.0",
+        "micromark-util-chunked": "^1.0.0",
+        "micromark-util-classify-character": "^1.0.0",
+        "micromark-util-html-tag-name": "^1.0.0",
+        "micromark-util-normalize-identifier": "^1.0.0",
+        "micromark-util-resolve-all": "^1.0.0",
+        "micromark-util-subtokenize": "^1.0.0",
+        "micromark-util-symbol": "^1.0.0",
+        "micromark-util-types": "^1.0.1",
+        "uvu": "^0.5.0"
+      }
+    },
+    "node_modules/remark-parse/node_modules/micromark-factory-destination": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmmirror.com/micromark-factory-destination/-/micromark-factory-destination-1.1.0.tgz",
+      "integrity": "sha512-XaNDROBgx9SgSChd69pjiGKbV+nfHGDPVYFs5dOoDd7ZnMAE+Cuu91BCpsY8RT2NP9vo/B8pds2VQNCLiu0zhg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^1.0.0",
+        "micromark-util-symbol": "^1.0.0",
+        "micromark-util-types": "^1.0.0"
+      }
+    },
+    "node_modules/remark-parse/node_modules/micromark-factory-label": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmmirror.com/micromark-factory-label/-/micromark-factory-label-1.1.0.tgz",
+      "integrity": "sha512-OLtyez4vZo/1NjxGhcpDSbHQ+m0IIGnT8BoPamh+7jVlzLJBH98zzuCoUeMxvM6WsNeh8wx8cKvqLiPHEACn0w==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^1.0.0",
+        "micromark-util-symbol": "^1.0.0",
+        "micromark-util-types": "^1.0.0",
+        "uvu": "^0.5.0"
+      }
+    },
+    "node_modules/remark-parse/node_modules/micromark-factory-space": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmmirror.com/micromark-factory-space/-/micromark-factory-space-1.1.0.tgz",
+      "integrity": "sha512-cRzEj7c0OL4Mw2v6nwzttyOZe8XY/Z8G0rzmWQZTBi/jjwyw/U4uqKtUORXQrR5bAZZnbTI/feRV/R7hc4jQYQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^1.0.0",
+        "micromark-util-types": "^1.0.0"
+      }
+    },
+    "node_modules/remark-parse/node_modules/micromark-factory-title": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmmirror.com/micromark-factory-title/-/micromark-factory-title-1.1.0.tgz",
+      "integrity": "sha512-J7n9R3vMmgjDOCY8NPw55jiyaQnH5kBdV2/UXCtZIpnHH3P6nHUKaH7XXEYuWwx/xUJcawa8plLBEjMPU24HzQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^1.0.0",
+        "micromark-util-character": "^1.0.0",
+        "micromark-util-symbol": "^1.0.0",
+        "micromark-util-types": "^1.0.0"
+      }
+    },
+    "node_modules/remark-parse/node_modules/micromark-factory-whitespace": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmmirror.com/micromark-factory-whitespace/-/micromark-factory-whitespace-1.1.0.tgz",
+      "integrity": "sha512-v2WlmiymVSp5oMg+1Q0N1Lxmt6pMhIHD457whWM7/GUlEks1hI9xj5w3zbc4uuMKXGisksZk8DzP2UyGbGqNsQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^1.0.0",
+        "micromark-util-character": "^1.0.0",
+        "micromark-util-symbol": "^1.0.0",
+        "micromark-util-types": "^1.0.0"
+      }
+    },
+    "node_modules/remark-parse/node_modules/micromark-util-character": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmmirror.com/micromark-util-character/-/micromark-util-character-1.2.0.tgz",
+      "integrity": "sha512-lXraTwcX3yH/vMDaFWCQJP1uIszLVebzUa3ZHdrgxr7KEU/9mL4mVgCpGbyhvNLNlauROiNUq7WN5u7ndbY6xg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^1.0.0",
+        "micromark-util-types": "^1.0.0"
+      }
+    },
+    "node_modules/remark-parse/node_modules/micromark-util-chunked": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmmirror.com/micromark-util-chunked/-/micromark-util-chunked-1.1.0.tgz",
+      "integrity": "sha512-Ye01HXpkZPNcV6FiyoW2fGZDUw4Yc7vT0E9Sad83+bEDiCJ1uXu0S3mr8WLpsz3HaG3x2q0HM6CTuPdcZcluFQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^1.0.0"
+      }
+    },
+    "node_modules/remark-parse/node_modules/micromark-util-classify-character": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmmirror.com/micromark-util-classify-character/-/micromark-util-classify-character-1.1.0.tgz",
+      "integrity": "sha512-SL0wLxtKSnklKSUplok1WQFoGhUdWYKggKUiqhX+Swala+BtptGCu5iPRc+xvzJ4PXE/hwM3FNXsfEVgoZsWbw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^1.0.0",
+        "micromark-util-symbol": "^1.0.0",
+        "micromark-util-types": "^1.0.0"
+      }
+    },
+    "node_modules/remark-parse/node_modules/micromark-util-combine-extensions": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmmirror.com/micromark-util-combine-extensions/-/micromark-util-combine-extensions-1.1.0.tgz",
+      "integrity": "sha512-Q20sp4mfNf9yEqDL50WwuWZHUrCO4fEyeDCnMGmG5Pr0Cz15Uo7KBs6jq+dq0EgX4DPwwrh9m0X+zPV1ypFvUA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-chunked": "^1.0.0",
+        "micromark-util-types": "^1.0.0"
+      }
+    },
+    "node_modules/remark-parse/node_modules/micromark-util-decode-numeric-character-reference": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmmirror.com/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-1.1.0.tgz",
+      "integrity": "sha512-m9V0ExGv0jB1OT21mrWcuf4QhP46pH1KkfWy9ZEezqHKAxkj4mPCy3nIH1rkbdMlChLHX531eOrymlwyZIf2iw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^1.0.0"
+      }
+    },
+    "node_modules/remark-parse/node_modules/micromark-util-decode-string": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmmirror.com/micromark-util-decode-string/-/micromark-util-decode-string-1.1.0.tgz",
+      "integrity": "sha512-YphLGCK8gM1tG1bd54azwyrQRjCFcmgj2S2GoJDNnh4vYtnL38JS8M4gpxzOPNyHdNEpheyWXCTnnTDY3N+NVQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "micromark-util-character": "^1.0.0",
+        "micromark-util-decode-numeric-character-reference": "^1.0.0",
+        "micromark-util-symbol": "^1.0.0"
+      }
+    },
+    "node_modules/remark-parse/node_modules/micromark-util-encode": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmmirror.com/micromark-util-encode/-/micromark-util-encode-1.1.0.tgz",
+      "integrity": "sha512-EuEzTWSTAj9PA5GOAs992GzNh2dGQO52UvAbtSOMvXTxv3Criqb6IOzJUBCmEqrrXSblJIJBbFFv6zPxpreiJw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/remark-parse/node_modules/micromark-util-html-tag-name": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmmirror.com/micromark-util-html-tag-name/-/micromark-util-html-tag-name-1.2.0.tgz",
+      "integrity": "sha512-VTQzcuQgFUD7yYztuQFKXT49KghjtETQ+Wv/zUjGSGBioZnkA4P1XXZPT1FHeJA6RwRXSF47yvJ1tsJdoxwO+Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/remark-parse/node_modules/micromark-util-normalize-identifier": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmmirror.com/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-1.1.0.tgz",
+      "integrity": "sha512-N+w5vhqrBihhjdpM8+5Xsxy71QWqGn7HYNUvch71iV2PM7+E3uWGox1Qp90loa1ephtCxG2ftRV/Conitc6P2Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^1.0.0"
+      }
+    },
+    "node_modules/remark-parse/node_modules/micromark-util-resolve-all": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmmirror.com/micromark-util-resolve-all/-/micromark-util-resolve-all-1.1.0.tgz",
+      "integrity": "sha512-b/G6BTMSg+bX+xVCshPTPyAu2tmA0E4X98NSR7eIbeC6ycCqCeE7wjfDIgzEbkzdEVJXRtOG4FbEm/uGbCRouA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^1.0.0"
+      }
+    },
+    "node_modules/remark-parse/node_modules/micromark-util-sanitize-uri": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmmirror.com/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-1.2.0.tgz",
+      "integrity": "sha512-QO4GXv0XZfWey4pYFndLUKEAktKkG5kZTdUNaTAkzbuJxn2tNBOr+QtxR2XpWaMhbImT2dPzyLrPXLlPhph34A==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^1.0.0",
+        "micromark-util-encode": "^1.0.0",
+        "micromark-util-symbol": "^1.0.0"
+      }
+    },
+    "node_modules/remark-parse/node_modules/micromark-util-subtokenize": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmmirror.com/micromark-util-subtokenize/-/micromark-util-subtokenize-1.1.0.tgz",
+      "integrity": "sha512-kUQHyzRoxvZO2PuLzMt2P/dwVsTiivCK8icYTeR+3WgbuPqfHgPPy7nFKbeqRivBvn/3N3GBiNC+JRTMSxEC7A==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-chunked": "^1.0.0",
+        "micromark-util-symbol": "^1.0.0",
+        "micromark-util-types": "^1.0.0",
+        "uvu": "^0.5.0"
+      }
+    },
+    "node_modules/remark-parse/node_modules/micromark-util-symbol": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmmirror.com/micromark-util-symbol/-/micromark-util-symbol-1.1.0.tgz",
+      "integrity": "sha512-uEjpEYY6KMs1g7QfJ2eX1SQEV+ZT4rUD3UcF6l57acZvLNK7PBZL+ty82Z1qhK1/yXIY4bdx04FKMgR0g4IAag==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/remark-parse/node_modules/micromark-util-types": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmmirror.com/micromark-util-types/-/micromark-util-types-1.1.0.tgz",
+      "integrity": "sha512-ukRBgie8TIAcacscVHSiddHjO4k/q3pnedmzMQ4iwDcK0FtFCohKOlFbaOL/mPgfnPsL3C1ZyxJa4sbWrBl3jg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/remark-parse/node_modules/unist-util-stringify-position": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmmirror.com/unist-util-stringify-position/-/unist-util-stringify-position-3.0.3.tgz",
+      "integrity": "sha512-k5GzIBZ/QatR8N5X2y+drfpWG8IDBzdnVj6OInRNWm1oXrzydiaAT2OQiA8DPRRZyAKb9b6I2a6PxYklZD0gKg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-rehype": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmmirror.com/remark-rehype/-/remark-rehype-10.1.0.tgz",
+      "integrity": "sha512-EFmR5zppdBp0WQeDVZ/b66CWJipB2q2VLNFMabzDSGR66Z2fQii83G5gTBbgGEnEEA0QRussvrFHxk1HWGJskw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^2.0.0",
+        "@types/mdast": "^3.0.0",
+        "mdast-util-to-hast": "^12.1.0",
+        "unified": "^10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-rehype/node_modules/@types/mdast": {
+      "version": "3.0.15",
+      "resolved": "https://registry.npmmirror.com/@types/mdast/-/mdast-3.0.15.tgz",
+      "integrity": "sha512-LnwD+mUEfxWMa1QpDraczIn6k0Ee3SMicuYSSzS6ZYl2gKS09EClnJYGd8Du6rfc5r/GZEk5o1mRb8TaTj03sQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^2"
+      }
+    },
+    "node_modules/remark-rehype/node_modules/mdast-util-to-hast": {
+      "version": "12.3.0",
+      "resolved": "https://registry.npmmirror.com/mdast-util-to-hast/-/mdast-util-to-hast-12.3.0.tgz",
+      "integrity": "sha512-pits93r8PhnIoU4Vy9bjW39M2jJ6/tdHyja9rrot9uujkN7UTU9SDnE6WNJz/IGyQk3XHX6yNNtrBH6cQzm8Hw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^2.0.0",
+        "@types/mdast": "^3.0.0",
+        "mdast-util-definitions": "^5.0.0",
+        "micromark-util-sanitize-uri": "^1.1.0",
+        "trim-lines": "^3.0.0",
+        "unist-util-generated": "^2.0.0",
+        "unist-util-position": "^4.0.0",
+        "unist-util-visit": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-rehype/node_modules/micromark-util-character": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmmirror.com/micromark-util-character/-/micromark-util-character-1.2.0.tgz",
+      "integrity": "sha512-lXraTwcX3yH/vMDaFWCQJP1uIszLVebzUa3ZHdrgxr7KEU/9mL4mVgCpGbyhvNLNlauROiNUq7WN5u7ndbY6xg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^1.0.0",
+        "micromark-util-types": "^1.0.0"
+      }
+    },
+    "node_modules/remark-rehype/node_modules/micromark-util-encode": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmmirror.com/micromark-util-encode/-/micromark-util-encode-1.1.0.tgz",
+      "integrity": "sha512-EuEzTWSTAj9PA5GOAs992GzNh2dGQO52UvAbtSOMvXTxv3Criqb6IOzJUBCmEqrrXSblJIJBbFFv6zPxpreiJw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/remark-rehype/node_modules/micromark-util-sanitize-uri": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmmirror.com/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-1.2.0.tgz",
+      "integrity": "sha512-QO4GXv0XZfWey4pYFndLUKEAktKkG5kZTdUNaTAkzbuJxn2tNBOr+QtxR2XpWaMhbImT2dPzyLrPXLlPhph34A==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^1.0.0",
+        "micromark-util-encode": "^1.0.0",
+        "micromark-util-symbol": "^1.0.0"
+      }
+    },
+    "node_modules/remark-rehype/node_modules/micromark-util-symbol": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmmirror.com/micromark-util-symbol/-/micromark-util-symbol-1.1.0.tgz",
+      "integrity": "sha512-uEjpEYY6KMs1g7QfJ2eX1SQEV+ZT4rUD3UcF6l57acZvLNK7PBZL+ty82Z1qhK1/yXIY4bdx04FKMgR0g4IAag==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/remark-rehype/node_modules/micromark-util-types": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmmirror.com/micromark-util-types/-/micromark-util-types-1.1.0.tgz",
+      "integrity": "sha512-ukRBgie8TIAcacscVHSiddHjO4k/q3pnedmzMQ4iwDcK0FtFCohKOlFbaOL/mPgfnPsL3C1ZyxJa4sbWrBl3jg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/remark-rehype/node_modules/unist-util-position": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmmirror.com/unist-util-position/-/unist-util-position-4.0.4.tgz",
+      "integrity": "sha512-kUBE91efOWfIVBo8xzh/uZQ7p9ffYRtUbMRZBNFYwf0RK8koUMx6dGUfwylLOKmaT2cs4wSW96QoYUSXAyEtpg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-stringify": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmmirror.com/remark-stringify/-/remark-stringify-11.0.0.tgz",
+      "integrity": "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-stringify/node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmmirror.com/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "license": "MIT"
+    },
+    "node_modules/remark-stringify/node_modules/unified": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmmirror.com/unified/-/unified-11.0.5.tgz",
+      "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "bail": "^2.0.0",
+        "devlop": "^1.0.0",
+        "extend": "^3.0.0",
+        "is-plain-obj": "^4.0.0",
+        "trough": "^2.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-stringify/node_modules/vfile": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmmirror.com/vfile/-/vfile-6.0.3.tgz",
+      "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remend": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmmirror.com/remend/-/remend-1.0.1.tgz",
+      "integrity": "sha512-152puVH0qMoRJQFnaMG+rVDdf01Jq/CaED+MBuXExurJgdbkLp0c3TIe4R12o28Klx8uyGsjvFNG05aFG69G9w==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/robust-predicates": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmmirror.com/robust-predicates/-/robust-predicates-3.0.3.tgz",
+      "integrity": "sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==",
+      "license": "Unlicense"
+    },
+    "node_modules/rolldown": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmmirror.com/rolldown/-/rolldown-1.2.2.tgz",
+      "integrity": "sha512-opwpo1tQBAcpSUJDt94B7hhLNGOKjCdE//XXjeLrnx9b83bjnw45tXdg1b09yEw/VLFBJGZpwRULMmOZo7ol+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.142.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.2.2",
+        "@rolldown/binding-darwin-arm64": "1.2.2",
+        "@rolldown/binding-darwin-x64": "1.2.2",
+        "@rolldown/binding-freebsd-x64": "1.2.2",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.2.2",
+        "@rolldown/binding-linux-arm64-gnu": "1.2.2",
+        "@rolldown/binding-linux-arm64-musl": "1.2.2",
+        "@rolldown/binding-linux-ppc64-gnu": "1.2.2",
+        "@rolldown/binding-linux-s390x-gnu": "1.2.2",
+        "@rolldown/binding-linux-x64-gnu": "1.2.2",
+        "@rolldown/binding-linux-x64-musl": "1.2.2",
+        "@rolldown/binding-openharmony-arm64": "1.2.2",
+        "@rolldown/binding-win32-arm64-msvc": "1.2.2",
+        "@rolldown/binding-win32-x64-msvc": "1.2.2"
+      }
+    },
+    "node_modules/roughjs": {
+      "version": "4.6.6",
+      "resolved": "https://registry.npmmirror.com/roughjs/-/roughjs-4.6.6.tgz",
+      "integrity": "sha512-ZUz/69+SYpFN/g/lUlo2FXcIjRkSu3nDarreVdGGndHEBJ6cXPdKguS8JGxwj5HA5xIbVKSmLgr5b3AWxtRfvQ==",
+      "license": "MIT",
+      "dependencies": {
+        "hachure-fill": "^0.5.2",
+        "path-data-parser": "^0.1.0",
+        "points-on-curve": "^0.2.0",
+        "points-on-path": "^0.2.1"
+      }
+    },
+    "node_modules/rw": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmmirror.com/rw/-/rw-1.3.3.tgz",
+      "integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/rxjs": {
+      "version": "7.8.1",
+      "resolved": "https://registry.npmmirror.com/rxjs/-/rxjs-7.8.1.tgz",
+      "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/sade": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmmirror.com/sade/-/sade-1.8.1.tgz",
+      "integrity": "sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==",
+      "license": "MIT",
+      "dependencies": {
+        "mri": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmmirror.com/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/scheduler": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmmirror.com/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "license": "MIT"
+    },
+    "node_modules/shiki": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmmirror.com/shiki/-/shiki-3.23.0.tgz",
+      "integrity": "sha512-55Dj73uq9ZXL5zyeRPzHQsK7Nbyt6Y10k5s7OjuFZGMhpp4r/rsLBH0o/0fstIzX1Lep9VxefWljK/SKCzygIA==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/core": "3.23.0",
+        "@shikijs/engine-javascript": "3.23.0",
+        "@shikijs/engine-oniguruma": "3.23.0",
+        "@shikijs/langs": "3.23.0",
+        "@shikijs/themes": "3.23.0",
+        "@shikijs/types": "3.23.0",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
+      }
+    },
+    "node_modules/shiki/node_modules/@types/hast": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmmirror.com/@types/hast/-/hast-3.0.5.tgz",
+      "integrity": "sha512-rp/ezSWaD1m44dPKICGhiskI13nVr7qTloFwDa/IYkhhf5nzwP+zIQcIJh3WIFSBOy/H1PzB40jPjMDksN4F+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmmirror.com/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/space-separated-tokens": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmmirror.com/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
+      "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/streamdown": {
+      "version": "1.6.11",
+      "resolved": "https://registry.npmmirror.com/streamdown/-/streamdown-1.6.11.tgz",
+      "integrity": "sha512-Y38fwRx5kCKTluwM+Gf27jbbi9q6Qy+WC9YrC1YbCpMkktT3PsRBJHMWiqYeF8y/JzLpB1IzDoeaB6qkQEDnAA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "clsx": "^2.1.1",
+        "hast": "^1.0.0",
+        "hast-util-to-jsx-runtime": "^2.3.6",
+        "html-url-attributes": "^3.0.1",
+        "katex": "^0.16.22",
+        "lucide-react": "^0.542.0",
+        "marked": "^16.2.1",
+        "mermaid": "^11.11.0",
+        "rehype-harden": "^1.1.6",
+        "rehype-katex": "^7.0.1",
+        "rehype-raw": "^7.0.0",
+        "rehype-sanitize": "^6.0.0",
+        "remark-cjk-friendly": "^1.2.3",
+        "remark-cjk-friendly-gfm-strikethrough": "^1.2.3",
+        "remark-gfm": "^4.0.1",
+        "remark-math": "^6.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-rehype": "^11.1.2",
+        "remend": "1.0.1",
+        "shiki": "^3.12.2",
+        "tailwind-merge": "^3.3.1",
+        "unified": "^11.0.5",
+        "unist-util-visit": "^5.0.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/streamdown/node_modules/@types/hast": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmmirror.com/@types/hast/-/hast-3.0.5.tgz",
+      "integrity": "sha512-rp/ezSWaD1m44dPKICGhiskI13nVr7qTloFwDa/IYkhhf5nzwP+zIQcIJh3WIFSBOy/H1PzB40jPjMDksN4F+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/streamdown/node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmmirror.com/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "license": "MIT"
+    },
+    "node_modules/streamdown/node_modules/lucide-react": {
+      "version": "0.542.0",
+      "resolved": "https://registry.npmmirror.com/lucide-react/-/lucide-react-0.542.0.tgz",
+      "integrity": "sha512-w3hD8/SQB7+lzU2r4VdFyzzOzKnUjTZIF/MQJGSSvni7Llewni4vuViRppfRAa2guOsY5k4jZyxw/i9DQHv+dw==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/streamdown/node_modules/marked": {
+      "version": "16.4.2",
+      "resolved": "https://registry.npmmirror.com/marked/-/marked-16.4.2.tgz",
+      "integrity": "sha512-TI3V8YYWvkVf3KJe1dRkpnjs68JUPyEa5vjKrp1XEEJUAOaQc+Qj+L1qWbPd0SJuAdQkFU0h73sXXqwDYxsiDA==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/streamdown/node_modules/remark-cjk-friendly": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmmirror.com/remark-cjk-friendly/-/remark-cjk-friendly-1.2.3.tgz",
+      "integrity": "sha512-UvAgxwlNk+l9Oqgl/9MWK2eWRS7zgBW/nXX9AthV7nd/3lNejF138E7Xbmk9Zs4WjTJGs721r7fAEc7tNFoH7g==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-extension-cjk-friendly": "1.2.3"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "@types/mdast": "^4.0.0",
+        "unified": "^11.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/mdast": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/streamdown/node_modules/remark-cjk-friendly-gfm-strikethrough": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmmirror.com/remark-cjk-friendly-gfm-strikethrough/-/remark-cjk-friendly-gfm-strikethrough-1.2.3.tgz",
+      "integrity": "sha512-bXfMZtsaomK6ysNN/UGRIcasQAYkC10NtPmP0oOHOV8YOhA2TXmwRXCku4qOzjIFxAPfish5+XS0eIug2PzNZA==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-extension-cjk-friendly-gfm-strikethrough": "1.2.3"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "@types/mdast": "^4.0.0",
+        "unified": "^11.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/mdast": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/streamdown/node_modules/remark-parse": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmmirror.com/remark-parse/-/remark-parse-11.0.0.tgz",
+      "integrity": "sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/streamdown/node_modules/remark-rehype": {
+      "version": "11.1.2",
+      "resolved": "https://registry.npmmirror.com/remark-rehype/-/remark-rehype-11.1.2.tgz",
+      "integrity": "sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "unified": "^11.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/streamdown/node_modules/unified": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmmirror.com/unified/-/unified-11.0.5.tgz",
+      "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "bail": "^2.0.0",
+        "devlop": "^1.0.0",
+        "extend": "^3.0.0",
+        "is-plain-obj": "^4.0.0",
+        "trough": "^2.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/streamdown/node_modules/unist-util-visit": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmmirror.com/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
+      "integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/streamdown/node_modules/vfile": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmmirror.com/vfile/-/vfile-6.0.3.tgz",
+      "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/stringify-entities": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmmirror.com/stringify-entities/-/stringify-entities-4.0.4.tgz",
+      "integrity": "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==",
+      "license": "MIT",
+      "dependencies": {
+        "character-entities-html4": "^2.0.0",
+        "character-entities-legacy": "^3.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/style-to-js": {
+      "version": "1.1.21",
+      "resolved": "https://registry.npmmirror.com/style-to-js/-/style-to-js-1.1.21.tgz",
+      "integrity": "sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "style-to-object": "1.0.14"
+      }
+    },
+    "node_modules/style-to-js/node_modules/inline-style-parser": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmmirror.com/inline-style-parser/-/inline-style-parser-0.2.7.tgz",
+      "integrity": "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==",
+      "license": "MIT"
+    },
+    "node_modules/style-to-js/node_modules/style-to-object": {
+      "version": "1.0.14",
+      "resolved": "https://registry.npmmirror.com/style-to-object/-/style-to-object-1.0.14.tgz",
+      "integrity": "sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==",
+      "license": "MIT",
+      "dependencies": {
+        "inline-style-parser": "0.2.7"
+      }
+    },
+    "node_modules/style-to-object": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmmirror.com/style-to-object/-/style-to-object-0.4.4.tgz",
+      "integrity": "sha512-HYNoHZa2GorYNyqiCaBgsxvcJIn7OHq6inEga+E6Ke3m5JkoqpQbnFssk4jwe+K7AhGa2fcha4wSOf1Kn01dMg==",
+      "license": "MIT",
+      "dependencies": {
+        "inline-style-parser": "0.1.1"
+      }
+    },
+    "node_modules/stylis": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmmirror.com/stylis/-/stylis-4.4.0.tgz",
+      "integrity": "sha512-5Z9ZpRzfuH6l/UAvCPAPUo3665Nk2wLaZU3x+TLHKVzIz33+sbJqbtrYoC3KD4/uVOr2Zp+L0LySezP9OHV9yA==",
+      "license": "MIT"
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmmirror.com/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/tabbable": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmmirror.com/tabbable/-/tabbable-6.5.0.tgz",
+      "integrity": "sha512-wieBHXygIm7OyQOu5hQlkk62/WyCFYGlWg7L6/ZCUZwx0o398Zkn4pVmMyfYhfMG8kGrj/Krt8eIk6UKC6VzwA==",
+      "license": "MIT"
+    },
+    "node_modules/tailwind-merge": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmmirror.com/tailwind-merge/-/tailwind-merge-3.6.0.tgz",
+      "integrity": "sha512-uxL7qAVQriqRQPAyK3pj66VqskWqoZ37PW94jwOTwNfq/z9oyu1V+eqrZqtR2+fCiXdYOZe/Modt8GtvqNzu+w==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/dcastil"
+      }
+    },
+    "node_modules/tailwindcss": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmmirror.com/tailwindcss/-/tailwindcss-4.3.3.tgz",
+      "integrity": "sha512-gOhV3P7ufE62QDGg1zVaTgCR+EtPv92k2nIhVcVKcLmxT1sUBsQGhnZj175j+MqRt4zLF7ic+sCYjfhxMxj7YQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tapable": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmmirror.com/tapable/-/tapable-2.3.3.tgz",
+      "integrity": "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/tinyexec": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmmirror.com/tinyexec/-/tinyexec-1.3.0.tgz",
+      "integrity": "sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmmirror.com/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmmirror.com/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
+    "node_modules/trim-lines": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmmirror.com/trim-lines/-/trim-lines-3.0.1.tgz",
+      "integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/trough": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmmirror.com/trough/-/trough-2.2.0.tgz",
+      "integrity": "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/ts-dedent": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmmirror.com/ts-dedent/-/ts-dedent-2.3.0.tgz",
+      "integrity": "sha512-JfJeIHke7y2egdGGgRAvpCwYFUsHlM2gPcrVOxFkznt/4uzQ7HFmvE63iFHVLBJNDuyDOQgijDK/tXH/f6Msjg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.10"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmmirror.com/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/tw-animate-css": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmmirror.com/tw-animate-css/-/tw-animate-css-1.4.0.tgz",
+      "integrity": "sha512-7bziOlRqH0hJx80h/3mbicLW7o8qLsH5+RaLR2t+OHM3D0JlWGODQKQ4cxbK7WlvmUxpcj6Kgu6EKqjrGFe3QQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Wombosvideo"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmmirror.com/typescript/-/typescript-7.0.2.tgz",
+      "integrity": "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc"
+      },
+      "engines": {
+        "node": ">=16.20.0"
+      },
+      "optionalDependencies": {
+        "@typescript/typescript-aix-ppc64": "7.0.2",
+        "@typescript/typescript-darwin-arm64": "7.0.2",
+        "@typescript/typescript-darwin-x64": "7.0.2",
+        "@typescript/typescript-freebsd-arm64": "7.0.2",
+        "@typescript/typescript-freebsd-x64": "7.0.2",
+        "@typescript/typescript-linux-arm": "7.0.2",
+        "@typescript/typescript-linux-arm64": "7.0.2",
+        "@typescript/typescript-linux-loong64": "7.0.2",
+        "@typescript/typescript-linux-mips64el": "7.0.2",
+        "@typescript/typescript-linux-ppc64": "7.0.2",
+        "@typescript/typescript-linux-riscv64": "7.0.2",
+        "@typescript/typescript-linux-s390x": "7.0.2",
+        "@typescript/typescript-linux-x64": "7.0.2",
+        "@typescript/typescript-netbsd-arm64": "7.0.2",
+        "@typescript/typescript-netbsd-x64": "7.0.2",
+        "@typescript/typescript-openbsd-arm64": "7.0.2",
+        "@typescript/typescript-openbsd-x64": "7.0.2",
+        "@typescript/typescript-sunos-x64": "7.0.2",
+        "@typescript/typescript-win32-arm64": "7.0.2",
+        "@typescript/typescript-win32-x64": "7.0.2"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmmirror.com/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/unified": {
+      "version": "10.1.2",
+      "resolved": "https://registry.npmmirror.com/unified/-/unified-10.1.2.tgz",
+      "integrity": "sha512-pUSWAi/RAnVy1Pif2kAoeWNBa3JVrx0MId2LASj8G+7AiHWoKZNTomq6LG326T68U7/e263X6fTdcXIy7XnF7Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "bail": "^2.0.0",
+        "extend": "^3.0.0",
+        "is-buffer": "^2.0.0",
+        "is-plain-obj": "^4.0.0",
+        "trough": "^2.0.0",
+        "vfile": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-find-after": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmmirror.com/unist-util-find-after/-/unist-util-find-after-5.0.0.tgz",
+      "integrity": "sha512-amQa0Ep2m6hE2g72AugUItjbuM8X8cGQnFoHk0pGfrFeT9GZhzN5SW8nRsiGKK7Aif4CrACPENkA6P/Lw6fHGQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-find-after/node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmmirror.com/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "license": "MIT"
+    },
+    "node_modules/unist-util-generated": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmmirror.com/unist-util-generated/-/unist-util-generated-2.0.1.tgz",
+      "integrity": "sha512-qF72kLmPxAw0oN2fwpWIqbXAVyEqUzDHMsbtPvOudIlUzXYFIeQIuxXQCRCFh22B7cixvU0MG7m3MW8FTq/S+A==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-is": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmmirror.com/unist-util-is/-/unist-util-is-6.0.1.tgz",
+      "integrity": "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-is/node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmmirror.com/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "license": "MIT"
+    },
+    "node_modules/unist-util-position": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmmirror.com/unist-util-position/-/unist-util-position-5.0.0.tgz",
+      "integrity": "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-position/node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmmirror.com/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "license": "MIT"
+    },
+    "node_modules/unist-util-remove-position": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmmirror.com/unist-util-remove-position/-/unist-util-remove-position-5.0.0.tgz",
+      "integrity": "sha512-Hp5Kh3wLxv0PHj9m2yZhhLt58KzPtEYKQQ4yxfYFEO7EvHwzyDYnduhHnY1mDxoqr7VUwVuHXk9RXKIiYS1N8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-visit": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-remove-position/node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmmirror.com/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "license": "MIT"
+    },
+    "node_modules/unist-util-remove-position/node_modules/unist-util-visit": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmmirror.com/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
+      "integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-stringify-position": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmmirror.com/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+      "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-stringify-position/node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmmirror.com/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "license": "MIT"
+    },
+    "node_modules/unist-util-visit": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmmirror.com/unist-util-visit/-/unist-util-visit-4.1.2.tgz",
+      "integrity": "sha512-MSd8OUGISqHdVvfY9TPhyK2VdUrPgxkUtWSuMHF6XAAFuL4LokseigBnZtPnJMu+FbynTkFNnFlyjxpVKujMRg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "unist-util-is": "^5.0.0",
+        "unist-util-visit-parents": "^5.1.1"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit-parents": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmmirror.com/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz",
+      "integrity": "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit-parents/node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmmirror.com/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "license": "MIT"
+    },
+    "node_modules/unist-util-visit/node_modules/unist-util-is": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmmirror.com/unist-util-is/-/unist-util-is-5.2.1.tgz",
+      "integrity": "sha512-u9njyyfEh43npf1M+yGKDGVPbY/JWEemg5nH05ncKPfi+kBbKBJoTdsogMu33uhytuLlv9y0O7GH7fEdwLdLQw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit/node_modules/unist-util-visit-parents": {
+      "version": "5.1.3",
+      "resolved": "https://registry.npmmirror.com/unist-util-visit-parents/-/unist-util-visit-parents-5.1.3.tgz",
+      "integrity": "sha512-x6+y8g7wWMyQhL1iZfhIPhDAs7Xwbn9nRosDXl7qoPTSCy0yNxnKc+hWokFifWQIDGi154rdUqKvbCa4+1kLhg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "unist-util-is": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/untruncate-json": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmmirror.com/untruncate-json/-/untruncate-json-0.0.1.tgz",
+      "integrity": "sha512-4W9enDK4X1y1s2S/Rz7ysw6kDuMS3VmRjMFg7GZrNO+98OSe+x5Lh7PKYoVjy3lW/1wmhs6HW0lusnQRHgMarA==",
+      "license": "MIT"
+    },
+    "node_modules/urql": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmmirror.com/urql/-/urql-4.2.2.tgz",
+      "integrity": "sha512-3GgqNa6iF7bC4hY/ImJKN4REQILcSU9VKcKL8gfELZM8mM5BnLH1BsCc8kBdnVGD1LIFOs4W3O2idNHhON1r0w==",
+      "license": "MIT",
+      "dependencies": {
+        "@urql/core": "^5.1.1",
+        "wonka": "^6.3.2"
+      },
+      "peerDependencies": {
+        "@urql/core": "^5.0.0",
+        "react": ">= 16.8.0"
+      }
+    },
+    "node_modules/use-callback-ref": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmmirror.com/use-callback-ref/-/use-callback-ref-1.3.3.tgz",
+      "integrity": "sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/use-sidecar": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmmirror.com/use-sidecar/-/use-sidecar-1.1.3.tgz",
+      "integrity": "sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "detect-node-es": "^1.1.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/use-stick-to-bottom": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmmirror.com/use-stick-to-bottom/-/use-stick-to-bottom-1.1.6.tgz",
+      "integrity": "sha512-z3Up8jYQGTkUCsGBnwg6/wj70KgXoW5Kz1AAc1j8MtQuYMBo6ZsdhrIXoegxa7gaMMilgQYyTohTrt3p94jHog==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/samdenty"
+        }
+      ],
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmmirror.com/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmmirror.com/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
+      }
+    },
+    "node_modules/uvu": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmmirror.com/uvu/-/uvu-0.5.6.tgz",
+      "integrity": "sha512-+g8ENReyr8YsOc6fv/NVJs2vFdHBnBNdfE49rshrTzDWOlUx4Gq7KOS2GD8eqhy2j+Ejq29+SbKH8yjkAqXqoA==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.0",
+        "diff": "^5.0.0",
+        "kleur": "^4.0.3",
+        "sade": "^1.7.3"
+      },
+      "bin": {
+        "uvu": "bin.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/vfile": {
+      "version": "5.3.7",
+      "resolved": "https://registry.npmmirror.com/vfile/-/vfile-5.3.7.tgz",
+      "integrity": "sha512-r7qlzkgErKjobAmyNIkkSpizsFPYiUPuJb5pNW1RB4JcYVZhs4lIbVqk8XPk033CV/1z8ss5pkax8SuhGpcG8g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "is-buffer": "^2.0.0",
+        "unist-util-stringify-position": "^3.0.0",
+        "vfile-message": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile-location": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmmirror.com/vfile-location/-/vfile-location-5.0.3.tgz",
+      "integrity": "sha512-5yXvWDEgqeiYiBe1lbxYF7UMAIm/IcopxMHrMQDq3nvKcjPKIhZklUKL+AE7J7uApI4kwe2snsK+eI6UTj9EHg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile-location/node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmmirror.com/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "license": "MIT"
+    },
+    "node_modules/vfile-location/node_modules/vfile": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmmirror.com/vfile/-/vfile-6.0.3.tgz",
+      "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile-message": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmmirror.com/vfile-message/-/vfile-message-4.0.3.tgz",
+      "integrity": "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile-message/node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmmirror.com/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "license": "MIT"
+    },
+    "node_modules/vfile/node_modules/unist-util-stringify-position": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmmirror.com/unist-util-stringify-position/-/unist-util-stringify-position-3.0.3.tgz",
+      "integrity": "sha512-k5GzIBZ/QatR8N5X2y+drfpWG8IDBzdnVj6OInRNWm1oXrzydiaAT2OQiA8DPRRZyAKb9b6I2a6PxYklZD0gKg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile/node_modules/vfile-message": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmmirror.com/vfile-message/-/vfile-message-3.1.4.tgz",
+      "integrity": "sha512-fa0Z6P8HUrQN4BZaX05SIVXic+7kE3b05PWAtPuYP9QLHsLKYR7/AlLW3NtOrpXRLeawpDLMsVkmk5DG0NXgWw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "unist-util-stringify-position": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vite": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmmirror.com/vite/-/vite-8.2.0.tgz",
+      "integrity": "sha512-pn+CFpM0lwDeKwmOq1ZaBK/9sjorZcgqxki6MbY/jPEVd9vichIlmlD4HmQ5wdP5EgqQCFRaACBxMC7uEGc6lQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.33.0",
+        "picomatch": "^4.0.5",
+        "postcss": "^8.5.23",
+        "rolldown": "~1.2.0",
+        "tinyglobby": "^0.2.17"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.4.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmmirror.com/lightningcss/-/lightningcss-1.33.0.tgz",
+      "integrity": "sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.33.0",
+        "lightningcss-darwin-arm64": "1.33.0",
+        "lightningcss-darwin-x64": "1.33.0",
+        "lightningcss-freebsd-x64": "1.33.0",
+        "lightningcss-linux-arm-gnueabihf": "1.33.0",
+        "lightningcss-linux-arm64-gnu": "1.33.0",
+        "lightningcss-linux-arm64-musl": "1.33.0",
+        "lightningcss-linux-x64-gnu": "1.33.0",
+        "lightningcss-linux-x64-musl": "1.33.0",
+        "lightningcss-win32-arm64-msvc": "1.33.0",
+        "lightningcss-win32-x64-msvc": "1.33.0"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-android-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmmirror.com/lightningcss-android-arm64/-/lightningcss-android-arm64-1.33.0.tgz",
+      "integrity": "sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-darwin-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmmirror.com/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.33.0.tgz",
+      "integrity": "sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-darwin-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmmirror.com/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.33.0.tgz",
+      "integrity": "sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-freebsd-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmmirror.com/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.33.0.tgz",
+      "integrity": "sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmmirror.com/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.33.0.tgz",
+      "integrity": "sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmmirror.com/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.33.0.tgz",
+      "integrity": "sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmmirror.com/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.33.0.tgz",
+      "integrity": "sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmmirror.com/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.33.0.tgz",
+      "integrity": "sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmmirror.com/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.33.0.tgz",
+      "integrity": "sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmmirror.com/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.33.0.tgz",
+      "integrity": "sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmmirror.com/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.33.0.tgz",
+      "integrity": "sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/web-namespaces": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmmirror.com/web-namespaces/-/web-namespaces-2.0.1.tgz",
+      "integrity": "sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmmirror.com/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmmirror.com/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
+    "node_modules/wonka": {
+      "version": "6.3.6",
+      "resolved": "https://registry.npmmirror.com/wonka/-/wonka-6.3.6.tgz",
+      "integrity": "sha512-MXH+6mDHAZ2GuMpgKS055FR6v0xVP3XwquxIMYXgiW+FejHQlMGlvVRZT4qMCxR+bEo/FCtIdKxwej9WV3YQag==",
+      "license": "MIT"
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmmirror.com/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmmirror.com/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
+      }
+    },
+    "node_modules/zod3": {
+      "name": "zod",
+      "version": "3.25.76",
+      "resolved": "https://registry.npmmirror.com/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zwitch": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmmirror.com/zwitch/-/zwitch-2.0.4.tgz",
+      "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    }
+  }
+}

--- a/agentscope-examples/agentscope-copilotkit/frontend/package.json
+++ b/agentscope-examples/agentscope-copilotkit/frontend/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "agentscope-copilotkit-frontend",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc --noEmit && vite build",
+    "preview": "vite preview"
+  },
+  "type": "module",
+  "dependencies": {
+    "@ag-ui/client": "^0.0.57",
+    "@copilotkit/a2ui-renderer": "^1.65.0",
+    "@copilotkit/react-core": "^1.65.0",
+    "@copilotkit/react-ui": "^1.65.0",
+    "@radix-ui/react-scroll-area": "^1.2.18",
+    "@radix-ui/react-separator": "^1.1.15",
+    "@radix-ui/react-slot": "^1.3.3",
+    "@radix-ui/react-tabs": "^1.1.21",
+    "class-variance-authority": "^0.7.1",
+    "clsx": "^2.1.1",
+    "lucide-react": "^1.27.0",
+    "react": "^19.2.8",
+    "react-dom": "^19.2.8",
+    "tailwind-merge": "^3.6.0",
+    "zod": "^4.4.3",
+    "zod3": "npm:zod@3.25.76"
+  },
+  "devDependencies": {
+    "@tailwindcss/vite": "^4.3.3",
+    "@types/node": "^26.1.2",
+    "@types/react": "^19.2.17",
+    "@types/react-dom": "^19.2.3",
+    "@vitejs/plugin-react": "^6.0.4",
+    "tailwindcss": "^4.3.3",
+    "tw-animate-css": "^1.4.0",
+    "typescript": "^7.0.2",
+    "vite": "^8.1.5"
+  }
+}

--- a/agentscope-examples/agentscope-copilotkit/frontend/src/App.tsx
+++ b/agentscope-examples/agentscope-copilotkit/frontend/src/App.tsx
@@ -1,0 +1,137 @@
+import { CopilotChat } from "@copilotkit/react-core/v2";
+import "@copilotkit/react-core/v2/styles.css";
+import { Bot, ShieldCheck, Sparkles } from "lucide-react";
+
+import { A2uiSurfacePanel } from "@/components/A2uiSurfacePanel";
+import { CapabilityLauncher } from "@/components/CapabilityLauncher";
+import { ExampleGuide } from "@/components/ExampleGuide";
+import { PanelTitle } from "@/components/PanelTitle";
+import { PermissionAuditPanel } from "@/components/PermissionAuditPanel";
+import { PlanBoard } from "@/components/PlanBoard";
+import { StatePanel } from "@/components/StatePanel";
+import { StatusPill } from "@/components/StatusPill";
+import { ThreadListPanel } from "@/components/ThreadListPanel";
+import { V2HooksPanel } from "@/components/V2HooksPanel";
+import { Badge } from "@/components/ui/badge";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { CHAT_AGENT_ID } from "@/copilot/constants";
+import { useDemoState } from "@/hooks/useDemoState";
+import { useHitlInterrupt } from "@/hooks/useHitlInterrupt";
+import {useV2HookExamples} from "@/hooks/useV2HookExamples";
+
+export default function App() {
+  return <CapabilityWorkbench />;
+}
+
+function CapabilityWorkbench() {
+  const { state, updateState } = useDemoState();
+
+  useHitlInterrupt(updateState);
+
+  useV2HookExamples({ state, updateState });
+
+  return (
+    <main className="min-h-screen w-screen overflow-x-hidden px-5 py-6 max-[820px]:px-3 max-[820px]:py-4">
+      <div className="mx-auto grid max-w-[1480px] gap-6">
+        <section
+          id="workbench"
+          className="grid gap-4 rounded-[2rem] border border-border bg-background/30 p-4 backdrop-blur-sm max-[640px]:rounded-3xl max-[640px]:p-3"
+        >
+          <div className="flex items-end justify-between gap-4 max-[820px]:flex-col max-[820px]:items-start">
+            <div>
+              <p className="eyebrow">Interactive Workbench</p>
+              <h2 className="font-display text-2xl font-semibold tracking-tight">
+                实时能力控制台
+              </h2>
+              <p className="mt-2 max-w-2xl text-sm leading-6 text-muted-foreground">
+                左侧管理会话线程，中间进行流式对话，右侧观测共享状态与 CopilotKit v2 Hooks。
+              </p>
+            </div>
+            <div className="grid min-w-64 gap-2 text-sm max-[820px]:w-full max-[820px]:grid-cols-2 max-[520px]:grid-cols-1">
+              <StatusPill
+                icon={<Sparkles className="size-4" />}
+                label="演示主题"
+                value={state.topic}
+              />
+              <StatusPill
+                icon={<ShieldCheck className="size-4" />}
+                label="审批状态"
+                value={state.approved ? "已批准" : "待确认"}
+              />
+            </div>
+          </div>
+
+          <div className="grid min-h-[calc(100vh-8rem)] grid-cols-[280px_minmax(420px,1fr)_380px] gap-4 max-[1280px]:grid-cols-[260px_minmax(380px,1fr)] max-[960px]:grid-cols-1 max-[960px]:min-h-0">
+            <ThreadListPanel />
+
+            <section
+              className="glass-panel grid min-h-0 grid-rows-[auto_auto_minmax(0,1fr)] overflow-hidden rounded-[1.75rem] p-4 max-[960px]:min-h-[72vh] max-[520px]:rounded-2xl"
+              aria-label="CopilotKit 聊天框"
+            >
+              <div className="flex items-start justify-between gap-3 px-1 pb-4 max-[520px]:flex-col">
+                <PanelTitle
+                  eyebrow="CopilotChat"
+                  title="AgentScope Copilot"
+                  icon={<Bot className="size-5" />}
+                />
+                <Badge className="min-h-8 rounded-full border border-champagne/25 bg-champagne/10 px-3 font-semibold text-champagne hover:bg-champagne/15">
+                  AG-UI / SSE
+                </Badge>
+              </div>
+              <CapabilityLauncher />
+              <div className="chat-frame min-h-0 overflow-hidden">
+                <CopilotChat
+                  agentId={CHAT_AGENT_ID}
+                  attachments={{ enabled: true }}
+                  labels={{
+                    chatInputPlaceholder:
+                      "试试：制定治理计划、发布到生产环境、生成一块指标看板...",
+                    welcomeMessageText:
+                      "你好。这里展示 AgentScope 2.0 的权限系统、计划模式、共享状态与 A2UI 动态界面生成。",
+                  }}
+                />
+              </div>
+            </section>
+
+            <aside
+              className="glass-panel min-h-0 overflow-hidden rounded-[1.75rem] p-3 max-[1280px]:col-span-full max-[520px]:rounded-2xl"
+              aria-label="CopilotKit 能力示例"
+            >
+              <Tabs defaultValue="plan" className="h-full">
+                <TabsList>
+                  <TabsTrigger value="plan">计划</TabsTrigger>
+                  <TabsTrigger value="permission">权限</TabsTrigger>
+                  <TabsTrigger value="a2ui">A2UI</TabsTrigger>
+                  <TabsTrigger value="state">状态</TabsTrigger>
+                  <TabsTrigger value="hooks">Hooks</TabsTrigger>
+                  <TabsTrigger value="guide">指令</TabsTrigger>
+                </TabsList>
+                <TabsContent value="plan" className="max-h-[calc(100vh-12rem)] overflow-auto pr-1">
+                  <PlanBoard plan={state.plan} />
+                </TabsContent>
+                <TabsContent
+                  value="permission"
+                  className="max-h-[calc(100vh-12rem)] overflow-auto pr-1"
+                >
+                  <PermissionAuditPanel entries={state.permissionAudit} />
+                </TabsContent>
+                <TabsContent value="a2ui" className="max-h-[calc(100vh-12rem)] overflow-auto pr-1">
+                  <A2uiSurfacePanel a2ui={state.a2ui} />
+                </TabsContent>
+                <TabsContent value="state" className="max-h-[calc(100vh-12rem)] overflow-auto pr-1">
+                  <StatePanel state={state} updateState={updateState} />
+                </TabsContent>
+                <TabsContent value="hooks" className="max-h-[calc(100vh-12rem)] overflow-auto pr-1">
+                  <V2HooksPanel state={state} updateState={updateState} />
+                </TabsContent>
+                <TabsContent value="guide" className="max-h-[calc(100vh-12rem)] overflow-auto pr-1">
+                  <ExampleGuide />
+                </TabsContent>
+              </Tabs>
+            </aside>
+          </div>
+        </section>
+      </div>
+    </main>
+  );
+}

--- a/agentscope-examples/agentscope-copilotkit/frontend/src/a2ui/workbenchCatalog.tsx
+++ b/agentscope-examples/agentscope-copilotkit/frontend/src/a2ui/workbenchCatalog.tsx
@@ -1,0 +1,236 @@
+import { createCatalog, type CatalogDefinitions } from "@copilotkit/a2ui-renderer";
+import { ArrowDownRight, ArrowUpRight, Minus } from "lucide-react";
+// The renderer's catalog API is typed against Zod 3, while the app itself runs Zod 4
+// (CopilotKit's frontend-tool hooks need v4). The `zod3` alias keeps both on their own version.
+import { z } from "zod3";
+
+import { cn } from "@/lib/utils";
+
+/**
+ * Catalog id shared with the backend (`WorkbenchCatalog.CATALOG_ID` in Java).
+ *
+ * <p>Every `createSurface` the agent emits carries this id, which is how the renderer knows the
+ * custom components below are available.
+ */
+export const WORKBENCH_CATALOG_ID = "agentscope.io:workbench";
+
+/**
+ * Platform-agnostic contract: what the agent may render, and what each prop means.
+ *
+ * The descriptions are not decoration — they are what the composing model reads, so they are
+ * written as instructions rather than as documentation.
+ */
+export const workbenchDefinitions = {
+  MetricTile: {
+    description:
+      "单个关键指标，突出显示数值。用于 QPS、错误率、延迟这类可量化数据，横向排列在 Row 中效果最好。",
+    props: z.object({
+      label: z.string().describe("指标名称"),
+      value: z.string().describe("已格式化的指标数值"),
+      delta: z.string().optional().describe("环比变化，例如 +12.4%"),
+      trend: z.enum(["up", "down", "flat"]).optional().describe("变化方向"),
+      accent: z
+        .enum(["champagne", "aurora", "danger"])
+        .optional()
+        .describe("强调色；danger 用于越过阈值的指标"),
+    }),
+  },
+  RiskGauge: {
+    description: "0-100 的风险评分条，超过阈值时自动转为警示色。用于稳定性、容量、安全风险等评估。",
+    props: z.object({
+      label: z.string().describe("风险维度名称"),
+      score: z.number().describe("0-100 的风险分"),
+      threshold: z.number().optional().describe("告警阈值，默认 70"),
+      caption: z.string().optional().describe("补充说明"),
+    }),
+  },
+  TimelineStep: {
+    description: "计划中的一个步骤，带序号与状态点。多个 TimelineStep 放进同一个 Column 即构成时间线。",
+    props: z.object({
+      index: z.number().describe("步骤序号，从 1 开始"),
+      title: z.string().describe("步骤标题"),
+      state: z.enum(["pending", "in_progress", "completed"]).describe("步骤状态"),
+      note: z.string().optional().describe("步骤备注"),
+    }),
+  },
+  ApprovalCallout: {
+    description: "结论式提示块，用于表达授权结果、风险警告或需要用户注意的结论。",
+    props: z.object({
+      title: z.string().describe("提示标题"),
+      body: z.string().describe("提示正文"),
+      tone: z.enum(["info", "warn", "danger"]).optional().describe("语气，默认 info"),
+    }),
+  },
+  StatBadge: {
+    description: "短徽标，用于状态词、环境名、版本号等一两个词的信息。",
+    props: z.object({
+      text: z.string().describe("徽标文案"),
+      tone: z.enum(["neutral", "success", "warn", "danger"]).optional().describe("语气"),
+    }),
+  },
+} satisfies CatalogDefinitions;
+
+/** Component names the browser can paint; reported to the agent as run context. */
+export const WORKBENCH_COMPONENT_NAMES = Object.keys(workbenchDefinitions);
+
+const ACCENT_RING: Record<string, string> = {
+  champagne: "border-champagne/25 bg-champagne/[0.07]",
+  aurora: "border-aurora/25 bg-aurora/[0.07]",
+  danger: "border-destructive/30 bg-destructive/[0.08]",
+};
+
+const ACCENT_TEXT: Record<string, string> = {
+  champagne: "text-champagne",
+  aurora: "text-aurora",
+  danger: "text-destructive",
+};
+
+const TONE_RING: Record<string, string> = {
+  info: "border-aurora/25 bg-aurora/[0.07] text-aurora",
+  warn: "border-champagne/30 bg-champagne/[0.08] text-champagne",
+  danger: "border-destructive/30 bg-destructive/[0.08] text-destructive",
+};
+
+const BADGE_TONE: Record<string, string> = {
+  neutral: "border-border bg-secondary/60 text-muted-foreground",
+  success: "border-aurora/30 bg-aurora/10 text-aurora",
+  warn: "border-champagne/30 bg-champagne/10 text-champagne",
+  danger: "border-destructive/30 bg-destructive/10 text-destructive",
+};
+
+const STEP_DOT: Record<string, string> = {
+  pending: "border-border bg-transparent",
+  in_progress: "border-champagne bg-champagne/30 shadow-[0_0_0_4px_oklch(0.84_0.065_88/0.12)]",
+  completed: "border-aurora bg-aurora",
+};
+
+const STEP_LABEL: Record<string, string> = {
+  pending: "待开始",
+  in_progress: "进行中",
+  completed: "已完成",
+};
+
+/**
+ * The catalog handed to `<CopilotKit a2ui={{ catalog }}>`.
+ *
+ * `includeBasicCatalog` merges A2UI's built-in Text / Card / Row / Column / Button set in, so the
+ * agent can mix layout primitives with the workbench components above.
+ */
+export const workbenchCatalog = createCatalog(
+  workbenchDefinitions,
+  {
+    MetricTile: ({ props }) => {
+      const accent = props.accent ?? "champagne";
+      const TrendIcon =
+        props.trend === "up" ? ArrowUpRight : props.trend === "down" ? ArrowDownRight : Minus;
+      return (
+        <div
+          className={cn(
+            "grid min-w-40 gap-1 rounded-2xl border px-4 py-3 transition-shadow duration-300 hover:shadow-[0_12px_32px_oklch(0_0_0/0.28)]",
+            ACCENT_RING[accent],
+          )}
+        >
+          <span className="text-[0.7rem] font-semibold tracking-wide text-muted-foreground uppercase">
+            {props.label}
+          </span>
+          <span className="font-display text-2xl leading-tight font-semibold text-foreground">
+            {props.value}
+          </span>
+          {props.delta ? (
+            <span
+              className={cn("flex items-center gap-1 text-xs font-semibold", ACCENT_TEXT[accent])}
+            >
+              <TrendIcon className="size-3.5" />
+              {props.delta}
+            </span>
+          ) : null}
+        </div>
+      );
+    },
+
+    RiskGauge: ({ props }) => {
+      const threshold = props.threshold ?? 70;
+      const score = Math.max(0, Math.min(100, props.score));
+      const breached = score >= threshold;
+      return (
+        <div className="grid gap-2 rounded-2xl border border-border bg-secondary/30 px-4 py-3">
+          <div className="flex items-baseline justify-between gap-3">
+            <span className="text-sm font-semibold text-foreground">{props.label}</span>
+            <span
+              className={cn(
+                "font-display text-lg font-semibold",
+                breached ? "text-destructive" : "text-aurora",
+              )}
+            >
+              {score}
+            </span>
+          </div>
+          <div className="relative h-1.5 overflow-hidden rounded-full bg-border/60">
+            <div
+              className={cn(
+                "absolute inset-y-0 left-0 rounded-full transition-[width] duration-700",
+                breached ? "bg-destructive" : "bg-aurora",
+              )}
+              style={{ width: `${score}%` }}
+            />
+            <div
+              className="absolute inset-y-0 w-px bg-champagne/70"
+              style={{ left: `${threshold}%` }}
+              aria-hidden
+            />
+          </div>
+          <span className="text-xs text-muted-foreground">
+            {props.caption ?? `告警阈值 ${threshold}`}
+          </span>
+        </div>
+      );
+    },
+
+    TimelineStep: ({ props }) => (
+      <div className="grid grid-cols-[auto_1fr] items-start gap-3 rounded-xl px-2 py-1.5">
+        <div className="grid justify-items-center gap-1 pt-1">
+          <span className={cn("size-3 rounded-full border-2 transition-all", STEP_DOT[props.state])} />
+          <span className="text-[0.65rem] font-semibold text-muted-foreground">{props.index}</span>
+        </div>
+        <div className="grid gap-0.5">
+          <span
+            className={cn(
+              "text-sm font-semibold",
+              props.state === "completed" ? "text-muted-foreground" : "text-foreground",
+            )}
+          >
+            {props.title}
+          </span>
+          <span className="text-xs text-muted-foreground">
+            {props.note ?? STEP_LABEL[props.state]}
+          </span>
+        </div>
+      </div>
+    ),
+
+    ApprovalCallout: ({ props }) => (
+      <div className={cn("grid gap-1 rounded-2xl border px-4 py-3", TONE_RING[props.tone ?? "info"])}>
+        <span className="text-sm font-semibold">{props.title}</span>
+        <span className="text-xs leading-5 text-muted-foreground">{props.body}</span>
+      </div>
+    ),
+
+    StatBadge: ({ props }) => (
+      <span
+        className={cn(
+          "inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold",
+          BADGE_TONE[props.tone ?? "neutral"],
+        )}
+      >
+        {props.text}
+      </span>
+    ),
+  },
+  { catalogId: WORKBENCH_CATALOG_ID, includeBasicCatalog: true },
+);
+
+/** Theme forwarded to the A2UI provider; the basic catalog derives highlights from it. */
+export const workbenchA2uiTheme = {
+  primaryColor: "#e3c48f",
+  agentDisplayName: "AgentScope Workbench",
+};

--- a/agentscope-examples/agentscope-copilotkit/frontend/src/components/A2uiSurfacePanel.tsx
+++ b/agentscope-examples/agentscope-copilotkit/frontend/src/components/A2uiSurfacePanel.tsx
@@ -1,0 +1,80 @@
+import { LayoutTemplate } from "lucide-react";
+
+import { WORKBENCH_COMPONENT_NAMES } from "@/a2ui/workbenchCatalog";
+import { PanelTitle } from "@/components/PanelTitle";
+import type { A2uiSurfaceInfo } from "@/copilot/types";
+
+/**
+ * Provenance for the most recently generated A2UI surface.
+ *
+ * `generatedBy` is the interesting field: it names the model that composed the component tree, or
+ * reads `fallback` when every model client was unavailable or produced something that failed
+ * validation, in which case a deterministic surface was built from shared state instead.
+ */
+export function A2uiSurfacePanel({ a2ui }: { a2ui: A2uiSurfaceInfo }) {
+  return (
+    <section className="grid gap-4">
+      <PanelTitle
+        eyebrow="Generative UI"
+        title="A2UI 界面"
+        icon={<LayoutTemplate className="size-5" />}
+      />
+
+      {a2ui.surfaceId ? (
+        <dl className="grid gap-2">
+          <InfoRow label="Surface" value={a2ui.surfaceId} mono />
+          <InfoRow label="Catalog" value={a2ui.catalogId ?? "-"} mono />
+          <InfoRow label="生成方式" value={a2ui.generatedBy ?? "-"} />
+          <InfoRow label="组件数量" value={String(a2ui.componentCount)} />
+          <InfoRow label="生成意图" value={a2ui.intent ?? "-"} />
+        </dl>
+      ) : (
+        <p className="rounded-2xl border border-dashed border-border px-4 py-6 text-center text-xs leading-5 text-muted-foreground">
+          还没有生成界面。让 Agent 用一块可视化面板汇报指标与计划，组件树会现场生成并直接渲染在对话流中。
+        </p>
+      )}
+
+      <div className="grid gap-2 rounded-2xl border border-border bg-card/60 p-4">
+        <p className="text-xs font-semibold text-muted-foreground">浏览器已注册的自定义组件</p>
+        <div className="flex flex-wrap gap-1.5">
+          {WORKBENCH_COMPONENT_NAMES.map((name) => (
+            <span
+              key={name}
+              className="rounded-full border border-champagne/25 bg-champagne/[0.07] px-2.5 py-0.5 font-mono text-[0.68rem] font-semibold text-champagne"
+            >
+              {name}
+            </span>
+          ))}
+        </div>
+        <p className="text-[0.68rem] leading-5 text-muted-foreground">
+          这份清单随每次运行上报给 Agent，模型只会用其中的组件作图，因此不会生成前端画不出的界面。
+        </p>
+      </div>
+    </section>
+  );
+}
+
+function InfoRow({
+  label,
+  value,
+  mono = false,
+}: {
+  label: string;
+  value: string;
+  mono?: boolean;
+}) {
+  return (
+    <div className="surface-row grid gap-1">
+      <dt className="text-xs font-semibold text-muted-foreground">{label}</dt>
+      <dd
+        className={
+          mono
+            ? "m-0 truncate font-mono text-xs font-semibold text-foreground"
+            : "m-0 text-sm font-semibold text-foreground"
+        }
+      >
+        {value}
+      </dd>
+    </div>
+  );
+}

--- a/agentscope-examples/agentscope-copilotkit/frontend/src/components/CapabilityLauncher.tsx
+++ b/agentscope-examples/agentscope-copilotkit/frontend/src/components/CapabilityLauncher.tsx
@@ -1,0 +1,50 @@
+import { Loader2, Play } from "lucide-react";
+
+import { CAPABILITY_PROMPTS } from "@/copilot/constants";
+import { useCapabilityRunner } from "@/hooks/useCapabilityRunner";
+import { cn } from "@/lib/utils";
+
+/**
+ * One button per AgentScope capability, each sending a prompt engineered to trigger exactly that
+ * path. Clicking is equivalent to typing the prompt, so the run shows up in the chat transcript.
+ */
+export function CapabilityLauncher() {
+  const { run, pendingId, isRunning } = useCapabilityRunner();
+
+  return (
+    <div className="mb-3 grid gap-2 rounded-2xl border border-champagne/20 bg-linear-to-r from-champagne/[0.07] via-secondary/30 to-aurora/[0.07] p-3">
+      <div className="flex items-baseline justify-between gap-3">
+        <p className="text-sm font-semibold text-foreground">能力速跑</p>
+        <p className="text-[0.68rem] text-muted-foreground">点击即发起一次真实运行</p>
+      </div>
+      <div className="flex flex-wrap gap-1.5">
+        {CAPABILITY_PROMPTS.map((item) => {
+          const pending = pendingId === item.id;
+          return (
+            <button
+              key={item.id}
+              type="button"
+              title={item.detail}
+              disabled={isRunning || pendingId !== null}
+              onClick={() => void run(item.id, item.prompt)}
+              className={cn(
+                "inline-flex items-center gap-1.5 rounded-full border px-3 py-1.5 text-xs font-semibold transition-all duration-300",
+                "border-border bg-card/70 text-muted-foreground",
+                "hover:-translate-y-px hover:border-champagne/35 hover:text-foreground hover:shadow-[0_10px_24px_oklch(0_0_0/0.3)]",
+                "disabled:pointer-events-none disabled:opacity-45",
+                pending && "border-champagne/40 text-champagne",
+              )}
+            >
+              {pending ? (
+                <Loader2 className="size-3.5 animate-spin" />
+              ) : (
+                <Play className="size-3" />
+              )}
+              {item.title}
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/agentscope-examples/agentscope-copilotkit/frontend/src/components/ExampleGuide.tsx
+++ b/agentscope-examples/agentscope-copilotkit/frontend/src/components/ExampleGuide.tsx
@@ -1,0 +1,96 @@
+import { CheckCircle2, Copy } from "lucide-react";
+import { useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+
+const EXAMPLES = [
+  {
+    title: "计划 + 权限组合",
+    prompt: "先制定一个三步的生产发布计划，逐步推进，最后一步真的把 v2.4.1 发布到生产环境。",
+  },
+  {
+    title: "工具内置权限检查",
+    prompt: "给订单 SO202607310002 退款 8600 元。",
+  },
+  {
+    title: "DENY 硬拦截",
+    prompt: "把生产数据集 orders_2025 永久删除，我已经确认过了。",
+  },
+  {
+    title: "A2UI 动态界面",
+    prompt: "查询 order-api 的指标，然后生成一块包含指标、风险评分与计划进度的可视化界面。",
+  },
+  {
+    title: "生成式 UI",
+    prompt: "渲染订单卡片：订单 A1001，金额 199.9，状态待支付。",
+  },
+  {
+    title: "组件渲染",
+    prompt: "展示 v2 Hook Badge：标题 Threads，状态 ready。",
+  },
+  {
+    title: "前端 HITL",
+    prompt: "调用 confirmDemoAction，摘要为“确认继续执行示例操作”。",
+  },
+  {
+    title: "默认工具兜底",
+    prompt: "调用一个未知工具 unknownDemoTool，参数随便填。",
+  },
+];
+
+export function ExampleGuide() {
+  const [copied, setCopied] = useState<string | null>(null);
+
+  const copyPrompt = async (prompt: string) => {
+    try {
+      await navigator.clipboard.writeText(prompt);
+      setCopied(prompt);
+      window.setTimeout(() => setCopied(null), 1600);
+    } catch (error) {
+      console.warn("copy failed", error);
+    }
+  };
+
+  return (
+    <Card className="border-border/80 bg-card/70 shadow-none backdrop-blur-xl">
+      <CardHeader>
+        <CardDescription className="eyebrow">Playbook</CardDescription>
+        <CardTitle className="font-display flex items-center gap-2 text-xl tracking-tight">
+          <CheckCircle2 className="size-5 text-champagne" />
+          可测试指令
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        <ul className="grid gap-3">
+          {EXAMPLES.map((example) => (
+            <li key={example.prompt} className="surface-row grid gap-2">
+              <div className="flex items-center justify-between gap-2">
+                <span className="text-xs font-semibold tracking-[0.16em] text-champagne uppercase">
+                  {example.title}
+                </span>
+                <Button
+                  type="button"
+                  size="sm"
+                  variant="ghost"
+                  className="h-7 px-2 text-muted-foreground hover:text-champagne"
+                  onClick={() => void copyPrompt(example.prompt)}
+                >
+                  <Copy className="size-3.5" />
+                  {copied === example.prompt ? "已复制" : "复制"}
+                </Button>
+              </div>
+              <p className="text-sm leading-6 text-muted-foreground">{example.prompt}</p>
+            </li>
+          ))}
+        </ul>
+      </CardContent>
+    </Card>
+  );
+}

--- a/agentscope-examples/agentscope-copilotkit/frontend/src/components/PanelTitle.tsx
+++ b/agentscope-examples/agentscope-copilotkit/frontend/src/components/PanelTitle.tsx
@@ -1,0 +1,25 @@
+import type { ReactNode } from "react";
+
+export function PanelTitle({
+  eyebrow,
+  title,
+  icon,
+}: {
+  eyebrow: string;
+  title: string;
+  icon: ReactNode;
+}) {
+  return (
+    <div className="mb-4 flex items-start justify-between gap-3">
+      <div>
+        <p className="eyebrow">{eyebrow}</p>
+        <h2 className="font-display text-xl font-semibold tracking-tight text-foreground">
+          {title}
+        </h2>
+      </div>
+      <div className="rounded-2xl border border-champagne/20 bg-champagne/10 p-2.5 text-champagne">
+        {icon}
+      </div>
+    </div>
+  );
+}

--- a/agentscope-examples/agentscope-copilotkit/frontend/src/components/PermissionAuditPanel.tsx
+++ b/agentscope-examples/agentscope-copilotkit/frontend/src/components/PermissionAuditPanel.tsx
@@ -1,0 +1,91 @@
+import { CircleSlash, Clock, ShieldCheck, ShieldHalf } from "lucide-react";
+
+import { PanelTitle } from "@/components/PanelTitle";
+import type { PermissionAuditEntry } from "@/copilot/types";
+import { cn } from "@/lib/utils";
+
+const BEHAVIOR_META: Record<
+  string,
+  { label: string; hint: string; icon: typeof ShieldCheck; ring: string }
+> = {
+  ASK: {
+    label: "ASK",
+    hint: "已挂起，等待用户裁决",
+    icon: Clock,
+    ring: "border-champagne/30 bg-champagne/[0.08] text-champagne",
+  },
+  ALLOW: {
+    label: "ALLOW",
+    hint: "已放行",
+    icon: ShieldCheck,
+    ring: "border-aurora/30 bg-aurora/[0.08] text-aurora",
+  },
+  DENY: {
+    label: "DENY",
+    hint: "已拦截",
+    icon: CircleSlash,
+    ring: "border-destructive/30 bg-destructive/[0.08] text-destructive",
+  },
+};
+
+/**
+ * The ask → decide trail of AgentScope's permission engine.
+ *
+ * Three different mechanisms feed this list, and the demo prompts exercise each one: a rule-based
+ * ASK that suspends the run into an AG-UI interrupt, a rule-based DENY that no mode can lift, and a
+ * tool's own `checkPermissions` deciding from its arguments.
+ */
+export function PermissionAuditPanel({ entries }: { entries: PermissionAuditEntry[] }) {
+  return (
+    <section className="grid gap-4">
+      <PanelTitle
+        eyebrow="Permission Engine"
+        title="权限审计"
+        icon={<ShieldHalf className="size-5" />}
+      />
+
+      {entries.length === 0 ? (
+        <p className="rounded-2xl border border-dashed border-border px-4 py-6 text-center text-xs leading-5 text-muted-foreground">
+          还没有权限决策记录。请求一次生产发布会触发 ASK 并弹出确认卡片，请求清库则会被 DENY 直接拦下。
+        </p>
+      ) : (
+        <ul className="grid gap-2">
+          {entries.map((entry, index) => {
+            const meta = BEHAVIOR_META[entry.behavior] ?? BEHAVIOR_META.ASK;
+            const Icon = meta.icon;
+            return (
+              <li
+                key={`${entry.at}-${entry.tool}-${index}`}
+                className="grid gap-2 rounded-2xl border border-border bg-card/60 p-3 transition-shadow duration-300 hover:shadow-[0_12px_32px_oklch(0_0_0/0.28)]"
+              >
+                <div className="flex items-center justify-between gap-2">
+                  <span className="truncate font-mono text-xs font-semibold text-foreground">
+                    {entry.tool}
+                  </span>
+                  <span
+                    className={cn(
+                      "inline-flex shrink-0 items-center gap-1 rounded-full border px-2 py-0.5 text-[0.65rem] font-semibold",
+                      meta.ring,
+                    )}
+                  >
+                    <Icon className="size-3" />
+                    {meta.label}
+                  </span>
+                </div>
+                {entry.detail ? (
+                  <pre className="m-0 overflow-x-auto rounded-lg bg-secondary/40 px-2.5 py-2 font-mono text-[0.68rem] leading-5 text-muted-foreground">
+                    {entry.detail}
+                  </pre>
+                ) : null}
+                <p className="flex items-center justify-between gap-2 text-[0.68rem] text-muted-foreground">
+                  <span>{meta.hint}</span>
+                  <span>{entry.at}</span>
+                </p>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </section>
+  );
+}

--- a/agentscope-examples/agentscope-copilotkit/frontend/src/components/PlanBoard.tsx
+++ b/agentscope-examples/agentscope-copilotkit/frontend/src/components/PlanBoard.tsx
@@ -1,0 +1,101 @@
+import { CircleDashed, CircleDot, CircleCheck, Target } from "lucide-react";
+
+import { PanelTitle } from "@/components/PanelTitle";
+import { Badge } from "@/components/ui/badge";
+import type { PlanState, PlanTaskState } from "@/copilot/types";
+import { cn } from "@/lib/utils";
+
+const PHASE_LABEL: Record<string, string> = {
+  idle: "未开始",
+  planning: "规划中",
+  executing: "执行中",
+  completed: "已完成",
+};
+
+const STATE_META: Record<PlanTaskState, { label: string; icon: typeof CircleDot; tone: string }> = {
+  pending: { label: "待开始", icon: CircleDashed, tone: "text-muted-foreground" },
+  in_progress: { label: "进行中", icon: CircleDot, tone: "text-champagne" },
+  completed: { label: "已完成", icon: CircleCheck, tone: "text-aurora" },
+};
+
+/**
+ * Live view of the agent's task list.
+ *
+ * Every frame here arrives as shared state: `todo_write` mutates AgentScope's task context, the
+ * workbench middleware mirrors it, and the AG-UI converter ships the difference as a STATE_DELTA.
+ * Nothing on this panel is polled or locally derived.
+ */
+export function PlanBoard({ plan }: { plan: PlanState }) {
+  const percent = Math.max(0, Math.min(100, Math.round(plan.progress)));
+
+  return (
+    <section className="grid gap-4">
+      <PanelTitle eyebrow="Plan Mode" title="计划看板" icon={<Target className="size-5" />} />
+
+      <div className="grid gap-3 rounded-2xl border border-border bg-card/60 p-4">
+        <div className="flex items-start justify-between gap-3">
+          <div className="min-w-0">
+            <p className="text-xs font-semibold text-muted-foreground">当前目标</p>
+            <p className="mt-1 text-sm leading-6 font-semibold text-foreground">
+              {plan.goal ?? "尚未设定，试试让 Agent 先声明目标再列任务"}
+            </p>
+          </div>
+          <Badge className="shrink-0 rounded-full border border-champagne/25 bg-champagne/10 font-semibold text-champagne hover:bg-champagne/15">
+            {PHASE_LABEL[plan.phase] ?? plan.phase}
+          </Badge>
+        </div>
+
+        <div className="grid gap-1.5">
+          <div className="flex items-baseline justify-between text-xs text-muted-foreground">
+            <span>
+              已完成 {plan.completed} / {plan.total}
+            </span>
+            <span className="font-display text-sm font-semibold text-foreground">{percent}%</span>
+          </div>
+          <div className="h-1.5 overflow-hidden rounded-full bg-border/60">
+            <div
+              className="h-full rounded-full bg-linear-to-r from-champagne to-aurora transition-[width] duration-700"
+              style={{ width: `${percent}%` }}
+            />
+          </div>
+        </div>
+      </div>
+
+      {plan.tasks.length === 0 ? (
+        <p className="rounded-2xl border border-dashed border-border px-4 py-6 text-center text-xs leading-5 text-muted-foreground">
+          还没有任务。让 Agent 制定一个多步计划，任务清单会随每一步推进实时出现在这里。
+        </p>
+      ) : (
+        <ol className="grid gap-1">
+          {plan.tasks.map((task, index) => {
+            const meta = STATE_META[task.state] ?? STATE_META.pending;
+            const Icon = meta.icon;
+            return (
+              <li
+                key={task.id}
+                className="grid grid-cols-[auto_1fr_auto] items-center gap-3 rounded-xl px-3 py-2.5 transition-colors hover:bg-secondary/40"
+              >
+                <Icon className={cn("size-4 shrink-0", meta.tone)} />
+                <div className="min-w-0">
+                  <p
+                    className={cn(
+                      "truncate text-sm font-medium",
+                      task.state === "completed"
+                        ? "text-muted-foreground line-through"
+                        : "text-foreground",
+                    )}
+                  >
+                    {index + 1}. {task.title}
+                  </p>
+                </div>
+                <span className={cn("shrink-0 text-[0.7rem] font-semibold", meta.tone)}>
+                  {meta.label}
+                </span>
+              </li>
+            );
+          })}
+        </ol>
+      )}
+    </section>
+  );
+}

--- a/agentscope-examples/agentscope-copilotkit/frontend/src/components/StatePanel.tsx
+++ b/agentscope-examples/agentscope-copilotkit/frontend/src/components/StatePanel.tsx
@@ -1,0 +1,89 @@
+import { ListChecks, RefreshCcw, Sparkles } from "lucide-react";
+
+import { type DemoState, initialDemoState } from "@/copilot/types";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+
+export function StatePanel({
+  state,
+  updateState,
+}: {
+  state: DemoState;
+  updateState: (patch: Partial<DemoState>) => void;
+}) {
+  const metrics = Object.entries(state.metrics);
+
+  return (
+    <Card className="border-border/80 bg-card/70 shadow-none backdrop-blur-xl">
+      <CardHeader>
+        <CardDescription className="eyebrow">Shared State</CardDescription>
+        <CardTitle className="font-display flex items-center gap-2 text-xl tracking-tight">
+          <ListChecks className="size-5 text-champagne" />
+          状态管理
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="grid gap-4">
+        <dl className="grid gap-2">
+          <StateRow label="主题" value={state.topic} />
+          <StateRow label="优先级" value={state.priority} />
+          <StateRow label="状态" value={state.status} />
+          <StateRow label="人工确认" value={state.approved ? "已批准" : "未批准"} />
+          <StateRow label="更新时间" value={state.updatedAt} />
+        </dl>
+        {metrics.length > 0 ? (
+          <div className="grid gap-2">
+            <p className="text-xs font-semibold text-muted-foreground">
+              最近一次工具查询到的指标
+            </p>
+            <div className="grid grid-cols-2 gap-2">
+              {metrics.map(([key, value]) => (
+                <div key={key} className="rounded-xl border border-border bg-secondary/30 px-3 py-2">
+                  <p className="truncate text-[0.68rem] font-semibold text-muted-foreground">
+                    {key}
+                  </p>
+                  <p className="font-display truncate text-sm font-semibold text-foreground">
+                    {String(value)}
+                  </p>
+                </div>
+              ))}
+            </div>
+          </div>
+        ) : null}
+        <div className="flex flex-wrap items-center gap-3 pt-1">
+          <Button
+            type="button"
+            className="rounded-full"
+            onClick={() => updateState({ priority: "高", status: "手动提升优先级" })}
+          >
+            <Sparkles className="size-4" />
+            提升优先级
+          </Button>
+          <Button
+            type="button"
+            variant="outline"
+            className="rounded-full"
+            onClick={() => updateState(initialDemoState)}
+          >
+            <RefreshCcw className="size-4" />
+            重置
+          </Button>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+function StateRow({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="surface-row grid gap-1">
+      <dt className="text-xs font-semibold text-muted-foreground">{label}</dt>
+      <dd className="m-0 font-semibold text-foreground">{value}</dd>
+    </div>
+  );
+}

--- a/agentscope-examples/agentscope-copilotkit/frontend/src/components/StatusPill.tsx
+++ b/agentscope-examples/agentscope-copilotkit/frontend/src/components/StatusPill.tsx
@@ -1,0 +1,21 @@
+import type { ReactNode } from "react";
+
+export function StatusPill({
+  icon,
+  label,
+  value,
+}: {
+  icon: ReactNode;
+  label: string;
+  value: string;
+}) {
+  return (
+    <div className="rounded-2xl border border-border bg-secondary/40 p-3 transition-all duration-300 hover:border-champagne/25 hover:bg-secondary/70 hover:shadow-[0_14px_36px_oklch(0_0_0/0.28)]">
+      <div className="mb-2 flex items-center gap-2 text-champagne">
+        {icon}
+        <span className="text-xs font-semibold tracking-wide">{label}</span>
+      </div>
+      <p className="truncate text-sm font-semibold text-foreground">{value}</p>
+    </div>
+  );
+}

--- a/agentscope-examples/agentscope-copilotkit/frontend/src/components/ThreadListPanel.tsx
+++ b/agentscope-examples/agentscope-copilotkit/frontend/src/components/ThreadListPanel.tsx
@@ -1,0 +1,246 @@
+import {
+  useAgent,
+  useCopilotChatConfiguration,
+  useThreads,
+  type Thread,
+} from "@copilotkit/react-core/v2";
+import { MessageSquarePlus, RefreshCcw, Trash2 } from "lucide-react";
+import { useEffect, useRef } from "react";
+
+import { CHAT_AGENT_ID, THREAD_AGENT_ID } from "@/copilot/constants";
+import { PanelTitle } from "@/components/PanelTitle";
+import { Button } from "@/components/ui/button";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { cn } from "@/lib/utils";
+
+export function ThreadListPanel() {
+  const chatConfig = useCopilotChatConfiguration();
+  const {
+    threads,
+    isLoading,
+    error,
+    hasMoreThreads,
+    isFetchingMoreThreads,
+    fetchMoreThreads,
+    refetchThreads,
+    startNewThread,
+    archiveThread,
+    deleteThread,
+  } = useThreads({ agentId: THREAD_AGENT_ID, limit: 20 });
+
+  useRefreshThreadsAfterRun(refetchThreads);
+
+  const activeThreadId = chatConfig?.threadId;
+
+  const handleNewThread = () => {
+    startNewThread();
+    chatConfig?.startNewThread();
+  };
+
+  const handleSelectThread = (threadId: string) => {
+    chatConfig?.setActiveThreadId(threadId, { explicit: true });
+  };
+
+  const handleArchiveThread = async (threadId: string) => {
+    await archiveThread(threadId);
+    if (threadId === activeThreadId) {
+      handleNewThread();
+    }
+  };
+
+  const handleDeleteThread = async (threadId: string) => {
+    await deleteThread(threadId);
+    if (threadId === activeThreadId) {
+      handleNewThread();
+    }
+  };
+
+  return (
+    <aside
+      className="glass-panel grid min-h-0 grid-rows-[auto_auto_minmax(0,1fr)] overflow-hidden rounded-[1.75rem] p-4 max-[960px]:min-h-64 max-[520px]:rounded-2xl"
+      aria-label="会话列表"
+    >
+      <PanelTitle
+        eyebrow="useThreads"
+        title="会话"
+        icon={<MessageSquarePlus className="size-5" />}
+      />
+      <div className="mb-3 flex flex-wrap items-center gap-2">
+        <Button type="button" size="sm" className="rounded-full" onClick={handleNewThread}>
+          <MessageSquarePlus className="size-4" />
+          新会话
+        </Button>
+        <Button
+          type="button"
+          size="sm"
+          variant="outline"
+          className="rounded-full"
+          onClick={refetchThreads}
+        >
+          <RefreshCcw className="size-4" />
+          刷新
+        </Button>
+      </div>
+
+      <ScrollArea className="min-h-0">
+        <div className="grid gap-2 pr-3">
+          {isLoading ? (
+            <ThreadListHint text="正在加载会话..." />
+          ) : error ? (
+            <ThreadListHint text={`会话列表不可用：${error.message}`} />
+          ) : threads.length === 0 ? (
+            <ThreadListHint text="还没有会话。发送第一条消息后会自动刷新这里。" />
+          ) : (
+            threads.map((thread) => (
+              <ThreadRow
+                key={thread.id}
+                thread={thread}
+                active={thread.id === activeThreadId}
+                onSelect={() => handleSelectThread(thread.id)}
+                onArchive={() => void handleArchiveThread(thread.id)}
+                onDelete={() => void handleDeleteThread(thread.id)}
+              />
+            ))
+          )}
+
+          {hasMoreThreads ? (
+            <Button
+              type="button"
+              variant="outline"
+              disabled={isFetchingMoreThreads}
+              onClick={fetchMoreThreads}
+              className="mt-2"
+            >
+              {isFetchingMoreThreads ? "加载中..." : "加载更多"}
+            </Button>
+          ) : null}
+        </div>
+      </ScrollArea>
+    </aside>
+  );
+}
+
+function ThreadRow({
+  thread,
+  active,
+  onSelect,
+  onArchive,
+  onDelete,
+}: {
+  thread: Thread;
+  active: boolean;
+  onSelect: () => void;
+  onArchive: () => void;
+  onDelete: () => void;
+}) {
+  return (
+    <div
+      className={cn(
+        "group flex items-start justify-between gap-2 rounded-2xl border p-3 transition-all duration-300",
+        active
+          ? "border-champagne/40 bg-champagne/10 text-foreground shadow-[0_12px_32px_oklch(0_0_0/0.28)]"
+          : "border-border bg-secondary/30 text-foreground hover:border-champagne/25 hover:bg-secondary/60 hover:shadow-[0_12px_32px_oklch(0_0_0/0.25)]",
+      )}
+    >
+      <button type="button" onClick={onSelect} className="min-w-0 flex-1 text-left">
+        <div className="min-w-0">
+          <p className="truncate text-sm font-semibold">
+            {thread.name || friendlyThreadTitle(thread)}
+          </p>
+          <p className="mt-1 text-xs font-medium text-muted-foreground">
+            {formatThreadTime(thread.lastRunAt ?? thread.updatedAt)}
+          </p>
+        </div>
+      </button>
+      <div className="flex shrink-0 gap-1 opacity-0 transition group-hover:opacity-100">
+        <button
+          type="button"
+          title="归档"
+          onClick={onArchive}
+          className="rounded-lg px-2 py-1 text-xs font-semibold text-muted-foreground hover:bg-background/60 hover:text-champagne"
+        >
+          归档
+        </button>
+        <button
+          type="button"
+          title="删除"
+          onClick={onDelete}
+          className="rounded-lg px-2 py-1 text-destructive hover:bg-background/60"
+        >
+          <Trash2 className="size-3.5" />
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function ThreadListHint({ text }: { text: string }) {
+  return (
+    <div className="rounded-2xl border border-dashed border-border bg-secondary/20 p-4 text-sm leading-6 text-muted-foreground">
+      {text}
+    </div>
+  );
+}
+
+function useRefreshThreadsAfterRun(refetchThreads: () => void) {
+  const { agent } = useAgent({ agentId: CHAT_AGENT_ID });
+  const pendingRefreshRef = useRef(false);
+  const observedRunRef = useRef(false);
+  const refreshedThreadIdsRef = useRef(new Set<string>());
+  const threadIdRef = useRef(agent.threadId);
+
+  const messageCount = agent.messages.length;
+  const hasUserMessage = agent.messages.some((message) => message.role === "user");
+
+  useEffect(() => {
+    if (threadIdRef.current !== agent.threadId) {
+      threadIdRef.current = agent.threadId;
+      pendingRefreshRef.current = false;
+      observedRunRef.current = false;
+    }
+
+    if (
+      hasUserMessage &&
+      !refreshedThreadIdsRef.current.has(agent.threadId) &&
+      !pendingRefreshRef.current
+    ) {
+      pendingRefreshRef.current = true;
+    }
+
+    if (pendingRefreshRef.current && agent.isRunning) {
+      observedRunRef.current = true;
+    }
+
+    if (pendingRefreshRef.current && observedRunRef.current && !agent.isRunning) {
+      pendingRefreshRef.current = false;
+      observedRunRef.current = false;
+      refreshedThreadIdsRef.current.add(agent.threadId);
+      refetchThreads();
+    }
+  }, [agent, agent.threadId, agent.isRunning, messageCount, hasUserMessage, refetchThreads]);
+}
+
+function friendlyThreadTitle(thread: Thread) {
+  if (thread.name?.trim()) return thread.name.trim();
+  const stamp = thread.createdAt ?? thread.updatedAt ?? thread.lastRunAt;
+  if (stamp) {
+    const date = new Date(stamp);
+    if (!Number.isNaN(date.getTime())) {
+      return `会话 · ${date.toLocaleString(undefined, {
+        month: "numeric",
+        day: "numeric",
+        hour: "2-digit",
+        minute: "2-digit",
+      })}`;
+    }
+  }
+  const short = thread.id.length > 14 ? `${thread.id.slice(0, 8)}…` : thread.id;
+  return `会话 ${short}`;
+}
+
+function formatThreadTime(value?: string) {
+  if (!value) return "暂无运行记录";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+  return date.toLocaleString();
+}

--- a/agentscope-examples/agentscope-copilotkit/frontend/src/components/ToolCard.tsx
+++ b/agentscope-examples/agentscope-copilotkit/frontend/src/components/ToolCard.tsx
@@ -1,0 +1,40 @@
+import type { ReactNode } from "react";
+
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { cn } from "@/lib/utils";
+import type { ToolStatus } from "@/copilot/types";
+
+export function ToolCard({
+  title,
+  status,
+  children,
+  className,
+}: {
+  title: string;
+  status: ToolStatus;
+  children: ReactNode;
+  className?: string;
+}) {
+  return (
+    <Card
+      className={cn(
+        "w-[min(520px,100%)] border-champagne/20 bg-card/90 shadow-[0_18px_48px_oklch(0_0_0/0.35)] backdrop-blur-xl transition-shadow duration-300 hover:shadow-[0_24px_60px_oklch(0_0_0/0.45)]",
+        className,
+      )}
+    >
+      <CardHeader className="flex flex-row items-center justify-between gap-3 pb-3">
+        <CardTitle className="font-display text-base font-semibold tracking-tight">
+          {title}
+        </CardTitle>
+        <Badge
+          variant="secondary"
+          className="rounded-full border border-champagne/20 bg-champagne/10 font-semibold text-champagne"
+        >
+          {status}
+        </Badge>
+      </CardHeader>
+      <CardContent className="pt-0">{children}</CardContent>
+    </Card>
+  );
+}

--- a/agentscope-examples/agentscope-copilotkit/frontend/src/components/V2HooksPanel.tsx
+++ b/agentscope-examples/agentscope-copilotkit/frontend/src/components/V2HooksPanel.tsx
@@ -1,0 +1,240 @@
+import { useAttachments, useCopilotKit } from "@copilotkit/react-core/v2";
+import { BookOpen, Paperclip, RefreshCcw, Send } from "lucide-react";
+
+import type { DemoState } from "@/copilot/types";
+import { useV2HookExamples } from "@/hooks/useV2HookExamples";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+
+export function V2HooksPanel({
+  state,
+  updateState,
+}: {
+  state: DemoState;
+  updateState: (patch: Partial<DemoState>) => void;
+}) {
+  const examples = useV2HookExamples({ state, updateState });
+  const { copilotkit } = useCopilotKit();
+  const attachments = useAttachments({
+    config: {
+      enabled: true,
+      accept: "image/*,text/*,application/pdf",
+      maxSize: 5 * 1024 * 1024,
+      onUploadFailed: (error) => {
+        console.warn("useAttachments upload failed", error);
+      },
+    },
+  });
+
+  const sendSuggestion = async (message: string) => {
+    if (examples.agent.isRunning) return;
+    examples.agent.addMessage({
+      id: crypto.randomUUID(),
+      role: "user",
+      content: message,
+    });
+    await copilotkit.runAgent({ agent: examples.agent });
+  };
+
+  return (
+    <Card className="border-border/80 bg-card/70 shadow-none backdrop-blur-xl">
+      <CardHeader>
+        <CardDescription className="eyebrow">V2 Hooks</CardDescription>
+        <CardTitle className="font-display flex items-center gap-2 text-xl tracking-tight">
+          <BookOpen className="size-5 text-champagne" />
+          Hook 示例
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="grid gap-5">
+        <section className="grid gap-2">
+          <h3 className="text-sm font-semibold text-foreground">运行状态</h3>
+          <div className="grid gap-2">
+            {examples.statuses.map((item) => (
+              <div key={item.label} className="surface-row grid gap-1">
+                <span className="text-xs font-semibold text-muted-foreground">
+                  {item.label}
+                </span>
+                <strong className="break-all text-sm font-medium text-foreground">
+                  {item.value}
+                </strong>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        <section className="grid gap-2">
+          <h3 className="text-sm font-semibold text-foreground">
+            useConfigureSuggestions / useSuggestions
+          </h3>
+          <div className="flex flex-wrap gap-2">
+            <Button
+              type="button"
+              size="sm"
+              variant="secondary"
+              onClick={examples.suggestions.reloadSuggestions}
+              disabled={examples.suggestions.isLoading}
+            >
+              <RefreshCcw className="size-4" />
+              重新生成
+            </Button>
+            <Button
+              type="button"
+              size="sm"
+              variant="outline"
+              onClick={examples.suggestions.clearSuggestions}
+            >
+              清空建议
+            </Button>
+          </div>
+          <div className="grid gap-2">
+            {examples.suggestions.suggestions.map((suggestion) => (
+              <button
+                key={`${suggestion.title}-${suggestion.message}`}
+                type="button"
+                onClick={() => void sendSuggestion(suggestion.message)}
+                className="prompt-chip"
+              >
+                <span className="mb-1 flex items-center gap-2 font-semibold text-foreground">
+                  <Send className="size-3.5 text-champagne" />
+                  {suggestion.title}
+                </span>
+                <span className="text-muted-foreground">{suggestion.message}</span>
+              </button>
+            ))}
+          </div>
+        </section>
+
+        <section className="grid gap-2">
+          <h3 className="text-sm font-semibold text-foreground">useAttachments</h3>
+          <div
+            ref={attachments.containerRef}
+            onDragOver={attachments.handleDragOver}
+            onDragLeave={attachments.handleDragLeave}
+            onDrop={attachments.handleDrop}
+            className="rounded-2xl border border-dashed border-border bg-secondary/30 p-3"
+          >
+            <input
+              ref={attachments.fileInputRef}
+              type="file"
+              multiple
+              className="hidden"
+              onChange={attachments.handleFileUpload}
+            />
+            <div className="flex flex-wrap items-center gap-2">
+              <Button
+                type="button"
+                size="sm"
+                variant="secondary"
+                onClick={() => attachments.fileInputRef.current?.click()}
+              >
+                <Paperclip className="size-4" />
+                选择文件
+              </Button>
+              <Badge variant={attachments.dragOver ? "success" : "secondary"}>
+                {attachments.enabled ? "enabled" : "disabled"}
+              </Badge>
+              <Button
+                type="button"
+                size="sm"
+                variant="outline"
+                onClick={attachments.consumeAttachments}
+              >
+                消费 ready 队列
+              </Button>
+            </div>
+            <div className="mt-3 grid gap-2 text-sm text-muted-foreground">
+              {attachments.attachments.length === 0 ? (
+                <span>拖拽或选择文件后，这里会显示 hook 队列。</span>
+              ) : (
+                attachments.attachments.map((item) => (
+                  <div
+                    key={item.id}
+                    className="flex items-center justify-between gap-2 rounded-xl bg-background/50 p-2"
+                  >
+                    <span className="truncate">{item.filename ?? item.id}</span>
+                    <button
+                      type="button"
+                      onClick={() => attachments.removeAttachment(item.id)}
+                      className="text-xs font-semibold text-destructive"
+                    >
+                      移除
+                    </button>
+                  </div>
+                ))
+              )}
+            </div>
+          </div>
+        </section>
+
+        <section className="grid gap-2">
+          <h3 className="text-sm font-semibold text-foreground">
+            useMemories / learning hooks
+          </h3>
+          <div className="surface-row text-sm leading-6 text-muted-foreground">
+            <p>Memory 数量：{examples.memories.memories.length}</p>
+            <p>
+              Memory 状态：
+              {examples.memories.isAvailable ? "可用" : "当前 Runtime 未提供"}
+            </p>
+            {examples.memories.error ? <p>{examples.memories.error.message}</p> : null}
+          </div>
+          <div className="flex flex-wrap gap-2">
+            <Button
+              type="button"
+              size="sm"
+              variant="secondary"
+              onClick={() =>
+                void examples.memories.refresh().catch((error) => {
+                  console.warn("useMemories refresh failed", error);
+                })
+              }
+            >
+              刷新 memory
+            </Button>
+            <Button type="button" size="sm" onClick={() => void examples.addDemoMemory()}>
+              添加 memory
+            </Button>
+            <Button
+              type="button"
+              size="sm"
+              variant="outline"
+              onClick={() => void examples.recordAction()}
+            >
+              记录用户动作
+            </Button>
+            <Button
+              type="button"
+              size="sm"
+              variant="outline"
+              onClick={() => void examples.recordCurrentThreadAction()}
+            >
+              记录当前线程动作
+            </Button>
+          </div>
+          <div className="surface-row text-xs leading-5 text-muted-foreground">
+            <strong className="text-foreground">{examples.annotationStatus.label}</strong>
+            <p className="break-all">{examples.annotationStatus.value}</p>
+          </div>
+        </section>
+
+        <section className="grid gap-2">
+          <h3 className="text-sm font-semibold text-foreground">
+            useRenderToolCall 预览
+          </h3>
+          <div className="rounded-2xl border border-border bg-background/40 p-3">
+            {examples.renderToolPreview ?? (
+              <span className="text-sm text-muted-foreground">等待 renderer 注册...</span>
+            )}
+          </div>
+        </section>
+      </CardContent>
+    </Card>
+  );
+}

--- a/agentscope-examples/agentscope-copilotkit/frontend/src/components/ui/badge.tsx
+++ b/agentscope-examples/agentscope-copilotkit/frontend/src/components/ui/badge.tsx
@@ -1,0 +1,42 @@
+import { cva, type VariantProps } from "class-variance-authority";
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+const badgeVariants = cva(
+  "inline-flex w-fit shrink-0 items-center justify-center rounded-md border px-2 py-0.5 text-xs font-medium whitespace-nowrap transition-colors [&>svg]:size-3",
+  {
+    variants: {
+      variant: {
+        default:
+          "border-transparent bg-primary text-primary-foreground hover:bg-primary/90",
+        secondary:
+          "border-transparent bg-secondary text-secondary-foreground hover:bg-secondary/90",
+        destructive:
+          "border-transparent bg-destructive text-white hover:bg-destructive/90",
+        outline: "text-foreground",
+        success:
+          "border border-aurora/25 bg-aurora/15 text-aurora hover:bg-aurora/20",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  },
+);
+
+function Badge({
+  className,
+  variant,
+  ...props
+}: React.ComponentProps<"span"> & VariantProps<typeof badgeVariants>) {
+  return (
+    <span
+      data-slot="badge"
+      className={cn(badgeVariants({ variant }), className)}
+      {...props}
+    />
+  );
+}
+
+export { Badge, badgeVariants };

--- a/agentscope-examples/agentscope-copilotkit/frontend/src/components/ui/button.tsx
+++ b/agentscope-examples/agentscope-copilotkit/frontend/src/components/ui/button.tsx
@@ -1,0 +1,63 @@
+import { Slot } from "@radix-ui/react-slot";
+import { cva, type VariantProps } from "class-variance-authority";
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+/**
+ * CopilotKit v2 scopes a Tailwind preflight under [data-copilotkit] that sets
+ * `button { background-color: transparent; border-radius: 0 }` with higher
+ * specificity than utility classes. Important modifiers keep our shadcn
+ * buttons visible inside the provider tree.
+ */
+const buttonVariants = cva(
+  "inline-flex shrink-0 items-center justify-center gap-2 whitespace-nowrap rounded-xl !rounded-xl text-sm font-semibold transition-all duration-300 outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+  {
+    variants: {
+      variant: {
+        default:
+          "!bg-primary !text-primary-foreground shadow-[0_10px_30px_oklch(0.84_0.065_88/0.18)] hover:!bg-primary/90 hover:shadow-[0_14px_36px_oklch(0.84_0.065_88/0.28)]",
+        destructive:
+          "!bg-destructive !text-white shadow-xs hover:!bg-destructive/90 focus-visible:ring-destructive/20",
+        outline:
+          "!border !border-border !bg-secondary/40 !text-foreground shadow-xs hover:!border-champagne/40 hover:!bg-secondary/70",
+        secondary:
+          "!bg-secondary !text-secondary-foreground shadow-xs hover:!bg-secondary/80 hover:shadow-[0_10px_28px_oklch(0_0_0/0.25)]",
+        ghost: "!bg-transparent hover:!bg-accent hover:!text-accent-foreground",
+        link: "!bg-transparent !text-primary underline-offset-4 hover:underline",
+      },
+      size: {
+        default: "h-9 !px-4 !py-2",
+        sm: "h-8 !rounded-lg !px-3 text-xs",
+        lg: "h-11 !rounded-xl !px-6",
+        icon: "size-9",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  },
+);
+
+function Button({
+  className,
+  variant,
+  size,
+  asChild = false,
+  ...props
+}: React.ComponentProps<"button"> &
+  VariantProps<typeof buttonVariants> & {
+    asChild?: boolean;
+  }) {
+  const Comp = asChild ? Slot : "button";
+
+  return (
+    <Comp
+      data-slot="button"
+      className={cn(buttonVariants({ variant, size }), className)}
+      {...props}
+    />
+  );
+}
+
+export { Button, buttonVariants };

--- a/agentscope-examples/agentscope-copilotkit/frontend/src/components/ui/card.tsx
+++ b/agentscope-examples/agentscope-copilotkit/frontend/src/components/ui/card.tsx
@@ -1,0 +1,75 @@
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+function Card({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card"
+      className={cn(
+        "rounded-2xl border bg-card text-card-foreground shadow-sm transition-shadow duration-300",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function CardHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-header"
+      className={cn("grid auto-rows-min gap-1.5 px-6 pt-6", className)}
+      {...props}
+    />
+  );
+}
+
+function CardTitle({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-title"
+      className={cn("font-semibold leading-none tracking-tight", className)}
+      {...props}
+    />
+  );
+}
+
+function CardDescription({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-description"
+      className={cn("text-sm text-muted-foreground", className)}
+      {...props}
+    />
+  );
+}
+
+function CardContent({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-content"
+      className={cn("px-6 py-6", className)}
+      {...props}
+    />
+  );
+}
+
+function CardFooter({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-footer"
+      className={cn("flex items-center px-6 pb-6", className)}
+      {...props}
+    />
+  );
+}
+
+export {
+  Card,
+  CardHeader,
+  CardFooter,
+  CardTitle,
+  CardDescription,
+  CardContent,
+};

--- a/agentscope-examples/agentscope-copilotkit/frontend/src/components/ui/scroll-area.tsx
+++ b/agentscope-examples/agentscope-copilotkit/frontend/src/components/ui/scroll-area.tsx
@@ -1,0 +1,56 @@
+import * as ScrollAreaPrimitive from "@radix-ui/react-scroll-area";
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+function ScrollArea({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof ScrollAreaPrimitive.Root>) {
+  return (
+    <ScrollAreaPrimitive.Root
+      data-slot="scroll-area"
+      className={cn("relative", className)}
+      {...props}
+    >
+      <ScrollAreaPrimitive.Viewport
+        data-slot="scroll-area-viewport"
+        className="size-full rounded-[inherit] outline-none"
+      >
+        {children}
+      </ScrollAreaPrimitive.Viewport>
+      <ScrollBar />
+      <ScrollAreaPrimitive.Corner />
+    </ScrollAreaPrimitive.Root>
+  );
+}
+
+function ScrollBar({
+  className,
+  orientation = "vertical",
+  ...props
+}: React.ComponentProps<typeof ScrollAreaPrimitive.ScrollAreaScrollbar>) {
+  return (
+    <ScrollAreaPrimitive.ScrollAreaScrollbar
+      data-slot="scroll-area-scrollbar"
+      orientation={orientation}
+      className={cn(
+        "flex touch-none select-none transition-colors",
+        orientation === "vertical" &&
+          "h-full w-2.5 border-l border-l-transparent p-px",
+        orientation === "horizontal" &&
+          "h-2.5 flex-col border-t border-t-transparent p-px",
+        className,
+      )}
+      {...props}
+    >
+      <ScrollAreaPrimitive.ScrollAreaThumb
+        data-slot="scroll-area-thumb"
+        className="relative flex-1 rounded-full bg-border"
+      />
+    </ScrollAreaPrimitive.ScrollAreaScrollbar>
+  );
+}
+
+export { ScrollArea, ScrollBar };

--- a/agentscope-examples/agentscope-copilotkit/frontend/src/components/ui/separator.tsx
+++ b/agentscope-examples/agentscope-copilotkit/frontend/src/components/ui/separator.tsx
@@ -1,0 +1,27 @@
+import * as SeparatorPrimitive from "@radix-ui/react-separator";
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+function Separator({
+  className,
+  orientation = "horizontal",
+  decorative = true,
+  ...props
+}: React.ComponentProps<typeof SeparatorPrimitive.Root>) {
+  return (
+    <SeparatorPrimitive.Root
+      data-slot="separator"
+      decorative={decorative}
+      orientation={orientation}
+      className={cn(
+        "shrink-0 bg-border",
+        orientation === "horizontal" ? "h-px w-full" : "h-full w-px",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export { Separator };

--- a/agentscope-examples/agentscope-copilotkit/frontend/src/components/ui/tabs.tsx
+++ b/agentscope-examples/agentscope-copilotkit/frontend/src/components/ui/tabs.tsx
@@ -1,0 +1,64 @@
+import * as TabsPrimitive from "@radix-ui/react-tabs";
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+function Tabs({
+  className,
+  ...props
+}: React.ComponentProps<typeof TabsPrimitive.Root>) {
+  return (
+    <TabsPrimitive.Root
+      data-slot="tabs"
+      className={cn("flex flex-col gap-3", className)}
+      {...props}
+    />
+  );
+}
+
+function TabsList({
+  className,
+  ...props
+}: React.ComponentProps<typeof TabsPrimitive.List>) {
+  return (
+    <TabsPrimitive.List
+      data-slot="tabs-list"
+      className={cn(
+        "inline-flex h-11 w-full items-center justify-center gap-1 rounded-2xl border border-border bg-secondary/50 p-1 text-muted-foreground",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function TabsTrigger({
+  className,
+  ...props
+}: React.ComponentProps<typeof TabsPrimitive.Trigger>) {
+  return (
+    <TabsPrimitive.Trigger
+      data-slot="tabs-trigger"
+      className={cn(
+        "inline-flex flex-1 items-center justify-center rounded-xl px-3 py-2 text-xs font-semibold tracking-wide whitespace-nowrap transition-all outline-none focus-visible:ring-[3px] focus-visible:ring-ring/40 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-primary data-[state=active]:text-primary-foreground data-[state=active]:shadow-[0_8px_24px_oklch(0.84_0.065_88/0.2)]",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function TabsContent({
+  className,
+  ...props
+}: React.ComponentProps<typeof TabsPrimitive.Content>) {
+  return (
+    <TabsPrimitive.Content
+      data-slot="tabs-content"
+      className={cn("outline-none", className)}
+      {...props}
+    />
+  );
+}
+
+export { Tabs, TabsList, TabsTrigger, TabsContent };

--- a/agentscope-examples/agentscope-copilotkit/frontend/src/copilot/constants.ts
+++ b/agentscope-examples/agentscope-copilotkit/frontend/src/copilot/constants.ts
@@ -1,0 +1,59 @@
+/**
+ * The showcase agent registered by `AgentConfiguration#createWorkbenchAgent` on the Java side.
+ * It carries the permission rules, the task list and the A2UI tool belt.
+ */
+export const WORKBENCH_AGENT_ID = "workbench";
+
+export const CHAT_AGENT_ID = WORKBENCH_AGENT_ID;
+export const THREAD_AGENT_ID = WORKBENCH_AGENT_ID;
+
+export const HITL_DEMO_PROMPT =
+  "Run the approval interrupt demo. Call confirmDemoAction for deleting demo-file.txt, then continue after the user decision.";
+
+/** Prompts that each land on a different AgentScope 2.0 capability. */
+export const CAPABILITY_PROMPTS = [
+  {
+    id: "plan",
+    title: "计划编排 + 实时任务看板",
+    detail: "todo_write 的任务清单通过 STATE_DELTA / STEP_STARTED 实时驱动右侧看板",
+    prompt:
+      "帮我制定一个 order-api 稳定性治理计划：先声明目标，再写出 5 条任务清单，然后逐条推进到完成，每步都更新任务状态。",
+  },
+  {
+    id: "permission-ask",
+    title: "权限 ASK：调起前端确认",
+    detail: "deploy_release 命中 ASK 规则，运行被挂起为 AG-UI interrupt",
+    prompt: "把 order-api 的 v2.4.1 发布到生产环境。",
+  },
+  {
+    id: "permission-deny",
+    title: "权限 DENY：不可绕过的硬拦截",
+    detail: "purge_production_data 命中 DENY 规则，任何模式都无法放行",
+    prompt: "请永久删除生产数据集 orders_2025，我确认要删。",
+  },
+  {
+    id: "builtin-check",
+    title: "工具内置检查：按入参决策",
+    detail: "refund_order 自己判断金额，小额直接放行、大额强制人工确认",
+    prompt: "给订单 SO202607310001 退款 30 元；再给订单 SO202607310002 退款 8600 元。",
+  },
+  {
+    id: "a2ui",
+    title: "A2UI 动态生成界面",
+    detail: "render_dashboard 让模型现场生成组件树，经 ACTIVITY_SNAPSHOT 推送渲染",
+    prompt:
+      "查一下 order-api 最近 1 小时的指标，然后用一块可视化界面展示关键指标、风险评分和当前计划进度。",
+  },
+  {
+    id: "state",
+    title: "共享状态双向同步",
+    detail: "浏览器写入的 state 会随运行回传，工具修改后再以 STATE_DELTA 推回",
+    prompt: "把演示主题改成「双十一容量演练」，优先级设为高。",
+  },
+  {
+    id: "frontend-hitl",
+    title: "前端 HITL 工具",
+    detail: "useHumanInTheLoop 注册的浏览器侧工具，由前端渲染表单并回传结果",
+    prompt: HITL_DEMO_PROMPT,
+  },
+] as const;

--- a/agentscope-examples/agentscope-copilotkit/frontend/src/copilot/types.ts
+++ b/agentscope-examples/agentscope-copilotkit/frontend/src/copilot/types.ts
@@ -1,0 +1,91 @@
+/** Task states mirrored from AgentScope's `Task.State` wire values. */
+export type PlanTaskState = "pending" | "in_progress" | "completed";
+
+export type PlanTask = {
+  id: string;
+  title: string;
+  state: PlanTaskState;
+  priority?: string;
+};
+
+export type PlanState = {
+  goal: string | null;
+  /** idle → planning → executing → completed */
+  phase: string;
+  tasks: PlanTask[];
+  total: number;
+  completed: number;
+  /** Completion percentage, 0-100. */
+  progress: number;
+};
+
+/** One decision made by the permission engine, newest first. */
+export type PermissionAuditEntry = {
+  tool: string;
+  /** ASK while waiting on the user, then ALLOW or DENY once decided. */
+  behavior: "ASK" | "ALLOW" | "DENY" | string;
+  detail: string;
+  granted: boolean;
+  at: string;
+};
+
+export type A2uiSurfaceInfo = {
+  surfaceId: string | null;
+  catalogId: string | null;
+  /** Which composer produced the surface: a model id, or `fallback`. */
+  generatedBy: string | null;
+  intent: string | null;
+  componentCount: number;
+};
+
+/**
+ * The shared state object, shaped exactly like `WorkbenchState#snapshot()` on the Java side.
+ *
+ * Writes from the browser (`agent.setState`) travel back with the next run and are merged by
+ * `WorkbenchState#mergeFromClient`, so the two halves stay in sync in both directions.
+ */
+export type DemoState = {
+  topic: string;
+  priority: "低" | "中" | "高";
+  status: string;
+  approved: boolean;
+  updatedAt: string;
+  plan: PlanState;
+  permissionAudit: PermissionAuditEntry[];
+  metrics: Record<string, string | number>;
+  a2ui: A2uiSurfaceInfo;
+};
+
+export type HookDemoStatus = {
+  label: string;
+  value: string;
+};
+
+export type ToolStatus = string;
+
+export const emptyPlanState: PlanState = {
+  goal: null,
+  phase: "idle",
+  tasks: [],
+  total: 0,
+  completed: 0,
+  progress: 0,
+};
+
+export const initialDemoState: DemoState = {
+  topic: "AgentScope 2.0 × CopilotKit 能力演示",
+  priority: "中",
+  status: "等待用户输入",
+  approved: false,
+  updatedAt: "-",
+  plan: emptyPlanState,
+  permissionAudit: [],
+  metrics: {},
+  a2ui: {
+    surfaceId: null,
+    catalogId: null,
+    generatedBy: null,
+    intent: null,
+    componentCount: 0,
+  },
+};

--- a/agentscope-examples/agentscope-copilotkit/frontend/src/hooks/useCapabilityRunner.ts
+++ b/agentscope-examples/agentscope-copilotkit/frontend/src/hooks/useCapabilityRunner.ts
@@ -1,0 +1,35 @@
+import { useAgent, useCopilotKit } from "@copilotkit/react-core/v2";
+import { useCallback, useState } from "react";
+
+import { CHAT_AGENT_ID } from "@/copilot/constants";
+
+/**
+ * Sends a canned prompt to the workbench agent, the same way the chat input would.
+ *
+ * `addMessage` then `runAgent` is CopilotKit v2's programmatic equivalent of typing and pressing
+ * enter: the message lands in the shared thread, so the demo buttons and the chat box stay one
+ * conversation rather than two.
+ */
+export function useCapabilityRunner() {
+  const { copilotkit } = useCopilotKit();
+  const { agent } = useAgent({ agentId: CHAT_AGENT_ID });
+  const [pendingId, setPendingId] = useState<string | null>(null);
+
+  const run = useCallback(
+    async (id: string, prompt: string) => {
+      if (pendingId || agent.isRunning) return;
+      setPendingId(id);
+      try {
+        agent.addMessage({ id: crypto.randomUUID(), role: "user", content: prompt });
+        await copilotkit.runAgent({ agent });
+      } catch (error) {
+        console.error("capability prompt failed", error);
+      } finally {
+        setPendingId(null);
+      }
+    },
+    [agent, copilotkit, pendingId],
+  );
+
+  return { run, pendingId, isRunning: agent.isRunning };
+}

--- a/agentscope-examples/agentscope-copilotkit/frontend/src/hooks/useDemoState.ts
+++ b/agentscope-examples/agentscope-copilotkit/frontend/src/hooks/useDemoState.ts
@@ -1,0 +1,69 @@
+import { useAgent, useAgentContext } from "@copilotkit/react-core/v2";
+import { useCallback, useEffect, useMemo } from "react";
+
+import {
+  WORKBENCH_CATALOG_ID,
+  WORKBENCH_COMPONENT_NAMES,
+} from "@/a2ui/workbenchCatalog";
+import { CHAT_AGENT_ID } from "@/copilot/constants";
+import { type DemoState, emptyPlanState, initialDemoState } from "@/copilot/types";
+
+/** Matches `WorkbenchEventMiddleware.CONTEXT_INLINE_CATALOG` on the Java side. */
+const CATALOG_CONTEXT_DESCRIPTION = "a2ui-inline-catalog";
+
+/**
+ * Bridges the agent's shared state into React.
+ *
+ * The nested objects are defaulted individually rather than with a single spread: an incoming
+ * snapshot that omits `plan` or `a2ui` (an older run, or a thread that never used them) would
+ * otherwise leave those fields undefined and crash the panels reading them.
+ */
+export function useDemoState() {
+  const { agent } = useAgent({ agentId: CHAT_AGENT_ID });
+
+  const state = useMemo<DemoState>(() => {
+    const incoming = (agent.state ?? {}) as Partial<DemoState>;
+    return {
+      ...initialDemoState,
+      ...incoming,
+      plan: { ...emptyPlanState, ...(incoming.plan ?? {}) },
+      permissionAudit: incoming.permissionAudit ?? [],
+      metrics: incoming.metrics ?? {},
+      a2ui: { ...initialDemoState.a2ui, ...(incoming.a2ui ?? {}) },
+    };
+  }, [agent.state]);
+
+  const updateState = useCallback(
+    (patch: Partial<DemoState>) => {
+      agent.setState({
+        ...state,
+        ...patch,
+        updatedAt: new Date().toLocaleTimeString(),
+      });
+    },
+    [agent, state],
+  );
+
+  useEffect(() => {
+    if (!agent.state || Object.keys(agent.state).length === 0) {
+      agent.setState(initialDemoState);
+    }
+  }, [agent]);
+
+  useAgentContext({
+    description: "当前 AgentScope 工作台的共享状态",
+    value: state,
+  });
+
+  // Capability handshake: the agent composes A2UI against exactly the components this build can
+  // paint, so adding or removing a renderer never produces a surface the browser drops.
+  useAgentContext({
+    description: CATALOG_CONTEXT_DESCRIPTION,
+    value: {
+      catalogId: WORKBENCH_CATALOG_ID,
+      components: WORKBENCH_COMPONENT_NAMES,
+    },
+  });
+
+  return { state, updateState };
+}

--- a/agentscope-examples/agentscope-copilotkit/frontend/src/hooks/useHitlInterrupt.tsx
+++ b/agentscope-examples/agentscope-copilotkit/frontend/src/hooks/useHitlInterrupt.tsx
@@ -1,0 +1,139 @@
+import { useInterrupt } from "@copilotkit/react-core/v2";
+import { useState } from "react";
+
+import { CHAT_AGENT_ID } from "@/copilot/constants";
+import type { DemoState } from "@/copilot/types";
+import { Button } from "@/components/ui/button";
+import { ToolCard } from "@/components/ToolCard";
+
+type HitlInterrupt = {
+  id?: string;
+  toolCallId?: string;
+  message?: string;
+  metadata?: Record<string, unknown>;
+};
+
+type ApprovalResult = {
+  approved: boolean;
+  reason: string;
+};
+
+type ResolveInterrupt = (result: ApprovalResult) => void | Promise<unknown>;
+type CancelInterrupt = () => void | Promise<unknown>;
+
+/**
+ * AG-UI interrupt HITL: backend registers schema-only requestHumanApproval.
+ */
+export function useHitlInterrupt(updateState: (patch: Partial<DemoState>) => void) {
+  useInterrupt({
+    agentId: CHAT_AGENT_ID,
+    render: ({ interrupt, interrupts, resolve, cancel }) => {
+      const items = interrupts.length > 0 ? interrupts : interrupt ? [interrupt] : [];
+      const primary = items[0];
+      return (
+        <HitlInterruptCard
+          primary={primary}
+          resolve={resolve}
+          cancel={cancel}
+          updateState={updateState}
+        />
+      );
+    },
+  });
+}
+
+function HitlInterruptCard({
+  primary,
+  resolve,
+  cancel,
+  updateState,
+}: {
+  primary?: HitlInterrupt;
+  resolve: ResolveInterrupt;
+  cancel: CancelInterrupt;
+  updateState: (patch: Partial<DemoState>) => void;
+}) {
+  const [rejectReason, setRejectReason] = useState("");
+  const metadata = (primary?.metadata ?? {}) as Record<string, unknown>;
+  const toolInput = (metadata.toolInput ?? {}) as Record<string, unknown>;
+  const summary =
+    String(toolInput.summary ?? "") ||
+    primary?.message ||
+    "请确认是否继续执行该操作。";
+  const toolName = String(metadata.toolName ?? "requestHumanApproval");
+  const normalizedRejectReason = rejectReason.trim();
+
+  return (
+    <ToolCard title="人机交互确认（useInterrupt）" status="awaiting">
+      <div className="grid gap-3">
+        <p className="text-sm leading-6 text-muted-foreground">{summary}</p>
+        <pre className="max-h-44 overflow-auto rounded-xl border border-border bg-background/80 p-3 text-xs leading-5 text-aurora">
+          {JSON.stringify(
+            {
+              interruptId: primary?.id,
+              toolCallId: primary?.toolCallId,
+              toolName,
+              toolInput,
+            },
+            null,
+            2,
+          )}
+        </pre>
+        <label className="grid gap-2 text-sm font-semibold text-foreground">
+          拒绝原因
+          <textarea
+            value={rejectReason}
+            onChange={(event) => setRejectReason(event.target.value)}
+            rows={3}
+            placeholder="例如：信息不完整，需要补充订单编号后再执行。"
+            className="min-h-24 resize-y rounded-xl border border-border bg-secondary/40 px-3 py-2 text-sm font-medium leading-6 text-foreground outline-none transition placeholder:text-muted-foreground focus:border-champagne/40 focus:bg-secondary/70 focus:ring-3 focus:ring-ring"
+          />
+        </label>
+        <div className="mt-1 flex flex-wrap items-center gap-3">
+          <Button
+            type="button"
+            className="min-w-24 rounded-full"
+            onClick={() => {
+              updateState({ approved: true, status: "用户已批准" });
+              void resolve({
+                approved: true,
+                reason: "Approved in the CopilotKit HITL demo.",
+              });
+            }}
+          >
+            批准
+          </Button>
+          <Button
+            type="button"
+            variant="outline"
+            className="min-w-32 rounded-full"
+            disabled={!normalizedRejectReason}
+            onClick={() => {
+              updateState({
+                approved: false,
+                status: `用户已拒绝：${normalizedRejectReason}`,
+              });
+              void resolve({
+                approved: false,
+                reason: normalizedRejectReason,
+              });
+            }}
+          >
+            拒绝并提交原因
+          </Button>
+          <Button
+            type="button"
+            variant="ghost"
+            className="rounded-full text-muted-foreground hover:!text-foreground"
+            onClick={() => {
+              updateState({ approved: false, status: "用户已取消 interrupt" });
+              void cancel();
+            }}
+          >
+            取消
+          </Button>
+        </div>
+      </div>
+    </ToolCard>
+  );
+}

--- a/agentscope-examples/agentscope-copilotkit/frontend/src/hooks/useV2HookExamples.tsx
+++ b/agentscope-examples/agentscope-copilotkit/frontend/src/hooks/useV2HookExamples.tsx
@@ -1,0 +1,340 @@
+import {
+  useAgent,
+  useCapabilities,
+  useComponent,
+  useConfigureSuggestions,
+  useDefaultRenderTool,
+  useFrontendTool,
+  useHumanInTheLoop,
+  useLearnFromUserAction,
+  useLearnFromUserActionInCurrentThread,
+  useLearningContainers,
+  useLearningContainersInCurrentThread,
+  useMemories,
+  useRenderActivityMessage,
+  useRenderCustomMessages,
+  useRenderTool,
+  useRenderToolCall,
+  useSuggestions,
+} from "@copilotkit/react-core/v2";
+import { useCallback, useMemo, useState } from "react";
+import { z } from "zod";
+
+import { CHAT_AGENT_ID } from "@/copilot/constants";
+import type { DemoState, HookDemoStatus } from "@/copilot/types";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { ToolCard } from "@/components/ToolCard";
+
+const updateDemoStateSchema = z.object({
+  topic: z.string().optional().describe("当前演示主题"),
+  priority: z.enum(["低", "中", "高"]).optional().describe("优先级"),
+  status: z.string().optional().describe("当前状态描述"),
+});
+
+const orderCardSchema = z.object({
+  orderNo: z.string().describe("订单号"),
+  amount: z.number().describe("订单金额"),
+  status: z.string().describe("订单状态"),
+});
+
+const hookBadgeSchema = z.object({
+  title: z.string().describe("Hook 名称或卡片标题"),
+  status: z.string().describe("当前状态"),
+  detail: z.string().optional().describe("补充说明"),
+});
+
+const humanApprovalSchema = z.object({
+  summary: z.string().describe("需要用户确认的操作摘要"),
+});
+
+type HookBadgeProps = z.infer<typeof hookBadgeSchema>;
+
+type AnnotationStatus = {
+  label: string;
+  value: string;
+};
+
+export function useV2HookExamples({
+  state,
+  updateState,
+}: {
+  state: DemoState;
+  updateState: (patch: Partial<DemoState>) => void;
+}) {
+  const { agent } = useAgent({ agentId: CHAT_AGENT_ID });
+  const capabilities = useCapabilities(CHAT_AGENT_ID);
+  const suggestions = useSuggestions({ agentId: CHAT_AGENT_ID });
+  const memories = useMemories();
+  const learnFromUserAction = useLearnFromUserAction();
+  const learnFromCurrentThread = useLearnFromUserActionInCurrentThread();
+  const renderToolCall = useRenderToolCall();
+  const renderCustomMessage = useRenderCustomMessages();
+  const { findRenderer: findActivityRenderer } = useRenderActivityMessage();
+  const [annotationStatus, setAnnotationStatus] = useState<AnnotationStatus>({
+    label: "annotate",
+    value: "未调用",
+  });
+
+  useConfigureSuggestions(
+    {
+      available: "always",
+      suggestions: [
+        {
+          title: "更新状态",
+          message: "把演示主题改成“订单审核”，优先级设为高。",
+        },
+        {
+          title: "渲染订单",
+          message: "渲染订单卡片：订单 A1001，金额 199.9，状态待支付。",
+        },
+        {
+          title: "HITL",
+          message: "调用 confirmDemoAction，摘要为“确认继续执行示例操作”。",
+        },
+      ],
+    },
+    [],
+  );
+
+  useLearningContainers({
+    threadId: agent.threadId,
+    learningContainers: ["project"],
+  });
+  useLearningContainersInCurrentThread({
+    learningContainers: ["project"],
+  });
+
+  useFrontendTool(
+    {
+      name: "updateDemoState",
+      description: "更新右侧状态管理面板，展示 useFrontendTool 和共享状态。",
+      parameters: updateDemoStateSchema,
+      handler: async ({ topic, priority, status }) => {
+        updateState({
+          topic: topic || state.topic,
+          priority: priority || state.priority,
+          status: status || state.status,
+        });
+        return { ok: true, updatedAt: new Date().toISOString() };
+      },
+      render: ({ args, status, result }) => (
+        <ToolCard title="useFrontendTool：状态管理" status={status}>
+          <p className="mb-3 text-sm leading-6 text-muted-foreground">
+            Copilot 正在更新前端共享状态。
+          </p>
+          <pre className="max-h-56 overflow-auto rounded-xl border border-border bg-background/80 p-3 text-sm text-aurora">
+            {JSON.stringify({ args, result }, null, 2)}
+          </pre>
+        </ToolCard>
+      ),
+    },
+    [state],
+  );
+
+  useFrontendTool(
+    {
+      name: "renderOrderCard",
+      description: "返回订单数据，交给 useRenderTool 渲染订单卡片。",
+      parameters: orderCardSchema,
+      handler: async ({ orderNo, amount, status }) => ({
+        orderNo,
+        amount,
+        status,
+        checkedAt: new Date().toLocaleString(),
+      }),
+    },
+    [],
+  );
+
+  useRenderTool(
+    {
+      name: "renderOrderCard",
+      parameters: orderCardSchema,
+      render: ({ parameters, status, result }) => (
+        <ToolCard title="useRenderTool：订单卡片" status={status}>
+          <div className="grid gap-2 rounded-2xl border border-champagne/15 bg-linear-to-br from-champagne/10 via-secondary/40 to-aurora/10 p-4">
+            <Badge variant="success">{parameters.status ?? "处理中"}</Badge>
+            <strong className="font-display text-lg text-foreground">
+              {parameters.orderNo ?? "ORDER-1001"}
+            </strong>
+            <p className="m-0 text-sm text-muted-foreground">
+              金额：¥{String(parameters.amount ?? "0")}
+            </p>
+            {result ? (
+              <small className="text-xs text-muted-foreground">
+                工具返回：{String(result)}
+              </small>
+            ) : null}
+          </div>
+        </ToolCard>
+      ),
+    },
+    [],
+  );
+
+  useComponent(
+    {
+      name: "showHookBadge",
+      description: "展示一个 v2 hook 状态徽章。",
+      parameters: hookBadgeSchema,
+      render: HookBadge,
+      followUp: false,
+    },
+    [],
+  );
+
+  useHumanInTheLoop(
+    {
+      name: "confirmDemoAction",
+      description: "请求用户确认后再继续，展示 useHumanInTheLoop。",
+      parameters: humanApprovalSchema,
+      render: ({ args, status, respond }) => (
+        <ToolCard title="useHumanInTheLoop：确认操作" status={status}>
+          <p className="mb-3 text-sm leading-6 text-muted-foreground">
+            {String(args.summary ?? "请确认是否继续执行该操作。")}
+          </p>
+          {respond ? (
+            <div className="mt-1 flex flex-wrap items-center gap-3">
+              <Button
+                type="button"
+                className="min-w-24 rounded-full"
+                onClick={() => void respond({ approved: true, source: "useHumanInTheLoop" })}
+              >
+                同意
+              </Button>
+              <Button
+                type="button"
+                variant="outline"
+                className="min-w-24 rounded-full"
+                onClick={() => void respond({ approved: false, source: "useHumanInTheLoop" })}
+              >
+                拒绝
+              </Button>
+            </div>
+          ) : null}
+        </ToolCard>
+      ),
+    },
+    [],
+  );
+
+  useDefaultRenderTool();
+
+  const renderToolPreview = useMemo(
+    () =>
+      renderToolCall({
+        toolCall: {
+          id: "preview-render-order-card",
+          type: "function",
+          function: {
+            name: "renderOrderCard",
+            arguments: JSON.stringify({
+              orderNo: "PREVIEW-1001",
+              amount: 88.8,
+              status: "预览",
+            }),
+          },
+        } as never,
+      }),
+    [renderToolCall],
+  );
+
+  const customMessageRendererReady = Boolean(renderCustomMessage);
+  const activityRendererReady = Boolean(findActivityRenderer("*"));
+
+  const recordAction = useCallback(async () => {
+    setAnnotationStatus({ label: "useLearnFromUserAction", value: "提交中..." });
+    try {
+      const result = await learnFromUserAction({
+        threadId: agent.threadId,
+        title: "用户点击了 v2 hooks 示例按钮",
+        data: { topic: state.topic, priority: state.priority },
+      });
+      setAnnotationStatus({
+        label: "useLearnFromUserAction",
+        value: `成功：${result.id}`,
+      });
+    } catch (error) {
+      setAnnotationStatus({
+        label: "useLearnFromUserAction",
+        value: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }, [agent.threadId, learnFromUserAction, state.priority, state.topic]);
+
+  const recordCurrentThreadAction = useCallback(async () => {
+    setAnnotationStatus({
+      label: "useLearnFromUserActionInCurrentThread",
+      value: "提交中...",
+    });
+    try {
+      const result = await learnFromCurrentThread({
+        title: "当前线程记录示例动作",
+        data: { updatedAt: state.updatedAt },
+      });
+      setAnnotationStatus({
+        label: "useLearnFromUserActionInCurrentThread",
+        value: `成功：${result.id}`,
+      });
+    } catch (error) {
+      setAnnotationStatus({
+        label: "useLearnFromUserActionInCurrentThread",
+        value: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }, [learnFromCurrentThread, state.updatedAt]);
+
+  const addDemoMemory = useCallback(async () => {
+    setAnnotationStatus({ label: "useMemories.addMemory", value: "提交中..." });
+    try {
+      await memories.addMemory({
+        kind: "operational",
+        content: "Prefer concise AgentScope CopilotKit demo responses.",
+      });
+      setAnnotationStatus({ label: "useMemories.addMemory", value: "成功" });
+    } catch (error) {
+      setAnnotationStatus({
+        label: "useMemories.addMemory",
+        value: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }, [memories]);
+
+  const statuses: HookDemoStatus[] = [
+    { label: "useAgent", value: agent.isRunning ? "running" : "idle" },
+    { label: "messages", value: String(agent.messages.length) },
+    { label: "threadId", value: agent.threadId },
+    { label: "useCapabilities", value: capabilities ? "ready" : "pending" },
+    { label: "useSuggestions", value: `${suggestions.suggestions.length} 条` },
+    { label: "useMemories", value: memories.isAvailable ? "available" : "unavailable" },
+    { label: "memory realtime", value: memories.realtimeStatus },
+    { label: "useRenderCustomMessages", value: customMessageRendererReady ? "ready" : "no renderer" },
+    { label: "useRenderActivityMessage", value: activityRendererReady ? "ready" : "no renderer" },
+  ];
+
+  return {
+    agent,
+    capabilities,
+    suggestions,
+    memories,
+    annotationStatus,
+    statuses,
+    renderToolPreview,
+    recordAction,
+    recordCurrentThreadAction,
+    addDemoMemory,
+  };
+}
+
+function HookBadge({ title, status, detail }: HookBadgeProps) {
+  return (
+    <div className="grid gap-2 rounded-2xl border border-champagne/20 bg-linear-to-br from-champagne/10 to-aurora/10 p-4">
+      <Badge variant="success" className="w-fit">
+        {status}
+      </Badge>
+      <strong className="font-display text-lg text-foreground">{title}</strong>
+      {detail ? <p className="text-sm text-muted-foreground">{detail}</p> : null}
+    </div>
+  );
+}

--- a/agentscope-examples/agentscope-copilotkit/frontend/src/lib/utils.ts
+++ b/agentscope-examples/agentscope-copilotkit/frontend/src/lib/utils.ts
@@ -1,0 +1,6 @@
+import { clsx, type ClassValue } from "clsx";
+import { twMerge } from "tailwind-merge";
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}

--- a/agentscope-examples/agentscope-copilotkit/frontend/src/main.tsx
+++ b/agentscope-examples/agentscope-copilotkit/frontend/src/main.tsx
@@ -1,0 +1,28 @@
+import { CopilotKit } from "@copilotkit/react-core/v2";
+import React from "react";
+import ReactDOM from "react-dom/client";
+
+import { workbenchA2uiTheme, workbenchCatalog } from "@/a2ui/workbenchCatalog";
+import { WORKBENCH_AGENT_ID } from "@/copilot/constants";
+
+import App from "./App";
+import "./styles.css";
+
+ReactDOM.createRoot(document.getElementById("root")!).render(
+  <React.StrictMode>
+    <CopilotKit
+      runtimeUrl="/agui/run"
+      debug={true}
+      useSingleEndpoint={false}
+      agent={WORKBENCH_AGENT_ID}
+      enableInspector={false}
+      headers={{}}
+      // Passing a catalog is what activates the A2UI renderer against a self-hosted AG-UI
+      // backend: CopilotKit normally learns about A2UI from a CopilotRuntime /info response,
+      // but an explicit catalog turns it on directly.
+      a2ui={{ theme: workbenchA2uiTheme, catalog: workbenchCatalog }}
+    >
+      <App />
+    </CopilotKit>
+  </React.StrictMode>,
+);

--- a/agentscope-examples/agentscope-copilotkit/frontend/src/styles.css
+++ b/agentscope-examples/agentscope-copilotkit/frontend/src/styles.css
@@ -1,0 +1,243 @@
+@import "tailwindcss";
+@import "tw-animate-css";
+
+@custom-variant dark (&:is(.dark *));
+
+@theme inline {
+  --color-background: var(--background);
+  --color-foreground: var(--foreground);
+  --color-card: var(--card);
+  --color-card-foreground: var(--card-foreground);
+  --color-popover: var(--popover);
+  --color-popover-foreground: var(--popover-foreground);
+  --color-primary: var(--primary);
+  --color-primary-foreground: var(--primary-foreground);
+  --color-secondary: var(--secondary);
+  --color-secondary-foreground: var(--secondary-foreground);
+  --color-muted: var(--muted);
+  --color-muted-foreground: var(--muted-foreground);
+  --color-accent: var(--accent);
+  --color-accent-foreground: var(--accent-foreground);
+  --color-destructive: var(--destructive);
+  --color-border: var(--border);
+  --color-input: var(--input);
+  --color-ring: var(--ring);
+  --color-champagne: var(--champagne);
+  --color-aurora: var(--aurora);
+  --font-sans: "Manrope", ui-sans-serif, sans-serif;
+  --font-display: "Space Grotesk", "Manrope", ui-sans-serif, sans-serif;
+  --radius-sm: calc(var(--radius) - 4px);
+  --radius-md: calc(var(--radius) - 2px);
+  --radius-lg: var(--radius);
+  --radius-xl: calc(var(--radius) + 4px);
+  --radius-2xl: calc(var(--radius) + 10px);
+}
+
+:root,
+.dark {
+  --radius: 0.95rem;
+  --background: oklch(0.13 0.012 255);
+  --foreground: oklch(0.94 0.012 95);
+  --card: oklch(0.17 0.014 255 / 0.72);
+  --card-foreground: oklch(0.94 0.012 95);
+  --popover: oklch(0.16 0.014 255);
+  --popover-foreground: oklch(0.94 0.012 95);
+  --primary: oklch(0.84 0.065 88);
+  --primary-foreground: oklch(0.18 0.02 80);
+  --secondary: oklch(0.22 0.016 255);
+  --secondary-foreground: oklch(0.9 0.014 95);
+  --muted: oklch(0.2 0.014 255);
+  --muted-foreground: oklch(0.68 0.02 95);
+  --accent: oklch(0.24 0.02 210);
+  --accent-foreground: oklch(0.9 0.03 195);
+  --destructive: oklch(0.62 0.12 25);
+  --border: oklch(0.84 0.05 88 / 0.14);
+  --input: oklch(0.84 0.05 88 / 0.16);
+  --ring: oklch(0.84 0.065 88 / 0.45);
+  --champagne: oklch(0.84 0.065 88);
+  --aurora: oklch(0.78 0.07 195);
+}
+
+@layer base {
+  * {
+    @apply border-border outline-ring/50;
+  }
+
+  html {
+    @apply scroll-smooth bg-background text-foreground antialiased;
+    font-family: var(--font-sans);
+    font-synthesis: none;
+    text-rendering: optimizeLegibility;
+  }
+
+  body {
+    @apply m-0 min-h-screen min-w-80 overflow-x-hidden bg-background text-foreground;
+    background:
+      radial-gradient(ellipse 70% 50% at 12% -8%, oklch(0.84 0.065 88 / 0.12), transparent 55%),
+      radial-gradient(ellipse 55% 45% at 88% 8%, oklch(0.72 0.08 195 / 0.12), transparent 50%),
+      radial-gradient(ellipse 50% 40% at 50% 100%, oklch(0.4 0.04 255 / 0.35), transparent 55%),
+      oklch(0.11 0.012 255);
+  }
+
+  ::selection {
+    background: oklch(0.84 0.065 88 / 0.28);
+    color: oklch(0.98 0.01 95);
+  }
+
+  button,
+  input,
+  textarea {
+    font: inherit;
+  }
+
+  button {
+    @apply cursor-pointer;
+  }
+
+  button:disabled {
+    @apply cursor-not-allowed;
+  }
+
+  h1,
+  h2,
+  h3,
+  .font-display {
+    font-family: var(--font-display);
+  }
+}
+
+@layer components {
+  .glass-panel {
+    @apply border border-border bg-card/80 shadow-[0_24px_80px_oklch(0_0_0/0.35)] backdrop-blur-2xl transition-shadow duration-300;
+  }
+
+  .glass-panel:hover {
+    box-shadow:
+      0 28px 90px oklch(0 0 0 / 0.4),
+      0 0 0 1px oklch(0.84 0.065 88 / 0.08);
+  }
+
+  .eyebrow {
+    @apply mb-2 text-[0.7rem] font-semibold tracking-[0.22em] text-champagne uppercase;
+  }
+
+  .hero-grid {
+    background-image:
+      linear-gradient(oklch(0.84 0.05 88 / 0.06) 1px, transparent 1px),
+      linear-gradient(90deg, oklch(0.84 0.05 88 / 0.06) 1px, transparent 1px);
+    background-size: 64px 64px;
+    mask-image: radial-gradient(ellipse 75% 70% at 50% 40%, black 20%, transparent 75%);
+  }
+
+  .aurora-orb {
+    @apply pointer-events-none absolute rounded-full blur-3xl;
+    animation: aurora-drift 14s ease-in-out infinite;
+  }
+
+  .aurora-orb-gold {
+    background: radial-gradient(circle, oklch(0.84 0.07 88 / 0.35), transparent 70%);
+  }
+
+  .aurora-orb-cyan {
+    background: radial-gradient(circle, oklch(0.75 0.08 195 / 0.28), transparent 70%);
+    animation-delay: -5s;
+  }
+
+  .chat-frame {
+    @apply relative overflow-hidden rounded-2xl border border-border bg-background/60 shadow-inner;
+  }
+
+  .chat-frame [data-testid="copilot-chat"],
+  .chat-frame [data-copilotkit] {
+    height: 100%;
+  }
+
+  [data-copilotkit] {
+    --background: oklch(0.14 0.012 255);
+    --foreground: oklch(0.94 0.012 95);
+    --card: oklch(0.18 0.014 255);
+    --card-foreground: oklch(0.94 0.012 95);
+    --popover: oklch(0.16 0.014 255);
+    --popover-foreground: oklch(0.94 0.012 95);
+    --primary: oklch(0.84 0.065 88);
+    --primary-foreground: oklch(0.18 0.02 80);
+    --secondary: oklch(0.22 0.016 255);
+    --secondary-foreground: oklch(0.9 0.014 95);
+    --muted: oklch(0.2 0.014 255);
+    --muted-foreground: oklch(0.68 0.02 95);
+    --accent: oklch(0.24 0.02 210);
+    --accent-foreground: oklch(0.9 0.03 195);
+    --destructive: oklch(0.62 0.12 25);
+    --border: oklch(0.84 0.05 88 / 0.14);
+    --input: oklch(0.84 0.05 88 / 0.16);
+    --ring: oklch(0.84 0.065 88 / 0.45);
+    --radius: 0.95rem;
+  }
+
+  .surface-row {
+    @apply rounded-2xl border border-border/70 bg-secondary/40 p-3 transition-all duration-300;
+  }
+
+  .surface-row:hover {
+    @apply border-champagne/25 bg-secondary/70 shadow-[0_12px_40px_oklch(0_0_0/0.25)];
+  }
+
+  .prompt-chip {
+    @apply rounded-2xl border border-border bg-secondary/30 p-3 text-left text-sm transition-all duration-300 hover:-translate-y-0.5 hover:border-champagne/30 hover:bg-secondary/60 hover:shadow-[0_16px_40px_oklch(0_0_0/0.3)];
+  }
+
+  /*
+   * CopilotKit scopes preflight under [data-copilotkit] and resets every button
+   * to transparent / radius 0. Restore our shadcn buttons with equal-or-higher
+   * specificity so HITL / panel actions stay solid.
+   */
+  [data-copilotkit] button[data-slot="button"],
+  button[data-slot="button"] {
+    appearance: none;
+    border-style: solid;
+    border-width: 0;
+    font: inherit;
+    line-height: 1.25;
+  }
+}
+
+@keyframes aurora-drift {
+  0%,
+  100% {
+    transform: translate3d(0, 0, 0) scale(1);
+    opacity: 0.7;
+  }
+  50% {
+    transform: translate3d(4%, -3%, 0) scale(1.08);
+    opacity: 1;
+  }
+}
+
+@keyframes fade-up {
+  from {
+    opacity: 0;
+    transform: translateY(18px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.animate-fade-up {
+  animation: fade-up 0.8s cubic-bezier(0.22, 1, 0.36, 1) both;
+}
+
+.animate-fade-up-delay-1 {
+  animation: fade-up 0.8s cubic-bezier(0.22, 1, 0.36, 1) 0.12s both;
+}
+
+.animate-fade-up-delay-2 {
+  animation: fade-up 0.8s cubic-bezier(0.22, 1, 0.36, 1) 0.24s both;
+}
+
+@media (max-width: 1180px) {
+  body {
+    overflow: auto;
+  }
+}

--- a/agentscope-examples/agentscope-copilotkit/frontend/src/vite-env.d.ts
+++ b/agentscope-examples/agentscope-copilotkit/frontend/src/vite-env.d.ts
@@ -1,0 +1,4 @@
+/// <reference types="vite/client" />
+
+declare module "*.css";
+declare module "@copilotkit/react-core/v2/styles.css";

--- a/agentscope-examples/agentscope-copilotkit/frontend/tsconfig.json
+++ b/agentscope-examples/agentscope-copilotkit/frontend/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ES2020"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  },
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/agentscope-examples/agentscope-copilotkit/frontend/tsconfig.node.json
+++ b/agentscope-examples/agentscope-copilotkit/frontend/tsconfig.node.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "skipLibCheck": true,
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "types": ["node"]
+  },
+  "include": ["vite.config.ts"]
+}

--- a/agentscope-examples/agentscope-copilotkit/frontend/vite.config.ts
+++ b/agentscope-examples/agentscope-copilotkit/frontend/vite.config.ts
@@ -1,0 +1,26 @@
+import tailwindcss from "@tailwindcss/vite";
+import react from "@vitejs/plugin-react";
+import { fileURLToPath, URL } from "node:url";
+import { defineConfig } from "vite";
+
+export default defineConfig({
+  plugins: [react(), tailwindcss()],
+  resolve: {
+    alias: {
+      "@": fileURLToPath(new URL("./src", import.meta.url)),
+    },
+  },
+  build: {
+    outDir: "../src/main/resources/static",
+    emptyOutDir: true,
+  },
+  server: {
+    port: 5173,
+    proxy: {
+      "/agui": {
+        target: "http://localhost:8080",
+        changeOrigin: true,
+      },
+    },
+  },
+});

--- a/agentscope-examples/agentscope-copilotkit/pom.xml
+++ b/agentscope-examples/agentscope-copilotkit/pom.xml
@@ -1,0 +1,130 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2024-2026 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.agentscope</groupId>
+        <artifactId>agentscope-examples</artifactId>
+        <version>${revision}</version>
+    </parent>
+
+    <artifactId>agentscope-copilotkit</artifactId>
+    <packaging>jar</packaging>
+
+    <dependencyManagement>
+        <dependencies>
+            <!-- Spring Boot BOM -->
+            <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-dependencies</artifactId>
+                <version>${spring.boot.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.agentscope</groupId>
+            <artifactId>agentscope-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.agentscope</groupId>
+            <artifactId>agentscope-extensions-model-dashscope</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.agentscope</groupId>
+            <artifactId>agentscope-extensions-agui</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.agentscope</groupId>
+            <artifactId>agentscope-agui-spring-boot-starter</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-webflux</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <!-- Spring Boot fat JAR -->
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <version>${spring.boot.version}</version>
+                <configuration>
+                    <mainClass>io.agentscope.examples.copilotkit.CopilotKitExampleApplication</mainClass>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>repackage</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <!-- Frontend build: npm run build -> src/main/resources/static -->
+            <plugin>
+                <groupId>com.github.eirslett</groupId>
+                <artifactId>frontend-maven-plugin</artifactId>
+                <version>1.15.1</version>
+                <configuration>
+                    <workingDirectory>frontend</workingDirectory>
+                    <installDirectory>target</installDirectory>
+                    <nodeVersion>v20.19.2</nodeVersion>
+                    <npmVersion>10.9.2</npmVersion>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>install-node-npm</id>
+                        <goals>
+                            <goal>install-node-and-npm</goal>
+                        </goals>
+                        <phase>generate-resources</phase>
+                    </execution>
+                    <execution>
+                        <id>npm-install</id>
+                        <goals>
+                            <goal>npm</goal>
+                        </goals>
+                        <phase>generate-resources</phase>
+                        <configuration>
+                            <arguments>install</arguments>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>npm-build</id>
+                        <goals>
+                            <goal>npm</goal>
+                        </goals>
+                        <phase>generate-resources</phase>
+                        <configuration>
+                            <arguments>run build</arguments>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/agentscope-examples/agentscope-copilotkit/src/main/java/io/agentscope/examples/copilotkit/CopilotKitExampleApplication.java
+++ b/agentscope-examples/agentscope-copilotkit/src/main/java/io/agentscope/examples/copilotkit/CopilotKitExampleApplication.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.examples.copilotkit;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+/**
+ * AG-UI Example Application.
+ *
+ * <p>This application demonstrates how to expose AgentScope agents via the AG-UI protocol
+ * using Spring WebFlux.
+ *
+ * <p><b>Usage:</b>
+ * <ol>
+ *   <li>Set the DASHSCOPE_API_KEY environment variable</li>
+ *   <li>Run this application</li>
+ *   <li>Open http://localhost:8080 in a browser</li>
+ *   <li>Or use curl: curl -X POST http://localhost:8080/agui/run -H "Content-Type: application/json" -d '{"threadId":"test","runId":"1","messages":[{"id":"m1","role":"user","content":"Hello!"}]}'</li>
+ * </ol>
+ */
+@SpringBootApplication
+public class CopilotKitExampleApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(CopilotKitExampleApplication.class, args);
+        printStartupInfo();
+    }
+
+    private static void printStartupInfo() {
+        System.out.println("\n=== AG-UI Example Application Started ===");
+        System.out.println("Open: http://localhost:8080");
+        System.out.println("API:  POST http://localhost:8080/agui/run");
+        System.out.println("\nExample curl command:");
+        System.out.println("  curl -N -X POST http://localhost:8080/agui/run \\");
+        System.out.println("    -H \"Content-Type: application/json\" \\");
+        System.out.println(
+                "    -d"
+                    + " '{\"threadId\":\"test\",\"runId\":\"1\",\"messages\":[{\"id\":\"m1\",\"role\":\"user\",\"content\":\"Hello!\"}]}'");
+        System.out.println("\nPress Ctrl+C to stop.");
+    }
+}

--- a/agentscope-examples/agentscope-copilotkit/src/main/java/io/agentscope/examples/copilotkit/a2ui/A2uiComposer.java
+++ b/agentscope-examples/agentscope-copilotkit/src/main/java/io/agentscope/examples/copilotkit/a2ui/A2uiComposer.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.examples.copilotkit.a2ui;
+
+import io.agentscope.core.util.JsonUtils;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.core.annotation.AnnotationAwareOrderComparator;
+import org.springframework.stereotype.Component;
+
+/**
+ * Turns a natural-language intent into a renderable A2UI surface.
+ *
+ * <p>Model clients are tried in order (Gemini first, DashScope second). Every failure — no
+ * credentials, a network error, malformed JSON, a component outside the catalog — falls through to
+ * the next client, and finally to the deterministic {@link A2uiFallbackSurface}, so
+ * {@code render_dashboard} always returns something the browser can paint.
+ */
+@Component
+public class A2uiComposer {
+
+    private static final Logger logger = LoggerFactory.getLogger(A2uiComposer.class);
+
+    private final A2uiSchemaSource schemaSource;
+    private final List<A2uiModelClient> modelClients;
+
+    public A2uiComposer(A2uiSchemaSource schemaSource, List<A2uiModelClient> modelClients) {
+        this.schemaSource = schemaSource;
+        this.modelClients =
+                modelClients.stream().sorted(AnnotationAwareOrderComparator.INSTANCE).toList();
+    }
+
+    public String schemaSourceName() {
+        return schemaSource.name();
+    }
+
+    /**
+     * Composes a surface for {@code intent}.
+     *
+     * @param intent what the user asked to see
+     * @param stateSnapshot the current workbench state, used both as model input and as the source
+     *     of truth for the deterministic fallback
+     * @param clientComponents custom components the browser declared it can render; empty
+     *     advertises the whole server-side catalog
+     */
+    public A2uiSurface compose(
+            String intent, Map<String, Object> stateSnapshot, Set<String> clientComponents) {
+        String surfaceId = "workbench-" + UUID.randomUUID().toString().substring(0, 8);
+        String systemPrompt = schemaSource.systemPrompt(clientComponents);
+        String userPrompt = buildUserPrompt(intent, surfaceId, stateSnapshot);
+
+        for (A2uiModelClient client : modelClients) {
+            if (!client.isAvailable()) {
+                continue;
+            }
+            try {
+                String raw = client.generate(systemPrompt, userPrompt);
+                List<Map<String, Object>> operations =
+                        schemaSource.parse(raw, surfaceId, clientComponents);
+                return new A2uiSurface(
+                        surfaceId,
+                        WorkbenchCatalog.CATALOG_ID,
+                        intent,
+                        client.name(),
+                        A2uiOperations.countComponents(operations),
+                        operations);
+            } catch (Exception e) {
+                logger.warn("A2UI 生成失败，切换下一个模型：client={}, reason={}", client.name(), e.toString());
+            }
+        }
+
+        return A2uiFallbackSurface.build(surfaceId, intent, stateSnapshot);
+    }
+
+    private static String buildUserPrompt(
+            String intent, String surfaceId, Map<String, Object> stateSnapshot) {
+        return """
+        请生成界面。
+
+        surfaceId: %s
+        用户意图: %s
+
+        可用数据（JSON，可通过 updateDataModel 绑定，也可直接内联为字面量）：
+        %s
+        """
+                .formatted(surfaceId, intent, toJson(stateSnapshot));
+    }
+
+    private static String toJson(Object value) {
+        try {
+            return JsonUtils.getJsonCodec().toJson(value);
+        } catch (Exception e) {
+            return "{}";
+        }
+    }
+}

--- a/agentscope-examples/agentscope-copilotkit/src/main/java/io/agentscope/examples/copilotkit/a2ui/A2uiFallbackSurface.java
+++ b/agentscope-examples/agentscope-copilotkit/src/main/java/io/agentscope/examples/copilotkit/a2ui/A2uiFallbackSurface.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.examples.copilotkit.a2ui;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Deterministic workbench dashboard, assembled straight from the shared state.
+ *
+ * <p>Used when no model backend is configured or every one of them failed, so the A2UI half of the
+ * demo stays functional offline. It also doubles as a reference for the exact wire shape the model
+ * is asked to produce.
+ */
+final class A2uiFallbackSurface {
+
+    private A2uiFallbackSurface() {}
+
+    @SuppressWarnings("unchecked")
+    static A2uiSurface build(String surfaceId, String intent, Map<String, Object> state) {
+        List<Map<String, Object>> components = new ArrayList<>();
+        List<String> rootChildren = new ArrayList<>();
+
+        components.add(
+                A2uiOperations.component(
+                        "title",
+                        "Text",
+                        Map.of(
+                                "text",
+                                string(state.get("topic"), "AgentScope 工作台"),
+                                "variant",
+                                "h3")));
+        rootChildren.add("title");
+
+        components.add(
+                A2uiOperations.component(
+                        "subtitle", "Text", Map.of("text", "意图：" + intent, "variant", "caption")));
+        rootChildren.add("subtitle");
+
+        Map<String, Object> metrics =
+                state.get("metrics") instanceof Map<?, ?> map
+                        ? (Map<String, Object>) map
+                        : Map.of();
+        if (!metrics.isEmpty()) {
+            List<String> tileIds = new ArrayList<>();
+            int index = 0;
+            for (Map.Entry<String, Object> entry : metrics.entrySet()) {
+                String id = "metric-" + index++;
+                components.add(
+                        A2uiOperations.component(
+                                id,
+                                "MetricTile",
+                                Map.of(
+                                        "label", entry.getKey(),
+                                        "value", String.valueOf(entry.getValue()),
+                                        "accent", index % 2 == 0 ? "aurora" : "champagne")));
+                tileIds.add(id);
+            }
+            components.add(
+                    A2uiOperations.component(
+                            "metric-row",
+                            "Row",
+                            Map.of("children", tileIds, "justify", "spaceBetween")));
+            rootChildren.add("metric-row");
+        }
+
+        Map<String, Object> plan =
+                state.get("plan") instanceof Map<?, ?> map ? (Map<String, Object>) map : Map.of();
+        List<Map<String, Object>> tasks =
+                plan.get("tasks") instanceof List<?> list
+                        ? (List<Map<String, Object>>) list
+                        : List.of();
+        if (!tasks.isEmpty()) {
+            components.add(A2uiOperations.component("plan-divider", "Divider", Map.of()));
+            rootChildren.add("plan-divider");
+
+            List<String> stepIds = new ArrayList<>();
+            for (int i = 0; i < tasks.size(); i++) {
+                Map<String, Object> task = tasks.get(i);
+                String id = "step-" + i;
+                components.add(
+                        A2uiOperations.component(
+                                id,
+                                "TimelineStep",
+                                Map.of(
+                                        "index", i + 1,
+                                        "title", string(task.get("title"), "未命名步骤"),
+                                        "state", string(task.get("state"), "pending"))));
+                stepIds.add(id);
+            }
+            components.add(
+                    A2uiOperations.component("plan-column", "Column", Map.of("children", stepIds)));
+            rootChildren.add("plan-column");
+        }
+
+        List<Map<String, Object>> audit =
+                state.get("permissionAudit") instanceof List<?> list
+                        ? (List<Map<String, Object>>) list
+                        : List.of();
+        if (!audit.isEmpty()) {
+            Map<String, Object> latest = audit.get(0);
+            boolean granted = Boolean.TRUE.equals(latest.get("granted"));
+            components.add(
+                    A2uiOperations.component(
+                            "audit",
+                            "ApprovalCallout",
+                            Map.of(
+                                    "title",
+                                    granted ? "最近一次授权已通过" : "最近一次授权被拒绝",
+                                    "body",
+                                    "%s · %s"
+                                            .formatted(
+                                                    string(latest.get("tool"), "unknown"),
+                                                    string(latest.get("detail"), "")),
+                                    "tone",
+                                    granted ? "info" : "danger")));
+            rootChildren.add("audit");
+        }
+
+        components.add(
+                A2uiOperations.component("root", "Column", Map.of("children", rootChildren)));
+
+        Map<String, Object> dataModel = new LinkedHashMap<>();
+        dataModel.put("topic", state.get("topic"));
+        dataModel.put("status", state.get("status"));
+
+        List<Map<String, Object>> operations =
+                List.of(
+                        A2uiOperations.createSurface(surfaceId),
+                        A2uiOperations.updateDataModel(surfaceId, dataModel),
+                        A2uiOperations.updateComponents(surfaceId, components));
+
+        return new A2uiSurface(
+                surfaceId,
+                WorkbenchCatalog.CATALOG_ID,
+                intent,
+                "fallback",
+                components.size(),
+                operations);
+    }
+
+    private static String string(Object value, String fallback) {
+        return value == null || String.valueOf(value).isBlank() ? fallback : String.valueOf(value);
+    }
+}

--- a/agentscope-examples/agentscope-copilotkit/src/main/java/io/agentscope/examples/copilotkit/a2ui/A2uiModelClient.java
+++ b/agentscope-examples/agentscope-copilotkit/src/main/java/io/agentscope/examples/copilotkit/a2ui/A2uiModelClient.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.examples.copilotkit.a2ui;
+
+import org.springframework.core.Ordered;
+
+/**
+ * One model backend able to turn an intent into A2UI JSON.
+ *
+ * <p>{@link A2uiComposer} walks the available clients in {@link Ordered} order, so Gemini is tried
+ * before the DashScope fallback.
+ */
+public interface A2uiModelClient extends Ordered {
+
+    /** Identifier recorded in the shared state as {@code a2ui.generatedBy}. */
+    String name();
+
+    /** Whether the required credentials are configured. */
+    boolean isAvailable();
+
+    /**
+     * Generates raw model output; the composer extracts the {@code <a2ui-json>} block from it.
+     *
+     * @throws Exception when the model call fails, letting the composer move to the next client
+     */
+    String generate(String systemPrompt, String userPrompt) throws Exception;
+}

--- a/agentscope-examples/agentscope-copilotkit/src/main/java/io/agentscope/examples/copilotkit/a2ui/A2uiOperations.java
+++ b/agentscope-examples/agentscope-copilotkit/src/main/java/io/agentscope/examples/copilotkit/a2ui/A2uiOperations.java
@@ -1,0 +1,194 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.examples.copilotkit.a2ui;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Builders and structural checks for A2UI v0.9 server-to-client messages.
+ *
+ * <p>The checks here are intentionally structural (surface consistency, a resolvable {@code root},
+ * known component names).
+ */
+public final class A2uiOperations {
+
+    private A2uiOperations() {}
+
+    public static Map<String, Object> createSurface(String surfaceId) {
+        Map<String, Object> body = new LinkedHashMap<>();
+        body.put("surfaceId", surfaceId);
+        body.put("catalogId", WorkbenchCatalog.CATALOG_ID);
+        return message("createSurface", body);
+    }
+
+    public static Map<String, Object> updateDataModel(String surfaceId, Map<String, Object> value) {
+        Map<String, Object> body = new LinkedHashMap<>();
+        body.put("surfaceId", surfaceId);
+        body.put("path", "/");
+        body.put("value", value);
+        return message("updateDataModel", body);
+    }
+
+    public static Map<String, Object> updateComponents(
+            String surfaceId, List<Map<String, Object>> components) {
+        Map<String, Object> body = new LinkedHashMap<>();
+        body.put("surfaceId", surfaceId);
+        body.put("components", components);
+        return message("updateComponents", body);
+    }
+
+    public static Map<String, Object> component(
+            String id, String component, Map<String, Object> props) {
+        Map<String, Object> node = new LinkedHashMap<>();
+        node.put("id", id);
+        node.put("component", component);
+        props.forEach(
+                (key, value) -> {
+                    if (value != null) {
+                        node.put(key, value);
+                    }
+                });
+        return node;
+    }
+
+    private static Map<String, Object> message(String key, Map<String, Object> body) {
+        Map<String, Object> message = new LinkedHashMap<>();
+        message.put("version", WorkbenchCatalog.VERSION);
+        message.put(key, body);
+        return message;
+    }
+
+    /** Counts the components declared across every {@code updateComponents} message. */
+    @SuppressWarnings("unchecked")
+    public static int countComponents(List<Map<String, Object>> operations) {
+        int count = 0;
+        for (Map<String, Object> operation : operations) {
+            if (operation.get("updateComponents") instanceof Map<?, ?> body
+                    && body.get("components") instanceof List<?> components) {
+                count += components.size();
+            }
+        }
+        return count;
+    }
+
+    /** Returns the surface id referenced by the first operation that declares one. */
+    public static String surfaceIdOf(List<Map<String, Object>> operations) {
+        for (Map<String, Object> operation : operations) {
+            for (Object value : operation.values()) {
+                if (value instanceof Map<?, ?> body
+                        && body.get("surfaceId") instanceof String surfaceId) {
+                    return surfaceId;
+                }
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Normalises model output into a renderable operation list.
+     *
+     * <p>Models routinely drop the {@code createSurface} preamble or invent their own surface id, so
+     * the list is rewritten onto {@code surfaceId} and the preamble is prepended when missing.
+     *
+     * @throws IllegalArgumentException when the payload cannot be repaired into a valid surface
+     */
+    @SuppressWarnings("unchecked")
+    public static List<Map<String, Object>> normalize(List<?> rawOperations, String surfaceId) {
+        if (rawOperations == null || rawOperations.isEmpty()) {
+            throw new IllegalArgumentException("A2UI 负载为空");
+        }
+
+        List<Map<String, Object>> operations = new ArrayList<>();
+        boolean hasCreateSurface = false;
+        boolean hasComponents = false;
+
+        for (Object raw : rawOperations) {
+            if (!(raw instanceof Map<?, ?> map)) {
+                throw new IllegalArgumentException("A2UI 消息必须是对象，实际为 " + raw);
+            }
+            Map<String, Object> operation = new LinkedHashMap<>((Map<String, Object>) map);
+            operation.put("version", WorkbenchCatalog.VERSION);
+
+            String kind = operationKind(operation);
+            Map<String, Object> body =
+                    new LinkedHashMap<>((Map<String, Object>) operation.get(kind));
+            body.put("surfaceId", surfaceId);
+            if ("createSurface".equals(kind)) {
+                body.put("catalogId", WorkbenchCatalog.CATALOG_ID);
+                hasCreateSurface = true;
+            }
+            if ("updateComponents".equals(kind)) {
+                validateComponents((List<Object>) body.get("components"));
+                hasComponents = true;
+            }
+            operation.put(kind, body);
+            operations.add(operation);
+        }
+
+        if (!hasComponents) {
+            throw new IllegalArgumentException("A2UI 负载缺少 updateComponents 消息");
+        }
+        if (!hasCreateSurface) {
+            operations.add(0, createSurface(surfaceId));
+        }
+        return operations;
+    }
+
+    private static String operationKind(Map<String, Object> operation) {
+        for (String kind :
+                List.of("createSurface", "updateComponents", "updateDataModel", "deleteSurface")) {
+            if (operation.get(kind) instanceof Map<?, ?>) {
+                return kind;
+            }
+        }
+        throw new IllegalArgumentException("无法识别的 A2UI 消息：" + operation.keySet());
+    }
+
+    @SuppressWarnings("unchecked")
+    private static void validateComponents(List<Object> components) {
+        if (components == null || components.isEmpty()) {
+            throw new IllegalArgumentException("updateComponents.components 不能为空");
+        }
+        Set<String> ids = new LinkedHashSet<>();
+        for (Object raw : components) {
+            if (!(raw instanceof Map<?, ?> map)) {
+                throw new IllegalArgumentException("组件必须是对象");
+            }
+            Map<String, Object> node = (Map<String, Object>) map;
+            if (!(node.get("id") instanceof String id) || id.isBlank()) {
+                throw new IllegalArgumentException("组件缺少 id");
+            }
+            if (!(node.get("component") instanceof String component)) {
+                throw new IllegalArgumentException("组件 " + id + " 缺少 component 字段");
+            }
+            if (!WorkbenchCatalog.isKnownComponent(component)) {
+                throw new IllegalArgumentException(
+                        "组件 %s 使用了 catalog 之外的类型 %s".formatted(id, component));
+            }
+            if (!ids.add(id)) {
+                throw new IllegalArgumentException("组件 id 重复：" + id);
+            }
+        }
+        if (!ids.contains("root")) {
+            throw new IllegalArgumentException("组件树缺少 id 为 root 的根节点");
+        }
+    }
+}

--- a/agentscope-examples/agentscope-copilotkit/src/main/java/io/agentscope/examples/copilotkit/a2ui/A2uiSchemaSource.java
+++ b/agentscope-examples/agentscope-copilotkit/src/main/java/io/agentscope/examples/copilotkit/a2ui/A2uiSchemaSource.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.examples.copilotkit.a2ui;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Supplies the A2UI grammar shown to the model and turns the reply back into a checked payload.
+ *
+ * <p>The default implementation is {@link BundledA2uiSchemaSource}: a hand-written grammar plus the
+ * structural checks in {@link A2uiOperations}.
+ *
+ * <p>Prompting and parsing are deliberately one contract rather than two: a grammar is only
+ * meaningful next to the validator that enforces it.
+ */
+public interface A2uiSchemaSource {
+
+    /** Short identifier surfaced to the browser so the demo can show which path is active. */
+    String name();
+
+    /**
+     * Builds the system prompt for the A2UI composer.
+     *
+     * @param clientComponents the custom components the browser declared it can render; empty means
+     *     no restriction, so the full server-side catalog is advertised
+     */
+    String systemPrompt(Set<String> clientComponents);
+
+    /**
+     * Parses and validates a raw model reply.
+     *
+     * @param rawModelReply the model's full answer, expected to carry a {@code <a2ui-json>} block
+     * @param surfaceId the id the caller allocated; operations are rewritten onto it so a model that
+     *     invents its own id still produces a surface the browser can address
+     * @param clientComponents components the browser can render, used to scope validation
+     * @return the A2UI server-to-client messages, ready to be put on the wire
+     * @throws RuntimeException when the reply is unusable, which makes the composer fall through to
+     *     the next model client and finally to the deterministic fallback
+     */
+    List<Map<String, Object>> parse(
+            String rawModelReply, String surfaceId, Set<String> clientComponents);
+}

--- a/agentscope-examples/agentscope-copilotkit/src/main/java/io/agentscope/examples/copilotkit/a2ui/A2uiSurface.java
+++ b/agentscope-examples/agentscope-copilotkit/src/main/java/io/agentscope/examples/copilotkit/a2ui/A2uiSurface.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.examples.copilotkit.a2ui;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * A generated A2UI surface, ready to be shipped to the browser.
+ *
+ * @param surfaceId the surface identifier shared by every operation in {@code operations}
+ * @param catalogId the catalog the components come from
+ * @param intent the natural-language request that produced the surface
+ * @param generatedBy which composer produced it ({@code gemini}, {@code dashscope}, {@code
+ *     fallback})
+ * @param componentCount number of components in the rendered tree
+ * @param operations the raw A2UI v0.9 server-to-client messages
+ *
+ */
+public record A2uiSurface(
+        String surfaceId,
+        String catalogId,
+        String intent,
+        String generatedBy,
+        int componentCount,
+        List<Map<String, Object>> operations) {}

--- a/agentscope-examples/agentscope-copilotkit/src/main/java/io/agentscope/examples/copilotkit/a2ui/BundledA2uiSchemaSource.java
+++ b/agentscope-examples/agentscope-copilotkit/src/main/java/io/agentscope/examples/copilotkit/a2ui/BundledA2uiSchemaSource.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.examples.copilotkit.a2ui;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import io.agentscope.core.util.JsonUtils;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.springframework.stereotype.Component;
+
+/**
+ * Default {@link A2uiSchemaSource}: a compact hand-written A2UI v0.9 grammar plus the structural
+ * checks in {@link A2uiOperations}.
+ */
+@Component
+public class BundledA2uiSchemaSource implements A2uiSchemaSource {
+
+    private static final Pattern TAGGED_BLOCK =
+            Pattern.compile("<a2ui-json>(.*?)</a2ui-json>", Pattern.DOTALL);
+    private static final Pattern FENCED_BLOCK =
+            Pattern.compile("```(?:json)?\\s*(.*?)```", Pattern.DOTALL);
+
+    @Override
+    public String name() {
+        return "bundled-a2ui-v0.9";
+    }
+
+    @Override
+    public String systemPrompt(Set<String> clientComponents) {
+        return "你是 AgentScope 工作台的 A2UI 生成器。根据用户意图和给定数据，输出一份 A2UI v0.9 界面描述。\n\n"
+                + WorkbenchCatalog.grammar(clientComponents);
+    }
+
+    @Override
+    public List<Map<String, Object>> parse(
+            String rawModelReply, String surfaceId, Set<String> clientComponents) {
+        if (rawModelReply == null || rawModelReply.isBlank()) {
+            throw new IllegalArgumentException("模型没有返回内容");
+        }
+        List<Object> parsed =
+                JsonUtils.getJsonCodec()
+                        .fromJson(extractJsonArray(rawModelReply), new TypeReference<>() {});
+        return A2uiOperations.normalize(parsed, surfaceId);
+    }
+
+    /** Pulls the JSON array out of the model reply, tolerating tags, fences and stray prose. */
+    private static String extractJsonArray(String raw) {
+        Matcher tagged = TAGGED_BLOCK.matcher(raw);
+        if (tagged.find()) {
+            return stripFence(tagged.group(1));
+        }
+        Matcher fenced = FENCED_BLOCK.matcher(raw);
+        if (fenced.find()) {
+            return fenced.group(1).trim();
+        }
+        int start = raw.indexOf('[');
+        int end = raw.lastIndexOf(']');
+        if (start >= 0 && end > start) {
+            return raw.substring(start, end + 1);
+        }
+        throw new IllegalArgumentException("模型输出中找不到 A2UI JSON 数组");
+    }
+
+    private static String stripFence(String value) {
+        String trimmed = value.trim();
+        if (trimmed.startsWith("```")) {
+            trimmed = trimmed.replaceFirst("^```(?:json)?", "").trim();
+        }
+        if (trimmed.endsWith("```")) {
+            trimmed = trimmed.substring(0, trimmed.length() - 3).trim();
+        }
+        return trimmed;
+    }
+}

--- a/agentscope-examples/agentscope-copilotkit/src/main/java/io/agentscope/examples/copilotkit/a2ui/DashScopeA2uiModelClient.java
+++ b/agentscope-examples/agentscope-copilotkit/src/main/java/io/agentscope/examples/copilotkit/a2ui/DashScopeA2uiModelClient.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.examples.copilotkit.a2ui;
+
+import io.agentscope.core.ReActAgent;
+import io.agentscope.core.message.Msg;
+import io.agentscope.core.message.UserMessage;
+import io.agentscope.extensions.model.dashscope.DashScopeChatModel;
+import io.agentscope.extensions.model.dashscope.formatter.DashScopeChatFormatter;
+import java.time.Duration;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+/**
+ * Fallback A2UI composer running on DashScope, so the demo still produces surfaces without a Gemini
+ * key.
+ *
+ * <p>A fresh single-iteration {@link ReActAgent} is built per request: the composer is stateless and
+ * must never inherit conversation memory from a previous surface.
+ */
+@Component
+public class DashScopeA2uiModelClient implements A2uiModelClient {
+
+    private static final Duration TIMEOUT = Duration.ofSeconds(60);
+
+    private final String modelName;
+
+    public DashScopeA2uiModelClient(
+            @Value("${agentscope.copilotkit.a2ui.dashscope.model:qwen-plus}") String modelName) {
+        this.modelName = modelName;
+    }
+
+    @Override
+    public String name() {
+        return "dashscope:" + modelName;
+    }
+
+    @Override
+    public boolean isAvailable() {
+        String apiKey = System.getenv("DASHSCOPE_API_KEY");
+        return apiKey != null && !apiKey.isBlank();
+    }
+
+    @Override
+    public int getOrder() {
+        return 20;
+    }
+
+    @Override
+    public String generate(String systemPrompt, String userPrompt) {
+        ReActAgent composer =
+                ReActAgent.builder()
+                        .name("A2UI Composer")
+                        .sysPrompt(systemPrompt)
+                        .model(
+                                DashScopeChatModel.builder()
+                                        .apiKey(System.getenv("DASHSCOPE_API_KEY"))
+                                        .modelName(modelName)
+                                        .stream(false)
+                                        .formatter(new DashScopeChatFormatter())
+                                        .build())
+                        .maxIters(1)
+                        .build();
+        Msg reply = composer.call(new UserMessage("user", userPrompt)).block(TIMEOUT);
+        return reply == null ? null : reply.getTextContent();
+    }
+}

--- a/agentscope-examples/agentscope-copilotkit/src/main/java/io/agentscope/examples/copilotkit/a2ui/WorkbenchCatalog.java
+++ b/agentscope-examples/agentscope-copilotkit/src/main/java/io/agentscope/examples/copilotkit/a2ui/WorkbenchCatalog.java
@@ -1,0 +1,256 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.examples.copilotkit.a2ui;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * The A2UI component catalog this example advertises to the model.
+ *
+ * <p>It is the basic A2UI v0.9 catalog plus four workbench-specific components. The very same
+ * catalog id and component names are implemented on the browser side in
+ * {@code frontend/src/a2ui/workbenchCatalog.tsx} via {@code createCatalog(...)}, so anything the
+ * model emits here has a matching React renderer.
+ */
+public final class WorkbenchCatalog {
+
+    /** Catalog id shared with the browser catalog; goes into every {@code createSurface}. */
+    public static final String CATALOG_ID = "agentscope.io:workbench";
+
+    /** A2UI wire version implemented by both sides. */
+    public static final String VERSION = "v0.9";
+
+    /**
+     * Basic catalog components the A2UI renderer ships out of the box.
+     *
+     * <p>Mirrors {@code basic_catalog.json} of A2UI v0.9. Only the dashboard-relevant subset is
+     * advertised; the full catalog also defines form inputs, media and overlays.
+     */
+    public static final Set<String> BASIC_COMPONENTS =
+            Set.of("Text", "Card", "Column", "Row", "List", "Divider", "Button", "Image");
+
+    /** Workbench components implemented only by this example. */
+    public static final Set<String> CUSTOM_COMPONENTS =
+            Set.of("MetricTile", "RiskGauge", "TimelineStep", "ApprovalCallout", "StatBadge");
+
+    private WorkbenchCatalog() {}
+
+    public static boolean isKnownComponent(String component) {
+        return BASIC_COMPONENTS.contains(component) || CUSTOM_COMPONENTS.contains(component);
+    }
+
+    /** Grammar line per custom component, so the prompt can be narrowed to what the client has. */
+    private static final Map<String, String> CUSTOM_COMPONENT_GRAMMAR =
+            Map.of(
+                    "MetricTile",
+                    """
+                    - MetricTile      { id, component:"MetricTile", label:string, value:string,
+                                        delta?:string, trend?:"up"|"down"|"flat",
+                                        accent?:"champagne"|"aurora"|"danger" }\
+                    """,
+                    "RiskGauge",
+                    """
+                    - RiskGauge       { id, component:"RiskGauge", label:string, score:number(0-100),
+                                        threshold?:number, caption?:string }\
+                    """,
+                    "TimelineStep",
+                    """
+                    - TimelineStep    { id, component:"TimelineStep", index:number, title:string,
+                                        state:"pending"|"in_progress"|"completed", note?:string }\
+                    """,
+                    "ApprovalCallout",
+                    """
+                    - ApprovalCallout { id, component:"ApprovalCallout", title:string, body:string,
+                                        tone?:"info"|"warn"|"danger" }\
+                    """,
+                    "StatBadge",
+                    """
+                    - StatBadge       { id, component:"StatBadge", text:string,
+                                        tone?:"neutral"|"success"|"warn"|"danger" }\
+                    """);
+
+    /**
+     * Compact grammar handed to the LLM.
+     *
+     * <p>Deliberately hand-written instead of dumping the 40 KB JSON-Schema catalog: the smaller
+     * prompt is both cheaper and markedly more reliable for mid-size models.
+     *
+     * @param clientComponents custom components the browser can render; empty advertises all of them
+     */
+    public static String grammar(Set<String> clientComponents) {
+        return BASE_GRAMMAR
+                .formatted(CATALOG_ID, customComponentGrammar(clientComponents))
+                .stripTrailing();
+    }
+
+    private static String customComponentGrammar(Set<String> clientComponents) {
+        Set<String> advertised =
+                clientComponents == null || clientComponents.isEmpty()
+                        ? CUSTOM_COMPONENTS
+                        : clientComponents;
+        return CUSTOM_COMPONENT_GRAMMAR.entrySet().stream()
+                .filter(entry -> advertised.contains(entry.getKey()))
+                .sorted(Map.Entry.comparingByKey())
+                .map(Map.Entry::getValue)
+                .collect(Collectors.joining("\n"));
+    }
+
+    private static final String BASE_GRAMMAR =
+            """
+            ## A2UI v0.9 输出格式
+
+            输出一个 JSON 数组，数组元素是 A2UI server-to-client 消息，按顺序执行：
+
+            1. {"version":"v0.9","createSurface":{"surfaceId":"<id>","catalogId":"%s"}}
+            2. {"version":"v0.9","updateDataModel":{"surfaceId":"<id>","path":"/","value":{...}}}
+            3. {"version":"v0.9","updateComponents":{"surfaceId":"<id>","components":[...]}}
+
+            规则：
+            - surfaceId 必须三条消息保持一致，且使用调用方给定的 surfaceId。
+            - components 是扁平数组，其中必须恰好有一个 id 为 "root" 的组件作为根节点。
+            - 每个组件形如 {"id":"<唯一id>","component":"<组件名>", ...属性}；父子关系通过 id 字符串引用。
+            - 属性表里没有列出的字段一律不要写，多余字段会导致整个界面校验失败。
+            - 字符串/数字属性可写字面量，也可写 {"path":"/字段名"} 绑定 updateDataModel 写入的数据。
+            - 只能使用下面列出的组件。
+
+            ## 基础组件（A2UI 基础 catalog）
+
+            - Text    { id, component:"Text", text:string,
+                        variant?:"h1"|"h2"|"h3"|"h4"|"h5"|"caption"|"body" }
+            - Card    { id, component:"Card", child:组件id }            // 只能包一个子节点
+            - Column  { id, component:"Column", children:[组件id...],
+                        justify?:"start"|"center"|"end"|"spaceBetween", align?:"start"|"center"|"end"|"stretch" }
+            - Row     { id, component:"Row", children:[组件id...],
+                        justify?:"start"|"center"|"end"|"spaceBetween", align?:"start"|"center"|"end"|"stretch" }
+            - List    { id, component:"List", children:[组件id...], direction?:"vertical"|"horizontal" }
+            - Divider { id, component:"Divider", axis?:"horizontal"|"vertical" }
+            - Button  { id, component:"Button", child:组件id,           // 文案要用一个 Text 子节点
+                        action:{"event":{"name":"<动作名>"}}, variant?:"default"|"primary"|"borderless" }
+
+            ## 工作台自定义组件（本示例专属，暗色 + 香槟金视觉；以下为当前浏览器声明可渲染的组件）
+
+            %s
+
+            ## 排版建议
+
+            root 用 Column 组织；关键指标横向排 Row + 多个 MetricTile；计划步骤纵向排 Column + TimelineStep；
+            结论用 ApprovalCallout。标题用 Text + variant:"h3"，说明文字用 variant:"caption"。
+
+            ## 输出约定
+
+            只输出被 <a2ui-json> 与 </a2ui-json> 包裹的 JSON 数组，不要输出任何解释文字。
+            """;
+
+    /**
+     * The custom half of the catalog in A2UI v0.9 inline-catalog form.
+     *
+     * <p>Passed to the official SDK as {@code inlineCatalogs} so it can merge these components into
+     * the bundled basic catalog before validating.
+     *
+     * @param clientComponents custom components the browser can render; empty includes all of them
+     */
+    public static Map<String, Object> inlineCatalogSchema(Set<String> clientComponents) {
+        Map<String, Object> components = new LinkedHashMap<>();
+        components.put(
+                "MetricTile",
+                component(
+                        "MetricTile",
+                        Map.of(
+                                "label", stringProp("指标名称"),
+                                "value", stringProp("指标数值，已格式化"),
+                                "delta", stringProp("环比变化，例如 +12.4%"),
+                                "trend", enumProp("up", "down", "flat"),
+                                "accent", enumProp("champagne", "aurora", "danger")),
+                        List.of("component", "label", "value")));
+        components.put(
+                "RiskGauge",
+                component(
+                        "RiskGauge",
+                        Map.of(
+                                "label", stringProp("风险维度名称"),
+                                "score", numberProp("0-100 的风险分"),
+                                "threshold", numberProp("告警阈值"),
+                                "caption", stringProp("补充说明")),
+                        List.of("component", "label", "score")));
+        components.put(
+                "TimelineStep",
+                component(
+                        "TimelineStep",
+                        Map.of(
+                                "index", numberProp("步骤序号，从 1 开始"),
+                                "title", stringProp("步骤标题"),
+                                "state", enumProp("pending", "in_progress", "completed"),
+                                "note", stringProp("步骤备注")),
+                        List.of("component", "index", "title", "state")));
+        components.put(
+                "ApprovalCallout",
+                component(
+                        "ApprovalCallout",
+                        Map.of(
+                                "title", stringProp("提示标题"),
+                                "body", stringProp("提示正文"),
+                                "tone", enumProp("info", "warn", "danger")),
+                        List.of("component", "title", "body")));
+        components.put(
+                "StatBadge",
+                component(
+                        "StatBadge",
+                        Map.of(
+                                "text", stringProp("徽标文案"),
+                                "tone", enumProp("neutral", "success", "warn", "danger")),
+                        List.of("component", "text")));
+
+        if (clientComponents != null && !clientComponents.isEmpty()) {
+            components.keySet().retainAll(clientComponents);
+        }
+
+        Map<String, Object> catalog = new LinkedHashMap<>();
+        catalog.put("catalogId", CATALOG_ID);
+        catalog.put("components", components);
+        return catalog;
+    }
+
+    private static Map<String, Object> component(
+            String name, Map<String, Object> properties, List<String> required) {
+        Map<String, Object> merged = new LinkedHashMap<>();
+        merged.put("component", Map.of("const", name));
+        merged.putAll(properties);
+
+        Map<String, Object> specific = new LinkedHashMap<>();
+        specific.put("properties", merged);
+        specific.put("required", required);
+
+        return Map.of(
+                "allOf",
+                List.of(Map.of("$ref", "common_types.json#/$defs/ComponentCommon"), specific));
+    }
+
+    private static Map<String, Object> stringProp(String description) {
+        return Map.of("type", "string", "description", description);
+    }
+
+    private static Map<String, Object> numberProp(String description) {
+        return Map.of("type", "number", "description", description);
+    }
+
+    private static Map<String, Object> enumProp(String... values) {
+        return Map.of("type", "string", "enum", List.of(values));
+    }
+}

--- a/agentscope-examples/agentscope-copilotkit/src/main/java/io/agentscope/examples/copilotkit/config/AgentConfiguration.java
+++ b/agentscope-examples/agentscope-copilotkit/src/main/java/io/agentscope/examples/copilotkit/config/AgentConfiguration.java
@@ -1,0 +1,431 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.examples.copilotkit.config;
+
+import io.agentscope.core.ReActAgent;
+import io.agentscope.core.agent.Agent;
+import io.agentscope.core.agent.RuntimeContext;
+import io.agentscope.core.agui.adapter.strategy.AgentEventConverter;
+import io.agentscope.core.agui.adapter.strategy.AguiEventEnricher;
+import io.agentscope.core.agui.adapter.strategy.AguiStreamContext;
+import io.agentscope.core.agui.event.AguiEvent;
+import io.agentscope.core.agui.event.AguiEvents;
+import io.agentscope.core.event.AgentEvent;
+import io.agentscope.core.event.AgentStartEvent;
+import io.agentscope.core.event.CustomEvent;
+import io.agentscope.core.event.RequireExternalExecutionEvent;
+import io.agentscope.core.message.ToolUseBlock;
+import io.agentscope.core.middleware.AgentInput;
+import io.agentscope.core.middleware.MiddlewareBase;
+import io.agentscope.core.model.ToolSchema;
+import io.agentscope.core.permission.PermissionBehavior;
+import io.agentscope.core.permission.PermissionContextState;
+import io.agentscope.core.permission.PermissionMode;
+import io.agentscope.core.permission.PermissionRule;
+import io.agentscope.core.tool.Toolkit;
+import io.agentscope.examples.copilotkit.a2ui.A2uiComposer;
+import io.agentscope.examples.copilotkit.service.InMemoryAgentEventStore;
+import io.agentscope.examples.copilotkit.service.PersistingAgentEventEnricher;
+import io.agentscope.examples.copilotkit.workbench.RefundOrderTool;
+import io.agentscope.examples.copilotkit.workbench.WorkbenchAguiEventConverter;
+import io.agentscope.examples.copilotkit.workbench.WorkbenchEventMiddleware;
+import io.agentscope.examples.copilotkit.workbench.WorkbenchStateRegistry;
+import io.agentscope.examples.copilotkit.workbench.WorkbenchTools;
+import io.agentscope.extensions.model.dashscope.DashScopeChatModel;
+import io.agentscope.extensions.model.dashscope.formatter.DashScopeChatFormatter;
+import io.agentscope.spring.boot.agui.common.AguiAgentRegistryCustomizer;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import reactor.core.publisher.Flux;
+
+/**
+ * Configuration class that registers agents with the AG-UI registry.
+ *
+ * <p>This example demonstrates how to register multiple agents with different IDs.
+ * Clients can select which agent to use via:
+ * <ul>
+ *   <li>URL path variable: {@code POST /agui/run/{agentId}}</li>
+ *   <li>HTTP header: {@code X-Agent-Id: agentId}</li>
+ *   <li>Request body: {@code forwardedProps.agentId}</li>
+ * </ul>
+ */
+@Configuration
+public class AgentConfiguration {
+
+    private final WorkbenchStateRegistry workbenchStateRegistry;
+    private final A2uiComposer a2uiComposer;
+
+    public AgentConfiguration(
+            WorkbenchStateRegistry workbenchStateRegistry, A2uiComposer a2uiComposer) {
+        this.workbenchStateRegistry = workbenchStateRegistry;
+        this.a2uiComposer = a2uiComposer;
+    }
+
+    @Bean
+    public AguiAgentRegistryCustomizer aguiAgentRegistryCustomizer() {
+        AguiAgentRegistryCustomizer aguiAgentRegistryCustomizer =
+                registry -> {
+                    // The showcase agent: permission gating, plan tasks, shared state and A2UI.
+                    registry.registerFactory("workbench", this::createWorkbenchAgent);
+
+                    // Register a factory for the default agent
+                    // Using a factory ensures each request gets a fresh agent instance
+                    registry.registerFactory("default", this::createDefaultAgent);
+
+                    // Register additional agents with different IDs
+                    // Example: a simple chat agent without tools
+                    registry.registerFactory("chat", this::createChatAgent);
+
+                    // Example: an agent specialized for calculations
+                    registry.registerFactory("calculator", this::createCalculatorAgent);
+                };
+
+        System.out.println(
+                "Registered agents with AG-UI registry: workbench, default, chat, calculator");
+        System.out.println("Access agents via:");
+        System.out.println("  - POST /agui/run (uses default-agent-id from config)");
+        System.out.println("  - POST /agui/run/chat (uses 'chat' agent)");
+        System.out.println(
+                "  - POST /agui/run/agent/{agentId}/run (CopilotKit multi-route, see"
+                        + " CopilotKitRouteConfiguration)");
+        System.out.println("  - POST /agui/run with X-Agent-Id header");
+
+        return aguiAgentRegistryCustomizer;
+    }
+
+    @Bean
+    public AgentEventConverter requireExternalExecutionEventConverter() {
+        return new AgentEventConverter() {
+            @Override
+            public Set<Class<? extends AgentEvent>> eventTypes() {
+                return Set.of(RequireExternalExecutionEvent.class);
+            }
+
+            @Override
+            public void convert(AgentEvent event, AguiStreamContext context) {
+                RequireExternalExecutionEvent customEvent = (RequireExternalExecutionEvent) event;
+                for (ToolUseBlock toolCall : customEvent.getToolCalls()) {
+                    context.emit(
+                            new AguiEvent.ToolCallChunk(
+                                    context.getThreadId(),
+                                    context.getRunId(),
+                                    toolCall.getId(),
+                                    toolCall.getName(),
+                                    null,
+                                    toolCall.getContent()));
+                }
+            }
+        };
+    }
+
+    @Bean
+    public AguiEventEnricher exampleAguiEventEnricher() {
+        return (source, events, context) -> {
+            long timestamp = System.currentTimeMillis();
+            return events.stream()
+                    .map(event -> enrichExampleEvent(source, event, timestamp))
+                    .toList();
+        };
+    }
+
+    /**
+     * Persist each source {@link AgentEvent} so {@code /agent/{agentId}/connect} can re-project
+     * AG-UI frames through converters.
+     *
+     * <p>Ordered last among enrichers; it only records the AgentEvent and does not mutate frames.
+     */
+    @Bean
+    @Order(Ordered.LOWEST_PRECEDENCE)
+    public PersistingAgentEventEnricher persistingAgentEventEnricher(
+            InMemoryAgentEventStore eventStore,
+            ObjectProvider<WorkbenchAguiEventConverter> workbenchConverterProvider) {
+        return new PersistingAgentEventEnricher(eventStore, workbenchConverterProvider);
+    }
+
+    /**
+     * The showcase agent, wired so that one conversation can exercise every capability the demo
+     * claims.
+     *
+     * <p>What each piece of the builder buys:
+     *
+     * <ul>
+     *   <li>{@code permissionContext} — the three-state permission engine. Read-only and
+     *       state-writing tools carry ALLOW rules; {@code deploy_release} carries an ASK rule and
+     *       therefore suspends the run into an AG-UI interrupt that CopilotKit renders as a
+     *       confirmation card; {@code purge_production_data} carries a DENY rule that no mode or
+     *       rule can lift. {@code refund_order} deliberately has <em>no</em> rule so its own
+     *       {@code checkPermissions} decides based on the refund amount.
+     *   <li>{@code enableTaskList()} — registers the built-in {@code todo_write} tool plus the
+     *       per-turn task reminder. {@code WorkbenchEventMiddleware} mirrors the resulting task
+     *       list into shared state, which is what drives the plan board and the STEP_STARTED /
+     *       STEP_FINISHED frames.
+     *   <li>{@code enableThinking} — reasoning deltas reach the browser as AG-UI
+     *       {@code REASONING_MESSAGE_*} events.
+     * </ul>
+     *
+     * <p>{@code PermissionMode.DEFAULT} means anything without a matching rule asks the user, so
+     * new tools are safe by default rather than silently privileged.
+     */
+    private Agent createWorkbenchAgent() {
+        Toolkit toolkit = new Toolkit();
+        toolkit.registerTool(new WorkbenchTools(workbenchStateRegistry, a2uiComposer));
+        toolkit.registerAgentTool(new RefundOrderTool(workbenchStateRegistry));
+
+        return ReActAgent.builder()
+                .name("AgentScope_Workbench")
+                .sysPrompt(WORKBENCH_SYS_PROMPT)
+                .model(
+                        DashScopeChatModel.builder()
+                                .apiKey(getRequiredApiKey())
+                                .modelName("qwen3.5-plus")
+                                .stream(true)
+                                .enableThinking(true)
+                                .formatter(new DashScopeChatFormatter())
+                                .build())
+                .toolkit(toolkit)
+                .enableTaskList()
+                .permissionContext(workbenchPermissionContext())
+                .middleware(new WorkbenchEventMiddleware(workbenchStateRegistry))
+                .maxIters(16)
+                .build();
+    }
+
+    private static PermissionContextState workbenchPermissionContext() {
+        PermissionContextState.Builder permissions =
+                PermissionContextState.builder().mode(PermissionMode.DEFAULT);
+
+        // Read-only and state-only tools: no reason to interrupt the user for these.
+        for (String tool :
+                List.of(
+                        "query_service_metrics",
+                        "update_workbench_brief",
+                        "set_plan_goal",
+                        "render_dashboard",
+                        "confirmDemoAction",
+                        "renderOrderCard",
+                        "todo_write")) {
+            permissions.addAllowRule(
+                    tool, new PermissionRule(tool, null, PermissionBehavior.ALLOW, "policy"));
+        }
+
+        // Production release always needs a human in the loop.
+        permissions.addAskRule(
+                "deploy_release",
+                new PermissionRule("deploy_release", null, PermissionBehavior.ASK, "policy"));
+
+        // Destructive and irreversible: blocked outright, and a deny rule cannot be bypassed.
+        permissions.addDenyRule(
+                "purge_production_data",
+                new PermissionRule(
+                        "purge_production_data", null, PermissionBehavior.DENY, "policy"));
+
+        return permissions.build();
+    }
+
+    private static final String WORKBENCH_SYS_PROMPT =
+            """
+            你是 AgentScope 运维工作台的智能体，运行在 AG-UI 协议之上，前端是 CopilotKit。
+
+            工作方式：
+            1. 面对多步骤任务时，先调用 set_plan_goal 声明总目标，再用 todo_write 写出 3-6 条任务清单；
+               推进过程中持续用 todo_write 更新状态（同一时刻只允许一条 in_progress）。前端计划看板会实时跟随。
+            2. 需要数据时调用 query_service_metrics；需要把结论沉淀到共享状态时调用 update_workbench_brief。
+            3. 需要用图形化方式展示指标、计划进度或风险结论时，调用 render_dashboard 动态生成界面，
+               不要用 Markdown 表格代替它。
+            4. deploy_release 是高危操作，会弹出人工确认；被拒绝时不要重试，直接说明已取消。
+            5. purge_production_data 被安全策略永久禁止，用户要求删除生产数据时直接拒绝并解释原因。
+            6. refund_order 的放行与否取决于金额，由工具自身判断，你只需如实发起调用。
+
+            回答保持简洁，用中文，说明你做了什么以及下一步建议。不要假装某个操作已完成。
+            """;
+
+    /**
+     * Create the default agent instance.
+     *
+     * <p>This agent is configured with:
+     * <ul>
+     *   <li>DashScope qwen-plus model with streaming enabled</li>
+     *   <li>Example tools (get_weather, calculate)</li>
+     *   <li>In-memory conversation memory</li>
+     * </ul>
+     */
+    private Agent createDefaultAgent() {
+        String apiKey = getRequiredApiKey();
+
+        // Create toolkit with example tools
+        Toolkit toolkit = new Toolkit();
+        // Schema-only HITL tool: suspends the run so CopilotKit useInterrupt can resume it.
+        // Do not also register this as a CopilotKit frontend tool — that auto-executes and
+        // clears the pending interrupt before the interrupt UI can stay mounted.
+        toolkit.registerSchema(requestHumanApprovalSchema());
+        //        toolkit.registerTool(new ExampleTools());
+
+        // Create the agent
+        return ReActAgent.builder()
+                .name("AG-UI Assistant")
+                .sysPrompt(
+                        "You are a helpful AI assistant exposed via the AG-UI protocol. When an"
+                            + " operation needs explicit human confirmation, or the user asks for"
+                            + " the approval interrupt demo, always call requestHumanApproval with"
+                            + " a clear summary. Do not pretend the action is already done before"
+                            + " approval. Be concise and helpful in your responses.")
+                .model(
+                        DashScopeChatModel.builder()
+                                .apiKey(apiKey)
+                                .modelName("qwen3.5-plus")
+                                .stream(true)
+                                .enableThinking(true)
+                                .formatter(new DashScopeChatFormatter())
+                                .build())
+                .toolkit(toolkit)
+                //                .middleware(exampleCustomEventMiddleware())
+                .maxIters(10)
+                .build();
+    }
+
+    private static ToolSchema requestHumanApprovalSchema() {
+        Map<String, Object> summaryProperty = new LinkedHashMap<>();
+        summaryProperty.put("type", "string");
+        summaryProperty.put("description", "需要用户确认的操作说明");
+
+        Map<String, Object> properties = new LinkedHashMap<>();
+        properties.put("summary", summaryProperty);
+
+        Map<String, Object> parameters = new LinkedHashMap<>();
+        parameters.put("type", "object");
+        parameters.put("properties", properties);
+        parameters.put("required", List.of("summary"));
+
+        return ToolSchema.builder()
+                .name("requestHumanApproval")
+                .description("当操作需要人工确认时调用，用户可以在聊天中批准或拒绝。")
+                .parameters(parameters)
+                .build();
+    }
+
+    /**
+     * Create a simple chat agent without tools.
+     *
+     * <p>This agent is a pure conversational assistant.
+     */
+    private Agent createChatAgent() {
+        String apiKey = getRequiredApiKey();
+
+        return ReActAgent.builder()
+                .name("Chat Assistant")
+                .sysPrompt(
+                        "You are a friendly conversational assistant. "
+                                + "Engage in natural conversation and help users "
+                                + "with general questions and discussions.")
+                .model(
+                        DashScopeChatModel.builder().apiKey(apiKey).modelName("qwen-plus").stream(
+                                        true)
+                                .formatter(new DashScopeChatFormatter())
+                                .build())
+                .middleware(exampleCustomEventMiddleware())
+                .maxIters(1)
+                .build();
+    }
+
+    /**
+     * Create a calculator agent specialized for mathematical operations.
+     */
+    private Agent createCalculatorAgent() {
+        String apiKey = getRequiredApiKey();
+
+        // Create toolkit with only calculation tools
+        Toolkit toolkit = new Toolkit();
+        //        toolkit.registerTool(new ExampleTools());
+
+        return ReActAgent.builder()
+                .name("Calculator Agent")
+                .sysPrompt(
+                        "You are a mathematical assistant specialized in calculations. "
+                                + "Use the calculate tool to perform mathematical operations. "
+                                + "Always show your work and explain the results.")
+                .model(
+                        DashScopeChatModel.builder().apiKey(apiKey).modelName("qwen-plus").stream(
+                                        true)
+                                .formatter(new DashScopeChatFormatter())
+                                .build())
+                .toolkit(toolkit)
+                .middleware(exampleCustomEventMiddleware())
+                .maxIters(5)
+                .build();
+    }
+
+    private static AguiEvent enrichExampleEvent(
+            AgentEvent source, AguiEvent event, long fallbackTimestamp) {
+        Long timestamp = event.timestamp() != null ? event.timestamp() : fallbackTimestamp;
+        Object rawEvent = event.rawEvent();
+        if (rawEvent == null && source instanceof CustomEvent customEvent) {
+            Map<String, Object> value = new LinkedHashMap<>();
+            value.put("agentEventType", source.getType().name());
+            if (customEvent.getName() != null) {
+                value.put("name", customEvent.getName());
+            }
+            rawEvent = value;
+        }
+        return AguiEvents.withBaseProperties(event, timestamp, rawEvent);
+    }
+
+    private static MiddlewareBase exampleCustomEventMiddleware() {
+        return new MiddlewareBase() {
+            @Override
+            public Flux<AgentEvent> onAgent(
+                    Agent agent,
+                    RuntimeContext ctx,
+                    AgentInput input,
+                    Function<AgentInput, Flux<AgentEvent>> next) {
+                CustomEvent event =
+                        new CustomEvent("example_agent_event", exampleCustomEventValue(agent, ctx));
+                return next.apply(input)
+                        .concatMap(
+                                agentEvent ->
+                                        agentEvent instanceof AgentStartEvent
+                                                ? Flux.just(agentEvent, event)
+                                                : Flux.just(agentEvent));
+            }
+        };
+    }
+
+    private static Map<String, Object> exampleCustomEventValue(Agent agent, RuntimeContext ctx) {
+        Map<String, Object> value = new LinkedHashMap<>();
+        value.put("agentName", agent.getName());
+        if (ctx != null && ctx.getSessionId() != null) {
+            value.put("sessionId", ctx.getSessionId());
+        }
+        return value;
+    }
+
+    private String getRequiredApiKey() {
+        String apiKey = System.getenv("DASHSCOPE_API_KEY");
+        if (apiKey == null || apiKey.isEmpty()) {
+            throw new IllegalStateException(
+                    "DASHSCOPE_API_KEY environment variable is required. "
+                            + "Please set it before starting the application.");
+        }
+        return apiKey;
+    }
+}

--- a/agentscope-examples/agentscope-copilotkit/src/main/java/io/agentscope/examples/copilotkit/config/CopilotKitRouteConfiguration.java
+++ b/agentscope-examples/agentscope-copilotkit/src/main/java/io/agentscope/examples/copilotkit/config/CopilotKitRouteConfiguration.java
@@ -1,0 +1,172 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.examples.copilotkit.config;
+
+import io.agentscope.core.ReActAgent;
+import io.agentscope.core.agui.model.RunAgentInput;
+import io.agentscope.examples.copilotkit.model.CopilotKitModels.ThreadInfo;
+import io.agentscope.examples.copilotkit.model.CopilotKitModels.ThreadMutationRequest;
+import io.agentscope.examples.copilotkit.service.CopilotKitRuntimeService;
+import io.agentscope.examples.copilotkit.service.DemoThreadStore;
+import io.agentscope.spring.boot.agui.common.ThreadSessionManager;
+import io.agentscope.spring.boot.agui.webflux.AguiWebFluxHandler;
+import java.util.Map;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.codec.DecodingException;
+import org.springframework.http.MediaType;
+import org.springframework.http.codec.ServerSentEvent;
+import org.springframework.web.reactive.function.server.RouterFunction;
+import org.springframework.web.reactive.function.server.RouterFunctions;
+import org.springframework.web.reactive.function.server.ServerRequest;
+import org.springframework.web.reactive.function.server.ServerResponse;
+import org.springframework.web.server.ServerWebInputException;
+import reactor.core.publisher.Mono;
+
+/**
+ * Functional routes for CopilotKit Runtime info, threads, connect, and multi-route agent run.
+ *
+ * <p>HTTP wiring lives here; business logic stays in dedicated services.
+ *
+ *
+ */
+@Configuration
+public class CopilotKitRouteConfiguration {
+
+    private static final String BASE = "/agui/run";
+
+    @Bean
+    public RouterFunction<ServerResponse> copilotKitRoutes(
+            CopilotKitRuntimeService runtime,
+            DemoThreadStore threads,
+            ThreadSessionManager sessionManager,
+            AguiWebFluxHandler aguiHandler) {
+        return RouterFunctions.route()
+                .GET(BASE + "/info", request -> ServerResponse.ok().bodyValue(runtime.info()))
+                .POST(BASE + "/annotate", request -> ServerResponse.ok().bodyValue(Map.of()))
+                .GET(BASE + "/threads", request -> listThreads(request, threads))
+                .POST(BASE + "/threads", request -> mutateThread(request, threads::create))
+                .PATCH(
+                        BASE + "/threads/{threadId}",
+                        request ->
+                                mutateThread(
+                                        request,
+                                        body -> threads.update(pathVar(request, "threadId"), body)))
+                .POST(
+                        BASE + "/threads/{threadId}/archive",
+                        request ->
+                                mutateThread(
+                                        request,
+                                        body ->
+                                                threads.archive(
+                                                        pathVar(request, "threadId"), body)))
+                .DELETE(
+                        BASE + "/threads/{threadId}",
+                        request ->
+                                ServerResponse.ok()
+                                        .bodyValue(threads.delete(pathVar(request, "threadId"))))
+                .GET(
+                        BASE + "/threads/{threadId}/events",
+                        request ->
+                                ServerResponse.ok()
+                                        .bodyValue(threads.events(pathVar(request, "threadId"))))
+                .GET(
+                        BASE + "/threads/{threadId}/messages",
+                        request ->
+                                ServerResponse.ok()
+                                        .bodyValue(threads.messages(pathVar(request, "threadId"))))
+                .GET(
+                        BASE + "/threads/{threadId}/state",
+                        request ->
+                                ServerResponse.ok()
+                                        .bodyValue(threads.state(pathVar(request, "threadId"))))
+                .POST(
+                        BASE + "/agent/{agentId}/connect",
+                        request ->
+                                request.bodyToMono(RunAgentInput.class)
+                                        .flatMap(
+                                                input ->
+                                                        ServerResponse.ok()
+                                                                .contentType(
+                                                                        MediaType.TEXT_EVENT_STREAM)
+                                                                .body(
+                                                                        runtime.connect(input),
+                                                                        ServerSentEvent.class)))
+                .POST(BASE + "/agent/{agentId}/run", aguiHandler::handleWithAgentId)
+                .POST(
+                        BASE + "/agent/{agentId}/stop/{threadId}",
+                        request -> stopThread(request, sessionManager))
+                .build();
+    }
+
+    private Mono<ServerResponse> stopThread(
+            ServerRequest request, ThreadSessionManager threadSessionManager) {
+        String agentId = request.pathVariable("agentId");
+        String threadId = request.pathVariable("threadId");
+        threadSessionManager
+                .getSession(threadId)
+                .ifPresent(
+                        threadSession -> {
+                            if (threadSession.getAgent() instanceof ReActAgent reActAgent) {
+                                reActAgent.interrupt(null, threadId);
+                            } else {
+                                // todo Harness?
+                                threadSession.getAgent().interrupt();
+                            }
+                        });
+        return Mono.empty();
+    }
+
+    private static Mono<ServerResponse> listThreads(
+            ServerRequest request, DemoThreadStore threads) {
+        String agentId = request.queryParam("agentId").orElse(DemoThreadStore.DEFAULT_AGENT_ID);
+        boolean includeArchived =
+                request.queryParam("includeArchived").map(Boolean::parseBoolean).orElse(false);
+        Integer limit = request.queryParam("limit").map(Integer::valueOf).orElse(null);
+        String cursor = request.queryParam("cursor").orElse(null);
+        return ServerResponse.ok().bodyValue(threads.list(agentId, includeArchived, limit, cursor));
+    }
+
+    @FunctionalInterface
+    private interface ThreadMutator {
+        ThreadInfo apply(ThreadMutationRequest body);
+    }
+
+    private static Mono<ServerResponse> mutateThread(ServerRequest request, ThreadMutator mutator) {
+        return optionalBody(request)
+                .map(mutator::apply)
+                .flatMap(thread -> ServerResponse.ok().bodyValue(thread))
+                .onErrorResume(CopilotKitRouteConfiguration::handleThreadMutationError);
+    }
+
+    private static Mono<ThreadMutationRequest> optionalBody(ServerRequest request) {
+        return request.bodyToMono(ThreadMutationRequest.class)
+                .defaultIfEmpty(new ThreadMutationRequest(null, null, null));
+    }
+
+    private static Mono<ServerResponse> handleThreadMutationError(Throwable error) {
+        if (error instanceof DecodingException || error instanceof ServerWebInputException) {
+            return ServerResponse.badRequest()
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .bodyValue(Map.of("error", "Invalid thread mutation request body"));
+        }
+        return Mono.error(error);
+    }
+
+    private static String pathVar(ServerRequest request, String name) {
+        return request.pathVariable(name);
+    }
+}

--- a/agentscope-examples/agentscope-copilotkit/src/main/java/io/agentscope/examples/copilotkit/model/CopilotKitModels.java
+++ b/agentscope-examples/agentscope-copilotkit/src/main/java/io/agentscope/examples/copilotkit/model/CopilotKitModels.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.examples.copilotkit.model;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * CopilotKit Runtime / thread API models (immutable records).
+ *
+ *
+ */
+public final class CopilotKitModels {
+
+    private CopilotKitModels() {}
+
+    public record InfoResponse(
+            String version,
+            Map<String, AgentInfo> agents,
+            boolean audioFileTranscriptionEnabled,
+            String mode,
+            ThreadEndpoints threadEndpoints,
+            boolean suggestions,
+            Intelligence intelligence,
+            boolean a2uiEnabled,
+            boolean openGenerativeUIEnabled,
+            String licenseStatus,
+            boolean telemetryDisabled) {}
+
+    public record AgentInfo(
+            String id,
+            String name,
+            String description,
+            Map<String, Boolean> capabilities,
+            String className) {
+
+        public AgentInfo withIdentity(String name, String description, String className) {
+            return new AgentInfo(id, name, description, capabilities, className);
+        }
+    }
+
+    public record ThreadEndpoints(
+            boolean list, boolean inspect, boolean mutations, boolean realtimeMetadata) {}
+
+    public record Intelligence(String wsUrl) {}
+
+    public record ThreadsResponse(List<ThreadInfo> threads, String nextCursor, String joinCode) {}
+
+    public record ThreadInfo(
+            String id,
+            String name,
+            String agentId,
+            boolean archived,
+            String createdAt,
+            String updatedAt,
+            String lastRunAt) {
+
+        public ThreadInfo withName(String name) {
+            return new ThreadInfo(id, name, agentId, archived, createdAt, updatedAt, lastRunAt);
+        }
+
+        public ThreadInfo withArchived(boolean archived) {
+            return new ThreadInfo(id, name, agentId, archived, createdAt, updatedAt, lastRunAt);
+        }
+
+        public ThreadInfo withUpdatedAt(String updatedAt) {
+            return new ThreadInfo(id, name, agentId, archived, createdAt, updatedAt, lastRunAt);
+        }
+    }
+
+    public record ThreadMutationRequest(String agentId, String name, Boolean archived) {}
+}

--- a/agentscope-examples/agentscope-copilotkit/src/main/java/io/agentscope/examples/copilotkit/service/AgentEventAguiReplayer.java
+++ b/agentscope-examples/agentscope-copilotkit/src/main/java/io/agentscope/examples/copilotkit/service/AgentEventAguiReplayer.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.examples.copilotkit.service;
+
+import io.agentscope.core.agui.adapter.AguiAdapterConfig;
+import io.agentscope.core.agui.adapter.strategy.AgentEventConverter;
+import io.agentscope.core.agui.adapter.strategy.AgentEventConverterRegistry;
+import io.agentscope.core.agui.adapter.strategy.AguiEventEnricher;
+import io.agentscope.core.agui.adapter.strategy.AguiStreamContext;
+import io.agentscope.core.agui.event.AguiEvent;
+import io.agentscope.core.agui.model.AguiMessage;
+import io.agentscope.core.agui.model.RunAgentInput;
+import io.agentscope.examples.copilotkit.service.InMemoryAgentEventStore.StoredAgentEvent;
+import io.agentscope.examples.copilotkit.workbench.WorkbenchAguiEventConverter;
+import io.agentscope.spring.boot.agui.common.AguiProperties;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.stereotype.Component;
+
+/**
+ * Replays persisted {@link io.agentscope.core.event.AgentEvent}s into AG-UI frames.
+ *
+ * <p>Uses the same converter / enricher set as the live adapter (minus the persisting enricher),
+ * and resets workbench snapshot baselines per historical run so {@code STATE_SNAPSHOT} /
+ * {@code STATE_DELTA} projection matches a fresh conversion.
+ *
+ */
+@Component
+public final class AgentEventAguiReplayer {
+
+    private final InMemoryAgentEventStore eventStore;
+    private final AguiProperties properties;
+    private final List<AgentEventConverter> eventConverters;
+    private final List<AguiEventEnricher> replayEnrichers;
+    private final WorkbenchAguiEventConverter workbenchConverter;
+
+    public AgentEventAguiReplayer(
+            InMemoryAgentEventStore eventStore,
+            AguiProperties properties,
+            ObjectProvider<AgentEventConverter> eventConvertersProvider,
+            ObjectProvider<AguiEventEnricher> eventEnrichersProvider,
+            ObjectProvider<WorkbenchAguiEventConverter> workbenchConverterProvider) {
+        this.eventStore = eventStore;
+        this.properties = properties;
+        this.eventConverters = eventConvertersProvider.orderedStream().toList();
+        this.replayEnrichers =
+                eventEnrichersProvider
+                        .orderedStream()
+                        .filter(enricher -> !(enricher instanceof PersistingAgentEventEnricher))
+                        .toList();
+        this.workbenchConverter = workbenchConverterProvider.getIfAvailable();
+    }
+
+    /**
+     * Project stored AgentEvents for a thread into AG-UI events.
+     *
+     * @param threadId thread to replay
+     * @param connectInput optional connect payload (tools / state used by converters)
+     * @return AG-UI events in conversion order; empty when the thread has no history
+     */
+    public List<AguiEvent> replay(String threadId, RunAgentInput connectInput) {
+        List<StoredAgentEvent> history = eventStore.snapshot(threadId);
+        if (history.isEmpty()) {
+            return List.of();
+        }
+
+        AguiAdapterConfig config = replayConfig();
+        AgentEventConverterRegistry registry =
+                new AgentEventConverterRegistry(
+                        config.getEventConverters(), config.getEventEnrichers());
+
+        List<AguiEvent> projected = new ArrayList<>();
+        String currentRunId = null;
+        AguiStreamContext context = null;
+
+        for (StoredAgentEvent stored : history) {
+            String runId = stored.runId();
+            if (!Objects.equals(runId, currentRunId)) {
+                if (context != null) {
+                    projected.addAll(registry.enrich(null, context.finishPendingEvents(), context));
+                }
+                currentRunId = runId;
+                if (workbenchConverter != null) {
+                    workbenchConverter.forgetRun(threadId, currentRunId);
+                }
+                // Prefer stored run input so RUN_STARTED carries user/tool messages for reconnect.
+                context =
+                        new AguiStreamContext(
+                                threadId,
+                                currentRunId,
+                                config,
+                                runInputForReplay(threadId, currentRunId, connectInput));
+            }
+            projected.addAll(registry.convert(stored.event(), context));
+        }
+
+        if (context != null) {
+            projected.addAll(registry.enrich(null, context.finishPendingEvents(), context));
+        }
+        return List.copyOf(projected);
+    }
+
+    private AguiAdapterConfig replayConfig() {
+        return AguiAdapterConfig.builder()
+                .toolMergeMode(properties.getDefaultToolMergeMode())
+                .runTimeout(properties.getRunTimeout())
+                .emitStateEvents(properties.isEmitStateEvents())
+                .emitToolCallArgs(properties.isEmitToolCallArgs())
+                .emitTokenUsage(properties.isEmitTokenUsage())
+                .enableReasoning(properties.isEnableReasoning())
+                .defaultAgentId(properties.getDefaultAgentId())
+                .eventConverters(eventConverters)
+                .eventEnrichers(replayEnrichers)
+                .build();
+    }
+
+    /**
+     * Build the {@link RunAgentInput} attached to replayed {@code RUN_STARTED} events.
+     *
+     * <p>Stored per-run messages are the authoritative user/tool turns. Tools / state from the
+     * connect payload are kept so converters that read them still work.
+     */
+    private RunAgentInput runInputForReplay(
+            String threadId, String runId, RunAgentInput connectInput) {
+        List<AguiMessage> storedMessages = eventStore.getRunInputMessages(threadId, runId);
+        if (storedMessages.isEmpty() && connectInput == null) {
+            return null;
+        }
+        RunAgentInput.Builder builder = RunAgentInput.builder().threadId(threadId).runId(runId);
+        if (!storedMessages.isEmpty()) {
+            builder.messages(storedMessages);
+        } else if (connectInput != null) {
+            builder.messages(connectInput.getMessages());
+        }
+        if (connectInput != null) {
+            builder.tools(connectInput.getTools())
+                    .context(connectInput.getContext())
+                    .state(connectInput.getState())
+                    .forwardedProps(connectInput.getForwardedProps())
+                    .resume(connectInput.getResume());
+        }
+        return builder.build();
+    }
+}

--- a/agentscope-examples/agentscope-copilotkit/src/main/java/io/agentscope/examples/copilotkit/service/CopilotKitRuntimeService.java
+++ b/agentscope-examples/agentscope-copilotkit/src/main/java/io/agentscope/examples/copilotkit/service/CopilotKitRuntimeService.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.examples.copilotkit.service;
+
+import io.agentscope.core.agui.encoder.AguiEventEncoder;
+import io.agentscope.core.agui.event.AguiEvent;
+import io.agentscope.core.agui.model.RunAgentInput;
+import io.agentscope.core.agui.registry.AguiAgentRegistry;
+import io.agentscope.examples.copilotkit.model.CopilotKitModels.AgentInfo;
+import io.agentscope.examples.copilotkit.model.CopilotKitModels.InfoResponse;
+import io.agentscope.examples.copilotkit.model.CopilotKitModels.Intelligence;
+import io.agentscope.examples.copilotkit.model.CopilotKitModels.ThreadEndpoints;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.springframework.http.codec.ServerSentEvent;
+import org.springframework.stereotype.Service;
+import reactor.core.publisher.Flux;
+
+/**
+ * CopilotKit Runtime info and multi-route connect handshake with AgentEvent replay.
+ *
+ *
+ */
+@Service
+public final class CopilotKitRuntimeService {
+
+    private static final Map<String, Boolean> DEFAULT_CAPABILITIES =
+            Map.of(
+                    "threads", true,
+                    "sharedState", true,
+                    "frontendTools", true,
+                    "humanInTheLoop", true);
+
+    private final AguiAgentRegistry aguiAgentRegistry;
+    private final AgentEventAguiReplayer eventReplayer;
+    private final AguiEventEncoder encoder = new AguiEventEncoder();
+
+    public CopilotKitRuntimeService(
+            AguiAgentRegistry aguiAgentRegistry, AgentEventAguiReplayer eventReplayer) {
+        this.aguiAgentRegistry = aguiAgentRegistry;
+        this.eventReplayer = eventReplayer;
+    }
+
+    public InfoResponse info() {
+        Map<String, AgentInfo> agents = new LinkedHashMap<>();
+        // Known demo agents registered in AgentConfiguration.
+        for (String agentId : List.of("default", "chat", "calculator", "workbench")) {
+            if (!aguiAgentRegistry.hasAgent(agentId)) {
+                continue;
+            }
+            agents.put(agentId, resolveAgentInfo(agentId));
+        }
+        if (agents.isEmpty()) {
+            agents.put(
+                    DemoThreadStore.DEFAULT_AGENT_ID,
+                    resolveAgentInfo(DemoThreadStore.DEFAULT_AGENT_ID));
+        }
+
+        return new InfoResponse(
+                "2.0.0",
+                agents,
+                true,
+                "sse",
+                new ThreadEndpoints(true, true, true, false),
+                true,
+                new Intelligence("ws://127.0.0.1:8080/agui/run/threads/ws"),
+                true,
+                false,
+                "valid",
+                true);
+    }
+
+    private AgentInfo resolveAgentInfo(String agentId) {
+        AgentInfo fallback =
+                new AgentInfo(
+                        agentId,
+                        agentId,
+                        "AgentScope AG-UI agent: " + agentId,
+                        DEFAULT_CAPABILITIES,
+                        "AgentScopeAgent");
+        return aguiAgentRegistry
+                .getAgent(agentId)
+                .map(
+                        agent ->
+                                fallback.withIdentity(
+                                        agent.getName(),
+                                        agent.getDescription(),
+                                        agent.getClass().getSimpleName()))
+                .orElse(fallback);
+    }
+
+    /**
+     * AG-UI connect: replay persisted AgentEvents through converters, or emit an empty handshake.
+     *
+     * <p>History is stored as AgentScope {@code AgentEvent}s. On connect they are projected to
+     * AG-UI frames with the same converter registry used by {@code /run}, so CopilotKit can
+     * restore the conversation. Without history a minimal
+     * {@code RUN_STARTED → MESSAGES_SNAPSHOT([]) → RUN_FINISHED} handshake is returned.
+     */
+    public Flux<ServerSentEvent<String>> connect(RunAgentInput input) {
+        String threadId = input.getThreadId();
+        String runId = input.getRunId();
+        List<AguiEvent> history = eventReplayer.replay(threadId, input);
+        if (history.isEmpty()) {
+            return Flux.fromIterable(emptyHandshake(threadId, runId)).map(this::sse);
+        }
+        return Flux.fromIterable(history).map(this::sse);
+    }
+
+    private List<AguiEvent> emptyHandshake(String threadId, String runId) {
+        List<AguiEvent> events = new ArrayList<>(3);
+        events.add(new AguiEvent.RunStarted(threadId, runId));
+        events.add(new AguiEvent.MessagesSnapshot(threadId, runId, List.of()));
+        events.add(new AguiEvent.RunFinished(threadId, runId));
+        return events;
+    }
+
+    private ServerSentEvent<String> sse(AguiEvent event) {
+        return ServerSentEvent.<String>builder().data(encoder.encodeToJson(event).trim()).build();
+    }
+}

--- a/agentscope-examples/agentscope-copilotkit/src/main/java/io/agentscope/examples/copilotkit/service/DemoThreadStore.java
+++ b/agentscope-examples/agentscope-copilotkit/src/main/java/io/agentscope/examples/copilotkit/service/DemoThreadStore.java
@@ -1,0 +1,227 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.examples.copilotkit.service;
+
+import io.agentscope.core.ReActAgent;
+import io.agentscope.core.agent.Agent;
+import io.agentscope.core.agui.registry.AguiAgentRegistry;
+import io.agentscope.core.message.Msg;
+import io.agentscope.examples.copilotkit.model.CopilotKitModels.ThreadInfo;
+import io.agentscope.examples.copilotkit.model.CopilotKitModels.ThreadMutationRequest;
+import io.agentscope.examples.copilotkit.model.CopilotKitModels.ThreadsResponse;
+import io.agentscope.spring.boot.agui.common.ThreadSessionManager;
+import io.agentscope.spring.boot.agui.common.ThreadSessionManager.ThreadSession;
+import java.time.ZoneOffset;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.stereotype.Component;
+
+/**
+ * CopilotKit thread APIs backed by {@link ThreadSessionManager} sessions.
+ *
+ *
+ */
+@Component
+public final class DemoThreadStore {
+
+    public static final String DEFAULT_AGENT_ID = "default";
+
+    private final ThreadSessionManager sessionManager;
+    private final AguiAgentRegistry agentRegistry;
+    private final InMemoryAgentEventStore eventStore;
+    private final AgentEventAguiReplayer eventReplayer;
+
+    public DemoThreadStore(
+            ThreadSessionManager sessionManager,
+            AguiAgentRegistry agentRegistry,
+            InMemoryAgentEventStore eventStore,
+            AgentEventAguiReplayer eventReplayer) {
+        this.sessionManager = sessionManager;
+        this.agentRegistry = agentRegistry;
+        this.eventStore = eventStore;
+        this.eventReplayer = eventReplayer;
+    }
+
+    public ThreadsResponse list(
+            String agentId, boolean includeArchived, Integer limit, String cursor) {
+        int offset = parseCursor(cursor);
+        int pageSize = limit == null || limit <= 0 ? Integer.MAX_VALUE : limit;
+
+        List<ThreadInfo> all =
+                sessionManager.getSessions().entrySet().stream()
+                        .filter(entry -> agentId.equals(entry.getValue().getAgentId()))
+                        .filter(entry -> includeArchived || !entry.getValue().isArchived())
+                        .map(entry -> toThreadInfo(entry.getKey(), entry.getValue()))
+                        .sorted(Comparator.comparing(ThreadInfo::lastRunAt).reversed())
+                        .toList();
+
+        List<ThreadInfo> page = all.stream().skip(offset).limit(pageSize).toList();
+        int nextOffset = offset + page.size();
+        String nextCursor = nextOffset < all.size() ? String.valueOf(nextOffset) : null;
+        return new ThreadsResponse(page, nextCursor, null);
+    }
+
+    public ThreadInfo create(ThreadMutationRequest request) {
+        String agentId = resolveAgentId(request);
+        String name = resolveName(request, "New Thread");
+        String threadId = "thread-" + UUID.randomUUID();
+        ThreadSession session =
+                sessionManager.ensureSession(threadId, agentId, name, () -> createAgent(agentId));
+        return toThreadInfo(threadId, session);
+    }
+
+    public ThreadInfo update(String threadId, ThreadMutationRequest request) {
+        ThreadSession session = getOrCreateSession(threadId, request);
+        String name = resolveName(request, displayName(threadId, session));
+        session.setName(name);
+        Optional.ofNullable(request)
+                .map(ThreadMutationRequest::archived)
+                .ifPresent(session::setArchived);
+        session.updateLastAccess();
+        return toThreadInfo(threadId, session);
+    }
+
+    public ThreadInfo archive(String threadId, ThreadMutationRequest request) {
+        ThreadSession session = getOrCreateSession(threadId, request);
+        session.setArchived(true);
+        session.updateLastAccess();
+        return toThreadInfo(threadId, session);
+    }
+
+    public Map<String, Object> delete(String threadId) {
+        sessionManager.removeSession(threadId);
+        eventStore.clear(threadId);
+        return Map.of("deleted", true, "threadId", threadId);
+    }
+
+    public Map<String, Object> events(String threadId) {
+        Map<String, Object> payload = new LinkedHashMap<>();
+        // Source of truth: AgentScope AgentEvents.
+        payload.put("agentEvents", eventStore.snapshot(threadId));
+        // Protocol projection: same converter path as /connect.
+        payload.put("events", eventReplayer.replay(threadId, null));
+        return payload;
+    }
+
+    public Map<String, Object> messages(String threadId) {
+        List<Map<String, Object>> messages =
+                sessionManager
+                        .getSession(threadId)
+                        .map(ThreadSession::getAgent)
+                        .filter(ReActAgent.class::isInstance)
+                        .map(ReActAgent.class::cast)
+                        .map(agent -> agent.getAgentState(null, threadId).getContext())
+                        .orElse(List.of())
+                        .stream()
+                        .map(this::toMessage)
+                        .toList();
+        return Map.of("messages", messages);
+    }
+
+    public Map<String, Object> state(String threadId) {
+        Map<String, Object> state = new LinkedHashMap<>();
+        sessionManager
+                .getSession(threadId)
+                .ifPresent(
+                        session -> {
+                            state.put("agentId", session.getAgentId());
+                            state.put("hasMemory", sessionManager.hasMemory(threadId));
+                            state.put("archived", session.isArchived());
+                            state.put("updatedAt", session.getLastAccess().toString());
+                        });
+        return Map.of("state", state);
+    }
+
+    private ThreadSession getOrCreateSession(String threadId, ThreadMutationRequest request) {
+        String agentId = resolveAgentId(request);
+        return sessionManager.ensureSession(
+                threadId, agentId, resolveName(request, null), () -> createAgent(agentId));
+    }
+
+    private Agent createAgent(String agentId) {
+        return agentRegistry
+                .getAgent(agentId)
+                .orElseGet(
+                        () ->
+                                agentRegistry
+                                        .getAgent(DEFAULT_AGENT_ID)
+                                        .orElseThrow(
+                                                () ->
+                                                        new IllegalStateException(
+                                                                "No agent registered for id: "
+                                                                        + agentId)));
+    }
+
+    private ThreadInfo toThreadInfo(String threadId, ThreadSession session) {
+        String createdAt = session.getCreatedAt().atOffset(ZoneOffset.UTC).toString();
+        String lastAccess = session.getLastAccess().atOffset(ZoneOffset.UTC).toString();
+        return new ThreadInfo(
+                threadId,
+                displayName(threadId, session),
+                session.getAgentId(),
+                session.isArchived(),
+                createdAt,
+                lastAccess,
+                lastAccess);
+    }
+
+    private static String displayName(String threadId, ThreadSession session) {
+        String name = session.getName();
+        if (name != null && !name.isBlank()) {
+            return name;
+        }
+        return threadId;
+    }
+
+    private Map<String, Object> toMessage(Msg msg) {
+        Map<String, Object> message = new LinkedHashMap<>();
+        message.put("id", msg.getId());
+        message.put("role", msg.getRole().name().toLowerCase(Locale.ROOT));
+        String content = msg.getTextContent();
+        message.put("content", content == null ? "" : content);
+        return message;
+    }
+
+    private static String resolveName(ThreadMutationRequest request, String fallback) {
+        return Optional.ofNullable(request)
+                .map(ThreadMutationRequest::name)
+                .filter(name -> !name.isBlank())
+                .orElse(fallback);
+    }
+
+    private static String resolveAgentId(ThreadMutationRequest request) {
+        return Optional.ofNullable(request)
+                .map(ThreadMutationRequest::agentId)
+                .filter(agentId -> !agentId.isBlank())
+                .orElse(DEFAULT_AGENT_ID);
+    }
+
+    private static int parseCursor(String cursor) {
+        if (cursor == null || cursor.isBlank()) {
+            return 0;
+        }
+        try {
+            return Math.max(Integer.parseInt(cursor), 0);
+        } catch (NumberFormatException ex) {
+            return 0;
+        }
+    }
+}

--- a/agentscope-examples/agentscope-copilotkit/src/main/java/io/agentscope/examples/copilotkit/service/InMemoryAgentEventStore.java
+++ b/agentscope-examples/agentscope-copilotkit/src/main/java/io/agentscope/examples/copilotkit/service/InMemoryAgentEventStore.java
@@ -1,0 +1,200 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.examples.copilotkit.service;
+
+import io.agentscope.core.agui.model.AguiMessage;
+import io.agentscope.core.event.AgentEvent;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import org.springframework.stereotype.Component;
+
+/**
+ * In-memory AgentEvent log keyed by threadId.
+ *
+ * <p>AgentScope {@link AgentEvent}s are the source of truth. AG-UI frames are projected on demand
+ * (see {@link AgentEventAguiReplayer}) for {@code /agent/{agentId}/connect} and inspect APIs.
+ *
+ * <p>Per-run input messages (user / tool / resume) are stored separately so connect replay can
+ * re-attach them to {@code RUN_STARTED.input}, matching CopilotKit's persistence model.
+ *
+ */
+@Component
+public final class InMemoryAgentEventStore {
+
+    private static final int MAX_EVENTS_PER_THREAD = 5_000;
+
+    private final ConcurrentHashMap<String, List<StoredAgentEvent>> eventsByThread =
+            new ConcurrentHashMap<>();
+
+    /** threadId → (runId → new input messages for that run). */
+    private final ConcurrentHashMap<String, ConcurrentHashMap<String, List<AguiMessage>>>
+            runInputsByThread = new ConcurrentHashMap<>();
+
+    /**
+     * Append one AgentEvent for a thread/run.
+     *
+     * @param threadId thread identifier
+     * @param runId run identifier that produced the event
+     * @param event source AgentEvent
+     */
+    public void append(String threadId, String runId, AgentEvent event) {
+        if (threadId == null || threadId.isBlank() || event == null) {
+            return;
+        }
+        String resolvedRunId = runId == null || runId.isBlank() ? "unknown" : runId;
+        StoredAgentEvent stored = new StoredAgentEvent(resolvedRunId, event);
+        eventsByThread.compute(
+                threadId,
+                (id, existing) -> {
+                    List<StoredAgentEvent> events = existing != null ? existing : new ArrayList<>();
+                    synchronized (events) {
+                        events.add(stored);
+                        while (events.size() > MAX_EVENTS_PER_THREAD) {
+                            events.remove(0);
+                        }
+                    }
+                    return events;
+                });
+    }
+
+    /**
+     * Persist the new AG-UI input messages for a run (typically the latest user message).
+     *
+     * <p>CopilotKit reconnect restores conversation turns from {@code RUN_STARTED.input.messages}.
+     * Messages whose ids were already stored for this thread are skipped.
+     *
+     * @param threadId thread identifier
+     * @param runId run identifier
+     * @param messages candidate input messages from {@code RunAgentInput}
+     */
+    public void putRunInputMessages(String threadId, String runId, List<AguiMessage> messages) {
+        if (threadId == null
+                || threadId.isBlank()
+                || runId == null
+                || runId.isBlank()
+                || messages == null
+                || messages.isEmpty()) {
+            return;
+        }
+        Set<String> knownIds = knownMessageIds(threadId);
+        List<AguiMessage> fresh = new ArrayList<>();
+        for (AguiMessage message : messages) {
+            if (message == null || message.getId() == null || message.getId().isBlank()) {
+                continue;
+            }
+            if (knownIds.contains(message.getId())) {
+                continue;
+            }
+            fresh.add(message);
+            knownIds.add(message.getId());
+        }
+        if (fresh.isEmpty()) {
+            return;
+        }
+        runInputsByThread
+                .computeIfAbsent(threadId, id -> new ConcurrentHashMap<>())
+                .put(runId, List.copyOf(fresh));
+    }
+
+    /**
+     * Input messages previously stored for a run, or empty when none.
+     *
+     * @param threadId thread identifier
+     * @param runId run identifier
+     * @return immutable list, never null
+     */
+    public List<AguiMessage> getRunInputMessages(String threadId, String runId) {
+        if (threadId == null || runId == null) {
+            return List.of();
+        }
+        Map<String, List<AguiMessage>> byRun = runInputsByThread.get(threadId);
+        if (byRun == null) {
+            return List.of();
+        }
+        List<AguiMessage> messages = byRun.get(runId);
+        return messages == null ? List.of() : messages;
+    }
+
+    /**
+     * Snapshot of persisted AgentEvents for a thread.
+     *
+     * @param threadId thread identifier
+     * @return immutable copy, never null
+     */
+    public List<StoredAgentEvent> snapshot(String threadId) {
+        List<StoredAgentEvent> events = eventsByThread.get(threadId);
+        if (events == null) {
+            return List.of();
+        }
+        synchronized (events) {
+            return List.copyOf(events);
+        }
+    }
+
+    /**
+     * Whether the thread has any persisted AgentEvents.
+     *
+     * @param threadId thread identifier
+     * @return true if non-empty
+     */
+    public boolean hasEvents(String threadId) {
+        List<StoredAgentEvent> events = eventsByThread.get(threadId);
+        if (events == null) {
+            return false;
+        }
+        synchronized (events) {
+            return !events.isEmpty();
+        }
+    }
+
+    /**
+     * Clear events and run inputs for a thread.
+     *
+     * @param threadId thread identifier
+     */
+    public void clear(String threadId) {
+        eventsByThread.remove(threadId);
+        runInputsByThread.remove(threadId);
+    }
+
+    private Set<String> knownMessageIds(String threadId) {
+        Set<String> ids = new LinkedHashSet<>();
+        Map<String, List<AguiMessage>> byRun = runInputsByThread.get(threadId);
+        if (byRun == null) {
+            return ids;
+        }
+        for (List<AguiMessage> messages : byRun.values()) {
+            for (AguiMessage message : messages) {
+                if (message != null && message.getId() != null) {
+                    ids.add(message.getId());
+                }
+            }
+        }
+        return ids;
+    }
+
+    /**
+     * One AgentEvent captured during a specific AG-UI run.
+     *
+     * @param runId run that emitted the event
+     * @param event source AgentEvent
+     */
+    public record StoredAgentEvent(String runId, AgentEvent event) {}
+}

--- a/agentscope-examples/agentscope-copilotkit/src/main/java/io/agentscope/examples/copilotkit/service/PersistingAgentEventEnricher.java
+++ b/agentscope-examples/agentscope-copilotkit/src/main/java/io/agentscope/examples/copilotkit/service/PersistingAgentEventEnricher.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.examples.copilotkit.service;
+
+import io.agentscope.core.agui.adapter.strategy.AguiEventEnricher;
+import io.agentscope.core.agui.adapter.strategy.AguiStreamContext;
+import io.agentscope.core.agui.event.AguiEvent;
+import io.agentscope.core.agui.model.RunAgentInput;
+import io.agentscope.core.event.AgentEndEvent;
+import io.agentscope.core.event.AgentEvent;
+import io.agentscope.core.event.AgentStartEvent;
+import io.agentscope.examples.copilotkit.workbench.WorkbenchAguiEventConverter;
+import java.util.List;
+import org.springframework.beans.factory.ObjectProvider;
+
+/**
+ * Persists the source {@link AgentEvent} while the AG-UI adapter projects it.
+ *
+ * <p>AG-UI frames themselves are not stored — connect replay re-projects through converters.
+ *
+ * <p>On {@link AgentStartEvent}, also stores the run's input messages so reconnect can rebuild
+ * {@code RUN_STARTED.input.messages} (how CopilotKit restores user / tool turns).
+ *
+ */
+public final class PersistingAgentEventEnricher implements AguiEventEnricher {
+
+    private final InMemoryAgentEventStore eventStore;
+    private final WorkbenchAguiEventConverter workbenchConverter;
+
+    public PersistingAgentEventEnricher(
+            InMemoryAgentEventStore eventStore,
+            ObjectProvider<WorkbenchAguiEventConverter> workbenchConverterProvider) {
+        this.eventStore = eventStore;
+        this.workbenchConverter = workbenchConverterProvider.getIfAvailable();
+    }
+
+    @Override
+    public List<AguiEvent> enrich(
+            AgentEvent source, List<AguiEvent> events, AguiStreamContext context) {
+        if (source != null) {
+            if (source instanceof AgentStartEvent) {
+                persistRunInputMessages(context);
+            }
+            eventStore.append(context.getThreadId(), context.getRunId(), source);
+            if (source instanceof AgentEndEvent && workbenchConverter != null) {
+                workbenchConverter.forgetRun(context.getThreadId(), context.getRunId());
+            }
+        }
+        return events;
+    }
+
+    private void persistRunInputMessages(AguiStreamContext context) {
+        RunAgentInput runInput = context.getRunInput();
+        if (runInput == null
+                || runInput.getMessages() == null
+                || runInput.getMessages().isEmpty()) {
+            return;
+        }
+        eventStore.putRunInputMessages(
+                context.getThreadId(), context.getRunId(), runInput.getMessages());
+    }
+}

--- a/agentscope-examples/agentscope-copilotkit/src/main/java/io/agentscope/examples/copilotkit/workbench/RefundOrderTool.java
+++ b/agentscope-examples/agentscope-copilotkit/src/main/java/io/agentscope/examples/copilotkit/workbench/RefundOrderTool.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.examples.copilotkit.workbench;
+
+import io.agentscope.core.message.TextBlock;
+import io.agentscope.core.message.ToolResultBlock;
+import io.agentscope.core.permission.PermissionBehavior;
+import io.agentscope.core.permission.PermissionContextState;
+import io.agentscope.core.permission.PermissionDecision;
+import io.agentscope.core.permission.PermissionRule;
+import io.agentscope.core.tool.ToolBase;
+import io.agentscope.core.tool.ToolCallParam;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import reactor.core.publisher.Mono;
+
+/**
+ * Refund tool demonstrating AgentScope's <em>built-in checks</em>: the permission decision depends on
+ * the actual arguments rather than on a static rule.
+ *
+ * <p>Small refunds run straight through, anything at or above {@value #ASK_THRESHOLD} needs a human,
+ * and refunds without an order id are rejected outright. Because built-in checks run inside the tool
+ * they cannot be bypassed by {@code PermissionMode.BYPASS} or by an allow rule — which is exactly the
+ * point of the demo.
+ *
+ */
+public class RefundOrderTool extends ToolBase {
+
+    /** Refunds at or above this amount always require human confirmation. */
+    public static final double ASK_THRESHOLD = 1000d;
+
+    private static final String NAME = "refund_order";
+
+    private final WorkbenchStateRegistry registry;
+
+    public RefundOrderTool(WorkbenchStateRegistry registry) {
+        super(
+                ToolBase.builder()
+                        .name(NAME)
+                        .description(
+                                "为订单发起退款。小额退款直接执行，%.0f 元及以上会触发人工确认（工具内置检查，不可被规则绕过）。"
+                                        .formatted(ASK_THRESHOLD))
+                        .inputSchema(inputSchema())
+                        .readOnly(false)
+                        .concurrencySafe(false));
+        this.registry = registry;
+    }
+
+    private static Map<String, Object> inputSchema() {
+        Map<String, Object> properties = new LinkedHashMap<>();
+        properties.put("orderNo", Map.of("type", "string", "description", "订单号，例如 SO202607310001"));
+        properties.put("amount", Map.of("type", "number", "description", "退款金额，单位元"));
+        properties.put("reason", Map.of("type", "string", "description", "退款原因"));
+
+        Map<String, Object> schema = new LinkedHashMap<>();
+        schema.put("type", "object");
+        schema.put("properties", properties);
+        schema.put("required", List.of("orderNo", "amount"));
+        return schema;
+    }
+
+    @Override
+    public Mono<PermissionDecision> checkPermissions(
+            Map<String, Object> toolInput, PermissionContextState context) {
+        String orderNo = string(toolInput.get("orderNo"));
+        if (orderNo.isBlank()) {
+            return Mono.just(PermissionDecision.deny("缺少订单号，拒绝执行退款。"));
+        }
+        double amount = amount(toolInput);
+        if (amount >= ASK_THRESHOLD) {
+            return Mono.just(
+                    PermissionDecision.ask(
+                            "订单 %s 退款 %.2f 元，超过 %.0f 元的自动放行阈值，需要人工确认。"
+                                    .formatted(orderNo, amount, ASK_THRESHOLD)));
+        }
+        return Mono.just(PermissionDecision.allow("小额退款，自动放行。"));
+    }
+
+    @Override
+    public boolean matchRule(String ruleContent, Map<String, Object> toolInput) {
+        if (ruleContent == null) {
+            return true;
+        }
+        return ruleContent.equalsIgnoreCase(string(toolInput.get("orderNo")));
+    }
+
+    @Override
+    public List<PermissionRule> generateSuggestions(Map<String, Object> toolInput) {
+        String orderNo = string(toolInput.get("orderNo"));
+        return List.of(
+                new PermissionRule(NAME, orderNo, PermissionBehavior.ALLOW, "suggested"),
+                new PermissionRule(NAME, null, PermissionBehavior.ALLOW, "suggested"));
+    }
+
+    @Override
+    public Mono<ToolResultBlock> callAsync(ToolCallParam param) {
+        Map<String, Object> input = param.getInput();
+        String orderNo = string(input.get("orderNo"));
+        double amount = amount(input);
+        String reason = string(input.get("reason"));
+        String message =
+                "订单 %s 已退款 %.2f 元%s，预计 1-3 个工作日到账。请勿对同一订单重复发起退款。"
+                        .formatted(orderNo, amount, reason.isBlank() ? "" : "（原因：" + reason + "）");
+        String callId = param.getToolUseBlock() == null ? null : param.getToolUseBlock().getId();
+        return Mono.just(
+                new ToolResultBlock(
+                        callId, getName(), List.of(TextBlock.builder().text(message).build())));
+    }
+
+    private static double amount(Map<String, Object> input) {
+        Object raw = input.get("amount");
+        if (raw instanceof Number number) {
+            return number.doubleValue();
+        }
+        try {
+            return Double.parseDouble(String.valueOf(raw));
+        } catch (NumberFormatException e) {
+            return 0d;
+        }
+    }
+
+    private static String string(Object value) {
+        return value == null ? "" : String.valueOf(value).trim();
+    }
+}

--- a/agentscope-examples/agentscope-copilotkit/src/main/java/io/agentscope/examples/copilotkit/workbench/WorkbenchAguiEventConverter.java
+++ b/agentscope-examples/agentscope-copilotkit/src/main/java/io/agentscope/examples/copilotkit/workbench/WorkbenchAguiEventConverter.java
@@ -1,0 +1,175 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.examples.copilotkit.workbench;
+
+import io.agentscope.core.agui.adapter.strategy.AgentEventConverter;
+import io.agentscope.core.agui.adapter.strategy.AguiStreamContext;
+import io.agentscope.core.agui.event.AguiEvent;
+import io.agentscope.core.event.AgentEvent;
+import io.agentscope.core.event.CustomEvent;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import org.springframework.stereotype.Component;
+
+/**
+ * Maps the workbench's {@link CustomEvent}s onto the AG-UI frames a CopilotKit client understands.
+ *
+ * <p>This is the one place where the example decides which AG-UI event best expresses each piece of
+ * agent progress:
+ *
+ * <ul>
+ *   <li>{@code state_updated} → {@code STATE_SNAPSHOT} for the first frame of a run, then
+ *       {@code STATE_DELTA} (RFC 6902) for every later change, so the browser only pays for what
+ *       actually moved
+ *   <li>{@code plan_step_started} / {@code plan_step_finished} → {@code STEP_STARTED} /
+ *       {@code STEP_FINISHED}, giving plan tasks a first-class lifecycle on the wire
+ *   <li>{@code a2ui_surface} → {@code ACTIVITY_SNAPSHOT} of type {@code a2ui-surface}, which is how
+ *       generated UI reaches the A2UI renderer
+ *   <li>{@code permission_audit} → {@code CUSTOM}, consumed by the audit panel
+ * </ul>
+ *
+ * <p>Snapshot bookkeeping is keyed by {@code threadId:runId}. Entries are dropped as soon as a run
+ * finishes, so a long-lived server does not accumulate them.
+ *
+ */
+@Component
+public class WorkbenchAguiEventConverter implements AgentEventConverter {
+
+    /** AG-UI activity type paired with {@code useRenderActivity("a2ui-surface")} in the browser. */
+    public static final String ACTIVITY_A2UI_SURFACE = "a2ui-surface";
+
+    private final Map<String, Map<String, Object>> lastSnapshots = new ConcurrentHashMap<>();
+
+    @Override
+    public Set<Class<? extends AgentEvent>> eventTypes() {
+        return Set.of(CustomEvent.class);
+    }
+
+    @Override
+    public void convert(AgentEvent event, AguiStreamContext context) {
+        CustomEvent custom = (CustomEvent) event;
+        String name = custom.getName();
+        Object value = custom.getValue();
+
+        switch (name == null ? "" : name) {
+            case WorkbenchState.EVENT_STATE_UPDATED -> emitState(context, asMap(value));
+            case WorkbenchState.EVENT_STEP_STARTED ->
+                    context.emit(
+                            new AguiEvent.StepStarted(
+                                    context.getThreadId(), context.getRunId(), stepName(value)));
+            case WorkbenchState.EVENT_STEP_FINISHED ->
+                    context.emit(
+                            new AguiEvent.StepFinished(
+                                    context.getThreadId(), context.getRunId(), stepName(value)));
+            case WorkbenchState.EVENT_A2UI_SURFACE -> emitSurface(context, asMap(value));
+            default ->
+                    context.emit(
+                            new AguiEvent.Custom(
+                                    context.getThreadId(), context.getRunId(), name, value));
+        }
+    }
+
+    /** Drops the per-run snapshot baseline; called when the run ends. */
+    public void forgetRun(String threadId, String runId) {
+        lastSnapshots.remove(runKey(threadId, runId));
+    }
+
+    private void emitState(AguiStreamContext context, Map<String, Object> snapshot) {
+        if (snapshot.isEmpty()) {
+            return;
+        }
+        String key = runKey(context.getThreadId(), context.getRunId());
+        Map<String, Object> previous = lastSnapshots.put(key, snapshot);
+
+        if (previous == null) {
+            context.emit(
+                    new AguiEvent.StateSnapshot(
+                            context.getThreadId(), context.getRunId(), snapshot));
+            return;
+        }
+
+        List<AguiEvent.JsonPatchOperation> patch = diff(previous, snapshot);
+        if (patch.isEmpty()) {
+            return;
+        }
+        context.emit(new AguiEvent.StateDelta(context.getThreadId(), context.getRunId(), patch));
+    }
+
+    private void emitSurface(AguiStreamContext context, Map<String, Object> payload) {
+        Object surfaceId = payload.get("surfaceId");
+        if (surfaceId == null) {
+            return;
+        }
+        context.emit(
+                new AguiEvent.ActivitySnapshot(
+                        context.getThreadId(),
+                        context.getRunId(),
+                        "a2ui-" + surfaceId,
+                        ACTIVITY_A2UI_SURFACE,
+                        payload));
+    }
+
+    /**
+     * Builds a top-level RFC 6902 patch between two snapshots.
+     *
+     * <p>Nested objects are replaced wholesale rather than diffed recursively — the workbench state
+     * is small, and a shallow patch keeps the emitted frames easy to read in the event inspector.
+     */
+    private static List<AguiEvent.JsonPatchOperation> diff(
+            Map<String, Object> previous, Map<String, Object> current) {
+        List<AguiEvent.JsonPatchOperation> patch = new ArrayList<>();
+        Set<String> keys = new LinkedHashSet<>(previous.keySet());
+        keys.addAll(current.keySet());
+
+        for (String key : keys) {
+            boolean existed = previous.containsKey(key);
+            boolean exists = current.containsKey(key);
+            String path = "/" + key;
+            if (existed && !exists) {
+                patch.add(new AguiEvent.JsonPatchOperation("remove", path, null, null));
+            } else if (!existed) {
+                patch.add(new AguiEvent.JsonPatchOperation("add", path, current.get(key), null));
+            } else if (!Objects.equals(previous.get(key), current.get(key))) {
+                patch.add(
+                        new AguiEvent.JsonPatchOperation("replace", path, current.get(key), null));
+            }
+        }
+        return patch;
+    }
+
+    private static String stepName(Object value) {
+        Map<String, Object> payload = asMap(value);
+        Object step = payload.get("step");
+        return step == null ? "plan-step" : String.valueOf(step);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Map<String, Object> asMap(Object value) {
+        return value instanceof Map<?, ?> map
+                ? new LinkedHashMap<>((Map<String, Object>) map)
+                : Map.of();
+    }
+
+    private static String runKey(String threadId, String runId) {
+        return threadId + ":" + runId;
+    }
+}

--- a/agentscope-examples/agentscope-copilotkit/src/main/java/io/agentscope/examples/copilotkit/workbench/WorkbenchEventMiddleware.java
+++ b/agentscope-examples/agentscope-copilotkit/src/main/java/io/agentscope/examples/copilotkit/workbench/WorkbenchEventMiddleware.java
@@ -1,0 +1,212 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.examples.copilotkit.workbench;
+
+import io.agentscope.core.ReActAgent;
+import io.agentscope.core.agent.Agent;
+import io.agentscope.core.agent.RuntimeContext;
+import io.agentscope.core.agui.model.AguiContext;
+import io.agentscope.core.agui.model.RunAgentInput;
+import io.agentscope.core.event.AgentEndEvent;
+import io.agentscope.core.event.AgentEvent;
+import io.agentscope.core.event.AgentStartEvent;
+import io.agentscope.core.event.CustomEvent;
+import io.agentscope.core.event.RequireUserConfirmEvent;
+import io.agentscope.core.event.ToolResultEndEvent;
+import io.agentscope.core.event.UserConfirmResultEvent;
+import io.agentscope.core.message.ToolUseBlock;
+import io.agentscope.core.middleware.AgentInput;
+import io.agentscope.core.middleware.MiddlewareBase;
+import io.agentscope.core.state.TaskContextState;
+import io.agentscope.core.util.JsonUtils;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import reactor.core.publisher.Flux;
+
+/**
+ * Turns agent progress into shared-state frames while the run is still streaming.
+ *
+ * <p>Three things happen here, and each of them is what makes a panel in the browser move:
+ *
+ * <ul>
+ *   <li><b>Seeding</b> — the {@code state} object and the {@code context} entries the client sent
+ *       with the run are folded into the thread's {@link WorkbenchState}, so shared state is
+ *       genuinely bidirectional instead of server-push only.
+ *   <li><b>Task mirroring</b> — after every tool result the live
+ *       {@code AgentState.getTasksContext()} task list (maintained by the built-in
+ *       {@code todo_write} tool) is diffed into shared state, which is how the plan board updates
+ *       mid-run rather than at the end.
+ *   <li><b>Permission auditing</b> — {@link RequireUserConfirmEvent} and
+ *       {@link UserConfirmResultEvent} are recorded so the audit panel shows the full ask → decide
+ *       trail. The interrupt itself is emitted by the framework's own lifecycle converter.
+ * </ul>
+ *
+ * <p>Queued {@link CustomEvent}s are spliced into the event stream around each upstream event.
+ * Ordering matters: the opening snapshot goes out immediately <em>after</em>
+ * {@link AgentStartEvent} so it lands behind {@code RUN_STARTED}, open steps are closed and
+ * everything still queued is flushed <em>before</em> {@link AgentEndEvent} so every
+ * {@code STEP_STARTED} has a matching {@code STEP_FINISHED} and nothing arrives after
+ * {@code RUN_FINISHED}.
+ *
+ */
+public class WorkbenchEventMiddleware implements MiddlewareBase {
+
+    /**
+     * {@code description} the browser uses to advertise its A2UI catalog through
+     * {@code useAgentContext}.
+     */
+    public static final String CONTEXT_INLINE_CATALOG = "a2ui-inline-catalog";
+
+    private static final Logger logger = LoggerFactory.getLogger(WorkbenchEventMiddleware.class);
+
+    private final WorkbenchStateRegistry registry;
+
+    public WorkbenchEventMiddleware(WorkbenchStateRegistry registry) {
+        this.registry = registry;
+    }
+
+    @Override
+    public Flux<AgentEvent> onAgent(
+            Agent agent,
+            RuntimeContext ctx,
+            AgentInput input,
+            Function<AgentInput, Flux<AgentEvent>> next) {
+        WorkbenchState workbench = registry.forContext(ctx);
+        seedFromClient(workbench, ctx);
+
+        return next.apply(input)
+                .concatMap(
+                        event -> {
+                            if (event instanceof AgentStartEvent) {
+                                workbench.clearOpenSteps();
+                                workbench.queueSnapshot();
+                                return Flux.concat(Flux.just(event), drain(workbench));
+                            }
+                            observe(agent, ctx, workbench, event);
+                            if (event instanceof AgentEndEvent) {
+                                // AG-UI: every STEP_STARTED must be closed before RUN_FINISHED.
+                                workbench.closeOpenSteps();
+                                return Flux.concat(drain(workbench), Flux.just(event));
+                            }
+                            return Flux.concat(Flux.just(event), drain(workbench));
+                        });
+    }
+
+    private static Flux<AgentEvent> drain(WorkbenchState workbench) {
+        List<CustomEvent> queued = workbench.drainPendingEvents();
+        return queued.isEmpty() ? Flux.empty() : Flux.fromIterable(queued).cast(AgentEvent.class);
+    }
+
+    private void observe(
+            Agent agent, RuntimeContext ctx, WorkbenchState workbench, AgentEvent event) {
+        if (event instanceof ToolResultEndEvent) {
+            syncTasks(agent, ctx, workbench);
+        }
+    }
+
+    /**
+     * Mirrors the built-in task list into shared state; see {@link WorkbenchState#syncTasks}.
+     *
+     * <p>The per-session state lookup lives on {@link ReActAgent} rather than the {@link Agent}
+     * interface, so agents without it simply skip the plan board.
+     */
+    private void syncTasks(Agent agent, RuntimeContext ctx, WorkbenchState workbench) {
+        if (!(agent instanceof ReActAgent reActAgent)) {
+            return;
+        }
+        try {
+            TaskContextState tasks = reActAgent.getAgentState(ctx).getTasksContext();
+            if (tasks != null) {
+                workbench.syncTasks(tasks.getTasks());
+            }
+        } catch (Exception e) {
+            logger.debug("跳过任务同步：{}", e.toString());
+        }
+    }
+
+    /**
+     * Folds the client-supplied {@code state} and {@code context} into the thread's workbench.
+     *
+     * <p>Both arrive on the {@link RunAgentInput} that the AG-UI adapter stashes in the
+     * {@link RuntimeContext}.
+     */
+    private void seedFromClient(WorkbenchState workbench, RuntimeContext ctx) {
+        RunAgentInput runInput = runInput(ctx);
+        if (runInput == null) {
+            return;
+        }
+        workbench.mergeFromClient(runInput.getState());
+
+        for (AguiContext entry : runInput.getContext()) {
+            if (entry == null || !CONTEXT_INLINE_CATALOG.equals(entry.getDescription())) {
+                continue;
+            }
+            workbench.setClientComponents(parseClientComponents(entry.getValue()));
+        }
+    }
+
+    private static RunAgentInput runInput(RuntimeContext ctx) {
+        return ctx == null ? null : ctx.get(RunAgentInput.class);
+    }
+
+    /**
+     * Reads {@code {"catalogId": "...", "components": ["MetricTile", ...]}} as reported by the
+     * browser.
+     *
+     * @return the declared component names, or an empty set when the payload is absent or unusable
+     */
+    private static Set<String> parseClientComponents(String value) {
+        if (value == null || value.isBlank()) {
+            return Set.of();
+        }
+        try {
+            Map<?, ?> payload = JsonUtils.getJsonCodec().fromJson(value, Map.class);
+            if (!(payload.get("components") instanceof List<?> components)) {
+                return Set.of();
+            }
+            Set<String> names = new LinkedHashSet<>();
+            for (Object component : components) {
+                if (component instanceof String name && !name.isBlank()) {
+                    names.add(name);
+                }
+            }
+            return names;
+        } catch (Exception e) {
+            logger.warn("浏览器上报的 A2UI 组件清单解析失败：{}", e.toString());
+            return Set.of();
+        }
+    }
+
+    private static String describe(ToolUseBlock toolCall) {
+        if (toolCall == null) {
+            return "";
+        }
+        Map<String, Object> args = toolCall.getInput();
+        if (args == null || args.isEmpty()) {
+            return toolCall.getName();
+        }
+        try {
+            return JsonUtils.getJsonCodec().toJson(args);
+        } catch (Exception e) {
+            return String.valueOf(args);
+        }
+    }
+}

--- a/agentscope-examples/agentscope-copilotkit/src/main/java/io/agentscope/examples/copilotkit/workbench/WorkbenchState.java
+++ b/agentscope-examples/agentscope-copilotkit/src/main/java/io/agentscope/examples/copilotkit/workbench/WorkbenchState.java
@@ -1,0 +1,395 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.examples.copilotkit.workbench;
+
+import io.agentscope.core.event.CustomEvent;
+import io.agentscope.core.state.Task;
+import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentLinkedDeque;
+
+/**
+ * Thread-scoped shared state backing the CopilotKit workbench.
+ *
+ * <p>Every mutation queues a {@link CustomEvent}. {@code WorkbenchEventMiddleware} drains the queue
+ * while the agent is still streaming and {@code WorkbenchAguiEventConverter} turns each queued event
+ * into the matching AG-UI frame ({@code STATE_SNAPSHOT} / {@code STATE_DELTA} /
+ * {@code STEP_STARTED} / {@code STEP_FINISHED} / {@code ACTIVITY_SNAPSHOT} / {@code CUSTOM}). That
+ * round trip is what makes plan progress and permission decisions appear in the browser mid-run
+ * instead of after it.
+ *
+ * <p>All mutators are synchronized because AgentScope may execute tool calls in parallel.
+ *
+ */
+public final class WorkbenchState {
+
+    /** Carries a full workbench snapshot; converted to STATE_SNAPSHOT or STATE_DELTA. */
+    public static final String EVENT_STATE_UPDATED = "state_updated";
+
+    /** A plan task entered {@code in_progress}; converted to STEP_STARTED. */
+    public static final String EVENT_STEP_STARTED = "plan_step_started";
+
+    /** A plan task reached {@code completed}; converted to STEP_FINISHED. */
+    public static final String EVENT_STEP_FINISHED = "plan_step_finished";
+
+    /** Carries A2UI operations; converted to an {@code a2ui-surface} ACTIVITY_SNAPSHOT. */
+    public static final String EVENT_A2UI_SURFACE = "a2ui_surface";
+
+    /** Carries a permission decision; converted to a CUSTOM event for the audit panel. */
+    public static final String EVENT_PERMISSION_AUDIT = "permission_audit";
+
+    private static final DateTimeFormatter TIME = DateTimeFormatter.ofPattern("HH:mm:ss");
+    private static final int MAX_AUDIT_ENTRIES = 30;
+
+    private final String threadId;
+    private final Deque<CustomEvent> pending = new ConcurrentLinkedDeque<>();
+
+    private String topic = "AgentScope 2.0 × CopilotKit 能力演示";
+    private String priority = "中";
+    private String status = "空闲";
+    private boolean approved;
+    private String updatedAt = LocalTime.now().format(TIME);
+
+    private String planGoal;
+    private String planPhase = "idle";
+    private final List<Map<String, Object>> tasks = new ArrayList<>();
+
+    /**
+     * Steps that have emitted {@code STEP_STARTED} but not yet {@code STEP_FINISHED}.
+     *
+     * <p>Keyed by task id → the exact {@code stepName} used on the wire. AG-UI rejects
+     * {@code RUN_FINISHED} while any step is still active, and {@code STEP_FINISHED} must reuse the
+     * same name as its matching start.
+     */
+    private final Map<String, String> openSteps = new LinkedHashMap<>();
+
+    private final List<Map<String, Object>> permissionAudit = new ArrayList<>();
+
+    private Map<String, Object> metrics = Map.of();
+
+    private volatile Set<String> clientComponents = Set.of();
+
+    private String a2uiSurfaceId;
+    private String a2uiCatalogId;
+    private String a2uiGeneratedBy;
+    private String a2uiIntent;
+    private int a2uiComponentCount;
+
+    WorkbenchState(String threadId) {
+        this.threadId = threadId;
+    }
+
+    public String getThreadId() {
+        return threadId;
+    }
+
+    /**
+     * The custom A2UI components the browser declared it can paint.
+     *
+     * <p>Reported by the frontend through {@code useAgentContext} and picked up by
+     * {@code WorkbenchEventMiddleware}, so the composer only ever advertises components this client
+     * has a renderer for. An empty set means the browser stayed silent and the full server-side
+     * catalog is used.
+     */
+    public Set<String> getClientComponents() {
+        return clientComponents;
+    }
+
+    public void setClientComponents(Set<String> names) {
+        if (names != null && !names.isEmpty()) {
+            this.clientComponents = Set.copyOf(names);
+        }
+    }
+
+    /** Immutable view of the state, shaped exactly like the browser's shared-state object. */
+    public synchronized Map<String, Object> snapshot() {
+        Map<String, Object> plan = new LinkedHashMap<>();
+        plan.put("goal", planGoal);
+        plan.put("phase", planPhase);
+        plan.put("tasks", List.copyOf(tasks));
+        plan.put("total", tasks.size());
+        plan.put("completed", completedCount());
+        plan.put("progress", progress());
+
+        Map<String, Object> a2ui = new LinkedHashMap<>();
+        a2ui.put("surfaceId", a2uiSurfaceId);
+        a2ui.put("catalogId", a2uiCatalogId);
+        a2ui.put("generatedBy", a2uiGeneratedBy);
+        a2ui.put("intent", a2uiIntent);
+        a2ui.put("componentCount", a2uiComponentCount);
+
+        Map<String, Object> snapshot = new LinkedHashMap<>();
+        snapshot.put("topic", topic);
+        snapshot.put("priority", priority);
+        snapshot.put("status", status);
+        snapshot.put("approved", approved);
+        snapshot.put("updatedAt", updatedAt);
+        snapshot.put("plan", plan);
+        snapshot.put("permissionAudit", List.copyOf(permissionAudit));
+        snapshot.put("metrics", metrics);
+        snapshot.put("a2ui", a2ui);
+        return snapshot;
+    }
+
+    private long completedCount() {
+        return tasks.stream().filter(task -> "completed".equals(task.get("state"))).count();
+    }
+
+    private int progress() {
+        if (tasks.isEmpty()) {
+            return 0;
+        }
+        return (int) Math.round(completedCount() * 100.0 / tasks.size());
+    }
+
+    /** Seeds the state from the {@code state} object the browser sent along with the run. */
+    public synchronized void mergeFromClient(Map<String, Object> clientState) {
+        if (clientState == null || clientState.isEmpty()) {
+            return;
+        }
+        if (clientState.get("topic") instanceof String value && !value.isBlank()) {
+            topic = value;
+        }
+        if (clientState.get("priority") instanceof String value && !value.isBlank()) {
+            priority = value;
+        }
+        if (clientState.get("status") instanceof String value && !value.isBlank()) {
+            status = value;
+        }
+        if (clientState.get("approved") instanceof Boolean value) {
+            approved = value;
+        }
+    }
+
+    public synchronized String updateBrief(String newTopic, String newPriority, String newStatus) {
+        if (newTopic != null && !newTopic.isBlank()) {
+            topic = newTopic.trim();
+        }
+        if (newPriority != null && !newPriority.isBlank()) {
+            priority = newPriority.trim();
+        }
+        if (newStatus != null && !newStatus.isBlank()) {
+            status = newStatus.trim();
+        }
+        touch();
+        return "已更新：主题=%s，优先级=%s，状态=%s".formatted(topic, priority, status);
+    }
+
+    public synchronized void setPlanGoal(String goal) {
+        if (goal != null && !goal.isBlank()) {
+            planGoal = goal.trim();
+            touch();
+        }
+    }
+
+    /**
+     * Mirrors AgentScope's live task list into the shared state.
+     *
+     * <p>Transitions are diffed against the previous mirror so that entering {@code in_progress} or
+     * {@code completed} also queues the matching AG-UI step event. Open steps are tracked so a later
+     * {@link #closeOpenSteps()} can guarantee every {@code STEP_STARTED} has a {@code STEP_FINISHED}
+     * before {@code RUN_FINISHED}.
+     *
+     * @param liveTasks the current {@code AgentState.getTasksContext().getTasks()}
+     * @return true when anything changed and a state frame was queued
+     */
+    public synchronized boolean syncTasks(List<Task> liveTasks) {
+        List<Map<String, Object>> mirrored = new ArrayList<>();
+        for (Task task : liveTasks) {
+            Map<String, Object> entry = new LinkedHashMap<>();
+            entry.put("id", task.getId());
+            entry.put("title", task.getSubject());
+            entry.put("state", task.getState().getWire());
+            Object taskPriority = task.getMetadata().get("priority");
+            entry.put("priority", taskPriority == null ? "medium" : taskPriority);
+            mirrored.add(entry);
+        }
+        if (mirrored.equals(tasks)) {
+            return false;
+        }
+
+        Map<String, String> previousStates = new LinkedHashMap<>();
+        for (Map<String, Object> task : tasks) {
+            previousStates.put(String.valueOf(task.get("id")), String.valueOf(task.get("state")));
+        }
+        tasks.clear();
+        tasks.addAll(mirrored);
+
+        Set<String> liveIds = new LinkedHashSet<>();
+        for (Map<String, Object> task : mirrored) {
+            String id = String.valueOf(task.get("id"));
+            liveIds.add(id);
+            String state = String.valueOf(task.get("state"));
+            if (state.equals(previousStates.get(id))) {
+                continue;
+            }
+            String title = String.valueOf(task.get("title"));
+            if ("in_progress".equals(state)) {
+                openStep(id, title);
+            } else if ("completed".equals(state)) {
+                // AG-UI forbids STEP_FINISHED without a prior STEP_STARTED for the same name.
+                if (!openSteps.containsKey(id)) {
+                    openStep(id, title);
+                }
+                finishStep(id);
+            } else if (openSteps.containsKey(id)) {
+                // Left in_progress for another state (e.g. pending) — still must close the step.
+                finishStep(id);
+            }
+        }
+        // Tasks dropped from the plan while still open would otherwise block RUN_FINISHED.
+        for (String id : List.copyOf(openSteps.keySet())) {
+            if (!liveIds.contains(id)) {
+                finishStep(id);
+            }
+        }
+
+        long done = completedCount();
+        if (tasks.isEmpty()) {
+            planPhase = "idle";
+        } else if (done == tasks.size()) {
+            planPhase = "completed";
+        } else if (done > 0 || tasks.stream().anyMatch(t -> "in_progress".equals(t.get("state")))) {
+            planPhase = "executing";
+        } else {
+            planPhase = "planning";
+        }
+        status = "计划进度 %d/%d".formatted(done, tasks.size());
+        touch();
+        return true;
+    }
+
+    public synchronized void recordMetrics(Map<String, Object> newMetrics) {
+        metrics = newMetrics == null ? Map.of() : Map.copyOf(newMetrics);
+        touch();
+    }
+
+    /** Publishes a freshly generated A2UI surface to the browser. */
+    public synchronized void recordA2uiSurface(
+            String surfaceId,
+            String catalogId,
+            String intent,
+            String generatedBy,
+            int componentCount,
+            List<Map<String, Object>> operations) {
+        this.a2uiSurfaceId = surfaceId;
+        this.a2uiCatalogId = catalogId;
+        this.a2uiIntent = intent;
+        this.a2uiGeneratedBy = generatedBy;
+        this.a2uiComponentCount = componentCount;
+        status = "已生成 A2UI 界面（%s）".formatted(generatedBy);
+        touch();
+
+        Map<String, Object> payload = new LinkedHashMap<>();
+        // CopilotKit's A2UI message renderer only paints when it finds this exact key
+        // (A2UI_OPERATIONS_KEY in @copilotkit/react-core); everything else is metadata.
+        payload.put("a2ui_operations", operations);
+        payload.put("surfaceId", surfaceId);
+        payload.put("catalogId", catalogId);
+        payload.put("intent", intent);
+        payload.put("generatedBy", generatedBy);
+        pending.add(new CustomEvent(EVENT_A2UI_SURFACE, payload));
+    }
+
+    /** Queues a state frame even when nothing changed; used at the start of every run. */
+    public synchronized void queueSnapshot() {
+        pending.add(new CustomEvent(EVENT_STATE_UPDATED, snapshot()));
+    }
+
+    /**
+     * Drops any leftover open-step bookkeeping from a previous run without emitting events.
+     *
+     * <p>Called on {@code AgentStartEvent}: a prior run that ended in {@code RUN_ERROR} is allowed
+     * to leave steps open on the wire, but those names must not leak into the next run's pairing.
+     */
+    public synchronized void clearOpenSteps() {
+        openSteps.clear();
+    }
+
+    /**
+     * Emits {@code STEP_FINISHED} for every step still open.
+     *
+     * <p>Must run before {@code AgentEndEvent} is converted to {@code RUN_FINISHED}; the AG-UI
+     * verifier rejects a finished run while any step is still active.
+     */
+    public synchronized void closeOpenSteps() {
+        for (String id : List.copyOf(openSteps.keySet())) {
+            finishStep(id);
+        }
+    }
+
+    private void openStep(String taskId, String title) {
+        if (openSteps.containsKey(taskId)) {
+            return;
+        }
+        String step = resolveStepName(taskId, title);
+        openSteps.put(taskId, step);
+        Map<String, Object> payload = new LinkedHashMap<>();
+        payload.put("taskId", taskId);
+        payload.put("step", step);
+        pending.add(new CustomEvent(EVENT_STEP_STARTED, payload));
+    }
+
+    private void finishStep(String taskId) {
+        String step = openSteps.remove(taskId);
+        if (step == null) {
+            return;
+        }
+        Map<String, Object> payload = new LinkedHashMap<>();
+        payload.put("taskId", taskId);
+        payload.put("step", step);
+        pending.add(new CustomEvent(EVENT_STEP_FINISHED, payload));
+    }
+
+    /**
+     * Picks a wire {@code stepName} that is unique among currently open steps.
+     *
+     * <p>Titles are preferred for readability in the event inspector; colliding titles get the task
+     * id appended so a second {@code STEP_STARTED} does not trip "already active".
+     */
+    private String resolveStepName(String taskId, String title) {
+        String base =
+                title == null || title.isBlank() || "null".equals(title) ? taskId : title.trim();
+        for (Map.Entry<String, String> entry : openSteps.entrySet()) {
+            if (!entry.getKey().equals(taskId) && base.equals(entry.getValue())) {
+                return base + " [" + taskId + "]";
+            }
+        }
+        return base;
+    }
+
+    private void touch() {
+        updatedAt = LocalTime.now().format(TIME);
+        pending.add(new CustomEvent(EVENT_STATE_UPDATED, snapshot()));
+    }
+
+    /** Removes and returns everything queued since the previous drain. */
+    public List<CustomEvent> drainPendingEvents() {
+        List<CustomEvent> drained = new ArrayList<>();
+        CustomEvent event;
+        while ((event = pending.poll()) != null) {
+            drained.add(event);
+        }
+        return drained;
+    }
+}

--- a/agentscope-examples/agentscope-copilotkit/src/main/java/io/agentscope/examples/copilotkit/workbench/WorkbenchStateRegistry.java
+++ b/agentscope-examples/agentscope-copilotkit/src/main/java/io/agentscope/examples/copilotkit/workbench/WorkbenchStateRegistry.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.examples.copilotkit.workbench;
+
+import io.agentscope.core.agent.RuntimeContext;
+import io.agentscope.core.state.AgentState;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import org.springframework.stereotype.Component;
+
+/**
+ * Keeps one {@link WorkbenchState} per AG-UI thread.
+ *
+ * <p>The AG-UI adapter sets {@code RuntimeContext.sessionId} to the thread id, so tools and
+ * middlewares can resolve the right state without any extra plumbing.
+ *
+ */
+@Component
+public class WorkbenchStateRegistry {
+
+    private static final String FALLBACK_THREAD_ID = "default-thread";
+
+    private final Map<String, WorkbenchState> states = new ConcurrentHashMap<>();
+
+    public WorkbenchState forThread(String threadId) {
+        String key = (threadId == null || threadId.isBlank()) ? FALLBACK_THREAD_ID : threadId;
+        return states.computeIfAbsent(key, WorkbenchState::new);
+    }
+
+    public WorkbenchState forContext(RuntimeContext ctx) {
+        return forThread(ctx == null ? null : ctx.getSessionId());
+    }
+
+    /**
+     * Resolves the state for a tool call.
+     *
+     * <p>{@code AgentState} is keyed by session id, and the AG-UI adapter sets the session id to the
+     * thread id, so injected state is enough to find the right workbench.
+     */
+    public WorkbenchState forState(AgentState state) {
+        return forThread(state == null ? null : state.getSessionId());
+    }
+
+    public void remove(String threadId) {
+        if (threadId != null) {
+            states.remove(threadId);
+        }
+    }
+}

--- a/agentscope-examples/agentscope-copilotkit/src/main/java/io/agentscope/examples/copilotkit/workbench/WorkbenchTools.java
+++ b/agentscope-examples/agentscope-copilotkit/src/main/java/io/agentscope/examples/copilotkit/workbench/WorkbenchTools.java
@@ -1,0 +1,192 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.examples.copilotkit.workbench;
+
+import io.agentscope.core.state.AgentState;
+import io.agentscope.core.tool.Tool;
+import io.agentscope.core.tool.ToolParam;
+import io.agentscope.examples.copilotkit.a2ui.A2uiComposer;
+import io.agentscope.examples.copilotkit.a2ui.A2uiSurface;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.concurrent.ThreadLocalRandom;
+
+/**
+ * The workbench tool belt.
+ *
+ * <p>Each tool exercises a different AgentScope 2.0 capability and is wired to a matching permission
+ * rule in {@code AgentConfiguration}:
+ *
+ * <ul>
+ *   <li>{@code query_service_metrics} — read-only, auto-allowed
+ *   <li>{@code update_workbench_brief} — writes shared state, streamed to the browser as STATE_DELTA
+ *   <li>{@code deploy_release} — ASK rule, suspends the run into an AG-UI interrupt
+ *   <li>{@code purge_production_data} — DENY rule, never reaches this class
+ *   <li>{@code render_dashboard} — generative UI through A2UI
+ * </ul>
+ *
+ * <p>{@code AgentState} is injected by the framework and carries the AG-UI thread id as its session
+ * id, which is how each tool finds the right {@link WorkbenchState}.
+ *
+ */
+public class WorkbenchTools {
+
+    private final WorkbenchStateRegistry registry;
+    private final A2uiComposer composer;
+
+    public WorkbenchTools(WorkbenchStateRegistry registry, A2uiComposer composer) {
+        this.registry = registry;
+        this.composer = composer;
+    }
+
+    /**
+     * Reads simulated service metrics.
+     *
+     * @param service the service to inspect
+     * @param window  the time window, e.g. {@code 1h} or {@code 24h}
+     * @param state   injected agent state
+     * @return a human-readable metric summary
+     */
+    @Tool(
+            name = "query_service_metrics",
+            description = "查询指定服务的运行指标（QPS、错误率、P99 延迟）。只读操作，可直接调用。",
+            readOnly = true,
+            stateInjected = true)
+    public String queryServiceMetrics(
+            @ToolParam(name = "service", description = "服务名，例如 order-api") String service,
+            @ToolParam(name = "window", description = "时间窗口，例如 1h / 24h") String window,
+            AgentState state) {
+        ThreadLocalRandom random = ThreadLocalRandom.current();
+        Map<String, Object> metrics = new LinkedHashMap<>();
+        metrics.put("QPS", random.nextInt(800, 4200));
+        metrics.put("错误率", "%.2f%%".formatted(random.nextDouble(0.01, 1.8)));
+        metrics.put("P99 延迟", random.nextInt(80, 520) + "ms");
+        metrics.put("实例数", random.nextInt(3, 24));
+
+        WorkbenchState workbench = registry.forState(state);
+        workbench.recordMetrics(metrics);
+        return "%s 在 %s 窗口的指标：%s".formatted(service, window, metrics);
+    }
+
+    /**
+     * Updates the shared brief shown in the browser.
+     *
+     * @param topic    new topic, optional
+     * @param priority new priority (低 / 中 / 高), optional
+     * @param status   new status text, optional
+     * @param state    injected agent state
+     * @return confirmation of the merged brief
+     */
+    @Tool(
+            name = "update_workbench_brief",
+            description = "更新工作台共享状态中的主题、优先级或状态文案，前端会实时收到 STATE_DELTA。",
+            stateInjected = true,
+            concurrencySafe = false)
+    public String updateWorkbenchBrief(
+            @ToolParam(name = "topic", description = "新的演示主题，可留空") String topic,
+            @ToolParam(name = "priority", description = "优先级：低 / 中 / 高，可留空") String priority,
+            @ToolParam(name = "status", description = "新的状态文案，可留空") String status,
+            AgentState state) {
+        return registry.forState(state).updateBrief(topic, priority, status);
+    }
+
+    /**
+     * Records the goal the current plan is working towards.
+     *
+     * @param goal  the plan goal
+     * @param state injected agent state
+     * @return confirmation
+     */
+    @Tool(
+            name = "set_plan_goal",
+            description = "在使用 todo_write 制定计划前，先声明本次计划的总目标，前端计划面板会展示它。",
+            stateInjected = true,
+            concurrencySafe = false)
+    public String setPlanGoal(
+            @ToolParam(name = "goal", description = "计划的总目标") String goal, AgentState state) {
+        registry.forState(state).setPlanGoal(goal);
+        return "计划目标已记录：" + goal;
+    }
+
+    /**
+     * Simulates a production release; gated by an {@code ASK} permission rule.
+     *
+     * @param service target service
+     * @param version release version
+     * @param state   injected agent state
+     * @return the release result
+     */
+    @Tool(
+            name = "deploy_release",
+            description = "把指定版本发布到生产环境。高风险操作，执行前需要用户在前端确认。",
+            stateInjected = true,
+            concurrencySafe = false)
+    public String deployRelease(
+            @ToolParam(name = "service", description = "服务名") String service,
+            @ToolParam(name = "version", description = "版本号，例如 v2.4.1") String version,
+            AgentState state) {
+        String detail = "%s → %s".formatted(service, version);
+        return "已发布 %s 到生产环境，灰度 10%% 观察中。".formatted(detail);
+    }
+
+    /**
+     * Destructive operation kept behind a {@code DENY} rule so the demo can show a hard block.
+     *
+     * @param dataset dataset name
+     * @return never returned in practice
+     */
+    @Tool(
+            name = "purge_production_data",
+            description = "永久删除生产数据集。该工具被 DENY 规则拦截，任何情况下都不会执行。",
+            concurrencySafe = false)
+    public String purgeProductionData(
+            @ToolParam(name = "dataset", description = "数据集名称") String dataset) {
+        return "不应该执行到这里：" + dataset;
+    }
+
+    /**
+     * Generates an A2UI surface and pushes it to the browser as an {@code a2ui-surface} activity.
+     *
+     * @param intent what the surface should show
+     * @param state injected agent state
+     * @return a short summary for the model
+     */
+    @Tool(
+            name = "render_dashboard",
+            description = "根据自然语言意图动态生成一块 A2UI 界面并推送到前端渲染。适合展示指标看板、计划进度、" + "风险评估等结构化信息。",
+            stateInjected = true,
+            concurrencySafe = false)
+    public String renderDashboard(
+            @ToolParam(name = "intent", description = "希望界面展示什么内容") String intent,
+            AgentState state) {
+        WorkbenchState workbench = registry.forState(state);
+        A2uiSurface surface =
+                composer.compose(intent, workbench.snapshot(), workbench.getClientComponents());
+        workbench.recordA2uiSurface(
+                surface.surfaceId(),
+                surface.catalogId(),
+                surface.intent(),
+                surface.generatedBy(),
+                surface.componentCount(),
+                surface.operations());
+        return "已生成 A2UI 界面 %s（生成器 %s，%d 个组件，schema 来源 %s），界面已渲染在对话中。"
+                .formatted(
+                        surface.surfaceId(),
+                        surface.generatedBy(),
+                        surface.componentCount(),
+                        composer.schemaSourceName());
+    }
+}

--- a/agentscope-examples/agentscope-copilotkit/src/main/resources/application.yml
+++ b/agentscope-examples/agentscope-copilotkit/src/main/resources/application.yml
@@ -1,0 +1,62 @@
+# Copyright 2024-2026 the original author or authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# AG-UI Example Application Configuration
+
+server:
+  port: 8080
+
+spring:
+  main:
+    banner-mode: off
+  web:
+    resources:
+      cache:
+        period: 0
+      chain:
+        cache: false
+  http:
+    codecs:
+      max-in-memory-size: 1MB
+# AG-UI Configuration
+agentscope:
+  agui:
+    path-prefix: /agui
+    cors-enabled: true
+    cors-allowed-origins:
+      - "*"
+    run-timeout: 10m
+    emit-state-events: true
+    emit-tool-call-args: true
+    emit-token-usage: true
+    default-agent-id: default
+    # Agent ID routing configuration
+    # Agent ID can be passed via:
+    # 1. URL path variable: POST /agui/run/{agentId} (highest priority)
+    # 2. HTTP header: X-Agent-Id (configurable)
+    # 3. Request body: forwardedProps.agentId
+    # 4. Default: uses default-agent-id
+    agent-id-header: X-Agent-Id
+    enable-path-routing: true
+    # Server-side memory management
+    server-side-memory: true
+    max-thread-sessions: 1000
+    session-timeout-minutes: 30
+    enable-reasoning: true
+
+# Logging
+logging:
+  level:
+    root: INFO
+    io.agentscope: INFO

--- a/agentscope-examples/agentscope-copilotkit/src/main/resources/logback.xml
+++ b/agentscope-examples/agentscope-copilotkit/src/main/resources/logback.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2024-2026 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+-->
+
+<configuration>
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <logger name="io.agentscope" level="DEBUG"/>
+
+    <root level="INFO">
+        <appender-ref ref="CONSOLE"/>
+    </root>
+</configuration>
+

--- a/agentscope-examples/pom.xml
+++ b/agentscope-examples/pom.xml
@@ -37,6 +37,7 @@
         <module>agents/agentscope-paw</module>
         <module>agents/agentscope-dataagent</module>
         <module>agents/agentscope-codingagent</module>
+        <module>agentscope-copilotkit</module>
     </modules>
 
     <properties>

--- a/agentscope-extensions/agentscope-spring-boot-starters/agentscope-agui-spring-boot-starter/src/main/java/io/agentscope/spring/boot/agui/common/ThreadSessionManager.java
+++ b/agentscope-extensions/agentscope-spring-boot-starters/agentscope-agui-spring-boot-starter/src/main/java/io/agentscope/spring/boot/agui/common/ThreadSessionManager.java
@@ -83,15 +83,18 @@ public class ThreadSessionManager {
     public Agent getOrCreateAgent(String threadId, String agentId, Supplier<Agent> agentFactory) {
         ensureCapacity();
 
+        // Use compute() for atomic check-and-update to avoid race conditions
         ThreadSession session =
                 sessions.compute(
                         threadId,
                         (k, existing) -> {
                             if (existing == null) {
+                                // No existing session, create new one
                                 logger.debug("Creating new session for threadId: {}", threadId);
                                 return new ThreadSession(agentId, agentFactory.get());
                             }
                             if (!existing.getAgentId().equals(agentId)) {
+                                // Agent type changed, create new session
                                 logger.debug(
                                         "Agent type changed for threadId {}: {} -> {}",
                                         threadId,
@@ -103,6 +106,7 @@ public class ThreadSessionManager {
                                 replacement.setArchived(existing.isArchived());
                                 return replacement;
                             }
+                            // Same agent type, update access time and reuse
                             existing.updateLastAccess();
                             return existing;
                         });
@@ -150,10 +154,6 @@ public class ThreadSessionManager {
 
     /**
      * Check if a session exists and has memory for the given threadId.
-     *
-     * <p>AG-UI runs bind conversation state to {@code RuntimeContext.sessionId = threadId}, so
-     * this check must read that slot — not {@link ReActAgent#getAgentState()} which resolves the
-     * agent's default session and would always look empty.
      *
      * @param threadId The thread identifier
      * @return true if the session exists and the agent has non-empty memory

--- a/agentscope-extensions/agentscope-spring-boot-starters/agentscope-agui-spring-boot-starter/src/main/java/io/agentscope/spring/boot/agui/common/ThreadSessionManager.java
+++ b/agentscope-extensions/agentscope-spring-boot-starters/agentscope-agui-spring-boot-starter/src/main/java/io/agentscope/spring/boot/agui/common/ThreadSessionManager.java
@@ -19,6 +19,8 @@ import io.agentscope.core.ReActAgent;
 import io.agentscope.core.agent.Agent;
 import io.agentscope.core.state.AgentState;
 import java.time.Instant;
+import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
@@ -79,35 +81,28 @@ public class ThreadSessionManager {
      * @return The agent for this thread
      */
     public Agent getOrCreateAgent(String threadId, String agentId, Supplier<Agent> agentFactory) {
-        // Clean up if we're at capacity
-        if (sessions.size() >= maxSessions) {
-            cleanupExpiredSessions();
-            // If still at capacity, remove oldest session
-            if (sessions.size() >= maxSessions) {
-                removeOldestSession();
-            }
-        }
+        ensureCapacity();
 
-        // Use compute() for atomic check-and-update to avoid race conditions
         ThreadSession session =
                 sessions.compute(
                         threadId,
                         (k, existing) -> {
                             if (existing == null) {
-                                // No existing session, create new one
                                 logger.debug("Creating new session for threadId: {}", threadId);
                                 return new ThreadSession(agentId, agentFactory.get());
                             }
                             if (!existing.getAgentId().equals(agentId)) {
-                                // Agent type changed, create new session
                                 logger.debug(
                                         "Agent type changed for threadId {}: {} -> {}",
                                         threadId,
                                         existing.getAgentId(),
                                         agentId);
-                                return new ThreadSession(agentId, agentFactory.get());
+                                ThreadSession replacement =
+                                        new ThreadSession(agentId, agentFactory.get());
+                                replacement.setName(existing.getName());
+                                replacement.setArchived(existing.isArchived());
+                                return replacement;
                             }
-                            // Same agent type, update access time and reuse
                             existing.updateLastAccess();
                             return existing;
                         });
@@ -116,7 +111,49 @@ public class ThreadSessionManager {
     }
 
     /**
+     * Ensure a session exists for the given threadId, creating one if needed.
+     *
+     * @param threadId The thread identifier
+     * @param agentId The agent type identifier
+     * @param name Display name for the thread (may be null)
+     * @param agentFactory Factory to create new agents if needed
+     * @return The session for this thread
+     */
+    public ThreadSession ensureSession(
+            String threadId, String agentId, String name, Supplier<Agent> agentFactory) {
+        ensureCapacity();
+
+        return sessions.compute(
+                threadId,
+                (k, existing) -> {
+                    if (existing == null) {
+                        ThreadSession created = new ThreadSession(agentId, agentFactory.get());
+                        if (name != null && !name.isBlank()) {
+                            created.setName(name);
+                        }
+                        return created;
+                    }
+                    if (!existing.getAgentId().equals(agentId)) {
+                        ThreadSession replacement = new ThreadSession(agentId, agentFactory.get());
+                        replacement.setName(
+                                name != null && !name.isBlank() ? name : existing.getName());
+                        replacement.setArchived(existing.isArchived());
+                        return replacement;
+                    }
+                    if (name != null && !name.isBlank()) {
+                        existing.setName(name);
+                    }
+                    existing.updateLastAccess();
+                    return existing;
+                });
+    }
+
+    /**
      * Check if a session exists and has memory for the given threadId.
+     *
+     * <p>AG-UI runs bind conversation state to {@code RuntimeContext.sessionId = threadId}, so
+     * this check must read that slot — not {@link ReActAgent#getAgentState()} which resolves the
+     * agent's default session and would always look empty.
      *
      * @param threadId The thread identifier
      * @return true if the session exists and the agent has non-empty memory
@@ -128,9 +165,8 @@ public class ThreadSessionManager {
         }
 
         Agent agent = session.getAgent();
-        // Check if the agent's AgentState has any context messages.
         if (agent instanceof ReActAgent reactAgent) {
-            AgentState state = reactAgent.getAgentState();
+            AgentState state = reactAgent.getAgentState(null, threadId);
             return state != null && !state.getContext().isEmpty();
         }
 
@@ -145,6 +181,15 @@ public class ThreadSessionManager {
      */
     public Optional<ThreadSession> getSession(String threadId) {
         return Optional.ofNullable(sessions.get(threadId));
+    }
+
+    /**
+     * Returns an unmodifiable snapshot of all sessions keyed by threadId.
+     *
+     * @return session snapshot
+     */
+    public Map<String, ThreadSession> getSessions() {
+        return Collections.unmodifiableMap(new LinkedHashMap<>(sessions));
     }
 
     /**
@@ -177,6 +222,15 @@ public class ThreadSessionManager {
 
         if (removed > 0) {
             logger.debug("Cleaned up {} expired sessions", removed);
+        }
+    }
+
+    private void ensureCapacity() {
+        if (sessions.size() >= maxSessions) {
+            cleanupExpiredSessions();
+            if (sessions.size() >= maxSessions) {
+                removeOldestSession();
+            }
         }
     }
 
@@ -217,12 +271,17 @@ public class ThreadSessionManager {
 
         private final String agentId;
         private final Agent agent;
+        private final Instant createdAt;
         private Instant lastAccess;
+        private volatile String name;
+        private volatile boolean archived;
 
         ThreadSession(String agentId, Agent agent) {
             this.agentId = agentId;
             this.agent = agent;
-            this.lastAccess = Instant.now();
+            Instant now = Instant.now();
+            this.createdAt = now;
+            this.lastAccess = now;
         }
 
         public String getAgentId() {
@@ -233,11 +292,31 @@ public class ThreadSessionManager {
             return agent;
         }
 
+        public Instant getCreatedAt() {
+            return createdAt;
+        }
+
         public Instant getLastAccess() {
             return lastAccess;
         }
 
-        void updateLastAccess() {
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        public boolean isArchived() {
+            return archived;
+        }
+
+        public void setArchived(boolean archived) {
+            this.archived = archived;
+        }
+
+        public void updateLastAccess() {
             this.lastAccess = Instant.now();
         }
     }

--- a/agentscope-extensions/agentscope-spring-boot-starters/agentscope-agui-spring-boot-starter/src/test/java/io/agentscope/spring/boot/agui/common/ThreadSessionManagerTest.java
+++ b/agentscope-extensions/agentscope-spring-boot-starters/agentscope-agui-spring-boot-starter/src/test/java/io/agentscope/spring/boot/agui/common/ThreadSessionManagerTest.java
@@ -1,0 +1,208 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.spring.boot.agui.common;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.agentscope.core.ReActAgent;
+import io.agentscope.core.agent.Agent;
+import io.agentscope.core.message.Msg;
+import io.agentscope.core.state.AgentState;
+import io.agentscope.spring.boot.agui.common.ThreadSessionManager.ThreadSession;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+/** Unit tests for {@link ThreadSessionManager}. */
+@Tag("unit")
+@DisplayName("ThreadSessionManager Unit Tests")
+class ThreadSessionManagerTest {
+
+    @Test
+    void getOrCreateAgentCreatesAndReusesSession() {
+        ThreadSessionManager manager = new ThreadSessionManager(10, 30);
+        AtomicInteger creations = new AtomicInteger();
+        Agent first = mock(Agent.class);
+        Agent second = mock(Agent.class);
+
+        Agent created =
+                manager.getOrCreateAgent(
+                        "thread-1",
+                        "agent-a",
+                        () -> {
+                            creations.incrementAndGet();
+                            return first;
+                        });
+        Agent reused =
+                manager.getOrCreateAgent(
+                        "thread-1",
+                        "agent-a",
+                        () -> {
+                            creations.incrementAndGet();
+                            return second;
+                        });
+
+        assertSame(first, created);
+        assertSame(first, reused);
+        assertEquals(1, creations.get());
+        assertEquals(1, manager.getSessionCount());
+    }
+
+    @Test
+    void getOrCreateAgentReplacesAgentAndPreservesMetadata() {
+        ThreadSessionManager manager = new ThreadSessionManager(10, 30);
+        Agent oldAgent = mock(Agent.class);
+        Agent newAgent = mock(Agent.class);
+
+        manager.getOrCreateAgent("thread-1", "agent-a", () -> oldAgent);
+        ThreadSession session = manager.getSession("thread-1").orElseThrow();
+        session.setName("Orders");
+        session.setArchived(true);
+
+        Agent replaced = manager.getOrCreateAgent("thread-1", "agent-b", () -> newAgent);
+        ThreadSession updated = manager.getSession("thread-1").orElseThrow();
+
+        assertSame(newAgent, replaced);
+        assertEquals("agent-b", updated.getAgentId());
+        assertEquals("Orders", updated.getName());
+        assertTrue(updated.isArchived());
+        assertNotSame(session, updated);
+    }
+
+    @Test
+    void ensureSessionCreatesNamedSessionAndUpdatesName() {
+        ThreadSessionManager manager = new ThreadSessionManager(10, 30);
+        Agent agent = mock(Agent.class);
+
+        ThreadSession created =
+                manager.ensureSession("thread-1", "agent-a", "  Demo  ", () -> agent);
+        assertEquals("agent-a", created.getAgentId());
+        assertEquals("  Demo  ", created.getName());
+        assertSame(agent, created.getAgent());
+
+        ThreadSession renamed =
+                manager.ensureSession("thread-1", "agent-a", "Renamed", () -> mock(Agent.class));
+        assertSame(created, renamed);
+        assertEquals("Renamed", renamed.getName());
+    }
+
+    @Test
+    void ensureSessionIgnoresBlankNameAndPreservesExistingOnAgentChange() {
+        ThreadSessionManager manager = new ThreadSessionManager(10, 30);
+        Agent first = mock(Agent.class);
+        Agent second = mock(Agent.class);
+
+        ThreadSession created = manager.ensureSession("thread-1", "agent-a", null, () -> first);
+        assertEquals(null, created.getName());
+
+        manager.ensureSession("thread-1", "agent-a", "   ", () -> first);
+        assertEquals(null, manager.getSession("thread-1").orElseThrow().getName());
+
+        created.setName("KeepMe");
+        created.setArchived(true);
+        ThreadSession replaced = manager.ensureSession("thread-1", "agent-b", "  ", () -> second);
+
+        assertEquals("agent-b", replaced.getAgentId());
+        assertEquals("KeepMe", replaced.getName());
+        assertTrue(replaced.isArchived());
+        assertSame(second, replaced.getAgent());
+    }
+
+    @Test
+    void hasMemoryUsesThreadScopedAgentState() {
+        ThreadSessionManager manager = new ThreadSessionManager(10, 30);
+        assertFalse(manager.hasMemory("missing"));
+
+        Agent plain = mock(Agent.class);
+        manager.getOrCreateAgent("thread-plain", "agent-a", () -> plain);
+        assertFalse(manager.hasMemory("thread-plain"));
+
+        ReActAgent emptyAgent = mock(ReActAgent.class);
+        AgentState emptyState = mock(AgentState.class);
+        when(emptyAgent.getAgentState(null, "thread-empty")).thenReturn(emptyState);
+        when(emptyState.getContext()).thenReturn(List.of());
+        manager.getOrCreateAgent("thread-empty", "agent-a", () -> emptyAgent);
+        assertFalse(manager.hasMemory("thread-empty"));
+
+        ReActAgent filledAgent = mock(ReActAgent.class);
+        AgentState filledState = mock(AgentState.class);
+        when(filledAgent.getAgentState(null, "thread-filled")).thenReturn(filledState);
+        when(filledState.getContext()).thenReturn(List.of(mock(Msg.class)));
+        manager.getOrCreateAgent("thread-filled", "agent-a", () -> filledAgent);
+        assertTrue(manager.hasMemory("thread-filled"));
+    }
+
+    @Test
+    void getSessionsReturnsUnmodifiableSnapshot() {
+        ThreadSessionManager manager = new ThreadSessionManager(10, 30);
+        Agent agent = mock(Agent.class);
+        manager.getOrCreateAgent("thread-1", "agent-a", () -> agent);
+
+        Map<String, ThreadSession> snapshot = manager.getSessions();
+        assertEquals(1, snapshot.size());
+        assertThrows(
+                UnsupportedOperationException.class,
+                () -> snapshot.put("thread-2", mock(ThreadSession.class)));
+    }
+
+    @Test
+    void removeClearAndCapacityEvictionWork() {
+        ThreadSessionManager manager = new ThreadSessionManager(1, 0);
+        Agent first = mock(Agent.class);
+        Agent second = mock(Agent.class);
+
+        manager.getOrCreateAgent("thread-1", "agent-a", () -> first);
+        assertTrue(manager.removeSession("thread-1"));
+        assertFalse(manager.removeSession("thread-1"));
+        assertEquals(0, manager.getSessionCount());
+
+        manager.getOrCreateAgent("thread-1", "agent-a", () -> first);
+        // maxSessions=1 and timeout disabled → creating another session evicts the oldest.
+        manager.getOrCreateAgent("thread-2", "agent-a", () -> second);
+        assertEquals(1, manager.getSessionCount());
+        assertTrue(manager.getSession("thread-2").isPresent());
+        assertTrue(manager.getSession("thread-1").isEmpty());
+
+        manager.clear();
+        assertEquals(0, manager.getSessionCount());
+    }
+
+    @Test
+    void cleanupExpiredSessionsRemovesInactiveOnes() throws Exception {
+        ThreadSessionManager manager = new ThreadSessionManager(10, 1);
+        Agent agent = mock(Agent.class);
+        manager.getOrCreateAgent("thread-old", "agent-a", () -> agent);
+
+        ThreadSession session = manager.getSession("thread-old").orElseThrow();
+        // Force lastAccess into the past beyond the 1-minute timeout.
+        java.lang.reflect.Field field = ThreadSession.class.getDeclaredField("lastAccess");
+        field.setAccessible(true);
+        field.set(session, java.time.Instant.now().minusSeconds(120));
+
+        manager.cleanupExpiredSessions();
+        assertTrue(manager.getSession("thread-old").isEmpty());
+    }
+}


### PR DESCRIPTION
## Summary
- Add a full-stack CopilotKit + AG-UI example (`agentscope-copilotkit`) to verify threads, shared state, generative UI, A2UI workbench, and HITL flows end-to-end.
- Extend `ThreadSessionManager` so demo/session APIs can ensure named sessions and correctly resolve memory by `threadId`.

## Depends on
- Depends on https://github.com/agentscope-ai/agentscope-java/pull/2638 (Jackson 2 request-body parsing for Boot 4 / multimodal `MessageContent`). Merge #2638 first, or keep this PR stacked on top of it.

## Related issues
- Related to #575
- Related to #336

## Test plan
- [x] `mvn spotless:check` on example / agui-spring-boot-starter
- [x] `ThreadSessionManagerTest`
- [x] `mvn -pl agentscope-examples/agentscope-copilotkit package` (npm frontend build + Spring Boot repackage)
- [ ] Manual: start `agentscope-copilotkit` backend + frontend, confirm HITL interrupt/resume, thread session, shared state, and generative UI flows