### PR TITLE
feat(channel): allow callers to pass RuntimeContext into Gateway

### DIFF
--- a/agentscope-examples/documentation/src/main/java/io/agentscope/examples/documentation2/harness/channel/ChannelSendExample.java
+++ b/agentscope-examples/documentation/src/main/java/io/agentscope/examples/documentation2/harness/channel/ChannelSendExample.java
@@ -15,11 +15,16 @@
  */
 package io.agentscope.examples.documentation2.harness.channel;
 
+import io.agentscope.core.message.ImageBlock;
 import io.agentscope.core.message.Msg;
+import io.agentscope.core.message.MsgRole;
+import io.agentscope.core.message.TextBlock;
+import io.agentscope.core.message.URLSource;
 import io.agentscope.core.state.InMemoryAgentStateStore;
 import io.agentscope.harness.agent.HarnessAgent;
 import io.agentscope.harness.agent.gateway.channel.chatui.ChatUiChannel;
 import io.agentscope.harness.agent.gateway.channel.chatui.SendOptions;
+import java.util.List;
 
 /**
  * The simplest Channel usage: build a {@link HarnessAgent}, bind a
@@ -92,6 +97,26 @@ public class ChannelSendExample {
         Msg sessionB = chat.send(SendOptions.of("user-1", "session-b"), "Topic B").block();
         System.out.println(
                 "Session B: " + (sessionB != null ? sessionB.getTextContent() : "(null)"));
+
+        // Multimodal / structured Msg overload (image URL is illustrative).
+        Msg multimodal =
+                Msg.builder()
+                        .role(MsgRole.USER)
+                        .content(
+                                TextBlock.builder().text("What is in this image?").build(),
+                                ImageBlock.builder()
+                                        .source(
+                                                URLSource.builder()
+                                                        .url("https://example.com/photo.png")
+                                                        .build())
+                                        .build())
+                        .build();
+        Msg vision =
+                chat.send(SendOptions.userId("user-1"), multimodal).block();
+        System.out.println(
+                "Multimodal: " + (vision != null ? vision.getTextContent() : "(null)"));
+        // Equivalent list form:
+        chat.send(SendOptions.userId("user-1"), List.of(multimodal)).block();
 
         Thread.sleep(10000); // Wait for async processing to complete before exiting
     }

--- a/agentscope-examples/documentation/src/main/java/io/agentscope/examples/documentation2/harness/channel/ChannelSendExample.java
+++ b/agentscope-examples/documentation/src/main/java/io/agentscope/examples/documentation2/harness/channel/ChannelSendExample.java
@@ -79,6 +79,16 @@ public class ChannelSendExample {
         System.out.println(
                 "Session A: " + (sessionA != null ? sessionA.getTextContent() : "(null)"));
 
+        // Attach application context (attributes / force-sync) via SendOptions.
+        Msg withCtx =
+                chat.send(
+                                SendOptions.userId("user-1")
+                                        .withAttribute("tenant", "demo"),
+                                "Reply with a short hello.")
+                        .block();
+        System.out.println(
+                "With context: " + (withCtx != null ? withCtx.getTextContent() : "(null)"));
+
         Msg sessionB = chat.send(SendOptions.of("user-1", "session-b"), "Topic B").block();
         System.out.println(
                 "Session B: " + (sessionB != null ? sessionB.getTextContent() : "(null)"));

--- a/agentscope-extensions/agentscope-extensions-channel/agentscope-extensions-channel-dingtalk/src/main/java/io/agentscope/extensions/channel/dingtalk/DingTalkChannel.java
+++ b/agentscope-extensions/agentscope-extensions-channel/agentscope-extensions-channel-dingtalk/src/main/java/io/agentscope/extensions/channel/dingtalk/DingTalkChannel.java
@@ -154,7 +154,12 @@ public final class DingTalkChannel implements Channel {
                             "DingTalkChannel '" + channelId + "' has no gateway"));
         }
         RouteResult route = router.resolveRoute(config, message);
-        return g.run(route.context(), message.messages(), route.outboundAddress())
+        return g.run(
+                route.context(),
+                message.messages(),
+                route.outboundAddress(),
+                message.runtimeContext(),
+                message)
                 .flatMap(reply -> sendReply(route.outboundAddress(), reply).thenReturn(reply));
     }
 

--- a/agentscope-extensions/agentscope-extensions-channel/agentscope-extensions-channel-feishu/src/main/java/io/agentscope/extensions/channel/feishu/FeishuChannel.java
+++ b/agentscope-extensions/agentscope-extensions-channel/agentscope-extensions-channel-feishu/src/main/java/io/agentscope/extensions/channel/feishu/FeishuChannel.java
@@ -159,7 +159,12 @@ public final class FeishuChannel implements Channel {
                     new IllegalStateException("FeishuChannel '" + channelId + "' has no gateway"));
         }
         RouteResult route = router.resolveRoute(config, message);
-        return g.run(route.context(), message.messages(), route.outboundAddress())
+        return g.run(
+                route.context(),
+                message.messages(),
+                route.outboundAddress(),
+                message.runtimeContext(),
+                message)
                 .flatMap(reply -> sendReply(route.outboundAddress(), reply).thenReturn(reply));
     }
 

--- a/agentscope-extensions/agentscope-extensions-channel/agentscope-extensions-channel-github/src/main/java/io/agentscope/extensions/channel/github/GitHubChannel.java
+++ b/agentscope-extensions/agentscope-extensions-channel/agentscope-extensions-channel-github/src/main/java/io/agentscope/extensions/channel/github/GitHubChannel.java
@@ -156,7 +156,12 @@ public final class GitHubChannel implements Channel {
                     new IllegalStateException("GitHubChannel '" + channelId + "' has no gateway"));
         }
         RouteResult route = router.resolveRoute(config, message);
-        return g.run(route.context(), message.messages(), route.outboundAddress())
+        return g.run(
+                route.context(),
+                message.messages(),
+                route.outboundAddress(),
+                message.runtimeContext(),
+                message)
                 .flatMap(reply -> sendReply(route.outboundAddress(), reply).thenReturn(reply));
     }
 

--- a/agentscope-extensions/agentscope-extensions-channel/agentscope-extensions-channel-gitlab/src/main/java/io/agentscope/extensions/channel/gitlab/GitLabChannel.java
+++ b/agentscope-extensions/agentscope-extensions-channel/agentscope-extensions-channel-gitlab/src/main/java/io/agentscope/extensions/channel/gitlab/GitLabChannel.java
@@ -149,7 +149,12 @@ public final class GitLabChannel implements Channel {
                     new IllegalStateException("GitLabChannel '" + channelId + "' has no gateway"));
         }
         RouteResult route = router.resolveRoute(config, message);
-        return g.run(route.context(), message.messages(), route.outboundAddress())
+        return g.run(
+                route.context(),
+                message.messages(),
+                route.outboundAddress(),
+                message.runtimeContext(),
+                message)
                 .flatMap(reply -> sendReply(route.outboundAddress(), reply).thenReturn(reply));
     }
 

--- a/agentscope-extensions/agentscope-extensions-channel/agentscope-extensions-channel-wecom/src/main/java/io/agentscope/extensions/channel/wecom/WeComChannel.java
+++ b/agentscope-extensions/agentscope-extensions-channel/agentscope-extensions-channel-wecom/src/main/java/io/agentscope/extensions/channel/wecom/WeComChannel.java
@@ -167,7 +167,12 @@ public final class WeComChannel implements Channel {
                     new IllegalStateException("WeComChannel '" + channelId + "' has no gateway"));
         }
         RouteResult route = router.resolveRoute(config, message);
-        return g.run(route.context(), message.messages(), route.outboundAddress())
+        return g.run(
+                route.context(),
+                message.messages(),
+                route.outboundAddress(),
+                message.runtimeContext(),
+                message)
                 .flatMap(reply -> sendReply(route.outboundAddress(), reply).thenReturn(reply));
     }
 

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/gateway/Gateway.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/gateway/Gateway.java
@@ -15,9 +15,11 @@
  */
 package io.agentscope.harness.agent.gateway;
 
+import io.agentscope.core.agent.RuntimeContext;
 import io.agentscope.core.event.AgentEvent;
 import io.agentscope.core.message.Msg;
 import io.agentscope.harness.agent.HarnessAgent;
+import io.agentscope.harness.agent.gateway.channel.InboundMessage;
 import io.agentscope.harness.agent.gateway.channel.OutboundAddress;
 import java.util.List;
 import reactor.core.publisher.Flux;
@@ -29,6 +31,10 @@ import reactor.core.publisher.Mono;
  *
  * <p>Implementations should serialize turns per logical session (fair wait) so injected announce
  * runs and user/channel {@link #run} calls do not race the same {@code HarnessAgent} turn.
+ *
+ * <p>Callers may supply a {@link RuntimeContext} that is merged into the agent turn. Gateway-owned
+ * identity fields ({@code sessionId}, {@code userId}, {@code outboundAddress}, …) always win on
+ * conflict.
  */
 public interface Gateway {
 
@@ -58,6 +64,41 @@ public interface Gateway {
      * @param outboundAddress the delivery target for proactive replies; may be null
      */
     default Mono<Msg> run(MsgContext context, List<Msg> messages, OutboundAddress outboundAddress) {
+        return run(context, messages, outboundAddress, null);
+    }
+
+    /**
+     * Inbound turn with outbound address and an optional caller {@link RuntimeContext}.
+     *
+     * <p>The caller context is merged into the turn; gateway identity fields take precedence. The
+     * default implementation ignores {@code callerContext} and delegates to {@link
+     * #run(MsgContext, List)}.
+     *
+     * @param context routing context for session key resolution
+     * @param messages the inbound messages
+     * @param outboundAddress the delivery target for proactive replies; may be null
+     * @param callerContext optional application context to merge; may be null
+     */
+    default Mono<Msg> run(
+            MsgContext context,
+            List<Msg> messages,
+            OutboundAddress outboundAddress,
+            RuntimeContext callerContext) {
+        return run(context, messages, outboundAddress, callerContext, null);
+    }
+
+    /**
+     * Inbound turn with full Channel metadata for {@link
+     * io.agentscope.harness.agent.gateway.channel.ChannelRuntimeContextResolver}.
+     *
+     * @param inboundMessage optional inbound envelope passed to the resolver; may be null
+     */
+    default Mono<Msg> run(
+            MsgContext context,
+            List<Msg> messages,
+            OutboundAddress outboundAddress,
+            RuntimeContext callerContext,
+            InboundMessage inboundMessage) {
         return run(context, messages);
     }
 
@@ -68,12 +109,38 @@ public interface Gateway {
 
     /** Streaming variant of {@link #run(MsgContext, List)}. Returns fine-grained events. */
     default Flux<AgentEvent> runStream(MsgContext context, List<Msg> messages) {
-        return runStream(context, messages, null);
+        return runStream(context, messages, null, null);
     }
 
     /** Streaming variant of {@link #run(MsgContext, List, OutboundAddress)}. */
     default Flux<AgentEvent> runStream(
             MsgContext context, List<Msg> messages, OutboundAddress outboundAddress) {
+        return runStream(context, messages, outboundAddress, null);
+    }
+
+    /**
+     * Streaming variant of {@link #run(MsgContext, List, OutboundAddress, RuntimeContext)}.
+     *
+     * <p>The default signals unsupported streaming.
+     */
+    default Flux<AgentEvent> runStream(
+            MsgContext context,
+            List<Msg> messages,
+            OutboundAddress outboundAddress,
+            RuntimeContext callerContext) {
+        return runStream(context, messages, outboundAddress, callerContext, null);
+    }
+
+    /**
+     * Streaming variant of {@link #run(MsgContext, List, OutboundAddress, RuntimeContext,
+     * InboundMessage)}.
+     */
+    default Flux<AgentEvent> runStream(
+            MsgContext context,
+            List<Msg> messages,
+            OutboundAddress outboundAddress,
+            RuntimeContext callerContext,
+            InboundMessage inboundMessage) {
         return Flux.error(new UnsupportedOperationException("Streaming not supported"));
     }
 

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/gateway/GatewayBootstrap.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/gateway/GatewayBootstrap.java
@@ -20,6 +20,7 @@ import io.agentscope.harness.agent.DistributedStore;
 import io.agentscope.harness.agent.HarnessAgent;
 import io.agentscope.harness.agent.gateway.channel.Channel;
 import io.agentscope.harness.agent.gateway.channel.ChannelConfig;
+import io.agentscope.harness.agent.gateway.channel.ChannelRuntimeContextResolver;
 import io.agentscope.harness.agent.gateway.channel.chatui.ChatUiChannel;
 import io.agentscope.harness.agent.subagent.DefaultAgentManager;
 import java.util.ArrayList;
@@ -179,6 +180,7 @@ public final class GatewayBootstrap {
         private final List<Channel> channels = new ArrayList<>();
         private Consumer<HarnessAgent.Builder> agentCustomizer;
         private DistributedStore distributedStore;
+        private ChannelRuntimeContextResolver runtimeContextResolver;
 
         private Builder() {}
 
@@ -245,6 +247,16 @@ public final class GatewayBootstrap {
         }
 
         /**
+         * Sets a {@link ChannelRuntimeContextResolver} that supplies / replaces caller {@code
+         * RuntimeContext} on each Gateway turn before identity fields are applied. Useful for
+         * attaching tenant / auth / tool dependencies from the surrounding request.
+         */
+        public Builder runtimeContextResolver(ChannelRuntimeContextResolver resolver) {
+            this.runtimeContextResolver = resolver;
+            return this;
+        }
+
+        /**
          * Builds the gateway bootstrap. At least one agent must be registered.
          *
          * @throws IllegalStateException if no agents are registered
@@ -270,6 +282,9 @@ public final class GatewayBootstrap {
             }
 
             HarnessGateway gw = HarnessGateway.create(cm);
+            if (runtimeContextResolver != null) {
+                gw.setRuntimeContextResolver(runtimeContextResolver);
+            }
 
             // Register all agents, bind the main one
             HarnessAgent mainHa = agents.get(resolvedMainId);

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/gateway/HarnessGateway.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/gateway/HarnessGateway.java
@@ -23,6 +23,9 @@ import io.agentscope.core.event.AgentResultEvent;
 import io.agentscope.core.message.Msg;
 import io.agentscope.harness.agent.HarnessAgent;
 import io.agentscope.harness.agent.bus.MessageBus;
+import io.agentscope.harness.agent.gateway.channel.ChannelRuntimeContextRequest;
+import io.agentscope.harness.agent.gateway.channel.ChannelRuntimeContextResolver;
+import io.agentscope.harness.agent.gateway.channel.InboundMessage;
 import io.agentscope.harness.agent.gateway.channel.OutboundAddress;
 import java.time.Instant;
 import java.util.List;
@@ -94,6 +97,12 @@ public final class HarnessGateway implements Gateway, WakeupDispatcher.WakeupTar
     private final ConcurrentHashMap<String, OutboundAddress> lastRouteBySession =
             new ConcurrentHashMap<>();
 
+    /**
+     * Optional resolver that supplies / replaces the caller {@link RuntimeContext} before gateway
+     * identity fields are applied.
+     */
+    private volatile ChannelRuntimeContextResolver runtimeContextResolver;
+
     private HarnessGateway(ChannelManager channelManager, MessageBus messageBus) {
         this.channelManager = channelManager;
         this.messageBus = messageBus;
@@ -125,6 +134,19 @@ public final class HarnessGateway implements Gateway, WakeupDispatcher.WakeupTar
         return channelManager;
     }
 
+    /**
+     * Sets an optional {@link ChannelRuntimeContextResolver} used when building the per-turn {@link
+     * RuntimeContext}. Passing {@code null} clears any previously configured resolver.
+     */
+    public void setRuntimeContextResolver(ChannelRuntimeContextResolver runtimeContextResolver) {
+        this.runtimeContextResolver = runtimeContextResolver;
+    }
+
+    /** Returns the configured {@link ChannelRuntimeContextResolver}, or {@code null}. */
+    public ChannelRuntimeContextResolver getRuntimeContextResolver() {
+        return runtimeContextResolver;
+    }
+
     @Override
     public void bindMainAgent(HarnessAgent agent) {
         Objects.requireNonNull(agent, "agent");
@@ -152,11 +174,30 @@ public final class HarnessGateway implements Gateway, WakeupDispatcher.WakeupTar
 
     @Override
     public Mono<Msg> run(MsgContext context, List<Msg> messages) {
-        return run(context, messages, null);
+        return run(context, messages, null, null);
     }
 
     @Override
     public Mono<Msg> run(MsgContext context, List<Msg> messages, OutboundAddress outboundAddress) {
+        return run(context, messages, outboundAddress, null);
+    }
+
+    @Override
+    public Mono<Msg> run(
+            MsgContext context,
+            List<Msg> messages,
+            OutboundAddress outboundAddress,
+            RuntimeContext callerContext) {
+        return run(context, messages, outboundAddress, callerContext, null);
+    }
+
+    @Override
+    public Mono<Msg> run(
+            MsgContext context,
+            List<Msg> messages,
+            OutboundAddress outboundAddress,
+            RuntimeContext callerContext,
+            InboundMessage inboundMessage) {
         MsgContext ctx = context != null ? context : MsgContext.defaultContext();
         String gateKey = ctx.canonicalKey();
 
@@ -174,16 +215,9 @@ public final class HarnessGateway implements Gateway, WakeupDispatcher.WakeupTar
             lastRouteBySession.put(sessionId, outboundAddress);
         }
 
-        RuntimeContext.Builder rtcBuilder =
-                RuntimeContext.builder()
-                        .sessionId(sessionId)
-                        .put("msgContext", ctx)
-                        .put("gateKey", gateKey)
-                        .put("outboundAddress", outboundAddress);
-        if (ctx.userId() != null && !ctx.userId().isBlank()) {
-            rtcBuilder.userId(ctx.userId());
-        }
-        RuntimeContext runtimeContext = rtcBuilder.build();
+        RuntimeContext runtimeContext =
+                buildRuntimeContext(
+                        ctx, outboundAddress, callerContext, inboundMessage, sessionId, gateKey);
 
         return withGatedTurn(gateKey, () -> ha.call(messages, runtimeContext));
     }
@@ -191,6 +225,25 @@ public final class HarnessGateway implements Gateway, WakeupDispatcher.WakeupTar
     @Override
     public Flux<AgentEvent> runStream(
             MsgContext context, List<Msg> messages, OutboundAddress outboundAddress) {
+        return runStream(context, messages, outboundAddress, null, null);
+    }
+
+    @Override
+    public Flux<AgentEvent> runStream(
+            MsgContext context,
+            List<Msg> messages,
+            OutboundAddress outboundAddress,
+            RuntimeContext callerContext) {
+        return runStream(context, messages, outboundAddress, callerContext, null);
+    }
+
+    @Override
+    public Flux<AgentEvent> runStream(
+            MsgContext context,
+            List<Msg> messages,
+            OutboundAddress outboundAddress,
+            RuntimeContext callerContext,
+            InboundMessage inboundMessage) {
         MsgContext ctx = context != null ? context : MsgContext.defaultContext();
         String gateKey = ctx.canonicalKey();
 
@@ -208,18 +261,63 @@ public final class HarnessGateway implements Gateway, WakeupDispatcher.WakeupTar
             lastRouteBySession.put(sessionId, outboundAddress);
         }
 
-        RuntimeContext.Builder rtcBuilder =
-                RuntimeContext.builder()
-                        .sessionId(sessionId)
-                        .put("msgContext", ctx)
-                        .put("gateKey", gateKey)
-                        .put("outboundAddress", outboundAddress);
-        if (ctx.userId() != null && !ctx.userId().isBlank()) {
-            rtcBuilder.userId(ctx.userId());
-        }
-        RuntimeContext runtimeContext = rtcBuilder.build();
+        RuntimeContext runtimeContext =
+                buildRuntimeContext(
+                        ctx, outboundAddress, callerContext, inboundMessage, sessionId, gateKey);
 
         return withGatedStream(gateKey, () -> ha.streamEvents(messages, runtimeContext));
+    }
+
+    /**
+     * Builds the effective {@link RuntimeContext} for a Gateway turn.
+     *
+     * <ol>
+     *   <li>Start from {@code callerContext} (may be null)
+     *   <li>If a {@link ChannelRuntimeContextResolver} is configured and returns non-null, that
+     *       value replaces the caller base
+     *   <li>Gateway identity fields ({@code sessionId}, {@code userId}, {@code msgContext}, {@code
+     *       gateKey}, {@code outboundAddress}) are applied and win on conflict
+     * </ol>
+     *
+     * @param inboundMessage optional inbound envelope (for resolver); may be null
+     */
+    RuntimeContext buildRuntimeContext(
+            MsgContext ctx,
+            OutboundAddress outboundAddress,
+            RuntimeContext callerContext,
+            InboundMessage inboundMessage,
+            String sessionId,
+            String gateKey) {
+        RuntimeContext base = callerContext;
+        ChannelRuntimeContextResolver resolver = this.runtimeContextResolver;
+        if (resolver != null) {
+            ChannelRuntimeContextRequest request =
+                    new ChannelRuntimeContextRequest(
+                            ctx != null ? ctx.channel() : null,
+                            inboundMessage,
+                            ctx,
+                            outboundAddress,
+                            callerContext);
+            RuntimeContext resolved = resolver.resolve(request);
+            if (resolved != null) {
+                base = resolved;
+            }
+        }
+
+        RuntimeContext.Builder rtcBuilder = RuntimeContext.builder(base).sessionId(sessionId);
+        if (ctx != null) {
+            rtcBuilder.put("msgContext", ctx);
+        }
+        if (gateKey != null) {
+            rtcBuilder.put("gateKey", gateKey);
+        }
+        if (outboundAddress != null) {
+            rtcBuilder.put("outboundAddress", outboundAddress);
+        }
+        if (ctx != null && ctx.userId() != null && !ctx.userId().isBlank()) {
+            rtcBuilder.userId(ctx.userId());
+        }
+        return rtcBuilder.build();
     }
 
     /**

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/gateway/channel/Channel.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/gateway/channel/Channel.java
@@ -43,7 +43,9 @@ import reactor.core.publisher.Mono;
  * <h2>Message dispatch</h2>
  *
  * Implementations call {@link Gateway#run} with the {@link
- * io.agentscope.harness.agent.gateway.MsgContext} produced by {@link ChannelRouter#resolveRoute}.
+ * io.agentscope.harness.agent.gateway.MsgContext} produced by {@link ChannelRouter#resolveRoute},
+ * the resolved {@link OutboundAddress}, and any caller {@link
+ * io.agentscope.core.agent.RuntimeContext} carried on {@link InboundMessage#runtimeContext()}.
  * The returned {@link Msg} reply is delivered back to the originating platform by the channel
  * adapter.
  *

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/gateway/channel/ChannelRuntimeContextRequest.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/gateway/channel/ChannelRuntimeContextRequest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.harness.agent.gateway.channel;
+
+import io.agentscope.core.agent.RuntimeContext;
+import io.agentscope.harness.agent.gateway.MsgContext;
+
+/**
+ * Inputs available to a {@link ChannelRuntimeContextResolver} when resolving caller context for a
+ * Gateway turn.
+ *
+ * @param channelId originating channel id (e.g. {@code "chatui"}, {@code "dingtalk"}); may be null
+ * @param inboundMessage the normalized inbound envelope when the turn came through {@link
+ *     Channel#dispatch}; {@code null} for programmatic {@code SendOptions} paths that skip an
+ *     inbound envelope
+ * @param msgContext resolved routing context for this turn
+ * @param outboundAddress delivery target for replies; may be null
+ * @param callerContext context carried on {@link
+ *     io.agentscope.harness.agent.gateway.channel.chatui.SendOptions} or {@link InboundMessage};
+ *     may be null
+ */
+public record ChannelRuntimeContextRequest(
+        String channelId,
+        InboundMessage inboundMessage,
+        MsgContext msgContext,
+        OutboundAddress outboundAddress,
+        RuntimeContext callerContext) {}

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/gateway/channel/ChannelRuntimeContextResolver.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/gateway/channel/ChannelRuntimeContextResolver.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.harness.agent.gateway.channel;
+
+import io.agentscope.core.agent.RuntimeContext;
+
+/**
+ * Resolves a caller-provided {@link RuntimeContext} for a Channel / Gateway turn.
+ *
+ * <p>Applications can plug this into {@link
+ * io.agentscope.harness.agent.gateway.HarnessGateway} (or via {@link
+ * io.agentscope.harness.agent.gateway.GatewayBootstrap}) to attach request-scoped values such as
+ * tenant information, force-sync flags, or tool dependencies. Gateway identity fields ({@code
+ * sessionId}, {@code userId}, {@code outboundAddress}, …) are still applied after resolution and
+ * take precedence over conflicting caller values.
+ *
+ * <p>Return {@code null} to leave the existing caller context (from {@link
+ * ChannelRuntimeContextRequest#callerContext()}) unchanged.
+ */
+@FunctionalInterface
+public interface ChannelRuntimeContextResolver {
+
+    /**
+     * Resolve the runtime context for the current channel turn.
+     *
+     * @param request channel turn metadata, including any caller-supplied context
+     * @return a runtime context to use as the merge base, or {@code null} to keep {@link
+     *     ChannelRuntimeContextRequest#callerContext()}
+     */
+    RuntimeContext resolve(ChannelRuntimeContextRequest request);
+}

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/gateway/channel/InboundMessage.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/gateway/channel/InboundMessage.java
@@ -15,6 +15,7 @@
  */
 package io.agentscope.harness.agent.gateway.channel;
 
+import io.agentscope.core.agent.RuntimeContext;
 import io.agentscope.core.message.Msg;
 import java.util.List;
 import java.util.Objects;
@@ -33,6 +34,9 @@ import java.util.Set;
  *       HarnessAgent namespace isolation. In DM scenarios these are equal; in group/channel
  *       scenarios {@code peer.id} is the group and {@code senderId} is the individual author.
  * </ul>
+ *
+ * <p>{@link #runtimeContext()} is <em>not</em> used for routing and does not participate in session
+ * key computation. It is forwarded to the Gateway as the caller merge base for the agent turn.
  *
  * @param channelId identifier of the originating channel (e.g. {@code "chatui"}, {@code "slack"})
  * @param accountId optional multi-account identifier (e.g. Slack app installation id); null for
@@ -53,6 +57,8 @@ import java.util.Set;
  *     card); the router still builds session and outbound context normally so bindings continue to
  *     control {@code sessionScope} and outbound addressing. {@code null} for normal binding-driven
  *     routing.
+ * @param runtimeContext optional caller-supplied {@link RuntimeContext} merged into the agent
+ *     turn; {@code null} when none. Not part of routing / session identity.
  */
 public record InboundMessage(
         String channelId,
@@ -64,7 +70,8 @@ public record InboundMessage(
         String team,
         Set<String> roles,
         List<Msg> messages,
-        String preferredAgentId) {
+        String preferredAgentId,
+        RuntimeContext runtimeContext) {
 
     public InboundMessage {
         Objects.requireNonNull(channelId, "channelId");
@@ -90,6 +97,7 @@ public record InboundMessage(
                 null,
                 Set.of(),
                 List.copyOf(messages),
+                null,
                 null);
     }
 
@@ -110,7 +118,8 @@ public record InboundMessage(
                 null,
                 Set.of(),
                 List.copyOf(messages),
-                agentId);
+                agentId,
+                null);
     }
 
     /**
@@ -129,6 +138,7 @@ public record InboundMessage(
                 null,
                 Set.of(),
                 List.copyOf(messages),
+                null,
                 null);
     }
 
@@ -148,6 +158,7 @@ public record InboundMessage(
                 null,
                 Set.of(),
                 List.copyOf(messages),
+                null,
                 null);
     }
 
@@ -159,6 +170,22 @@ public record InboundMessage(
     /** Whether this message is a thread-nested reply. */
     public boolean isThread() {
         return peer.kind().isThread();
+    }
+
+    /** Returns a copy carrying the given {@link RuntimeContext}. */
+    public InboundMessage withRuntimeContext(RuntimeContext runtimeContext) {
+        return new InboundMessage(
+                channelId,
+                accountId,
+                peer,
+                senderId,
+                parentPeer,
+                guild,
+                team,
+                roles,
+                messages,
+                preferredAgentId,
+                runtimeContext);
     }
 
     /** Returns a builder for constructing messages with all optional fields. */
@@ -177,6 +204,7 @@ public record InboundMessage(
         private String team;
         private Set<String> roles = Set.of();
         private String preferredAgentId;
+        private RuntimeContext runtimeContext;
 
         private Builder(String channelId, Peer peer, List<Msg> messages) {
             this.channelId = channelId;
@@ -219,6 +247,11 @@ public record InboundMessage(
             return this;
         }
 
+        public Builder runtimeContext(RuntimeContext runtimeContext) {
+            this.runtimeContext = runtimeContext;
+            return this;
+        }
+
         public InboundMessage build() {
             return new InboundMessage(
                     channelId,
@@ -230,7 +263,8 @@ public record InboundMessage(
                     team,
                     roles,
                     messages,
-                    preferredAgentId);
+                    preferredAgentId,
+                    runtimeContext);
         }
     }
 }

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/gateway/channel/chatui/ChatUiChannel.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/gateway/channel/chatui/ChatUiChannel.java
@@ -149,7 +149,13 @@ public final class ChatUiChannel implements Channel {
     public Mono<Msg> dispatch(InboundMessage message) {
         Objects.requireNonNull(message, "message");
         RouteResult route = router.resolveRoute(config, message);
-        return resolveGateway().run(route.context(), message.messages(), route.outboundAddress());
+        return resolveGateway()
+                .run(
+                        route.context(),
+                        message.messages(),
+                        route.outboundAddress(),
+                        message.runtimeContext(),
+                        message);
     }
 
     /**
@@ -242,7 +248,12 @@ public final class ChatUiChannel implements Channel {
         Objects.requireNonNull(message, "message");
         RouteResult route = router.resolveRoute(config, message);
         return resolveGateway()
-                .runStream(route.context(), message.messages(), route.outboundAddress());
+                .runStream(
+                        route.context(),
+                        message.messages(),
+                        route.outboundAddress(),
+                        message.runtimeContext(),
+                        message);
     }
 
     /** Streaming variant of {@link #send(String)}. Returns fine-grained {@link AgentEvent}s. */
@@ -289,13 +300,13 @@ public final class ChatUiChannel implements Channel {
     private Mono<Msg> dispatchWithOptions(SendOptions options, List<Msg> messages) {
         MsgContext ctx = buildContextFromOptions(options);
         OutboundAddress outbound = buildOutboundFromOptions(options);
-        return resolveGateway().run(ctx, messages, outbound);
+        return resolveGateway().run(ctx, messages, outbound, options.runtimeContext());
     }
 
     private Flux<AgentEvent> dispatchStreamWithOptions(SendOptions options, List<Msg> messages) {
         MsgContext ctx = buildContextFromOptions(options);
         OutboundAddress outbound = buildOutboundFromOptions(options);
-        return resolveGateway().runStream(ctx, messages, outbound);
+        return resolveGateway().runStream(ctx, messages, outbound, options.runtimeContext());
     }
 
     private MsgContext buildContextFromOptions(SendOptions options) {

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/gateway/channel/chatui/ChatUiChannel.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/gateway/channel/chatui/ChatUiChannel.java
@@ -201,11 +201,52 @@ public final class ChatUiChannel implements Channel {
         return send(ChatUiRequest.of(Objects.requireNonNull(text, "text")));
     }
 
+    /**
+     * Sends a pre-built {@link Msg} (text or multimodal) in single-session mode.
+     *
+     * <pre>{@code
+     * Msg multimodal = Msg.builder()
+     *         .role(MsgRole.USER)
+     *         .content(
+     *                 TextBlock.builder().text("Describe this").build(),
+     *                 ImageBlock.builder()
+     *                         .source(URLSource.builder().url(imageUrl).build())
+     *                         .build())
+     *         .build();
+     * chat.send(multimodal).block();
+     * }</pre>
+     */
+    public Mono<Msg> send(Msg message) {
+        Objects.requireNonNull(message, "message");
+        return send(ChatUiRequest.of(List.of(message)));
+    }
+
+    /**
+     * Sends one or more pre-built {@link Msg}s in single-session mode. Use this for multimodal
+     * content or multi-part user turns.
+     */
+    public Mono<Msg> send(List<Msg> messages) {
+        return send(ChatUiRequest.of(requireMessages(messages)));
+    }
+
     /** Sends a plain-text message from a specific peer. */
     public Mono<Msg> send(String peerId, String text) {
         Objects.requireNonNull(peerId, "peerId");
         Objects.requireNonNull(text, "text");
         return send(ChatUiRequest.withPeer(peerId, text));
+    }
+
+    /** Sends a pre-built {@link Msg} from a specific peer. */
+    public Mono<Msg> send(String peerId, Msg message) {
+        Objects.requireNonNull(peerId, "peerId");
+        Objects.requireNonNull(message, "message");
+        return send(ChatUiRequest.withPeer(peerId, List.of(message)));
+    }
+
+    /** Sends one or more pre-built {@link Msg}s from a specific peer. */
+    public Mono<Msg> send(String peerId, List<Msg> messages) {
+        Objects.requireNonNull(peerId, "peerId");
+        return send(ChatUiRequest.withPeer(peerId, requireMessages(messages)));
     }
 
     /**
@@ -222,12 +263,45 @@ public final class ChatUiChannel implements Channel {
         return dispatchWithOptions(options, List.of(msg));
     }
 
+    /**
+     * Sends a pre-built {@link Msg} with explicit routing identity. Prefer this overload for
+     * multimodal content (images, audio, …) while still using {@link SendOptions} for session
+     * routing.
+     */
+    public Mono<Msg> send(SendOptions options, Msg message) {
+        Objects.requireNonNull(options, "options");
+        Objects.requireNonNull(message, "message");
+        return dispatchWithOptions(options, List.of(message));
+    }
+
+    /**
+     * Sends one or more pre-built {@link Msg}s with explicit routing identity. Useful for
+     * multimodal or multi-part user turns.
+     */
+    public Mono<Msg> send(SendOptions options, List<Msg> messages) {
+        Objects.requireNonNull(options, "options");
+        return dispatchWithOptions(options, requireMessages(messages));
+    }
+
     /** Sends a message directly to an exposed subagent, bypassing normal routing. */
     public Mono<Msg> sendToSubagent(String subagentId, String text) {
         Objects.requireNonNull(subagentId, "subagentId");
         Objects.requireNonNull(text, "text");
         Msg msg = Msg.builder().role(MsgRole.USER).textContent(text).build();
         return resolveGateway().runSubagent(subagentId, List.of(msg));
+    }
+
+    /** Sends a pre-built {@link Msg} directly to an exposed subagent. */
+    public Mono<Msg> sendToSubagent(String subagentId, Msg message) {
+        Objects.requireNonNull(subagentId, "subagentId");
+        Objects.requireNonNull(message, "message");
+        return resolveGateway().runSubagent(subagentId, List.of(message));
+    }
+
+    /** Sends one or more pre-built {@link Msg}s directly to an exposed subagent. */
+    public Mono<Msg> sendToSubagent(String subagentId, List<Msg> messages) {
+        Objects.requireNonNull(subagentId, "subagentId");
+        return resolveGateway().runSubagent(subagentId, requireMessages(messages));
     }
 
     /** Sends a structured {@link ChatUiRequest} and returns the agent reply reactively. */
@@ -261,11 +335,35 @@ public final class ChatUiChannel implements Channel {
         return sendStream(ChatUiRequest.of(Objects.requireNonNull(text, "text")));
     }
 
+    /** Streaming variant of {@link #send(Msg)}. */
+    public Flux<AgentEvent> sendStream(Msg message) {
+        Objects.requireNonNull(message, "message");
+        return sendStream(ChatUiRequest.of(List.of(message)));
+    }
+
+    /** Streaming variant of {@link #send(List)}. */
+    public Flux<AgentEvent> sendStream(List<Msg> messages) {
+        return sendStream(ChatUiRequest.of(requireMessages(messages)));
+    }
+
     /** Streaming variant of {@link #send(String, String)}. */
     public Flux<AgentEvent> sendStream(String peerId, String text) {
         Objects.requireNonNull(peerId, "peerId");
         Objects.requireNonNull(text, "text");
         return sendStream(ChatUiRequest.withPeer(peerId, text));
+    }
+
+    /** Streaming variant of {@link #send(String, Msg)}. */
+    public Flux<AgentEvent> sendStream(String peerId, Msg message) {
+        Objects.requireNonNull(peerId, "peerId");
+        Objects.requireNonNull(message, "message");
+        return sendStream(ChatUiRequest.withPeer(peerId, List.of(message)));
+    }
+
+    /** Streaming variant of {@link #send(String, List)}. */
+    public Flux<AgentEvent> sendStream(String peerId, List<Msg> messages) {
+        Objects.requireNonNull(peerId, "peerId");
+        return sendStream(ChatUiRequest.withPeer(peerId, requireMessages(messages)));
     }
 
     /** Streaming variant of {@link #send(SendOptions, String)}. */
@@ -276,12 +374,38 @@ public final class ChatUiChannel implements Channel {
         return dispatchStreamWithOptions(options, List.of(msg));
     }
 
+    /** Streaming variant of {@link #send(SendOptions, Msg)}. */
+    public Flux<AgentEvent> sendStream(SendOptions options, Msg message) {
+        Objects.requireNonNull(options, "options");
+        Objects.requireNonNull(message, "message");
+        return dispatchStreamWithOptions(options, List.of(message));
+    }
+
+    /** Streaming variant of {@link #send(SendOptions, List)}. */
+    public Flux<AgentEvent> sendStream(SendOptions options, List<Msg> messages) {
+        Objects.requireNonNull(options, "options");
+        return dispatchStreamWithOptions(options, requireMessages(messages));
+    }
+
     /** Streaming variant of {@link #sendToSubagent(String, String)}. */
     public Flux<AgentEvent> sendToSubagentStream(String subagentId, String text) {
         Objects.requireNonNull(subagentId, "subagentId");
         Objects.requireNonNull(text, "text");
         Msg msg = Msg.builder().role(MsgRole.USER).textContent(text).build();
         return resolveGateway().runSubagentStream(subagentId, List.of(msg));
+    }
+
+    /** Streaming variant of {@link #sendToSubagent(String, Msg)}. */
+    public Flux<AgentEvent> sendToSubagentStream(String subagentId, Msg message) {
+        Objects.requireNonNull(subagentId, "subagentId");
+        Objects.requireNonNull(message, "message");
+        return resolveGateway().runSubagentStream(subagentId, List.of(message));
+    }
+
+    /** Streaming variant of {@link #sendToSubagent(String, List)}. */
+    public Flux<AgentEvent> sendToSubagentStream(String subagentId, List<Msg> messages) {
+        Objects.requireNonNull(subagentId, "subagentId");
+        return resolveGateway().runSubagentStream(subagentId, requireMessages(messages));
     }
 
     /** Streaming variant of {@link #send(ChatUiRequest)}. */
@@ -296,6 +420,14 @@ public final class ChatUiChannel implements Channel {
     // -----------------------------------------------------------------
     //  Internal
     // -----------------------------------------------------------------
+
+    private static List<Msg> requireMessages(List<Msg> messages) {
+        Objects.requireNonNull(messages, "messages");
+        if (messages.isEmpty()) {
+            throw new IllegalArgumentException("messages must not be empty");
+        }
+        return messages;
+    }
 
     private Mono<Msg> dispatchWithOptions(SendOptions options, List<Msg> messages) {
         MsgContext ctx = buildContextFromOptions(options);

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/gateway/channel/chatui/SendOptions.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/gateway/channel/chatui/SendOptions.java
@@ -15,6 +15,7 @@
  */
 package io.agentscope.harness.agent.gateway.channel.chatui;
 
+import io.agentscope.core.agent.RuntimeContext;
 import java.util.Objects;
 
 /**
@@ -31,6 +32,9 @@ import java.util.Objects;
  *       default.
  *   <li>{@code agentId} — optional target agent override for multi-agent setups. When null, the
  *       channel's default agent is used.
+ *   <li>{@code runtimeContext} — optional per-call {@link RuntimeContext} merged into the agent
+ *       turn (attributes, typed values, force-sync flags, …). Gateway-owned identity fields still
+ *       win on conflict.
  * </ul>
  *
  * <h2>Usage</h2>
@@ -45,13 +49,25 @@ import java.util.Objects;
  *
  * // Target a specific agent in multi-agent setups
  * chat.send(SendOptions.userId("user-1").withAgentId("support"), "help me");
+ *
+ * // Pass application context into the agent turn
+ * chat.send(
+ *     SendOptions.userId("user-1")
+ *         .withAttribute("tenant", "acme")
+ *         .withRuntimeContext(
+ *             RuntimeContext.builder()
+ *                 .put(AgentSpawnTool.CTX_FORCE_SYNC, true)
+ *                 .build()),
+ *     "hello");
  * }</pre>
  *
  * @param userId the user identity (required)
  * @param sessionId optional conversation identifier; null means one session per user
  * @param agentId optional target agent override; null for default routing
+ * @param runtimeContext optional caller-supplied runtime context; null when none
  */
-public record SendOptions(String userId, String sessionId, String agentId) {
+public record SendOptions(
+        String userId, String sessionId, String agentId, RuntimeContext runtimeContext) {
 
     public SendOptions {
         Objects.requireNonNull(userId, "userId");
@@ -59,18 +75,44 @@ public record SendOptions(String userId, String sessionId, String agentId) {
 
     /** One session per user — the most common case. */
     public static SendOptions userId(String userId) {
-        return new SendOptions(userId, null, null);
+        return new SendOptions(userId, null, null, null);
     }
 
     /** Explicit user + session — multiple conversations for the same user. */
     public static SendOptions of(String userId, String sessionId) {
         Objects.requireNonNull(sessionId, "sessionId");
-        return new SendOptions(userId, sessionId, null);
+        return new SendOptions(userId, sessionId, null, null);
     }
 
     /** Returns a copy with the given agent id override. */
     public SendOptions withAgentId(String agentId) {
-        return new SendOptions(userId, sessionId, agentId);
+        return new SendOptions(userId, sessionId, agentId, runtimeContext);
+    }
+
+    /**
+     * Returns a copy that carries the given {@link RuntimeContext} into the agent turn. Replaces
+     * any previously attached context.
+     */
+    public SendOptions withRuntimeContext(RuntimeContext runtimeContext) {
+        return new SendOptions(userId, sessionId, agentId, runtimeContext);
+    }
+
+    /**
+     * Returns a copy with a string attribute merged into the carried {@link RuntimeContext}.
+     * Creates a new context from empty when none is present yet.
+     */
+    public SendOptions withAttribute(String key, Object value) {
+        RuntimeContext next = RuntimeContext.builder(runtimeContext).put(key, value).build();
+        return new SendOptions(userId, sessionId, agentId, next);
+    }
+
+    /**
+     * Returns a copy with a typed attribute merged into the carried {@link RuntimeContext}.
+     * Creates a new context from empty when none is present yet.
+     */
+    public <T> SendOptions withAttribute(Class<T> type, T value) {
+        RuntimeContext next = RuntimeContext.builder(runtimeContext).put(type, value).build();
+        return new SendOptions(userId, sessionId, agentId, next);
     }
 
     /** The effective session key: sessionId if provided, otherwise userId. */

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/gateway/HarnessGatewayRuntimeContextMergeTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/gateway/HarnessGatewayRuntimeContextMergeTest.java
@@ -1,0 +1,211 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.harness.agent.gateway;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.spy;
+
+import io.agentscope.core.agent.RuntimeContext;
+import io.agentscope.core.agent.test.MockModel;
+import io.agentscope.core.message.Msg;
+import io.agentscope.core.message.MsgRole;
+import io.agentscope.harness.agent.HarnessAgent;
+import io.agentscope.harness.agent.gateway.channel.ChannelRuntimeContextRequest;
+import io.agentscope.harness.agent.gateway.channel.InboundMessage;
+import io.agentscope.harness.agent.gateway.channel.OutboundAddress;
+import io.agentscope.harness.agent.gateway.channel.chatui.ChatUiChannel;
+import io.agentscope.harness.agent.gateway.channel.chatui.SendOptions;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Mono;
+
+/** Verifies Gateway merge of caller {@link RuntimeContext} for Channel turns. */
+@DisplayName("HarnessGateway RuntimeContext merge")
+class HarnessGatewayRuntimeContextMergeTest {
+
+    @Test
+    @DisplayName("caller attributes survive; gateway identity fields win")
+    void mergeKeepsCallerAttrsAndOverlaysIdentity() {
+        HarnessGateway gw = HarnessGateway.create();
+        MsgContext ctx = new MsgContext("chatui", null, "sess-a", null, null, Map.of(), "user-1");
+        OutboundAddress outbound = OutboundAddress.direct("chatui", "chatui:sess-a");
+        RuntimeContext caller =
+                RuntimeContext.builder()
+                        .sessionId("caller-should-lose")
+                        .userId("caller-user")
+                        .put("tenant", "acme")
+                        .put("outboundAddress", "caller-outbound")
+                        .build();
+
+        RuntimeContext merged =
+                gw.buildRuntimeContext(ctx, outbound, caller, null, "gw-abc123", "gate-key");
+
+        assertEquals("gw-abc123", merged.getSessionId());
+        assertEquals("user-1", merged.getUserId());
+        assertEquals("acme", merged.get("tenant"));
+        assertSame(outbound, merged.get("outboundAddress"));
+        assertEquals("gate-key", merged.get("gateKey"));
+        assertSame(ctx, merged.get("msgContext"));
+    }
+
+    @Test
+    @DisplayName("resolver non-null result replaces caller base")
+    void resolverReplacesCallerBase() {
+        HarnessGateway gw = HarnessGateway.create();
+        AtomicReference<ChannelRuntimeContextRequest> seen = new AtomicReference<>();
+        gw.setRuntimeContextResolver(
+                req -> {
+                    seen.set(req);
+                    return RuntimeContext.builder()
+                            .put("fromResolver", true)
+                            .put("tenant", "resolved")
+                            .build();
+                });
+
+        MsgContext ctx = new MsgContext("chatui", null, "r", null, null, Map.of(), "u");
+        RuntimeContext caller = RuntimeContext.builder().put("tenant", "caller").build();
+        InboundMessage inbound = InboundMessage.dm("chatui", "u", List.of(userMsg("hi")));
+
+        RuntimeContext merged = gw.buildRuntimeContext(ctx, null, caller, inbound, "gw-x", "gate");
+
+        assertNotNull(seen.get());
+        assertSame(inbound, seen.get().inboundMessage());
+        assertSame(caller, seen.get().callerContext());
+        assertEquals(true, merged.get("fromResolver"));
+        assertEquals("resolved", merged.get("tenant"));
+    }
+
+    @Test
+    @DisplayName("resolver null keeps caller base")
+    void resolverNullKeepsCaller() {
+        HarnessGateway gw = HarnessGateway.create();
+        gw.setRuntimeContextResolver(req -> null);
+
+        MsgContext ctx = new MsgContext("chatui", null, "r", null, null, Map.of(), "u");
+        RuntimeContext caller = RuntimeContext.builder().put("tenant", "caller").build();
+
+        RuntimeContext merged = gw.buildRuntimeContext(ctx, null, caller, null, "gw-x", "gate");
+
+        assertEquals("caller", merged.get("tenant"));
+    }
+
+    @Test
+    @DisplayName("SendOptions attributes reach the agent via ChatUiChannel")
+    void sendOptionsAttributesReachAgent() {
+        AtomicReference<RuntimeContext> seen = new AtomicReference<>();
+        HarnessAgent agent =
+                spy(
+                        HarnessAgent.builder()
+                                .name("assistant")
+                                .sysPrompt("hi")
+                                .model(new MockModel("ok"))
+                                .build());
+        doAnswer(
+                        inv -> {
+                            seen.set(inv.getArgument(1));
+                            return Mono.just(
+                                    Msg.builder()
+                                            .role(MsgRole.ASSISTANT)
+                                            .textContent("ok")
+                                            .build());
+                        })
+                .when(agent)
+                .call(anyList(), any(RuntimeContext.class));
+
+        HarnessGateway gateway = HarnessGateway.create();
+        gateway.bindMainAgent(agent);
+        ChatUiChannel chat = ChatUiChannel.create(gateway);
+
+        SendOptions options =
+                SendOptions.userId("user-1")
+                        .withAttribute("tenant", "acme")
+                        .withAttribute(Foo.class, new Foo("bar"));
+
+        Msg reply = chat.send(options, "hello").block();
+        assertNotNull(reply);
+        assertNotNull(seen.get());
+        assertEquals("acme", seen.get().get("tenant"));
+        assertEquals("bar", seen.get().get(Foo.class).value());
+        assertEquals("user-1", seen.get().getUserId());
+        assertNotNull(seen.get().getSessionId());
+        assertTrue(seen.get().getSessionId().startsWith("gw-"));
+    }
+
+    @Test
+    @DisplayName("InboundMessage.runtimeContext is forwarded on dispatch")
+    void inboundRuntimeContextForwarded() {
+        AtomicReference<RuntimeContext> seen = new AtomicReference<>();
+        HarnessAgent agent =
+                spy(
+                        HarnessAgent.builder()
+                                .name("assistant")
+                                .sysPrompt("hi")
+                                .model(new MockModel("ok"))
+                                .build());
+        doAnswer(
+                        inv -> {
+                            seen.set(inv.getArgument(1));
+                            return Mono.just(
+                                    Msg.builder()
+                                            .role(MsgRole.ASSISTANT)
+                                            .textContent("ok")
+                                            .build());
+                        })
+                .when(agent)
+                .call(anyList(), any(RuntimeContext.class));
+
+        HarnessGateway gateway = HarnessGateway.create();
+        gateway.bindMainAgent(agent);
+        ChatUiChannel chat = ChatUiChannel.create(gateway);
+
+        RuntimeContext rtc = RuntimeContext.builder().put("fromInbound", true).build();
+        InboundMessage inbound =
+                InboundMessage.dm("chatui", "peer-1", List.of(userMsg("hi")))
+                        .withRuntimeContext(rtc);
+
+        chat.dispatch(inbound).block();
+
+        assertNotNull(seen.get());
+        assertEquals(true, seen.get().get("fromInbound"));
+    }
+
+    @Test
+    @DisplayName("SendOptions withRuntimeContext replaces prior attributes")
+    void withRuntimeContextReplaces() {
+        SendOptions options =
+                SendOptions.userId("u")
+                        .withAttribute("a", 1)
+                        .withRuntimeContext(RuntimeContext.builder().put("b", 2).build());
+        assertNull(options.runtimeContext().get("a"));
+        assertEquals(2, options.runtimeContext().get("b", Integer.class));
+    }
+
+    private static Msg userMsg(String text) {
+        return Msg.builder().role(MsgRole.USER).textContent(text).build();
+    }
+
+    private record Foo(String value) {}
+}

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/gateway/channel/chatui/ChatUiChannelMsgSendTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/gateway/channel/chatui/ChatUiChannelMsgSendTest.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.harness.agent.gateway.channel.chatui;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.spy;
+
+import io.agentscope.core.agent.RuntimeContext;
+import io.agentscope.core.agent.test.MockModel;
+import io.agentscope.core.message.ImageBlock;
+import io.agentscope.core.message.Msg;
+import io.agentscope.core.message.MsgRole;
+import io.agentscope.core.message.TextBlock;
+import io.agentscope.core.message.URLSource;
+import io.agentscope.harness.agent.HarnessAgent;
+import io.agentscope.harness.agent.gateway.HarnessGateway;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Mono;
+
+/** Verifies ChatUiChannel Msg / List&lt;Msg&gt; send overloads. */
+@DisplayName("ChatUiChannel Msg send overloads")
+class ChatUiChannelMsgSendTest {
+
+    @Test
+    @DisplayName("send(SendOptions, Msg) forwards multimodal message to agent")
+    void sendOptionsMsgForwardsContent() {
+        AtomicReference<List<Msg>> seen = new AtomicReference<>();
+        ChatUiChannel chat = chatCapturingMessages(seen);
+
+        Msg multimodal = multimodalMsg();
+        Msg reply = chat.send(SendOptions.userId("user-1"), multimodal).block();
+
+        assertEquals("ok", reply.getTextContent());
+        assertEquals(1, seen.get().size());
+        assertSame(multimodal, seen.get().get(0));
+        assertEquals(2, multimodal.getContent().size());
+    }
+
+    @Test
+    @DisplayName("send(SendOptions, List) forwards the list as-is")
+    void sendOptionsListForwards() {
+        AtomicReference<List<Msg>> seen = new AtomicReference<>();
+        ChatUiChannel chat = chatCapturingMessages(seen);
+
+        Msg first = Msg.builder().role(MsgRole.USER).textContent("a").build();
+        Msg second = multimodalMsg();
+        List<Msg> batch = List.of(first, second);
+
+        chat.send(SendOptions.userId("user-1"), batch).block();
+
+        assertEquals(2, seen.get().size());
+        assertSame(first, seen.get().get(0));
+        assertSame(second, seen.get().get(1));
+    }
+
+    @Test
+    @DisplayName("send(Msg) and send(List) work in single-session mode")
+    void sendMsgAndListSingleSession() {
+        AtomicReference<List<Msg>> seen = new AtomicReference<>();
+        ChatUiChannel chat = chatCapturingMessages(seen);
+
+        Msg multimodal = multimodalMsg();
+        chat.send(multimodal).block();
+        assertSame(multimodal, seen.get().get(0));
+
+        seen.set(null);
+        List<Msg> batch = List.of(multimodal);
+        chat.send(batch).block();
+        assertSame(multimodal, seen.get().get(0));
+    }
+
+    @Test
+    @DisplayName("send(peerId, Msg) and send(peerId, List) route by peer")
+    void sendPeerMsgAndList() {
+        AtomicReference<List<Msg>> seen = new AtomicReference<>();
+        ChatUiChannel chat = chatCapturingMessages(seen);
+
+        Msg multimodal = multimodalMsg();
+        chat.send("peer-1", multimodal).block();
+        assertSame(multimodal, seen.get().get(0));
+
+        seen.set(null);
+        chat.send("peer-2", List.of(multimodal)).block();
+        assertSame(multimodal, seen.get().get(0));
+    }
+
+    @Test
+    @DisplayName("empty List throw IllegalArgumentException")
+    void emptyListRejected() {
+        ChatUiChannel chat = ChatUiChannel.create(HarnessGateway.create());
+        assertThrows(IllegalArgumentException.class, () -> chat.send(List.of()));
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> chat.send(SendOptions.userId("u"), List.of()));
+        assertThrows(IllegalArgumentException.class, () -> chat.send("peer", List.of()));
+    }
+
+    private static ChatUiChannel chatCapturingMessages(AtomicReference<List<Msg>> seen) {
+        HarnessAgent agent =
+                spy(
+                        HarnessAgent.builder()
+                                .name("assistant")
+                                .sysPrompt("hi")
+                                .model(new MockModel("ok"))
+                                .build());
+        doAnswer(
+                        inv -> {
+                            seen.set(inv.getArgument(0));
+                            return Mono.just(
+                                    Msg.builder()
+                                            .role(MsgRole.ASSISTANT)
+                                            .textContent("ok")
+                                            .build());
+                        })
+                .when(agent)
+                .call(anyList(), any(RuntimeContext.class));
+
+        HarnessGateway gateway = HarnessGateway.create();
+        gateway.bindMainAgent(agent);
+        return ChatUiChannel.create(gateway);
+    }
+
+    private static Msg multimodalMsg() {
+        return Msg.builder()
+                .role(MsgRole.USER)
+                .content(
+                        TextBlock.builder().text("What is in this image?").build(),
+                        ImageBlock.builder()
+                                .source(
+                                        URLSource.builder()
+                                                .url("https://example.com/photo.png")
+                                                .build())
+                                .build())
+                .build();
+    }
+}

--- a/docs/v2/en/docs/harness/channel.md
+++ b/docs/v2/en/docs/harness/channel.md
@@ -68,6 +68,25 @@ chat.send(
         .block();
 ```
 
+### Multimodal / structured messages
+
+Plain-text `send(String)` is a convenience. For images, audio, or multi-part turns, pass a pre-built `Msg` (or `List<Msg>`) — every String overload has matching `Msg` / `List<Msg>` variants (including `SendOptions` and `sendStream`):
+
+```java
+Msg multimodal = Msg.builder()
+        .role(MsgRole.USER)
+        .content(
+                TextBlock.builder().text("What is in this image?").build(),
+                ImageBlock.builder()
+                        .source(URLSource.builder().url("https://example.com/photo.png").build())
+                        .build())
+        .build();
+
+chat.send(SendOptions.userId("user-1"), multimodal).block();
+chat.send(SendOptions.userId("user-1"), List.of(multimodal)).block();
+chat.send(multimodal).block(); // single-session mode
+```
+
 ### RuntimeContext merge
 
 Channel turns always build a `RuntimeContext` inside the Gateway. Callers can contribute a **caller base** via `SendOptions` / `InboundMessage.runtimeContext()` / a `ChannelRuntimeContextResolver`. Merge order:

--- a/docs/v2/en/docs/harness/channel.md
+++ b/docs/v2/en/docs/harness/channel.md
@@ -48,12 +48,48 @@ Msg otherUser = chat.send(SendOptions.userId("user-2"), "Hi there").block();
 | `SendOptions.userId("user-1")` | One session per user (most common) |
 | `SendOptions.of("user-1", "session-a")` | Explicit session — multiple conversations per user |
 | `SendOptions.userId("user-1").withAgentId("support")` | Route to a specific agent in multi-agent setups |
+| `SendOptions.userId("user-1").withAttribute("tenant", "acme")` | Attach string/typed attributes to the agent turn |
+| `SendOptions.userId("user-1").withRuntimeContext(rtc)` | Carry a full `RuntimeContext` (e.g. force-sync flags) |
 
 ```java
 // Same user, two independent conversations
 chat.send(SendOptions.of("user-1", "session-a"), "Topic A").block();
 chat.send(SendOptions.of("user-1", "session-b"), "Topic B").block();
+
+// Pass application context into the agent turn
+chat.send(
+        SendOptions.userId("user-1")
+                .withAttribute("tenant", "acme")
+                .withRuntimeContext(
+                        RuntimeContext.builder()
+                                .put(AgentSpawnTool.CTX_FORCE_SYNC, true)
+                                .build()),
+        "Investigate the ticket")
+        .block();
 ```
+
+### RuntimeContext merge
+
+Channel turns always build a `RuntimeContext` inside the Gateway. Callers can contribute a **caller base** via `SendOptions` / `InboundMessage.runtimeContext()` / a `ChannelRuntimeContextResolver`. Merge order:
+
+1. Start from the caller context (may be empty)
+2. If a `ChannelRuntimeContextResolver` is configured and returns non-null, that value **replaces** the caller base
+3. Gateway overlays identity fields — `sessionId` (`gw-…`), `userId`, `msgContext`, `gateKey`, `outboundAddress` — which always win on conflict
+
+Wire a resolver through `GatewayBootstrap`:
+
+```java
+GatewayBootstrap gw = GatewayBootstrap.builder()
+        .agent("main", b -> b.name("assistant").model(model))
+        .runtimeContextResolver(req ->
+                RuntimeContext.builder(req.callerContext())
+                        .put("tenant", resolveTenant(req))
+                        .build())
+        .build();
+ChatUiChannel chat = gw.chatUiChannel();
+```
+
+Or call `gateway.setRuntimeContextResolver(...)` after obtaining the gateway. Do **not** put business attributes in `MsgContext.extra` — that map participates in the session key.
 
 ## Streaming events + SSE
 

--- a/docs/v2/zh/docs/harness/channel.md
+++ b/docs/v2/zh/docs/harness/channel.md
@@ -68,6 +68,25 @@ chat.send(
         .block();
 ```
 
+### 多模态 / 结构化消息
+
+纯文本 `send(String)` 只是便捷方法。图片、音频或多段内容请传预构建的 `Msg`（或 `List<Msg>`）——每个 String 重载都有对应的 `Msg` / `List<Msg>` 版本（含 `SendOptions` 与 `sendStream`）：
+
+```java
+Msg multimodal = Msg.builder()
+        .role(MsgRole.USER)
+        .content(
+                TextBlock.builder().text("这张图里有什么？").build(),
+                ImageBlock.builder()
+                        .source(URLSource.builder().url("https://example.com/photo.png").build())
+                        .build())
+        .build();
+
+chat.send(SendOptions.userId("user-1"), multimodal).block();
+chat.send(SendOptions.userId("user-1"), List.of(multimodal)).block();
+chat.send(multimodal).block(); // 单 session 模式
+```
+
 ### RuntimeContext 合并
 
 Channel 路径会在 Gateway 内构建 `RuntimeContext`。调用方可通过 `SendOptions` / `InboundMessage.runtimeContext()` / `ChannelRuntimeContextResolver` 提供 **caller base**。合并顺序：

--- a/docs/v2/zh/docs/harness/channel.md
+++ b/docs/v2/zh/docs/harness/channel.md
@@ -48,12 +48,48 @@ Msg otherUser = chat.send(SendOptions.userId("user-2"), "你好").block();
 | `SendOptions.userId("user-1")` | 每个用户一个 session（最常用） |
 | `SendOptions.of("user-1", "session-a")` | 指定 session——同一用户多个对话 |
 | `SendOptions.userId("user-1").withAgentId("support")` | 在多 agent 场景下路由到指定 agent |
+| `SendOptions.userId("user-1").withAttribute("tenant", "acme")` | 给本轮 agent 调用附带字符串/类型化属性 |
+| `SendOptions.userId("user-1").withRuntimeContext(rtc)` | 携带完整 `RuntimeContext`（例如 force-sync 开关） |
 
 ```java
 // 同一用户，两个独立对话
 chat.send(SendOptions.of("user-1", "session-a"), "话题 A").block();
 chat.send(SendOptions.of("user-1", "session-b"), "话题 B").block();
+
+// 把应用侧上下文传入本轮 agent 调用
+chat.send(
+        SendOptions.userId("user-1")
+                .withAttribute("tenant", "acme")
+                .withRuntimeContext(
+                        RuntimeContext.builder()
+                                .put(AgentSpawnTool.CTX_FORCE_SYNC, true)
+                                .build()),
+        "排查这张工单")
+        .block();
 ```
+
+### RuntimeContext 合并
+
+Channel 路径会在 Gateway 内构建 `RuntimeContext`。调用方可通过 `SendOptions` / `InboundMessage.runtimeContext()` / `ChannelRuntimeContextResolver` 提供 **caller base**。合并顺序：
+
+1. 以 caller 上下文为起点（可为空）
+2. 若配置了 `ChannelRuntimeContextResolver` 且返回非 null，则 **替换** caller base
+3. Gateway 再覆盖身份字段——`sessionId`（`gw-…`）、`userId`、`msgContext`、`gateKey`、`outboundAddress`——冲突时以 Gateway 为准
+
+通过 `GatewayBootstrap` 接线：
+
+```java
+GatewayBootstrap gw = GatewayBootstrap.builder()
+        .agent("main", b -> b.name("assistant").model(model))
+        .runtimeContextResolver(req ->
+                RuntimeContext.builder(req.callerContext())
+                        .put("tenant", resolveTenant(req))
+                        .build())
+        .build();
+ChatUiChannel chat = gw.chatUiChannel();
+```
+
+也可以拿到 gateway 后调用 `gateway.setRuntimeContextResolver(...)`。**不要**把业务属性写进 `MsgContext.extra`——该 map 参与 session key 计算。
 
 ## 流式事件 + SSE
 


### PR DESCRIPTION
## Summary
- Add Gateway `run`/`runStream` overloads that accept a caller `RuntimeContext`, merged in `HarnessGateway` with AG-UI-style precedence (caller → optional `ChannelRuntimeContextResolver` replace → gateway identity wins).
- Carry RTC via `SendOptions.withRuntimeContext` / `withAttribute` and `InboundMessage.runtimeContext`, forwarding through ChatUi and platform channels.
- Document merge behavior (EN/ZH) and cover merge/resolver/SendOptions with unit tests.

## Test plan
- [x] `mvn -pl agentscope-harness -am test -Dtest=HarnessGatewayRuntimeContextMergeTest`
- [ ] Smoke ChatUi `send` with `withAttribute` / `CTX_FORCE_SYNC` and verify agent sees attributes
- [ ] Optional: wire `GatewayBootstrap.runtimeContextResolver(...)` and confirm resolver replaces caller base