### PR TITLE
fix(harness): hide host offload path from sandbox agents

### DIFF
--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/memory/MemoryFlushManager.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/memory/MemoryFlushManager.java
@@ -24,6 +24,7 @@ import io.agentscope.core.message.ToolResultBlock;
 import io.agentscope.core.message.ToolUseBlock;
 import io.agentscope.core.model.Model;
 import io.agentscope.core.util.JsonUtils;
+import io.agentscope.harness.agent.filesystem.sandbox.AbstractSandboxFilesystem;
 import io.agentscope.harness.agent.memory.compaction.ConversationCompactor;
 import io.agentscope.harness.agent.memory.session.SessionTranscriptWriter;
 import io.agentscope.harness.agent.workspace.WorkspaceConstants;
@@ -192,6 +193,11 @@ public class MemoryFlushManager {
      */
     @Deprecated
     public String resolveOffloadPath(RuntimeContext rc, String agentId, String sessionId) {
+        // Session archives are persisted in the host-side workspace. A sandboxed agent cannot
+        // resolve that path, so do not advertise it as agent-readable in the summary prompt.
+        if (workspaceManager.getFilesystem() instanceof AbstractSandboxFilesystem) {
+            return "";
+        }
         return new SessionTranscriptWriter(workspaceManager)
                 .resolveContextPath(rc, agentId, sessionId);
     }

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/memory/session/SessionTranscriptWriter.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/memory/session/SessionTranscriptWriter.java
@@ -25,6 +25,7 @@ import io.agentscope.core.message.ThinkingBlock;
 import io.agentscope.core.message.ToolResultBlock;
 import io.agentscope.core.message.ToolUseBlock;
 import io.agentscope.core.util.JsonUtils;
+import io.agentscope.harness.agent.filesystem.sandbox.AbstractSandboxFilesystem;
 import io.agentscope.harness.agent.transcript.TranscriptRef;
 import io.agentscope.harness.agent.transcript.TranscriptStore;
 import io.agentscope.harness.agent.workspace.WorkspaceConstants;
@@ -162,8 +163,18 @@ public class SessionTranscriptWriter {
     /**
      * Resolves the workspace-relative path of the session context JSONL (for compaction
      * summary references).
+     *
+     * <p>Returns an empty string for sandbox-backed filesystems: session archives live in the
+     * host-side workspace, which a sandboxed agent cannot resolve, so the path must not be
+     * advertised as agent-readable in the summary prompt. This mirrors the guard in {@link
+     * io.agentscope.harness.agent.memory.MemoryFlushManager#resolveOffloadPath}.
      */
     public String resolveContextPath(RuntimeContext rc, String agentId, String sessionId) {
+        // Session archives are persisted in the host-side workspace. A sandboxed agent cannot
+        // resolve that path, so do not advertise it as agent-readable in the summary prompt.
+        if (workspaceManager.getFilesystem() instanceof AbstractSandboxFilesystem) {
+            return "";
+        }
         try {
             Path file = workspaceManager.resolveSessionContextFile(rc, agentId, sessionId);
             Path ws = workspaceManager.getWorkspace();

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/memory/MemoryFlushManagerOffloadTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/memory/MemoryFlushManagerOffloadTest.java
@@ -16,11 +16,13 @@
 package io.agentscope.harness.agent.memory;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
 
 import io.agentscope.core.agent.RuntimeContext;
 import io.agentscope.core.message.Msg;
 import io.agentscope.core.message.MsgRole;
 import io.agentscope.core.message.TextBlock;
+import io.agentscope.harness.agent.filesystem.sandbox.AbstractSandboxFilesystem;
 import io.agentscope.harness.agent.memory.compaction.ConversationCompactor;
 import io.agentscope.harness.agent.memory.session.SessionEntry;
 import io.agentscope.harness.agent.memory.session.SessionTree;
@@ -35,6 +37,31 @@ import org.junit.jupiter.api.io.TempDir;
 class MemoryFlushManagerOffloadTest {
 
     @TempDir Path workspace;
+
+    @Test
+    void resolveOffloadPath_omitsHostPathForSandboxFilesystem() {
+        AbstractSandboxFilesystem filesystem = mock(AbstractSandboxFilesystem.class);
+        try (WorkspaceManager workspaceManager = new WorkspaceManager(workspace, filesystem)) {
+            MemoryFlushManager flushManager = new MemoryFlushManager(workspaceManager, null);
+
+            assertEquals(
+                    "",
+                    flushManager.resolveOffloadPath(
+                            RuntimeContext.empty(), "agent-a", "session-1"));
+        }
+    }
+
+    @Test
+    void resolveOffloadPath_keepsReachablePathForLocalFilesystem() {
+        try (WorkspaceManager workspaceManager = new WorkspaceManager(workspace)) {
+            MemoryFlushManager flushManager = new MemoryFlushManager(workspaceManager, null);
+
+            assertEquals(
+                    "agents/agent-a/sessions/session-1.jsonl",
+                    flushManager.resolveOffloadPath(
+                            RuntimeContext.empty(), "agent-a", "session-1"));
+        }
+    }
 
     @Test
     void offloadMessages_skipsAlreadyPersistedPrefix_andKeepsChain() throws Exception {

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/memory/session/SessionTranscriptWriterTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/memory/session/SessionTranscriptWriterTest.java
@@ -19,6 +19,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
 
 import io.agentscope.core.agent.RuntimeContext;
 import io.agentscope.core.message.ImageBlock;
@@ -28,6 +29,7 @@ import io.agentscope.core.message.TextBlock;
 import io.agentscope.core.message.ToolResultBlock;
 import io.agentscope.core.message.ToolUseBlock;
 import io.agentscope.core.message.URLSource;
+import io.agentscope.harness.agent.filesystem.sandbox.AbstractSandboxFilesystem;
 import io.agentscope.harness.agent.transcript.FilesystemTranscriptStore;
 import io.agentscope.harness.agent.transcript.TranscriptRef;
 import io.agentscope.harness.agent.transcript.TranscriptStore;
@@ -176,6 +178,28 @@ class SessionTranscriptWriterTest {
             }
         }
         assertTrue(totalLines >= 2, "segments should contain both entries across flushes");
+    }
+
+    @Test
+    void resolveContextPath_omitsHostPathForSandboxFilesystem() {
+        AbstractSandboxFilesystem filesystem = mock(AbstractSandboxFilesystem.class);
+        try (WorkspaceManager wm = new WorkspaceManager(workspace, filesystem)) {
+            SessionTranscriptWriter writer = new SessionTranscriptWriter(wm);
+
+            assertEquals(
+                    "", writer.resolveContextPath(RuntimeContext.empty(), "agent-a", "session-1"));
+        }
+    }
+
+    @Test
+    void resolveContextPath_keepsReachablePathForLocalFilesystem() {
+        try (WorkspaceManager wm = new WorkspaceManager(workspace)) {
+            SessionTranscriptWriter writer = new SessionTranscriptWriter(wm);
+
+            assertEquals(
+                    "agents/agent-a/sessions/session-1.jsonl",
+                    writer.resolveContextPath(RuntimeContext.empty(), "agent-a", "session-1"));
+        }
     }
 
     private static Msg text(String id, MsgRole role, String text) {


### PR DESCRIPTION
## Summary

- keep compaction offloading enabled for sandbox-backed filesystems
- omit the host-side session archive path from the agent-facing summary because that path is not resolvable inside the sandbox
- preserve the existing archive-path guidance for local filesystems
- add regression coverage for both sandbox and local behavior

Fixes #2566.

## Validation

- `mvn -pl agentscope-harness -am -Dtest=MemoryFlushManagerOffloadTest -Dsurefire.failIfNoSpecifiedTests=false test` — 5 tests run, 0 failures, 0 errors, 0 skipped; reactor build succeeded
- `mvn -q -pl agentscope-harness spotless:check` — passed
- `git diff --check` — passed

## Impact evidence

`MemoryFlushManager.resolveOffloadPath` currently resolves the archive through the host-side `WorkspaceManager` path, while sandbox filesystem operations use a separate namespace. Returning an empty path activates the compactor’s existing path-less summary branch, so the archive is still persisted but the agent is no longer told it can read a host-only path.

## Risk and rollback

The behavior change is limited to `AbstractSandboxFilesystem` implementations. Local filesystem summaries retain their current archive reference. Reverting this commit restores the previous behavior; no persisted data format or public API changes.



I used a coding agent to help write and verify this change.
