### PR TITLE
feat(agent-protocol): route tasks through AgentFactory

### DIFF
--- a/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agent-protocol/src/main/java/io/agentscope/extensions/agentprotocol/AgentFactory.java
+++ b/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agent-protocol/src/main/java/io/agentscope/extensions/agentprotocol/AgentFactory.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.extensions.agentprotocol;
+
+import io.agentscope.harness.agent.HarnessAgent;
+import java.util.Objects;
+import java.util.function.Supplier;
+
+/**
+ * Resolves the {@link HarnessAgent} that executes an Agent Protocol task.
+ *
+ * <p>Called once per run — on the initial {@code POST /tasks} submission and again for every
+ * {@code POST /tasks/{id}/resume} — with the full {@link AgentRequest}, including the submission
+ * {@code context} map. Implementations may therefore route by {@code agentId}, tenant, or any
+ * custom context attribute, and may build a fresh agent per task.
+ *
+ * <p>Register a bean of this type to override the default factory, which always returns the single
+ * {@link HarnessAgent} bean:
+ *
+ * <pre>{@code
+ * @Bean
+ * AgentFactory agentFactory(Map<String, HarnessAgent> agentsByName) {
+ *     return request -> agentsByName.getOrDefault(request.agentId(), agentsByName.get("default"));
+ * }
+ * }</pre>
+ *
+ * <p>For concurrent tasks, return a distinct instance per call (e.g. a prototype-scoped bean),
+ * or configure the shared agent with {@code checkRunning(false)}.
+ */
+@FunctionalInterface
+public interface AgentFactory {
+
+    /**
+     * Returns the agent for this run. Must not return {@code null}; throw to fail the task with an
+     * error status instead.
+     */
+    HarnessAgent create(AgentRequest request);
+
+    /** Factory that always returns the same agent, ignoring the request. */
+    static AgentFactory fixed(HarnessAgent agent) {
+        Objects.requireNonNull(agent, "agent");
+        return request -> agent;
+    }
+
+    /** Factory backed by a supplier, ignoring the request. */
+    static AgentFactory of(Supplier<HarnessAgent> supplier) {
+        Objects.requireNonNull(supplier, "supplier");
+        return request -> supplier.get();
+    }
+}

--- a/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agent-protocol/src/main/java/io/agentscope/extensions/agentprotocol/AgentProtocolAutoConfiguration.java
+++ b/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agent-protocol/src/main/java/io/agentscope/extensions/agentprotocol/AgentProtocolAutoConfiguration.java
@@ -20,6 +20,7 @@ import io.agentscope.harness.agent.workspace.WorkspaceManager;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
@@ -30,6 +31,10 @@ import org.springframework.context.annotation.Bean;
  * <p>{@link ConditionalOnBean} is applied at the {@code @Bean} method level (not class level) to
  * avoid Spring Boot auto-configuration ordering issues: class-level {@code @ConditionalOnBean} on
  * {@code @AutoConfiguration} classes may evaluate before user-defined beans are registered.
+ *
+ * <p>Agent selection goes through {@link AgentFactory}. Without a user-defined bean, the default
+ * factory resolves the single {@link HarnessAgent} bean for every task; define an
+ * {@link AgentFactory} bean to route per {@code agent_id} or submission context.
  *
  * <p>For concurrent task execution, register the {@link HarnessAgent} bean as
  * {@code @Scope("prototype")} so that each task obtains its own instance. Alternatively, configure
@@ -46,14 +51,20 @@ public class AgentProtocolAutoConfiguration {
     }
 
     @Bean
-    @ConditionalOnBean({HarnessAgent.class, WorkspaceManager.class})
+    @ConditionalOnBean(HarnessAgent.class)
+    @ConditionalOnMissingBean(AgentFactory.class)
+    public AgentFactory agentProtocolAgentFactory(ObjectProvider<HarnessAgent> agentProvider) {
+        return request -> agentProvider.getObject();
+    }
+
+    @Bean
+    @ConditionalOnBean({AgentFactory.class, WorkspaceManager.class})
     public AgentProtocolTaskStore agentProtocolTaskStore(
-            ObjectProvider<HarnessAgent> agentProvider,
+            AgentFactory agentFactory,
             WorkspaceManager workspaceManager,
             AgentProtocolTaskEventBus eventBus,
             AgentProtocolProperties properties) {
-        return new AgentProtocolTaskStore(
-                agentProvider::getObject, workspaceManager, eventBus, properties);
+        return new AgentProtocolTaskStore(agentFactory, workspaceManager, eventBus, properties);
     }
 
     @Bean

--- a/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agent-protocol/src/main/java/io/agentscope/extensions/agentprotocol/AgentProtocolTaskStore.java
+++ b/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agent-protocol/src/main/java/io/agentscope/extensions/agentprotocol/AgentProtocolTaskStore.java
@@ -48,7 +48,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicReference;
-import java.util.function.Supplier;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import reactor.core.publisher.Flux;
@@ -56,10 +55,10 @@ import reactor.core.publisher.Flux;
 /**
  * In-memory execution handles with workspace-backed {@link TaskRecord} persistence.
  *
- * <p>Each submitted task obtains a {@link HarnessAgent} instance via the {@code agentSupplier}.
- * For concurrent task execution, supply a factory that returns a new instance per call (e.g. a
- * Spring prototype-scoped bean). When a singleton bean is supplied, concurrent tasks will fail
- * at the agent level unless the agent is configured with {@code checkRunning(false)}.
+ * <p>Each run resolves its {@link HarnessAgent} through the {@link AgentFactory}, which receives
+ * the submission context and can therefore route per task. For concurrent task execution, return a
+ * new instance per call (e.g. a Spring prototype-scoped bean); a shared instance requires the agent
+ * to be configured with {@code checkRunning(false)}.
  */
 public final class AgentProtocolTaskStore {
 
@@ -69,7 +68,7 @@ public final class AgentProtocolTaskStore {
     /** Sentinel returned when the agent paused for HITL confirmation. */
     static final String AWAITING_CONFIRM_SENTINEL = "__awaiting_confirm__";
 
-    private final Supplier<HarnessAgent> agentSupplier;
+    private final AgentFactory agentFactory;
     private final WorkspaceManager workspaceManager;
     private final AgentProtocolTaskEventBus eventBus;
     private final AgentProtocolProperties properties;
@@ -86,27 +85,26 @@ public final class AgentProtocolTaskStore {
     private final Map<String, SubmitContext> submitContexts = new ConcurrentHashMap<>();
 
     public AgentProtocolTaskStore(
-            Supplier<HarnessAgent> agentSupplier,
+            AgentFactory agentFactory,
             WorkspaceManager workspaceManager,
             AgentProtocolTaskEventBus eventBus,
             AgentProtocolProperties properties) {
-        this.agentSupplier = Objects.requireNonNull(agentSupplier, "agentSupplier");
+        this.agentFactory = Objects.requireNonNull(agentFactory, "agentFactory");
         this.workspaceManager = Objects.requireNonNull(workspaceManager, "workspaceManager");
         this.eventBus = eventBus != null ? eventBus : new AgentProtocolTaskEventBus();
         this.properties = properties != null ? properties : new AgentProtocolProperties();
     }
 
-    public AgentProtocolTaskStore(
-            Supplier<HarnessAgent> agentSupplier, WorkspaceManager workspaceManager) {
+    public AgentProtocolTaskStore(AgentFactory agentFactory, WorkspaceManager workspaceManager) {
         this(
-                agentSupplier,
+                agentFactory,
                 workspaceManager,
                 new AgentProtocolTaskEventBus(),
                 new AgentProtocolProperties());
     }
 
     public AgentProtocolTaskStore(HarnessAgent harnessAgent, WorkspaceManager workspaceManager) {
-        this(() -> harnessAgent, workspaceManager);
+        this(AgentFactory.fixed(harnessAgent), workspaceManager);
     }
 
     public AgentProtocolTaskEventBus eventBus() {
@@ -224,7 +222,20 @@ public final class AgentProtocolTaskStore {
             }
             Msg msg = msgBuilder.build();
 
-            HarnessAgent agent = agentSupplier.get();
+            AgentRequest request =
+                    new AgentRequest(
+                            taskId,
+                            agentId,
+                            input,
+                            submitCtx.userId(),
+                            submitCtx.parentSessionId(),
+                            confirmResults != null,
+                            submitCtx.raw());
+            HarnessAgent agent = agentFactory.create(request);
+            if (agent == null) {
+                throw new IllegalStateException(
+                        "AgentFactory returned no agent for agent_id=" + agentId);
+            }
             AtomicReference<Msg> resultRef = new AtomicReference<>();
             String detail = submitCtx.detail();
 
@@ -604,9 +615,14 @@ public final class AgentProtocolTaskStore {
         }
     }
 
-    private record SubmitContext(String userId, String parentSessionId, String detail) {
+    /**
+     * Parsed protocol fields plus the {@code raw} submission map, which is handed to the {@link
+     * AgentFactory} so custom context keys survive routing on both submit and resume.
+     */
+    private record SubmitContext(
+            String userId, String parentSessionId, String detail, Map<String, Object> raw) {
         static SubmitContext empty() {
-            return new SubmitContext(null, null, "status");
+            return new SubmitContext(null, null, "status", Map.of());
         }
 
         static SubmitContext from(Map<String, Object> raw) {
@@ -619,7 +635,7 @@ public final class AgentProtocolTaskStore {
             if (detail == null || detail.isBlank()) {
                 detail = "status";
             }
-            return new SubmitContext(userId, parentSessionId, detail);
+            return new SubmitContext(userId, parentSessionId, detail, raw);
         }
 
         private static String stringVal(Object v) {

--- a/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agent-protocol/src/main/java/io/agentscope/extensions/agentprotocol/AgentRequest.java
+++ b/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agent-protocol/src/main/java/io/agentscope/extensions/agentprotocol/AgentRequest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.extensions.agentprotocol;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Everything an {@link AgentFactory} needs to pick or build the agent for one task run.
+ *
+ * @param taskId task identifier, also used as the agent session id
+ * @param agentId requested agent id from {@code POST /tasks}
+ * @param input user input; empty on a resume run, which carries confirmation decisions instead
+ * @param userId parsed from {@code context.user_id}
+ * @param parentSessionId parsed from {@code context.parent_session_id}
+ * @param resume whether this run resumes a task that was awaiting tool confirmation
+ * @param context the submission {@code context} map exactly as received, including any custom keys
+ */
+public record AgentRequest(
+        String taskId,
+        String agentId,
+        String input,
+        String userId,
+        String parentSessionId,
+        boolean resume,
+        Map<String, Object> context) {
+
+    public AgentRequest {
+        // JSON payloads may contain null values, so Map.copyOf is not usable here.
+        context =
+                context == null || context.isEmpty()
+                        ? Map.of()
+                        : Collections.unmodifiableMap(new LinkedHashMap<>(context));
+    }
+
+    /** Returns the raw {@code context} value for {@code key}, or {@code null} when absent. */
+    public Object contextValue(String key) {
+        return key == null ? null : context.get(key);
+    }
+
+    /** Returns the {@code context} value for {@code key} as a string, or {@code null}. */
+    public String contextString(String key) {
+        Object v = contextValue(key);
+        return v == null ? null : String.valueOf(v);
+    }
+}

--- a/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agent-protocol/src/test/java/io/agentscope/extensions/agentprotocol/AgentProtocolAgentFactoryTest.java
+++ b/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agent-protocol/src/test/java/io/agentscope/extensions/agentprotocol/AgentProtocolAgentFactoryTest.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.extensions.agentprotocol;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.agentscope.core.agent.RuntimeContext;
+import io.agentscope.core.event.AgentEndEvent;
+import io.agentscope.core.event.AgentResultEvent;
+import io.agentscope.core.event.AgentStartEvent;
+import io.agentscope.core.message.Msg;
+import io.agentscope.core.message.MsgRole;
+import io.agentscope.harness.agent.HarnessAgent;
+import io.agentscope.harness.agent.workspace.WorkspaceManager;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CopyOnWriteArrayList;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import reactor.core.publisher.Flux;
+
+/**
+ * {@link AgentFactory} routing: the factory sees the submission context (including custom keys)
+ * and decides which {@link HarnessAgent} runs each task.
+ */
+class AgentProtocolAgentFactoryTest {
+
+    @TempDir Path tempDir;
+
+    private WorkspaceManager workspaceManager;
+    private HarnessAgent researcher;
+    private HarnessAgent writer;
+    private final List<AgentRequest> seenRequests = new CopyOnWriteArrayList<>();
+
+    @BeforeEach
+    void setUp() {
+        workspaceManager = new WorkspaceManager(tempDir);
+        researcher = agentReplying("researched");
+        writer = agentReplying("written");
+    }
+
+    @Test
+    void factoryRoutesByAgentIdAndSeesCustomContextKeys() throws Exception {
+        AgentProtocolTaskStore store = storeWithRoutingFactory();
+
+        Map<String, Object> context = new HashMap<>();
+        context.put("user_id", "u-1");
+        context.put("parent_session_id", "sess-parent");
+        context.put("tenant", "acme");
+        context.put("ticket_id", "INC-1001");
+
+        store.submit("t-writer", "writer", "draft the summary", context);
+        awaitCondition(() -> "success".equals(store.snapshot("t-writer").get("status")), 5_000);
+
+        assertEquals("written", store.snapshot("t-writer").get("result"));
+        assertEquals(1, seenRequests.size());
+
+        AgentRequest req = seenRequests.get(0);
+        assertEquals("t-writer", req.taskId());
+        assertEquals("writer", req.agentId());
+        assertEquals("draft the summary", req.input());
+        assertEquals("u-1", req.userId());
+        assertEquals("sess-parent", req.parentSessionId());
+        assertFalse(req.resume());
+        assertEquals("acme", req.contextString("tenant"));
+        assertEquals("INC-1001", req.contextValue("ticket_id"));
+    }
+
+    @Test
+    void factoryPicksDifferentAgentsPerTask() throws Exception {
+        AgentProtocolTaskStore store = storeWithRoutingFactory();
+
+        store.submit("t-a", "researcher", "dig in", Map.of());
+        awaitCondition(() -> "success".equals(store.snapshot("t-a").get("status")), 5_000);
+        store.submit("t-b", "writer", "write up", Map.of());
+        awaitCondition(() -> "success".equals(store.snapshot("t-b").get("status")), 5_000);
+
+        assertEquals("researched", store.snapshot("t-a").get("result"));
+        assertEquals("written", store.snapshot("t-b").get("result"));
+    }
+
+    @Test
+    void fixedFactoryIgnoresRequest() {
+        AgentFactory factory = AgentFactory.fixed(researcher);
+        assertSame(
+                researcher,
+                factory.create(
+                        new AgentRequest("t", "anything", "in", null, null, false, Map.of())));
+    }
+
+    @Test
+    void agentRequestCopiesContextDefensively() {
+        Map<String, Object> mutable = new HashMap<>();
+        mutable.put("tenant", "acme");
+        AgentRequest req = new AgentRequest("t", "a", "in", null, null, false, mutable);
+
+        mutable.put("tenant", "changed");
+
+        assertEquals("acme", req.contextString("tenant"));
+        assertTrue(new AgentRequest("t", "a", "in", null, null, false, null).context().isEmpty());
+    }
+
+    private AgentProtocolTaskStore storeWithRoutingFactory() {
+        AgentFactory factory =
+                request -> {
+                    seenRequests.add(request);
+                    return "writer".equals(request.agentId()) ? writer : researcher;
+                };
+        return new AgentProtocolTaskStore(
+                factory,
+                workspaceManager,
+                new AgentProtocolTaskEventBus(),
+                new AgentProtocolProperties());
+    }
+
+    private static HarnessAgent agentReplying(String text) {
+        HarnessAgent agent = mock(HarnessAgent.class);
+        when(agent.streamEvents(any(Msg.class), any(RuntimeContext.class)))
+                .thenReturn(
+                        Flux.just(
+                                new AgentStartEvent("sess", null, "worker"),
+                                new AgentResultEvent(
+                                        Msg.builder()
+                                                .role(MsgRole.ASSISTANT)
+                                                .textContent(text)
+                                                .build()),
+                                new AgentEndEvent(null)));
+        return agent;
+    }
+
+    private static void awaitCondition(Condition condition, long timeoutMs) throws Exception {
+        long deadline = System.currentTimeMillis() + timeoutMs;
+        while (!condition.get()) {
+            if (System.currentTimeMillis() >= deadline) {
+                throw new AssertionError("Condition not met within " + timeoutMs + "ms");
+            }
+            Thread.sleep(25);
+        }
+    }
+
+    @FunctionalInterface
+    private interface Condition {
+        boolean get() throws Exception;
+    }
+}

--- a/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agent-protocol/src/test/java/io/agentscope/extensions/agentprotocol/AgentProtocolTaskStoreHitlTest.java
+++ b/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agent-protocol/src/test/java/io/agentscope/extensions/agentprotocol/AgentProtocolTaskStoreHitlTest.java
@@ -69,7 +69,10 @@ class AgentProtocolTaskStoreHitlTest {
         props.setStreamingEnabled(true);
         store =
                 new AgentProtocolTaskStore(
-                        () -> agent, workspaceManager, new AgentProtocolTaskEventBus(), props);
+                        AgentFactory.fixed(agent),
+                        workspaceManager,
+                        new AgentProtocolTaskEventBus(),
+                        props);
 
         when(agent.streamEvents(any(Msg.class), any(RuntimeContext.class)))
                 .thenAnswer(

--- a/docs/v2/en/integration/protocol/agent-protocol.md
+++ b/docs/v2/en/integration/protocol/agent-protocol.md
@@ -60,6 +60,39 @@ public HarnessAgent harnessAgent() {
 
 Concurrent requests for the same session are automatically serialized; different sessions run in parallel.
 
+## Agent selection (`AgentFactory`)
+
+Which agent runs a task is decided by an `AgentFactory` bean. Without one, the default factory returns the single `HarnessAgent` bean for every task.
+
+Define your own bean to route by `agent_id`, tenant, or any custom submission-context key:
+
+```java
+@Bean
+AgentFactory agentFactory(Map<String, HarnessAgent> agentsByName) {
+    return request -> {
+        String tenant = request.contextString("tenant");
+        log.info("task {} agent_id={} tenant={} resume={}",
+                request.taskId(), request.agentId(), tenant, request.resume());
+        return agentsByName.getOrDefault(request.agentId(), agentsByName.get("default"));
+    };
+}
+```
+
+`AgentRequest` fields:
+
+| Field | Notes |
+| --- | --- |
+| `taskId()` | Task identifier; also the agent session id |
+| `agentId()` | Requested `agent_id` from the submission |
+| `input()` | User input; empty on a resume run |
+| `userId()` / `parentSessionId()` | Parsed from `context.user_id` / `context.parent_session_id` |
+| `resume()` | `true` when re-running a task that was awaiting tool confirmation |
+| `context()` | The submission `context` map exactly as received, including custom keys; `contextValue(key)` / `contextString(key)` are convenience accessors |
+
+The factory is invoked once per run — on submit and again on every `/resume` — with the original submission context, so routing decisions stay stable across HITL pauses.
+
+Return a distinct instance per call (for example a prototype-scoped bean) when tasks run concurrently. Returning `null` fails the task with an error status.
+
 ## Endpoints
 
 ### Submit a task

--- a/docs/v2/zh/integration/protocol/agent-protocol.md
+++ b/docs/v2/zh/integration/protocol/agent-protocol.md
@@ -60,6 +60,39 @@ public HarnessAgent harnessAgent() {
 
 同一 session 的并发请求会自动串行化；不同 session 完全并行。
 
+## Agent 选择（`AgentFactory`）
+
+由哪个 agent 执行任务，交给 `AgentFactory` bean 决定。不定义时，默认工厂对所有任务返回唯一的 `HarnessAgent` bean。
+
+自定义 bean 即可按 `agent_id`、租户或任意自定义提交上下文字段路由：
+
+```java
+@Bean
+AgentFactory agentFactory(Map<String, HarnessAgent> agentsByName) {
+    return request -> {
+        String tenant = request.contextString("tenant");
+        log.info("task {} agent_id={} tenant={} resume={}",
+                request.taskId(), request.agentId(), tenant, request.resume());
+        return agentsByName.getOrDefault(request.agentId(), agentsByName.get("default"));
+    };
+}
+```
+
+`AgentRequest` 字段：
+
+| 字段 | 说明 |
+| --- | --- |
+| `taskId()` | 任务标识，同时作为 agent 的 session id |
+| `agentId()` | 提交时请求的 `agent_id` |
+| `input()` | 用户输入；resume 运行时为空 |
+| `userId()` / `parentSessionId()` | 解析自 `context.user_id` / `context.parent_session_id` |
+| `resume()` | 为 `true` 表示这是等待工具确认后的续跑 |
+| `context()` | 原样保留的提交 `context` map（含自定义键）；可用 `contextValue(key)` / `contextString(key)` 取值 |
+
+工厂每次运行调用一次——提交时一次，之后每次 `/resume` 再调用一次，且拿到的仍是最初的提交上下文，因此 HITL 暂停前后的路由结果保持一致。
+
+任务并发执行时请每次返回独立实例（例如 prototype 作用域 bean）。返回 `null` 会让任务以错误状态结束。
+
 ## 端点
 
 ### 提交任务


### PR DESCRIPTION
## Summary
- Replace `Supplier<HarnessAgent>` in `AgentProtocolTaskStore` with an `AgentFactory` that receives an `AgentRequest` (taskId, agentId, input, userId, parentSessionId, resume flag, and the raw submission `context` map including custom keys)
- Keep the submission context alive across HITL, so `/resume` runs route identically to the original submit
- Auto-configuration registers a default `AgentFactory` backed by the single `HarnessAgent` bean; define your own bean to override routing
- Docs (en/zh Agent Protocol) gain an "Agent selection" section

## Breaking change
The `AgentProtocolTaskStore(Supplier<HarnessAgent>, ...)` constructors are removed. Migrate with `AgentFactory.of(supplier)` or `AgentFactory.fixed(agent)`; the `(HarnessAgent, WorkspaceManager)` convenience constructor is unchanged.

## Test plan
- [x] `mvn -pl agentscope-extensions/.../agentscope-extensions-agent-protocol -am test` (full module suite)
- [x] New `AgentProtocolAgentFactoryTest`: routing by `agent_id`, custom context keys visible, defensive context copy
- [ ] In a Spring app, define an `AgentFactory` bean and confirm it overrides the default while `/tasks` still starts
- [ ] Confirm a task paused for HITL resumes onto the same routed agent