### PR TITLE
feat(harness): remote subagent event streaming and HITL resume

### DIFF
--- a/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agent-protocol/src/main/java/io/agentscope/extensions/agentprotocol/AgentProtocolAutoConfiguration.java
+++ b/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agent-protocol/src/main/java/io/agentscope/extensions/agentprotocol/AgentProtocolAutoConfiguration.java
@@ -41,15 +41,25 @@ import org.springframework.context.annotation.Bean;
 public class AgentProtocolAutoConfiguration {
 
     @Bean
+    public AgentProtocolTaskEventBus agentProtocolTaskEventBus(AgentProtocolProperties properties) {
+        return new AgentProtocolTaskEventBus(properties.getSseReplayBufferSize());
+    }
+
+    @Bean
     @ConditionalOnBean({HarnessAgent.class, WorkspaceManager.class})
     public AgentProtocolTaskStore agentProtocolTaskStore(
-            ObjectProvider<HarnessAgent> agentProvider, WorkspaceManager workspaceManager) {
-        return new AgentProtocolTaskStore(agentProvider::getObject, workspaceManager);
+            ObjectProvider<HarnessAgent> agentProvider,
+            WorkspaceManager workspaceManager,
+            AgentProtocolTaskEventBus eventBus,
+            AgentProtocolProperties properties) {
+        return new AgentProtocolTaskStore(
+                agentProvider::getObject, workspaceManager, eventBus, properties);
     }
 
     @Bean
     @ConditionalOnBean(AgentProtocolTaskStore.class)
-    public AgentProtocolController agentProtocolController(AgentProtocolTaskStore store) {
-        return new AgentProtocolController(store);
+    public AgentProtocolController agentProtocolController(
+            AgentProtocolTaskStore store, AgentProtocolProperties properties) {
+        return new AgentProtocolController(store, properties);
     }
 }

--- a/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agent-protocol/src/main/java/io/agentscope/extensions/agentprotocol/AgentProtocolController.java
+++ b/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agent-protocol/src/main/java/io/agentscope/extensions/agentprotocol/AgentProtocolController.java
@@ -15,38 +15,60 @@
  */
 package io.agentscope.extensions.agentprotocol;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.agentscope.harness.agent.subagent.protocol.RemoteAgentEvent;
+import io.agentscope.harness.agent.subagent.protocol.RemoteConfirmDecision;
+import java.time.Duration;
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.codec.ServerSentEvent;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import reactor.core.publisher.Flux;
 
 /** Internal AgentScope task protocol ({@code /tasks/...}). */
 @RestController
 public class AgentProtocolController {
 
+    private static final ObjectMapper JSON = new ObjectMapper();
+
     private final AgentProtocolTaskStore store;
+    private final AgentProtocolProperties properties;
+
+    public AgentProtocolController(
+            AgentProtocolTaskStore store, AgentProtocolProperties properties) {
+        this.store = store;
+        this.properties = properties != null ? properties : new AgentProtocolProperties();
+    }
 
     public AgentProtocolController(AgentProtocolTaskStore store) {
-        this.store = store;
+        this(store, new AgentProtocolProperties());
     }
 
     @PostMapping(value = "/tasks", consumes = MediaType.APPLICATION_JSON_VALUE)
-    public ResponseEntity<Map<String, Object>> submit(@RequestBody Map<String, String> body) {
-        String taskId = body.get("task_id");
-        String agentId = body.get("agent_id");
-        String input = body.get("input");
+    public ResponseEntity<Map<String, Object>> submit(@RequestBody Map<String, Object> body) {
+        String taskId = stringVal(body.get("task_id"));
+        String agentId = stringVal(body.get("agent_id"));
+        String input = stringVal(body.get("input"));
         if (taskId == null || taskId.isBlank()) {
             return ResponseEntity.badRequest().body(Map.of("error", "task_id is required"));
         }
+        @SuppressWarnings("unchecked")
+        Map<String, Object> context =
+                body.get("context") instanceof Map<?, ?> m ? (Map<String, Object>) m : null;
         try {
-            store.submit(taskId, agentId, input);
+            store.submit(taskId, agentId, input, context);
             Map<String, Object> ok = new LinkedHashMap<>();
             ok.put("task_id", taskId);
             ok.put("status", "pending");
@@ -74,5 +96,88 @@ public class AgentProtocolController {
     public ResponseEntity<Void> cancel(@PathVariable("taskId") String taskId) {
         store.cancel(taskId);
         return ResponseEntity.ok().build();
+    }
+
+    /**
+     * SSE event stream for a task. Supports {@code from_seq} query param and {@code Last-Event-ID}
+     * header for reconnect.
+     */
+    @GetMapping(value = "/tasks/{taskId}/events", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+    public Flux<ServerSentEvent<String>> events(
+            @PathVariable("taskId") String taskId,
+            @RequestParam(name = "from_seq", required = false) Long fromSeq,
+            @RequestHeader(name = "Last-Event-ID", required = false) String lastEventId) {
+        if (!properties.isStreamingEnabled()) {
+            return Flux.error(new IllegalStateException("streaming is disabled"));
+        }
+        long from = 0L;
+        if (fromSeq != null && fromSeq > 0) {
+            from = fromSeq;
+        } else if (lastEventId != null && !lastEventId.isBlank()) {
+            try {
+                from = Long.parseLong(lastEventId.trim());
+            } catch (NumberFormatException ignored) {
+            }
+        }
+        Duration timeout = Duration.ofMillis(Math.max(1_000L, properties.getSseTimeoutMs()));
+        return store.eventBus().subscribe(taskId, from).map(this::toSse).take(timeout);
+    }
+
+    @PostMapping(value = "/tasks/{taskId}/resume", consumes = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<Map<String, Object>> resume(
+            @PathVariable("taskId") String taskId, @RequestBody Map<String, Object> body) {
+        List<RemoteConfirmDecision> decisions = parseDecisions(body.get("decisions"));
+        try {
+            store.resume(taskId, decisions);
+            Map<String, Object> ok = new LinkedHashMap<>();
+            ok.put("task_id", taskId);
+            ok.put("status", "running");
+            return ResponseEntity.ok(ok);
+        } catch (IllegalStateException e) {
+            return ResponseEntity.status(HttpStatus.CONFLICT).body(Map.of("error", e.getMessage()));
+        }
+    }
+
+    private ServerSentEvent<String> toSse(RemoteAgentEvent event) {
+        String data;
+        try {
+            data = JSON.writeValueAsString(event);
+        } catch (JsonProcessingException e) {
+            data = "{\"error\":\"serialize_failed\"}";
+        }
+        return ServerSentEvent.<String>builder()
+                .id(String.valueOf(event.getSeq()))
+                .event(event.getType() != null ? event.getType().name() : "message")
+                .data(data)
+                .build();
+    }
+
+    @SuppressWarnings("unchecked")
+    private static List<RemoteConfirmDecision> parseDecisions(Object raw) {
+        if (!(raw instanceof List<?> list)) {
+            return List.of();
+        }
+        List<RemoteConfirmDecision> out = new ArrayList<>();
+        for (Object item : list) {
+            if (!(item instanceof Map<?, ?> map)) {
+                continue;
+            }
+            Map<String, Object> m = (Map<String, Object>) map;
+            String toolCallId = stringVal(m.get("toolCallId"));
+            if (toolCallId == null) {
+                toolCallId = stringVal(m.get("tool_call_id"));
+            }
+            Object approved = m.get("approved");
+            boolean ok =
+                    approved instanceof Boolean b
+                            ? b
+                            : approved != null && Boolean.parseBoolean(String.valueOf(approved));
+            out.add(new RemoteConfirmDecision(toolCallId, ok));
+        }
+        return out;
+    }
+
+    private static String stringVal(Object v) {
+        return v == null ? null : String.valueOf(v);
     }
 }

--- a/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agent-protocol/src/main/java/io/agentscope/extensions/agentprotocol/AgentProtocolProperties.java
+++ b/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agent-protocol/src/main/java/io/agentscope/extensions/agentprotocol/AgentProtocolProperties.java
@@ -24,11 +24,55 @@ public class AgentProtocolProperties {
     /** When {@code true}, registers {@code /tasks} REST endpoints. */
     private boolean enabled = false;
 
+    /** When {@code true}, servers push AgentEvents over SSE {@code /tasks/{id}/events}. */
+    private boolean streamingEnabled = true;
+
+    /** When {@code true}, pause remote tasks for tool confirmation (HITL). */
+    private boolean hitlEnabled = true;
+
+    /** Replay buffer size per task for late SSE subscribers. */
+    private int sseReplayBufferSize = 256;
+
+    /** Client idle timeout hint for SSE (ms); not enforced server-side by default. */
+    private long sseTimeoutMs = 10_800_000L;
+
     public boolean isEnabled() {
         return enabled;
     }
 
     public void setEnabled(boolean enabled) {
         this.enabled = enabled;
+    }
+
+    public boolean isStreamingEnabled() {
+        return streamingEnabled;
+    }
+
+    public void setStreamingEnabled(boolean streamingEnabled) {
+        this.streamingEnabled = streamingEnabled;
+    }
+
+    public boolean isHitlEnabled() {
+        return hitlEnabled;
+    }
+
+    public void setHitlEnabled(boolean hitlEnabled) {
+        this.hitlEnabled = hitlEnabled;
+    }
+
+    public int getSseReplayBufferSize() {
+        return sseReplayBufferSize;
+    }
+
+    public void setSseReplayBufferSize(int sseReplayBufferSize) {
+        this.sseReplayBufferSize = sseReplayBufferSize;
+    }
+
+    public long getSseTimeoutMs() {
+        return sseTimeoutMs;
+    }
+
+    public void setSseTimeoutMs(long sseTimeoutMs) {
+        this.sseTimeoutMs = sseTimeoutMs;
     }
 }

--- a/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agent-protocol/src/main/java/io/agentscope/extensions/agentprotocol/AgentProtocolTaskEventBus.java
+++ b/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agent-protocol/src/main/java/io/agentscope/extensions/agentprotocol/AgentProtocolTaskEventBus.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.extensions.agentprotocol;
+
+import io.agentscope.harness.agent.subagent.protocol.RemoteAgentEvent;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Sinks;
+
+/**
+ * Per-task event bus for Agent Protocol SSE streaming. Uses a replay buffer so late subscribers /
+ * reconnects can catch up from {@code fromSeq}.
+ */
+public final class AgentProtocolTaskEventBus {
+
+    private static final Logger log = LoggerFactory.getLogger(AgentProtocolTaskEventBus.class);
+
+    private final int replayBufferSize;
+    private final Map<String, Channel> channels = new ConcurrentHashMap<>();
+
+    public AgentProtocolTaskEventBus() {
+        this(256);
+    }
+
+    public AgentProtocolTaskEventBus(int replayBufferSize) {
+        this.replayBufferSize = Math.max(16, replayBufferSize);
+    }
+
+    /** Publishes an event, assigning a monotonic {@code seq}. */
+    public RemoteAgentEvent publish(String taskId, RemoteAgentEvent event) {
+        Channel ch = channels.computeIfAbsent(taskId, id -> new Channel(replayBufferSize));
+        long seq = ch.seq.incrementAndGet();
+        event.setSeq(seq);
+        event.setTaskId(taskId);
+        Sinks.EmitResult result = ch.sink.tryEmitNext(event);
+        if (result.isFailure()) {
+            log.debug("Failed to emit event seq={} for task {}: {}", seq, taskId, result);
+        }
+        return event;
+    }
+
+    /**
+     * Subscribes to events for {@code taskId}, optionally skipping those with {@code seq <=
+     * fromSeq}.
+     */
+    public Flux<RemoteAgentEvent> subscribe(String taskId, long fromSeq) {
+        Channel ch = channels.computeIfAbsent(taskId, id -> new Channel(replayBufferSize));
+        Flux<RemoteAgentEvent> flux = ch.sink.asFlux();
+        if (fromSeq > 0) {
+            return flux.filter(e -> e.getSeq() > fromSeq);
+        }
+        return flux;
+    }
+
+    /** Completes and removes the channel after a terminal event has been published. */
+    public void complete(String taskId) {
+        Channel ch = channels.remove(taskId);
+        if (ch != null) {
+            ch.sink.tryEmitComplete();
+        }
+    }
+
+    private static final class Channel {
+        private final Sinks.Many<RemoteAgentEvent> sink;
+        private final AtomicLong seq = new AtomicLong();
+
+        Channel(int replayBufferSize) {
+            this.sink = Sinks.many().replay().limit(replayBufferSize);
+        }
+    }
+}

--- a/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agent-protocol/src/main/java/io/agentscope/extensions/agentprotocol/AgentProtocolTaskStore.java
+++ b/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agent-protocol/src/main/java/io/agentscope/extensions/agentprotocol/AgentProtocolTaskStore.java
@@ -15,15 +15,31 @@
  */
 package io.agentscope.extensions.agentprotocol;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.agentscope.core.agent.RuntimeContext;
+import io.agentscope.core.event.AgentEvent;
+import io.agentscope.core.event.AgentResultEvent;
+import io.agentscope.core.event.ConfirmResult;
+import io.agentscope.core.message.GenerateReason;
 import io.agentscope.core.message.Msg;
 import io.agentscope.core.message.MsgRole;
+import io.agentscope.core.message.ToolCallState;
+import io.agentscope.core.message.ToolUseBlock;
 import io.agentscope.harness.agent.HarnessAgent;
+import io.agentscope.harness.agent.subagent.protocol.RemoteAgentEvent;
+import io.agentscope.harness.agent.subagent.protocol.RemoteConfirmDecision;
+import io.agentscope.harness.agent.subagent.protocol.RemoteEventCodec;
+import io.agentscope.harness.agent.subagent.protocol.RemoteEventType;
+import io.agentscope.harness.agent.subagent.protocol.RemotePendingConfirm;
 import io.agentscope.harness.agent.subagent.task.TaskRecord;
 import io.agentscope.harness.agent.subagent.task.TaskStatus;
 import io.agentscope.harness.agent.workspace.WorkspaceManager;
 import java.time.Duration;
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -31,10 +47,11 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import reactor.core.publisher.Mono;
+import reactor.core.publisher.Flux;
 
 /**
  * In-memory execution handles with workspace-backed {@link TaskRecord} persistence.
@@ -47,9 +64,15 @@ import reactor.core.publisher.Mono;
 public final class AgentProtocolTaskStore {
 
     private static final Logger log = LoggerFactory.getLogger(AgentProtocolTaskStore.class);
+    private static final ObjectMapper JSON = new ObjectMapper();
+
+    /** Sentinel returned when the agent paused for HITL confirmation. */
+    static final String AWAITING_CONFIRM_SENTINEL = "__awaiting_confirm__";
 
     private final Supplier<HarnessAgent> agentSupplier;
     private final WorkspaceManager workspaceManager;
+    private final AgentProtocolTaskEventBus eventBus;
+    private final AgentProtocolProperties properties;
     private final ExecutorService executor =
             Executors.newCachedThreadPool(
                     r -> {
@@ -60,20 +83,34 @@ public final class AgentProtocolTaskStore {
                     });
 
     private final Map<String, CompletableFuture<String>> futures = new ConcurrentHashMap<>();
+    private final Map<String, SubmitContext> submitContexts = new ConcurrentHashMap<>();
 
-    /**
-     * Creates the store with an agent factory. Each task invocation calls {@code agentSupplier}
-     * once; for true concurrent execution supply a prototype-scoped factory.
-     */
     public AgentProtocolTaskStore(
-            Supplier<HarnessAgent> agentSupplier, WorkspaceManager workspaceManager) {
+            Supplier<HarnessAgent> agentSupplier,
+            WorkspaceManager workspaceManager,
+            AgentProtocolTaskEventBus eventBus,
+            AgentProtocolProperties properties) {
         this.agentSupplier = Objects.requireNonNull(agentSupplier, "agentSupplier");
         this.workspaceManager = Objects.requireNonNull(workspaceManager, "workspaceManager");
+        this.eventBus = eventBus != null ? eventBus : new AgentProtocolTaskEventBus();
+        this.properties = properties != null ? properties : new AgentProtocolProperties();
     }
 
-    /** Convenience constructor for the common single-instance case. */
+    public AgentProtocolTaskStore(
+            Supplier<HarnessAgent> agentSupplier, WorkspaceManager workspaceManager) {
+        this(
+                agentSupplier,
+                workspaceManager,
+                new AgentProtocolTaskEventBus(),
+                new AgentProtocolProperties());
+    }
+
     public AgentProtocolTaskStore(HarnessAgent harnessAgent, WorkspaceManager workspaceManager) {
         this(() -> harnessAgent, workspaceManager);
+    }
+
+    public AgentProtocolTaskEventBus eventBus() {
+        return eventBus;
     }
 
     /**
@@ -83,6 +120,10 @@ public final class AgentProtocolTaskStore {
      * @throws IllegalStateException if the task id already completed (HTTP 409)
      */
     public void submit(String taskId, String agentId, String input) {
+        submit(taskId, agentId, input, null);
+    }
+
+    public void submit(String taskId, String agentId, String input, Map<String, Object> context) {
         Optional<TaskRecord> existing =
                 workspaceManager.readTaskRecord(
                         RuntimeContext.empty(),
@@ -97,6 +138,9 @@ public final class AgentProtocolTaskStore {
             return;
         }
 
+        SubmitContext ctx = SubmitContext.from(context);
+        submitContexts.put(taskId, ctx);
+
         TaskRecord pending =
                 new TaskRecord(
                         taskId,
@@ -108,32 +152,215 @@ public final class AgentProtocolTaskStore {
         persist(pending);
 
         CompletableFuture<String> f =
-                CompletableFuture.supplyAsync(() -> runAgent(taskId, agentId, input), executor);
+                CompletableFuture.supplyAsync(
+                        () -> runAgent(taskId, agentId, input, ctx, null), executor);
         futures.put(taskId, f);
         f.whenComplete((r, ex) -> futures.remove(taskId));
     }
 
-    private String runAgent(String taskId, String agentId, String input) {
+    /**
+     * Resumes a task paused for HITL confirmation with the given decisions.
+     *
+     * @throws IllegalStateException if the task is not awaiting confirmation
+     */
+    public void resume(String taskId, List<RemoteConfirmDecision> decisions) {
+        if (!properties.isHitlEnabled()) {
+            throw new IllegalStateException("HITL is disabled on this server");
+        }
+        Optional<TaskRecord> existing =
+                workspaceManager.readTaskRecord(
+                        RuntimeContext.empty(),
+                        AgentProtocolConstants.PROTOCOL_AGENT_ID,
+                        AgentProtocolConstants.PROTOCOL_SESSION_ID,
+                        taskId);
+        if (existing.isEmpty() || !existing.get().isAwaitingConfirm()) {
+            throw new IllegalStateException("task is not awaiting confirmation: " + taskId);
+        }
+        TaskRecord rec = existing.get();
+        CompletableFuture<String> prior = futures.get(taskId);
+        if (prior != null && !prior.isDone()) {
+            throw new IllegalStateException("task is already running: " + taskId);
+        }
+
+        List<RemotePendingConfirm> pending =
+                rec.getPendingConfirms() != null ? rec.getPendingConfirms() : List.of();
+        List<ConfirmResult> confirmResults = toConfirmResults(pending, decisions);
+
+        rec.setAwaitingConfirm(false);
+        rec.setPendingConfirms(null);
+        rec.setStatus(TaskStatus.RUNNING);
+        persist(rec);
+
+        SubmitContext ctx = submitContexts.getOrDefault(taskId, SubmitContext.empty());
+        String agentId = rec.getSubAgentId();
+        String dummyInput = ""; // resume uses confirm metadata, not a new user prompt
+        CompletableFuture<String> f =
+                CompletableFuture.supplyAsync(
+                        () -> runAgent(taskId, agentId, dummyInput, ctx, confirmResults), executor);
+        futures.put(taskId, f);
+        f.whenComplete((r, ex) -> futures.remove(taskId));
+    }
+
+    private String runAgent(
+            String taskId,
+            String agentId,
+            String input,
+            SubmitContext submitCtx,
+            List<ConfirmResult> confirmResults) {
         try {
-            update(taskId, TaskStatus.RUNNING, null, null, agentId);
-            RuntimeContext ctx = RuntimeContext.builder().sessionId(taskId).build();
-            Msg msg =
-                    Msg.builder()
-                            .role(MsgRole.USER)
-                            .textContent(input != null ? input : "")
-                            .build();
+            updateRunning(taskId, agentId);
+            RuntimeContext.Builder ctxBuilder = RuntimeContext.builder().sessionId(taskId);
+            if (submitCtx.userId() != null) {
+                ctxBuilder.userId(submitCtx.userId());
+            }
+            RuntimeContext ctx = ctxBuilder.build();
+
+            Msg.Builder msgBuilder =
+                    Msg.builder().role(MsgRole.USER).textContent(input != null ? input : "");
+            if (confirmResults != null && !confirmResults.isEmpty()) {
+                Map<String, Object> meta = new HashMap<>();
+                meta.put(Msg.METADATA_CONFIRM_RESULTS, confirmResults);
+                msgBuilder.metadata(meta);
+            }
+            Msg msg = msgBuilder.build();
+
             HarnessAgent agent = agentSupplier.get();
-            Mono<Msg> mono = agent.call(msg, ctx);
-            Msg reply = mono.block(Duration.ofHours(2));
+            AtomicReference<Msg> resultRef = new AtomicReference<>();
+            String detail = submitCtx.detail();
+
+            Flux<AgentEvent> events = agent.streamEvents(msg, ctx);
+            events.doOnNext(
+                            event -> {
+                                if (event instanceof AgentResultEvent resultEvent) {
+                                    resultRef.set(resultEvent.getResult());
+                                }
+                                if (!properties.isStreamingEnabled()) {
+                                    return;
+                                }
+                                RemoteEventCodec.fromAgentEvent(event)
+                                        .filter(
+                                                dto ->
+                                                        RemoteEventCodec.matchesDetail(
+                                                                dto.getType(), detail))
+                                        .ifPresent(
+                                                dto -> {
+                                                    dto.setAgentId(agentId);
+                                                    eventBus.publish(taskId, dto);
+                                                });
+                            })
+                    .blockLast(Duration.ofHours(2));
+
+            Msg reply = resultRef.get();
+            if (reply != null
+                    && reply.getGenerateReason() == GenerateReason.PERMISSION_ASKING
+                    && properties.isHitlEnabled()) {
+                List<RemotePendingConfirm> pending = extractPendingConfirms(reply);
+                markAwaitingConfirm(taskId, agentId, pending);
+                RemoteAgentEvent require = new RemoteAgentEvent();
+                require.setType(RemoteEventType.REQUIRE_CONFIRM);
+                require.setAgentId(agentId);
+                require.setPendingConfirms(pending);
+                require.setStatus("awaiting_confirm");
+                eventBus.publish(taskId, require);
+                return AWAITING_CONFIRM_SENTINEL;
+            }
+
             String text = reply != null ? reply.getTextContent() : "";
-            update(taskId, TaskStatus.COMPLETED, text, null, agentId);
+            update(taskId, TaskStatus.COMPLETED, text, null, agentId, false, null);
+            publishStatus(taskId, agentId, "success", null);
+            eventBus.complete(taskId);
             return text;
         } catch (Exception e) {
             String err = e.getMessage() != null ? e.getMessage() : e.getClass().getSimpleName();
             log.warn("Protocol task {} failed", taskId, e);
-            update(taskId, TaskStatus.FAILED, null, err, agentId);
+            update(taskId, TaskStatus.FAILED, null, err, agentId, false, null);
+            RemoteAgentEvent error = new RemoteAgentEvent();
+            error.setType(RemoteEventType.RUN_ERROR);
+            error.setAgentId(agentId);
+            error.setError(err);
+            error.setStatus("error");
+            eventBus.publish(taskId, error);
+            eventBus.complete(taskId);
             throw new RuntimeException(e);
         }
+    }
+
+    private void publishStatus(String taskId, String agentId, String status, String error) {
+        RemoteAgentEvent evt = new RemoteAgentEvent();
+        evt.setType(RemoteEventType.STATUS);
+        evt.setAgentId(agentId);
+        evt.setStatus(status);
+        evt.setError(error);
+        eventBus.publish(taskId, evt);
+    }
+
+    private void markAwaitingConfirm(
+            String taskId, String agentId, List<RemotePendingConfirm> pending) {
+        Optional<TaskRecord> prev =
+                workspaceManager.readTaskRecord(
+                        RuntimeContext.empty(),
+                        AgentProtocolConstants.PROTOCOL_AGENT_ID,
+                        AgentProtocolConstants.PROTOCOL_SESSION_ID,
+                        taskId);
+        TaskRecord r =
+                prev.orElseGet(
+                        () ->
+                                new TaskRecord(
+                                        taskId,
+                                        agentId != null ? agentId : "default",
+                                        AgentProtocolConstants.PROTOCOL_AGENT_ID,
+                                        AgentProtocolConstants.PROTOCOL_SESSION_ID,
+                                        null));
+        r.setStatus(TaskStatus.RUNNING);
+        r.setAwaitingConfirm(true);
+        r.setPendingConfirms(pending);
+        r.touch();
+        persist(r);
+    }
+
+    private static List<RemotePendingConfirm> extractPendingConfirms(Msg reply) {
+        List<RemotePendingConfirm> pending = new ArrayList<>();
+        for (ToolUseBlock block : reply.getContentBlocks(ToolUseBlock.class)) {
+            if (block.getState() == ToolCallState.ASKING) {
+                pending.add(
+                        new RemotePendingConfirm(
+                                block.getId(), block.getName(), toJsonQuiet(block.getInput())));
+            }
+        }
+        if (pending.isEmpty()) {
+            // Fall back to all tool uses if state wasn't stamped
+            for (ToolUseBlock block : reply.getContentBlocks(ToolUseBlock.class)) {
+                pending.add(
+                        new RemotePendingConfirm(
+                                block.getId(), block.getName(), toJsonQuiet(block.getInput())));
+            }
+        }
+        return pending;
+    }
+
+    private static List<ConfirmResult> toConfirmResults(
+            List<RemotePendingConfirm> pending, List<RemoteConfirmDecision> decisions) {
+        Map<String, Boolean> byId = new HashMap<>();
+        if (decisions != null) {
+            for (RemoteConfirmDecision d : decisions) {
+                if (d.getToolCallId() != null) {
+                    byId.put(d.getToolCallId(), d.isApproved());
+                }
+            }
+        }
+        List<ConfirmResult> results = new ArrayList<>();
+        for (RemotePendingConfirm p : pending) {
+            boolean approved = byId.getOrDefault(p.getToolCallId(), false);
+            Map<String, Object> input = parseInputQuiet(p.getToolInputJson());
+            ToolUseBlock toolCall =
+                    ToolUseBlock.builder()
+                            .id(p.getToolCallId())
+                            .name(p.getToolName())
+                            .input(input)
+                            .build();
+            results.add(new ConfirmResult(approved, toolCall));
+        }
+        return results;
     }
 
     private void persist(TaskRecord r) {
@@ -144,8 +371,18 @@ public final class AgentProtocolTaskStore {
                 r);
     }
 
+    private void updateRunning(String taskId, String agentId) {
+        update(taskId, TaskStatus.RUNNING, null, null, agentId, false, null);
+    }
+
     private void update(
-            String taskId, TaskStatus status, String result, String error, String agentId) {
+            String taskId,
+            TaskStatus status,
+            String result,
+            String error,
+            String agentId,
+            boolean awaitingConfirm,
+            List<RemotePendingConfirm> pendingConfirms) {
         Optional<TaskRecord> prev =
                 workspaceManager.readTaskRecord(
                         RuntimeContext.empty(),
@@ -163,6 +400,8 @@ public final class AgentProtocolTaskStore {
                                         null));
         r.setSubAgentId(agentId != null ? agentId : r.getSubAgentId());
         r.setStatus(status);
+        r.setAwaitingConfirm(awaitingConfirm);
+        r.setPendingConfirms(pendingConfirms);
         if (result != null) {
             r.setResult(result);
         }
@@ -187,16 +426,20 @@ public final class AgentProtocolTaskStore {
             return m;
         }
         TaskRecord r = rec.get();
-        m.put("status", mapStatus(r.getStatus()));
+        m.put("status", mapStatus(r));
         if (r.getErrorMessage() != null) {
             m.put("error", r.getErrorMessage());
         }
         if (r.getStatus() == TaskStatus.COMPLETED && r.getResult() != null) {
             m.put("result", r.getResult());
         }
+        if (r.isAwaitingConfirm() && r.getPendingConfirms() != null) {
+            m.put("pending_confirms", r.getPendingConfirms());
+        }
         CompletableFuture<String> f = futures.get(taskId);
         if (f != null
                 && !f.isDone()
+                && !r.isAwaitingConfirm()
                 && (r.getStatus() == TaskStatus.RUNNING || r.getStatus() == TaskStatus.PENDING)) {
             m.put("status", "running");
         }
@@ -204,12 +447,8 @@ public final class AgentProtocolTaskStore {
     }
 
     /**
-     * Blocks until the task reaches a terminal state or the timeout elapses.
-     *
-     * @param taskId task to wait for
-     * @param timeoutMs maximum wait time in milliseconds; 0 means no explicit deadline (uses the
-     *     in-memory future's natural completion if available, then falls back to a single workspace
-     *     read)
+     * Blocks until the task reaches a terminal state or the timeout elapses. Does not complete while
+     * awaiting confirmation — returns {@code awaiting_confirm} so the client can resume.
      */
     public Map<String, Object> waitFor(String taskId, long timeoutMs) throws Exception {
         long deadline = timeoutMs > 0 ? System.currentTimeMillis() + timeoutMs : Long.MAX_VALUE;
@@ -247,9 +486,17 @@ public final class AgentProtocolTaskStore {
                 return err;
             }
             TaskRecord r = rec.get();
+            if (r.isAwaitingConfirm()) {
+                Map<String, Object> out = new LinkedHashMap<>();
+                out.put("status", "awaiting_confirm");
+                if (r.getPendingConfirms() != null) {
+                    out.put("pending_confirms", r.getPendingConfirms());
+                }
+                return out;
+            }
             if (r.getStatus().isTerminal()) {
                 Map<String, Object> out = new LinkedHashMap<>();
-                out.put("status", mapStatus(r.getStatus()));
+                out.put("status", mapStatus(r));
                 if (r.getStatus() == TaskStatus.COMPLETED) {
                     out.put("result", r.getResult() != null ? r.getResult() : "");
                 } else if (r.getStatus() == TaskStatus.FAILED) {
@@ -286,20 +533,81 @@ public final class AgentProtocolTaskStore {
         if (rec.isPresent()) {
             TaskRecord r = rec.get();
             r.setCancelRequested(true);
+            r.setAwaitingConfirm(false);
             if (!r.getStatus().isTerminal()) {
                 r.setStatus(TaskStatus.CANCELLED);
             }
             persist(r);
         }
+        eventBus.complete(taskId);
     }
 
-    private static String mapStatus(TaskStatus s) {
-        return switch (s) {
+    private static String mapStatus(TaskRecord r) {
+        if (r.isAwaitingConfirm()) {
+            return "awaiting_confirm";
+        }
+        return switch (r.getStatus()) {
             case PENDING -> "pending";
             case RUNNING -> "running";
             case COMPLETED -> "success";
             case FAILED -> "error";
             case CANCELLED -> "cancelled";
         };
+    }
+
+    private static String toJsonQuiet(Object value) {
+        if (value == null) {
+            return null;
+        }
+        try {
+            return JSON.writeValueAsString(value);
+        } catch (JsonProcessingException e) {
+            return String.valueOf(value);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Map<String, Object> parseInputQuiet(String json) {
+        if (json == null || json.isBlank()) {
+            return Map.of();
+        }
+        try {
+            Object parsed = JSON.readValue(json, Object.class);
+            if (parsed instanceof Map<?, ?> map) {
+                Map<String, Object> out = new HashMap<>();
+                for (Map.Entry<?, ?> e : map.entrySet()) {
+                    if (e.getKey() != null) {
+                        out.put(String.valueOf(e.getKey()), e.getValue());
+                    }
+                }
+                return out;
+            }
+            return Map.of("raw", parsed);
+        } catch (JsonProcessingException e) {
+            return Map.of("raw", json);
+        }
+    }
+
+    private record SubmitContext(String userId, String parentSessionId, String detail) {
+        static SubmitContext empty() {
+            return new SubmitContext(null, null, "status");
+        }
+
+        static SubmitContext from(Map<String, Object> raw) {
+            if (raw == null || raw.isEmpty()) {
+                return empty();
+            }
+            String userId = stringVal(raw.get("user_id"));
+            String parentSessionId = stringVal(raw.get("parent_session_id"));
+            String detail = stringVal(raw.get("detail"));
+            if (detail == null || detail.isBlank()) {
+                detail = "status";
+            }
+            return new SubmitContext(userId, parentSessionId, detail);
+        }
+
+        private static String stringVal(Object v) {
+            return v == null ? null : String.valueOf(v);
+        }
     }
 }

--- a/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agent-protocol/src/main/java/io/agentscope/extensions/agentprotocol/AgentProtocolTaskStore.java
+++ b/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agent-protocol/src/main/java/io/agentscope/extensions/agentprotocol/AgentProtocolTaskStore.java
@@ -269,6 +269,7 @@ public final class AgentProtocolTaskStore {
             update(taskId, TaskStatus.COMPLETED, text, null, agentId, false, null);
             publishStatus(taskId, agentId, "success", null);
             eventBus.complete(taskId);
+            clearSubmitContext(taskId);
             return text;
         } catch (Exception e) {
             String err = e.getMessage() != null ? e.getMessage() : e.getClass().getSimpleName();
@@ -281,6 +282,7 @@ public final class AgentProtocolTaskStore {
             error.setStatus("error");
             eventBus.publish(taskId, error);
             eventBus.complete(taskId);
+            clearSubmitContext(taskId);
             throw new RuntimeException(e);
         }
     }
@@ -540,6 +542,20 @@ public final class AgentProtocolTaskStore {
             persist(r);
         }
         eventBus.complete(taskId);
+        clearSubmitContext(taskId);
+    }
+
+    /**
+     * Drops in-memory submit metadata for {@code taskId}. Kept during {@code awaiting_confirm} so
+     * {@link #resume} can reuse detail/userId, and cleared only on terminal completion/cancel.
+     */
+    private void clearSubmitContext(String taskId) {
+        submitContexts.remove(taskId);
+    }
+
+    /** Visible for tests — whether a submit context is still retained for {@code taskId}. */
+    boolean hasSubmitContext(String taskId) {
+        return submitContexts.containsKey(taskId);
     }
 
     private static String mapStatus(TaskRecord r) {

--- a/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agent-protocol/src/test/java/io/agentscope/extensions/agentprotocol/AgentProtocolControllerTest.java
+++ b/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agent-protocol/src/test/java/io/agentscope/extensions/agentprotocol/AgentProtocolControllerTest.java
@@ -1,0 +1,189 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.extensions.agentprotocol;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.agentscope.harness.agent.subagent.protocol.RemoteAgentEvent;
+import io.agentscope.harness.agent.subagent.protocol.RemoteConfirmDecision;
+import io.agentscope.harness.agent.subagent.protocol.RemoteEventType;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.codec.ServerSentEvent;
+
+class AgentProtocolControllerTest {
+
+    private AgentProtocolTaskStore store;
+    private AgentProtocolProperties properties;
+    private AgentProtocolController controller;
+
+    @BeforeEach
+    void setUp() {
+        store = mock(AgentProtocolTaskStore.class);
+        properties = new AgentProtocolProperties();
+        properties.setStreamingEnabled(true);
+        properties.setSseTimeoutMs(2_000L);
+        controller = new AgentProtocolController(store, properties);
+    }
+
+    @Test
+    void submit_passesContextToStore() {
+        Map<String, Object> context = Map.of("user_id", "u1", "detail", "full");
+        Map<String, Object> body =
+                Map.of("task_id", "t1", "agent_id", "worker", "input", "hello", "context", context);
+
+        ResponseEntity<Map<String, Object>> resp = controller.submit(body);
+
+        assertEquals(HttpStatus.OK, resp.getStatusCode());
+        assertEquals("t1", resp.getBody().get("task_id"));
+        assertEquals("pending", resp.getBody().get("status"));
+        verify(store).submit(eq("t1"), eq("worker"), eq("hello"), eq(context));
+    }
+
+    @Test
+    void submit_rejectsMissingTaskId() {
+        ResponseEntity<Map<String, Object>> resp =
+                controller.submit(Map.of("agent_id", "a", "input", "x"));
+
+        assertEquals(HttpStatus.BAD_REQUEST, resp.getStatusCode());
+        assertTrue(String.valueOf(resp.getBody().get("error")).contains("task_id"));
+    }
+
+    @Test
+    void resume_parsesCamelAndSnakeCaseDecisions() {
+        Map<String, Object> body =
+                Map.of(
+                        "decisions",
+                        List.of(
+                                Map.of("toolCallId", "tc1", "approved", true),
+                                Map.of("tool_call_id", "tc2", "approved", "false")));
+
+        ResponseEntity<Map<String, Object>> resp = controller.resume("t-hitl", body);
+
+        assertEquals(HttpStatus.OK, resp.getStatusCode());
+        assertEquals("running", resp.getBody().get("status"));
+
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<List<RemoteConfirmDecision>> captor = ArgumentCaptor.forClass(List.class);
+        verify(store).resume(eq("t-hitl"), captor.capture());
+
+        List<RemoteConfirmDecision> decisions = captor.getValue();
+        assertEquals(2, decisions.size());
+        assertEquals("tc1", decisions.get(0).getToolCallId());
+        assertTrue(decisions.get(0).isApproved());
+        assertEquals("tc2", decisions.get(1).getToolCallId());
+        assertFalse(decisions.get(1).isApproved());
+    }
+
+    @Test
+    void resume_returnsConflictWhenStoreRejects() {
+        doThrow(new IllegalStateException("task is not awaiting confirmation: t1"))
+                .when(store)
+                .resume(anyString(), anyList());
+
+        ResponseEntity<Map<String, Object>> resp =
+                controller.resume("t1", Map.of("decisions", List.of()));
+
+        assertEquals(HttpStatus.CONFLICT, resp.getStatusCode());
+        assertNotNull(resp.getBody().get("error"));
+    }
+
+    @Test
+    void events_returnsSseFromEventBus() {
+        AgentProtocolTaskEventBus bus = new AgentProtocolTaskEventBus();
+        when(store.eventBus()).thenReturn(bus);
+
+        RemoteAgentEvent published = new RemoteAgentEvent();
+        published.setType(RemoteEventType.TEXT_DELTA);
+        published.setText("hi");
+        bus.publish("t-sse", published);
+
+        List<ServerSentEvent<String>> events =
+                controller
+                        .events("t-sse", null, null)
+                        .take(1)
+                        .collectList()
+                        .block(Duration.ofSeconds(3));
+
+        assertEquals(1, events.size());
+        assertEquals("1", events.get(0).id());
+        assertEquals(RemoteEventType.TEXT_DELTA.name(), events.get(0).event());
+        assertTrue(events.get(0).data().contains("\"text\":\"hi\""));
+    }
+
+    @Test
+    void events_honorsFromSeqQueryParam() {
+        AgentProtocolTaskEventBus bus = new AgentProtocolTaskEventBus();
+        when(store.eventBus()).thenReturn(bus);
+
+        bus.publish("t-from", event(RemoteEventType.RUN_STARTED));
+        bus.publish("t-from", event(RemoteEventType.TEXT_DELTA));
+        bus.publish("t-from", event(RemoteEventType.STATUS));
+
+        List<ServerSentEvent<String>> events =
+                controller
+                        .events("t-from", 1L, null)
+                        .take(2)
+                        .collectList()
+                        .block(Duration.ofSeconds(3));
+
+        assertEquals(2, events.size());
+        assertEquals("2", events.get(0).id());
+        assertEquals("3", events.get(1).id());
+    }
+
+    @Test
+    void events_errorsWhenStreamingDisabled() {
+        properties.setStreamingEnabled(false);
+        controller = new AgentProtocolController(store, properties);
+
+        AtomicReference<Throwable> error = new AtomicReference<>();
+        controller
+                .events("t1", null, null)
+                .collectList()
+                .doOnError(error::set)
+                .onErrorComplete()
+                .block(Duration.ofSeconds(2));
+
+        assertNotNull(error.get());
+        assertInstanceOf(IllegalStateException.class, error.get());
+        assertTrue(error.get().getMessage().contains("streaming is disabled"));
+    }
+
+    private static RemoteAgentEvent event(RemoteEventType type) {
+        RemoteAgentEvent e = new RemoteAgentEvent();
+        e.setType(type);
+        return e;
+    }
+}

--- a/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agent-protocol/src/test/java/io/agentscope/extensions/agentprotocol/AgentProtocolTaskEventBusTest.java
+++ b/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agent-protocol/src/test/java/io/agentscope/extensions/agentprotocol/AgentProtocolTaskEventBusTest.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.extensions.agentprotocol;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.agentscope.harness.agent.subagent.protocol.RemoteAgentEvent;
+import io.agentscope.harness.agent.subagent.protocol.RemoteEventType;
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import reactor.core.Disposable;
+
+class AgentProtocolTaskEventBusTest {
+
+    private AgentProtocolTaskEventBus bus;
+
+    @BeforeEach
+    void setUp() {
+        bus = new AgentProtocolTaskEventBus();
+    }
+
+    @Test
+    void publish_assignsMonotonicSeqAndTaskId() {
+        RemoteAgentEvent first = bus.publish("task-a", event(RemoteEventType.RUN_STARTED));
+        RemoteAgentEvent second = bus.publish("task-a", event(RemoteEventType.TEXT_DELTA));
+        RemoteAgentEvent other = bus.publish("task-b", event(RemoteEventType.STATUS));
+
+        assertEquals(1L, first.getSeq());
+        assertEquals("task-a", first.getTaskId());
+        assertEquals(2L, second.getSeq());
+        assertEquals("task-a", second.getTaskId());
+        assertEquals(1L, other.getSeq());
+        assertEquals("task-b", other.getTaskId());
+    }
+
+    @Test
+    void subscribe_fromSeq_skipsOlderEventsOnReplay() {
+        bus.publish("task-replay", event(RemoteEventType.RUN_STARTED));
+        bus.publish("task-replay", event(RemoteEventType.TEXT_DELTA));
+        bus.publish("task-replay", event(RemoteEventType.STATUS));
+
+        List<RemoteAgentEvent> received =
+                bus.subscribe("task-replay", 1L).take(2).collectList().block(Duration.ofSeconds(2));
+
+        assertEquals(2, received.size());
+        assertEquals(2L, received.get(0).getSeq());
+        assertEquals(RemoteEventType.TEXT_DELTA, received.get(0).getType());
+        assertEquals(3L, received.get(1).getSeq());
+        assertEquals(RemoteEventType.STATUS, received.get(1).getType());
+    }
+
+    @Test
+    void complete_stopsFurtherDelivery() throws Exception {
+        List<RemoteAgentEvent> received = new CopyOnWriteArrayList<>();
+        CountDownLatch gotFirst = new CountDownLatch(1);
+        AtomicBoolean completed = new AtomicBoolean(false);
+
+        Disposable sub =
+                bus.subscribe("task-done", 0L)
+                        .subscribe(
+                                e -> {
+                                    received.add(e);
+                                    gotFirst.countDown();
+                                },
+                                err -> {},
+                                () -> completed.set(true));
+
+        bus.publish("task-done", event(RemoteEventType.RUN_STARTED));
+        assertTrue(gotFirst.await(2, TimeUnit.SECONDS));
+
+        bus.complete("task-done");
+        awaitCondition(completed::get, 2_000);
+
+        int sizeAfterComplete = received.size();
+        bus.publish("task-done", event(RemoteEventType.TEXT_DELTA));
+        Thread.sleep(100);
+
+        assertEquals(sizeAfterComplete, received.size());
+        assertTrue(completed.get());
+        sub.dispose();
+    }
+
+    private static RemoteAgentEvent event(RemoteEventType type) {
+        RemoteAgentEvent e = new RemoteAgentEvent();
+        e.setType(type);
+        return e;
+    }
+
+    private static void awaitCondition(Condition condition, long timeoutMs) throws Exception {
+        long deadline = System.currentTimeMillis() + timeoutMs;
+        while (!condition.get()) {
+            if (System.currentTimeMillis() >= deadline) {
+                throw new AssertionError("Condition not met within " + timeoutMs + " ms");
+            }
+            Thread.sleep(20);
+        }
+    }
+
+    @FunctionalInterface
+    private interface Condition {
+        boolean get() throws Exception;
+    }
+}

--- a/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agent-protocol/src/test/java/io/agentscope/extensions/agentprotocol/AgentProtocolTaskStoreHitlTest.java
+++ b/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agent-protocol/src/test/java/io/agentscope/extensions/agentprotocol/AgentProtocolTaskStoreHitlTest.java
@@ -16,8 +16,10 @@
 package io.agentscope.extensions.agentprotocol;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -102,6 +104,8 @@ class AgentProtocolTaskStoreHitlTest {
         assertEquals(1, pending.size());
         assertEquals("tc-ask", pending.get(0).getToolCallId());
         assertEquals("bash", pending.get(0).getToolName());
+        // Submit context must survive awaiting_confirm so resume can reuse detail/userId.
+        assertTrue(store.hasSubmitContext("hitl-1"));
 
         store.resume("hitl-1", List.of(new RemoteConfirmDecision("tc-ask", false)));
 
@@ -111,6 +115,21 @@ class AgentProtocolTaskStoreHitlTest {
         assertEquals("success", done.get("status"));
         assertEquals("denied and done", done.get("result"));
         assertEquals(2, streamCalls.get());
+        assertFalse(store.hasSubmitContext("hitl-1"));
+    }
+
+    @Test
+    void submitContextClearedOnDirectSuccess() throws Exception {
+        when(agent.streamEvents(any(Msg.class), any(RuntimeContext.class)))
+                .thenReturn(
+                        Flux.just(
+                                new AgentStartEvent("sess", null, "worker"),
+                                new AgentResultEvent(completedMsg()),
+                                new AgentEndEvent(null)));
+
+        store.submit("ok-1", "worker", "hello", Map.of("user_id", "u1", "detail", "status"));
+        awaitCondition(() -> "success".equals(store.snapshot("ok-1").get("status")), 5_000);
+        assertFalse(store.hasSubmitContext("ok-1"));
     }
 
     @Test

--- a/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agent-protocol/src/test/java/io/agentscope/extensions/agentprotocol/AgentProtocolTaskStoreHitlTest.java
+++ b/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agent-protocol/src/test/java/io/agentscope/extensions/agentprotocol/AgentProtocolTaskStoreHitlTest.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.extensions.agentprotocol;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.agentscope.core.agent.RuntimeContext;
+import io.agentscope.core.event.AgentEndEvent;
+import io.agentscope.core.event.AgentEvent;
+import io.agentscope.core.event.AgentResultEvent;
+import io.agentscope.core.event.AgentStartEvent;
+import io.agentscope.core.message.GenerateReason;
+import io.agentscope.core.message.Msg;
+import io.agentscope.core.message.MsgRole;
+import io.agentscope.core.message.ToolCallState;
+import io.agentscope.core.message.ToolUseBlock;
+import io.agentscope.harness.agent.HarnessAgent;
+import io.agentscope.harness.agent.subagent.protocol.RemoteConfirmDecision;
+import io.agentscope.harness.agent.subagent.protocol.RemotePendingConfirm;
+import io.agentscope.harness.agent.workspace.WorkspaceManager;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import reactor.core.publisher.Flux;
+
+/**
+ * Lightweight HITL path for {@link AgentProtocolTaskStore}: mock {@link HarnessAgent} streams a
+ * {@link GenerateReason#PERMISSION_ASKING} result, then a completed reply after resume/deny.
+ */
+class AgentProtocolTaskStoreHitlTest {
+
+    @TempDir Path tempDir;
+
+    private HarnessAgent agent;
+    private WorkspaceManager workspaceManager;
+    private AgentProtocolTaskStore store;
+    private final AtomicInteger streamCalls = new AtomicInteger();
+
+    @BeforeEach
+    void setUp() {
+        agent = mock(HarnessAgent.class);
+        workspaceManager = new WorkspaceManager(tempDir);
+        AgentProtocolProperties props = new AgentProtocolProperties();
+        props.setHitlEnabled(true);
+        props.setStreamingEnabled(true);
+        store =
+                new AgentProtocolTaskStore(
+                        () -> agent, workspaceManager, new AgentProtocolTaskEventBus(), props);
+
+        when(agent.streamEvents(any(Msg.class), any(RuntimeContext.class)))
+                .thenAnswer(
+                        inv -> {
+                            int n = streamCalls.incrementAndGet();
+                            if (n == 1) {
+                                return Flux.just(
+                                        new AgentStartEvent("sess", null, "worker"),
+                                        new AgentResultEvent(askingMsg()),
+                                        new AgentEndEvent(null));
+                            }
+                            return Flux.just(
+                                    new AgentStartEvent("sess", null, "worker"),
+                                    new AgentResultEvent(completedMsg()),
+                                    new AgentEndEvent(null));
+                        });
+    }
+
+    @Test
+    void submit_pausesOnPermissionAsking_andResumeDenyCompletes() throws Exception {
+        store.submit("hitl-1", "worker", "please run bash", Map.of("detail", "full"));
+
+        awaitCondition(
+                () -> "awaiting_confirm".equals(store.snapshot("hitl-1").get("status")), 5_000);
+
+        Map<String, Object> snap = store.snapshot("hitl-1");
+        assertEquals("awaiting_confirm", snap.get("status"));
+        assertNotNull(snap.get("pending_confirms"));
+        @SuppressWarnings("unchecked")
+        List<RemotePendingConfirm> pending =
+                (List<RemotePendingConfirm>) snap.get("pending_confirms");
+        assertEquals(1, pending.size());
+        assertEquals("tc-ask", pending.get(0).getToolCallId());
+        assertEquals("bash", pending.get(0).getToolName());
+
+        store.resume("hitl-1", List.of(new RemoteConfirmDecision("tc-ask", false)));
+
+        awaitCondition(() -> "success".equals(store.snapshot("hitl-1").get("status")), 5_000);
+
+        Map<String, Object> done = store.snapshot("hitl-1");
+        assertEquals("success", done.get("status"));
+        assertEquals("denied and done", done.get("result"));
+        assertEquals(2, streamCalls.get());
+    }
+
+    @Test
+    void agentResultEvent_carriesPermissionAskingMsg() {
+        Msg asking = askingMsg();
+        assertEquals(GenerateReason.PERMISSION_ASKING, asking.getGenerateReason());
+        ToolUseBlock block = asking.getContentBlocks(ToolUseBlock.class).get(0);
+        assertEquals(ToolCallState.ASKING, block.getState());
+
+        AgentEvent event = new AgentResultEvent(asking);
+        assertInstanceOf(AgentResultEvent.class, event);
+        assertEquals(asking, ((AgentResultEvent) event).getResult());
+    }
+
+    private static Msg askingMsg() {
+        return Msg.builder()
+                .role(MsgRole.ASSISTANT)
+                .content(
+                        ToolUseBlock.builder()
+                                .id("tc-ask")
+                                .name("bash")
+                                .input(Map.of("cmd", "rm -rf /"))
+                                .state(ToolCallState.ASKING)
+                                .build())
+                .generateReason(GenerateReason.PERMISSION_ASKING)
+                .build();
+    }
+
+    private static Msg completedMsg() {
+        return Msg.builder().role(MsgRole.ASSISTANT).textContent("denied and done").build();
+    }
+
+    private static void awaitCondition(Condition condition, long timeoutMs) throws Exception {
+        long deadline = System.currentTimeMillis() + timeoutMs;
+        while (!condition.get()) {
+            if (System.currentTimeMillis() >= deadline) {
+                throw new AssertionError("Condition not met within " + timeoutMs + " ms");
+            }
+            Thread.sleep(50);
+        }
+    }
+
+    @FunctionalInterface
+    private interface Condition {
+        boolean get() throws Exception;
+    }
+}

--- a/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/main/java/io/agentscope/core/agui/adapter/AguiAdapterConfig.java
+++ b/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/main/java/io/agentscope/core/agui/adapter/AguiAdapterConfig.java
@@ -42,6 +42,7 @@ public class AguiAdapterConfig {
     private final List<AgentEventConverter> eventConverters;
     private final List<AguiEventEnricher> eventEnrichers;
     private final boolean baseEventPropertiesEnricherEnabled;
+    private final boolean emitSubagentEventsAsNative;
 
     private AguiAdapterConfig(Builder builder) {
         this.toolMergeMode = builder.toolMergeMode;
@@ -54,6 +55,7 @@ public class AguiAdapterConfig {
         this.eventConverters = List.copyOf(builder.eventConverters);
         this.eventEnrichers = buildEventEnrichers(builder);
         this.baseEventPropertiesEnricherEnabled = builder.baseEventPropertiesEnricherEnabled;
+        this.emitSubagentEventsAsNative = builder.emitSubagentEventsAsNative;
     }
 
     /**
@@ -155,6 +157,17 @@ public class AguiAdapterConfig {
     }
 
     /**
+     * When {@code false} (default), AgentEvents with a non-null {@code source} (subagent events)
+     * are emitted as AG-UI {@code CUSTOM} events under the {@code subagent.*} namespace instead of
+     * native {@code TEXT_MESSAGE_*} / run lifecycle events.
+     *
+     * @return true to keep the legacy native presentation for subagent events
+     */
+    public boolean isEmitSubagentEventsAsNative() {
+        return emitSubagentEventsAsNative;
+    }
+
+    /**
      * Creates a new builder for AguiAdapterConfig.
      *
      * @return A new builder instance
@@ -196,6 +209,7 @@ public class AguiAdapterConfig {
         private final List<AgentEventConverter> eventConverters = new ArrayList<>();
         private final List<AguiEventEnricher> eventEnrichers = new ArrayList<>();
         private boolean baseEventPropertiesEnricherEnabled = false;
+        private boolean emitSubagentEventsAsNative = false;
 
         /**
          * Set the tool merge mode.
@@ -343,6 +357,21 @@ public class AguiAdapterConfig {
         public Builder baseEventPropertiesEnricherEnabled(
                 boolean baseEventPropertiesEnricherEnabled) {
             this.baseEventPropertiesEnricherEnabled = baseEventPropertiesEnricherEnabled;
+            return this;
+        }
+
+        /**
+         * Set whether subagent-sourced events should use native AG-UI event types.
+         *
+         * <p>Default is {@code false}: subagent events become {@code CUSTOM} events named {@code
+         * subagent.*}. Set {@code true} to restore the previous behavior where child text and
+         * lifecycle events map to the same AG-UI types as the parent.
+         *
+         * @param emitSubagentEventsAsNative true for legacy native presentation
+         * @return This builder
+         */
+        public Builder emitSubagentEventsAsNative(boolean emitSubagentEventsAsNative) {
+            this.emitSubagentEventsAsNative = emitSubagentEventsAsNative;
             return this;
         }
 

--- a/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/main/java/io/agentscope/core/agui/adapter/AguiAgentAdapter.java
+++ b/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/main/java/io/agentscope/core/agui/adapter/AguiAgentAdapter.java
@@ -106,7 +106,9 @@ public class AguiAgentAdapter {
         this.toolConverter = new AguiToolConverter();
         this.agentEventConverterRegistry =
                 new AgentEventConverterRegistry(
-                        config.getEventConverters(), config.getEventEnrichers());
+                        config.getEventConverters(),
+                        config.getEventEnrichers(),
+                        config.isEmitSubagentEventsAsNative());
     }
 
     /**

--- a/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/main/java/io/agentscope/core/agui/adapter/strategy/AgentEventConverterRegistry.java
+++ b/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/main/java/io/agentscope/core/agui/adapter/strategy/AgentEventConverterRegistry.java
@@ -33,10 +33,12 @@ public class AgentEventConverterRegistry {
 
     private final Map<Class<? extends AgentEvent>, AgentEventConverter> converters;
     private final RawAgentEventConverter rawConverter = new RawAgentEventConverter();
+    private final SubagentEventConverter subagentConverter = new SubagentEventConverter();
     private final List<AguiEventEnricher> enrichers;
+    private final boolean emitSubagentEventsAsNative;
 
     public AgentEventConverterRegistry() {
-        this(List.of(), List.of());
+        this(List.of(), List.of(), false);
     }
 
     /**
@@ -47,6 +49,23 @@ public class AgentEventConverterRegistry {
      */
     public AgentEventConverterRegistry(
             List<AgentEventConverter> customConverters, List<AguiEventEnricher> enrichers) {
+        this(customConverters, enrichers, false);
+    }
+
+    /**
+     * Create a registry with built-in converters, custom converters, enrichers, and subagent
+     * presentation mode.
+     *
+     * @param customConverters converters registered after built-in converters
+     * @param enrichers enrichers applied after each conversion
+     * @param emitSubagentEventsAsNative when {@code true}, child events use the same converters as
+     *     the parent; when {@code false} (default), {@code source != null} events become {@code
+     *     subagent.*} CUSTOM / RAW events
+     */
+    public AgentEventConverterRegistry(
+            List<AgentEventConverter> customConverters,
+            List<AguiEventEnricher> enrichers,
+            boolean emitSubagentEventsAsNative) {
         Map<Class<? extends AgentEvent>, AgentEventConverter> map = new LinkedHashMap<>();
         register(map, new AgentLifecycleEventConverter());
         register(map, new TextBlockEventConverter());
@@ -62,6 +81,7 @@ public class AgentEventConverterRegistry {
         }
         this.converters = Map.copyOf(map);
         this.enrichers = enrichers != null ? List.copyOf(enrichers) : List.of();
+        this.emitSubagentEventsAsNative = emitSubagentEventsAsNative;
     }
 
     /**
@@ -75,7 +95,13 @@ public class AgentEventConverterRegistry {
         Objects.requireNonNull(event, "event cannot be null");
         Objects.requireNonNull(context, "context cannot be null");
         context.beginEvent();
-        converters.getOrDefault(event.getClass(), rawConverter).convert(event, context);
+        if (!emitSubagentEventsAsNative
+                && event.getSource() != null
+                && !event.getSource().isBlank()) {
+            subagentConverter.convert(event, context);
+        } else {
+            converters.getOrDefault(event.getClass(), rawConverter).convert(event, context);
+        }
         return enrich(event, context.drainEvents(), context);
     }
 

--- a/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/main/java/io/agentscope/core/agui/adapter/strategy/SubagentEventConverter.java
+++ b/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/main/java/io/agentscope/core/agui/adapter/strategy/SubagentEventConverter.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.core.agui.adapter.strategy;
+
+import io.agentscope.core.agui.event.AguiEvent;
+import io.agentscope.core.event.AgentEndEvent;
+import io.agentscope.core.event.AgentEvent;
+import io.agentscope.core.event.AgentStartEvent;
+import io.agentscope.core.event.RequireUserConfirmEvent;
+import io.agentscope.core.event.TextBlockDeltaEvent;
+import io.agentscope.core.event.ThinkingBlockDeltaEvent;
+import io.agentscope.core.event.ToolCallEndEvent;
+import io.agentscope.core.event.ToolCallStartEvent;
+import io.agentscope.core.event.ToolResultEndEvent;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Converts subagent-sourced {@link AgentEvent}s ({@code source != null}) into AG-UI {@code CUSTOM}
+ * events under the {@code subagent.*} name namespace so they do not pollute the parent run lifecycle
+ * or text stream.
+ */
+final class SubagentEventConverter implements AgentEventConverter {
+
+    static final String NAME_LIFECYCLE = "subagent.lifecycle";
+    static final String NAME_TEXT = "subagent.text";
+    static final String NAME_THINKING = "subagent.thinking";
+    static final String NAME_TOOL_CALL = "subagent.tool_call";
+    static final String NAME_TOOL_RESULT = "subagent.tool_result";
+    static final String NAME_CONFIRM = "subagent.require_confirm";
+    static final String NAME_OTHER = "subagent.event";
+
+    private final RawAgentEventConverter rawFallback = new RawAgentEventConverter();
+
+    @Override
+    public Set<Class<? extends AgentEvent>> eventTypes() {
+        // Not registered by type — invoked by AgentEventConverterRegistry when source != null.
+        return Set.of();
+    }
+
+    @Override
+    public void convert(AgentEvent event, AguiStreamContext context) {
+        String source = event.getSource();
+        if (event instanceof AgentStartEvent start) {
+            context.emit(
+                    custom(
+                            context,
+                            NAME_LIFECYCLE,
+                            value(
+                                    source,
+                                    "AGENT_START",
+                                    Map.of("name", nullToEmpty(start.getName())))));
+            return;
+        }
+        if (event instanceof AgentEndEvent) {
+            context.emit(custom(context, NAME_LIFECYCLE, value(source, "AGENT_END", Map.of())));
+            return;
+        }
+        if (event instanceof TextBlockDeltaEvent text) {
+            context.emit(
+                    custom(
+                            context,
+                            NAME_TEXT,
+                            value(
+                                    source,
+                                    "TEXT_BLOCK_DELTA",
+                                    Map.of("delta", nullToEmpty(text.getDelta())))));
+            return;
+        }
+        if (event instanceof ThinkingBlockDeltaEvent thinking) {
+            context.emit(
+                    custom(
+                            context,
+                            NAME_THINKING,
+                            value(
+                                    source,
+                                    "THINKING_BLOCK_DELTA",
+                                    Map.of("delta", nullToEmpty(thinking.getDelta())))));
+            return;
+        }
+        if (event instanceof ToolCallStartEvent toolStart) {
+            Map<String, Object> extra = new LinkedHashMap<>();
+            extra.put("toolCallId", nullToEmpty(toolStart.getToolCallId()));
+            extra.put("toolName", nullToEmpty(toolStart.getToolCallName()));
+            context.emit(custom(context, NAME_TOOL_CALL, value(source, "TOOL_CALL_START", extra)));
+            return;
+        }
+        if (event instanceof ToolCallEndEvent toolEnd) {
+            Map<String, Object> extra = new LinkedHashMap<>();
+            extra.put("toolCallId", nullToEmpty(toolEnd.getToolCallId()));
+            extra.put("toolName", nullToEmpty(toolEnd.getToolCallName()));
+            context.emit(custom(context, NAME_TOOL_CALL, value(source, "TOOL_CALL_END", extra)));
+            return;
+        }
+        if (event instanceof ToolResultEndEvent toolResult) {
+            Map<String, Object> extra = new LinkedHashMap<>();
+            extra.put("toolCallId", nullToEmpty(toolResult.getToolCallId()));
+            extra.put("toolName", nullToEmpty(toolResult.getToolCallName()));
+            if (toolResult.getState() != null) {
+                extra.put("state", toolResult.getState().name());
+            }
+            context.emit(
+                    custom(context, NAME_TOOL_RESULT, value(source, "TOOL_RESULT_END", extra)));
+            return;
+        }
+        if (event instanceof RequireUserConfirmEvent confirm) {
+            Map<String, Object> extra = new LinkedHashMap<>();
+            extra.put("toolCallCount", confirm.getToolCalls().size());
+            context.emit(
+                    custom(context, NAME_CONFIRM, value(source, "REQUIRE_USER_CONFIRM", extra)));
+            return;
+        }
+        // Unknown typed events: prefer Raw (already carries source) over opaque custom.
+        rawFallback.convert(event, context);
+    }
+
+    private static AguiEvent.Custom custom(
+            AguiStreamContext context, String name, Map<String, Object> value) {
+        return new AguiEvent.Custom(context.getThreadId(), context.getRunId(), name, value);
+    }
+
+    private static Map<String, Object> value(
+            String source, String type, Map<String, Object> extra) {
+        Map<String, Object> value = new LinkedHashMap<>();
+        value.put("source", source);
+        value.put("type", type);
+        if (extra != null) {
+            value.putAll(extra);
+        }
+        return value;
+    }
+
+    private static String nullToEmpty(String s) {
+        return s != null ? s : "";
+    }
+}

--- a/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/test/java/io/agentscope/core/agui/adapter/strategy/SubagentEventConverterTest.java
+++ b/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/test/java/io/agentscope/core/agui/adapter/strategy/SubagentEventConverterTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.core.agui.adapter.strategy;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.agentscope.core.agui.adapter.AguiAdapterConfig;
+import io.agentscope.core.agui.event.AguiEvent;
+import io.agentscope.core.event.AgentStartEvent;
+import io.agentscope.core.event.TextBlockDeltaEvent;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class SubagentEventConverterTest {
+
+    @Test
+    void parentEventsUnchanged() {
+        AgentEventConverterRegistry registry = new AgentEventConverterRegistry();
+        AguiStreamContext context =
+                new AguiStreamContext("t1", "r1", AguiAdapterConfig.defaultConfig());
+        List<AguiEvent> events =
+                registry.convert(new AgentStartEvent("sess", null, "main"), context);
+        assertTrue(events.stream().anyMatch(e -> e instanceof AguiEvent.RunStarted));
+    }
+
+    @Test
+    void subagentEventsDowngradeToCustomByDefault() {
+        AgentEventConverterRegistry registry = new AgentEventConverterRegistry();
+        AguiStreamContext context =
+                new AguiStreamContext("t1", "r1", AguiAdapterConfig.defaultConfig());
+
+        AgentStartEvent childStart = new AgentStartEvent("child-sess", null, "researcher");
+        childStart.withSource("main/researcher");
+        List<AguiEvent> startEvents = registry.convert(childStart, context);
+        assertEquals(1, startEvents.size());
+        AguiEvent.Custom custom = assertInstanceOf(AguiEvent.Custom.class, startEvents.get(0));
+        assertEquals(SubagentEventConverter.NAME_LIFECYCLE, custom.name());
+        @SuppressWarnings("unchecked")
+        Map<String, Object> value = (Map<String, Object>) custom.value();
+        assertEquals("main/researcher", value.get("source"));
+        assertEquals("AGENT_START", value.get("type"));
+
+        TextBlockDeltaEvent delta = new TextBlockDeltaEvent(null, "b1", "hi");
+        delta.withSource("main/researcher");
+        List<AguiEvent> textEvents = registry.convert(delta, context);
+        assertEquals(1, textEvents.size());
+        AguiEvent.Custom textCustom = assertInstanceOf(AguiEvent.Custom.class, textEvents.get(0));
+        assertEquals(SubagentEventConverter.NAME_TEXT, textCustom.name());
+    }
+
+    @Test
+    void nativeModeKeepsLegacyBehavior() {
+        AgentEventConverterRegistry registry =
+                new AgentEventConverterRegistry(List.of(), List.of(), true);
+        AguiStreamContext context =
+                new AguiStreamContext(
+                        "t1",
+                        "r1",
+                        AguiAdapterConfig.builder().emitSubagentEventsAsNative(true).build());
+
+        AgentStartEvent childStart = new AgentStartEvent("child-sess", null, "researcher");
+        childStart.withSource("main/researcher");
+        List<AguiEvent> events = registry.convert(childStart, context);
+        assertTrue(events.stream().anyMatch(e -> e instanceof AguiEvent.RunStarted));
+    }
+
+    @Test
+    void configFlagDefaultsFalse() {
+        assertTrue(!AguiAdapterConfig.defaultConfig().isEmitSubagentEventsAsNative());
+        assertTrue(
+                AguiAdapterConfig.builder()
+                        .emitSubagentEventsAsNative(true)
+                        .build()
+                        .isEmitSubagentEventsAsNative());
+    }
+}

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/subagent/RemoteAskPolicy.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/subagent/RemoteAskPolicy.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.harness.agent.subagent;
+
+/**
+ * Policy for resolving a remote subagent's tool-confirmation (HITL) requests when the parent
+ * cannot forward the decision to an interactive human within this call.
+ */
+public enum RemoteAskPolicy {
+
+    /**
+     * Auto-deny every pending remote confirmation (safe default). Applied whenever the parent
+     * call has no live event-stream consumer, or when this policy is explicitly configured.
+     */
+    DENY,
+
+    /**
+     * Forward the confirmation request upstream (via the parent's {@code AgentEventEmitter}
+     * stream) instead of auto-denying, so an interactive consumer can decide.
+     */
+    PROPAGATE
+}

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/subagent/SubagentDeclaration.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/subagent/SubagentDeclaration.java
@@ -101,6 +101,15 @@ public final class SubagentDeclaration {
 
     private final Map<String, String> headers;
 
+    /**
+     * Whether remote subagent events should be streamed back into the parent's event stream.
+     * {@code null} defaults to {@code true}; see {@link #isRemoteStreaming()}.
+     */
+    private final Boolean remoteStreaming;
+
+    /** Policy for resolving remote HITL confirmations. Defaults to {@link RemoteAskPolicy#DENY}. */
+    private final RemoteAskPolicy remoteAskPolicy;
+
     private SubagentDeclaration(Builder b) {
         this.name = b.name;
         this.description = b.description;
@@ -121,6 +130,8 @@ public final class SubagentDeclaration {
         this.skills = b.skills != null ? List.copyOf(b.skills) : List.of();
         this.url = b.url;
         this.headers = b.headers != null && !b.headers.isEmpty() ? Map.copyOf(b.headers) : null;
+        this.remoteStreaming = b.remoteStreaming;
+        this.remoteAskPolicy = b.remoteAskPolicy != null ? b.remoteAskPolicy : RemoteAskPolicy.DENY;
     }
 
     /** Factory method for a new builder. */
@@ -300,6 +311,24 @@ public final class SubagentDeclaration {
         return headers;
     }
 
+    /**
+     * Whether remote subagent events (text deltas, tool calls, confirmations) should be streamed
+     * back into the parent's live event stream when one is present. Defaults to {@code true}
+     * when unset.
+     */
+    public boolean isRemoteStreaming() {
+        return remoteStreaming == null || remoteStreaming;
+    }
+
+    /**
+     * Policy for resolving remote HITL (tool-confirmation) requests. Defaults to
+     * {@link RemoteAskPolicy#DENY}, which auto-denies pending confirmations rather than leaving
+     * the remote task blocked indefinitely.
+     */
+    public RemoteAskPolicy getRemoteAskPolicy() {
+        return remoteAskPolicy;
+    }
+
     /** Returns {@code true} when this declaration points at an external definition workspace. */
     public boolean hasDefinitionWorkspace() {
         return workspacePath != null;
@@ -330,6 +359,8 @@ public final class SubagentDeclaration {
         private List<String> skills;
         private String url;
         private Map<String, String> headers;
+        private Boolean remoteStreaming;
+        private RemoteAskPolicy remoteAskPolicy = RemoteAskPolicy.DENY;
 
         private Builder() {}
 
@@ -516,6 +547,25 @@ public final class SubagentDeclaration {
          */
         public Builder headers(Map<String, String> headers) {
             this.headers = headers;
+            return this;
+        }
+
+        /**
+         * Whether remote subagent events should be streamed back into the parent's event stream.
+         * {@code null} (default) is treated as {@code true}. Only relevant when {@link #url(String)}
+         * is set.
+         */
+        public Builder remoteStreaming(Boolean remoteStreaming) {
+            this.remoteStreaming = remoteStreaming;
+            return this;
+        }
+
+        /**
+         * Policy for resolving remote HITL confirmations. {@code null} is treated as
+         * {@link RemoteAskPolicy#DENY}. Only relevant when {@link #url(String)} is set.
+         */
+        public Builder remoteAskPolicy(RemoteAskPolicy remoteAskPolicy) {
+            this.remoteAskPolicy = remoteAskPolicy != null ? remoteAskPolicy : RemoteAskPolicy.DENY;
             return this;
         }
 

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/subagent/protocol/RemoteAgentEvent.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/subagent/protocol/RemoteAgentEvent.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.harness.agent.subagent.protocol;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import java.util.List;
+
+/**
+ * Stable Protocol DTO for remote subagent event streaming.
+ *
+ * <p>Fields are optional per event type; unknown fields are ignored for forward compatibility.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class RemoteAgentEvent {
+
+    private long seq;
+    private RemoteEventType type;
+    private String taskId;
+    private String agentId;
+    private String timestamp;
+    private String text;
+    private String toolCallId;
+    private String toolName;
+    private String toolInput;
+    private List<RemotePendingConfirm> pendingConfirms;
+    private String status;
+    private String error;
+
+    public RemoteAgentEvent() {}
+
+    public long getSeq() {
+        return seq;
+    }
+
+    public void setSeq(long seq) {
+        this.seq = seq;
+    }
+
+    public RemoteEventType getType() {
+        return type;
+    }
+
+    public void setType(RemoteEventType type) {
+        this.type = type;
+    }
+
+    public String getTaskId() {
+        return taskId;
+    }
+
+    public void setTaskId(String taskId) {
+        this.taskId = taskId;
+    }
+
+    public String getAgentId() {
+        return agentId;
+    }
+
+    public void setAgentId(String agentId) {
+        this.agentId = agentId;
+    }
+
+    public String getTimestamp() {
+        return timestamp;
+    }
+
+    public void setTimestamp(String timestamp) {
+        this.timestamp = timestamp;
+    }
+
+    public String getText() {
+        return text;
+    }
+
+    public void setText(String text) {
+        this.text = text;
+    }
+
+    public String getToolCallId() {
+        return toolCallId;
+    }
+
+    public void setToolCallId(String toolCallId) {
+        this.toolCallId = toolCallId;
+    }
+
+    public String getToolName() {
+        return toolName;
+    }
+
+    public void setToolName(String toolName) {
+        this.toolName = toolName;
+    }
+
+    public String getToolInput() {
+        return toolInput;
+    }
+
+    public void setToolInput(String toolInput) {
+        this.toolInput = toolInput;
+    }
+
+    public List<RemotePendingConfirm> getPendingConfirms() {
+        return pendingConfirms;
+    }
+
+    public void setPendingConfirms(List<RemotePendingConfirm> pendingConfirms) {
+        this.pendingConfirms = pendingConfirms;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public void setStatus(String status) {
+        this.status = status;
+    }
+
+    public String getError() {
+        return error;
+    }
+
+    public void setError(String error) {
+        this.error = error;
+    }
+}

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/subagent/protocol/RemoteConfirmDecision.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/subagent/protocol/RemoteConfirmDecision.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.harness.agent.subagent.protocol;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+/**
+ * User decision for a remote pending tool confirmation.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class RemoteConfirmDecision {
+
+    private String toolCallId;
+    private boolean approved;
+
+    public RemoteConfirmDecision() {}
+
+    public RemoteConfirmDecision(String toolCallId, boolean approved) {
+        this.toolCallId = toolCallId;
+        this.approved = approved;
+    }
+
+    public String getToolCallId() {
+        return toolCallId;
+    }
+
+    public void setToolCallId(String toolCallId) {
+        this.toolCallId = toolCallId;
+    }
+
+    public boolean isApproved() {
+        return approved;
+    }
+
+    public void setApproved(boolean approved) {
+        this.approved = approved;
+    }
+}

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/subagent/protocol/RemoteEventCodec.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/subagent/protocol/RemoteEventCodec.java
@@ -1,0 +1,241 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.harness.agent.subagent.protocol;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.agentscope.core.event.AgentEndEvent;
+import io.agentscope.core.event.AgentEvent;
+import io.agentscope.core.event.AgentStartEvent;
+import io.agentscope.core.event.RequireUserConfirmEvent;
+import io.agentscope.core.event.TextBlockDeltaEvent;
+import io.agentscope.core.event.ThinkingBlockDeltaEvent;
+import io.agentscope.core.event.ToolCallEndEvent;
+import io.agentscope.core.event.ToolCallStartEvent;
+import io.agentscope.core.event.ToolResultEndEvent;
+import io.agentscope.core.message.ToolCallState;
+import io.agentscope.core.message.ToolResultState;
+import io.agentscope.core.message.ToolUseBlock;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Bidirectional mapping between internal {@link AgentEvent}s and stable {@link RemoteAgentEvent}
+ * wire DTOs.
+ */
+public final class RemoteEventCodec {
+
+    private static final ObjectMapper JSON = new ObjectMapper();
+
+    private RemoteEventCodec() {}
+
+    /**
+     * Maps an internal agent event to a protocol DTO (without seq/taskId — those are assigned by
+     * the server event bus).
+     */
+    public static Optional<RemoteAgentEvent> fromAgentEvent(AgentEvent event) {
+        if (event == null) {
+            return Optional.empty();
+        }
+        RemoteAgentEvent dto = new RemoteAgentEvent();
+        dto.setTimestamp(event.getCreatedAt());
+        if (event instanceof AgentStartEvent start) {
+            dto.setType(RemoteEventType.RUN_STARTED);
+            dto.setAgentId(start.getName());
+            return Optional.of(dto);
+        }
+        if (event instanceof AgentEndEvent) {
+            dto.setType(RemoteEventType.RUN_FINISHED);
+            return Optional.of(dto);
+        }
+        if (event instanceof TextBlockDeltaEvent text) {
+            dto.setType(RemoteEventType.TEXT_DELTA);
+            dto.setText(text.getDelta());
+            return Optional.of(dto);
+        }
+        if (event instanceof ThinkingBlockDeltaEvent thinking) {
+            dto.setType(RemoteEventType.THINKING_DELTA);
+            dto.setText(thinking.getDelta());
+            return Optional.of(dto);
+        }
+        if (event instanceof ToolCallStartEvent toolStart) {
+            dto.setType(RemoteEventType.TOOL_CALL_START);
+            dto.setToolCallId(toolStart.getToolCallId());
+            dto.setToolName(toolStart.getToolCallName());
+            return Optional.of(dto);
+        }
+        if (event instanceof ToolCallEndEvent toolEnd) {
+            dto.setType(RemoteEventType.TOOL_CALL_END);
+            dto.setToolCallId(toolEnd.getToolCallId());
+            dto.setToolName(toolEnd.getToolCallName());
+            return Optional.of(dto);
+        }
+        if (event instanceof ToolResultEndEvent toolResult) {
+            dto.setType(RemoteEventType.TOOL_RESULT);
+            dto.setToolCallId(toolResult.getToolCallId());
+            dto.setToolName(toolResult.getToolCallName());
+            ToolResultState state = toolResult.getState();
+            if (state != null) {
+                dto.setStatus(state.name());
+            }
+            return Optional.of(dto);
+        }
+        if (event instanceof RequireUserConfirmEvent confirm) {
+            dto.setType(RemoteEventType.REQUIRE_CONFIRM);
+            List<RemotePendingConfirm> pending = new ArrayList<>();
+            for (ToolUseBlock block : confirm.getToolCalls()) {
+                pending.add(
+                        new RemotePendingConfirm(
+                                block.getId(), block.getName(), toJson(block.getInput())));
+            }
+            dto.setPendingConfirms(pending);
+            return Optional.of(dto);
+        }
+        return Optional.empty();
+    }
+
+    /**
+     * Maps a protocol DTO back to an internal {@link AgentEvent}. Unknown or incomplete types are
+     * dropped.
+     */
+    public static Optional<AgentEvent> toAgentEvent(RemoteAgentEvent remote) {
+        if (remote == null || remote.getType() == null) {
+            return Optional.empty();
+        }
+        return switch (remote.getType()) {
+            case RUN_STARTED ->
+                    Optional.of(
+                            new AgentStartEvent(
+                                    null,
+                                    null,
+                                    remote.getAgentId() != null ? remote.getAgentId() : "remote"));
+            case RUN_FINISHED -> Optional.of(new AgentEndEvent(null));
+            case RUN_ERROR -> Optional.empty();
+            case TEXT_DELTA ->
+                    Optional.of(
+                            new TextBlockDeltaEvent(
+                                    null, null, remote.getText() != null ? remote.getText() : ""));
+            case THINKING_DELTA ->
+                    Optional.of(
+                            new ThinkingBlockDeltaEvent(
+                                    null, null, remote.getText() != null ? remote.getText() : ""));
+            case TOOL_CALL_START ->
+                    Optional.of(
+                            new ToolCallStartEvent(
+                                    null, remote.getToolCallId(), remote.getToolName()));
+            case TOOL_CALL_END ->
+                    Optional.of(
+                            new ToolCallEndEvent(
+                                    null, remote.getToolCallId(), remote.getToolName()));
+            case TOOL_RESULT ->
+                    Optional.of(
+                            new ToolResultEndEvent(
+                                    null,
+                                    remote.getToolCallId(),
+                                    remote.getToolName(),
+                                    parseToolResultState(remote.getStatus())));
+            case REQUIRE_CONFIRM -> Optional.of(toRequireConfirm(remote));
+            case STATUS -> Optional.empty();
+        };
+    }
+
+    /**
+     * Whether this event type should be emitted for the given detail level.
+     *
+     * @param type event type
+     * @param detail {@code "full"} includes text/thinking deltas; anything else is status-level
+     */
+    public static boolean matchesDetail(RemoteEventType type, String detail) {
+        if (type == null) {
+            return false;
+        }
+        boolean full = detail != null && "full".equalsIgnoreCase(detail);
+        return switch (type) {
+            case TEXT_DELTA, THINKING_DELTA -> full;
+            default -> true;
+        };
+    }
+
+    private static RequireUserConfirmEvent toRequireConfirm(RemoteAgentEvent remote) {
+        List<ToolUseBlock> toolCalls = new ArrayList<>();
+        List<RemotePendingConfirm> pending =
+                remote.getPendingConfirms() != null ? remote.getPendingConfirms() : List.of();
+        for (RemotePendingConfirm p : pending) {
+            Map<String, Object> input = parseInput(p.getToolInputJson());
+            toolCalls.add(
+                    ToolUseBlock.builder()
+                            .id(p.getToolCallId())
+                            .name(p.getToolName())
+                            .input(input)
+                            .state(ToolCallState.ASKING)
+                            .build());
+        }
+        return new RequireUserConfirmEvent(null, toolCalls);
+    }
+
+    private static ToolResultState parseToolResultState(String status) {
+        if (status == null || status.isBlank()) {
+            return ToolResultState.SUCCESS;
+        }
+        try {
+            return ToolResultState.valueOf(status);
+        } catch (IllegalArgumentException e) {
+            for (ToolResultState s : ToolResultState.values()) {
+                if (s.getValue().equalsIgnoreCase(status)) {
+                    return s;
+                }
+            }
+            return ToolResultState.SUCCESS;
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Map<String, Object> parseInput(String json) {
+        if (json == null || json.isBlank()) {
+            return Collections.emptyMap();
+        }
+        try {
+            Object parsed = JSON.readValue(json, Object.class);
+            if (parsed instanceof Map<?, ?> map) {
+                Map<String, Object> out = new HashMap<>();
+                for (Map.Entry<?, ?> e : map.entrySet()) {
+                    if (e.getKey() != null) {
+                        out.put(String.valueOf(e.getKey()), e.getValue());
+                    }
+                }
+                return out;
+            }
+            return Map.of("raw", parsed);
+        } catch (JsonProcessingException e) {
+            return Map.of("raw", json);
+        }
+    }
+
+    private static String toJson(Object value) {
+        if (value == null) {
+            return null;
+        }
+        try {
+            return JSON.writeValueAsString(value);
+        } catch (JsonProcessingException e) {
+            return String.valueOf(value);
+        }
+    }
+}

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/subagent/protocol/RemoteEventType.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/subagent/protocol/RemoteEventType.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.harness.agent.subagent.protocol;
+
+/**
+ * Stable wire event types for remote subagent streaming over Agent Protocol.
+ *
+ * <p>These values must remain backward-compatible across versions; unknown types should be ignored
+ * by older clients.
+ */
+public enum RemoteEventType {
+    RUN_STARTED,
+    RUN_FINISHED,
+    RUN_ERROR,
+    TEXT_DELTA,
+    THINKING_DELTA,
+    TOOL_CALL_START,
+    TOOL_CALL_END,
+    TOOL_RESULT,
+    REQUIRE_CONFIRM,
+    STATUS
+}

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/subagent/protocol/RemotePendingConfirm.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/subagent/protocol/RemotePendingConfirm.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.harness.agent.subagent.protocol;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+/**
+ * A single remote tool call awaiting user confirmation (HITL).
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class RemotePendingConfirm {
+
+    private String toolCallId;
+    private String toolName;
+    private String toolInputJson;
+
+    public RemotePendingConfirm() {}
+
+    public RemotePendingConfirm(String toolCallId, String toolName, String toolInputJson) {
+        this.toolCallId = toolCallId;
+        this.toolName = toolName;
+        this.toolInputJson = toolInputJson;
+    }
+
+    public String getToolCallId() {
+        return toolCallId;
+    }
+
+    public void setToolCallId(String toolCallId) {
+        this.toolCallId = toolCallId;
+    }
+
+    public String getToolName() {
+        return toolName;
+    }
+
+    public void setToolName(String toolName) {
+        this.toolName = toolName;
+    }
+
+    public String getToolInputJson() {
+        return toolInputJson;
+    }
+
+    public void setToolInputJson(String toolInputJson) {
+        this.toolInputJson = toolInputJson;
+    }
+}

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/subagent/protocol/RemotePendingConfirm.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/subagent/protocol/RemotePendingConfirm.java
@@ -17,6 +17,7 @@ package io.agentscope.harness.agent.subagent.protocol;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import java.util.Objects;
 
 /**
  * A single remote tool call awaiting user confirmation (HITL).
@@ -59,5 +60,23 @@ public class RemotePendingConfirm {
 
     public void setToolInputJson(String toolInputJson) {
         this.toolInputJson = toolInputJson;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof RemotePendingConfirm that)) {
+            return false;
+        }
+        return Objects.equals(toolCallId, that.toolCallId)
+                && Objects.equals(toolName, that.toolName)
+                && Objects.equals(toolInputJson, that.toolInputJson);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(toolCallId, toolName, toolInputJson);
     }
 }

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/subagent/task/AgentProtocolTaskClient.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/subagent/task/AgentProtocolTaskClient.java
@@ -17,7 +17,16 @@ package io.agentscope.harness.agent.subagent.task;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.agentscope.harness.agent.subagent.protocol.RemoteAgentEvent;
+import io.agentscope.harness.agent.subagent.protocol.RemoteConfirmDecision;
+import io.agentscope.harness.agent.subagent.protocol.RemotePendingConfirm;
+import java.io.BufferedReader;
+import java.io.Closeable;
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.net.URI;
 import java.net.URLEncoder;
 import java.net.http.HttpClient;
@@ -25,8 +34,15 @@ import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Consumer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Minimal HTTP client for the internal AgentScope task protocol ({@code POST/GET /tasks/...}).
@@ -35,6 +51,7 @@ import java.util.Objects;
  */
 public final class AgentProtocolTaskClient {
 
+    private static final Logger log = LoggerFactory.getLogger(AgentProtocolTaskClient.class);
     private static final ObjectMapper JSON = new ObjectMapper();
 
     private final HttpClient http;
@@ -51,7 +68,7 @@ public final class AgentProtocolTaskClient {
         this.http = Objects.requireNonNull(http, "http");
     }
 
-    /** {@code POST /tasks} with body {@code {task_id, agent_id, input}}. */
+    /** {@code POST /tasks} with body {@code {task_id, agent_id, input}} (+ optional context). */
     public void submitTask(
             String baseUrl,
             Map<String, String> headers,
@@ -59,18 +76,36 @@ public final class AgentProtocolTaskClient {
             String agentId,
             String input)
             throws IOException, InterruptedException {
-        String body =
-                JSON.writeValueAsString(
-                        JSON.createObjectNode()
-                                .put("task_id", taskId)
-                                .put("agent_id", agentId)
-                                .put("input", input != null ? input : ""));
+        submitTask(baseUrl, headers, taskId, agentId, input, null);
+    }
+
+    /**
+     * {@code POST /tasks} with body {@code {task_id, agent_id, input, context?}}.
+     *
+     * <p>Legacy servers ignore unknown {@code context} field.
+     */
+    public void submitTask(
+            String baseUrl,
+            Map<String, String> headers,
+            String taskId,
+            String agentId,
+            String input,
+            RemoteSubmitContext context)
+            throws IOException, InterruptedException {
+        ObjectNode body =
+                JSON.createObjectNode()
+                        .put("task_id", taskId)
+                        .put("agent_id", agentId)
+                        .put("input", input != null ? input : "");
+        if (context != null) {
+            body.set("context", JSON.valueToTree(context.toMap()));
+        }
         HttpRequest.Builder b =
                 HttpRequest.newBuilder()
                         .uri(URI.create(join(baseUrl, "/tasks")))
                         .timeout(Duration.ofMinutes(10))
                         .header("Content-Type", "application/json")
-                        .POST(HttpRequest.BodyPublishers.ofString(body));
+                        .POST(HttpRequest.BodyPublishers.ofString(JSON.writeValueAsString(body)));
         applyHeaders(b, headers);
         HttpResponse<String> resp = http.send(b.build(), HttpResponse.BodyHandlers.ofString());
         if (resp.statusCode() >= 400) {
@@ -98,7 +133,8 @@ public final class AgentProtocolTaskClient {
         JsonNode n = JSON.readTree(resp.body());
         String st = textOrEmpty(n, "status");
         String err = n.hasNonNull("error") ? n.get("error").asText() : null;
-        return new RemoteTaskStatus(st, err);
+        List<RemotePendingConfirm> pending = parsePendingConfirms(n.get("pending_confirms"));
+        return new RemoteTaskStatus(st, err, pending);
     }
 
     /**
@@ -143,6 +179,198 @@ public final class AgentProtocolTaskClient {
             throw new IOException(
                     "cancelTask failed: HTTP " + resp.statusCode() + " body=" + resp.body());
         }
+    }
+
+    /**
+     * {@code POST /tasks/{taskId}/resume} with body {@code {decisions: [...]}}.
+     *
+     * @throws IOException on HTTP error (including 404 when the server lacks HITL support)
+     */
+    public void resumeTask(
+            String baseUrl,
+            Map<String, String> headers,
+            String taskId,
+            List<RemoteConfirmDecision> decisions)
+            throws IOException, InterruptedException {
+        ObjectNode body = JSON.createObjectNode();
+        ArrayNode arr = body.putArray("decisions");
+        if (decisions != null) {
+            for (RemoteConfirmDecision d : decisions) {
+                arr.add(
+                        JSON.createObjectNode()
+                                .put("toolCallId", d.getToolCallId())
+                                .put("approved", d.isApproved()));
+            }
+        }
+        HttpRequest.Builder b =
+                HttpRequest.newBuilder()
+                        .uri(URI.create(join(baseUrl, "/tasks/" + encode(taskId) + "/resume")))
+                        .timeout(Duration.ofMinutes(2))
+                        .header("Content-Type", "application/json")
+                        .POST(HttpRequest.BodyPublishers.ofString(JSON.writeValueAsString(body)));
+        applyHeaders(b, headers);
+        HttpResponse<String> resp = http.send(b.build(), HttpResponse.BodyHandlers.ofString());
+        if (resp.statusCode() >= 400) {
+            throw new IOException(
+                    "resumeTask failed: HTTP " + resp.statusCode() + " body=" + resp.body());
+        }
+    }
+
+    /**
+     * Opens {@code GET /tasks/{taskId}/events} as an SSE stream and delivers parsed events to {@code
+     * consumer}. Silently no-ops (returns a closed handle) when the server returns 404.
+     */
+    public Closeable openEventStream(
+            String baseUrl,
+            Map<String, String> headers,
+            String taskId,
+            long fromSeq,
+            Consumer<RemoteAgentEvent> consumer)
+            throws IOException, InterruptedException {
+        Objects.requireNonNull(consumer, "consumer");
+        String path = "/tasks/" + encode(taskId) + "/events";
+        if (fromSeq > 0) {
+            path = path + "?from_seq=" + fromSeq;
+        }
+        HttpRequest.Builder b =
+                HttpRequest.newBuilder()
+                        .uri(URI.create(join(baseUrl, path)))
+                        .timeout(Duration.ofHours(3))
+                        .header("Accept", "text/event-stream")
+                        .GET();
+        if (fromSeq > 0) {
+            b.header("Last-Event-ID", String.valueOf(fromSeq));
+        }
+        applyHeaders(b, headers);
+
+        AtomicBoolean closed = new AtomicBoolean(false);
+        CompletableFuture<HttpResponse<InputStream>> future =
+                http.sendAsync(b.build(), HttpResponse.BodyHandlers.ofInputStream());
+
+        HttpResponse<InputStream> resp;
+        try {
+            resp = future.join();
+        } catch (Exception e) {
+            throw new IOException("openEventStream failed to connect", e);
+        }
+        if (resp.statusCode() == 404 || resp.statusCode() == 405) {
+            try {
+                resp.body().close();
+            } catch (IOException ignored) {
+            }
+            log.debug("Remote server does not support /events for task {}", taskId);
+            return () -> {};
+        }
+        if (resp.statusCode() >= 400) {
+            String body;
+            try (InputStream in = resp.body()) {
+                body = new String(in.readAllBytes(), StandardCharsets.UTF_8);
+            }
+            throw new IOException(
+                    "openEventStream failed: HTTP " + resp.statusCode() + " body=" + body);
+        }
+
+        InputStream bodyStream = resp.body();
+        Thread reader =
+                new Thread(
+                        () -> readSse(bodyStream, consumer, closed),
+                        "agent-protocol-sse-" + taskId);
+        reader.setDaemon(true);
+        reader.start();
+
+        return () -> {
+            if (closed.compareAndSet(false, true)) {
+                try {
+                    bodyStream.close();
+                } catch (IOException ignored) {
+                }
+            }
+        };
+    }
+
+    private static void readSse(
+            InputStream bodyStream, Consumer<RemoteAgentEvent> consumer, AtomicBoolean closed) {
+        try (BufferedReader reader =
+                new BufferedReader(new InputStreamReader(bodyStream, StandardCharsets.UTF_8))) {
+            StringBuilder data = new StringBuilder();
+            String id = null;
+            String line;
+            while (!closed.get() && (line = reader.readLine()) != null) {
+                if (line.isEmpty()) {
+                    if (data.length() > 0) {
+                        dispatchSseEvent(data.toString(), id, consumer);
+                        data.setLength(0);
+                        id = null;
+                    }
+                    continue;
+                }
+                if (line.startsWith(":")) {
+                    continue;
+                }
+                if (line.startsWith("id:")) {
+                    id = line.substring(3).trim();
+                } else if (line.startsWith("data:")) {
+                    String payload = line.substring(5);
+                    if (payload.startsWith(" ")) {
+                        payload = payload.substring(1);
+                    }
+                    if (data.length() > 0) {
+                        data.append('\n');
+                    }
+                    data.append(payload);
+                }
+            }
+            if (data.length() > 0) {
+                dispatchSseEvent(data.toString(), id, consumer);
+            }
+        } catch (IOException e) {
+            if (!closed.get()) {
+                log.debug("SSE stream closed: {}", e.toString());
+            }
+        }
+    }
+
+    private static void dispatchSseEvent(
+            String data, String id, Consumer<RemoteAgentEvent> consumer) {
+        try {
+            RemoteAgentEvent event = JSON.readValue(data, RemoteAgentEvent.class);
+            if (id != null && !id.isBlank() && event.getSeq() <= 0) {
+                try {
+                    event.setSeq(Long.parseLong(id.trim()));
+                } catch (NumberFormatException ignored) {
+                }
+            }
+            consumer.accept(event);
+        } catch (Exception e) {
+            log.debug("Skipping unparseable SSE data: {}", e.toString());
+        }
+    }
+
+    private static List<RemotePendingConfirm> parsePendingConfirms(JsonNode node) {
+        if (node == null || !node.isArray()) {
+            return List.of();
+        }
+        List<RemotePendingConfirm> out = new ArrayList<>();
+        for (JsonNode item : node) {
+            RemotePendingConfirm p = new RemotePendingConfirm();
+            if (item.hasNonNull("toolCallId")) {
+                p.setToolCallId(item.get("toolCallId").asText());
+            } else if (item.hasNonNull("tool_call_id")) {
+                p.setToolCallId(item.get("tool_call_id").asText());
+            }
+            if (item.hasNonNull("toolName")) {
+                p.setToolName(item.get("toolName").asText());
+            } else if (item.hasNonNull("tool_name")) {
+                p.setToolName(item.get("tool_name").asText());
+            }
+            if (item.hasNonNull("toolInputJson")) {
+                p.setToolInputJson(item.get("toolInputJson").asText());
+            } else if (item.hasNonNull("tool_input_json")) {
+                p.setToolInputJson(item.get("tool_input_json").asText());
+            }
+            out.add(p);
+        }
+        return List.copyOf(out);
     }
 
     private static void applyHeaders(HttpRequest.Builder b, Map<String, String> headers) {

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/subagent/task/AgentProtocolTransport.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/subagent/task/AgentProtocolTransport.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.harness.agent.subagent.task;
+
+import io.agentscope.harness.agent.subagent.protocol.RemoteAgentEvent;
+import io.agentscope.harness.agent.subagent.protocol.RemoteConfirmDecision;
+import java.io.Closeable;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Consumer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** {@link RemoteSubagentTransport} backed by the Agent Protocol HTTP client. */
+public final class AgentProtocolTransport implements RemoteSubagentTransport {
+
+    public static final String TYPE = "agent-protocol";
+
+    private static final Logger log = LoggerFactory.getLogger(AgentProtocolTransport.class);
+
+    private final AgentProtocolTaskClient client;
+
+    public AgentProtocolTransport() {
+        this(new AgentProtocolTaskClient());
+    }
+
+    public AgentProtocolTransport(AgentProtocolTaskClient client) {
+        this.client = Objects.requireNonNull(client, "client");
+    }
+
+    @Override
+    public String transportType() {
+        return TYPE;
+    }
+
+    @Override
+    public void submit(
+            RemoteTarget target,
+            String taskId,
+            String agentId,
+            String input,
+            RemoteSubmitContext context)
+            throws Exception {
+        client.submitTask(
+                target.baseUrl(),
+                target.headers(),
+                taskId,
+                agentId,
+                input,
+                context != null ? context : RemoteSubmitContext.empty());
+    }
+
+    @Override
+    public RemoteTaskStatus getStatus(RemoteTarget target, String taskId) throws Exception {
+        return client.getStatus(target.baseUrl(), target.headers(), taskId);
+    }
+
+    @Override
+    public String waitForResult(RemoteTarget target, String taskId, long timeoutSeconds)
+            throws Exception {
+        return client.waitForResult(target.baseUrl(), target.headers(), taskId, timeoutSeconds);
+    }
+
+    @Override
+    public void cancel(RemoteTarget target, String taskId) throws Exception {
+        client.cancelTask(target.baseUrl(), target.headers(), taskId);
+    }
+
+    @Override
+    public void resume(RemoteTarget target, String taskId, List<RemoteConfirmDecision> decisions)
+            throws Exception {
+        client.resumeTask(target.baseUrl(), target.headers(), taskId, decisions);
+    }
+
+    @Override
+    public Closeable streamEvents(
+            RemoteTarget target, String taskId, long fromSeq, Consumer<RemoteAgentEvent> consumer) {
+        try {
+            return client.openEventStream(
+                    target.baseUrl(), target.headers(), taskId, fromSeq, consumer);
+        } catch (Exception e) {
+            log.debug(
+                    "Failed to open remote event stream for task {} (degrading to poll): {}",
+                    taskId,
+                    e.toString());
+            return () -> {};
+        }
+    }
+}

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/subagent/task/RemoteSubagentTransport.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/subagent/task/RemoteSubagentTransport.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.harness.agent.subagent.task;
+
+import io.agentscope.harness.agent.subagent.protocol.RemoteAgentEvent;
+import io.agentscope.harness.agent.subagent.protocol.RemoteConfirmDecision;
+import java.io.Closeable;
+import java.util.List;
+import java.util.function.Consumer;
+
+/**
+ * Transport abstraction for remote subagent execution (Agent Protocol today; A2A later).
+ */
+public interface RemoteSubagentTransport {
+
+    /** Stable transport type string persisted on {@link TaskRecord#getTransportType()}. */
+    String transportType();
+
+    void submit(
+            RemoteTarget target,
+            String taskId,
+            String agentId,
+            String input,
+            RemoteSubmitContext context)
+            throws Exception;
+
+    RemoteTaskStatus getStatus(RemoteTarget target, String taskId) throws Exception;
+
+    String waitForResult(RemoteTarget target, String taskId, long timeoutSeconds) throws Exception;
+
+    void cancel(RemoteTarget target, String taskId) throws Exception;
+
+    void resume(RemoteTarget target, String taskId, List<RemoteConfirmDecision> decisions)
+            throws Exception;
+
+    /**
+     * Opens an event stream for the remote task. Default is a no-op so transports without streaming
+     * degrade gracefully to polling.
+     *
+     * @return closeable handle that stops the subscription
+     */
+    default Closeable streamEvents(
+            RemoteTarget target, String taskId, long fromSeq, Consumer<RemoteAgentEvent> consumer) {
+        return () -> {};
+    }
+}

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/subagent/task/RemoteSubmitContext.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/subagent/task/RemoteSubmitContext.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.harness.agent.subagent.task;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Context sent with a remote task submission (permissions, streaming preferences, parent identity).
+ */
+public final class RemoteSubmitContext {
+
+    private final String userId;
+    private final String parentSessionId;
+    private final boolean stream;
+    private final String detail;
+    private final List<Map<String, String>> denyRules;
+
+    private RemoteSubmitContext(Builder builder) {
+        this.userId = builder.userId;
+        this.parentSessionId = builder.parentSessionId;
+        this.stream = builder.stream;
+        this.detail = builder.detail != null ? builder.detail : "status";
+        this.denyRules =
+                builder.denyRules == null || builder.denyRules.isEmpty()
+                        ? List.of()
+                        : List.copyOf(builder.denyRules);
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static RemoteSubmitContext empty() {
+        return builder().build();
+    }
+
+    public String userId() {
+        return userId;
+    }
+
+    public String parentSessionId() {
+        return parentSessionId;
+    }
+
+    public boolean stream() {
+        return stream;
+    }
+
+    public String detail() {
+        return detail;
+    }
+
+    public List<Map<String, String>> denyRules() {
+        return denyRules;
+    }
+
+    public Map<String, Object> toMap() {
+        Map<String, Object> m = new java.util.LinkedHashMap<>();
+        if (userId != null) {
+            m.put("user_id", userId);
+        }
+        if (parentSessionId != null) {
+            m.put("parent_session_id", parentSessionId);
+        }
+        m.put("stream", stream);
+        m.put("detail", detail);
+        if (!denyRules.isEmpty()) {
+            m.put("deny_rules", denyRules);
+        }
+        return Collections.unmodifiableMap(m);
+    }
+
+    public static final class Builder {
+        private String userId;
+        private String parentSessionId;
+        private boolean stream = true;
+        private String detail = "status";
+        private List<Map<String, String>> denyRules;
+
+        public Builder userId(String userId) {
+            this.userId = userId;
+            return this;
+        }
+
+        public Builder parentSessionId(String parentSessionId) {
+            this.parentSessionId = parentSessionId;
+            return this;
+        }
+
+        public Builder stream(boolean stream) {
+            this.stream = stream;
+            return this;
+        }
+
+        public Builder detail(String detail) {
+            this.detail = detail;
+            return this;
+        }
+
+        public Builder denyRules(List<Map<String, String>> denyRules) {
+            this.denyRules = denyRules;
+            return this;
+        }
+
+        public RemoteSubmitContext build() {
+            Objects.requireNonNull(detail, "detail");
+            return new RemoteSubmitContext(this);
+        }
+    }
+}

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/subagent/task/RemoteTarget.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/subagent/task/RemoteTarget.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.harness.agent.subagent.task;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Objects;
+
+/** Remote endpoint identity: base URL plus optional auth/routing headers. */
+public final class RemoteTarget {
+
+    private final String baseUrl;
+    private final Map<String, String> headers;
+
+    public RemoteTarget(String baseUrl, Map<String, String> headers) {
+        this.baseUrl = Objects.requireNonNull(baseUrl, "baseUrl");
+        this.headers =
+                headers == null || headers.isEmpty()
+                        ? Map.of()
+                        : Collections.unmodifiableMap(headers);
+    }
+
+    public String baseUrl() {
+        return baseUrl;
+    }
+
+    public Map<String, String> headers() {
+        return headers;
+    }
+}

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/subagent/task/RemoteTaskStatus.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/subagent/task/RemoteTaskStatus.java
@@ -43,6 +43,7 @@ public record RemoteTaskStatus(
         return "error".equalsIgnoreCase(status) || "failed".equalsIgnoreCase(status);
     }
 
-public boolean isCancelled() {
-    return "cancelled".equalsIgnoreCase(status) || "canceled".equalsIgnoreCase(status);
+    public boolean isCancelled() {
+        return "cancelled".equalsIgnoreCase(status) || "canceled".equalsIgnoreCase(status);
+    }
 }

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/subagent/task/RemoteTaskStatus.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/subagent/task/RemoteTaskStatus.java
@@ -15,5 +15,35 @@
  */
 package io.agentscope.harness.agent.subagent.task;
 
-/** Status snapshot returned by the remote task HTTP API ({@code GET /tasks/{taskId}}). */
-public record RemoteTaskStatus(String status, String error) {}
+import io.agentscope.harness.agent.subagent.protocol.RemotePendingConfirm;
+import java.util.List;
+
+/**
+ * Status snapshot returned by the remote task HTTP API ({@code GET /tasks/{taskId}}).
+ *
+ * <p>Known status values: {@code pending}, {@code running}, {@code success}, {@code error},
+ * {@code cancelled}, {@code awaiting_confirm}.
+ */
+public record RemoteTaskStatus(
+        String status, String error, List<RemotePendingConfirm> pendingConfirms) {
+
+    public RemoteTaskStatus(String status, String error) {
+        this(status, error, List.of());
+    }
+
+    public boolean isAwaitingConfirm() {
+        return "awaiting_confirm".equalsIgnoreCase(status);
+    }
+
+    public boolean isTerminalSuccess() {
+        return "success".equalsIgnoreCase(status);
+    }
+
+    public boolean isTerminalFailure() {
+        return "error".equalsIgnoreCase(status) || "failed".equalsIgnoreCase(status);
+    }
+
+    public boolean isCancelled() {
+        return "cancelled".equalsIgnoreCase(status);
+    }
+}

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/subagent/task/RemoteTaskStatus.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/subagent/task/RemoteTaskStatus.java
@@ -43,7 +43,6 @@ public record RemoteTaskStatus(
         return "error".equalsIgnoreCase(status) || "failed".equalsIgnoreCase(status);
     }
 
-    public boolean isCancelled() {
-        return "cancelled".equalsIgnoreCase(status);
-    }
+public boolean isCancelled() {
+    return "cancelled".equalsIgnoreCase(status) || "canceled".equalsIgnoreCase(status);
 }

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/subagent/task/TaskRecord.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/subagent/task/TaskRecord.java
@@ -17,8 +17,10 @@ package io.agentscope.harness.agent.subagent.task;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import io.agentscope.harness.agent.subagent.protocol.RemotePendingConfirm;
 import java.time.Instant;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -63,6 +65,17 @@ public class TaskRecord {
     private String remoteBaseUrl;
 
     private Map<String, String> remoteHeaders;
+
+    /**
+     * When {@code true}, the remote (or local) agent is paused waiting for user tool confirmation.
+     * Status remains {@link TaskStatus#RUNNING} so barriers keep waiting.
+     */
+    private boolean awaitingConfirm;
+
+    private List<RemotePendingConfirm> pendingConfirms;
+
+    /** Last remote event sequence observed by the parent (for SSE resume). */
+    private long lastEventSeq;
 
     public TaskRecord() {}
 
@@ -234,5 +247,32 @@ public class TaskRecord {
     /** Whether this task is executed via the HTTP task protocol. */
     public boolean isAgentProtocolTransport() {
         return transportType != null && "agent-protocol".equalsIgnoreCase(transportType);
+    }
+
+    public boolean isAwaitingConfirm() {
+        return awaitingConfirm;
+    }
+
+    public void setAwaitingConfirm(boolean awaitingConfirm) {
+        this.awaitingConfirm = awaitingConfirm;
+    }
+
+    public List<RemotePendingConfirm> getPendingConfirms() {
+        return pendingConfirms;
+    }
+
+    public void setPendingConfirms(List<RemotePendingConfirm> pendingConfirms) {
+        this.pendingConfirms =
+                pendingConfirms == null || pendingConfirms.isEmpty()
+                        ? null
+                        : List.copyOf(pendingConfirms);
+    }
+
+    public long getLastEventSeq() {
+        return lastEventSeq;
+    }
+
+    public void setLastEventSeq(long lastEventSeq) {
+        this.lastEventSeq = lastEventSeq;
     }
 }

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/subagent/task/TaskRunSpec.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/subagent/task/TaskRunSpec.java
@@ -34,11 +34,23 @@ public sealed interface TaskRunSpec {
 
     /**
      * Remote HTTP task execution. The {@code taskId} is chosen by the client and used as the
-     * remote task key end-to-end.
+     * remote task key end-to-end. {@code context} carries submission-time metadata (streaming
+     * preference, propagated deny rules, parent identity); defaults to
+     * {@link RemoteSubmitContext#empty()} for callers that predate this field.
      */
     record RemoteTaskRunSpec(
-            String baseUrl, Map<String, String> headers, String agentId, String input)
-            implements TaskRunSpec {}
+            String baseUrl,
+            Map<String, String> headers,
+            String agentId,
+            String input,
+            RemoteSubmitContext context)
+            implements TaskRunSpec {
+
+        public RemoteTaskRunSpec(
+                String baseUrl, Map<String, String> headers, String agentId, String input) {
+            this(baseUrl, headers, agentId, input, RemoteSubmitContext.empty());
+        }
+    }
 
     /**
      * Adopts an already-running {@link CompletableFuture} as a tracked background task. Used when

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/subagent/task/WorkspaceTaskRepository.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/subagent/task/WorkspaceTaskRepository.java
@@ -16,6 +16,7 @@
 package io.agentscope.harness.agent.subagent.task;
 
 import io.agentscope.core.agent.RuntimeContext;
+import io.agentscope.harness.agent.subagent.protocol.RemotePendingConfirm;
 import io.agentscope.harness.agent.workspace.WorkspaceManager;
 import java.time.Duration;
 import java.time.Instant;
@@ -25,6 +26,7 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
@@ -60,15 +62,19 @@ import org.slf4j.LoggerFactory;
  *       persisted terminal state without hanging.
  *   <li>Cancellation sets a {@link TaskRecord#isCancelRequested()} flag in workspace storage;
  *       the originating node checks this flag before invoking the subagent for best-effort cancel.
- *   <li>Remote {@link TaskRunSpec.RemoteTaskRunSpec} tasks use {@link AgentProtocolTaskClient} and
- *       persist {@link TaskRecord#getRemoteBaseUrl()} for cross-node resume.
+ *   <li>Remote {@link TaskRunSpec.RemoteTaskRunSpec} tasks use a {@link RemoteSubagentTransport}
+ *       (Agent Protocol by default) and persist {@link TaskRecord#getRemoteBaseUrl()} for
+ *       cross-node resume.
  * </ul>
  */
 public class WorkspaceTaskRepository implements TaskRepository {
 
     private static final Logger log = LoggerFactory.getLogger(WorkspaceTaskRepository.class);
 
-    private static final String TRANSPORT_AGENT_PROTOCOL = "agent-protocol";
+    private static final String TRANSPORT_AGENT_PROTOCOL = AgentProtocolTransport.TYPE;
+
+    /** Short, fixed poll interval used while a remote task is awaiting user confirmation. */
+    private static final long AWAITING_CONFIRM_POLL_MS = 750L;
 
     /**
      * How often (in seconds) the heartbeat refreshes {@code lastUpdatedAt} for live local tasks.
@@ -88,7 +94,7 @@ public class WorkspaceTaskRepository implements TaskRepository {
 
     private final WorkspaceManager workspaceManager;
     private final String parentAgentId;
-    private final AgentProtocolTaskClient protocolClient;
+    private volatile RemoteSubagentTransport transport;
 
     /**
      * In-memory local task handles. Keyed by {@code "<sessionId>:<taskId>"} to provide session
@@ -170,7 +176,7 @@ public class WorkspaceTaskRepository implements TaskRepository {
         this.parentAgentId = parentAgentId != null ? parentAgentId : "HarnessAgent";
         this.executor = executor;
         this.ownsExecutor = ownsExecutor;
-        this.protocolClient = new AgentProtocolTaskClient();
+        this.transport = new AgentProtocolTransport();
         if (enableMaintenance) {
             ScheduledExecutorService scheduler =
                     Executors.newSingleThreadScheduledExecutor(
@@ -211,6 +217,14 @@ public class WorkspaceTaskRepository implements TaskRepository {
      */
     public void setCompletionCallback(TaskCompletionCallback callback) {
         this.completionCallback = callback;
+    }
+
+    /**
+     * Test-only hook to inject a fake {@link RemoteSubagentTransport}, bypassing real HTTP calls
+     * for remote task tests.
+     */
+    void setTransport(RemoteSubagentTransport transport) {
+        this.transport = Objects.requireNonNull(transport, "transport");
     }
 
     @Override
@@ -337,6 +351,7 @@ public class WorkspaceTaskRepository implements TaskRepository {
             String subAgentId,
             TaskRunSpec.RemoteTaskRunSpec remote,
             boolean submitRemote) {
+        RemoteTarget target = new RemoteTarget(remote.baseUrl(), remote.headers());
         try {
             Optional<TaskRecord> latest =
                     workspaceManager.readTaskRecord(rc, parentAgentId, sessionId, taskId);
@@ -345,65 +360,98 @@ public class WorkspaceTaskRepository implements TaskRepository {
                 return null;
             }
             if (submitRemote) {
-                protocolClient.submitTask(
-                        remote.baseUrl(), remote.headers(), taskId, subAgentId, remote.input());
+                RemoteSubmitContext context =
+                        remote.context() != null ? remote.context() : RemoteSubmitContext.empty();
+                transport.submit(target, taskId, subAgentId, remote.input(), context);
                 updateStatus(rc, sessionId, taskId, TaskStatus.RUNNING, null, null);
             }
-            return pollRemoteUntilDone(rc, sessionId, taskId, remote.baseUrl(), remote.headers());
+            String result = pollRemoteUntilDone(rc, sessionId, taskId, target);
+            if (result != null) {
+                fireCompletionCallback(rc, taskId, subAgentId, sessionId, result);
+            }
+            return result;
         } catch (Exception e) {
             String errMsg = e.getMessage() != null ? e.getMessage() : e.getClass().getSimpleName();
             updateStatus(rc, sessionId, taskId, TaskStatus.FAILED, null, errMsg);
+            fireCompletionCallback(rc, taskId, subAgentId, sessionId, null);
             throw e instanceof RuntimeException re ? re : new RuntimeException(e);
         }
     }
 
     private String pollRemoteUntilDone(
-            RuntimeContext rc,
-            String sessionId,
-            String taskId,
-            String baseUrl,
-            Map<String, String> headers)
+            RuntimeContext rc, String sessionId, String taskId, RemoteTarget target)
             throws Exception {
         int attempt = 0;
+        boolean wasAwaitingConfirm = false;
         while (!Thread.currentThread().isInterrupted()) {
             Optional<TaskRecord> wr =
                     workspaceManager.readTaskRecord(rc, parentAgentId, sessionId, taskId);
             if (wr.isPresent() && wr.get().isCancelRequested()) {
                 try {
-                    protocolClient.cancelTask(baseUrl, headers, taskId);
+                    transport.cancel(target, taskId);
                 } catch (Exception ex) {
                     log.debug("Remote cancel after local cancel flag: {}", ex.getMessage());
                 }
                 markCancelled(rc, sessionId, taskId);
                 return null;
             }
-            RemoteTaskStatus st = protocolClient.getStatus(baseUrl, headers, taskId);
-            String s = st.status() == null ? "" : st.status().toLowerCase();
-            switch (s) {
-                case "success" -> {
-                    String result = protocolClient.waitForResult(baseUrl, headers, taskId, 120);
-                    updateStatus(rc, sessionId, taskId, TaskStatus.COMPLETED, result, null);
-                    return result;
-                }
-                case "error", "failed" -> {
-                    String err = st.error() != null ? st.error() : "remote task error";
-                    updateStatus(rc, sessionId, taskId, TaskStatus.FAILED, null, err);
-                    throw new RuntimeException(err);
-                }
-                case "cancelled", "canceled" -> {
-                    markCancelled(rc, sessionId, taskId);
-                    return null;
-                }
-                default -> {
-                    // pending, running, empty: keep polling
-                }
+            RemoteTaskStatus st = transport.getStatus(target, taskId);
+            if (st.isAwaitingConfirm()) {
+                wasAwaitingConfirm = true;
+                updateAwaitingConfirm(rc, sessionId, taskId, true, st.pendingConfirms());
+                Thread.sleep(AWAITING_CONFIRM_POLL_MS);
+                continue;
             }
+            if (wasAwaitingConfirm) {
+                updateAwaitingConfirm(rc, sessionId, taskId, false, null);
+                wasAwaitingConfirm = false;
+            }
+            if (st.isTerminalSuccess()) {
+                String result = transport.waitForResult(target, taskId, 120);
+                updateStatus(rc, sessionId, taskId, TaskStatus.COMPLETED, result, null);
+                return result;
+            }
+            if (st.isTerminalFailure()) {
+                String err = st.error() != null ? st.error() : "remote task error";
+                updateStatus(rc, sessionId, taskId, TaskStatus.FAILED, null, err);
+                throw new RuntimeException(err);
+            }
+            if (st.isCancelled()) {
+                markCancelled(rc, sessionId, taskId);
+                return null;
+            }
+            // pending, running, empty: keep polling with exponential backoff
             long sleepMs = Math.min(5_000L, 200L * (1L << Math.min(attempt++, 4)));
             Thread.sleep(sleepMs);
         }
         Thread.currentThread().interrupt();
         markCancelled(rc, sessionId, taskId);
         return null;
+    }
+
+    /**
+     * Persists {@link TaskRecord#isAwaitingConfirm()} and {@link TaskRecord#getPendingConfirms()}
+     * without touching {@link TaskRecord#getStatus()} — the task remains {@code RUNNING} while
+     * paused for user confirmation. No-op once the record has reached a terminal state.
+     */
+    private void updateAwaitingConfirm(
+            RuntimeContext rc,
+            String sessionId,
+            String taskId,
+            boolean awaiting,
+            List<RemotePendingConfirm> pendingConfirms) {
+        Optional<TaskRecord> existing =
+                workspaceManager.readTaskRecord(rc, parentAgentId, sessionId, taskId);
+        if (existing.isEmpty()) {
+            return;
+        }
+        TaskRecord record = existing.get();
+        if (record.getStatus() != null && record.getStatus().isTerminal()) {
+            return;
+        }
+        record.setAwaitingConfirm(awaiting);
+        record.setPendingConfirms(awaiting ? pendingConfirms : null);
+        persistRecord(rc, sessionId, record);
     }
 
     @Override
@@ -475,8 +523,10 @@ public class WorkspaceTaskRepository implements TaskRepository {
 
             if (agentProtocol) {
                 try {
-                    protocolClient.cancelTask(
-                            snapshot.getRemoteBaseUrl(), snapshot.getRemoteHeaders(), taskId);
+                    transport.cancel(
+                            new RemoteTarget(
+                                    snapshot.getRemoteBaseUrl(), snapshot.getRemoteHeaders()),
+                            taskId);
                 } catch (Exception e) {
                     log.warn("Remote cancel failed for task {}: {}", taskId, e.getMessage());
                 }

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/subagent/task/WorkspaceTaskRepository.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/subagent/task/WorkspaceTaskRepository.java
@@ -432,7 +432,9 @@ public class WorkspaceTaskRepository implements TaskRepository {
     /**
      * Persists {@link TaskRecord#isAwaitingConfirm()} and {@link TaskRecord#getPendingConfirms()}
      * without touching {@link TaskRecord#getStatus()} — the task remains {@code RUNNING} while
-     * paused for user confirmation. No-op once the record has reached a terminal state.
+     * paused for user confirmation. No-op once the record has reached a terminal state, and no-op
+     * when the awaiting flag and pending list are unchanged (avoids rewriting workspace JSON on
+     * every poll while blocked on confirmation).
      */
     private void updateAwaitingConfirm(
             RuntimeContext rc,
@@ -449,9 +451,25 @@ public class WorkspaceTaskRepository implements TaskRepository {
         if (record.getStatus() != null && record.getStatus().isTerminal()) {
             return;
         }
+        List<RemotePendingConfirm> nextPending = awaiting ? pendingConfirms : null;
+        if (record.isAwaitingConfirm() == awaiting
+                && pendingConfirmsUnchanged(record.getPendingConfirms(), nextPending)) {
+            return;
+        }
         record.setAwaitingConfirm(awaiting);
-        record.setPendingConfirms(awaiting ? pendingConfirms : null);
+        record.setPendingConfirms(nextPending);
         persistRecord(rc, sessionId, record);
+    }
+
+    private static boolean pendingConfirmsUnchanged(
+            List<RemotePendingConfirm> current, List<RemotePendingConfirm> next) {
+        if (current == null || current.isEmpty()) {
+            return next == null || next.isEmpty();
+        }
+        if (next == null || next.isEmpty()) {
+            return false;
+        }
+        return current.equals(next);
     }
 
     @Override

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/tool/AgentSpawnTool.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/tool/AgentSpawnTool.java
@@ -39,11 +39,22 @@ import io.agentscope.harness.agent.gateway.SessionIdUtils;
 import io.agentscope.harness.agent.gateway.SubagentGatewayBridge;
 import io.agentscope.harness.agent.gateway.channel.OutboundAddress;
 import io.agentscope.harness.agent.subagent.DefaultAgentManager;
+import io.agentscope.harness.agent.subagent.RemoteAskPolicy;
 import io.agentscope.harness.agent.subagent.SubagentDeclaration;
+import io.agentscope.harness.agent.subagent.protocol.RemoteConfirmDecision;
+import io.agentscope.harness.agent.subagent.protocol.RemoteEventCodec;
+import io.agentscope.harness.agent.subagent.protocol.RemotePendingConfirm;
+import io.agentscope.harness.agent.subagent.task.AgentProtocolTransport;
 import io.agentscope.harness.agent.subagent.task.BackgroundTask;
+import io.agentscope.harness.agent.subagent.task.RemoteSubagentTransport;
+import io.agentscope.harness.agent.subagent.task.RemoteSubmitContext;
+import io.agentscope.harness.agent.subagent.task.RemoteTarget;
+import io.agentscope.harness.agent.subagent.task.RemoteTaskStatus;
 import io.agentscope.harness.agent.subagent.task.TaskRepository;
 import io.agentscope.harness.agent.subagent.task.TaskRunSpec;
 import io.agentscope.harness.agent.subagent.task.TaskStatus;
+import java.io.Closeable;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -136,10 +147,14 @@ public class AgentSpawnTool {
             Do NOT call task_output immediately — the task has just started.\
             """;
 
+    /** Short poll interval used while waiting for a remote sync task, to detect awaiting_confirm promptly. */
+    private static final long REMOTE_CONFIRM_POLL_MS = 1_000L;
+
     private final DefaultAgentManager agentManager;
     private final TaskRepository taskRepository;
     private final int parentSpawnDepth;
     private volatile SubagentGatewayBridge gatewayBridge;
+    private volatile RemoteSubagentTransport remoteTransport = new AgentProtocolTransport();
 
     private record SpawnedAgent(
             String key, String agentId, String sessionId, String label, Agent agent, int depth) {}
@@ -194,6 +209,11 @@ public class AgentSpawnTool {
      */
     public void setGatewayBridge(SubagentGatewayBridge gatewayBridge) {
         this.gatewayBridge = gatewayBridge;
+    }
+
+    /** Test-only hook to inject a fake {@link RemoteSubagentTransport} for remote streaming/HITL tests. */
+    void setRemoteTransport(RemoteSubagentTransport remoteTransport) {
+        this.remoteTransport = Objects.requireNonNull(remoteTransport, "remoteTransport");
     }
 
     @Tool(
@@ -300,7 +320,13 @@ public class AgentSpawnTool {
                     return Mono.just(spawnInfo + "\nstatus: accepted (reused)");
                 }
                 return execSpawnTask(
-                        existing, runtimeContext, spawnInfo, task, timeoutSeconds, declOpt);
+                        existing,
+                        runtimeContext,
+                        parentState,
+                        spawnInfo,
+                        task,
+                        timeoutSeconds,
+                        declOpt);
             }
         } else {
             key = "agent:" + agentId + ":" + UUID.randomUUID();
@@ -365,7 +391,11 @@ public class AgentSpawnTool {
                 SubagentDeclaration d = declOpt.get();
                 spec =
                         new TaskRunSpec.RemoteTaskRunSpec(
-                                d.getUrl(), d.getHeaders(), agentId, capturedTask);
+                                d.getUrl(),
+                                d.getHeaders(),
+                                agentId,
+                                capturedTask,
+                                buildRemoteSubmitContext(runtimeContext, parentState, d));
             } else {
                 spec =
                         new TaskRunSpec.LocalTaskRunSpec(
@@ -403,16 +433,15 @@ public class AgentSpawnTool {
         if (remote) {
             final String finalTask = task;
             return withSubagentExposedEvent(
-                    Mono.fromCallable(
-                            () ->
-                                    runRemoteSync(
-                                            runtimeContext,
-                                            spawnInfo,
-                                            agentId,
-                                            parentSessionId,
-                                            declOpt.get(),
-                                            finalTask.trim(),
-                                            timeoutMs)),
+                    runRemoteSyncReactive(
+                            runtimeContext,
+                            parentState,
+                            spawnInfo,
+                            agentId,
+                            parentSessionId,
+                            declOpt.get(),
+                            finalTask.trim(),
+                            timeoutMs),
                     subagentId,
                     agentId,
                     sessionId,
@@ -534,7 +563,11 @@ public class AgentSpawnTool {
                 SubagentDeclaration d = declOpt.get();
                 spec =
                         new TaskRunSpec.RemoteTaskRunSpec(
-                                d.getUrl(), d.getHeaders(), spawned.agentId(), capturedMessage);
+                                d.getUrl(),
+                                d.getHeaders(),
+                                spawned.agentId(),
+                                capturedMessage,
+                                buildRemoteSubmitContext(runtimeContext, parentState, d));
             } else {
                 spec =
                         new TaskRunSpec.LocalTaskRunSpec(
@@ -565,16 +598,15 @@ public class AgentSpawnTool {
         if (remote) {
             final String finalMessage = message;
             final String finalKey = key;
-            return Mono.fromCallable(
-                    () ->
-                            runRemoteSync(
-                                    runtimeContext,
-                                    "agent_key: " + finalKey,
-                                    spawned.agentId(),
-                                    parentSessionId,
-                                    declOpt.get(),
-                                    finalMessage.trim(),
-                                    timeoutMs));
+            return runRemoteSyncReactive(
+                    runtimeContext,
+                    parentState,
+                    "agent_key: " + finalKey,
+                    spawned.agentId(),
+                    parentSessionId,
+                    declOpt.get(),
+                    finalMessage.trim(),
+                    timeoutMs);
         }
 
         final String finalKey = key;
@@ -1036,30 +1068,191 @@ public class AgentSpawnTool {
     }
 
     /**
-     * Submits a remote task through {@link TaskRepository} (for durable state) and blocks until
-     * it completes or the timeout elapses.
-     *
-     * <p>Using the repository ensures the task is visible to {@code task_list} and survives
-     * conversation compaction, just like async remote tasks do.
+     * Builds a {@code parentSession/agentId} source path for remote events forwarded into the
+     * parent's stream.
      */
-    private String runRemoteSync(
+    static String buildRemoteSourcePath(String parentSessionId, String agentId) {
+        String parent =
+                parentSessionId != null && !parentSessionId.isBlank() ? parentSessionId : "main";
+        String child = agentId != null && !agentId.isBlank() ? agentId : "remote";
+        return parent + "/" + child;
+    }
+
+    /**
+     * Builds submission metadata for a remote task (streaming preference, parent identity, denied
+     * permission rules).
+     */
+    private RemoteSubmitContext buildRemoteSubmitContext(
+            RuntimeContext runtimeContext, AgentState parentState, SubagentDeclaration decl) {
+        String userId = runtimeContext != null ? runtimeContext.getUserId() : null;
+        String parentSessionId = runtimeContext != null ? runtimeContext.getSessionId() : null;
+        boolean stream = decl != null && decl.isRemoteStreaming();
+        return RemoteSubmitContext.builder().userId(userId).parentSessionId(parentSessionId).stream(
+                        stream)
+                .detail(stream ? "full" : "status")
+                .denyRules(collectParentDenyRules(parentState, Optional.ofNullable(decl)))
+                .build();
+    }
+
+    /**
+     * Flattens parent DENY rules into wire maps for {@link RemoteSubmitContext}. Returns an empty
+     * list when inheritance is disabled or the parent has no DENY rules.
+     */
+    static List<Map<String, String>> collectParentDenyRules(
+            AgentState parentState, Optional<SubagentDeclaration> declaration) {
+        boolean inherit =
+                declaration.map(SubagentDeclaration::isInheritParentPermissions).orElse(true);
+        if (!inherit || parentState == null) {
+            return List.of();
+        }
+        PermissionContextState parentPermissions = parentState.getPermissionContext();
+        if (parentPermissions == null || parentPermissions.getDenyRules().isEmpty()) {
+            return List.of();
+        }
+        List<Map<String, String>> out = new ArrayList<>();
+        parentPermissions
+                .getDenyRules()
+                .forEach(
+                        (toolName, rules) -> {
+                            for (PermissionRule rule : rules) {
+                                Map<String, String> m = new LinkedHashMap<>();
+                                m.put("tool_name", rule.toolName());
+                                if (rule.ruleContent() != null) {
+                                    m.put("rule_content", rule.ruleContent());
+                                }
+                                m.put("behavior", rule.behavior().name());
+                                m.put("source", rule.source());
+                                out.add(m);
+                            }
+                        });
+        return out;
+    }
+
+    /**
+     * Reactive entry for remote sync execution. Captures {@link AgentEventEmitter} from Reactor
+     * Context before blocking on the remote task.
+     */
+    private Mono<String> runRemoteSyncReactive(
             RuntimeContext runtimeContext,
+            AgentState parentState,
             String header,
             String agentId,
             String parentSessionId,
             SubagentDeclaration decl,
             String input,
             long timeoutMs) {
+        return Mono.deferContextual(
+                ctxView -> {
+                    Optional<AgentEventEmitter> emitterOpt = AgentEventEmitter.fromContext(ctxView);
+                    return Mono.fromCallable(
+                            () ->
+                                    runRemoteSync(
+                                            runtimeContext,
+                                            parentState,
+                                            header,
+                                            agentId,
+                                            parentSessionId,
+                                            decl,
+                                            input,
+                                            timeoutMs,
+                                            emitterOpt.orElse(null)));
+                });
+    }
+
+    /**
+     * Submits a remote task through {@link TaskRepository} (for durable state) and blocks until
+     * it completes or the timeout elapses.
+     *
+     * <p>When an {@link AgentEventEmitter} is present and {@link SubagentDeclaration#isRemoteStreaming()}
+     * is true, remote events are forwarded into the parent stream. Without an emitter, or when
+     * {@link RemoteAskPolicy#DENY} applies, pending remote confirmations are auto-denied via
+     * {@link RemoteSubagentTransport#resume}.
+     */
+    private String runRemoteSync(
+            RuntimeContext runtimeContext,
+            AgentState parentState,
+            String header,
+            String agentId,
+            String parentSessionId,
+            SubagentDeclaration decl,
+            String input,
+            long timeoutMs,
+            AgentEventEmitter emitter) {
         String taskId = "task_" + UUID.randomUUID();
+        RemoteSubmitContext submitContext =
+                buildRemoteSubmitContext(runtimeContext, parentState, decl);
         TaskRunSpec spec =
-                new TaskRunSpec.RemoteTaskRunSpec(decl.getUrl(), decl.getHeaders(), agentId, input);
+                new TaskRunSpec.RemoteTaskRunSpec(
+                        decl.getUrl(), decl.getHeaders(), agentId, input, submitContext);
         BackgroundTask bgTask =
                 taskRepository.putTask(runtimeContext, taskId, agentId, parentSessionId, spec);
+
+        RemoteTarget target = new RemoteTarget(decl.getUrl(), decl.getHeaders());
+        RemoteSubagentTransport transport = this.remoteTransport;
+        String sourcePath = buildRemoteSourcePath(parentSessionId, agentId);
+        boolean wantStream = emitter != null && decl.isRemoteStreaming();
+        AtomicBoolean autoDenied = new AtomicBoolean(false);
+        AtomicBoolean resumedEpisode = new AtomicBoolean(false);
+
+        Closeable streamHandle = () -> {};
         try {
-            boolean done = bgTask.waitForCompletion(timeoutMs);
-            if (!done) {
-                return header + "\nstatus: timeout\ntask_id: " + taskId;
+            if (wantStream) {
+                streamHandle =
+                        transport.streamEvents(
+                                target,
+                                taskId,
+                                0L,
+                                remoteEvent ->
+                                        RemoteEventCodec.toAgentEvent(remoteEvent)
+                                                .ifPresent(
+                                                        ae ->
+                                                                emitter.emit(
+                                                                        ae.withSource(
+                                                                                sourcePath))));
             }
+
+            long deadlineMs = System.currentTimeMillis() + Math.max(timeoutMs, 0L);
+            while (true) {
+                long remaining = deadlineMs - System.currentTimeMillis();
+                if (remaining <= 0) {
+                    return header + "\nstatus: timeout\ntask_id: " + taskId;
+                }
+                long slice = Math.min(REMOTE_CONFIRM_POLL_MS, remaining);
+                boolean done = bgTask.waitForCompletion(slice);
+
+                try {
+                    RemoteTaskStatus st = transport.getStatus(target, taskId);
+                    if (st.isAwaitingConfirm()) {
+                        boolean shouldAutoDeny =
+                                emitter == null
+                                        || decl.getRemoteAskPolicy() == RemoteAskPolicy.DENY;
+                        if (shouldAutoDeny && resumedEpisode.compareAndSet(false, true)) {
+                            List<RemotePendingConfirm> pending =
+                                    st.pendingConfirms() != null ? st.pendingConfirms() : List.of();
+                            List<RemoteConfirmDecision> decisions = new ArrayList<>(pending.size());
+                            for (RemotePendingConfirm p : pending) {
+                                decisions.add(new RemoteConfirmDecision(p.getToolCallId(), false));
+                            }
+                            if (!decisions.isEmpty()) {
+                                transport.resume(target, taskId, decisions);
+                                autoDenied.set(true);
+                            }
+                        }
+                    } else {
+                        resumedEpisode.set(false);
+                    }
+                } catch (Exception e) {
+                    log.debug(
+                            "Remote status poll during sync wait failed for {}: {}",
+                            taskId,
+                            e.getMessage());
+                }
+
+                if (done) {
+                    break;
+                }
+            }
+
             TaskStatus ts = bgTask.getTaskStatus();
             if (ts == TaskStatus.FAILED) {
                 Exception err = bgTask.getError();
@@ -1070,11 +1263,22 @@ public class AgentSpawnTool {
                 return header + "\nstatus: cancelled\ntask_id: " + taskId;
             }
             String result = bgTask.getResult();
-            return header + "\nstatus: ok\nreply:\n" + (result != null ? result : "");
+            StringBuilder sb = new StringBuilder(header).append("\nstatus: ok");
+            if (autoDenied.get()) {
+                sb.append("\nnote: remote tool confirmation(s) were auto-denied");
+            }
+            sb.append("\nreply:\n").append(result != null ? result : "");
+            return sb.toString();
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             log.warn("agent remote sync interrupted: agentId={}", agentId);
             return header + "\nstatus: error\nerror: interrupted";
+        } finally {
+            try {
+                streamHandle.close();
+            } catch (IOException e) {
+                log.debug("Closing remote event stream failed: {}", e.getMessage());
+            }
         }
     }
 
@@ -1178,6 +1382,7 @@ public class AgentSpawnTool {
     private Mono<String> execSpawnTask(
             SpawnedAgent spawned,
             RuntimeContext runtimeContext,
+            AgentState parentState,
             String spawnInfo,
             String task,
             Integer timeoutSeconds,
@@ -1196,7 +1401,11 @@ public class AgentSpawnTool {
                 SubagentDeclaration d = declOpt.get();
                 spec =
                         new TaskRunSpec.RemoteTaskRunSpec(
-                                d.getUrl(), d.getHeaders(), spawned.agentId(), capturedTask);
+                                d.getUrl(),
+                                d.getHeaders(),
+                                spawned.agentId(),
+                                capturedTask,
+                                buildRemoteSubmitContext(runtimeContext, parentState, d));
             } else {
                 spec =
                         new TaskRunSpec.LocalTaskRunSpec(
@@ -1227,16 +1436,15 @@ public class AgentSpawnTool {
 
         if (remote) {
             final String finalTask = task;
-            return Mono.fromCallable(
-                    () ->
-                            runRemoteSync(
-                                    runtimeContext,
-                                    spawnInfo,
-                                    spawned.agentId(),
-                                    parentSessionId,
-                                    declOpt.get(),
-                                    finalTask.trim(),
-                                    timeoutMs));
+            return runRemoteSyncReactive(
+                    runtimeContext,
+                    parentState,
+                    spawnInfo,
+                    spawned.agentId(),
+                    parentSessionId,
+                    declOpt.get(),
+                    finalTask.trim(),
+                    timeoutMs);
         }
 
         final String finalTask = task.trim();

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/subagent/protocol/RemoteEventCodecTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/subagent/protocol/RemoteEventCodecTest.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.harness.agent.subagent.protocol;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.agentscope.core.event.AgentEndEvent;
+import io.agentscope.core.event.AgentEvent;
+import io.agentscope.core.event.AgentStartEvent;
+import io.agentscope.core.event.RequireUserConfirmEvent;
+import io.agentscope.core.event.TextBlockDeltaEvent;
+import io.agentscope.core.event.ToolCallStartEvent;
+import io.agentscope.core.message.ToolCallState;
+import io.agentscope.core.message.ToolUseBlock;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+
+class RemoteEventCodecTest {
+
+    @Test
+    void roundTripTextAndLifecycle() {
+        Optional<RemoteAgentEvent> startDto =
+                RemoteEventCodec.fromAgentEvent(new AgentStartEvent("sess", null, "researcher"));
+        assertTrue(startDto.isPresent());
+        assertEquals(RemoteEventType.RUN_STARTED, startDto.get().getType());
+        assertEquals("researcher", startDto.get().getAgentId());
+
+        AgentEvent startBack = RemoteEventCodec.toAgentEvent(startDto.get()).orElseThrow();
+        assertInstanceOf(AgentStartEvent.class, startBack);
+
+        Optional<RemoteAgentEvent> textDto =
+                RemoteEventCodec.fromAgentEvent(new TextBlockDeltaEvent(null, "b1", "hello"));
+        assertTrue(textDto.isPresent());
+        assertEquals(RemoteEventType.TEXT_DELTA, textDto.get().getType());
+        assertEquals("hello", textDto.get().getText());
+
+        AgentEvent textBack = RemoteEventCodec.toAgentEvent(textDto.get()).orElseThrow();
+        assertInstanceOf(TextBlockDeltaEvent.class, textBack);
+        assertEquals("hello", ((TextBlockDeltaEvent) textBack).getDelta());
+
+        Optional<RemoteAgentEvent> endDto =
+                RemoteEventCodec.fromAgentEvent(new AgentEndEvent(null));
+        assertTrue(endDto.isPresent());
+        assertEquals(RemoteEventType.RUN_FINISHED, endDto.get().getType());
+    }
+
+    @Test
+    void requireConfirmRoundTripPreservesAskState() {
+        ToolUseBlock ask =
+                ToolUseBlock.builder()
+                        .id("tc1")
+                        .name("bash")
+                        .input(Map.of("cmd", "rm -rf /"))
+                        .state(ToolCallState.ASKING)
+                        .build();
+        Optional<RemoteAgentEvent> dto =
+                RemoteEventCodec.fromAgentEvent(new RequireUserConfirmEvent(null, List.of(ask)));
+        assertTrue(dto.isPresent());
+        assertEquals(RemoteEventType.REQUIRE_CONFIRM, dto.get().getType());
+        assertEquals(1, dto.get().getPendingConfirms().size());
+        assertEquals("tc1", dto.get().getPendingConfirms().get(0).getToolCallId());
+
+        AgentEvent back = RemoteEventCodec.toAgentEvent(dto.get()).orElseThrow();
+        RequireUserConfirmEvent confirm = assertInstanceOf(RequireUserConfirmEvent.class, back);
+        assertEquals(1, confirm.getToolCalls().size());
+        assertEquals(ToolCallState.ASKING, confirm.getToolCalls().get(0).getState());
+        assertEquals("bash", confirm.getToolCalls().get(0).getName());
+    }
+
+    @Test
+    void toolCallStartMaps() {
+        Optional<RemoteAgentEvent> dto =
+                RemoteEventCodec.fromAgentEvent(new ToolCallStartEvent(null, "id1", "read_file"));
+        assertTrue(dto.isPresent());
+        assertEquals(RemoteEventType.TOOL_CALL_START, dto.get().getType());
+        AgentEvent back = RemoteEventCodec.toAgentEvent(dto.get()).orElseThrow();
+        ToolCallStartEvent start = assertInstanceOf(ToolCallStartEvent.class, back);
+        assertEquals("id1", start.getToolCallId());
+        assertEquals("read_file", start.getToolCallName());
+    }
+
+    @Test
+    void detailFilterHidesTextUnlessFull() {
+        assertFalse(RemoteEventCodec.matchesDetail(RemoteEventType.TEXT_DELTA, "status"));
+        assertTrue(RemoteEventCodec.matchesDetail(RemoteEventType.TEXT_DELTA, "full"));
+        assertTrue(RemoteEventCodec.matchesDetail(RemoteEventType.TOOL_CALL_START, "status"));
+        assertTrue(RemoteEventCodec.matchesDetail(RemoteEventType.REQUIRE_CONFIRM, null));
+    }
+
+    @Test
+    void unknownInternalEventsDropped() {
+        // Custom/other events without a codec mapping
+        assertTrue(RemoteEventCodec.fromAgentEvent(null).isEmpty());
+    }
+}

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/subagent/task/WorkspaceTaskRepositoryRemoteStreamingTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/subagent/task/WorkspaceTaskRepositoryRemoteStreamingTest.java
@@ -1,0 +1,188 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.harness.agent.subagent.task;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.agentscope.core.agent.RuntimeContext;
+import io.agentscope.harness.agent.subagent.protocol.RemoteAgentEvent;
+import io.agentscope.harness.agent.subagent.protocol.RemoteConfirmDecision;
+import io.agentscope.harness.agent.subagent.protocol.RemotePendingConfirm;
+import io.agentscope.harness.agent.workspace.WorkspaceManager;
+import java.io.Closeable;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Remote polling + HITL awaiting_confirm toggle for {@link WorkspaceTaskRepository}, using a fake
+ * {@link RemoteSubagentTransport} injected via {@link WorkspaceTaskRepository#setTransport}.
+ */
+class WorkspaceTaskRepositoryRemoteStreamingTest {
+
+    @TempDir Path tempDir;
+
+    private WorkspaceManager workspaceManager;
+    private WorkspaceTaskRepository repo;
+
+    @BeforeEach
+    void setUp() {
+        workspaceManager = new WorkspaceManager(tempDir);
+        repo = WorkspaceTaskRepository.forTests(workspaceManager, "test-agent");
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (repo != null) {
+            repo.shutdown();
+        }
+    }
+
+    @Test
+    void remoteTask_togglesAwaitingConfirm_thenFiresCompletionOnSuccess() throws Exception {
+        AtomicInteger statusCalls = new AtomicInteger();
+        List<Boolean> awaitingSnapshots = new CopyOnWriteArrayList<>();
+        FakeTransport transport = new FakeTransport(statusCalls);
+        repo.setTransport(transport);
+
+        AtomicReference<String> completedResult = new AtomicReference<>();
+        repo.setCompletionCallback(
+                (rc, taskId, subAgentId, sessionId, result) -> completedResult.set(result));
+
+        String session = "sess-remote";
+        String taskId = "task-remote-hitl";
+
+        repo.putTask(
+                RuntimeContext.empty(),
+                taskId,
+                "remote-worker",
+                session,
+                new TaskRunSpec.RemoteTaskRunSpec(
+                        "http://remote.test",
+                        Map.of(),
+                        "remote-worker",
+                        "do work",
+                        RemoteSubmitContext.empty()));
+
+        awaitCondition(
+                () -> {
+                    Optional<TaskRecord> r =
+                            workspaceManager.readTaskRecord(
+                                    RuntimeContext.empty(), "test-agent", session, taskId);
+                    if (r.isPresent() && r.get().isAwaitingConfirm()) {
+                        awaitingSnapshots.add(true);
+                    }
+                    return r.isPresent() && r.get().getStatus().isTerminal();
+                });
+
+        Optional<TaskRecord> finalRecord =
+                workspaceManager.readTaskRecord(
+                        RuntimeContext.empty(), "test-agent", session, taskId);
+        assertTrue(finalRecord.isPresent());
+        assertEquals(TaskStatus.COMPLETED, finalRecord.get().getStatus());
+        assertEquals("remote-ok", finalRecord.get().getResult());
+        assertFalse(finalRecord.get().isAwaitingConfirm());
+        assertTrue(
+                !awaitingSnapshots.isEmpty() || statusCalls.get() >= 2,
+                "expected at least one awaiting_confirm poll before success");
+        assertEquals("remote-ok", completedResult.get());
+        assertTrue(transport.submitCalled);
+    }
+
+    private static void awaitCondition(Condition condition) throws Exception {
+        long deadline = System.currentTimeMillis() + 10_000;
+        while (!condition.get()) {
+            if (System.currentTimeMillis() >= deadline) {
+                throw new AssertionError("Condition not met within 10 seconds");
+            }
+            Thread.sleep(50);
+        }
+    }
+
+    @FunctionalInterface
+    private interface Condition {
+        boolean get() throws Exception;
+    }
+
+    /** Returns awaiting_confirm twice, then success. */
+    private static final class FakeTransport implements RemoteSubagentTransport {
+        private final AtomicInteger statusCalls;
+        volatile boolean submitCalled;
+
+        FakeTransport(AtomicInteger statusCalls) {
+            this.statusCalls = statusCalls;
+        }
+
+        @Override
+        public String transportType() {
+            return "agent-protocol";
+        }
+
+        @Override
+        public void submit(
+                RemoteTarget target,
+                String taskId,
+                String agentId,
+                String input,
+                RemoteSubmitContext context) {
+            submitCalled = true;
+        }
+
+        @Override
+        public RemoteTaskStatus getStatus(RemoteTarget target, String taskId) {
+            int n = statusCalls.incrementAndGet();
+            if (n <= 2) {
+                return new RemoteTaskStatus(
+                        "awaiting_confirm",
+                        null,
+                        List.of(new RemotePendingConfirm("tc1", "bash", "{\"cmd\":\"ls\"}")));
+            }
+            return new RemoteTaskStatus("success", null);
+        }
+
+        @Override
+        public String waitForResult(RemoteTarget target, String taskId, long timeoutSeconds) {
+            return "remote-ok";
+        }
+
+        @Override
+        public void cancel(RemoteTarget target, String taskId) {}
+
+        @Override
+        public void resume(
+                RemoteTarget target, String taskId, List<RemoteConfirmDecision> decisions) {}
+
+        @Override
+        public Closeable streamEvents(
+                RemoteTarget target,
+                String taskId,
+                long fromSeq,
+                Consumer<RemoteAgentEvent> consumer) {
+            return () -> {};
+        }
+    }
+}

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/subagent/task/WorkspaceTaskRepositoryRemoteStreamingTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/subagent/task/WorkspaceTaskRepositoryRemoteStreamingTest.java
@@ -66,7 +66,7 @@ class WorkspaceTaskRepositoryRemoteStreamingTest {
     void remoteTask_togglesAwaitingConfirm_thenFiresCompletionOnSuccess() throws Exception {
         AtomicInteger statusCalls = new AtomicInteger();
         List<Boolean> awaitingSnapshots = new CopyOnWriteArrayList<>();
-        FakeTransport transport = new FakeTransport(statusCalls);
+        FakeTransport transport = new FakeTransport(statusCalls, 2);
         repo.setTransport(transport);
 
         AtomicReference<String> completedResult = new AtomicReference<>();
@@ -113,6 +113,50 @@ class WorkspaceTaskRepositoryRemoteStreamingTest {
         assertTrue(transport.submitCalled);
     }
 
+    @Test
+    void awaitingConfirm_doesNotRewriteWorkspaceEveryPoll() throws Exception {
+        CountingWorkspaceManager countingWm = new CountingWorkspaceManager(tempDir);
+        repo.shutdown();
+        workspaceManager = countingWm;
+        repo = WorkspaceTaskRepository.forTests(workspaceManager, "test-agent");
+
+        AtomicInteger statusCalls = new AtomicInteger();
+        // Stay in awaiting_confirm for several polls so a naive rewrite-every-poll would write
+        // often.
+        FakeTransport transport = new FakeTransport(statusCalls, 5);
+        repo.setTransport(transport);
+
+        String session = "sess-no-rewrite";
+        String taskId = "task-no-rewrite";
+        repo.putTask(
+                RuntimeContext.empty(),
+                taskId,
+                "remote-worker",
+                session,
+                new TaskRunSpec.RemoteTaskRunSpec(
+                        "http://remote.test",
+                        Map.of(),
+                        "remote-worker",
+                        "do work",
+                        RemoteSubmitContext.empty()));
+
+        awaitCondition(
+                () -> {
+                    Optional<TaskRecord> r =
+                            workspaceManager.readTaskRecord(
+                                    RuntimeContext.empty(), "test-agent", session, taskId);
+                    return r.isPresent() && r.get().getStatus().isTerminal();
+                });
+
+        assertTrue(statusCalls.get() >= 5, "expected multiple awaiting_confirm polls");
+        // PENDING persist + RUNNING + enter awaiting_confirm + leave awaiting + COMPLETED.
+        // Without the noop, five awaiting polls would add four extra writes (9 total).
+        assertEquals(
+                5,
+                countingWm.writeCount.get(),
+                "awaiting_confirm polls with unchanged pending must not re-persist");
+    }
+
     private static void awaitCondition(Condition condition) throws Exception {
         long deadline = System.currentTimeMillis() + 10_000;
         while (!condition.get()) {
@@ -128,13 +172,30 @@ class WorkspaceTaskRepositoryRemoteStreamingTest {
         boolean get() throws Exception;
     }
 
-    /** Returns awaiting_confirm twice, then success. */
+    private static final class CountingWorkspaceManager extends WorkspaceManager {
+        private final AtomicInteger writeCount = new AtomicInteger();
+
+        CountingWorkspaceManager(Path workspace) {
+            super(workspace);
+        }
+
+        @Override
+        public void writeTaskRecord(
+                RuntimeContext rc, String agentId, String sessionId, TaskRecord record) {
+            writeCount.incrementAndGet();
+            super.writeTaskRecord(rc, agentId, sessionId, record);
+        }
+    }
+
+    /** Returns awaiting_confirm for {@code awaitingPolls} status calls, then success. */
     private static final class FakeTransport implements RemoteSubagentTransport {
         private final AtomicInteger statusCalls;
+        private final int awaitingPolls;
         volatile boolean submitCalled;
 
-        FakeTransport(AtomicInteger statusCalls) {
+        FakeTransport(AtomicInteger statusCalls, int awaitingPolls) {
             this.statusCalls = statusCalls;
+            this.awaitingPolls = awaitingPolls;
         }
 
         @Override
@@ -155,7 +216,7 @@ class WorkspaceTaskRepositoryRemoteStreamingTest {
         @Override
         public RemoteTaskStatus getStatus(RemoteTarget target, String taskId) {
             int n = statusCalls.incrementAndGet();
-            if (n <= 2) {
+            if (n <= awaitingPolls) {
                 return new RemoteTaskStatus(
                         "awaiting_confirm",
                         null,

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/tool/AgentSpawnToolRemoteHelpersTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/tool/AgentSpawnToolRemoteHelpersTest.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.harness.agent.tool;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.agentscope.core.permission.PermissionBehavior;
+import io.agentscope.core.permission.PermissionContextState;
+import io.agentscope.core.permission.PermissionMode;
+import io.agentscope.core.permission.PermissionRule;
+import io.agentscope.core.state.AgentState;
+import io.agentscope.harness.agent.subagent.SubagentDeclaration;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+
+/** Smoke tests for package-visible remote helpers on {@link AgentSpawnTool}. */
+class AgentSpawnToolRemoteHelpersTest {
+
+    @Test
+    void buildRemoteSourcePath_joinsParentSessionAndAgentId() {
+        assertEquals(
+                "parent-sess/worker",
+                AgentSpawnTool.buildRemoteSourcePath("parent-sess", "worker"));
+    }
+
+    @Test
+    void buildRemoteSourcePath_defaultsBlankParts() {
+        assertEquals("main/remote", AgentSpawnTool.buildRemoteSourcePath(null, null));
+        assertEquals("main/remote", AgentSpawnTool.buildRemoteSourcePath("  ", ""));
+        assertEquals("sess/remote", AgentSpawnTool.buildRemoteSourcePath("sess", null));
+        assertEquals("main/agent", AgentSpawnTool.buildRemoteSourcePath(null, "agent"));
+    }
+
+    @Test
+    void collectParentDenyRules_returnsEmptyWhenInheritDisabled() {
+        AgentState parent =
+                AgentState.builder()
+                        .userId("u")
+                        .sessionId("s")
+                        .permissionContext(
+                                PermissionContextState.builder()
+                                        .mode(PermissionMode.BYPASS)
+                                        .addDenyRule(
+                                                "bash",
+                                                new PermissionRule(
+                                                        "bash",
+                                                        null,
+                                                        PermissionBehavior.DENY,
+                                                        "parent"))
+                                        .build())
+                        .build();
+        SubagentDeclaration decl =
+                SubagentDeclaration.builder()
+                        .name("worker")
+                        .description("d")
+                        .inheritParentPermissions(false)
+                        .build();
+
+        List<Map<String, String>> rules =
+                AgentSpawnTool.collectParentDenyRules(parent, Optional.of(decl));
+        assertTrue(rules.isEmpty());
+    }
+
+    @Test
+    void collectParentDenyRules_flattensDenyRulesWhenInheritEnabled() {
+        PermissionRule deny =
+                new PermissionRule("bash", "rm*", PermissionBehavior.DENY, "parent-policy");
+        AgentState parent =
+                AgentState.builder()
+                        .userId("u")
+                        .sessionId("s")
+                        .permissionContext(
+                                PermissionContextState.builder()
+                                        .mode(PermissionMode.BYPASS)
+                                        .addDenyRule("bash", deny)
+                                        .build())
+                        .build();
+
+        List<Map<String, String>> rules =
+                AgentSpawnTool.collectParentDenyRules(parent, Optional.empty());
+
+        assertEquals(1, rules.size());
+        assertEquals("bash", rules.get(0).get("tool_name"));
+        assertEquals("rm*", rules.get(0).get("rule_content"));
+        assertEquals(PermissionBehavior.DENY.name(), rules.get(0).get("behavior"));
+        assertEquals("parent-policy", rules.get(0).get("source"));
+    }
+}

--- a/docs/v2/en/docs/change-log.md
+++ b/docs/v2/en/docs/change-log.md
@@ -194,7 +194,7 @@ Python 2.0's `agent.reply_stream()` exposes a single streaming signature (`Async
 - **Types (soft deprecation, no `forRemoval` yet)**
   - `io.agentscope.core.agent.Event`, `EventType`, `EventSource`
   - Still consumed internally by the harness (subagent event forwarding: `SubAgentTool` / `SubagentEventBus` / `DefaultAgentManager` / `AgentSpawnTool`), AGUI, A2A, chat-completions-web, and Kotlin extension modules as the event-bus / adapter input. They will be flipped to `forRemoval = true` only after those modules migrate to `AgentEvent`, so the entire downstream is not warning-flooded in a single release.
-  - **Current gap:** `HarnessAgent.streamEvents(...)` does **not** forward subagent events yet — the `AgentEvent` hierarchy has no equivalent `EventSource` channel. Callers that need the child-agent stream must stay on the deprecated `stream(...)` path until that channel lands.
+  - Subagent events are forwarded on `HarnessAgent.streamEvents(...)` with a non-null `source` path (including remote Agent Protocol children when `remoteStreaming` is enabled).
 
 New code should use:
 
@@ -253,6 +253,7 @@ The capabilities below are additive in 2.0 — none of them break 1.x code. The 
 - New `AgentEventConverter` and `AguiEventEnricher` extension points: converters handle semantic mapping, while enrichers handle cross-cutting properties such as `timestamp` / `rawEvent`. The Spring Boot starter automatically collects both bean types.
 - Every `AguiEvent` supports AG-UI base event properties. `BaseEventPropertiesEnricher` is disabled by default; when explicitly enabled, it only fills missing `timestamp` values and does not default `rawEvent`.
 - `AguiAdapterConfig.emitTokenUsage` can emit `CUSTOM token_usage` events with model-call delta and run-level cumulative token usage.
+- **Behavior change:** AgentEvents with `source != null` (subagent events) are emitted as AG-UI `CUSTOM` events (`subagent.lifecycle`, `subagent.text`, `subagent.thinking`, `subagent.tool_call`, `subagent.tool_result`, `subagent.require_confirm`) instead of native `TEXT_MESSAGE_*` / `RUN_*`. Set `emitSubagentEventsAsNative(true)` to restore the legacy native mapping.
 - The Spring Boot starter supports `AguiRuntimeContextResolver`, custom `AguiAgentAdapterFactory`, frontend tool injection / merge mode, and HITL interrupt output.
 
 Detail → [AG-UI](../integration/protocol/agui.md)

--- a/docs/v2/en/docs/harness/subagent.md
+++ b/docs/v2/en/docs/harness/subagent.md
@@ -319,10 +319,30 @@ Just set `url` + optional `headers` and the subagent runs through a remote HTTP 
     .description("Remote research subagent")
     .url("http://agent-task-server:8080")
     .headers(Map.of("Authorization", "Bearer xxx"))
+    .remoteStreaming(true)          // default when unset
+    .remoteAskPolicy(RemoteAskPolicy.DENY)  // default
     .build())
 ```
 
 Same sync (`timeout_seconds>0`) / background (`timeout_seconds=0`) semantics apply.
+
+Declaration knobs specific to remote mode:
+
+| Field | Default | Notes |
+|-------|---------|-------|
+| `remoteStreaming` | `true` (when unset) | When the parent uses `streamEvents()`, forward remote task SSE events into the parent stream with a `source` tag |
+| `remoteAskPolicy` | `DENY` | How to resolve remote tool-confirmation (HITL) requests — see [Remote authorization](#remote-authorization) |
+
+### Remote authorization
+
+Parent DENY permission rules are forwarded in the remote submit `context.deny_rules` (same inheritance as local children; opt out with `inheritParentPermissions(false)`).
+
+When the remote agent pauses for tool confirmation (`awaiting_confirm`):
+
+- **Streaming parent + `remoteAskPolicy=PROPAGATE`**: a `RequireUserConfirmEvent` is forwarded into the parent's `streamEvents()` stream with a non-null `source` tag. Resume the remote task via Agent Protocol [`POST /tasks/{id}/resume`](../../integration/protocol/agent-protocol.md) with `decisions[{toolCallId, approved}]`.
+- **Non-streaming parent (`call`) or `remoteAskPolicy=DENY` (default)**: pending confirmations are auto-denied. The tool result includes a note: `remote tool confirmation(s) were auto-denied`.
+
+While awaiting confirmation, task status stays `RUNNING` (`awaitingConfirm=true`). Barriers such as `wait_async_results` therefore keep waiting until the task is resumed and reaches a terminal status.
 
 ## Background task storage
 
@@ -431,7 +451,8 @@ public Flux<ServerSentEvent<String>> chat(@RequestParam String message,
 | `streamEvents()` + synchronous local child (`timeout_seconds > 0`) | ✔ |
 | `call()` mode (non-streaming) | ✗ (child result returns as `tool_result` string) |
 | `timeout_seconds = 0` background task | ✗ (result pushed via reverse notification to parent's next round) |
-| Remote subagent (Agent Protocol) | ✗ |
+| Remote subagent (Agent Protocol) + parent `streamEvents()` + `remoteStreaming=true` (default) | ✔ |
+| Remote subagent + parent `call()` or `remoteStreaming=false` | ✗ |
 
 ### Error handling
 
@@ -443,5 +464,6 @@ When a child throws internally, the framework captures it and writes a `TOOL_RES
 - [Workspace](./workspace.md) — `subagents/` and `agents/<id>/tasks/` layout
 - [Plan Mode](./plan-mode.md) — restrictions on subagents during the plan phase
 - [Architecture](./architecture.md) — how parent and child cooperate
+- [Agent Protocol](../../integration/protocol/agent-protocol.md) — remote task endpoints (SSE + HITL resume)
 - [Message & Event](../building-blocks/message-and-event.md) — `AgentEvent` hierarchy (recommended) and the deprecated `Event` / `EventType` / `StreamOptions` types
 - [V1 Migration Guide B.4](../change-log.md) — `stream()` → `streamEvents()` deprecation timeline

--- a/docs/v2/en/integration/protocol/agent-protocol.md
+++ b/docs/v2/en/integration/protocol/agent-protocol.md
@@ -7,6 +7,17 @@
 - You want the Agent to be remotely scheduled like a cloud function.
 - An existing team uses an Agent Protocol client and you'd like to plug in directly.
 - You're embedding a Harness Agent in a Spring Boot service and want auto-exposed `/tasks` REST endpoints.
+- You're hosting a [remote subagent](../../docs/harness/subagent.md#remote-subagent) that another Harness parent calls over HTTP.
+
+## Protocol layering
+
+AgentScope uses different protocols for different trust / UX boundaries:
+
+| Layer | Role |
+| --- | --- |
+| **AG-UI** | User-facing chat UI event stream (browser ↔ app) |
+| **Agent Protocol** | Internal remote-subagent / task HTTP API (parent harness ↔ remote agent service) |
+| **A2A** | External agent-to-agent interop (separate extension; not part of this remote-subagent streaming/HITL work) |
 
 ## Add the dependency
 
@@ -31,7 +42,7 @@ agentscope:
     enabled: true
 ```
 
-The `/tasks` REST endpoints (per the Agent Protocol spec) are then registered automatically.
+The `/tasks` REST endpoints are then registered automatically.
 
 ## Concurrent execution
 
@@ -49,13 +60,108 @@ public HarnessAgent harnessAgent() {
 
 Concurrent requests for the same session are automatically serialized; different sessions run in parallel.
 
+## Endpoints
+
+### Submit a task
+
+`POST /tasks`
+
+```json
+{
+  "task_id": "task_123",
+  "agent_id": "researcher",
+  "input": "Summarize the latest release notes",
+  "context": {
+    "user_id": "u-1",
+    "parent_session_id": "sess-parent",
+    "stream": true,
+    "detail": "full",
+    "deny_rules": [
+      {
+        "tool_name": "bash",
+        "behavior": "DENY",
+        "source": "parent"
+      }
+    ]
+  }
+}
+```
+
+Optional `context` fields:
+
+| Field | Notes |
+| --- | --- |
+| `user_id` | Forwarded into the remote agent's `RuntimeContext` |
+| `parent_session_id` | Parent session identity (for tracing / correlation) |
+| `stream` | Whether the caller intends to consume SSE events |
+| `detail` | `status` (default) or `full` — `full` includes text/thinking deltas on the event stream |
+| `deny_rules` | Parent DENY permission rules to enforce on the remote side |
+
+Response on success: `{ "task_id", "status": "pending" }`.
+
+### Poll / wait / cancel
+
+| Method | Path | Notes |
+| --- | --- | --- |
+| `GET` | `/tasks/{taskId}` | Snapshot (`status`, result, errors, pending confirms) |
+| `GET` | `/tasks/{taskId}/wait?timeout_seconds=7200` | Block until terminal (or `awaiting_confirm`) |
+| `POST` | `/tasks/{taskId}/cancel` | Request cancellation |
+
+While the remote agent waits for tool confirmation, the snapshot reports `status: awaiting_confirm` but the stored `TaskStatus` remains `RUNNING` so parent barriers keep waiting.
+
+### Stream events (SSE)
+
+`GET /tasks/{taskId}/events`
+
+Server-Sent Events of agent progress. Requires `agentscope.agent-protocol.streaming-enabled=true` (default).
+
+Reconnect / resume:
+
+- Query param `from_seq` — start after this sequence number
+- Header `Last-Event-ID` — used when `from_seq` is omitted (same meaning)
+
+Each SSE message uses the event seq as `id`, the remote event type as `event`, and a JSON body as `data`.
+
+### Resume after HITL
+
+`POST /tasks/{taskId}/resume`
+
+```json
+{
+  "decisions": [
+    { "toolCallId": "call-1", "approved": true },
+    { "toolCallId": "call-2", "approved": false }
+  ]
+}
+```
+
+`tool_call_id` is also accepted as an alias for `toolCallId`. Requires `agentscope.agent-protocol.hitl-enabled=true` (default). On success returns `{ "task_id", "status": "running" }`.
+
+How remote HITL interacts with a calling parent harness is documented under [Remote authorization](../../docs/harness/subagent.md#remote-authorization).
+
 ## Configuration
 
 | Property | Type | Default | Notes |
 | --- | --- | --- | --- |
 | `agentscope.agent-protocol.enabled` | boolean | `false` | Whether to register the `/tasks` REST endpoints |
+| `agentscope.agent-protocol.streaming-enabled` | boolean | `true` | Expose SSE `GET /tasks/{id}/events` |
+| `agentscope.agent-protocol.hitl-enabled` | boolean | `true` | Pause tasks for tool confirmation and accept `/resume` |
+| `agentscope.agent-protocol.sse-replay-buffer-size` | int | `256` | Per-task replay buffer for late SSE subscribers |
+| `agentscope.agent-protocol.sse-timeout-ms` | long | `10800000` | Max SSE subscription duration (ms) |
 
-> When disabled (the default) the dependency stays inert — no REST endpoints are exposed, safe to ship.
+Example:
+
+```yaml
+agentscope:
+  agent-protocol:
+    enabled: true
+    streaming-enabled: true
+    hitl-enabled: true
+    sse-replay-buffer-size: 256
+    sse-timeout-ms: 10800000
+```
+
+> When `enabled` is `false` (the default) the dependency stays inert — no REST endpoints are exposed, safe to ship.
 
 ## Workspace integration
 

--- a/docs/v2/en/integration/protocol/agui.md
+++ b/docs/v2/en/integration/protocol/agui.md
@@ -79,6 +79,29 @@ The v2 path consumes `AgentEvent`. Built-in converters handle semantic mapping, 
 
 Normal `RUN_STARTED` and `RUN_FINISHED` events are driven by upstream `AgentStartEvent` and `AgentEndEvent`. If a normal stream completes without an upstream `AgentEndEvent`, the adapter does not synthesize `RUN_FINISHED`. On errors, the adapter emits a `RUN_ERROR` with a `timestamp`, then emits a fallback `RUN_FINISHED`.
 
+## Subagent events
+
+By default (`emitSubagentEventsAsNative=false`), AgentEvents with a non-null `source` (child / remote subagent events) are **not** mapped to native `TEXT_MESSAGE_*` / `RUN_*` / tool-call events. They become AG-UI `CUSTOM` events under the `subagent.*` namespace so they do not pollute the parent run lifecycle or text stream:
+
+| CUSTOM `name` | Typical AgentEvent |
+| --- | --- |
+| `subagent.lifecycle` | `AgentStartEvent` / `AgentEndEvent` |
+| `subagent.text` | `TextBlockDeltaEvent` |
+| `subagent.thinking` | `ThinkingBlockDeltaEvent` |
+| `subagent.tool_call` | `ToolCallStartEvent` / `ToolCallEndEvent` |
+| `subagent.tool_result` | `ToolResultEndEvent` |
+| `subagent.require_confirm` | `RequireUserConfirmEvent` |
+
+Each payload includes at least `source` and `type` (plus type-specific fields such as `delta` or `toolCallId`).
+
+To restore the previous behavior where child events used the same native converters as the parent:
+
+```java
+AguiAdapterConfig config = AguiAdapterConfig.builder()
+    .emitSubagentEventsAsNative(true)
+    .build();
+```
+
 ## AG-UI Base Event Properties
 
 Every `AguiEvent` supports the official base event properties: optional `timestamp` and `rawEvent`.

--- a/docs/v2/en/integration/protocol/overview.md
+++ b/docs/v2/en/integration/protocol/overview.md
@@ -13,5 +13,7 @@ AgentScope offers a few protocol adapters to let an Agent talk to the outside wo
 ## Choosing one
 
 - **Stream Agent events to a front-end UI (incl. ThinkingBlock)** → AG-UI
-- **Let other backend systems schedule the Agent over REST** → Agent Protocol
+- **Let other backend systems schedule the Agent over REST / host a remote subagent** → Agent Protocol
 - **Let multiple Agents (yours or third-party) call each other** → A2A
+
+> Layering: AG-UI is user-facing; Agent Protocol is the internal remote-subagent / task HTTP surface; A2A is external interop.

--- a/docs/v2/zh/docs/change-log.md
+++ b/docs/v2/zh/docs/change-log.md
@@ -194,7 +194,7 @@ Python 2.0 的 `agent.reply_stream()` 只返回一种事件流签名（`AsyncGen
 - **类型（软弃用，暂不 `forRemoval`）**
   - `io.agentscope.core.agent.Event`、`EventType`、`EventSource`
   - 这些类目前仍被 harness（子 agent 事件转发：`SubAgentTool` / `SubagentEventBus` / `DefaultAgentManager` / `AgentSpawnTool`）、AGUI、A2A、chat-completions-web、kotlin extension 等内部模块作为事件总线 / 适配器的输入消费。等这些模块完成迁移到 `AgentEvent` 后再翻成 `forRemoval = true`，避免一次性把下游全打成警告
-  - **当前 gap**：`HarnessAgent.streamEvents(...)` 暂时**不转发子 agent 事件** —— `AgentEvent` 体系还没有等价的 `EventSource` 通道；需要子 agent 事件流的场景仍需用 `stream(...)`（已弃用），等通道落地后再统一切换
+  - `HarnessAgent.streamEvents(...)` 会转发子 agent 事件（`source` 非空路径），远程 Agent Protocol 子 agent 在 `remoteStreaming` 开启时同样支持
 
 新代码统一改用：
 
@@ -253,6 +253,7 @@ ReActAgent agent = ReActAgent.builder()
 - 新增 `AgentEventConverter` 与 `AguiEventEnricher` 扩展点：converter 负责语义映射，enricher 负责 `timestamp` / `rawEvent` 等横切属性；Spring Boot starter 会自动收集对应 bean
 - 所有 `AguiEvent` 支持 AG-UI base event properties；默认不启用 `BaseEventPropertiesEnricher`，显式开启后只补缺失 `timestamp`，不默认填 `rawEvent`
 - `AguiAdapterConfig.emitTokenUsage` 可选输出 `CUSTOM token_usage` 事件，包含当前模型调用 delta 与本次 run cumulative token usage
+- **行为变更：** `source != null` 的 AgentEvent（子 agent 事件）默认映射为 AG-UI `CUSTOM`（`subagent.lifecycle` / `subagent.text` / `subagent.thinking` / `subagent.tool_call` / `subagent.tool_result` / `subagent.require_confirm`），不再走原生 `TEXT_MESSAGE_*` / `RUN_*`。设 `emitSubagentEventsAsNative(true)` 可恢复旧的原生映射
 - Spring Boot starter 支持 `AguiRuntimeContextResolver` 和自定义 `AguiAgentAdapterFactory`，并支持 frontend tool injection / merge mode 与 HITL interrupt 输出
 
 详见 → [AG-UI](../integration/protocol/agui.md)

--- a/docs/v2/zh/docs/harness/subagent.md
+++ b/docs/v2/zh/docs/harness/subagent.md
@@ -319,10 +319,30 @@ ChatUiChannel chat = agent.channel(ChatUiChannel.create());  // 恢复能力自�
     .description("远端调研子 agent")
     .url("http://agent-task-server:8080")
     .headers(Map.of("Authorization", "Bearer xxx"))
+    .remoteStreaming(true)          // 未设置时默认 true
+    .remoteAskPolicy(RemoteAskPolicy.DENY)  // 默认
     .build())
 ```
 
 同样支持同步（`timeout_seconds>0`）和后台（`timeout_seconds=0`）。
+
+远程模式专用声明字段：
+
+| 字段 | 默认 | 说明 |
+|------|------|------|
+| `remoteStreaming` | `true`（未设置时） | 父代理使用 `streamEvents()` 时，把远程任务的 SSE 事件转发进父流，并带 `source` 标记 |
+| `remoteAskPolicy` | `DENY` | 如何处理远程工具确认（HITL）请求——见 [远程授权](#远程授权) |
+
+### 远程授权
+
+父代理的 DENY 权限规则会随远程提交的 `context.deny_rules` 一并转发（与本地子 agent 的权限继承一致；可用 `inheritParentPermissions(false)` 关闭）。
+
+远程 agent 因工具确认而暂停（`awaiting_confirm`）时：
+
+- **父代理流式 + `remoteAskPolicy=PROPAGATE`**：向父的 `streamEvents()` 转发带非空 `source` 标记的 `RequireUserConfirmEvent`。通过 Agent Protocol [`POST /tasks/{id}/resume`](../../integration/protocol/agent-protocol.md) 恢复，请求体为 `decisions[{toolCallId, approved}]`。
+- **父代理非流式（`call`）或 `remoteAskPolicy=DENY`（默认）**：自动拒绝待确认项。工具结果中会附注：`remote tool confirmation(s) were auto-denied`。
+
+等待确认期间任务状态保持 `RUNNING`（`awaitingConfirm=true`）。因此 `wait_async_results` 等 barrier 会继续等待，直到任务被 resume 并进入终态。
 
 ## 异步任务的存储位置
 
@@ -431,7 +451,8 @@ public Flux<ServerSentEvent<String>> chat(@RequestParam String message,
 | `streamEvents()` + 同步本地子 agent（`timeout_seconds > 0`） | ✔ |
 | `call()` 模式（非流式） | ✗（子结果以 `tool_result` 字符串返回） |
 | `timeout_seconds = 0` 后台任务 | ✗（终态会通过反向通知给父 agent 下一轮） |
-| 远程子 agent（Agent Protocol） | ✗ |
+| 远程子 agent（Agent Protocol）+ 父 `streamEvents()` + `remoteStreaming=true`（默认） | ✔ |
+| 远程子 agent + 父 `call()` 或 `remoteStreaming=false` | ✗ |
 
 ### 错误处理
 
@@ -443,5 +464,6 @@ public Flux<ServerSentEvent<String>> chat(@RequestParam String message,
 - [工作区](./workspace.md) — `subagents/` 与 `agents/<id>/tasks/` 的目录布局
 - [计划模式](./plan-mode.md) — plan 阶段对子 agent 的限制
 - [架构](./architecture.md) — 主/子 agent 怎么协作
+- [Agent Protocol](../../integration/protocol/agent-protocol.md) — 远程任务端点（SSE + HITL resume）
 - [消息与事件](../building-blocks/message-and-event.md) — `AgentEvent` 体系（推荐）以及已弃用的 `Event` / `EventType` / `StreamOptions`
 - [V1 迁移指南 B.4](../change-log.md) — `stream()` → `streamEvents()` 弃用时间线

--- a/docs/v2/zh/integration/protocol/agent-protocol.md
+++ b/docs/v2/zh/integration/protocol/agent-protocol.md
@@ -7,6 +7,17 @@
 - 想让 Agent 像云函数一样被远程调度。
 - 已有团队在用 Agent Protocol 客户端，想直接接进去。
 - 把 AgentScope Harness Agent 嵌进 Spring Boot 服务，自动暴露 `/tasks` REST 端点。
+- 作为 [远程子 agent](../../docs/harness/subagent.md#远程子-agent) 的托管端，供另一个 Harness 父代理通过 HTTP 调用。
+
+## 协议分层
+
+AgentScope 用不同协议覆盖不同信任边界 / 交互面：
+
+| 层级 | 角色 |
+| --- | --- |
+| **AG-UI** | 面向用户的聊天 UI 事件流（浏览器 ↔ 应用） |
+| **Agent Protocol** | 内部远程子 agent / 任务 HTTP API（父 harness ↔ 远程 agent 服务） |
+| **A2A** | 外部 agent 间互操作（独立扩展；不属于本次远程子 agent 流式 / HITL 改动） |
 
 ## 添加依赖
 
@@ -31,7 +42,7 @@ agentscope:
     enabled: true
 ```
 
-随后会自动注册 `/tasks` 系列 REST 接口（基于 Agent Protocol 规范）。
+随后会自动注册 `/tasks` 系列 REST 接口。
 
 ## 并发执行
 
@@ -49,13 +60,108 @@ public HarnessAgent harnessAgent() {
 
 同一 session 的并发请求会自动串行化；不同 session 完全并行。
 
+## 端点
+
+### 提交任务
+
+`POST /tasks`
+
+```json
+{
+  "task_id": "task_123",
+  "agent_id": "researcher",
+  "input": "Summarize the latest release notes",
+  "context": {
+    "user_id": "u-1",
+    "parent_session_id": "sess-parent",
+    "stream": true,
+    "detail": "full",
+    "deny_rules": [
+      {
+        "tool_name": "bash",
+        "behavior": "DENY",
+        "source": "parent"
+      }
+    ]
+  }
+}
+```
+
+可选 `context` 字段：
+
+| 字段 | 说明 |
+| --- | --- |
+| `user_id` | 写入远程 agent 的 `RuntimeContext` |
+| `parent_session_id` | 父 session 标识（用于关联 / 追踪） |
+| `stream` | 调用方是否打算消费 SSE 事件 |
+| `detail` | `status`（默认）或 `full`——`full` 会在事件流中包含文本 / 思考增量 |
+| `deny_rules` | 父侧 DENY 权限规则，供远程侧执行 |
+
+成功响应：`{ "task_id", "status": "pending" }`。
+
+### 轮询 / 等待 / 取消
+
+| 方法 | 路径 | 说明 |
+| --- | --- | --- |
+| `GET` | `/tasks/{taskId}` | 快照（`status`、结果、错误、待确认项） |
+| `GET` | `/tasks/{taskId}/wait?timeout_seconds=7200` | 阻塞直到终态（或 `awaiting_confirm`） |
+| `POST` | `/tasks/{taskId}/cancel` | 请求取消 |
+
+远程 agent 等待工具确认时，快照会报告 `status: awaiting_confirm`，但存储的 `TaskStatus` 仍为 `RUNNING`，因此父侧 barrier 会继续等待。
+
+### 事件流（SSE）
+
+`GET /tasks/{taskId}/events`
+
+以 Server-Sent Events 推送 agent 进度。需要 `agentscope.agent-protocol.streaming-enabled=true`（默认开启）。
+
+断线重连 / 续订：
+
+- 查询参数 `from_seq` —— 从该序号之后开始
+- 请求头 `Last-Event-ID` —— 未传 `from_seq` 时使用（含义相同）
+
+每条 SSE 消息以事件序号为 `id`、远程事件类型为 `event`、JSON 正文为 `data`。
+
+### HITL 恢复
+
+`POST /tasks/{taskId}/resume`
+
+```json
+{
+  "decisions": [
+    { "toolCallId": "call-1", "approved": true },
+    { "toolCallId": "call-2", "approved": false }
+  ]
+}
+```
+
+`tool_call_id` 也可作为 `toolCallId` 的别名。需要 `agentscope.agent-protocol.hitl-enabled=true`（默认开启）。成功响应：`{ "task_id", "status": "running" }`。
+
+与调用方父 harness 的 HITL 交互见 [远程授权](../../docs/harness/subagent.md#远程授权)。
+
 ## 配置项
 
 | `application.yml` 键 | 类型 | 默认 | 说明 |
 | --- | --- | --- | --- |
 | `agentscope.agent-protocol.enabled` | boolean | `false` | 是否注册 `/tasks` REST 端点 |
+| `agentscope.agent-protocol.streaming-enabled` | boolean | `true` | 是否暴露 SSE `GET /tasks/{id}/events` |
+| `agentscope.agent-protocol.hitl-enabled` | boolean | `true` | 是否因工具确认暂停任务并接受 `/resume` |
+| `agentscope.agent-protocol.sse-replay-buffer-size` | int | `256` | 每个任务的 SSE 回放缓冲区大小 |
+| `agentscope.agent-protocol.sse-timeout-ms` | long | `10800000` | SSE 订阅最长持续时间（毫秒） |
 
-> 关闭时（默认）即使引入依赖也不会暴露任何 REST 接口，可放心打包。
+示例：
+
+```yaml
+agentscope:
+  agent-protocol:
+    enabled: true
+    streaming-enabled: true
+    hitl-enabled: true
+    sse-replay-buffer-size: 256
+    sse-timeout-ms: 10800000
+```
+
+> 关闭 `enabled` 时（默认）即使引入依赖也不会暴露任何 REST 接口，可放心打包。
 
 ## 与 Workspace 配合
 

--- a/docs/v2/zh/integration/protocol/agui.md
+++ b/docs/v2/zh/integration/protocol/agui.md
@@ -79,6 +79,29 @@ v2 正常链路以 `AgentEvent` 为输入，内置 converter 负责语义映射�
 
 正常运行的 `RUN_STARTED` 和 `RUN_FINISHED` 由上游 `AgentStartEvent` / `AgentEndEvent` 决定。正常流结束但上游没有发 `AgentEndEvent` 时，adapter 不会额外补 `RUN_FINISHED`。异常路径会输出带 `timestamp` 的 `RUN_ERROR`，并补发一个 `RUN_FINISHED`。
 
+## 子 agent 事件
+
+默认（`emitSubagentEventsAsNative=false`）下，带非空 `source` 的 AgentEvent（子 / 远程子 agent 事件）**不会**映射为原生的 `TEXT_MESSAGE_*` / `RUN_*` / 工具调用事件，而是变成 `subagent.*` 命名空间下的 AG-UI `CUSTOM` 事件，避免污染父 run 的生命周期与文本流：
+
+| CUSTOM `name` | 典型 AgentEvent |
+| --- | --- |
+| `subagent.lifecycle` | `AgentStartEvent` / `AgentEndEvent` |
+| `subagent.text` | `TextBlockDeltaEvent` |
+| `subagent.thinking` | `ThinkingBlockDeltaEvent` |
+| `subagent.tool_call` | `ToolCallStartEvent` / `ToolCallEndEvent` |
+| `subagent.tool_result` | `ToolResultEndEvent` |
+| `subagent.require_confirm` | `RequireUserConfirmEvent` |
+
+payload 至少包含 `source` 与 `type`（以及 `delta`、`toolCallId` 等类型相关字段）。
+
+若要恢复子事件与父事件使用同一套原生 converter 的旧行为：
+
+```java
+AguiAdapterConfig config = AguiAdapterConfig.builder()
+    .emitSubagentEventsAsNative(true)
+    .build();
+```
+
 ## AG-UI Base Event Properties
 
 所有 `AguiEvent` 都支持官方 base event properties：可选 `timestamp` 和 `rawEvent`。

--- a/docs/v2/zh/integration/protocol/overview.md
+++ b/docs/v2/zh/integration/protocol/overview.md
@@ -13,5 +13,7 @@ AgentScope 在 Java 侧提供了多种"让 Agent 与外部交互"的协议适配
 ## 怎么选
 
 - **想被前端 UI 实时消费 Agent 事件流（含 ThinkingBlock）** → AG-UI
-- **想让其他业务系统通过 REST 调度 Agent** → Agent Protocol
+- **想让其他业务系统通过 REST 调度 Agent / 托管远程子 agent** → Agent Protocol
 - **想让多个 Agent / Agent 与外部 Agent 系统互相调用** → A2A
+
+> 分层：AG-UI 面向用户；Agent Protocol 是内部远程子 agent / 任务 HTTP 面；A2A 用于外部互操作。


### PR DESCRIPTION
## Summary
- Add Agent Protocol SSE event streaming (`GET /tasks/{id}/events`) and HITL resume (`POST /tasks/{id}/resume`) so remote subagents can surface live status and pause for tool confirmation.
- Introduce `RemoteSubagentTransport` + stable wire DTOs; parent `AgentSpawnTool`/`WorkspaceTaskRepository` forward remote events into the parent's `streamEvents` path with `source` tagging, and auto-deny remote ASK when the parent is non-streaming (default `remoteAskPolicy=DENY`).
- AG-UI maps `source != null` child events to `subagent.*` CUSTOM events by default (`emitSubagentEventsAsNative` restores the previous native presentation).

## Test plan
- [ ] `mvn -pl agentscope-harness,agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agent-protocol,agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui -am test -Dtest=RemoteEventCodecTest,SubagentEventConverterTest,AgentProtocolTaskEventBusTest,AgentProtocolControllerTest,AgentProtocolTaskStoreHitlTest,WorkspaceTaskRepositoryRemoteStreamingTest,AgentSpawnToolRemoteHelpersTest -DfailIfNoTests=false`
- [ ] Manual: enable `agentscope.agent-protocol.enabled=true`, spawn a remote sync subagent under parent `streamEvents`, confirm child events arrive with `source` and AG-UI emits `subagent.*` CUSTOM (not extra `RUN_STARTED`)
- [ ] Manual: remote tool ASK → parent receives `RequireUserConfirmEvent` / `awaiting_confirm` → resume with decisions → task completes
- [ ] Manual: parent `call()` (no emitter) + remote ASK → auto-deny and note in tool result; old servers without `/events` fall back to polling