### PR TITLE
fix(harness): gate memory prompt guidance on disable flags

### DIFF
--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/HarnessAgent.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/HarnessAgent.java
@@ -1952,11 +1952,22 @@ public class HarnessAgent implements Agent, AutoCloseable {
             return this;
         }
 
+        /**
+         * Skips registration of {@code memory_search} / {@code memory_get} / {@code memory_save} /
+         * {@code session_search}, and omits matching Memory Recall / tool-based Persistence
+         * guidance from the workspace system prompt.
+         */
         public Builder disableMemoryTools() {
             this.disableMemoryTools = true;
             return this;
         }
 
+        /**
+         * Disables memory flush + background consolidation, and removes the "automatically
+         * extracted" Persistence line from the workspace system prompt. Combined with {@link
+         * #disableMemoryTools()}, also skips {@code MEMORY.md} injection into
+         * {@code <memory_context>}.
+         */
         public Builder disableMemoryHooks() {
             this.disableMemoryHooks = true;
             return this;
@@ -2218,7 +2229,9 @@ public class HarnessAgent implements Agent, AutoCloseable {
                                 wsManager,
                                 name != null ? name : "ReActAgent",
                                 environmentMemory,
-                                maxContextTokens);
+                                maxContextTokens,
+                                disableMemoryTools,
+                                disableMemoryHooks);
                 markdownMw.setAdditionalContextFiles(additionalContextFiles);
                 inner.middleware(markdownMw);
             }

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/middleware/WorkspaceContextMiddleware.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/middleware/WorkspaceContextMiddleware.java
@@ -40,6 +40,11 @@ import reactor.core.publisher.Mono;
  *
  * <p>Runs once per {@code call()} (just like the previous {@code WorkspaceContextHook}
  * fired on {@code PreCallEvent}).
+ *
+ * <p>Memory-related guidance and {@code <memory_context>} injection are gated by the same
+ * builder flags as Harness memory tools/hooks ({@code disableMemoryTools} /
+ * {@code disableMemoryHooks}) so the model is not instructed to use capabilities that are
+ * turned off.
  */
 public class WorkspaceContextMiddleware implements HarnessRuntimeMiddleware {
 
@@ -54,37 +59,70 @@ public class WorkspaceContextMiddleware implements HarnessRuntimeMiddleware {
             %s
             """;
 
-    private static final String GUIDANCE_TEMPLATE =
+    private static final String DOMAIN_KNOWLEDGE_GUIDANCE =
             """
             ## Domain Knowledge
             The workspace `knowledge/` tree holds many detailed reference documents (not only a single summary file). When the task needs specs, procedures, schemas, or domain facts, treat that directory as the source of truth.
             Below, `<domain_knowledge_context>` already includes what you need to navigate it: injected `knowledge/KNOWLEDGE.md` (if present) plus a **full list of knowledge file paths** under `knowledge/` — use that as the catalog of what exists and where.
             For content not inlined here, open only the paths you need with read_file, grep, or glob (prefer targeted reads over loading entire trees into the reply).
+            """;
 
+    private static final String MEMORY_RECALL_GUIDANCE =
+            """
             ## Memory Recall
             Before answering questions about prior work, decisions, dates, people, or preferences: \
             run memory_search on MEMORY.md + memory/*.md, then memory_get for needed lines. \
             Include Source: <path#line> citations when helpful.
+            """;
 
+    private static final String MEMORY_PERSISTENCE_HEADER =
+            """
             ## Memory Persistence
             You have a persistent MEMORY.md. Update it proactively when:
             - User shares preferences, project context, or decisions
             - Important outcomes or action items are established
-            Use the **memory_save** tool to persist memories — it atomically updates \
-            both MEMORY.md and the daily ledger. Do NOT use write_file or edit_file on \
-            MEMORY.md or any path under memory/ — always use memory_save instead. \
-            Memory is also automatically extracted at conversation end.
             """;
 
-    private static final String WORKSPACE_FILES_NOTICE =
+    private static final String MEMORY_PERSISTENCE_HEADER_HOOKS_ONLY =
+            """
+            ## Memory Persistence
+            You have a persistent MEMORY.md that the harness maintains automatically.
+            """;
+
+    private static final String MEMORY_SAVE_TOOL_GUIDANCE =
+            """
+            Use the **memory_save** tool to persist memories — it atomically updates \
+            both MEMORY.md and the daily ledger. Do NOT use write_file or edit_file on \
+            MEMORY.md or any path under memory/ — always use memory_save instead.
+            """;
+
+    private static final String MEMORY_WRITE_FILE_GUARD =
+            """
+            Do NOT use write_file or edit_file on MEMORY.md or any path under memory/ — \
+            the harness owns those files.
+            """;
+
+    private static final String MEMORY_AUTO_EXTRACT_GUIDANCE =
+            "Memory is also automatically extracted at conversation end.\n";
+
+    private static final String WORKSPACE_FILES_NOTICE_WITH_MEMORY =
             """
             ## Workspace Files (Injected)
             The following <loaded_context> was loaded in from files in your workspace.
             These files (for example, `AGENTS.md`, `MEMORY.md`, and `knowledge/KNOWLEDGE.md`) contain memory, facts, preferences, guidelines, and user-specific details learned from prior interactions with user.
             """;
 
-    private static final String TRUNCATION_NOTICE =
+    private static final String WORKSPACE_FILES_NOTICE_WITHOUT_MEMORY =
+            """
+            ## Workspace Files (Injected)
+            The following <loaded_context> was loaded in from files in your workspace.
+            These files (for example, `AGENTS.md` and `knowledge/KNOWLEDGE.md`) contain guidelines and domain context for this agent.
+            """;
+
+    private static final String TRUNCATION_NOTICE_WITH_SEARCH =
             "\n\n... (memory truncated — use memory_search for older entries) ...\n";
+
+    private static final String TRUNCATION_NOTICE_PLAIN = "\n\n... (memory truncated) ...\n";
 
     private static final int DEFAULT_MAX_CONTEXT_TOKENS = 8000;
 
@@ -92,14 +130,16 @@ public class WorkspaceContextMiddleware implements HarnessRuntimeMiddleware {
     private final String agentName;
     private final String environmentMemory;
     private final int maxContextTokens;
+    private final boolean disableMemoryTools;
+    private final boolean disableMemoryHooks;
     private List<String> additionalContextFiles = List.of();
 
     public WorkspaceContextMiddleware(WorkspaceManager workspaceManager) {
-        this(workspaceManager, "HarnessAgent", null, DEFAULT_MAX_CONTEXT_TOKENS);
+        this(workspaceManager, "HarnessAgent", null, DEFAULT_MAX_CONTEXT_TOKENS, false, false);
     }
 
     public WorkspaceContextMiddleware(WorkspaceManager workspaceManager, int maxContextTokens) {
-        this(workspaceManager, "HarnessAgent", null, maxContextTokens);
+        this(workspaceManager, "HarnessAgent", null, maxContextTokens, false, false);
     }
 
     public WorkspaceContextMiddleware(
@@ -107,14 +147,36 @@ public class WorkspaceContextMiddleware implements HarnessRuntimeMiddleware {
             String agentName,
             String environmentMemory,
             int maxContextTokens) {
+        this(workspaceManager, agentName, environmentMemory, maxContextTokens, false, false);
+    }
+
+    public WorkspaceContextMiddleware(
+            WorkspaceManager workspaceManager,
+            String agentName,
+            String environmentMemory,
+            int maxContextTokens,
+            boolean disableMemoryTools,
+            boolean disableMemoryHooks) {
         this.workspaceManager = workspaceManager;
         this.agentName = agentName != null && !agentName.isBlank() ? agentName : "HarnessAgent";
         this.environmentMemory = environmentMemory;
         this.maxContextTokens = maxContextTokens;
+        this.disableMemoryTools = disableMemoryTools;
+        this.disableMemoryHooks = disableMemoryHooks;
     }
 
     public void setAdditionalContextFiles(List<String> files) {
         this.additionalContextFiles = files != null ? files : List.of();
+    }
+
+    /** Whether memory tools are disabled for this middleware (affects prompt guidance). */
+    public boolean isDisableMemoryTools() {
+        return disableMemoryTools;
+    }
+
+    /** Whether memory hooks are disabled for this middleware (affects prompt guidance). */
+    public boolean isDisableMemoryHooks() {
+        return disableMemoryHooks;
     }
 
     @Override
@@ -131,7 +193,9 @@ public class WorkspaceContextMiddleware implements HarnessRuntimeMiddleware {
 
     private String buildWorkspaceSection(RuntimeContext rc) {
         String agentsContent = workspaceManager.readAgentsMd(rc).strip();
-        String memoryContent = workspaceManager.readMemoryMd(rc).strip();
+        boolean includeMemoryContext = includeMemoryContext();
+        String memoryContent =
+                includeMemoryContext ? workspaceManager.readMemoryMd(rc).strip() : "";
         String knowledgeContent = workspaceManager.readKnowledgeMd(rc).strip();
         Path workspace = workspaceManager.getWorkspace();
         String sessionContext = buildSessionContextSection(workspace, rc);
@@ -144,19 +208,59 @@ public class WorkspaceContextMiddleware implements HarnessRuntimeMiddleware {
                         + estimateTokens(agentsContent)
                         + estimateTokens(knowledgeBlock)
                         + estimateTokens(additionalBlock);
-        int memoryTokens = estimateTokens(memoryContent);
-        int available = maxContextTokens - fixedTokens;
-        if (available > 0 && memoryTokens > available) {
-            memoryContent = truncateToTokenBudget(memoryContent, available);
+        if (includeMemoryContext) {
+            int memoryTokens = estimateTokens(memoryContent);
+            int available = maxContextTokens - fixedTokens;
+            if (available > 0 && memoryTokens > available) {
+                memoryContent = truncateToTokenBudget(memoryContent, available);
+            }
         }
 
         String workspaceParagraph =
                 buildWorkspaceParagraph(workspace, workspaceManager.getFilesystem());
         String loadedContext =
                 buildLoadedContextSection(
-                        agentsContent, memoryContent, knowledgeBlock, additionalBlock, rc);
-        return assembleSection(
-                sessionContext, GUIDANCE_TEMPLATE, workspaceParagraph, loadedContext);
+                        agentsContent, memoryContent, knowledgeBlock, additionalBlock);
+        return assembleSection(sessionContext, buildGuidance(), workspaceParagraph, loadedContext);
+    }
+
+    /**
+     * Inject {@code MEMORY.md} unless both memory tools and hooks are disabled — at that point
+     * the harness memory surface is fully off and the file should not appear as model context.
+     */
+    private boolean includeMemoryContext() {
+        return !(disableMemoryTools && disableMemoryHooks);
+    }
+
+    private String buildGuidance() {
+        StringBuilder sb = new StringBuilder();
+        sb.append(DOMAIN_KNOWLEDGE_GUIDANCE.strip()).append("\n\n");
+        if (!disableMemoryTools) {
+            sb.append(MEMORY_RECALL_GUIDANCE.strip()).append("\n\n");
+        }
+        String persistence = buildMemoryPersistenceGuidance();
+        if (!persistence.isBlank()) {
+            sb.append(persistence.strip()).append("\n\n");
+        }
+        return sb.toString().stripTrailing() + "\n";
+    }
+
+    private String buildMemoryPersistenceGuidance() {
+        if (disableMemoryTools && disableMemoryHooks) {
+            return "";
+        }
+        StringBuilder sb = new StringBuilder();
+        if (!disableMemoryTools) {
+            sb.append(MEMORY_PERSISTENCE_HEADER.strip()).append("\n");
+            sb.append(MEMORY_SAVE_TOOL_GUIDANCE.strip()).append("\n");
+        } else {
+            sb.append(MEMORY_PERSISTENCE_HEADER_HOOKS_ONLY.strip()).append("\n");
+            sb.append(MEMORY_WRITE_FILE_GUARD.strip()).append("\n");
+        }
+        if (!disableMemoryHooks) {
+            sb.append(MEMORY_AUTO_EXTRACT_GUIDANCE.strip()).append("\n");
+        }
+        return sb.toString();
     }
 
     private static String assembleSection(
@@ -172,7 +276,7 @@ public class WorkspaceContextMiddleware implements HarnessRuntimeMiddleware {
         if (!workspaceParagraph.isEmpty()) {
             sb.append("\n").append(workspaceParagraph);
         }
-        sb.append("\n").append(WORKSPACE_FILES_NOTICE).append("\n").append(loadedContextSection);
+        sb.append("\n").append(loadedContextSection);
         return sb.toString();
     }
 
@@ -343,18 +447,27 @@ public class WorkspaceContextMiddleware implements HarnessRuntimeMiddleware {
             String agentsContent,
             String memoryContent,
             String knowledgeBlock,
-            String additionalBlock,
-            RuntimeContext rc) {
+            String additionalBlock) {
         StringBuilder sb = new StringBuilder();
+        sb.append(workspaceFilesNotice());
+        sb.append("\n");
         sb.append("<loaded_context>\n");
         sb.append(buildXmlContext("agents_context", agentsContent));
-        sb.append(buildXmlContext("memory_context", memoryContent));
+        if (includeMemoryContext()) {
+            sb.append(buildXmlContext("memory_context", memoryContent));
+        }
         sb.append(buildXmlContext("domain_knowledge_context", knowledgeBlock));
         if (!additionalBlock.isBlank()) {
             sb.append(additionalBlock);
         }
         sb.append("</loaded_context>\n");
         return sb.toString();
+    }
+
+    private String workspaceFilesNotice() {
+        return includeMemoryContext()
+                ? WORKSPACE_FILES_NOTICE_WITH_MEMORY
+                : WORKSPACE_FILES_NOTICE_WITHOUT_MEMORY;
     }
 
     private static String buildXmlContext(String tagName, String content) {
@@ -389,12 +502,14 @@ public class WorkspaceContextMiddleware implements HarnessRuntimeMiddleware {
         return text == null || text.isEmpty() ? 0 : text.length() / 4;
     }
 
-    private static String truncateToTokenBudget(String text, int maxTokens) {
+    private String truncateToTokenBudget(String text, int maxTokens) {
         int maxChars = maxTokens * 4;
         if (text.length() <= maxChars) {
             return text;
         }
-        return text.substring(0, maxChars) + TRUNCATION_NOTICE;
+        String notice =
+                disableMemoryTools ? TRUNCATION_NOTICE_PLAIN : TRUNCATION_NOTICE_WITH_SEARCH;
+        return text.substring(0, maxChars) + notice;
     }
 
     private String buildKnowledgeBlock(RuntimeContext rc, String knowledgeContent, Path workspace) {

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/HarnessAgentTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/HarnessAgentTest.java
@@ -55,6 +55,7 @@ import io.agentscope.harness.agent.filesystem.spec.RemoteFilesystemSpec;
 import io.agentscope.harness.agent.memory.compaction.CompactionConfig;
 import io.agentscope.harness.agent.middleware.AgentTraceMiddleware;
 import io.agentscope.harness.agent.middleware.SubagentEntry;
+import io.agentscope.harness.agent.middleware.WorkspaceContextMiddleware;
 import io.agentscope.harness.agent.sandbox.SandboxContext;
 import io.agentscope.harness.agent.subagent.AgentSpecLoader;
 import io.agentscope.harness.agent.subagent.SubagentDeclaration;
@@ -146,6 +147,37 @@ class HarnessAgentTest {
         assertFalse(toolNames.contains("memory_search"));
         assertFalse(toolNames.contains("memory_get"));
         assertFalse(toolNames.contains("session_search"));
+    }
+
+    @Test
+    void disableMemoryToolsAndHooks_omitMemoryGuidanceFromSystemPrompt() throws Exception {
+        Files.createDirectories(workspace);
+        Files.writeString(workspace.resolve("MEMORY.md"), "secret memory marker xyz");
+        Model model = stubModel("ok");
+        HarnessAgent agent =
+                HarnessAgent.builder()
+                        .name("t")
+                        .model(model)
+                        .workspace(workspace)
+                        .abstractFilesystem(new LocalFilesystem(workspace))
+                        .disableMemoryTools()
+                        .disableMemoryHooks()
+                        .build();
+
+        WorkspaceContextMiddleware mw =
+                agent.getDelegate().getMiddlewares().stream()
+                        .filter(WorkspaceContextMiddleware.class::isInstance)
+                        .map(WorkspaceContextMiddleware.class::cast)
+                        .findFirst()
+                        .orElseThrow();
+        String prompt = mw.onSystemPrompt(null, RuntimeContext.empty(), "BASE\n").block();
+        assertNotNull(prompt);
+        assertFalse(prompt.contains("## Memory Recall"));
+        assertFalse(prompt.contains("## Memory Persistence"));
+        assertFalse(prompt.contains("<memory_context>"));
+        assertFalse(prompt.contains("secret memory marker xyz"));
+        assertTrue(mw.isDisableMemoryTools());
+        assertTrue(mw.isDisableMemoryHooks());
     }
 
     @Test

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/middleware/WorkspaceContextMiddlewareMemoryPromptTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/middleware/WorkspaceContextMiddlewareMemoryPromptTest.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.harness.agent.middleware;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.agentscope.core.agent.RuntimeContext;
+import io.agentscope.harness.agent.workspace.WorkspaceManager;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Ensures Memory Recall / Persistence guidance and {@code <memory_context>} stay aligned with
+ * {@code disableMemoryTools} / {@code disableMemoryHooks}.
+ */
+class WorkspaceContextMiddlewareMemoryPromptTest {
+
+    private final List<WorkspaceManager> openManagers = new ArrayList<>();
+
+    @AfterEach
+    void closeOpenManagers() {
+        for (WorkspaceManager wm : openManagers) {
+            wm.close();
+        }
+        openManagers.clear();
+    }
+
+    private WorkspaceManager track(WorkspaceManager wm) {
+        openManagers.add(wm);
+        return wm;
+    }
+
+    @TempDir Path workspace;
+
+    @Test
+    void defaultFlags_includeMemoryRecallPersistenceAndContext() throws Exception {
+        Files.writeString(workspace.resolve("MEMORY.md"), "remember: cats prefer windowsills");
+        WorkspaceManager wm = track(new WorkspaceManager(workspace));
+        WorkspaceContextMiddleware mw = new WorkspaceContextMiddleware(wm);
+
+        String prompt = mw.onSystemPrompt(null, RuntimeContext.empty(), "BASE\n").block();
+        assertNotNull(prompt);
+        assertTrue(prompt.contains("## Domain Knowledge"));
+        assertTrue(prompt.contains("## Memory Recall"));
+        assertTrue(prompt.contains("memory_search"));
+        assertTrue(prompt.contains("## Memory Persistence"));
+        assertTrue(prompt.contains("memory_save"));
+        assertTrue(prompt.contains("automatically extracted"));
+        assertTrue(prompt.contains("<memory_context>"));
+        assertTrue(prompt.contains("cats prefer windowsills"));
+    }
+
+    @Test
+    void disableMemoryTools_omitsToolGuidance_keepsMemoryContextAndAutoExtract() throws Exception {
+        Files.writeString(workspace.resolve("MEMORY.md"), "prefer dark mode");
+        WorkspaceManager wm = track(new WorkspaceManager(workspace));
+        WorkspaceContextMiddleware mw =
+                new WorkspaceContextMiddleware(wm, "agent", null, 8000, true, false);
+
+        String prompt = mw.onSystemPrompt(null, RuntimeContext.empty(), "BASE\n").block();
+        assertNotNull(prompt);
+        assertTrue(prompt.contains("## Domain Knowledge"));
+        assertFalse(prompt.contains("## Memory Recall"));
+        assertFalse(prompt.contains("memory_search"));
+        assertFalse(prompt.contains("memory_get"));
+        assertFalse(prompt.contains("memory_save"));
+        assertTrue(prompt.contains("## Memory Persistence"));
+        assertTrue(prompt.contains("automatically extracted"));
+        assertTrue(prompt.contains("<memory_context>"));
+        assertTrue(prompt.contains("prefer dark mode"));
+    }
+
+    @Test
+    void disableMemoryHooks_keepsTools_omitsAutoExtract() throws Exception {
+        Files.writeString(workspace.resolve("MEMORY.md"), "prefer dark mode");
+        WorkspaceManager wm = track(new WorkspaceManager(workspace));
+        WorkspaceContextMiddleware mw =
+                new WorkspaceContextMiddleware(wm, "agent", null, 8000, false, true);
+
+        String prompt = mw.onSystemPrompt(null, RuntimeContext.empty(), "BASE\n").block();
+        assertNotNull(prompt);
+        assertTrue(prompt.contains("## Memory Recall"));
+        assertTrue(prompt.contains("memory_save"));
+        assertFalse(prompt.contains("automatically extracted"));
+        assertTrue(prompt.contains("<memory_context>"));
+    }
+
+    @Test
+    void bothDisabled_omitsMemoryGuidanceAndMemoryContext() throws Exception {
+        Files.writeString(workspace.resolve("MEMORY.md"), "should not appear in prompt");
+        WorkspaceManager wm = track(new WorkspaceManager(workspace));
+        WorkspaceContextMiddleware mw =
+                new WorkspaceContextMiddleware(wm, "agent", null, 8000, true, true);
+
+        String prompt = mw.onSystemPrompt(null, RuntimeContext.empty(), "BASE\n").block();
+        assertNotNull(prompt);
+        assertTrue(prompt.contains("## Domain Knowledge"));
+        assertFalse(prompt.contains("## Memory Recall"));
+        assertFalse(prompt.contains("## Memory Persistence"));
+        assertFalse(prompt.contains("memory_search"));
+        assertFalse(prompt.contains("memory_save"));
+        assertFalse(prompt.contains("automatically extracted"));
+        assertFalse(prompt.contains("<memory_context>"));
+        assertFalse(prompt.contains("should not appear in prompt"));
+        assertTrue(prompt.contains("<agents_context>"));
+        assertTrue(prompt.contains("<domain_knowledge_context>"));
+    }
+}

--- a/docs/v2/en/docs/harness/memory.md
+++ b/docs/v2/en/docs/harness/memory.md
@@ -251,12 +251,15 @@ If you want to handle memory yourself or wire your own tools:
 ```java
 HarnessAgent.builder()
     ...
-    .disableMemoryHooks()      // disables flush + background maintenance
-    .disableMemoryTools()      // skips memory_search / memory_get / session_search registration
+    .disableMemoryHooks()      // disables flush + background maintenance (+ auto-extract prompt line)
+    .disableMemoryTools()      // skips memory_search / memory_get / memory_save / session_search
+                               // and matching Memory Recall / tool Persistence guidance
     .build();
 ```
 
-`disableMemoryHooks()` is the nuclear option; if you only want to throttle, use `.memory(MemoryConfig.builder().flushTrigger(...).build())` instead.
+Together these also skip `<memory_context>` (`MEMORY.md`) injection while keeping Domain Knowledge / AGENTS / knowledge context.
+
+`disableMemoryHooks()` is the nuclear option for background memory work; if you only want to throttle, use `.memory(MemoryConfig.builder().flushTrigger(...).build())` instead.
 
 ## Related Pages
 

--- a/docs/v2/en/docs/harness/workspace.md
+++ b/docs/v2/en/docs/harness/workspace.md
@@ -161,8 +161,8 @@ Opt-out switches (rare in production, useful for debugging or self-management):
 | Method | What it disables |
 |--------|------------------|
 | `disableWorkspaceContext()` | system-prompt injection (`AGENTS.md` / `MEMORY.md` / `knowledge/`) |
-| `disableMemoryHooks()` | memory flush + background maintenance |
-| `disableMemoryTools()` | `memory_search` / `memory_get` / `session_search` tools |
+| `disableMemoryHooks()` | memory flush + background maintenance; also drops the "automatically extracted" Persistence line from the system prompt. Combined with `disableMemoryTools()`, also skips `<memory_context>` (`MEMORY.md`) injection |
+| `disableMemoryTools()` | `memory_search` / `memory_get` / `memory_save` / `session_search` tools; also omits Memory Recall and tool-based Persistence guidance from the system prompt |
 | `disableSubagents()` | the entire subagent subsystem |
 | `disableDynamicSkills()` | per-turn skill re-merge; falls back to one-shot merge at build time |
 | `disableToolsConfig()` | reading `tools.json` |
@@ -179,11 +179,11 @@ Before every reasoning step, `WorkspaceContextMiddleware` (`io.agentscope.harnes
 | Section | Source | Budgeted |
 |---------|--------|----------|
 | `## Session Context` | Template (today's date, OS, workspace absolute path, temp dir, current `sessionId`) | no |
-| `## Domain Knowledge` / `## Memory Recall` / `## Memory Persistence` guidance | Built-in templates (teach the model how to use memory + navigate knowledge) | no |
+| `## Domain Knowledge` / `## Memory Recall` / `## Memory Persistence` guidance | Built-in templates (teach the model how to use memory + navigate knowledge). Memory sections are omitted / trimmed when `disableMemoryTools()` / `disableMemoryHooks()` are set | no |
 | `## Workspace` section | Template, **branches per filesystem mode** (see below) — tells the model whether it runs locally / sandboxed / on a remote store | no |
 | `## Workspace Files (Injected)` notice | Framework auto-loads the following files from the workspace into a `<loaded_context>` XML block | see below |
 | `<agents_context>` | Full `AGENTS.md` | unlimited |
-| `<memory_context>` | `MEMORY.md`, char-truncated when over the remaining budget with a "use memory_search for older entries" note | `maxContextTokens`, default 8000 |
+| `<memory_context>` | `MEMORY.md`, char-truncated when over the remaining budget with a "use memory_search for older entries" note (plain truncate note when tools are disabled; omitted entirely when both memory tools and hooks are disabled) | `maxContextTokens`, default 8000 |
 | `<domain_knowledge_context>` | Full `knowledge/KNOWLEDGE.md` + listing of every file under `knowledge/` | unlimited (filenames only as the catalog) |
 | `<x_md>` / `<y_md>` | Anything you added with `additionalContextFile("X.md")` | unlimited |
 

--- a/docs/v2/zh/docs/harness/memory.md
+++ b/docs/v2/zh/docs/harness/memory.md
@@ -251,10 +251,13 @@ HarnessAgent.builder()
 ```java
 HarnessAgent.builder()
     ...
-    .disableMemoryHooks()      // 关掉 flush + 后台维护
-    .disableMemoryTools()      // 不注册 memory_search / memory_get / session_search
+    .disableMemoryHooks()      // 关掉 flush + 后台维护（并去掉「对话结束自动抽取」引导）
+    .disableMemoryTools()      // 不注册 memory_search / memory_get / memory_save / session_search
+                               // 同时去掉对应的 Memory Recall / 工具 Persistence 引导
     .build();
 ```
+
+两者一起用时，还会跳过 `<memory_context>`（`MEMORY.md`）注入，但保留 Domain Knowledge / AGENTS / knowledge 上下文。
 
 `disableMemoryHooks()` 是核选项；只想节流不想关，用 `.memory(MemoryConfig.builder().flushTrigger(...).build())`。
 

--- a/docs/v2/zh/docs/harness/workspace.md
+++ b/docs/v2/zh/docs/harness/workspace.md
@@ -158,8 +158,8 @@ env:
 | 方法 | 关掉的是 |
 |------|---------|
 | `disableWorkspaceContext()` | system prompt 注入（`AGENTS.md` / `MEMORY.md` / `knowledge/`） |
-| `disableMemoryHooks()` | 记忆 flush + 后台维护 |
-| `disableMemoryTools()` | `memory_search` / `memory_get` / `session_search` 工具 |
+| `disableMemoryHooks()` | 记忆 flush + 后台维护；同时去掉 Persistence 段里「对话结束自动抽取」的文案。与 `disableMemoryTools()` 一起用时，也不再注入 `<memory_context>`（`MEMORY.md`） |
+| `disableMemoryTools()` | `memory_search` / `memory_get` / `memory_save` / `session_search` 工具；同时去掉 Memory Recall 与依赖这些工具的 Persistence 引导 |
 | `disableSubagents()` | 整个子 agent 子系统 |
 | `disableDynamicSkills()` | 每轮重新合并技能；改成 build 时一次 |
 | `disableToolsConfig()` | 不读 `tools.json` |
@@ -176,11 +176,11 @@ env:
 | 段落 | 来源 | 受预算约束 |
 |------|------|-----------|
 | `## Session Context` | 模板生成（日期、操作系统、workspace 绝对路径、临时目录、当前 `sessionId`） | 否 |
-| `## Domain Knowledge` / `## Memory Recall` / `## Memory Persistence` 引导段 | 内置模板（教模型怎么用记忆 + 怎么查 knowledge） | 否 |
+| `## Domain Knowledge` / `## Memory Recall` / `## Memory Persistence` 引导段 | 内置模板（教模型怎么用记忆 + 怎么查 knowledge）。Memory 相关段会随 `disableMemoryTools()` / `disableMemoryHooks()` 裁剪或整段省略 | 否 |
 | `## Workspace` 段 | 模板生成，**按 filesystem 模式分支**（详见下面）—— 告诉模型自己跑在本机 / 沙箱 / 远端 | 否 |
 | `## Workspace Files (Injected)` 段 | 框架自动从工作区把以下文件拉成 `<loaded_context>` XML 块注入 | 见下 |
 | `<agents_context>` | `AGENTS.md` 全文 | 无限 |
-| `<memory_context>` | `MEMORY.md`（剩余预算下，超出按字符截断 + 提示「用 memory_search 查更早」） | `maxContextTokens` 默认 8000 |
+| `<memory_context>` | `MEMORY.md`（剩余预算下，超出按字符截断 + 提示「用 memory_search 查更早」；关 tools 时只硬截断不提工具；tools + hooks 都关时整段不注入） | `maxContextTokens` 默认 8000 |
 | `<domain_knowledge_context>` | `knowledge/KNOWLEDGE.md` 全文 + `knowledge/` 下所有文件路径列表 | 无限（仅文件名做索引） |
 | `<x_md>` / `<y_md>` | 你 `additionalContextFile("X.md")` 添加的任意文件 | 无限 |
 


### PR DESCRIPTION
## Summary
- Wire `disableMemoryTools` / `disableMemoryHooks` into `WorkspaceContextMiddleware` so Memory Recall / Persistence guidance matches registered capabilities
- When both are disabled, also skip `<memory_context>` (`MEMORY.md`) injection while keeping Domain Knowledge / AGENTS / knowledge
- Document the prompt-side effects in en/zh harness workspace + memory docs; add unit and HarnessAgent coverage

## Test plan
- [x] `mvn -pl agentscope-harness -am test -Dtest=WorkspaceContextMiddlewareMemoryPromptTest,WorkspaceContextMiddlewarePathBoundsTest,HarnessAgentTest#disableMemoryTools_omitsHarnessMemoryAndSessionTools+disableMemoryToolsAndHooks_omitMemoryGuidanceFromSystemPrompt`
- [ ] Confirm a HarnessAgent built with both disable flags no longer shows Memory Recall/Persistence in the assembled system prompt
- [ ] Confirm tools-only disable still injects `MEMORY.md` but omits `memory_search` / `memory_save` guidance