### PR TITLE
feat(harness): RuntimeContext force-sync for agent_spawn

### DIFF
--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/tool/AgentSpawnTool.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/tool/AgentSpawnTool.java
@@ -136,6 +136,32 @@ public class AgentSpawnTool {
      */
     public static final String CTX_AGENT_MANAGER = "agentscope.subagent.agent_manager";
 
+    /**
+     * {@link RuntimeContext} string key that forces synchronous subagent execution for the current
+     * call. Put a {@link Boolean} (or its string form) under this key to ignore LLM-requested
+     * background mode ({@code timeout_seconds=0}) and to disable timeout promotion to a background
+     * {@code task_id}.
+     *
+     * <p>When force-sync is on:
+     *
+     * <ul>
+     *   <li>{@code timeout_seconds=0} is coerced to the default sync timeout (30s)
+     *   <li>If the sync wait exceeds the timeout, the subagent is interrupted and the tool returns
+     *       {@code status: timeout} — it is <em>not</em> promoted to an async background task
+     * </ul>
+     *
+     * <pre>{@code
+     * RuntimeContext ctx = RuntimeContext.builder()
+     *     .sessionId("s-1")
+     *     .put(AgentSpawnTool.CTX_FORCE_SYNC, true)
+     *     .build();
+     * }</pre>
+     *
+     * <p>Applies to {@code agent_spawn} and {@code agent_send}. Multiple sync tool calls in one
+     * turn still run in parallel by default (Toolkit {@code parallel=true}).
+     */
+    public static final String CTX_FORCE_SYNC = "agentscope.subagent.force_sync";
+
     private static final String BG_RESULT_TEMPLATE =
             """
             status: accepted
@@ -380,7 +406,8 @@ public class AgentSpawnTool {
                     canonLabel);
         }
 
-        long timeoutMs = resolveTimeoutMs(timeoutSeconds, DEFAULT_TIMEOUT_SECONDS);
+        boolean forceSync = isForceSync(runtimeContext);
+        long timeoutMs = resolveEffectiveTimeoutMs(timeoutSeconds, forceSync);
         boolean remote = declOpt.map(SubagentDeclaration::isRemote).orElse(false);
 
         if (timeoutMs == 0) {
@@ -441,7 +468,8 @@ public class AgentSpawnTool {
                             parentSessionId,
                             declOpt.get(),
                             finalTask.trim(),
-                            timeoutMs),
+                            timeoutMs,
+                            forceSync),
                     subagentId,
                     agentId,
                     sessionId,
@@ -449,7 +477,9 @@ public class AgentSpawnTool {
         }
 
         // Sync-local execution with timeout promotion: if the agent doesn't finish within the
-        // timeout, its in-flight execution is promoted to an async task instead of being lost.
+        // timeout, its in-flight execution is promoted to an async task instead of being lost —
+        // unless force-sync is on, in which case the agent is interrupted and status: timeout
+        // is returned.
         final String finalTask = task.trim();
         final String finalSpawnInfo = spawnInfo;
         final String finalSubagentId = subagentId;
@@ -464,7 +494,8 @@ public class AgentSpawnTool {
                         runtimeContext,
                         finalSpawnInfo,
                         timeoutMs,
-                        agentId),
+                        agentId,
+                        forceSync),
                 finalSubagentId,
                 agentId,
                 sessionId,
@@ -545,7 +576,8 @@ public class AgentSpawnTool {
         }
         final SpawnedAgent spawned = resolved;
 
-        long timeoutMs = resolveTimeoutMs(timeoutSeconds, DEFAULT_TIMEOUT_SECONDS);
+        boolean forceSync = isForceSync(runtimeContext);
+        long timeoutMs = resolveEffectiveTimeoutMs(timeoutSeconds, forceSync);
         String currentUserId = runtimeContext != null ? runtimeContext.getUserId() : null;
         String parentSessionId = runtimeContext != null ? runtimeContext.getSessionId() : null;
         DefaultAgentManager manager = managerFor(runtimeContext);
@@ -606,7 +638,8 @@ public class AgentSpawnTool {
                     parentSessionId,
                     declOpt.get(),
                     finalMessage.trim(),
-                    timeoutMs);
+                    timeoutMs,
+                    forceSync);
         }
 
         final String finalKey = key;
@@ -619,7 +652,8 @@ public class AgentSpawnTool {
                 runtimeContext,
                 "agent_key: " + finalKey,
                 timeoutMs,
-                spawned.agentId());
+                spawned.agentId(),
+                forceSync);
     }
 
     @Tool(name = "agent_list", description = "List active subagents spawned by this agent.")
@@ -782,7 +816,8 @@ public class AgentSpawnTool {
     /**
      * Executes a local subagent with timeout promotion: if the agent doesn't finish within
      * {@code timeoutMs}, the in-flight execution is promoted to an async background task instead
-     * of being cancelled and lost.
+     * of being cancelled and lost — unless {@code forceSync} is true, in which case the agent is
+     * interrupted and {@code status: timeout} is returned with no background promotion.
      *
      * <p>The key mechanism is a {@link CompletableFuture} bridge that decouples execution from
      * observation. The Mono from {@link #execLocalSync} is subscribed with Reactor Context
@@ -792,8 +827,11 @@ public class AgentSpawnTool {
      *
      * <ul>
      *   <li>Agent finishes before timeout → normal result returned
-     *   <li>Timeout fires first → bridge (still running) is registered in {@link TaskRepository}
-     *       as an {@link TaskRunSpec.AdoptedTaskRunSpec}, and a {@code task_id} is returned
+     *   <li>Timeout fires first (default) → bridge (still running) is registered in {@link
+     *       TaskRepository} as an {@link TaskRunSpec.AdoptedTaskRunSpec}, and a {@code task_id} is
+     *       returned
+     *   <li>Timeout fires first ({@code forceSync}) → agent interrupted, {@code status: timeout},
+     *       no {@code task_id}
      *   <li>Agent errors → error message returned
      * </ul>
      */
@@ -806,7 +844,8 @@ public class AgentSpawnTool {
             RuntimeContext runtimeContext,
             String header,
             long timeoutMs,
-            String agentId) {
+            String agentId,
+            boolean forceSync) {
 
         return Mono.deferContextual(
                 parentCtx ->
@@ -872,7 +911,9 @@ public class AgentSpawnTool {
                                                             header,
                                                             timeoutMs,
                                                             agentId,
-                                                            sink);
+                                                            sink,
+                                                            forceSync,
+                                                            innerSub);
                                                 } else {
                                                     sink.success(
                                                             header
@@ -911,7 +952,8 @@ public class AgentSpawnTool {
 
     /**
      * Handles errors from the race future in {@link #execWithTimeoutPromotion}. Separated to keep
-     * the lambda readable — it distinguishes timeout (→ promote) from real errors (→ report).
+     * the lambda readable — it distinguishes timeout (→ promote, or hard-fail under force-sync)
+     * from real errors (→ report).
      */
     private void handleExecError(
             Throwable err,
@@ -920,10 +962,25 @@ public class AgentSpawnTool {
             String header,
             long timeoutMs,
             String agentId,
-            reactor.core.publisher.MonoSink<String> sink) {
+            reactor.core.publisher.MonoSink<String> sink,
+            boolean forceSync,
+            Disposable innerSub) {
 
         Throwable cause = err instanceof CompletionException ? err.getCause() : err;
         if (cause instanceof TimeoutException) {
+            if (forceSync) {
+                // Hard timeout: dispose triggers doFinally(CANCEL) → interruptAgent; no promote.
+                if (innerSub != null && !innerSub.isDisposed()) {
+                    innerSub.dispose();
+                }
+                log.info(
+                        "agent_spawn sync timeout after {}ms under force_sync (not promoted):"
+                                + " agentId={}",
+                        timeoutMs,
+                        agentId);
+                sink.success(header + "\n" + formatForceSyncTimeout(timeoutMs));
+                return;
+            }
             String taskId = "task_" + UUID.randomUUID();
             String parentSessionId = runtimeContext != null ? runtimeContext.getSessionId() : null;
             CompletableFuture<String> textFuture = bridge.thenApply(AgentSpawnTool::textOf);
@@ -1033,6 +1090,15 @@ public class AgentSpawnTool {
                 Do NOT retry the same task.\
                 """,
                 taskId, timeoutMs / 1000, taskId);
+    }
+
+    private static String formatForceSyncTimeout(long timeoutMs) {
+        return String.format(
+                """
+                status: timeout
+                The task exceeded the %ds sync timeout and was interrupted because force_sync                 is enabled. Background promotion is disabled for this call.\
+                """,
+                timeoutMs / 1000);
     }
 
     /**
@@ -1156,7 +1222,8 @@ public class AgentSpawnTool {
             String parentSessionId,
             SubagentDeclaration decl,
             String input,
-            long timeoutMs) {
+            long timeoutMs,
+            boolean forceSync) {
         return Mono.deferContextual(
                 ctxView -> {
                     Optional<AgentEventEmitter> emitterOpt = AgentEventEmitter.fromContext(ctxView);
@@ -1171,7 +1238,8 @@ public class AgentSpawnTool {
                                             decl,
                                             input,
                                             timeoutMs,
-                                            emitterOpt.orElse(null)));
+                                            emitterOpt.orElse(null),
+                                            forceSync));
                 });
     }
 
@@ -1193,7 +1261,8 @@ public class AgentSpawnTool {
             SubagentDeclaration decl,
             String input,
             long timeoutMs,
-            AgentEventEmitter emitter) {
+            AgentEventEmitter emitter,
+            boolean forceSync) {
         String taskId = "task_" + UUID.randomUUID();
         RemoteSubmitContext submitContext =
                 buildRemoteSubmitContext(runtimeContext, parentState, decl);
@@ -1233,6 +1302,16 @@ public class AgentSpawnTool {
             while (true) {
                 long remaining = deadlineMs - System.currentTimeMillis();
                 if (remaining <= 0) {
+                    if (forceSync) {
+                        taskRepository.cancelTask(runtimeContext, parentSessionId, taskId);
+                        log.info(
+                                "agent remote sync timeout after {}ms under force_sync"
+                                        + " (cancelled): agentId={}, taskId={}",
+                                timeoutMs,
+                                agentId,
+                                taskId);
+                        return header + "\n" + formatForceSyncTimeout(timeoutMs);
+                    }
                     return header + "\nstatus: timeout\ntask_id: " + taskId;
                 }
                 long slice = Math.min(REMOTE_CONFIRM_POLL_MS, remaining);
@@ -1351,6 +1430,28 @@ public class AgentSpawnTool {
     }
 
     /**
+     * Whether {@link #CTX_FORCE_SYNC} is enabled on the current call.
+     */
+    static boolean isForceSync(RuntimeContext ctx) {
+        if (ctx == null) {
+            return false;
+        }
+        return Boolean.TRUE.equals(asBoolean(ctx.get(CTX_FORCE_SYNC)));
+    }
+
+    /**
+     * Resolves the effective sync wait. Under force-sync, {@code timeout_seconds=0} (async /
+     * fire-and-forget) is coerced to the default sync timeout so background submission is skipped.
+     */
+    static long resolveEffectiveTimeoutMs(Integer timeoutSeconds, boolean forceSync) {
+        long timeoutMs = resolveTimeoutMs(timeoutSeconds, DEFAULT_TIMEOUT_SECONDS);
+        if (forceSync && timeoutMs == 0L) {
+            return (long) DEFAULT_TIMEOUT_SECONDS * 1_000;
+        }
+        return timeoutMs;
+    }
+
+    /**
      * Wraps a {@code Mono<String>} to emit a {@link SubagentExposedEvent} into the parent's event
      * stream when {@code subagentId} is non-null. When subagentId is null (no expose), returns the
      * original Mono unchanged.
@@ -1405,7 +1506,8 @@ public class AgentSpawnTool {
             String task,
             Integer timeoutSeconds,
             Optional<SubagentDeclaration> declOpt) {
-        long timeoutMs = resolveTimeoutMs(timeoutSeconds, DEFAULT_TIMEOUT_SECONDS);
+        boolean forceSync = isForceSync(runtimeContext);
+        long timeoutMs = resolveEffectiveTimeoutMs(timeoutSeconds, forceSync);
         String currentUserId = runtimeContext != null ? runtimeContext.getUserId() : null;
         String parentSessionId = runtimeContext != null ? runtimeContext.getSessionId() : null;
         DefaultAgentManager manager = managerFor(runtimeContext);
@@ -1462,7 +1564,8 @@ public class AgentSpawnTool {
                     parentSessionId,
                     declOpt.get(),
                     finalTask.trim(),
-                    timeoutMs);
+                    timeoutMs,
+                    forceSync);
         }
 
         final String finalTask = task.trim();
@@ -1476,7 +1579,8 @@ public class AgentSpawnTool {
                 runtimeContext,
                 finalSpawnInfo,
                 timeoutMs,
-                spawned.agentId());
+                spawned.agentId(),
+                forceSync);
     }
 
     /**

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/tool/AgentSpawnTool.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/tool/AgentSpawnTool.java
@@ -145,7 +145,8 @@ public class AgentSpawnTool {
      * <p>When force-sync is on:
      *
      * <ul>
-     *   <li>{@code timeout_seconds=0} is coerced to the default sync timeout (30s)
+     *   <li>{@code timeout_seconds=0} is coerced to the default sync timeout (30s), unless {@link
+     *       #CTX_FORCE_SYNC_TIMEOUT_SECONDS} supplies an absolute override
      *   <li>If the sync wait exceeds the timeout, the subagent is interrupted and the tool returns
      *       {@code status: timeout} — it is <em>not</em> promoted to an async background task
      * </ul>
@@ -154,6 +155,7 @@ public class AgentSpawnTool {
      * RuntimeContext ctx = RuntimeContext.builder()
      *     .sessionId("s-1")
      *     .put(AgentSpawnTool.CTX_FORCE_SYNC, true)
+     *     .put(AgentSpawnTool.CTX_FORCE_SYNC_TIMEOUT_SECONDS, 120)
      *     .build();
      * }</pre>
      *
@@ -161,6 +163,26 @@ public class AgentSpawnTool {
      * turn still run in parallel by default (Toolkit {@code parallel=true}).
      */
     public static final String CTX_FORCE_SYNC = "agentscope.subagent.force_sync";
+
+    /**
+     * Optional {@link RuntimeContext} override for the sync wait (seconds) when {@link
+     * #CTX_FORCE_SYNC} is enabled. Accepts an {@link Integer}/{@link Number} or its string form.
+     *
+     * <p>When present (and force-sync is on), this value fully replaces the LLM's {@code
+     * timeout_seconds} for the call. Values {@code <= 0} fall back to the default sync timeout
+     * (30s); values above 600 are clamped.
+     *
+     * <p>Ignored when force-sync is off.
+     *
+     * <pre>{@code
+     * RuntimeContext ctx = RuntimeContext.builder()
+     *     .put(AgentSpawnTool.CTX_FORCE_SYNC, true)
+     *     .put(AgentSpawnTool.CTX_FORCE_SYNC_TIMEOUT_SECONDS, 120)
+     *     .build();
+     * }</pre>
+     */
+    public static final String CTX_FORCE_SYNC_TIMEOUT_SECONDS =
+            "agentscope.subagent.force_sync_timeout_seconds";
 
     private static final String BG_RESULT_TEMPLATE =
             """
@@ -407,7 +429,7 @@ public class AgentSpawnTool {
         }
 
         boolean forceSync = isForceSync(runtimeContext);
-        long timeoutMs = resolveEffectiveTimeoutMs(timeoutSeconds, forceSync);
+        long timeoutMs = resolveEffectiveTimeoutMs(timeoutSeconds, runtimeContext);
         boolean remote = declOpt.map(SubagentDeclaration::isRemote).orElse(false);
 
         if (timeoutMs == 0) {
@@ -577,7 +599,7 @@ public class AgentSpawnTool {
         final SpawnedAgent spawned = resolved;
 
         boolean forceSync = isForceSync(runtimeContext);
-        long timeoutMs = resolveEffectiveTimeoutMs(timeoutSeconds, forceSync);
+        long timeoutMs = resolveEffectiveTimeoutMs(timeoutSeconds, runtimeContext);
         String currentUserId = runtimeContext != null ? runtimeContext.getUserId() : null;
         String parentSessionId = runtimeContext != null ? runtimeContext.getSessionId() : null;
         DefaultAgentManager manager = managerFor(runtimeContext);
@@ -1440,15 +1462,55 @@ public class AgentSpawnTool {
     }
 
     /**
-     * Resolves the effective sync wait. Under force-sync, {@code timeout_seconds=0} (async /
-     * fire-and-forget) is coerced to the default sync timeout so background submission is skipped.
+     * Resolves the effective sync wait for the current call.
+     *
+     * <p>Precedence under force-sync (highest first):
+     *
+     * <ol>
+     *   <li>{@link #CTX_FORCE_SYNC_TIMEOUT_SECONDS} when present — absolute app override
+     *   <li>LLM {@code timeout_seconds}, with {@code 0} coerced to the default sync timeout
+     * </ol>
+     *
+     * <p>Without force-sync, behavior matches {@link #resolveTimeoutMs} (including async {@code
+     * 0}).
      */
-    static long resolveEffectiveTimeoutMs(Integer timeoutSeconds, boolean forceSync) {
+    static long resolveEffectiveTimeoutMs(Integer timeoutSeconds, RuntimeContext ctx) {
+        boolean forceSync = isForceSync(ctx);
+        if (forceSync) {
+            Integer override = forceSyncTimeoutSeconds(ctx);
+            if (override != null) {
+                int seconds = override <= 0 ? DEFAULT_TIMEOUT_SECONDS : override;
+                return (long) Math.min(seconds, MAX_TIMEOUT_SECONDS) * 1_000;
+            }
+        }
         long timeoutMs = resolveTimeoutMs(timeoutSeconds, DEFAULT_TIMEOUT_SECONDS);
         if (forceSync && timeoutMs == 0L) {
             return (long) DEFAULT_TIMEOUT_SECONDS * 1_000;
         }
         return timeoutMs;
+    }
+
+    /** Reads {@link #CTX_FORCE_SYNC_TIMEOUT_SECONDS}; {@code null} means "no override". */
+    static Integer forceSyncTimeoutSeconds(RuntimeContext ctx) {
+        if (ctx == null) {
+            return null;
+        }
+        return asPositiveOrZeroInt(ctx.get(CTX_FORCE_SYNC_TIMEOUT_SECONDS));
+    }
+
+    /** Coerces a context value ({@link Number} or numeric string) to Integer; blank/invalid → null. */
+    private static Integer asPositiveOrZeroInt(Object v) {
+        if (v instanceof Number n) {
+            return n.intValue();
+        }
+        if (v instanceof String s && !s.isBlank()) {
+            try {
+                return Integer.parseInt(s.trim());
+            } catch (NumberFormatException ignored) {
+                return null;
+            }
+        }
+        return null;
     }
 
     /**
@@ -1507,7 +1569,7 @@ public class AgentSpawnTool {
             Integer timeoutSeconds,
             Optional<SubagentDeclaration> declOpt) {
         boolean forceSync = isForceSync(runtimeContext);
-        long timeoutMs = resolveEffectiveTimeoutMs(timeoutSeconds, forceSync);
+        long timeoutMs = resolveEffectiveTimeoutMs(timeoutSeconds, runtimeContext);
         String currentUserId = runtimeContext != null ? runtimeContext.getUserId() : null;
         String parentSessionId = runtimeContext != null ? runtimeContext.getSessionId() : null;
         DefaultAgentManager manager = managerFor(runtimeContext);

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/tool/AgentSpawnToolForceSyncTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/tool/AgentSpawnToolForceSyncTest.java
@@ -1,0 +1,279 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.harness.agent.tool;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.verify;
+
+import io.agentscope.core.ReActAgent;
+import io.agentscope.core.agent.RuntimeContext;
+import io.agentscope.core.agent.test.MockModel;
+import io.agentscope.core.message.TextBlock;
+import io.agentscope.core.message.ToolResultBlock;
+import io.agentscope.core.message.ToolUseBlock;
+import io.agentscope.core.model.ChatResponse;
+import io.agentscope.core.model.ChatUsage;
+import io.agentscope.core.tool.AgentTool;
+import io.agentscope.core.tool.ToolCallParam;
+import io.agentscope.core.tool.Toolkit;
+import io.agentscope.harness.agent.middleware.SubagentEntry;
+import io.agentscope.harness.agent.subagent.DefaultAgentManager;
+import io.agentscope.harness.agent.subagent.SubagentFactory;
+import io.agentscope.harness.agent.subagent.task.BackgroundTask;
+import io.agentscope.harness.agent.subagent.task.TaskRepository;
+import io.agentscope.harness.agent.subagent.task.TaskRunSpec;
+import io.agentscope.harness.agent.subagent.task.TaskStatus;
+import java.time.Duration;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Function;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.mockito.Mockito;
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
+
+/**
+ * Tests for {@link AgentSpawnTool#CTX_FORCE_SYNC}: coerce async to sync, and hard-fail on timeout
+ * without promoting to a background {@code task_id}.
+ */
+@DisplayName("AgentSpawnTool force_sync via RuntimeContext")
+class AgentSpawnToolForceSyncTest {
+
+    @Test
+    @DisplayName("isForceSync / resolveEffectiveTimeoutMs helpers")
+    void helpers() {
+        assertFalse(AgentSpawnTool.isForceSync(null));
+        assertFalse(AgentSpawnTool.isForceSync(RuntimeContext.empty()));
+        assertTrue(
+                AgentSpawnTool.isForceSync(
+                        RuntimeContext.builder().put(AgentSpawnTool.CTX_FORCE_SYNC, true).build()));
+        assertTrue(
+                AgentSpawnTool.isForceSync(
+                        RuntimeContext.builder()
+                                .put(AgentSpawnTool.CTX_FORCE_SYNC, "true")
+                                .build()));
+        assertFalse(
+                AgentSpawnTool.isForceSync(
+                        RuntimeContext.builder()
+                                .put(AgentSpawnTool.CTX_FORCE_SYNC, false)
+                                .build()));
+
+        // Without force-sync, 0 stays async.
+        assertTrue(AgentSpawnTool.resolveEffectiveTimeoutMs(0, false) == 0L);
+        // With force-sync, 0 coerces to the 30s default.
+        assertTrue(AgentSpawnTool.resolveEffectiveTimeoutMs(0, true) == 30_000L);
+        // Explicit positive timeouts are preserved.
+        assertTrue(AgentSpawnTool.resolveEffectiveTimeoutMs(5, true) == 5_000L);
+    }
+
+    @Test
+    @DisplayName("timeout_seconds=0 under force_sync waits synchronously (not background accepted)")
+    @Timeout(30)
+    void zeroTimeoutCoercedToSync() {
+        ReActAgent agent =
+                ReActAgent.builder()
+                        .name("fast_sub")
+                        .sysPrompt("fast")
+                        .model(new MockModel("done"))
+                        .build();
+        DefaultAgentManager manager =
+                new DefaultAgentManager(
+                        List.of(new SubagentEntry("fast_agent", "Fast", rc -> agent)), null);
+        CapturingTaskRepository repo = new CapturingTaskRepository();
+        AgentSpawnTool tool = new AgentSpawnTool(manager, repo, 0);
+
+        RuntimeContext ctx =
+                RuntimeContext.builder()
+                        .sessionId("s1")
+                        .userId("u1")
+                        .put(AgentSpawnTool.CTX_FORCE_SYNC, true)
+                        .build();
+
+        String result =
+                tool.agentSpawn(ctx, null, "fast_agent", "go", null, 0, null)
+                        .block(Duration.ofSeconds(15));
+
+        assertNotNull(result);
+        assertTrue(result.contains("status: ok"), "Expected sync ok reply, got: " + result);
+        assertFalse(
+                result.contains("status: accepted"),
+                "Force-sync must not return background accepted. Got: " + result);
+        assertTrue(repo.putCount.get() == 0, "No background task should be submitted");
+    }
+
+    @Test
+    @DisplayName("force_sync timeout interrupts agent and does not promote to AdoptedTaskRunSpec")
+    @Timeout(30)
+    void timeoutHardFailsWithoutPromotion() throws Exception {
+        AgentTool slowTool =
+                new AgentTool() {
+                    @Override
+                    public String getName() {
+                        return "slow_tool";
+                    }
+
+                    @Override
+                    public String getDescription() {
+                        return "Sleeps 2s, then returns ok.";
+                    }
+
+                    @Override
+                    public Map<String, Object> getParameters() {
+                        return Map.of("type", "object", "properties", Map.of());
+                    }
+
+                    @Override
+                    public Mono<ToolResultBlock> callAsync(ToolCallParam p) {
+                        return Mono.fromRunnable(
+                                        () -> {
+                                            try {
+                                                Thread.sleep(2_000);
+                                            } catch (InterruptedException e) {
+                                                Thread.currentThread().interrupt();
+                                            }
+                                        })
+                                .subscribeOn(Schedulers.boundedElastic())
+                                .then(
+                                        Mono.just(
+                                                ToolResultBlock.of(
+                                                        TextBlock.builder().text("ok").build())));
+                    }
+                };
+
+        Toolkit tk = new Toolkit();
+        tk.registerTool(slowTool);
+
+        AtomicInteger modelCall = new AtomicInteger(0);
+        Function<List<io.agentscope.core.message.Msg>, List<ChatResponse>> gen =
+                messages -> {
+                    if (modelCall.incrementAndGet() == 1) {
+                        Map<String, Object> args = new HashMap<>();
+                        return List.of(
+                                ChatResponse.builder()
+                                        .id("msg_" + java.util.UUID.randomUUID())
+                                        .content(
+                                                List.of(
+                                                        ToolUseBlock.builder()
+                                                                .name("slow_tool")
+                                                                .id("call_1")
+                                                                .input(args)
+                                                                .content("{}")
+                                                                .build()))
+                                        .usage(new ChatUsage(8, 15, 23))
+                                        .build());
+                    }
+                    return List.of(
+                            ChatResponse.builder()
+                                    .id("msg_" + java.util.UUID.randomUUID())
+                                    .content(List.of(TextBlock.builder().text("task done").build()))
+                                    .usage(new ChatUsage(10, 20, 30))
+                                    .build());
+                };
+        MockModel model = new MockModel(gen);
+
+        ReActAgent agentSpy =
+                Mockito.spy(
+                        ReActAgent.builder()
+                                .name("slow_sub")
+                                .sysPrompt("slow sub")
+                                .model(model)
+                                .toolkit(tk)
+                                .build());
+
+        SubagentFactory factory = rc -> agentSpy;
+        DefaultAgentManager manager =
+                new DefaultAgentManager(
+                        List.of(new SubagentEntry("slow_agent", "Test slow agent", factory)), null);
+
+        CapturingTaskRepository captureRepo = new CapturingTaskRepository();
+        AgentSpawnTool tool = new AgentSpawnTool(manager, captureRepo, 0);
+        RuntimeContext ctx =
+                RuntimeContext.builder()
+                        .sessionId("s1")
+                        .userId("u1")
+                        .put(AgentSpawnTool.CTX_FORCE_SYNC, true)
+                        .build();
+
+        String result =
+                tool.agentSpawn(ctx, null, "slow_agent", "go", null, 1, null)
+                        .block(Duration.ofSeconds(10));
+
+        assertNotNull(result, "agentSpawn returned null");
+        assertTrue(
+                result.contains("status: timeout"),
+                "Expected hard 'status: timeout', got: " + result);
+        assertFalse(
+                result.contains("timeout_promoted"), "Force-sync must not promote. Got: " + result);
+        assertFalse(
+                result.contains("task_id:"),
+                "Force-sync timeout must not return task_id. Got: " + result);
+        assertTrue(
+                captureRepo.putCount.get() == 0,
+                "TaskRepository.putTask must not be called under force_sync timeout");
+
+        // Dispose → CANCEL → interruptAgent
+        verify(agentSpy, atLeastOnce()).interrupt(any(RuntimeContext.class));
+    }
+
+    private static final class CapturingTaskRepository implements TaskRepository {
+        private final AtomicInteger putCount = new AtomicInteger(0);
+        private final AtomicReference<TaskRunSpec> capturedSpec = new AtomicReference<>();
+
+        @Override
+        public BackgroundTask putTask(
+                RuntimeContext rc,
+                String taskId,
+                String subAgentId,
+                String sessionId,
+                TaskRunSpec spec) {
+            putCount.incrementAndGet();
+            capturedSpec.set(spec);
+            return null;
+        }
+
+        @Override
+        public BackgroundTask getTask(RuntimeContext rc, String sessionId, String taskId) {
+            return null;
+        }
+
+        @Override
+        public void removeTask(RuntimeContext rc, String sessionId, String taskId) {}
+
+        @Override
+        public void clear() {}
+
+        @Override
+        public Collection<BackgroundTask> listTasks(
+                RuntimeContext rc, String sessionId, TaskStatus filter) {
+            return List.of();
+        }
+
+        @Override
+        public boolean cancelTask(RuntimeContext rc, String sessionId, String taskId) {
+            return false;
+        }
+    }
+}

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/tool/AgentSpawnToolForceSyncTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/tool/AgentSpawnToolForceSyncTest.java
@@ -81,12 +81,49 @@ class AgentSpawnToolForceSyncTest {
                                 .put(AgentSpawnTool.CTX_FORCE_SYNC, false)
                                 .build()));
 
-        // Without force-sync, 0 stays async.
-        assertTrue(AgentSpawnTool.resolveEffectiveTimeoutMs(0, false) == 0L);
-        // With force-sync, 0 coerces to the 30s default.
-        assertTrue(AgentSpawnTool.resolveEffectiveTimeoutMs(0, true) == 30_000L);
-        // Explicit positive timeouts are preserved.
-        assertTrue(AgentSpawnTool.resolveEffectiveTimeoutMs(5, true) == 5_000L);
+        RuntimeContext noForce = RuntimeContext.empty();
+        RuntimeContext forceOnly =
+                RuntimeContext.builder().put(AgentSpawnTool.CTX_FORCE_SYNC, true).build();
+        RuntimeContext forceWithOverride =
+                RuntimeContext.builder()
+                        .put(AgentSpawnTool.CTX_FORCE_SYNC, true)
+                        .put(AgentSpawnTool.CTX_FORCE_SYNC_TIMEOUT_SECONDS, 120)
+                        .build();
+        RuntimeContext forceWithStringOverride =
+                RuntimeContext.builder()
+                        .put(AgentSpawnTool.CTX_FORCE_SYNC, true)
+                        .put(AgentSpawnTool.CTX_FORCE_SYNC_TIMEOUT_SECONDS, "45")
+                        .build();
+        RuntimeContext overrideWithoutForce =
+                RuntimeContext.builder()
+                        .put(AgentSpawnTool.CTX_FORCE_SYNC_TIMEOUT_SECONDS, 120)
+                        .build();
+
+        // Without force-sync, 0 stays async — even if a timeout override is present.
+        assertTrue(AgentSpawnTool.resolveEffectiveTimeoutMs(0, noForce) == 0L);
+        assertTrue(AgentSpawnTool.resolveEffectiveTimeoutMs(0, overrideWithoutForce) == 0L);
+        // With force-sync, 0 coerces to the 30s default when no override is set.
+        assertTrue(AgentSpawnTool.resolveEffectiveTimeoutMs(0, forceOnly) == 30_000L);
+        // Explicit positive LLM timeouts are preserved without override.
+        assertTrue(AgentSpawnTool.resolveEffectiveTimeoutMs(5, forceOnly) == 5_000L);
+        // App override wins over LLM timeout (including async 0).
+        assertTrue(AgentSpawnTool.resolveEffectiveTimeoutMs(0, forceWithOverride) == 120_000L);
+        assertTrue(AgentSpawnTool.resolveEffectiveTimeoutMs(5, forceWithOverride) == 120_000L);
+        assertTrue(AgentSpawnTool.resolveEffectiveTimeoutMs(5, forceWithStringOverride) == 45_000L);
+        // Non-positive override falls back to the default sync timeout.
+        RuntimeContext forceBadOverride =
+                RuntimeContext.builder()
+                        .put(AgentSpawnTool.CTX_FORCE_SYNC, true)
+                        .put(AgentSpawnTool.CTX_FORCE_SYNC_TIMEOUT_SECONDS, 0)
+                        .build();
+        assertTrue(AgentSpawnTool.resolveEffectiveTimeoutMs(5, forceBadOverride) == 30_000L);
+        // Clamp at 600s.
+        RuntimeContext forceHuge =
+                RuntimeContext.builder()
+                        .put(AgentSpawnTool.CTX_FORCE_SYNC, true)
+                        .put(AgentSpawnTool.CTX_FORCE_SYNC_TIMEOUT_SECONDS, 9999)
+                        .build();
+        assertTrue(AgentSpawnTool.resolveEffectiveTimeoutMs(5, forceHuge) == 600_000L);
     }
 
     @Test

--- a/docs/v2/en/docs/harness/subagent.md
+++ b/docs/v2/en/docs/harness/subagent.md
@@ -107,8 +107,24 @@ No spec file needed; always available. Its role is "generic fallback" — it mir
 
 The parent creates a subagent with `agent_spawn`; the key knob is `timeout_seconds`:
 
-- `timeout_seconds > 0` (default 30, max 600) — **synchronous** call; the parent blocks on this step, result returns as the tool result.
+- `timeout_seconds > 0` (default 30, max 600) — **synchronous** call; the parent blocks on this step, result returns as the tool result. By default, when the wait expires the in-flight run is **promoted** to a background task (`status: timeout_promoted` + `task_id`) and keeps running.
 - `timeout_seconds = 0` — **background** call; returns a `task_id` immediately, subagent runs in the background.
+
+**Force sync via `RuntimeContext`.** Application code can put `AgentSpawnTool.CTX_FORCE_SYNC = true` on the current call's `RuntimeContext` to override the LLM's async choice:
+
+```java
+RuntimeContext ctx = RuntimeContext.builder()
+    .sessionId("s-1")
+    .put(AgentSpawnTool.CTX_FORCE_SYNC, true)
+    .build();
+```
+
+When enabled:
+
+1. An LLM-supplied `timeout_seconds=0` is coerced to the default sync timeout (30s) — **no** background task is submitted.
+2. If the sync wait expires, the tool returns `status: timeout` and interrupts the subagent — it is **not** promoted to a background `task_id`.
+
+`agent_send` honors the same switch. Multiple force-sync `agent_spawn` calls in one turn still run in parallel under the Toolkit default.
 
 If a goal can be split into independent subtasks that do not conflict on resources, the parent can issue multiple synchronous subagent calls in the same reasoning turn. Toolkit defaults to parallel tool execution (`ToolkitConfig.parallel=true`), so those synchronous calls advance in parallel on both `ReActAgent` and `HarnessAgent`; the parent enters the next reasoning step only after that batch of tool results has returned, forming a synchronous fan-out / fan-in barrier. To serialize tool calls, pass a custom `Toolkit` built with `ToolkitConfig.builder().parallel(false).build()`.
 

--- a/docs/v2/en/docs/harness/subagent.md
+++ b/docs/v2/en/docs/harness/subagent.md
@@ -110,19 +110,21 @@ The parent creates a subagent with `agent_spawn`; the key knob is `timeout_secon
 - `timeout_seconds > 0` (default 30, max 600) — **synchronous** call; the parent blocks on this step, result returns as the tool result. By default, when the wait expires the in-flight run is **promoted** to a background task (`status: timeout_promoted` + `task_id`) and keeps running.
 - `timeout_seconds = 0` — **background** call; returns a `task_id` immediately, subagent runs in the background.
 
-**Force sync via `RuntimeContext`.** Application code can put `AgentSpawnTool.CTX_FORCE_SYNC = true` on the current call's `RuntimeContext` to override the LLM's async choice:
+**Force sync via `RuntimeContext`.** Application code can put `AgentSpawnTool.CTX_FORCE_SYNC = true` on the current call's `RuntimeContext` to override the LLM's async choice, and optionally `CTX_FORCE_SYNC_TIMEOUT_SECONDS` for a hard wait budget (seconds):
 
 ```java
 RuntimeContext ctx = RuntimeContext.builder()
     .sessionId("s-1")
     .put(AgentSpawnTool.CTX_FORCE_SYNC, true)
+    .put(AgentSpawnTool.CTX_FORCE_SYNC_TIMEOUT_SECONDS, 120) // optional; overrides LLM timeout_seconds
     .build();
 ```
 
 When enabled:
 
-1. An LLM-supplied `timeout_seconds=0` is coerced to the default sync timeout (30s) — **no** background task is submitted.
-2. If the sync wait expires, the tool returns `status: timeout` and interrupts the subagent — it is **not** promoted to a background `task_id`.
+1. If `CTX_FORCE_SYNC_TIMEOUT_SECONDS` is set, it **fully replaces** the LLM's `timeout_seconds` (`<= 0` falls back to 30s; max 600s).
+2. Without that override, an LLM-supplied `timeout_seconds=0` is coerced to the default sync timeout (30s) — **no** background task is submitted — while a positive LLM timeout is preserved.
+3. If the sync wait expires, the tool returns `status: timeout` and interrupts the subagent — it is **not** promoted to a background `task_id`.
 
 `agent_send` honors the same switch. Multiple force-sync `agent_spawn` calls in one turn still run in parallel under the Toolkit default.
 

--- a/docs/v2/zh/docs/harness/subagent.md
+++ b/docs/v2/zh/docs/harness/subagent.md
@@ -110,19 +110,21 @@ HarnessAgent.builder()
 - `timeout_seconds > 0`（默认 30，最大 600）—— **同步**调用，主 agent 在这一步 block 等待结果，结果作为工具结果返回。默认超时后会 **promote** 成后台任务（`status: timeout_promoted` + `task_id`），子 agent 继续跑。
 - `timeout_seconds = 0` —— **后台**调用，立即返回一个 `task_id`，子 agent 在后台跑。
 
-**通过 `RuntimeContext` 强制同步。** 应用侧可在当前调用的 `RuntimeContext` 里放入 `AgentSpawnTool.CTX_FORCE_SYNC = true`，覆盖 LLM 的异步选择：
+**通过 `RuntimeContext` 强制同步。** 应用侧可在当前调用的 `RuntimeContext` 里放入 `AgentSpawnTool.CTX_FORCE_SYNC = true`，覆盖 LLM 的异步选择；可选再放 `CTX_FORCE_SYNC_TIMEOUT_SECONDS` 指定硬超时（秒）：
 
 ```java
 RuntimeContext ctx = RuntimeContext.builder()
     .sessionId("s-1")
     .put(AgentSpawnTool.CTX_FORCE_SYNC, true)
+    .put(AgentSpawnTool.CTX_FORCE_SYNC_TIMEOUT_SECONDS, 120) // 可选；覆盖 LLM 的 timeout_seconds
     .build();
 ```
 
 开启后：
 
-1. LLM 传的 `timeout_seconds=0` 会被改写成默认同步超时（30s），**不会**提交后台任务。
-2. 同步等待超时后返回 `status: timeout` 并中断子 agent，**不会** promote 成后台 `task_id`。
+1. 若设置了 `CTX_FORCE_SYNC_TIMEOUT_SECONDS`，它会**完全覆盖** LLM 的 `timeout_seconds`（`<=0` 回退到 30s，上限 600s）。
+2. 未设置时，LLM 传的 `timeout_seconds=0` 会被改写成默认同步超时（30s），**不会**提交后台任务；LLM 传的正数超时仍生效。
+3. 同步等待超时后返回 `status: timeout` 并中断子 agent，**不会** promote 成后台 `task_id`。
 
 `agent_send` 同样遵守该开关。同一轮里多个强制同步的 `agent_spawn` 仍可按 Toolkit 默认并行推进。
 

--- a/docs/v2/zh/docs/harness/subagent.md
+++ b/docs/v2/zh/docs/harness/subagent.md
@@ -107,8 +107,24 @@ HarnessAgent.builder()
 
 主 agent 通过 `agent_spawn` 创建子 agent，关键是 `timeout_seconds`：
 
-- `timeout_seconds > 0`（默认 30，最大 600）—— **同步**调用，主 agent 在这一步 block 等待结果，结果作为工具结果返回。
+- `timeout_seconds > 0`（默认 30，最大 600）—— **同步**调用，主 agent 在这一步 block 等待结果，结果作为工具结果返回。默认超时后会 **promote** 成后台任务（`status: timeout_promoted` + `task_id`），子 agent 继续跑。
 - `timeout_seconds = 0` —— **后台**调用，立即返回一个 `task_id`，子 agent 在后台跑。
+
+**通过 `RuntimeContext` 强制同步。** 应用侧可在当前调用的 `RuntimeContext` 里放入 `AgentSpawnTool.CTX_FORCE_SYNC = true`，覆盖 LLM 的异步选择：
+
+```java
+RuntimeContext ctx = RuntimeContext.builder()
+    .sessionId("s-1")
+    .put(AgentSpawnTool.CTX_FORCE_SYNC, true)
+    .build();
+```
+
+开启后：
+
+1. LLM 传的 `timeout_seconds=0` 会被改写成默认同步超时（30s），**不会**提交后台任务。
+2. 同步等待超时后返回 `status: timeout` 并中断子 agent，**不会** promote 成后台 `task_id`。
+
+`agent_send` 同样遵守该开关。同一轮里多个强制同步的 `agent_spawn` 仍可按 Toolkit 默认并行推进。
 
 如果一个目标可以拆成多个互不依赖、资源不冲突的子任务，主 agent 可以在同一轮 reasoning 里发起多个同步子 agent 调用。Toolkit 默认启用工具并行（`ToolkitConfig.parallel=true`），因此在 `ReActAgent` 与 `HarnessAgent` 上这些同步调用都会并行推进；主 agent 会等这一批工具结果都返回后再进入下一轮推理，相当于一次同步 fan-out / fan-in。若需串行执行工具，可传入 `ToolkitConfig.builder().parallel(false).build()` 构建的自定义 `Toolkit`。
 


### PR DESCRIPTION
## Summary
- Add `AgentSpawnTool.CTX_FORCE_SYNC` so application code can force synchronous `agent_spawn` / `agent_send` via `RuntimeContext`
- When force-sync is on, `timeout_seconds=0` is coerced to the default sync timeout (no background submission), and sync wait timeout hard-fails with `status: timeout` + interrupt instead of promoting to a background `task_id`
- Document the override in EN/ZH harness subagent docs; add unit coverage alongside the existing timeout-promotion regression test

## Test plan
- [x] `mvn -pl agentscope-harness -am test -Dtest=AgentSpawnToolForceSyncTest,AgentSpawnToolPromotionTest`
- [ ] Manual: build a parent agent with `RuntimeContext.put(CTX_FORCE_SYNC, true)` and confirm LLM `timeout_seconds=0` still blocks for the reply
- [ ] Manual: force-sync with a deliberately slow subagent under a short `timeout_seconds`; confirm `status: timeout`, no `task_id`, and no `timeout_promoted`
- [ ] Confirm multiple sync `agent_spawn` calls in one turn still run in parallel under default Toolkit config