### PR TITLE
feat(dataplane): bundle OpenAI-compatible model providers

### DIFF
--- a/agentscope-service/service-dataplane/pom.xml
+++ b/agentscope-service/service-dataplane/pom.xml
@@ -60,6 +60,12 @@
             <artifactId>agentscope-extensions-model-dashscope</artifactId>
         </dependency>
 
+        <!-- OpenAI-compatible model providers (openai/deepseek/glm/kimi/minimax) via ModelProvider SPI -->
+        <dependency>
+            <groupId>io.agentscope</groupId>
+            <artifactId>agentscope-extensions-model-openai</artifactId>
+        </dependency>
+
         <!-- JdbcStore-backed BaseStore for remote filesystem routes -->
         <dependency>
             <groupId>io.agentscope</groupId>


### PR DESCRIPTION
## Summary

- Add `agentscope-extensions-model-openai` to `agentscope-service/service-dataplane/pom.xml`
- This puts OpenAI + DeepSeek + GLM + Kimi + MiniMax `ModelProvider` SPI implementations on the dataplane classpath, so managed agents can use model ids like `deepseek:deepseek-chat` / `openai:gpt-4o` (resolved via `ModelRegistry`)
- API keys are read from the process environment (`DEEPSEEK_API_KEY`, `OPENAI_API_KEY`, etc.), or a custom `Model` bean can be declared (the DashScope default bean is `@ConditionalOnMissingBean`)

Fixes #2597

## Test plan

- [x] `mvn install -DskipTests -pl agentscope-service/service-dataplane -am` succeeds
- [x] fat jar contains `agentscope-extensions-model-openai-2.0.1-SNAPSHOT.jar` with `META-INF/services/io.agentscope.core.model.spi.ModelProvider`
- [x] managed agent with `model=deepseek:deepseek-v4-flash` resolves the provider and fails only on the missing `DEEPSEEK_API_KEY` (as expected without a key configured)