### PR TITLE
fix(openai): normalize strict structured output schemas

### DIFF
--- a/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-openai/src/main/java/io/agentscope/extensions/model/openai/formatter/OpenAIChatFormatter.java
+++ b/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-openai/src/main/java/io/agentscope/extensions/model/openai/formatter/OpenAIChatFormatter.java
@@ -15,6 +15,7 @@
  */
 package io.agentscope.extensions.model.openai.formatter;
 
+import io.agentscope.core.formatter.JsonSchema;
 import io.agentscope.core.formatter.ResponseFormat;
 import io.agentscope.core.message.Msg;
 import io.agentscope.core.model.GenerateOptions;
@@ -26,6 +27,7 @@ import io.agentscope.extensions.model.openai.dto.OpenAITool;
 import io.agentscope.extensions.model.openai.dto.OpenAIToolFunction;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import org.slf4j.Logger;
@@ -143,7 +145,7 @@ public class OpenAIChatFormatter extends OpenAIBaseFormatter {
         ResponseFormat responseFormat =
                 getOptionOrDefault(options, defaultOptions, GenerateOptions::getResponseFormat);
         if (responseFormat != null) {
-            request.setResponseFormat(responseFormat);
+            request.setResponseFormat(normalizeStrictResponseFormat(responseFormat));
         }
 
         // Apply additional body params (must be last to allow overriding)
@@ -276,7 +278,8 @@ public class OpenAIChatFormatter extends OpenAIBaseFormatter {
                         }
 
                         if (value instanceof ResponseFormat responseFormat) {
-                            request.setResponseFormat(responseFormat);
+                            request.setResponseFormat(
+                                    normalizeStrictResponseFormat(responseFormat));
                         }
 
                         break;
@@ -289,5 +292,63 @@ public class OpenAIChatFormatter extends OpenAIBaseFormatter {
             }
             log.debug("Applied {} additional body params to OpenAI request", params.size());
         }
+    }
+
+    /**
+     * Normalize a strict JSON Schema for OpenAI Structured Outputs.
+     *
+     * <p>OpenAI requires every object schema to disable additional properties and list every
+     * declared property as required when strict mode is enabled. The schema is copied recursively
+     * so callers' maps are never mutated.
+     */
+    private ResponseFormat normalizeStrictResponseFormat(ResponseFormat responseFormat) {
+        JsonSchema jsonSchema = responseFormat.getJsonSchema();
+        if (!"json_schema".equals(responseFormat.getType())
+                || jsonSchema == null
+                || !Boolean.TRUE.equals(jsonSchema.getStrict())
+                || jsonSchema.getSchema() == null) {
+            return responseFormat;
+        }
+
+        JsonSchema normalizedSchema =
+                JsonSchema.builder()
+                        .name(jsonSchema.getName())
+                        .description(jsonSchema.getDescription())
+                        .schema(normalizeSchemaMap(jsonSchema.getSchema()))
+                        .strict(true)
+                        .build();
+        return ResponseFormat.jsonSchema(normalizedSchema);
+    }
+
+    private Map<String, Object> normalizeSchemaMap(Map<?, ?> schema) {
+        Map<String, Object> normalized = new LinkedHashMap<>();
+        schema.forEach(
+                (key, value) -> normalized.put(String.valueOf(key), normalizeSchemaValue(value)));
+
+        if (isObjectSchema(normalized)) {
+            normalized.put("additionalProperties", false);
+            if (normalized.get("properties") instanceof Map<?, ?> properties) {
+                List<String> required = properties.keySet().stream().map(String::valueOf).toList();
+                normalized.put("required", required);
+            }
+        }
+        return normalized;
+    }
+
+    private Object normalizeSchemaValue(Object value) {
+        if (value instanceof Map<?, ?> map) {
+            return normalizeSchemaMap(map);
+        }
+        if (value instanceof List<?> list) {
+            return list.stream().map(this::normalizeSchemaValue).toList();
+        }
+        return value;
+    }
+
+    private boolean isObjectSchema(Map<String, Object> schema) {
+        Object type = schema.get("type");
+        return "object".equals(type)
+                || (type instanceof List<?> types && types.contains("object"))
+                || schema.get("properties") instanceof Map<?, ?>;
     }
 }

--- a/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-openai/src/test/java/io/agentscope/extensions/model/openai/formatter/OpenAIChatFormatterTest.java
+++ b/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-openai/src/test/java/io/agentscope/extensions/model/openai/formatter/OpenAIChatFormatterTest.java
@@ -567,8 +567,8 @@ class OpenAIChatFormatterTest {
         }
 
         @Test
-        @DisplayName("Should apply response_format parameter with ResponseFormat class")
-        void testApplyResponseFormatWithClass() {
+        @DisplayName("Should normalize strict response_format for OpenAI Structured Outputs")
+        void testApplyStrictResponseFormatWithClass() {
             OpenAIRequest request =
                     OpenAIRequest.builder().model("gpt-4").messages(List.of()).build();
 
@@ -582,9 +582,7 @@ class OpenAIChatFormatterTest {
                                     .schema(schema)
                                     .build());
             GenerateOptions options =
-                    GenerateOptions.builder()
-                            .additionalBodyParam("response_format", responseFormat)
-                            .build();
+                    GenerateOptions.builder().responseFormat(responseFormat).build();
 
             formatter.applyOptions(request, options, null);
 
@@ -600,6 +598,73 @@ class OpenAIChatFormatterTest {
                     (Map<String, Object>) format.getJsonSchema().getSchema().get("properties");
             assertTrue(properties.containsKey("name"));
             assertTrue(properties.containsKey("age"));
+            assertTrue(properties.containsKey("email"));
+            assertEquals(false, format.getJsonSchema().getSchema().get("additionalProperties"));
+            @SuppressWarnings("unchecked")
+            List<String> required =
+                    (List<String>) format.getJsonSchema().getSchema().get("required");
+            assertEquals(properties.size(), required.size());
+            assertTrue(required.containsAll(properties.keySet()));
+
+            // Normalization must not mutate the schema supplied by the caller.
+            assertNull(schema.get("additionalProperties"));
+        }
+
+        @Test
+        @DisplayName("Should recursively normalize nested strict object schemas")
+        void testRecursivelyNormalizeStrictResponseFormat() {
+            OpenAIRequest request =
+                    OpenAIRequest.builder().model("gpt-4").messages(List.of()).build();
+
+            Map<String, Object> nestedObject =
+                    Map.of(
+                            "type",
+                            "object",
+                            "properties",
+                            Map.of("value", Map.of("type", "string")));
+            Map<String, Object> schema =
+                    Map.of(
+                            "type",
+                            "object",
+                            "properties",
+                            Map.of("items", Map.of("type", "array", "items", nestedObject)),
+                            "$defs",
+                            Map.of("metadata", nestedObject));
+            ResponseFormat responseFormat =
+                    ResponseFormat.jsonSchema(
+                            JsonSchema.builder()
+                                    .name("nested_response")
+                                    .strict(true)
+                                    .schema(schema)
+                                    .build());
+
+            formatter.applyOptions(
+                    request,
+                    GenerateOptions.builder().responseFormat(responseFormat).build(),
+                    null);
+
+            ResponseFormat normalized = (ResponseFormat) request.getResponseFormat();
+            Map<String, Object> normalizedSchema = normalized.getJsonSchema().getSchema();
+            assertEquals(false, normalizedSchema.get("additionalProperties"));
+            assertEquals(List.of("items"), normalizedSchema.get("required"));
+
+            @SuppressWarnings("unchecked")
+            Map<String, Object> properties =
+                    (Map<String, Object>) normalizedSchema.get("properties");
+            @SuppressWarnings("unchecked")
+            Map<String, Object> items = (Map<String, Object>) properties.get("items");
+            @SuppressWarnings("unchecked")
+            Map<String, Object> normalizedNested = (Map<String, Object>) items.get("items");
+            assertEquals(false, normalizedNested.get("additionalProperties"));
+            assertEquals(List.of("value"), normalizedNested.get("required"));
+
+            @SuppressWarnings("unchecked")
+            Map<String, Object> definitions = (Map<String, Object>) normalizedSchema.get("$defs");
+            @SuppressWarnings("unchecked")
+            Map<String, Object> normalizedDefinition =
+                    (Map<String, Object>) definitions.get("metadata");
+            assertEquals(false, normalizedDefinition.get("additionalProperties"));
+            assertEquals(List.of("value"), normalizedDefinition.get("required"));
         }
 
         @Test

--- a/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-openai/src/test/java/io/agentscope/extensions/model/openai/formatter/OpenAIChatFormatterTest.java
+++ b/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-openai/src/test/java/io/agentscope/extensions/model/openai/formatter/OpenAIChatFormatterTest.java
@@ -668,6 +668,114 @@ class OpenAIChatFormatterTest {
         }
 
         @Test
+        @DisplayName("Should normalize strict response_format from additional body parameters")
+        void testNormalizeStrictResponseFormatFromAdditionalBodyParams() {
+            OpenAIRequest request =
+                    OpenAIRequest.builder().model("gpt-4").messages(List.of()).build();
+
+            Map<String, Object> schema =
+                    Map.of(
+                            "type",
+                            List.of("object", "null"),
+                            "properties",
+                            Map.of(
+                                    "implicitObject",
+                                    Map.of("properties", Map.of("value", Map.of("type", "string"))),
+                                    "emptyObject",
+                                    Map.of("type", "object"),
+                                    "nullableString",
+                                    Map.of("type", List.of("string", "null"))));
+            ResponseFormat responseFormat =
+                    ResponseFormat.jsonSchema(
+                            JsonSchema.builder()
+                                    .name("nullable_response")
+                                    .strict(true)
+                                    .schema(schema)
+                                    .build());
+
+            formatter.applyOptions(
+                    request,
+                    GenerateOptions.builder()
+                            .additionalBodyParam("response_format", responseFormat)
+                            .build(),
+                    null);
+
+            ResponseFormat normalized =
+                    assertInstanceOf(ResponseFormat.class, request.getResponseFormat());
+            Map<String, Object> normalizedSchema = normalized.getJsonSchema().getSchema();
+            assertEquals(false, normalizedSchema.get("additionalProperties"));
+            List<?> required = assertInstanceOf(List.class, normalizedSchema.get("required"));
+            assertEquals(3, required.size());
+            assertTrue(
+                    required.containsAll(
+                            List.of("implicitObject", "emptyObject", "nullableString")));
+
+            Map<?, ?> properties = assertInstanceOf(Map.class, normalizedSchema.get("properties"));
+            Map<?, ?> implicitObject =
+                    assertInstanceOf(Map.class, properties.get("implicitObject"));
+            assertEquals(false, implicitObject.get("additionalProperties"));
+            assertEquals(List.of("value"), implicitObject.get("required"));
+
+            Map<?, ?> emptyObject = assertInstanceOf(Map.class, properties.get("emptyObject"));
+            assertEquals(false, emptyObject.get("additionalProperties"));
+            assertNull(emptyObject.get("required"));
+
+            Map<?, ?> nullableString =
+                    assertInstanceOf(Map.class, properties.get("nullableString"));
+            assertNull(nullableString.get("additionalProperties"));
+        }
+
+        @Test
+        @DisplayName("Should preserve response formats without strict JSON schemas")
+        void testPreserveResponseFormatsWithoutStrictSchemas() {
+            ResponseFormat text = applyResponseFormat(ResponseFormat.text());
+            assertEquals("text", text.getType());
+            assertNull(text.getJsonSchema());
+
+            Map<String, Object> schema =
+                    Map.of(
+                            "type",
+                            "object",
+                            "properties",
+                            Map.of("value", Map.of("type", "string")));
+            ResponseFormat responseFormat =
+                    ResponseFormat.jsonSchema(
+                            JsonSchema.builder()
+                                    .name("non_strict_response")
+                                    .strict(false)
+                                    .schema(schema)
+                                    .build());
+            ResponseFormat preserved = applyResponseFormat(responseFormat);
+            assertEquals(false, preserved.getJsonSchema().getStrict());
+            assertEquals(schema, preserved.getJsonSchema().getSchema());
+            assertNull(preserved.getJsonSchema().getSchema().get("additionalProperties"));
+
+            ResponseFormat withoutJsonSchema = applyResponseFormat(ResponseFormat.jsonSchema(null));
+            assertEquals("json_schema", withoutJsonSchema.getType());
+            assertNull(withoutJsonSchema.getJsonSchema());
+
+            ResponseFormat withoutSchema =
+                    applyResponseFormat(
+                            ResponseFormat.jsonSchema(
+                                    JsonSchema.builder()
+                                            .name("missing_schema")
+                                            .strict(true)
+                                            .build()));
+            assertTrue(withoutSchema.getJsonSchema().getStrict());
+            assertNull(withoutSchema.getJsonSchema().getSchema());
+        }
+
+        private ResponseFormat applyResponseFormat(ResponseFormat responseFormat) {
+            OpenAIRequest request =
+                    OpenAIRequest.builder().model("gpt-4").messages(List.of()).build();
+            formatter.applyOptions(
+                    request,
+                    GenerateOptions.builder().responseFormat(responseFormat).build(),
+                    null);
+            return assertInstanceOf(ResponseFormat.class, request.getResponseFormat());
+        }
+
+        @Test
         @DisplayName("Should add unknown parameters to extraParams")
         void testApplyUnknownParams() {
             OpenAIRequest request =


### PR DESCRIPTION
## Summary

- normalize strict OpenAI Structured Output schemas before adding them to a request
- set `additionalProperties: false` and include every declared property in `required` for each object schema
- recursively normalize nested objects, arrays, and `$defs` without mutating the caller-provided schema
- add regression coverage for the `agent.call(..., Class)` schema path and nested schemas

## Root cause

`ReActAgent` enables strict mode for native structured output, while the general JSON Schema generator leaves fields optional by default and does not forbid additional properties. OpenAI rejects that schema when `strict: true` is used.

## Impact

OpenAI calls using typed structured outputs are no longer rejected for missing `additionalProperties: false` or incomplete/missing `required` arrays. Other model providers keep their existing schema generation behavior because normalization happens at the OpenAI formatter boundary.

## Validation

- `mvn -pl agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-openai -am -Dtest=OpenAIChatFormatterTest -Dsurefire.failIfNoSpecifiedTests=false test`
  - 43 tests passed
  - Spotless check passed

Fixes #2548
