### PR TITLE
fix(harness): stamp taskId on remote subagent forwarded events

### DIFF
--- a/agentscope-core/src/main/java/io/agentscope/core/event/AgentEvent.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/event/AgentEvent.java
@@ -72,6 +72,13 @@ import java.util.UUID;
 })
 public abstract class AgentEvent {
 
+    /**
+     * Well-known {@link #metadata} key correlating a forwarded subagent event to a harness
+     * {@code TaskRecord} / remote Agent Protocol task id. Distinct from {@link #source}, which
+     * identifies the originating agent path ({@code parentSession/agentId}).
+     */
+    public static final String METADATA_TASK_ID = "taskId";
+
     private final String id;
     private final String createdAt;
     private String source;
@@ -129,6 +136,27 @@ public abstract class AgentEvent {
      */
     public AgentEvent withMetadata(Map<String, Object> metadata) {
         this.metadata = metadata != null ? new LinkedHashMap<>(metadata) : null;
+        return this;
+    }
+
+    /**
+     * Merges a single metadata entry into this event (creates the map if absent) and returns it
+     * for chaining. Passing a {@code null} value removes the key when present.
+     */
+    public AgentEvent withMetadataEntry(String key, Object value) {
+        if (key == null || key.isBlank()) {
+            return this;
+        }
+        Map<String, Object> next = new LinkedHashMap<>();
+        if (this.metadata != null) {
+            next.putAll(this.metadata);
+        }
+        if (value == null) {
+            next.remove(key);
+        } else {
+            next.put(key, value);
+        }
+        this.metadata = next.isEmpty() ? null : next;
         return this;
     }
 

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/subagent/protocol/RemoteEventCodec.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/subagent/protocol/RemoteEventCodec.java
@@ -113,47 +113,62 @@ public final class RemoteEventCodec {
 
     /**
      * Maps a protocol DTO back to an internal {@link AgentEvent}. Unknown or incomplete types are
-     * dropped.
+     * dropped. When the DTO carries a {@code taskId}, it is copied onto {@link
+     * AgentEvent#METADATA_TASK_ID}.
      */
     public static Optional<AgentEvent> toAgentEvent(RemoteAgentEvent remote) {
         if (remote == null || remote.getType() == null) {
             return Optional.empty();
         }
-        return switch (remote.getType()) {
-            case RUN_STARTED ->
-                    Optional.of(
-                            new AgentStartEvent(
-                                    null,
-                                    null,
-                                    remote.getAgentId() != null ? remote.getAgentId() : "remote"));
-            case RUN_FINISHED -> Optional.of(new AgentEndEvent(null));
-            case RUN_ERROR -> Optional.empty();
-            case TEXT_DELTA ->
-                    Optional.of(
-                            new TextBlockDeltaEvent(
-                                    null, null, remote.getText() != null ? remote.getText() : ""));
-            case THINKING_DELTA ->
-                    Optional.of(
-                            new ThinkingBlockDeltaEvent(
-                                    null, null, remote.getText() != null ? remote.getText() : ""));
-            case TOOL_CALL_START ->
-                    Optional.of(
-                            new ToolCallStartEvent(
-                                    null, remote.getToolCallId(), remote.getToolName()));
-            case TOOL_CALL_END ->
-                    Optional.of(
-                            new ToolCallEndEvent(
-                                    null, remote.getToolCallId(), remote.getToolName()));
-            case TOOL_RESULT ->
-                    Optional.of(
-                            new ToolResultEndEvent(
-                                    null,
-                                    remote.getToolCallId(),
-                                    remote.getToolName(),
-                                    parseToolResultState(remote.getStatus())));
-            case REQUIRE_CONFIRM -> Optional.of(toRequireConfirm(remote));
-            case STATUS -> Optional.empty();
-        };
+        Optional<AgentEvent> mapped =
+                switch (remote.getType()) {
+                    case RUN_STARTED ->
+                            Optional.of(
+                                    new AgentStartEvent(
+                                            null,
+                                            null,
+                                            remote.getAgentId() != null
+                                                    ? remote.getAgentId()
+                                                    : "remote"));
+                    case RUN_FINISHED -> Optional.of(new AgentEndEvent(null));
+                    case RUN_ERROR -> Optional.empty();
+                    case TEXT_DELTA ->
+                            Optional.of(
+                                    new TextBlockDeltaEvent(
+                                            null,
+                                            null,
+                                            remote.getText() != null ? remote.getText() : ""));
+                    case THINKING_DELTA ->
+                            Optional.of(
+                                    new ThinkingBlockDeltaEvent(
+                                            null,
+                                            null,
+                                            remote.getText() != null ? remote.getText() : ""));
+                    case TOOL_CALL_START ->
+                            Optional.of(
+                                    new ToolCallStartEvent(
+                                            null, remote.getToolCallId(), remote.getToolName()));
+                    case TOOL_CALL_END ->
+                            Optional.of(
+                                    new ToolCallEndEvent(
+                                            null, remote.getToolCallId(), remote.getToolName()));
+                    case TOOL_RESULT ->
+                            Optional.of(
+                                    new ToolResultEndEvent(
+                                            null,
+                                            remote.getToolCallId(),
+                                            remote.getToolName(),
+                                            parseToolResultState(remote.getStatus())));
+                    case REQUIRE_CONFIRM -> Optional.of(toRequireConfirm(remote));
+                    case STATUS -> Optional.empty();
+                };
+        return mapped.map(
+                event -> {
+                    if (remote.getTaskId() != null && !remote.getTaskId().isBlank()) {
+                        event.withMetadataEntry(AgentEvent.METADATA_TASK_ID, remote.getTaskId());
+                    }
+                    return event;
+                });
     }
 
     /**

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/tool/AgentSpawnTool.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/tool/AgentSpawnTool.java
@@ -1079,6 +1079,22 @@ public class AgentSpawnTool {
     }
 
     /**
+     * Tags a remote-forwarded {@link AgentEvent} with the parent-visible {@code source} path and
+     * the harness {@link AgentEvent#METADATA_TASK_ID} so concurrent calls to the same remote agent
+     * stay correlatable to distinct {@code TaskRecord}s.
+     */
+    static AgentEvent tagRemoteForwardedEvent(AgentEvent event, String sourcePath, String taskId) {
+        if (event == null) {
+            return null;
+        }
+        event.withSource(sourcePath);
+        if (taskId != null && !taskId.isBlank()) {
+            event.withMetadataEntry(AgentEvent.METADATA_TASK_ID, taskId);
+        }
+        return event;
+    }
+
+    /**
      * Builds submission metadata for a remote task (streaming preference, parent identity, denied
      * permission rules).
      */
@@ -1207,8 +1223,10 @@ public class AgentSpawnTool {
                                                 .ifPresent(
                                                         ae ->
                                                                 emitter.emit(
-                                                                        ae.withSource(
-                                                                                sourcePath))));
+                                                                        tagRemoteForwardedEvent(
+                                                                                ae,
+                                                                                sourcePath,
+                                                                                taskId))));
             }
 
             long deadlineMs = System.currentTimeMillis() + Math.max(timeoutMs, 0L);

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/subagent/protocol/RemoteEventCodecTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/subagent/protocol/RemoteEventCodecTest.java
@@ -63,6 +63,17 @@ class RemoteEventCodecTest {
     }
 
     @Test
+    void toAgentEvent_copiesWireTaskIdIntoMetadata() {
+        RemoteAgentEvent dto = new RemoteAgentEvent();
+        dto.setType(RemoteEventType.TEXT_DELTA);
+        dto.setText("hi");
+        dto.setTaskId("task_from_wire");
+
+        AgentEvent back = RemoteEventCodec.toAgentEvent(dto).orElseThrow();
+        assertEquals("task_from_wire", back.getMetadata().get(AgentEvent.METADATA_TASK_ID));
+    }
+
+    @Test
     void requireConfirmRoundTripPreservesAskState() {
         ToolUseBlock ask =
                 ToolUseBlock.builder()

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/tool/AgentSpawnToolRemoteHelpersTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/tool/AgentSpawnToolRemoteHelpersTest.java
@@ -18,6 +18,8 @@ package io.agentscope.harness.agent.tool;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import io.agentscope.core.event.AgentEvent;
+import io.agentscope.core.event.TextBlockDeltaEvent;
 import io.agentscope.core.permission.PermissionBehavior;
 import io.agentscope.core.permission.PermissionContextState;
 import io.agentscope.core.permission.PermissionMode;
@@ -45,6 +47,19 @@ class AgentSpawnToolRemoteHelpersTest {
         assertEquals("main/remote", AgentSpawnTool.buildRemoteSourcePath("  ", ""));
         assertEquals("sess/remote", AgentSpawnTool.buildRemoteSourcePath("sess", null));
         assertEquals("main/agent", AgentSpawnTool.buildRemoteSourcePath(null, "agent"));
+    }
+
+    @Test
+    void tagRemoteForwardedEvent_setsSourceAndTaskIdMetadata() {
+        TextBlockDeltaEvent event = new TextBlockDeltaEvent(null, "b1", "hello");
+        event.withMetadataEntry("keep", "me");
+
+        AgentEvent tagged =
+                AgentSpawnTool.tagRemoteForwardedEvent(event, "parent/worker", "task_abc");
+
+        assertEquals("parent/worker", tagged.getSource());
+        assertEquals("task_abc", tagged.getMetadata().get(AgentEvent.METADATA_TASK_ID));
+        assertEquals("me", tagged.getMetadata().get("keep"));
     }
 
     @Test

--- a/docs/v2/en/docs/building-blocks/message-and-event.md
+++ b/docs/v2/en/docs/building-blocks/message-and-event.md
@@ -187,6 +187,7 @@ All events extend `AgentEvent` (`io.agentscope.core.event`), which exposes the c
 | `getCreatedAt()` | `String` | ISO 8601 timestamp |
 | `getType()` | `AgentEventType` | Event type enum |
 | `getSource()` | `String` | Source path identifying the originating agent. `null` for top-level agent events; a slash-separated path (e.g. `"main/researcher"`) for events forwarded from a subagent |
+| `getMetadata()` | `Map<String, Object>` | Optional key/value bag. Remote subagent forwards also set `taskId` (`AgentEvent.METADATA_TASK_ID`) to the harness / Agent Protocol task id when events are task-backed |
 
 Events are grouped below; unless noted otherwise, every event also carries `getReplyId()` linking it to the message being assembled.
 

--- a/docs/v2/en/docs/harness/subagent.md
+++ b/docs/v2/en/docs/harness/subagent.md
@@ -330,7 +330,7 @@ Declaration knobs specific to remote mode:
 
 | Field | Default | Notes |
 |-------|---------|-------|
-| `remoteStreaming` | `true` (when unset) | When the parent uses `streamEvents()`, forward remote task SSE events into the parent stream with a `source` tag |
+| `remoteStreaming` | `true` (when unset) | When the parent uses `streamEvents()`, forward remote task SSE events into the parent stream with a `source` tag and `metadata.taskId` (same id as the harness `TaskRecord`) |
 | `remoteAskPolicy` | `DENY` | How to resolve remote tool-confirmation (HITL) requests — see [Remote authorization](#remote-authorization) |
 
 ### Remote authorization
@@ -360,7 +360,7 @@ When the parent is in Plan Mode, spawned subagents **automatically inherit the r
 
 > New code should use `streamEvents()` (returns `Flux<AgentEvent>`). The legacy `stream()` family (`Flux<Event>`) is `@Deprecated(forRemoval = true)` since 2.0.0 — see [Message & Event](../building-blocks/message-and-event.md) and [V1 Migration Guide B.4](../change-log.md).
 
-When the parent calls a synchronous subagent via `agent_spawn` / `agent_send`, the child's intermediate events are **forwarded live** into the parent's `streamEvents()` stream. Each child event carries a `source` field (a `/`-separated path like `"main/researcher"`) so you can tell parent events (`source == null`) from child events.
+When the parent calls a synchronous subagent via `agent_spawn` / `agent_send`, the child's intermediate events are **forwarded live** into the parent's `streamEvents()` stream. Each child event carries a `source` field (a `/`-separated path like `"main/researcher"`) so you can tell parent events (`source == null`) from child events. Remote Agent Protocol children additionally set `metadata.taskId` (`AgentEvent.METADATA_TASK_ID`) to the harness task id, so two concurrent / same-turn calls to the same remote agent remain distinguishable even when they share a `source` path.
 
 ```
 caller

--- a/docs/v2/zh/docs/building-blocks/message-and-event.md
+++ b/docs/v2/zh/docs/building-blocks/message-and-event.md
@@ -187,6 +187,7 @@ sequenceDiagram
 | `getCreatedAt()` | `String` | ISO 8601 时间戳 |
 | `getType()` | `AgentEventType` | 事件类型枚举 |
 | `getSource()` | `String` | 事件来源路径。顶层 Agent 为 `null`；子 Agent 事件为斜杠分隔的路径（如 `"main/researcher"`），用于区分父子 Agent 事件 |
+| `getMetadata()` | `Map<String, Object>` | 可选键值元数据。远程子 agent 转发时会写入 `taskId`（`AgentEvent.METADATA_TASK_ID`），对应该 harness / Agent Protocol 任务 id |
 
 事件按类别分组如下。除特别说明外，每个事件还携带 `getReplyId()`，关联到正在构建的消息。
 

--- a/docs/v2/zh/docs/harness/subagent.md
+++ b/docs/v2/zh/docs/harness/subagent.md
@@ -330,7 +330,7 @@ ChatUiChannel chat = agent.channel(ChatUiChannel.create());  // 恢复能力自�
 
 | 字段 | 默认 | 说明 |
 |------|------|------|
-| `remoteStreaming` | `true`（未设置时） | 父代理使用 `streamEvents()` 时，把远程任务的 SSE 事件转发进父流，并带 `source` 标记 |
+| `remoteStreaming` | `true`（未设置时） | 父代理使用 `streamEvents()` 时，把远程任务的 SSE 事件转发进父流，并带 `source` 标记与 `metadata.taskId`（与 harness `TaskRecord` 的 task id 一致） |
 | `remoteAskPolicy` | `DENY` | 如何处理远程工具确认（HITL）请求——见 [远程授权](#远程授权) |
 
 ### 远程授权
@@ -360,7 +360,7 @@ ChatUiChannel chat = agent.channel(ChatUiChannel.create());  // 恢复能力自�
 
 > 新代码请用 `streamEvents()`（返回 `Flux<AgentEvent>`）。旧 `stream()` 系列（`Flux<Event>`）在 2.0.0 起 `@Deprecated(forRemoval = true)` —— 详见 [消息与事件](../building-blocks/message-and-event.md) 与 [V1 迁移指南 B.4](../change-log.md)。
 
-父 agent 通过 `agent_spawn` / `agent_send` 同步调用子 agent 时，子 agent 的中间事件会**实时转发**到父的 `streamEvents()` 流中。每个子事件都带一个 `source` 字段（`/` 分隔的路径，如 `"main/researcher"`），父事件的 `source` 为 `null`。
+父 agent 通过 `agent_spawn` / `agent_send` 同步调用子 agent 时，子 agent 的中间事件会**实时转发**到父的 `streamEvents()` 流中。每个子事件都带一个 `source` 字段（`/` 分隔的路径，如 `"main/researcher"`），父事件的 `source` 为 `null`。远程 Agent Protocol 子 agent 还会写入 `metadata.taskId`（`AgentEvent.METADATA_TASK_ID`），值为 harness 侧任务 id，因此同一轮里对同一远程 agent 的多次调用即使 `source` 相同也能区分。
 
 ```
 caller


### PR DESCRIPTION
## Summary
- Remote `streamEvents` forwarding now sets `AgentEvent.metadata.taskId` (`AgentEvent.METADATA_TASK_ID`) alongside `source`, so two same-turn calls to the same remote subagent remain correlatable to distinct `TaskRecord`s
- `RemoteEventCodec.toAgentEvent` copies wire `taskId` into that metadata key; `AgentEvent.withMetadataEntry` supports merge-safe updates
- Docs (en/zh subagent + message-and-event) updated

## Test plan
- [x] `mvn -pl agentscope-core,agentscope-harness -am test -Dtest=AgentSpawnToolRemoteHelpersTest,RemoteEventCodecTest`
- [ ] Reproduce SRE demo chat with two remote spawns of the same agent; confirm `[SRE_DEMO_MAIN_EVENT] ... taskId=` is non-null and distinct per spawn
- [ ] Confirm `source` remains `parentSession/agentId` (identity), while `taskId` identifies the task run