### PR TITLE
fix(frontend): render session.error events in managed session chat

### DIFF
--- a/agentscope-service/frontend/src/components/ChatPanel.tsx
+++ b/agentscope-service/frontend/src/components/ChatPanel.tsx
@@ -29,7 +29,7 @@ import {
 } from '../api/managedSessions';
 import MessageBlock from './MessageBlock';
 
-type Role = 'user' | 'assistant' | 'system';
+type Role = 'user' | 'assistant' | 'system' | 'error';
 
 interface ToolEntry {
   id: string;
@@ -123,6 +123,16 @@ function payloadText(payload?: Record<string, unknown>): string {
   return text != null ? String(text) : '';
 }
 
+function errorText(evt: SessionEvent): string {
+  const payload = evt.payload as Record<string, unknown> | undefined;
+  const raw = payload?.error;
+  const err = (typeof raw === 'object' && raw != null ? raw : {}) as Record<string, unknown>;
+  const code = err.code != null ? String(err.code) : '';
+  const message = err.message != null ? String(err.message) : '';
+  const label = code ? `[${code}]` : '[error]';
+  return `${label} ${message || 'Session turn failed'}`.trim();
+}
+
 function eventsToMessages(events: SessionEvent[]): Message[] {
   const out: Message[] = [];
   for (const evt of events) {
@@ -159,6 +169,8 @@ function eventsToMessages(events: SessionEvent[]): Message[] {
           break;
         }
       }
+    } else if (evt.type === 'session.error') {
+      out.push({ id: evt.id, role: 'error', text: errorText(evt), tools: [] });
     }
   }
   return out;
@@ -416,6 +428,16 @@ export default function ChatPanel({
         setMessages(prev => prev.map(m => m.id === replyId ? { ...m, pending: false } : m));
         replyMsgIdRef.current = null;
       }
+    } else if (evt.type === 'session.error') {
+      setMessages(prev => {
+        if (prev.some(m => m.id === evt.id)) return prev;
+        const replyId = replyMsgIdRef.current;
+        replyMsgIdRef.current = null;
+        return [
+          ...prev.map(m => (m.id === replyId ? { ...m, pending: false } : m)),
+          { id: evt.id, role: 'error', text: errorText(evt), tools: [] },
+        ];
+      });
     }
   }, []);
 

--- a/agentscope-service/frontend/src/components/MessageBlock.tsx
+++ b/agentscope-service/frontend/src/components/MessageBlock.tsx
@@ -25,7 +25,7 @@ export interface MessageBlockTool {
 }
 
 export interface MessageBlockProps {
-  role: 'user' | 'assistant' | 'system';
+  role: 'user' | 'assistant' | 'system' | 'error';
   text: string;
   tools: MessageBlockTool[];
   pending?: boolean;
@@ -73,6 +73,12 @@ const roleStyles: Record<MessageBlockProps['role'], React.CSSProperties> = {
     color: '#94a3b8',
     border: '1px dashed #e2e8f0',
     fontStyle: 'italic',
+  },
+  error: {
+    alignSelf: 'center',
+    background: '#fef2f2',
+    color: '#b91c1c',
+    border: '1px solid #fecaca',
   },
 };
 


### PR DESCRIPTION
## Summary

- `ChatPanel.tsx`: add a `session.error` branch to both `eventsToMessages` (initial load) and `handleManagedEvent` (live SSE) so failed turns surface as an error bubble in the chat; clear the in-flight reply's pending flag on failure
- `MessageBlock.tsx`: add an `error` message role with a red-tinted style
- Backend already persists `session.error` (payload `{error: {type, code, message}}`) via `SessionTurnRunner.failTurn` — this PR only makes the console render it

Fixes #2596

## Test plan

- [x] `tsc --noEmit` passes for changed files (2 pre-existing unrelated errors in the repo remain)
- [x] `vite build` succeeds
- [x] End-to-end: failed turn (missing provider key) → `session.error` event persisted + returned by `GET /api/sessions/{id}/events` → red error bubble rendered in `/sessions/:id` chat