### PR TITLE
fix(harness): inherit memory config in subagents

### DIFF
--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/HarnessAgentBuilderSupport.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/HarnessAgentBuilderSupport.java
@@ -36,6 +36,7 @@ import io.agentscope.harness.agent.filesystem.remote.store.BaseStore;
 import io.agentscope.harness.agent.filesystem.remote.store.NamespaceFactory;
 import io.agentscope.harness.agent.filesystem.sandbox.SandboxBackedFilesystem;
 import io.agentscope.harness.agent.filesystem.spec.LocalFilesystemSpec;
+import io.agentscope.harness.agent.memory.MemoryConfig;
 import io.agentscope.harness.agent.memory.compaction.CompactionConfig;
 import io.agentscope.harness.agent.memory.compaction.ToolResultEvictionConfig;
 import io.agentscope.harness.agent.middleware.DynamicSubagentsMiddleware;
@@ -289,6 +290,7 @@ final class HarnessAgentBuilderSupport {
         final ExecutionConfig capturedToolExec = b.toolExecutionConfig;
         final GenerateOptions capturedGenOpts = b.generateOptions;
         final String capturedEnvMemory = b.environmentMemory;
+        final MemoryConfig capturedMemoryConfig = b.memoryConfig;
         final List<Hook> capturedHooks = List.copyOf(b.hooks);
         final List<MiddlewareBase> capturedMiddlewares = List.copyOf(b.middlewares);
         final List<AgentSkillRepository> capturedSkillRepos = List.copyOf(b.skillRepositories);
@@ -332,6 +334,7 @@ final class HarnessAgentBuilderSupport {
                             .asLeafSubagent()
                             .maxIters(capturedMaxIters)
                             .environmentMemory(capturedEnvMemory)
+                            .memory(capturedMemoryConfig)
                             .useLegacyXmlWorkspaceContext(capturedUseLegacyXmlWorkspaceContext)
                             .enableAgentTracingLog(capturedAgentTracingLogEnabled)
                             .maxContextTokens(capturedMaxContextTokens);
@@ -389,6 +392,7 @@ final class HarnessAgentBuilderSupport {
         final List<MiddlewareBase> capturedMiddlewares = List.copyOf(b.middlewares);
         final AbstractFilesystem capturedSharedBackend =
                 sandboxFs != null ? sandboxFs : b.abstractFilesystem;
+        final MemoryConfig capturedMemoryConfig = b.memoryConfig;
         final boolean capturedUseLegacyXmlWorkspaceContext = b.useLegacyXmlWorkspaceContext;
         final boolean capturedDisableFilesystemTools = b.disableFilesystemTools;
         final boolean capturedDisableShellTool = b.disableShellTool;
@@ -450,6 +454,7 @@ final class HarnessAgentBuilderSupport {
                             .defaultSessionId(childSessionId)
                             .maxIters(decl.getSteps())
                             .asLeafSubagent()
+                            .memory(capturedMemoryConfig)
                             .useLegacyXmlWorkspaceContext(capturedUseLegacyXmlWorkspaceContext)
                             .sysPrompt(buildSubagentSysPrompt(sysPromptBase));
 

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/HarnessAgentTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/HarnessAgentTest.java
@@ -25,6 +25,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -52,6 +53,7 @@ import io.agentscope.harness.agent.filesystem.AbstractFilesystem;
 import io.agentscope.harness.agent.filesystem.local.LocalFilesystem;
 import io.agentscope.harness.agent.filesystem.remote.store.InMemoryStore;
 import io.agentscope.harness.agent.filesystem.spec.RemoteFilesystemSpec;
+import io.agentscope.harness.agent.memory.MemoryConfig;
 import io.agentscope.harness.agent.memory.compaction.CompactionConfig;
 import io.agentscope.harness.agent.middleware.AgentTraceMiddleware;
 import io.agentscope.harness.agent.middleware.SubagentEntry;
@@ -1109,6 +1111,45 @@ class HarnessAgentTest {
                 "declared subagent must inherit parent modelExecutionConfig");
     }
 
+    @Test
+    void declaredSubagent_honorsParentMemoryConfig() throws Exception {
+        Files.createDirectories(workspace);
+        Model model = stubModel("done");
+        MemoryConfig memoryConfig =
+                MemoryConfig.builder().flushTrigger(MemoryConfig.FlushTrigger.never()).build();
+        SubagentDeclaration declaration =
+                SubagentDeclaration.builder()
+                        .name("memory-worker")
+                        .description("declared worker")
+                        .workspaceMode(WorkspaceMode.ISOLATED)
+                        .inlineAgentsBody("You are a worker subagent.")
+                        .build();
+
+        List<SubagentEntry> entries =
+                HarnessAgent.builder()
+                        .model(model)
+                        .workspace(workspace)
+                        .memory(memoryConfig)
+                        .subagent(declaration)
+                        .buildSubagentEntries(workspace);
+
+        HarnessAgent child =
+                (HarnessAgent)
+                        entries.stream()
+                                .filter(e -> "memory-worker".equals(e.name()))
+                                .findFirst()
+                                .orElseThrow()
+                                .factory()
+                                .create(RuntimeContext.empty());
+
+        child.call(
+                        userText("Remember this."),
+                        RuntimeContext.builder().userId("user").sessionId("declared").build())
+                .block();
+
+        verify(model, times(1)).stream(anyList(), any(), any());
+    }
+
     // =========================================================================
     // general-purpose mirroring
     // =========================================================================
@@ -1156,6 +1197,37 @@ class HarnessAgentTest {
                                 .factory()
                                 .create(RuntimeContext.empty());
         assertNotNull(child.getCompactionHook(), "CompactionHook should be mirrored to GP child");
+    }
+
+    @Test
+    void generalPurpose_honorsParentMemoryConfig() throws Exception {
+        Files.createDirectories(workspace);
+        Model model = stubModel("done");
+        MemoryConfig memoryConfig =
+                MemoryConfig.builder().flushTrigger(MemoryConfig.FlushTrigger.never()).build();
+
+        List<SubagentEntry> entries =
+                HarnessAgent.builder()
+                        .model(model)
+                        .workspace(workspace)
+                        .memory(memoryConfig)
+                        .buildSubagentEntries(workspace);
+
+        HarnessAgent child =
+                (HarnessAgent)
+                        entries.stream()
+                                .filter(e -> "general-purpose".equals(e.name()))
+                                .findFirst()
+                                .orElseThrow()
+                                .factory()
+                                .create(RuntimeContext.empty());
+
+        child.call(
+                        userText("Remember this."),
+                        RuntimeContext.builder().userId("user").sessionId("gp").build())
+                .block();
+
+        verify(model, times(1)).stream(anyList(), any(), any());
     }
 
     // =========================================================================


### PR DESCRIPTION
## AgentScope-Java Version

2.0.1-SNAPSHOT

## Description

Fixes #2549.

### Background and root cause

Automatically built subagents inherited the parent agent's memory enable/disable flags, but both `buildGeneralPurposeFactory(...)` and `buildDeclaredFactory(...)` omitted the parent's `MemoryConfig`. Their child builders therefore fell back to `MemoryConfig.defaults()`, which could trigger unexpected flush/consolidation model calls and ignore custom memory prompts, retention settings, and model overrides.

### Changes

- Propagate the parent's immutable `MemoryConfig` to general-purpose subagents.
- Apply the same inheritance rule to declared subagents.
- Keep the existing memory tools/hooks disable flag propagation unchanged.
- Add focused regression tests for both factory paths. The tests configure `FlushTrigger.never()` and verify that a child call performs only the normal model invocation, with no unexpected memory flush call.

This PR is intentionally limited to configuration inheritance. Broader asynchronous memory-maintenance latency is outside its scope.

### Validation

- `mvn -pl agentscope-harness -am -Dtest=HarnessAgentTest -Dsurefire.failIfNoSpecifiedTests=false test`
  - 39 tests, 0 failures, 0 errors
- `mvn -pl agentscope-harness -am -Djava.awt.headless=true test`
  - `agentscope-core`: 2264 tests, 0 failures, 0 errors
  - `agentscope-harness`: 786 tests, 0 failures, 0 errors
- `git diff --check`

## Checklist

- [x] Code has been formatted with `mvn spotless:apply`
- [x] All tests are passing
- [x] Javadoc comments are complete and follow project conventions (no public API added)
- [x] Related documentation has been updated (not applicable; no documentation contract changed)
- [x] Code is ready for review
