### PR TITLE
feat(agent-protocol): pass caller context attributes into task runs

### DIFF
--- a/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agent-protocol/src/main/java/io/agentscope/extensions/agentprotocol/AgentProtocolAutoConfiguration.java
+++ b/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agent-protocol/src/main/java/io/agentscope/extensions/agentprotocol/AgentProtocolAutoConfiguration.java
@@ -36,6 +36,9 @@ import org.springframework.context.annotation.Bean;
  * factory resolves the single {@link HarnessAgent} bean for every task; define an
  * {@link AgentFactory} bean to route per {@code agent_id} or submission context.
  *
+ * <p>All {@link RuntimeContextCustomizer} beans are applied, in {@code @Order}, to the runtime
+ * context of every task run.
+ *
  * <p>For concurrent task execution, register the {@link HarnessAgent} bean as
  * {@code @Scope("prototype")} so that each task obtains its own instance. Alternatively, configure
  * the singleton with {@code checkRunning(false)} if concurrent access is otherwise safe.
@@ -63,8 +66,14 @@ public class AgentProtocolAutoConfiguration {
             AgentFactory agentFactory,
             WorkspaceManager workspaceManager,
             AgentProtocolTaskEventBus eventBus,
-            AgentProtocolProperties properties) {
-        return new AgentProtocolTaskStore(agentFactory, workspaceManager, eventBus, properties);
+            AgentProtocolProperties properties,
+            ObjectProvider<RuntimeContextCustomizer> runtimeContextCustomizers) {
+        return new AgentProtocolTaskStore(
+                agentFactory,
+                workspaceManager,
+                eventBus,
+                properties,
+                runtimeContextCustomizers.orderedStream().toList());
     }
 
     @Bean

--- a/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agent-protocol/src/main/java/io/agentscope/extensions/agentprotocol/AgentProtocolConstants.java
+++ b/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agent-protocol/src/main/java/io/agentscope/extensions/agentprotocol/AgentProtocolConstants.java
@@ -15,7 +15,13 @@
  */
 package io.agentscope.extensions.agentprotocol;
 
-/** Workspace partitioning for persisted task records served by the protocol endpoints. */
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Workspace partitioning for persisted task records served by the protocol endpoints, plus the
+ * contract for caller-supplied context attributes.
+ */
 public final class AgentProtocolConstants {
 
     private AgentProtocolConstants() {}
@@ -25,4 +31,49 @@ public final class AgentProtocolConstants {
 
     /** Single session bucket file holding all protocol tasks as a task-id map. */
     public static final String PROTOCOL_SESSION_ID = "_tasks";
+
+    /**
+     * Field inside the submission {@code context} that carries caller-defined attributes. Keeping
+     * them nested separates them from the protocol's own context fields ({@code user_id},
+     * {@code parent_session_id}, {@code stream}, {@code detail}, {@code deny_rules}).
+     */
+    public static final String CONTEXT_ATTRIBUTES_FIELD = "attributes";
+
+    /**
+     * {@link io.agentscope.core.agent.RuntimeContext} key holding the whole {@code
+     * context.attributes} map as an unmodifiable {@code Map<String, Object>}.
+     *
+     * <p>Attributes are namespaced under this single key so that no caller-controlled name can
+     * shadow a framework key. Tools and middlewares read them with {@code ctx.get(
+     * AgentProtocolConstants.RUNTIME_CONTEXT_ATTRIBUTES_KEY)}; to expose an attribute under its own
+     * top-level key instead, use {@link RuntimeContextCustomizer#flatten(String...)}.
+     */
+    public static final String RUNTIME_CONTEXT_ATTRIBUTES_KEY = "agentprotocol.context.attributes";
+
+    /** Exact runtime-context keys the framework reads; never overwritten by flattening. */
+    private static final Set<String> RESERVED_KEYS = Set.of("agentId", "outboundAddress");
+
+    /** Runtime-context key prefixes owned by the framework; never overwritten by flattening. */
+    private static final List<String> RESERVED_PREFIXES =
+            List.of("agentscope.", "agui.", "io.agentscope.");
+
+    /**
+     * Whether {@code key} is read by the framework itself and therefore unsafe to overwrite with a
+     * caller-supplied value. Examples: {@code agentId} drives async tool wakeup routing and
+     * {@code outboundAddress} carries the gateway reply address.
+     */
+    public static boolean isReservedRuntimeContextKey(String key) {
+        if (key == null || key.isBlank()) {
+            return true;
+        }
+        if (RESERVED_KEYS.contains(key)) {
+            return true;
+        }
+        for (String prefix : RESERVED_PREFIXES) {
+            if (key.startsWith(prefix)) {
+                return true;
+            }
+        }
+        return false;
+    }
 }

--- a/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agent-protocol/src/main/java/io/agentscope/extensions/agentprotocol/AgentProtocolTaskStore.java
+++ b/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agent-protocol/src/main/java/io/agentscope/extensions/agentprotocol/AgentProtocolTaskStore.java
@@ -59,6 +59,9 @@ import reactor.core.publisher.Flux;
  * the submission context and can therefore route per task. For concurrent task execution, return a
  * new instance per call (e.g. a Spring prototype-scoped bean); a shared instance requires the agent
  * to be configured with {@code checkRunning(false)}.
+ *
+ * <p>Caller-supplied {@code context.attributes} reach the run through its {@link RuntimeContext};
+ * see {@link RuntimeContextCustomizer} for controlling how.
  */
 public final class AgentProtocolTaskStore {
 
@@ -72,6 +75,7 @@ public final class AgentProtocolTaskStore {
     private final WorkspaceManager workspaceManager;
     private final AgentProtocolTaskEventBus eventBus;
     private final AgentProtocolProperties properties;
+    private final List<RuntimeContextCustomizer> runtimeContextCustomizers;
     private final ExecutorService executor =
             Executors.newCachedThreadPool(
                     r -> {
@@ -89,10 +93,23 @@ public final class AgentProtocolTaskStore {
             WorkspaceManager workspaceManager,
             AgentProtocolTaskEventBus eventBus,
             AgentProtocolProperties properties) {
+        this(agentFactory, workspaceManager, eventBus, properties, List.of());
+    }
+
+    public AgentProtocolTaskStore(
+            AgentFactory agentFactory,
+            WorkspaceManager workspaceManager,
+            AgentProtocolTaskEventBus eventBus,
+            AgentProtocolProperties properties,
+            List<RuntimeContextCustomizer> runtimeContextCustomizers) {
         this.agentFactory = Objects.requireNonNull(agentFactory, "agentFactory");
         this.workspaceManager = Objects.requireNonNull(workspaceManager, "workspaceManager");
         this.eventBus = eventBus != null ? eventBus : new AgentProtocolTaskEventBus();
         this.properties = properties != null ? properties : new AgentProtocolProperties();
+        this.runtimeContextCustomizers =
+                runtimeContextCustomizers == null
+                        ? List.of()
+                        : List.copyOf(runtimeContextCustomizers);
     }
 
     public AgentProtocolTaskStore(AgentFactory agentFactory, WorkspaceManager workspaceManager) {
@@ -207,11 +224,16 @@ public final class AgentProtocolTaskStore {
             List<ConfirmResult> confirmResults) {
         try {
             updateRunning(taskId, agentId);
-            RuntimeContext.Builder ctxBuilder = RuntimeContext.builder().sessionId(taskId);
-            if (submitCtx.userId() != null) {
-                ctxBuilder.userId(submitCtx.userId());
-            }
-            RuntimeContext ctx = ctxBuilder.build();
+            AgentRequest request =
+                    new AgentRequest(
+                            taskId,
+                            agentId,
+                            input,
+                            submitCtx.userId(),
+                            submitCtx.parentSessionId(),
+                            confirmResults != null,
+                            submitCtx.raw());
+            RuntimeContext ctx = buildRuntimeContext(request);
 
             Msg.Builder msgBuilder =
                     Msg.builder().role(MsgRole.USER).textContent(input != null ? input : "");
@@ -222,15 +244,6 @@ public final class AgentProtocolTaskStore {
             }
             Msg msg = msgBuilder.build();
 
-            AgentRequest request =
-                    new AgentRequest(
-                            taskId,
-                            agentId,
-                            input,
-                            submitCtx.userId(),
-                            submitCtx.parentSessionId(),
-                            confirmResults != null,
-                            submitCtx.raw());
             HarnessAgent agent = agentFactory.create(request);
             if (agent == null) {
                 throw new IllegalStateException(
@@ -296,6 +309,30 @@ public final class AgentProtocolTaskStore {
             clearSubmitContext(taskId);
             throw new RuntimeException(e);
         }
+    }
+
+    /**
+     * Builds the agent's runtime context for one run: session/user identity, the caller's {@code
+     * context.attributes} under {@link AgentProtocolConstants#RUNTIME_CONTEXT_ATTRIBUTES_KEY}, and
+     * whatever the registered {@link RuntimeContextCustomizer}s add on top.
+     *
+     * <p>Attributes stay behind a single namespaced key by default so that no caller-supplied name
+     * can shadow a key the framework reads (e.g. {@code agentId}); promoting individual attributes
+     * to their own keys is an explicit opt-in through a customizer.
+     */
+    private RuntimeContext buildRuntimeContext(AgentRequest request) {
+        RuntimeContext.Builder builder = RuntimeContext.builder().sessionId(request.taskId());
+        if (request.userId() != null) {
+            builder.userId(request.userId());
+        }
+        Map<String, Object> attributes = request.attributes();
+        if (!attributes.isEmpty()) {
+            builder.put(AgentProtocolConstants.RUNTIME_CONTEXT_ATTRIBUTES_KEY, attributes);
+        }
+        for (RuntimeContextCustomizer customizer : runtimeContextCustomizers) {
+            customizer.customize(request, builder);
+        }
+        return builder.build();
     }
 
     private void publishStatus(String taskId, String agentId, String status, String error) {

--- a/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agent-protocol/src/main/java/io/agentscope/extensions/agentprotocol/AgentRequest.java
+++ b/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agent-protocol/src/main/java/io/agentscope/extensions/agentprotocol/AgentRequest.java
@@ -57,4 +57,30 @@ public record AgentRequest(
         Object v = contextValue(key);
         return v == null ? null : String.valueOf(v);
     }
+
+    /**
+     * Caller-defined attributes from {@code context.attributes}, or an empty map when the caller
+     * sent none. These are the values propagated into the agent's {@link
+     * io.agentscope.core.agent.RuntimeContext}; the surrounding {@link #context()} also holds the
+     * protocol's own fields.
+     */
+    public Map<String, Object> attributes() {
+        Object raw = context.get(AgentProtocolConstants.CONTEXT_ATTRIBUTES_FIELD);
+        if (!(raw instanceof Map<?, ?> map) || map.isEmpty()) {
+            return Map.of();
+        }
+        Map<String, Object> out = new LinkedHashMap<>();
+        for (Map.Entry<?, ?> e : map.entrySet()) {
+            if (e.getKey() != null && e.getValue() != null) {
+                out.put(String.valueOf(e.getKey()), e.getValue());
+            }
+        }
+        return Collections.unmodifiableMap(out);
+    }
+
+    /** Returns the {@code context.attributes} value for {@code key} as a string, or {@code null}. */
+    public String attributeString(String key) {
+        Object v = key == null ? null : attributes().get(key);
+        return v == null ? null : String.valueOf(v);
+    }
 }

--- a/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agent-protocol/src/main/java/io/agentscope/extensions/agentprotocol/RuntimeContextCustomizer.java
+++ b/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agent-protocol/src/main/java/io/agentscope/extensions/agentprotocol/RuntimeContextCustomizer.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.extensions.agentprotocol;
+
+import io.agentscope.core.agent.RuntimeContext;
+import java.util.Arrays;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Hook for shaping the {@link RuntimeContext} of an Agent Protocol task run.
+ *
+ * <p>The store always exposes the caller's {@code context.attributes} as one map under {@link
+ * AgentProtocolConstants#RUNTIME_CONTEXT_ATTRIBUTES_KEY}, which cannot collide with framework keys.
+ * Register customizer beans (ordered with {@code @Order}) to go further — promote selected
+ * attributes to their own keys, translate them into typed values, or derive attributes of your own:
+ *
+ * <pre>{@code
+ * @Bean
+ * RuntimeContextCustomizer tenantContext() {
+ *     return (request, builder) -> {
+ *         String tenant = request.attributeString("tenant");
+ *         if (tenant != null) {
+ *             builder.put(TenantInfo.class, tenantService.load(tenant));
+ *         }
+ *     };
+ * }
+ * }</pre>
+ *
+ * <p>Customizers run after the namespaced injection and in bean order, so a later one overrides an
+ * earlier one. They are trusted: unlike {@link #flatten(String...)}, a hand-written customizer may
+ * write any key, including framework-reserved ones.
+ */
+@FunctionalInterface
+public interface RuntimeContextCustomizer {
+
+    /**
+     * Adjusts the context being built for {@code request}. Called once per run — on submit and
+     * again on every resume.
+     */
+    void customize(AgentRequest request, RuntimeContext.Builder builder);
+
+    /**
+     * Customizer that copies the listed {@code context.attributes} entries to top-level runtime
+     * context keys of the same name, for tools that read a plain key such as {@code
+     * ctx.get("tenant")}.
+     *
+     * <p>Only the listed names are copied, and names the framework itself reads (see {@link
+     * AgentProtocolConstants#isReservedRuntimeContextKey(String)}) are skipped with a warning, so a
+     * caller cannot hijack routing keys like {@code agentId} by naming an attribute after one.
+     */
+    static RuntimeContextCustomizer flatten(String... keys) {
+        Logger log = LoggerFactory.getLogger(RuntimeContextCustomizer.class);
+        Set<String> allowed = new LinkedHashSet<>(Arrays.asList(keys));
+        allowed.removeIf(
+                key -> {
+                    if (AgentProtocolConstants.isReservedRuntimeContextKey(key)) {
+                        log.warn(
+                                "Ignoring reserved runtime context key '{}' in"
+                                        + " RuntimeContextCustomizer.flatten",
+                                key);
+                        return true;
+                    }
+                    return false;
+                });
+        return (request, builder) -> {
+            Map<String, Object> attributes = request.attributes();
+            for (String key : allowed) {
+                Object value = attributes.get(key);
+                if (value != null) {
+                    builder.put(key, value);
+                }
+            }
+        };
+    }
+}

--- a/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agent-protocol/src/test/java/io/agentscope/extensions/agentprotocol/AgentProtocolContextAttributesTest.java
+++ b/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agent-protocol/src/test/java/io/agentscope/extensions/agentprotocol/AgentProtocolContextAttributesTest.java
@@ -1,0 +1,196 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.extensions.agentprotocol;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.agentscope.core.agent.RuntimeContext;
+import io.agentscope.core.event.AgentEndEvent;
+import io.agentscope.core.event.AgentResultEvent;
+import io.agentscope.core.event.AgentStartEvent;
+import io.agentscope.core.message.Msg;
+import io.agentscope.core.message.MsgRole;
+import io.agentscope.harness.agent.HarnessAgent;
+import io.agentscope.harness.agent.workspace.WorkspaceManager;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import reactor.core.publisher.Flux;
+
+/**
+ * How caller-supplied {@code context.attributes} reach the agent's {@link RuntimeContext}:
+ * namespaced by default, promoted to top-level keys only through a {@link
+ * RuntimeContextCustomizer}.
+ */
+class AgentProtocolContextAttributesTest {
+
+    @TempDir Path tempDir;
+
+    private WorkspaceManager workspaceManager;
+    private final AtomicReference<RuntimeContext> executed = new AtomicReference<>();
+
+    @BeforeEach
+    void setUp() {
+        workspaceManager = new WorkspaceManager(tempDir);
+    }
+
+    @Test
+    void attributesAreNamespacedAndNeverFlattenedByDefault() throws Exception {
+        AgentProtocolTaskStore store = store(List.of());
+
+        store.submit("t-1", "worker", "go", contextWithAttributes());
+        RuntimeContext ctx = awaitRun(store, "t-1");
+
+        Map<String, Object> attributes =
+                ctx.get(AgentProtocolConstants.RUNTIME_CONTEXT_ATTRIBUTES_KEY);
+        assertEquals("acme", attributes.get("tenant"));
+        assertEquals("INC-1001", attributes.get("ticket_id"));
+        assertEquals("hijacked", attributes.get("agentId"));
+
+        assertNull(ctx.get("tenant"));
+        assertNull(ctx.get("ticket_id"));
+        assertNull(ctx.get("agentId"), "framework keys must not be writable by callers");
+    }
+
+    @Test
+    void noAttributesLeavesTheKeyUnset() throws Exception {
+        AgentProtocolTaskStore store = store(List.of());
+
+        store.submit("t-2", "worker", "go", Map.of("user_id", "u-1"));
+        RuntimeContext ctx = awaitRun(store, "t-2");
+
+        assertNull(ctx.get(AgentProtocolConstants.RUNTIME_CONTEXT_ATTRIBUTES_KEY));
+        assertEquals("u-1", ctx.getUserId());
+        assertEquals("t-2", ctx.getSessionId());
+    }
+
+    @Test
+    void flattenPromotesAllowedKeysAndRefusesReservedOnes() throws Exception {
+        AgentProtocolTaskStore store =
+                store(List.of(RuntimeContextCustomizer.flatten("tenant", "agentId")));
+
+        store.submit("t-3", "worker", "go", contextWithAttributes());
+        RuntimeContext ctx = awaitRun(store, "t-3");
+
+        assertEquals("acme", ctx.get("tenant"));
+        assertNull(ctx.get("ticket_id"), "keys outside the allow-list stay namespaced");
+        assertNull(ctx.get("agentId"), "reserved keys are dropped from the allow-list");
+    }
+
+    @Test
+    void customizersRunInRegistrationOrderAndSeeTheRequest() throws Exception {
+        RuntimeContextCustomizer first =
+                (request, builder) -> {
+                    builder.put("route", "first");
+                    builder.put("task", request.taskId());
+                };
+        RuntimeContextCustomizer second =
+                (request, builder) -> builder.put("route", request.attributeString("tenant"));
+        AgentProtocolTaskStore store = store(List.of(first, second));
+
+        store.submit("t-4", "worker", "go", contextWithAttributes());
+        RuntimeContext ctx = awaitRun(store, "t-4");
+
+        assertEquals("acme", ctx.get("route"), "the later customizer wins");
+        assertEquals("t-4", ctx.get("task"));
+    }
+
+    @Test
+    void agentRequestExposesNestedAttributesOnly() {
+        Map<String, Object> context = new HashMap<>();
+        context.put("user_id", "u-1");
+        context.put("attributes", Map.of("tenant", "acme"));
+        AgentRequest request = new AgentRequest("t", "a", "in", "u-1", null, false, context);
+
+        assertEquals(Map.of("tenant", "acme"), request.attributes());
+        assertEquals("acme", request.attributeString("tenant"));
+        assertNull(request.attributeString("missing"));
+        assertEquals("u-1", request.contextString("user_id"));
+    }
+
+    @Test
+    void agentRequestToleratesMissingOrMalformedAttributes() {
+        assertTrue(
+                new AgentRequest("t", "a", "in", null, null, false, Map.of("attributes", "oops"))
+                        .attributes()
+                        .isEmpty());
+        assertTrue(
+                new AgentRequest("t", "a", "in", null, null, false, null).attributes().isEmpty());
+    }
+
+    private static Map<String, Object> contextWithAttributes() {
+        Map<String, Object> attributes = new HashMap<>();
+        attributes.put("tenant", "acme");
+        attributes.put("ticket_id", "INC-1001");
+        attributes.put("agentId", "hijacked");
+        Map<String, Object> context = new HashMap<>();
+        context.put("user_id", "u-1");
+        context.put("attributes", attributes);
+        return context;
+    }
+
+    private AgentProtocolTaskStore store(List<RuntimeContextCustomizer> customizers) {
+        return new AgentProtocolTaskStore(
+                AgentFactory.fixed(recordingAgent()),
+                workspaceManager,
+                new AgentProtocolTaskEventBus(),
+                new AgentProtocolProperties(),
+                customizers);
+    }
+
+    private HarnessAgent recordingAgent() {
+        HarnessAgent agent = mock(HarnessAgent.class);
+        when(agent.streamEvents(any(Msg.class), any(RuntimeContext.class)))
+                .thenAnswer(
+                        invocation -> {
+                            executed.set(invocation.getArgument(1));
+                            return Flux.just(
+                                    new AgentStartEvent("sess", null, "worker"),
+                                    new AgentResultEvent(
+                                            Msg.builder()
+                                                    .role(MsgRole.ASSISTANT)
+                                                    .textContent("done")
+                                                    .build()),
+                                    new AgentEndEvent(null));
+                        });
+        return agent;
+    }
+
+    private RuntimeContext awaitRun(AgentProtocolTaskStore store, String taskId) throws Exception {
+        long deadline = System.currentTimeMillis() + 5_000;
+        while (!"success".equals(store.snapshot(taskId).get("status"))) {
+            if (System.currentTimeMillis() >= deadline) {
+                throw new AssertionError("Task " + taskId + " did not finish in time");
+            }
+            Thread.sleep(25);
+        }
+        RuntimeContext ctx = executed.get();
+        if (ctx == null) {
+            throw new AssertionError("Agent was never invoked for task " + taskId);
+        }
+        return ctx;
+    }
+}

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/subagent/SubagentDeclaration.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/subagent/SubagentDeclaration.java
@@ -16,6 +16,8 @@
 package io.agentscope.harness.agent.subagent;
 
 import java.nio.file.Path;
+import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -110,6 +112,12 @@ public final class SubagentDeclaration {
     /** Policy for resolving remote HITL confirmations. Defaults to {@link RemoteAskPolicy#DENY}. */
     private final RemoteAskPolicy remoteAskPolicy;
 
+    /**
+     * Static attributes sent as {@code context.attributes} on every remote submission. Never empty
+     * when non-null.
+     */
+    private final Map<String, Object> remoteContextAttributes;
+
     private SubagentDeclaration(Builder b) {
         this.name = b.name;
         this.description = b.description;
@@ -132,6 +140,11 @@ public final class SubagentDeclaration {
         this.headers = b.headers != null && !b.headers.isEmpty() ? Map.copyOf(b.headers) : null;
         this.remoteStreaming = b.remoteStreaming;
         this.remoteAskPolicy = b.remoteAskPolicy != null ? b.remoteAskPolicy : RemoteAskPolicy.DENY;
+        this.remoteContextAttributes =
+                b.remoteContextAttributes != null && !b.remoteContextAttributes.isEmpty()
+                        ? Collections.unmodifiableMap(
+                                new LinkedHashMap<>(b.remoteContextAttributes))
+                        : null;
     }
 
     /** Factory method for a new builder. */
@@ -329,6 +342,15 @@ public final class SubagentDeclaration {
         return remoteAskPolicy;
     }
 
+    /**
+     * Static attributes sent as {@code context.attributes} with every remote submission, for the
+     * remote server to route on or expose to its agent. {@code null} when unset; never empty
+     * otherwise.
+     */
+    public Map<String, Object> getRemoteContextAttributes() {
+        return remoteContextAttributes;
+    }
+
     /** Returns {@code true} when this declaration points at an external definition workspace. */
     public boolean hasDefinitionWorkspace() {
         return workspacePath != null;
@@ -361,6 +383,7 @@ public final class SubagentDeclaration {
         private Map<String, String> headers;
         private Boolean remoteStreaming;
         private RemoteAskPolicy remoteAskPolicy = RemoteAskPolicy.DENY;
+        private Map<String, Object> remoteContextAttributes;
 
         private Builder() {}
 
@@ -566,6 +589,17 @@ public final class SubagentDeclaration {
          */
         public Builder remoteAskPolicy(RemoteAskPolicy remoteAskPolicy) {
             this.remoteAskPolicy = remoteAskPolicy != null ? remoteAskPolicy : RemoteAskPolicy.DENY;
+            return this;
+        }
+
+        /**
+         * Static attributes sent as {@code context.attributes} with every submission to this
+         * remote subagent (e.g. tenant or deployment tags). Values must be JSON-serializable. Per
+         * call attributes set on the parent's {@code RuntimeContext} are merged on top. Only
+         * relevant when {@link #url(String)} is set.
+         */
+        public Builder remoteContextAttributes(Map<String, Object> remoteContextAttributes) {
+            this.remoteContextAttributes = remoteContextAttributes;
             return this;
         }
 

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/subagent/task/RemoteSubmitContext.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/subagent/task/RemoteSubmitContext.java
@@ -16,6 +16,7 @@
 package io.agentscope.harness.agent.subagent.task;
 
 import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -30,6 +31,7 @@ public final class RemoteSubmitContext {
     private final boolean stream;
     private final String detail;
     private final List<Map<String, String>> denyRules;
+    private final Map<String, Object> attributes;
 
     private RemoteSubmitContext(Builder builder) {
         this.userId = builder.userId;
@@ -40,6 +42,10 @@ public final class RemoteSubmitContext {
                 builder.denyRules == null || builder.denyRules.isEmpty()
                         ? List.of()
                         : List.copyOf(builder.denyRules);
+        this.attributes =
+                builder.attributes == null || builder.attributes.isEmpty()
+                        ? Map.of()
+                        : Collections.unmodifiableMap(new LinkedHashMap<>(builder.attributes));
     }
 
     public static Builder builder() {
@@ -70,8 +76,16 @@ public final class RemoteSubmitContext {
         return denyRules;
     }
 
+    /**
+     * Caller-defined attributes forwarded as {@code context.attributes}. Never null; empty when the
+     * parent supplied none.
+     */
+    public Map<String, Object> attributes() {
+        return attributes;
+    }
+
     public Map<String, Object> toMap() {
-        Map<String, Object> m = new java.util.LinkedHashMap<>();
+        Map<String, Object> m = new LinkedHashMap<>();
         if (userId != null) {
             m.put("user_id", userId);
         }
@@ -83,6 +97,9 @@ public final class RemoteSubmitContext {
         if (!denyRules.isEmpty()) {
             m.put("deny_rules", denyRules);
         }
+        if (!attributes.isEmpty()) {
+            m.put("attributes", attributes);
+        }
         return Collections.unmodifiableMap(m);
     }
 
@@ -92,6 +109,7 @@ public final class RemoteSubmitContext {
         private boolean stream = true;
         private String detail = "status";
         private List<Map<String, String>> denyRules;
+        private Map<String, Object> attributes;
 
         public Builder userId(String userId) {
             this.userId = userId;
@@ -115,6 +133,15 @@ public final class RemoteSubmitContext {
 
         public Builder denyRules(List<Map<String, String>> denyRules) {
             this.denyRules = denyRules;
+            return this;
+        }
+
+        /**
+         * Caller-defined attributes sent as {@code context.attributes}, kept apart from the
+         * protocol's own context fields. Values must be JSON-serializable.
+         */
+        public Builder attributes(Map<String, Object> attributes) {
+            this.attributes = attributes;
             return this;
         }
 

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/tool/AgentSpawnTool.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/tool/AgentSpawnTool.java
@@ -137,6 +137,25 @@ public class AgentSpawnTool {
     public static final String CTX_AGENT_MANAGER = "agentscope.subagent.agent_manager";
 
     /**
+     * {@link RuntimeContext} string key holding a {@code Map<String, Object>} of caller-defined
+     * attributes to send with every remote subagent submission of the current call, as
+     * {@code context.attributes}:
+     *
+     * <pre>{@code
+     * RuntimeContext ctx = RuntimeContext.builder()
+     *     .sessionId("s-1")
+     *     .put(AgentSpawnTool.CTX_REMOTE_CONTEXT_ATTRIBUTES, Map.of("tenant", "acme"))
+     *     .build();
+     * }</pre>
+     *
+     * <p>Merged over the subagent's static {@link
+     * SubagentDeclaration#getRemoteContextAttributes()}, so a per-call value wins on conflict.
+     * Values must be JSON-serializable.
+     */
+    public static final String CTX_REMOTE_CONTEXT_ATTRIBUTES =
+            "agentscope.subagent.remote_context_attributes";
+
+    /**
      * {@link RuntimeContext} string key that forces synchronous subagent execution for the current
      * call. Put a {@link Boolean} (or its string form) under this key to ignore LLM-requested
      * background mode ({@code timeout_seconds=0}) and to disable timeout promotion to a background
@@ -1189,7 +1208,7 @@ public class AgentSpawnTool {
 
     /**
      * Builds submission metadata for a remote task (streaming preference, parent identity, denied
-     * permission rules).
+     * permission rules, caller-defined attributes).
      */
     private RemoteSubmitContext buildRemoteSubmitContext(
             RuntimeContext runtimeContext, AgentState parentState, SubagentDeclaration decl) {
@@ -1200,7 +1219,30 @@ public class AgentSpawnTool {
                         stream)
                 .detail(stream ? "full" : "status")
                 .denyRules(collectParentDenyRules(parentState, Optional.ofNullable(decl)))
+                .attributes(collectRemoteContextAttributes(runtimeContext, decl))
                 .build();
+    }
+
+    /**
+     * Merges the subagent's declared static attributes with the per-call ones from {@link
+     * #CTX_REMOTE_CONTEXT_ATTRIBUTES}; per-call entries win on conflict.
+     */
+    static Map<String, Object> collectRemoteContextAttributes(
+            RuntimeContext runtimeContext, SubagentDeclaration decl) {
+        Map<String, Object> merged = new LinkedHashMap<>();
+        if (decl != null && decl.getRemoteContextAttributes() != null) {
+            merged.putAll(decl.getRemoteContextAttributes());
+        }
+        Object perCall =
+                runtimeContext != null ? runtimeContext.get(CTX_REMOTE_CONTEXT_ATTRIBUTES) : null;
+        if (perCall instanceof Map<?, ?> map) {
+            for (Map.Entry<?, ?> e : map.entrySet()) {
+                if (e.getKey() != null && e.getValue() != null) {
+                    merged.put(String.valueOf(e.getKey()), e.getValue());
+                }
+            }
+        }
+        return merged;
     }
 
     /**

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/subagent/task/RemoteSubmitContextTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/subagent/task/RemoteSubmitContextTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.harness.agent.subagent.task;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+/** Wire shape of the {@code context} object sent with a remote task submission. */
+class RemoteSubmitContextTest {
+
+    @Test
+    void toMapNestsCallerAttributesUnderAttributes() {
+        Map<String, Object> attributes = new HashMap<>();
+        attributes.put("tenant", "acme");
+        attributes.put("ticket_id", "INC-1");
+
+        Map<String, Object> wire =
+                RemoteSubmitContext.builder().userId("u-1").parentSessionId("sess-parent").stream(
+                                true)
+                        .detail("full")
+                        .attributes(attributes)
+                        .build()
+                        .toMap();
+
+        assertEquals("u-1", wire.get("user_id"));
+        assertEquals("sess-parent", wire.get("parent_session_id"));
+        assertEquals(true, wire.get("stream"));
+        assertEquals("full", wire.get("detail"));
+        assertEquals(attributes, wire.get("attributes"));
+    }
+
+    @Test
+    void toMapOmitsAttributesWhenNoneProvided() {
+        Map<String, Object> wire = RemoteSubmitContext.empty().toMap();
+
+        assertFalse(wire.containsKey("attributes"));
+        assertTrue(RemoteSubmitContext.empty().attributes().isEmpty());
+    }
+
+    @Test
+    void attributesAreCopiedDefensively() {
+        Map<String, Object> mutable = new HashMap<>();
+        mutable.put("tenant", "acme");
+        RemoteSubmitContext context = RemoteSubmitContext.builder().attributes(mutable).build();
+
+        mutable.put("tenant", "changed");
+
+        assertEquals("acme", context.attributes().get("tenant"));
+    }
+}

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/tool/AgentSpawnToolRemoteHelpersTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/tool/AgentSpawnToolRemoteHelpersTest.java
@@ -18,6 +18,7 @@ package io.agentscope.harness.agent.tool;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import io.agentscope.core.agent.RuntimeContext;
 import io.agentscope.core.event.AgentEvent;
 import io.agentscope.core.event.TextBlockDeltaEvent;
 import io.agentscope.core.permission.PermissionBehavior;
@@ -133,5 +134,39 @@ class AgentSpawnToolRemoteHelpersTest {
         assertEquals("rm*", rules.get(0).get("rule_content"));
         assertEquals(PermissionBehavior.DENY.name(), rules.get(0).get("behavior"));
         assertEquals("parent-policy", rules.get(0).get("source"));
+    }
+
+    @Test
+    void collectRemoteContextAttributes_mergesPerCallOverDeclared() {
+        SubagentDeclaration decl =
+                SubagentDeclaration.builder()
+                        .name("worker")
+                        .description("d")
+                        .url("http://remote:8080")
+                        .remoteContextAttributes(Map.of("tenant", "default", "region", "cn"))
+                        .build();
+        RuntimeContext ctx =
+                RuntimeContext.builder()
+                        .put(
+                                AgentSpawnTool.CTX_REMOTE_CONTEXT_ATTRIBUTES,
+                                Map.of("tenant", "acme", "ticket_id", "INC-1"))
+                        .build();
+
+        Map<String, Object> merged = AgentSpawnTool.collectRemoteContextAttributes(ctx, decl);
+
+        assertEquals("acme", merged.get("tenant"));
+        assertEquals("cn", merged.get("region"));
+        assertEquals("INC-1", merged.get("ticket_id"));
+    }
+
+    @Test
+    void collectRemoteContextAttributes_isEmptyWithoutAnySource() {
+        SubagentDeclaration decl =
+                SubagentDeclaration.builder().name("worker").description("d").build();
+
+        assertTrue(AgentSpawnTool.collectRemoteContextAttributes(null, decl).isEmpty());
+        assertTrue(
+                AgentSpawnTool.collectRemoteContextAttributes(RuntimeContext.empty(), null)
+                        .isEmpty());
     }
 }

--- a/docs/v2/en/docs/harness/subagent.md
+++ b/docs/v2/en/docs/harness/subagent.md
@@ -339,6 +339,7 @@ Just set `url` + optional `headers` and the subagent runs through a remote HTTP 
     .headers(Map.of("Authorization", "Bearer xxx"))
     .remoteStreaming(true)          // default when unset
     .remoteAskPolicy(RemoteAskPolicy.DENY)  // default
+    .remoteContextAttributes(Map.of("region", "cn"))
     .build())
 ```
 
@@ -350,6 +351,7 @@ Declaration knobs specific to remote mode:
 |-------|---------|-------|
 | `remoteStreaming` | `true` (when unset) | When the parent uses `streamEvents()`, forward remote task SSE events into the parent stream with a `source` tag plus `metadata.taskId` / `metadata.parentSessionId` (same ids as the harness `TaskRecord` / parent session) |
 | `remoteAskPolicy` | `DENY` | How to resolve remote tool-confirmation (HITL) requests — see [Remote authorization](#remote-authorization) |
+| `remoteContextAttributes` | none | Static caller attributes sent as `context.attributes` on every submission. Merge per-call values by putting a map under `AgentSpawnTool.CTX_REMOTE_CONTEXT_ATTRIBUTES` on the parent's `RuntimeContext`; see [Context attributes](../../integration/protocol/agent-protocol.md#context-attributes) |
 
 ### Remote authorization
 

--- a/docs/v2/en/integration/protocol/agent-protocol.md
+++ b/docs/v2/en/integration/protocol/agent-protocol.md
@@ -88,10 +88,69 @@ AgentFactory agentFactory(Map<String, HarnessAgent> agentsByName) {
 | `userId()` / `parentSessionId()` | Parsed from `context.user_id` / `context.parent_session_id` |
 | `resume()` | `true` when re-running a task that was awaiting tool confirmation |
 | `context()` | The submission `context` map exactly as received, including custom keys; `contextValue(key)` / `contextString(key)` are convenience accessors |
+| `attributes()` | Just the `context.attributes` map; `attributeString(key)` is a convenience accessor |
 
 The factory is invoked once per run — on submit and again on every `/resume` — with the original submission context, so routing decisions stay stable across HITL pauses.
 
 Return a distinct instance per call (for example a prototype-scoped bean) when tasks run concurrently. Returning `null` fails the task with an error status.
+
+## Context attributes
+
+Callers pass their own data in `context.attributes`, nested so it never mixes with the protocol's own context fields. Besides being visible to the `AgentFactory`, attributes reach the running agent through its `RuntimeContext`.
+
+They arrive as **one map under a single namespaced key**, `AgentProtocolConstants.RUNTIME_CONTEXT_ATTRIBUTES_KEY` (`agentprotocol.context.attributes`):
+
+```java
+Map<String, Object> attributes = ctx.get(AgentProtocolConstants.RUNTIME_CONTEXT_ATTRIBUTES_KEY);
+String tenant = attributes != null ? (String) attributes.get("tenant") : null;
+```
+
+Attributes are namespaced rather than written as top-level keys because the framework itself reads a few plain runtime-context keys — `agentId` drives async tool wakeup routing, `outboundAddress` carries the gateway reply address. A caller naming an attribute after one of those would otherwise change how the agent behaves. Attributes are never rendered into the system prompt, so they do not affect what the model sees.
+
+### Promoting attributes to their own keys
+
+Register `RuntimeContextCustomizer` beans when a tool expects a plain key such as `ctx.get("tenant")`, or to turn attributes into typed values. `RuntimeContextCustomizer.flatten` copies an explicit allow-list, silently skipping framework-reserved names:
+
+```java
+@Bean
+RuntimeContextCustomizer promoteTenantKeys() {
+    return RuntimeContextCustomizer.flatten("tenant", "ticket_id");
+}
+
+@Bean
+RuntimeContextCustomizer tenantContext(TenantService tenants) {
+    return (request, builder) -> {
+        String tenant = request.attributeString("tenant");
+        if (tenant != null) {
+            builder.put(TenantInfo.class, tenants.load(tenant));
+        }
+    };
+}
+```
+
+Every customizer bean is applied to every run, in `@Order`, after the namespaced injection — a later customizer overrides an earlier one. Hand-written customizers are trusted and may write any key, including reserved ones.
+
+### Sending attributes from a parent agent
+
+A parent agent delegating to a remote subagent supplies attributes in two ways, merged with the per-call ones winning:
+
+```java
+// Static, per subagent
+SubagentDeclaration.builder()
+        .name("researcher")
+        .description("Remote researcher")
+        .url("http://remote:8080")
+        .remoteContextAttributes(Map.of("region", "cn"))
+        .build();
+
+// Per call, on the parent's RuntimeContext
+RuntimeContext.builder()
+        .sessionId("sess-1")
+        .put(AgentSpawnTool.CTX_REMOTE_CONTEXT_ATTRIBUTES, Map.of("tenant", "acme"))
+        .build();
+```
+
+Values must be JSON-serializable.
 
 ## Endpoints
 
@@ -115,7 +174,11 @@ Return a distinct instance per call (for example a prototype-scoped bean) when t
         "behavior": "DENY",
         "source": "parent"
       }
-    ]
+    ],
+    "attributes": {
+      "tenant": "acme",
+      "ticket_id": "INC-1001"
+    }
   }
 }
 ```
@@ -129,6 +192,7 @@ Optional `context` fields:
 | `stream` | Whether the caller intends to consume SSE events |
 | `detail` | `status` (default) or `full` — `full` includes text/thinking deltas on the event stream |
 | `deny_rules` | Parent DENY permission rules to enforce on the remote side |
+| `attributes` | Caller-defined key/values for routing and for the run's `RuntimeContext`; see [Context attributes](#context-attributes) |
 
 Response on success: `{ "task_id", "status": "pending" }`.
 

--- a/docs/v2/zh/docs/harness/subagent.md
+++ b/docs/v2/zh/docs/harness/subagent.md
@@ -339,6 +339,7 @@ ChatUiChannel chat = agent.channel(ChatUiChannel.create());  // 恢复能力自�
     .headers(Map.of("Authorization", "Bearer xxx"))
     .remoteStreaming(true)          // 未设置时默认 true
     .remoteAskPolicy(RemoteAskPolicy.DENY)  // 默认
+    .remoteContextAttributes(Map.of("region", "cn"))
     .build())
 ```
 
@@ -350,6 +351,7 @@ ChatUiChannel chat = agent.channel(ChatUiChannel.create());  // 恢复能力自�
 |------|------|------|
 | `remoteStreaming` | `true`（未设置时） | 父代理使用 `streamEvents()` 时，把远程任务的 SSE 事件转发进父流，并带 `source` 标记与 `metadata.taskId` / `metadata.parentSessionId`（与 harness `TaskRecord` / 父 session 一致） |
 | `remoteAskPolicy` | `DENY` | 如何处理远程工具确认（HITL）请求——见 [远程授权](#远程授权) |
+| `remoteContextAttributes` | 无 | 每次提交都携带的静态调用方属性，写入 `context.attributes`。按次追加时，在父代理的 `RuntimeContext` 上用 `AgentSpawnTool.CTX_REMOTE_CONTEXT_ATTRIBUTES` 放一个 map；见[上下文属性](../../integration/protocol/agent-protocol.md#上下文属性contextattributes) |
 
 ### 远程授权
 

--- a/docs/v2/zh/integration/protocol/agent-protocol.md
+++ b/docs/v2/zh/integration/protocol/agent-protocol.md
@@ -88,10 +88,69 @@ AgentFactory agentFactory(Map<String, HarnessAgent> agentsByName) {
 | `userId()` / `parentSessionId()` | 解析自 `context.user_id` / `context.parent_session_id` |
 | `resume()` | 为 `true` 表示这是等待工具确认后的续跑 |
 | `context()` | 原样保留的提交 `context` map（含自定义键）；可用 `contextValue(key)` / `contextString(key)` 取值 |
+| `attributes()` | 仅 `context.attributes` 这层 map；可用 `attributeString(key)` 取值 |
 
 工厂每次运行调用一次——提交时一次，之后每次 `/resume` 再调用一次，且拿到的仍是最初的提交上下文，因此 HITL 暂停前后的路由结果保持一致。
 
 任务并发执行时请每次返回独立实例（例如 prototype 作用域 bean）。返回 `null` 会让任务以错误状态结束。
+
+## 上下文属性（`context.attributes`）
+
+调用方的自定义数据放在 `context.attributes` 里，单独嵌一层，不与协议自身的上下文字段混在一起。除了 `AgentFactory` 能读到之外，这些属性还会随 `RuntimeContext` 进入实际执行的 agent。
+
+它们**整体挂在一个带命名空间的键下**——`AgentProtocolConstants.RUNTIME_CONTEXT_ATTRIBUTES_KEY`（`agentprotocol.context.attributes`）：
+
+```java
+Map<String, Object> attributes = ctx.get(AgentProtocolConstants.RUNTIME_CONTEXT_ATTRIBUTES_KEY);
+String tenant = attributes != null ? (String) attributes.get("tenant") : null;
+```
+
+之所以命名空间化而不是平铺成顶层键，是因为框架自身会读少量约定键：`agentId` 决定异步工具的唤醒路由，`outboundAddress` 携带网关回推地址。调用方一旦把属性命名成这些词，就会改变 agent 的行为。属性不会写进系统提示词，因此不影响模型看到的内容。
+
+### 把属性提升为独立键
+
+当某个工具期望直接读 `ctx.get("tenant")`，或需要把属性转成类型化对象时，注册 `RuntimeContextCustomizer` bean。`RuntimeContextCustomizer.flatten` 按显式白名单拷贝，并自动跳过框架保留键：
+
+```java
+@Bean
+RuntimeContextCustomizer promoteTenantKeys() {
+    return RuntimeContextCustomizer.flatten("tenant", "ticket_id");
+}
+
+@Bean
+RuntimeContextCustomizer tenantContext(TenantService tenants) {
+    return (request, builder) -> {
+        String tenant = request.attributeString("tenant");
+        if (tenant != null) {
+            builder.put(TenantInfo.class, tenants.load(tenant));
+        }
+    };
+}
+```
+
+所有 customizer bean 都会按 `@Order` 应用到每次运行，且在命名空间注入之后执行——后者覆盖前者。手写 customizer 属于可信扩展，可以写任意键，包括保留键。
+
+### 从父 agent 发送属性
+
+父 agent 调用远程子 agent 时有两个来源，二者合并且按调用传入的优先：
+
+```java
+// 静态：按子 agent 声明
+SubagentDeclaration.builder()
+        .name("researcher")
+        .description("远程研究员")
+        .url("http://remote:8080")
+        .remoteContextAttributes(Map.of("region", "cn"))
+        .build();
+
+// 动态：按本次调用，挂在父 agent 的 RuntimeContext 上
+RuntimeContext.builder()
+        .sessionId("sess-1")
+        .put(AgentSpawnTool.CTX_REMOTE_CONTEXT_ATTRIBUTES, Map.of("tenant", "acme"))
+        .build();
+```
+
+值必须可 JSON 序列化。
 
 ## 端点
 
@@ -115,7 +174,11 @@ AgentFactory agentFactory(Map<String, HarnessAgent> agentsByName) {
         "behavior": "DENY",
         "source": "parent"
       }
-    ]
+    ],
+    "attributes": {
+      "tenant": "acme",
+      "ticket_id": "INC-1001"
+    }
   }
 }
 ```
@@ -129,6 +192,7 @@ AgentFactory agentFactory(Map<String, HarnessAgent> agentsByName) {
 | `stream` | 调用方是否打算消费 SSE 事件 |
 | `detail` | `status`（默认）或 `full`——`full` 会在事件流中包含文本 / 思考增量 |
 | `deny_rules` | 父侧 DENY 权限规则，供远程侧执行 |
+| `attributes` | 调用方自定义键值，用于路由以及本次运行的 `RuntimeContext`；见[上下文属性](#上下文属性contextattributes) |
 
 成功响应：`{ "task_id", "status": "pending" }`。
 


### PR DESCRIPTION
## Summary
Re-implements [#2591](https://github.com/agentscope-ai/agentscope-java/pull/2591) on `release/2.0.1`. The original PR was stacked on `feat/agent-protocol-agent-factory` and never landed in this release line after `#2590` was merged separately.

- Wire `context.attributes` through `AgentRequest` into the task run's `RuntimeContext` under the namespaced key `agentprotocol.context.attributes`
- Add opt-in `RuntimeContextCustomizer` (with `flatten` allow-list helper) for promoting attributes to top-level keys
- Parent agents can send attributes via `SubagentDeclaration.remoteContextAttributes` merged with per-call `AgentSpawnTool.CTX_REMOTE_CONTEXT_ATTRIBUTES` (per-call wins)

Cherry-picked from `2812dad16` onto current `release/2.0.1`; resolved a constant-declaration conflict in `AgentSpawnTool` so force-sync keys from `#2592` coexist with the new remote attributes key.

## Test plan
- [x] `AgentProtocolContextAttributesTest`
- [x] `RemoteSubmitContextTest`
- [x] `AgentSpawnToolRemoteHelpersTest`
- [ ] Confirm docs render for the new "Context attributes" section in agent-protocol.md