### PR TITLE
fix(sandbox): preserve zero exit code in E2B JSON stream

### DIFF
--- a/agentscope-extensions/agentscope-extensions-sandbox/agentscope-extensions-sandbox-e2b/src/main/java/io/agentscope/extensions/sandbox/e2b/E2bEnvdProcessClient.java
+++ b/agentscope-extensions/agentscope-extensions-sandbox/agentscope-extensions-sandbox-e2b/src/main/java/io/agentscope/extensions/sandbox/e2b/E2bEnvdProcessClient.java
@@ -205,8 +205,7 @@ final class E2bEnvdProcessClient {
                     Descriptors.FieldDescriptor ec =
                             end.getDescriptorForType().findFieldByName("exit_code");
                     if (ec != null) {
-                        Object v = end.getField(ec);
-                        exit = v instanceof Integer ? (Integer) v : ((Long) v).intValue();
+                        exit = ((Number) end.getField(ec)).intValue();
                     }
                 }
             } catch (IOException e) {

--- a/agentscope-extensions/agentscope-extensions-sandbox/agentscope-extensions-sandbox-e2b/src/main/java/io/agentscope/extensions/sandbox/e2b/E2bEnvdProcessClient.java
+++ b/agentscope-extensions/agentscope-extensions-sandbox/agentscope-extensions-sandbox-e2b/src/main/java/io/agentscope/extensions/sandbox/e2b/E2bEnvdProcessClient.java
@@ -204,7 +204,7 @@ final class E2bEnvdProcessClient {
                     DynamicMessage end = (DynamicMessage) pe.getField(peEndF);
                     Descriptors.FieldDescriptor ec =
                             end.getDescriptorForType().findFieldByName("exit_code");
-                    if (end.hasField(ec)) {
+                    if (ec != null) {
                         Object v = end.getField(ec);
                         exit = v instanceof Integer ? (Integer) v : ((Long) v).intValue();
                     }
@@ -344,8 +344,6 @@ final class E2bEnvdProcessClient {
             JsonNode exitCodeNode = endNode.path("exitCode");
             if (exitCodeNode.canConvertToInt()) {
                 endBuilder.setField(exitCodeField, exitCodeNode.intValue());
-            }
-            if (!endBuilder.getAllFields().isEmpty()) {
                 event.setField(processEventDesc.findFieldByName("end"), endBuilder.build());
             }
         }

--- a/agentscope-extensions/agentscope-extensions-sandbox/agentscope-extensions-sandbox-e2b/src/test/java/io/agentscope/extensions/sandbox/e2b/E2bEnvdProcessClientTest.java
+++ b/agentscope-extensions/agentscope-extensions-sandbox/agentscope-extensions-sandbox-e2b/src/test/java/io/agentscope/extensions/sandbox/e2b/E2bEnvdProcessClientTest.java
@@ -147,6 +147,17 @@ class E2bEnvdProcessClientTest {
         assertEquals("", stderr.toString(StandardCharsets.UTF_8));
     }
 
+    @Test
+    void jsonCodecPreservesZeroExitCode() throws Exception {
+        E2bEnvdProcessClient client = new E2bEnvdProcessClient(options(E2bCodec.JSON));
+        ByteArrayOutputStream stdout = new ByteArrayOutputStream();
+        ByteArrayOutputStream stderr = new ByteArrayOutputStream();
+        int exit =
+                drainStartStream(client, connectFrame(responseJson(null, null, 0)), stdout, stderr);
+
+        assertEquals(0, exit);
+    }
+
     private static DynamicMessage dataResponse(
             E2bEnvdProcessClient client, String stdout, String stderr) {
         Descriptors.FileDescriptor fd = client.fileDescriptor();


### PR DESCRIPTION
## AgentScope-Java Version

2.0.1-SNAPSHOT

## Description

Fixes #2603.

In `E2bCodec.JSON` mode, an explicit `{"end":{"exitCode":0}}` frame was lost twice because proto3 does not include default scalar values in `getAllFields()` and reports no scalar presence through `hasField()`. As a result, successful commands kept the missing-exit sentinel and failed.

This change:

- attaches the JSON `end` event when an integer `exitCode` was explicitly parsed, including zero;
- reads the proto3 default scalar from the present end event instead of checking scalar presence;
- adds a focused regression test for a zero exit code.

Related duplicate reports: #2601, #2602.

Tested with:

```text
mvn -pl agentscope-extensions/agentscope-extensions-sandbox/agentscope-extensions-sandbox-e2b -am -Dtest=E2bEnvdProcessClientTest -Dsurefire.failIfNoSpecifiedTests=false test
```

Result: 8 tests passed, including `jsonCodecPreservesZeroExitCode`.

## Checklist

Please check the following items before code is ready to be reviewed.

- [x]  Code has been formatted with `mvn spotless:apply`
- [x]  All targeted tests are passing
- [x]  Javadoc comments are complete and follow project conventions (no public API changes)
- [x]  Related documentation has been updated (not applicable; behavior fix with regression coverage)
- [ ]  Code is ready for review
