### PR TITLE
fix(aistio): add cache-control headers to console static serving

### DIFF
--- a/agentscope-service/aistio/internal/httpapi/server.go
+++ b/agentscope-service/aistio/internal/httpapi/server.go
@@ -416,9 +416,18 @@ func (s *Server) spaFallback() gin.HandlerFunc {
 		}
 		path := filepath.Join(s.staticDir, filepath.Clean(c.Request.URL.Path))
 		if info, err := os.Stat(path); err == nil && !info.IsDir() {
+			// Vite content-hashes /assets/* filenames, so they are safe to cache
+			// immutably; everything else is revalidated so console updates land
+			// without a hard refresh.
+			if strings.HasPrefix(c.Request.URL.Path, "/assets/") {
+				c.Header("Cache-Control", "public, max-age=31536000, immutable")
+			} else {
+				c.Header("Cache-Control", "no-cache")
+			}
 			fileServer.ServeHTTP(c.Writer, c.Request)
 			return
 		}
+		c.Header("Cache-Control", "no-cache")
 		c.File(index)
 	}
 }


### PR DESCRIPTION
## Summary

`spaFallback` in `aistio/internal/httpapi/server.go` served the console bundle with no `Cache-Control` header, so browsers heuristic-cached `index.html` and kept showing the stale bundle after frontend rebuilds until a hard refresh.

- `index.html` / non-hashed docs → `Cache-Control: no-cache` (revalidated on every load, new bundles picked up automatically)
- `/assets/*` (Vite content-hashed filenames) → `Cache-Control: public, max-age=31536000, immutable`
- API paths unchanged

Fixes #2606

## Test plan

- [x] `go build ./cmd/aistiod` succeeds
- [x] Restarted the stack; verified headers via curl:
  - `GET /` → `Cache-Control: no-cache`
  - `GET /assets/index-*.js` → `Cache-Control: public, max-age=31536000, immutable`
- [x] API endpoints still return 401/200 as before