### PR TITLE
fix(tool): validate parsed input when content is absent

### DIFF
--- a/agentscope-core/src/main/java/io/agentscope/core/tool/ToolExecutor.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/tool/ToolExecutor.java
@@ -22,6 +22,7 @@ import io.agentscope.core.model.ExecutionConfig;
 import io.agentscope.core.shutdown.GracefulShutdownManager;
 import io.agentscope.core.tracing.TracerRegistry;
 import io.agentscope.core.util.ExceptionUtils;
+import io.agentscope.core.util.JsonUtils;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -208,7 +209,8 @@ class ToolExecutor {
 
         // Validate input against schema
         String validationError =
-                ToolValidator.validateInput(toolCall.getContent(), tool.getParameters());
+                ToolValidator.validateInput(
+                        JsonUtils.resolveToolCallArgsJson(toolCall), tool.getParameters());
         if (validationError != null) {
             String errorMsg =
                     String.format(

--- a/agentscope-core/src/test/java/io/agentscope/core/tool/ToolExecutorTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/tool/ToolExecutorTest.java
@@ -102,6 +102,21 @@ class ToolExecutorTest {
     }
 
     @Test
+    @DisplayName("Should validate parsed input when raw content is absent")
+    void shouldValidateInputWhenRawContentIsAbsent() {
+        Map<String, Object> input = Map.of("a", 10, "b", 20);
+        ToolUseBlock toolCall =
+                ToolUseBlock.builder().id("call-input-only").name("add").input(input).build();
+
+        ToolResultBlock result =
+                toolkit.callTool(ToolCallParam.builder().toolUseBlock(toolCall).build())
+                        .block(TIMEOUT);
+
+        assertNotNull(result, "Result should not be null");
+        assertEquals("30", extractFirstText(result));
+    }
+
+    @Test
     @DisplayName("Should wrap tool errors inside executor response")
     void shouldReturnErrorWhenToolThrows() {
         Map<String, Object> errorInput = Map.of("message", "test failure");


### PR DESCRIPTION
## Summary

- Validate tool-call arguments through `JsonUtils.resolveToolCallArgsJson`, preserving parsed `input` when raw `content` is absent or invalid.
- Add a regression test for an input-only `add` tool call.

## Testing

- `mvn -pl agentscope-core test` (2246 tests, 0 failures, 9 skipped)
- `mvn test` progressed through the completed modules successfully, then was blocked by Maven Central DNS failure while resolving `junit-platform-launcher:6.0.1` for `agentscope-spring-boot-starter`.

Related to #2337.