### PR TITLE
feat(harness): stamp parentSessionId on remote subagent events

### DIFF
--- a/agentscope-core/src/main/java/io/agentscope/core/event/AgentEvent.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/event/AgentEvent.java
@@ -79,6 +79,13 @@ public abstract class AgentEvent {
      */
     public static final String METADATA_TASK_ID = "taskId";
 
+    /**
+     * Well-known {@link #metadata} key identifying the parent agent's session that initiated a
+     * remote subagent run. Distinct from {@link #source} (which embeds the same id as a path
+     * prefix) and from {@link #METADATA_TASK_ID} (which identifies the harness task).
+     */
+    public static final String METADATA_PARENT_SESSION_ID = "parentSessionId";
+
     private final String id;
     private final String createdAt;
     private String source;

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/tool/AgentSpawnTool.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/tool/AgentSpawnTool.java
@@ -1167,17 +1167,22 @@ public class AgentSpawnTool {
     }
 
     /**
-     * Tags a remote-forwarded {@link AgentEvent} with the parent-visible {@code source} path and
-     * the harness {@link AgentEvent#METADATA_TASK_ID} so concurrent calls to the same remote agent
-     * stay correlatable to distinct {@code TaskRecord}s.
+     * Tags a remote-forwarded {@link AgentEvent} with the parent-visible {@code source} path, the
+     * harness {@link AgentEvent#METADATA_TASK_ID}, and {@link
+     * AgentEvent#METADATA_PARENT_SESSION_ID} so concurrent calls to the same remote agent stay
+     * correlatable to distinct {@code TaskRecord}s and to the parent session that spawned them.
      */
-    static AgentEvent tagRemoteForwardedEvent(AgentEvent event, String sourcePath, String taskId) {
+    static AgentEvent tagRemoteForwardedEvent(
+            AgentEvent event, String sourcePath, String taskId, String parentSessionId) {
         if (event == null) {
             return null;
         }
         event.withSource(sourcePath);
         if (taskId != null && !taskId.isBlank()) {
             event.withMetadataEntry(AgentEvent.METADATA_TASK_ID, taskId);
+        }
+        if (parentSessionId != null && !parentSessionId.isBlank()) {
+            event.withMetadataEntry(AgentEvent.METADATA_PARENT_SESSION_ID, parentSessionId.trim());
         }
         return event;
     }
@@ -1317,7 +1322,8 @@ public class AgentSpawnTool {
                                                                         tagRemoteForwardedEvent(
                                                                                 ae,
                                                                                 sourcePath,
-                                                                                taskId))));
+                                                                                taskId,
+                                                                                parentSessionId))));
             }
 
             long deadlineMs = System.currentTimeMillis() + Math.max(timeoutMs, 0L);

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/tool/AgentSpawnToolRemoteHelpersTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/tool/AgentSpawnToolRemoteHelpersTest.java
@@ -50,16 +50,34 @@ class AgentSpawnToolRemoteHelpersTest {
     }
 
     @Test
-    void tagRemoteForwardedEvent_setsSourceAndTaskIdMetadata() {
+    void tagRemoteForwardedEvent_setsSourceTaskIdAndParentSessionMetadata() {
         TextBlockDeltaEvent event = new TextBlockDeltaEvent(null, "b1", "hello");
         event.withMetadataEntry("keep", "me");
 
         AgentEvent tagged =
-                AgentSpawnTool.tagRemoteForwardedEvent(event, "parent/worker", "task_abc");
+                AgentSpawnTool.tagRemoteForwardedEvent(
+                        event, "parent/worker", "task_abc", "parent-sess");
 
         assertEquals("parent/worker", tagged.getSource());
         assertEquals("task_abc", tagged.getMetadata().get(AgentEvent.METADATA_TASK_ID));
+        assertEquals(
+                "parent-sess", tagged.getMetadata().get(AgentEvent.METADATA_PARENT_SESSION_ID));
         assertEquals("me", tagged.getMetadata().get("keep"));
+    }
+
+    @Test
+    void tagRemoteForwardedEvent_skipsBlankParentSessionId() {
+        TextBlockDeltaEvent event = new TextBlockDeltaEvent(null, "b1", "hello");
+
+        AgentEvent tagged =
+                AgentSpawnTool.tagRemoteForwardedEvent(event, "main/worker", "task_abc", "  ");
+
+        assertEquals("main/worker", tagged.getSource());
+        assertEquals("task_abc", tagged.getMetadata().get(AgentEvent.METADATA_TASK_ID));
+        assertTrue(
+                tagged.getMetadata() == null
+                        || !tagged.getMetadata()
+                                .containsKey(AgentEvent.METADATA_PARENT_SESSION_ID));
     }
 
     @Test

--- a/docs/v2/en/docs/building-blocks/message-and-event.md
+++ b/docs/v2/en/docs/building-blocks/message-and-event.md
@@ -187,7 +187,7 @@ All events extend `AgentEvent` (`io.agentscope.core.event`), which exposes the c
 | `getCreatedAt()` | `String` | ISO 8601 timestamp |
 | `getType()` | `AgentEventType` | Event type enum |
 | `getSource()` | `String` | Source path identifying the originating agent. `null` for top-level agent events; a slash-separated path (e.g. `"main/researcher"`) for events forwarded from a subagent |
-| `getMetadata()` | `Map<String, Object>` | Optional key/value bag. Remote subagent forwards also set `taskId` (`AgentEvent.METADATA_TASK_ID`) to the harness / Agent Protocol task id when events are task-backed |
+| `getMetadata()` | `Map<String, Object>` | Optional key/value bag. Remote subagent forwards also set `taskId` (`AgentEvent.METADATA_TASK_ID`) to the harness / Agent Protocol task id and `parentSessionId` (`AgentEvent.METADATA_PARENT_SESSION_ID`) to the parent session when events are task-backed |
 
 Events are grouped below; unless noted otherwise, every event also carries `getReplyId()` linking it to the message being assembled.
 

--- a/docs/v2/en/docs/harness/subagent.md
+++ b/docs/v2/en/docs/harness/subagent.md
@@ -348,7 +348,7 @@ Declaration knobs specific to remote mode:
 
 | Field | Default | Notes |
 |-------|---------|-------|
-| `remoteStreaming` | `true` (when unset) | When the parent uses `streamEvents()`, forward remote task SSE events into the parent stream with a `source` tag and `metadata.taskId` (same id as the harness `TaskRecord`) |
+| `remoteStreaming` | `true` (when unset) | When the parent uses `streamEvents()`, forward remote task SSE events into the parent stream with a `source` tag plus `metadata.taskId` / `metadata.parentSessionId` (same ids as the harness `TaskRecord` / parent session) |
 | `remoteAskPolicy` | `DENY` | How to resolve remote tool-confirmation (HITL) requests — see [Remote authorization](#remote-authorization) |
 
 ### Remote authorization
@@ -378,7 +378,7 @@ When the parent is in Plan Mode, spawned subagents **automatically inherit the r
 
 > New code should use `streamEvents()` (returns `Flux<AgentEvent>`). The legacy `stream()` family (`Flux<Event>`) is `@Deprecated(forRemoval = true)` since 2.0.0 — see [Message & Event](../building-blocks/message-and-event.md) and [V1 Migration Guide B.4](../change-log.md).
 
-When the parent calls a synchronous subagent via `agent_spawn` / `agent_send`, the child's intermediate events are **forwarded live** into the parent's `streamEvents()` stream. Each child event carries a `source` field (a `/`-separated path like `"main/researcher"`) so you can tell parent events (`source == null`) from child events. Remote Agent Protocol children additionally set `metadata.taskId` (`AgentEvent.METADATA_TASK_ID`) to the harness task id, so two concurrent / same-turn calls to the same remote agent remain distinguishable even when they share a `source` path.
+When the parent calls a synchronous subagent via `agent_spawn` / `agent_send`, the child's intermediate events are **forwarded live** into the parent's `streamEvents()` stream. Each child event carries a `source` field (a `/`-separated path like `"main/researcher"`) so you can tell parent events (`source == null`) from child events. Remote Agent Protocol children additionally set `metadata.taskId` (`AgentEvent.METADATA_TASK_ID`) to the harness task id and `metadata.parentSessionId` (`AgentEvent.METADATA_PARENT_SESSION_ID`) to the parent session, so two concurrent / same-turn calls to the same remote agent remain distinguishable even when they share a `source` path.
 
 ```
 caller

--- a/docs/v2/zh/docs/building-blocks/message-and-event.md
+++ b/docs/v2/zh/docs/building-blocks/message-and-event.md
@@ -187,7 +187,7 @@ sequenceDiagram
 | `getCreatedAt()` | `String` | ISO 8601 时间戳 |
 | `getType()` | `AgentEventType` | 事件类型枚举 |
 | `getSource()` | `String` | 事件来源路径。顶层 Agent 为 `null`；子 Agent 事件为斜杠分隔的路径（如 `"main/researcher"`），用于区分父子 Agent 事件 |
-| `getMetadata()` | `Map<String, Object>` | 可选键值元数据。远程子 agent 转发时会写入 `taskId`（`AgentEvent.METADATA_TASK_ID`），对应该 harness / Agent Protocol 任务 id |
+| `getMetadata()` | `Map<String, Object>` | 可选键值元数据。远程子 agent 转发时会写入 `taskId`（`AgentEvent.METADATA_TASK_ID`，对应 harness / Agent Protocol 任务 id）与 `parentSessionId`（`AgentEvent.METADATA_PARENT_SESSION_ID`，对应父 session） |
 
 事件按类别分组如下。除特别说明外，每个事件还携带 `getReplyId()`，关联到正在构建的消息。
 

--- a/docs/v2/zh/docs/harness/subagent.md
+++ b/docs/v2/zh/docs/harness/subagent.md
@@ -348,7 +348,7 @@ ChatUiChannel chat = agent.channel(ChatUiChannel.create());  // 恢复能力自�
 
 | 字段 | 默认 | 说明 |
 |------|------|------|
-| `remoteStreaming` | `true`（未设置时） | 父代理使用 `streamEvents()` 时，把远程任务的 SSE 事件转发进父流，并带 `source` 标记与 `metadata.taskId`（与 harness `TaskRecord` 的 task id 一致） |
+| `remoteStreaming` | `true`（未设置时） | 父代理使用 `streamEvents()` 时，把远程任务的 SSE 事件转发进父流，并带 `source` 标记与 `metadata.taskId` / `metadata.parentSessionId`（与 harness `TaskRecord` / 父 session 一致） |
 | `remoteAskPolicy` | `DENY` | 如何处理远程工具确认（HITL）请求——见 [远程授权](#远程授权) |
 
 ### 远程授权
@@ -378,7 +378,7 @@ ChatUiChannel chat = agent.channel(ChatUiChannel.create());  // 恢复能力自�
 
 > 新代码请用 `streamEvents()`（返回 `Flux<AgentEvent>`）。旧 `stream()` 系列（`Flux<Event>`）在 2.0.0 起 `@Deprecated(forRemoval = true)` —— 详见 [消息与事件](../building-blocks/message-and-event.md) 与 [V1 迁移指南 B.4](../change-log.md)。
 
-父 agent 通过 `agent_spawn` / `agent_send` 同步调用子 agent 时，子 agent 的中间事件会**实时转发**到父的 `streamEvents()` 流中。每个子事件都带一个 `source` 字段（`/` 分隔的路径，如 `"main/researcher"`），父事件的 `source` 为 `null`。远程 Agent Protocol 子 agent 还会写入 `metadata.taskId`（`AgentEvent.METADATA_TASK_ID`），值为 harness 侧任务 id，因此同一轮里对同一远程 agent 的多次调用即使 `source` 相同也能区分。
+父 agent 通过 `agent_spawn` / `agent_send` 同步调用子 agent 时，子 agent 的中间事件会**实时转发**到父的 `streamEvents()` 流中。每个子事件都带一个 `source` 字段（`/` 分隔的路径，如 `"main/researcher"`），父事件的 `source` 为 `null`。远程 Agent Protocol 子 agent 还会写入 `metadata.taskId`（`AgentEvent.METADATA_TASK_ID`，harness 侧任务 id）与 `metadata.parentSessionId`（`AgentEvent.METADATA_PARENT_SESSION_ID`，父 session），因此同一轮里对同一远程 agent 的多次调用即使 `source` 相同也能区分，并能回溯到发起方会话。
 
 ```
 caller


### PR DESCRIPTION
## Summary
- Add `AgentEvent.METADATA_PARENT_SESSION_ID` (`parentSessionId`) as a well-known metadata key
- Extend `AgentSpawnTool.tagRemoteForwardedEvent` to stamp the parent session alongside `source` and `taskId` when forwarding remote Agent Protocol events
- Document the new metadata field in EN/ZH harness and message-and-event docs

## Test plan
- [x] `mvn -pl agentscope-harness -am test -Dtest=AgentSpawnToolRemoteHelpersTest`
- [ ] Manual: stream a remote sync `agent_spawn` and confirm forwarded events carry both `metadata.taskId` and `metadata.parentSessionId`