### PR TITLE
feat(harness): forward the full remote subagent event stream

### DIFF
--- a/agentscope-core/src/main/java/io/agentscope/core/event/AllToolsDeniedEvent.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/event/AllToolsDeniedEvent.java
@@ -15,6 +15,8 @@
  */
 package io.agentscope.core.event;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import io.agentscope.core.message.ToolUseBlock;
 import java.util.List;
 
@@ -32,6 +34,15 @@ import java.util.List;
 public class AllToolsDeniedEvent extends AgentEvent {
 
     private final List<ToolUseBlock> deniedToolCalls;
+
+    @JsonCreator
+    public AllToolsDeniedEvent(
+            @JsonProperty("id") String id,
+            @JsonProperty("createdAt") String createdAt,
+            @JsonProperty("deniedToolCalls") List<ToolUseBlock> deniedToolCalls) {
+        super(id, createdAt);
+        this.deniedToolCalls = deniedToolCalls != null ? List.copyOf(deniedToolCalls) : List.of();
+    }
 
     public AllToolsDeniedEvent(List<ToolUseBlock> deniedToolCalls) {
         this.deniedToolCalls = deniedToolCalls != null ? List.copyOf(deniedToolCalls) : List.of();

--- a/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agent-protocol/src/main/java/io/agentscope/extensions/agentprotocol/AgentProtocolTaskStore.java
+++ b/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agent-protocol/src/main/java/io/agentscope/extensions/agentprotocol/AgentProtocolTaskStore.java
@@ -262,10 +262,7 @@ public final class AgentProtocolTaskStore {
                                     return;
                                 }
                                 RemoteEventCodec.fromAgentEvent(event)
-                                        .filter(
-                                                dto ->
-                                                        RemoteEventCodec.matchesDetail(
-                                                                dto.getType(), detail))
+                                        .filter(dto -> RemoteEventCodec.matchesDetail(dto, detail))
                                         .ifPresent(
                                                 dto -> {
                                                     dto.setAgentId(agentId);

--- a/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agent-protocol/src/test/java/io/agentscope/extensions/agentprotocol/AgentProtocolStreamDetailTest.java
+++ b/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agent-protocol/src/test/java/io/agentscope/extensions/agentprotocol/AgentProtocolStreamDetailTest.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.extensions.agentprotocol;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.agentscope.core.agent.RuntimeContext;
+import io.agentscope.core.event.AgentEndEvent;
+import io.agentscope.core.event.AgentEvent;
+import io.agentscope.core.event.AgentResultEvent;
+import io.agentscope.core.event.AgentStartEvent;
+import io.agentscope.core.event.ModelCallEndEvent;
+import io.agentscope.core.event.TextBlockDeltaEvent;
+import io.agentscope.core.event.TextBlockEndEvent;
+import io.agentscope.core.event.TextBlockStartEvent;
+import io.agentscope.core.event.ToolResultTextDeltaEvent;
+import io.agentscope.core.message.Msg;
+import io.agentscope.core.message.MsgRole;
+import io.agentscope.core.model.ChatUsage;
+import io.agentscope.harness.agent.HarnessAgent;
+import io.agentscope.harness.agent.subagent.protocol.RemoteAgentEvent;
+import io.agentscope.harness.agent.subagent.protocol.RemoteEventCodec;
+import io.agentscope.harness.agent.subagent.protocol.RemoteEventType;
+import io.agentscope.harness.agent.workspace.WorkspaceManager;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import reactor.core.publisher.Flux;
+
+/**
+ * What a subscriber receives per {@code context.detail} level, end to end through the task store's
+ * event bus.
+ */
+class AgentProtocolStreamDetailTest {
+
+    @TempDir Path tempDir;
+
+    private WorkspaceManager workspaceManager;
+    private HarnessAgent agent;
+
+    @BeforeEach
+    void setUp() {
+        workspaceManager = new WorkspaceManager(tempDir);
+        agent = mock(HarnessAgent.class);
+        when(agent.streamEvents(any(Msg.class), any(RuntimeContext.class)))
+                .thenReturn(Flux.fromIterable(agentRun()));
+    }
+
+    /** A run touching a wire-typed event, a delta, and several passthrough-only events. */
+    private static List<AgentEvent> agentRun() {
+        return List.of(
+                new AgentStartEvent("sess", "reply", "worker"),
+                new TextBlockStartEvent("reply", "b1"),
+                new TextBlockDeltaEvent("reply", "b1", "hello"),
+                new TextBlockEndEvent("reply", "b1"),
+                new ToolResultTextDeltaEvent("reply", "call-1", "read_file", "file contents"),
+                new ModelCallEndEvent("reply", new ChatUsage(10, 20, 0, 0.5)),
+                new AgentResultEvent(
+                        Msg.builder().role(MsgRole.ASSISTANT).textContent("done").build()),
+                new AgentEndEvent("reply"));
+    }
+
+    @Test
+    void statusLevelCarriesLifecycleOnly() {
+        Set<RemoteEventType> types = typesFor("status", "t-status");
+
+        assertTrue(types.contains(RemoteEventType.RUN_STARTED));
+        assertTrue(types.contains(RemoteEventType.RUN_FINISHED));
+        assertFalse(types.contains(RemoteEventType.TEXT_DELTA));
+        assertFalse(types.contains(RemoteEventType.AGENT_EVENT));
+    }
+
+    @Test
+    void fullLevelAddsDeltasButNotPassthrough() {
+        Set<RemoteEventType> types = typesFor("full", "t-full");
+
+        assertTrue(types.contains(RemoteEventType.TEXT_DELTA));
+        assertFalse(
+                types.contains(RemoteEventType.AGENT_EVENT),
+                "full keeps the pre-existing volume for deployments that never asked for more");
+    }
+
+    @Test
+    void verboseLevelForwardsEveryEvent() {
+        List<RemoteAgentEvent> events = collect("verbose", "t-verbose");
+
+        Set<String> eventTypes =
+                events.stream()
+                        .map(RemoteAgentEvent::getEventType)
+                        .filter(Objects::nonNull) // the server's own STATUS event has no source
+                        // type
+                        .collect(Collectors.toUnmodifiableSet());
+        assertTrue(eventTypes.contains("TEXT_BLOCK_START"), eventTypes.toString());
+        assertTrue(eventTypes.contains("TEXT_BLOCK_END"), eventTypes.toString());
+        assertTrue(eventTypes.contains("TOOL_RESULT_TEXT_DELTA"), eventTypes.toString());
+        assertTrue(eventTypes.contains("MODEL_CALL_END"), eventTypes.toString());
+        assertTrue(eventTypes.contains("AGENT_RESULT"), eventTypes.toString());
+
+        AgentEvent toolOutput =
+                events.stream()
+                        .filter(e -> "TOOL_RESULT_TEXT_DELTA".equals(e.getEventType()))
+                        .findFirst()
+                        .flatMap(RemoteEventCodec::toAgentEvent)
+                        .orElseThrow();
+        assertEquals("file contents", ((ToolResultTextDeltaEvent) toolOutput).getDelta());
+    }
+
+    private Set<RemoteEventType> typesFor(String detail, String taskId) {
+        return collect(detail, taskId).stream()
+                .map(RemoteAgentEvent::getType)
+                .collect(Collectors.toUnmodifiableSet());
+    }
+
+    private List<RemoteAgentEvent> collect(String detail, String taskId) {
+        AgentProtocolTaskEventBus bus = new AgentProtocolTaskEventBus();
+        AgentProtocolTaskStore store =
+                new AgentProtocolTaskStore(
+                        AgentFactory.fixed(agent),
+                        workspaceManager,
+                        bus,
+                        new AgentProtocolProperties());
+
+        Flux<RemoteAgentEvent> subscription = bus.subscribe(taskId, 0L);
+        store.submit(taskId, "worker", "go", Map.of("detail", detail));
+        return subscription.take(Duration.ofSeconds(5)).collectList().block();
+    }
+}

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/subagent/SubagentDeclaration.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/subagent/SubagentDeclaration.java
@@ -15,6 +15,7 @@
  */
 package io.agentscope.harness.agent.subagent;
 
+import io.agentscope.harness.agent.subagent.protocol.RemoteStreamDetail;
 import java.nio.file.Path;
 import java.util.Collections;
 import java.util.LinkedHashMap;
@@ -109,6 +110,12 @@ public final class SubagentDeclaration {
      */
     private final Boolean remoteStreaming;
 
+    /**
+     * How much of the remote event stream to request. {@code null} defaults to
+     * {@link RemoteStreamDetail#FULL}; see {@link #getRemoteStreamDetail()}.
+     */
+    private final RemoteStreamDetail remoteStreamDetail;
+
     /** Policy for resolving remote HITL confirmations. Defaults to {@link RemoteAskPolicy#DENY}. */
     private final RemoteAskPolicy remoteAskPolicy;
 
@@ -139,6 +146,7 @@ public final class SubagentDeclaration {
         this.url = b.url;
         this.headers = b.headers != null && !b.headers.isEmpty() ? Map.copyOf(b.headers) : null;
         this.remoteStreaming = b.remoteStreaming;
+        this.remoteStreamDetail = b.remoteStreamDetail;
         this.remoteAskPolicy = b.remoteAskPolicy != null ? b.remoteAskPolicy : RemoteAskPolicy.DENY;
         this.remoteContextAttributes =
                 b.remoteContextAttributes != null && !b.remoteContextAttributes.isEmpty()
@@ -334,6 +342,17 @@ public final class SubagentDeclaration {
     }
 
     /**
+     * How much of the remote event stream to forward. Defaults to {@link RemoteStreamDetail#FULL}
+     * (lifecycle, tool calls, text and thinking deltas). Use {@link RemoteStreamDetail#VERBOSE} to
+     * mirror a local subagent's stream in full — block boundaries, tool output deltas, model calls
+     * with token usage and every other event — at the cost of more traffic. Only relevant when
+     * {@link #isRemoteStreaming()} is true.
+     */
+    public RemoteStreamDetail getRemoteStreamDetail() {
+        return remoteStreamDetail != null ? remoteStreamDetail : RemoteStreamDetail.FULL;
+    }
+
+    /**
      * Policy for resolving remote HITL (tool-confirmation) requests. Defaults to
      * {@link RemoteAskPolicy#DENY}, which auto-denies pending confirmations rather than leaving
      * the remote task blocked indefinitely.
@@ -382,6 +401,7 @@ public final class SubagentDeclaration {
         private String url;
         private Map<String, String> headers;
         private Boolean remoteStreaming;
+        private RemoteStreamDetail remoteStreamDetail;
         private RemoteAskPolicy remoteAskPolicy = RemoteAskPolicy.DENY;
         private Map<String, Object> remoteContextAttributes;
 
@@ -580,6 +600,17 @@ public final class SubagentDeclaration {
          */
         public Builder remoteStreaming(Boolean remoteStreaming) {
             this.remoteStreaming = remoteStreaming;
+            return this;
+        }
+
+        /**
+         * How much of the remote event stream to forward. {@code null} (default) is treated as
+         * {@link RemoteStreamDetail#FULL}; {@link RemoteStreamDetail#VERBOSE} forwards every event
+         * the remote agent emits, matching a local subagent. Only relevant when
+         * {@link #remoteStreaming(Boolean)} is enabled.
+         */
+        public Builder remoteStreamDetail(RemoteStreamDetail remoteStreamDetail) {
+            this.remoteStreamDetail = remoteStreamDetail;
             return this;
         }
 

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/subagent/protocol/RemoteAgentEvent.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/subagent/protocol/RemoteAgentEvent.java
@@ -23,6 +23,10 @@ import java.util.List;
  * Stable Protocol DTO for remote subagent event streaming.
  *
  * <p>Fields are optional per event type; unknown fields are ignored for forward compatibility.
+ *
+ * <p>Besides the flat per-type fields, an event may carry {@link #getPayload()} — the source {@link
+ * io.agentscope.core.event.AgentEvent} serialized in full. Clients that understand it restore the
+ * original event (ids, timestamps, metadata and all); older ones keep reading the flat fields.
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -40,6 +44,8 @@ public class RemoteAgentEvent {
     private List<RemotePendingConfirm> pendingConfirms;
     private String status;
     private String error;
+    private String eventType;
+    private String payload;
 
     public RemoteAgentEvent() {}
 
@@ -137,5 +143,31 @@ public class RemoteAgentEvent {
 
     public void setError(String error) {
         this.error = error;
+    }
+
+    /**
+     * Name of the source {@link io.agentscope.core.event.AgentEventType}, e.g.
+     * {@code MODEL_CALL_END}. Lets a client filter or log events without deserializing {@link
+     * #getPayload()}.
+     */
+    public String getEventType() {
+        return eventType;
+    }
+
+    public void setEventType(String eventType) {
+        this.eventType = eventType;
+    }
+
+    /**
+     * The source {@link io.agentscope.core.event.AgentEvent} as JSON, or {@code null} for events
+     * the server synthesizes itself ({@code STATUS}, {@code RUN_ERROR}) and for events whose
+     * serialization failed.
+     */
+    public String getPayload() {
+        return payload;
+    }
+
+    public void setPayload(String payload) {
+        this.payload = payload;
     }
 }

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/subagent/protocol/RemoteEventCodec.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/subagent/protocol/RemoteEventCodec.java
@@ -16,6 +16,7 @@
 package io.agentscope.harness.agent.subagent.protocol;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.agentscope.core.event.AgentEndEvent;
 import io.agentscope.core.event.AgentEvent;
@@ -35,6 +36,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Bidirectional mapping between internal {@link AgentEvent}s and stable {@link RemoteAgentEvent}
@@ -42,13 +45,25 @@ import java.util.Optional;
  */
 public final class RemoteEventCodec {
 
-    private static final ObjectMapper JSON = new ObjectMapper();
+    private static final Logger log = LoggerFactory.getLogger(RemoteEventCodec.class);
+
+    /**
+     * Unknown properties are ignored so that a payload survives derived getters that no constructor
+     * accepts (for example {@code ChatUsage.getTotalTokens()}) and fields added by a newer peer.
+     */
+    private static final ObjectMapper JSON =
+            new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
 
     private RemoteEventCodec() {}
 
     /**
      * Maps an internal agent event to a protocol DTO (without seq/taskId — those are assigned by
      * the server event bus).
+     *
+     * <p>Every event also carries its full serialization in {@link RemoteAgentEvent#getPayload()},
+     * so a client can restore the original instance instead of the lossy flat fields. Event types
+     * without a dedicated wire type are forwarded as {@link RemoteEventType#AGENT_EVENT} and are
+     * only visible at {@code detail=verbose}.
      */
     public static Optional<RemoteAgentEvent> fromAgentEvent(AgentEvent event) {
         if (event == null) {
@@ -56,36 +71,49 @@ public final class RemoteEventCodec {
         }
         RemoteAgentEvent dto = new RemoteAgentEvent();
         dto.setTimestamp(event.getCreatedAt());
+        if (event.getType() != null) {
+            dto.setEventType(event.getType().name());
+        }
+        dto.setPayload(serializeEvent(event));
+        return Optional.of(withTypedFields(dto, event));
+    }
+
+    /**
+     * Fills the flat, type-specific fields kept for clients that do not read {@code payload}, and
+     * assigns the wire type. Falls back to {@link RemoteEventType#AGENT_EVENT} for events that
+     * never had a dedicated wire type.
+     */
+    private static RemoteAgentEvent withTypedFields(RemoteAgentEvent dto, AgentEvent event) {
         if (event instanceof AgentStartEvent start) {
             dto.setType(RemoteEventType.RUN_STARTED);
             dto.setAgentId(start.getName());
-            return Optional.of(dto);
+            return dto;
         }
         if (event instanceof AgentEndEvent) {
             dto.setType(RemoteEventType.RUN_FINISHED);
-            return Optional.of(dto);
+            return dto;
         }
         if (event instanceof TextBlockDeltaEvent text) {
             dto.setType(RemoteEventType.TEXT_DELTA);
             dto.setText(text.getDelta());
-            return Optional.of(dto);
+            return dto;
         }
         if (event instanceof ThinkingBlockDeltaEvent thinking) {
             dto.setType(RemoteEventType.THINKING_DELTA);
             dto.setText(thinking.getDelta());
-            return Optional.of(dto);
+            return dto;
         }
         if (event instanceof ToolCallStartEvent toolStart) {
             dto.setType(RemoteEventType.TOOL_CALL_START);
             dto.setToolCallId(toolStart.getToolCallId());
             dto.setToolName(toolStart.getToolCallName());
-            return Optional.of(dto);
+            return dto;
         }
         if (event instanceof ToolCallEndEvent toolEnd) {
             dto.setType(RemoteEventType.TOOL_CALL_END);
             dto.setToolCallId(toolEnd.getToolCallId());
             dto.setToolName(toolEnd.getToolCallName());
-            return Optional.of(dto);
+            return dto;
         }
         if (event instanceof ToolResultEndEvent toolResult) {
             dto.setType(RemoteEventType.TOOL_RESULT);
@@ -95,7 +123,7 @@ public final class RemoteEventCodec {
             if (state != null) {
                 dto.setStatus(state.name());
             }
-            return Optional.of(dto);
+            return dto;
         }
         if (event instanceof RequireUserConfirmEvent confirm) {
             dto.setType(RemoteEventType.REQUIRE_CONFIRM);
@@ -106,18 +134,31 @@ public final class RemoteEventCodec {
                                 block.getId(), block.getName(), toJson(block.getInput())));
             }
             dto.setPendingConfirms(pending);
-            return Optional.of(dto);
+            return dto;
         }
-        return Optional.empty();
+        dto.setType(RemoteEventType.AGENT_EVENT);
+        return dto;
     }
 
     /**
      * Maps a protocol DTO back to an internal {@link AgentEvent}. Unknown or incomplete types are
      * dropped. When the DTO carries a {@code taskId}, it is copied onto {@link
      * AgentEvent#METADATA_TASK_ID}.
+     *
+     * <p>A {@code payload} is preferred over the flat fields: it restores the original event with
+     * its ids, timestamps and metadata intact, and is the only way to recover events sent as
+     * {@link RemoteEventType#AGENT_EVENT}. Servers too old to send one still decode through the
+     * per-type mapping below.
      */
     public static Optional<AgentEvent> toAgentEvent(RemoteAgentEvent remote) {
-        if (remote == null || remote.getType() == null) {
+        if (remote == null) {
+            return Optional.empty();
+        }
+        Optional<AgentEvent> fromPayload = deserializeEvent(remote.getPayload());
+        if (fromPayload.isPresent()) {
+            return fromPayload.map(event -> stampTaskId(event, remote));
+        }
+        if (remote.getType() == null) {
             return Optional.empty();
         }
         Optional<AgentEvent> mapped =
@@ -161,31 +202,39 @@ public final class RemoteEventCodec {
                                             parseToolResultState(remote.getStatus())));
                     case REQUIRE_CONFIRM -> Optional.of(toRequireConfirm(remote));
                     case STATUS -> Optional.empty();
+                    case AGENT_EVENT -> Optional.empty();
                 };
-        return mapped.map(
-                event -> {
-                    if (remote.getTaskId() != null && !remote.getTaskId().isBlank()) {
-                        event.withMetadataEntry(AgentEvent.METADATA_TASK_ID, remote.getTaskId());
-                    }
-                    return event;
-                });
+        return mapped.map(event -> stampTaskId(event, remote));
+    }
+
+    private static AgentEvent stampTaskId(AgentEvent event, RemoteAgentEvent remote) {
+        if (remote.getTaskId() != null && !remote.getTaskId().isBlank()) {
+            event.withMetadataEntry(AgentEvent.METADATA_TASK_ID, remote.getTaskId());
+        }
+        return event;
     }
 
     /**
      * Whether this event type should be emitted for the given detail level.
      *
      * @param type event type
-     * @param detail {@code "full"} includes text/thinking deltas; anything else is status-level
+     * @param detail see {@link RemoteStreamDetail}
      */
     public static boolean matchesDetail(RemoteEventType type, String detail) {
         if (type == null) {
             return false;
         }
-        boolean full = detail != null && "full".equalsIgnoreCase(detail);
+        RemoteStreamDetail level = RemoteStreamDetail.parse(detail);
         return switch (type) {
-            case TEXT_DELTA, THINKING_DELTA -> full;
+            case TEXT_DELTA, THINKING_DELTA -> level.includes(RemoteStreamDetail.FULL);
+            case AGENT_EVENT -> level.includes(RemoteStreamDetail.VERBOSE);
             default -> true;
         };
+    }
+
+    /** Detail check for a whole DTO; equivalent to {@link #matchesDetail(RemoteEventType, String)}. */
+    public static boolean matchesDetail(RemoteAgentEvent event, String detail) {
+        return event != null && matchesDetail(event.getType(), detail);
     }
 
     private static RequireUserConfirmEvent toRequireConfirm(RemoteAgentEvent remote) {
@@ -240,6 +289,35 @@ public final class RemoteEventCodec {
             return Map.of("raw", parsed);
         } catch (JsonProcessingException e) {
             return Map.of("raw", json);
+        }
+    }
+
+    /**
+     * Serializes an event for {@link RemoteAgentEvent#getPayload()}. Returns {@code null} when the
+     * event cannot be represented as JSON, in which case the receiver falls back to the flat wire
+     * fields rather than the run failing.
+     */
+    private static String serializeEvent(AgentEvent event) {
+        try {
+            return JSON.writeValueAsString(event);
+        } catch (Exception e) {
+            log.debug(
+                    "Skipping payload for event {}: {}",
+                    event.getClass().getSimpleName(),
+                    e.toString());
+            return null;
+        }
+    }
+
+    private static Optional<AgentEvent> deserializeEvent(String payload) {
+        if (payload == null || payload.isBlank()) {
+            return Optional.empty();
+        }
+        try {
+            return Optional.ofNullable(JSON.readValue(payload, AgentEvent.class));
+        } catch (Exception e) {
+            log.debug("Skipping unreadable event payload: {}", e.toString());
+            return Optional.empty();
         }
     }
 

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/subagent/protocol/RemoteEventType.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/subagent/protocol/RemoteEventType.java
@@ -31,5 +31,12 @@ public enum RemoteEventType {
     TOOL_CALL_END,
     TOOL_RESULT,
     REQUIRE_CONFIRM,
-    STATUS
+    STATUS,
+
+    /**
+     * Carries an {@link io.agentscope.core.event.AgentEvent} that has no dedicated wire type, fully
+     * serialized in {@link RemoteAgentEvent#getPayload()}. Emitted only at {@code detail=verbose};
+     * clients that predate this type skip it.
+     */
+    AGENT_EVENT
 }

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/subagent/protocol/RemoteStreamDetail.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/subagent/protocol/RemoteStreamDetail.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.harness.agent.subagent.protocol;
+
+import java.util.Locale;
+
+/**
+ * How much of a remote subagent's event stream the caller wants, sent as {@code context.detail}.
+ *
+ * <p>Each level is a superset of the previous one. The wire value is the lower-case enum name.
+ */
+public enum RemoteStreamDetail {
+
+    /** Lifecycle, tool call boundaries, tool results and confirmation requests. */
+    STATUS,
+
+    /** {@link #STATUS} plus text and thinking deltas. The default for a streaming parent. */
+    FULL,
+
+    /**
+     * {@link #FULL} plus every remaining {@link io.agentscope.core.event.AgentEvent} — block
+     * boundaries, tool argument and tool output deltas, model calls with token usage, hints,
+     * custom events — forwarded as {@link RemoteEventType#AGENT_EVENT}.
+     *
+     * <p>This is the only level that reproduces a local subagent's stream in full, at the cost of
+     * noticeably more traffic on high-frequency runs.
+     */
+    VERBOSE;
+
+    /** Lower-case wire value, e.g. {@code "verbose"}. */
+    public String wireValue() {
+        return name().toLowerCase(Locale.ROOT);
+    }
+
+    /** Whether this level includes events requiring at least {@code required}. */
+    public boolean includes(RemoteStreamDetail required) {
+        return required != null && ordinal() >= required.ordinal();
+    }
+
+    /** Parses a wire value, falling back to {@link #STATUS} for null or unknown input. */
+    public static RemoteStreamDetail parse(String value) {
+        if (value == null || value.isBlank()) {
+            return STATUS;
+        }
+        for (RemoteStreamDetail level : values()) {
+            if (level.name().equalsIgnoreCase(value.trim())) {
+                return level;
+            }
+        }
+        return STATUS;
+    }
+}

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/subagent/task/AgentProtocolTaskClient.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/subagent/task/AgentProtocolTaskClient.java
@@ -15,6 +15,7 @@
  */
 package io.agentscope.harness.agent.subagent.task;
 
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
@@ -52,7 +53,15 @@ import org.slf4j.LoggerFactory;
 public final class AgentProtocolTaskClient {
 
     private static final Logger log = LoggerFactory.getLogger(AgentProtocolTaskClient.class);
-    private static final ObjectMapper JSON = new ObjectMapper();
+
+    /**
+     * Unknown {@code type} values deserialize to {@code null} instead of throwing, so a newer
+     * server introducing a wire event type degrades to "this client ignores it" rather than
+     * dropping the event as unparseable — and an event carrying a {@code payload} still decodes.
+     */
+    private static final ObjectMapper JSON =
+            new ObjectMapper()
+                    .configure(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_AS_NULL, true);
 
     private final HttpClient http;
 

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/tool/AgentSpawnTool.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/tool/AgentSpawnTool.java
@@ -44,6 +44,7 @@ import io.agentscope.harness.agent.subagent.SubagentDeclaration;
 import io.agentscope.harness.agent.subagent.protocol.RemoteConfirmDecision;
 import io.agentscope.harness.agent.subagent.protocol.RemoteEventCodec;
 import io.agentscope.harness.agent.subagent.protocol.RemotePendingConfirm;
+import io.agentscope.harness.agent.subagent.protocol.RemoteStreamDetail;
 import io.agentscope.harness.agent.subagent.task.AgentProtocolTransport;
 import io.agentscope.harness.agent.subagent.task.BackgroundTask;
 import io.agentscope.harness.agent.subagent.task.RemoteSubagentTransport;
@@ -1215,9 +1216,13 @@ public class AgentSpawnTool {
         String userId = runtimeContext != null ? runtimeContext.getUserId() : null;
         String parentSessionId = runtimeContext != null ? runtimeContext.getSessionId() : null;
         boolean stream = decl != null && decl.isRemoteStreaming();
+        String detail =
+                stream
+                        ? decl.getRemoteStreamDetail().wireValue()
+                        : RemoteStreamDetail.STATUS.wireValue();
         return RemoteSubmitContext.builder().userId(userId).parentSessionId(parentSessionId).stream(
                         stream)
-                .detail(stream ? "full" : "status")
+                .detail(detail)
                 .denyRules(collectParentDenyRules(parentState, Optional.ofNullable(decl)))
                 .attributes(collectRemoteContextAttributes(runtimeContext, decl))
                 .build();

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/subagent/protocol/RemoteEventCodecPassthroughTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/subagent/protocol/RemoteEventCodecPassthroughTest.java
@@ -1,0 +1,285 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.harness.agent.subagent.protocol;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.agentscope.core.event.AgentEndEvent;
+import io.agentscope.core.event.AgentEvent;
+import io.agentscope.core.event.AgentEventType;
+import io.agentscope.core.event.AgentResultEvent;
+import io.agentscope.core.event.AgentStartEvent;
+import io.agentscope.core.event.AllToolsDeniedEvent;
+import io.agentscope.core.event.ConfirmResult;
+import io.agentscope.core.event.CustomEvent;
+import io.agentscope.core.event.DataBlockDeltaEvent;
+import io.agentscope.core.event.DataBlockEndEvent;
+import io.agentscope.core.event.DataBlockStartEvent;
+import io.agentscope.core.event.ExceedMaxItersEvent;
+import io.agentscope.core.event.ExternalExecutionResultEvent;
+import io.agentscope.core.event.HintBlockEvent;
+import io.agentscope.core.event.ModelCallEndEvent;
+import io.agentscope.core.event.ModelCallStartEvent;
+import io.agentscope.core.event.RequestStopEvent;
+import io.agentscope.core.event.RequireExternalExecutionEvent;
+import io.agentscope.core.event.RequireUserConfirmEvent;
+import io.agentscope.core.event.SubagentExposedEvent;
+import io.agentscope.core.event.TextBlockDeltaEvent;
+import io.agentscope.core.event.TextBlockEndEvent;
+import io.agentscope.core.event.TextBlockStartEvent;
+import io.agentscope.core.event.ThinkingBlockDeltaEvent;
+import io.agentscope.core.event.ThinkingBlockEndEvent;
+import io.agentscope.core.event.ThinkingBlockStartEvent;
+import io.agentscope.core.event.ToolCallDeltaEvent;
+import io.agentscope.core.event.ToolCallEndEvent;
+import io.agentscope.core.event.ToolCallStartEvent;
+import io.agentscope.core.event.ToolResultDataDeltaEvent;
+import io.agentscope.core.event.ToolResultEndEvent;
+import io.agentscope.core.event.ToolResultStartEvent;
+import io.agentscope.core.event.ToolResultTextDeltaEvent;
+import io.agentscope.core.event.UserConfirmResultEvent;
+import io.agentscope.core.message.GenerateReason;
+import io.agentscope.core.message.Msg;
+import io.agentscope.core.message.MsgRole;
+import io.agentscope.core.message.TextBlock;
+import io.agentscope.core.message.ToolResultBlock;
+import io.agentscope.core.message.ToolResultState;
+import io.agentscope.core.message.ToolUseBlock;
+import io.agentscope.core.model.ChatUsage;
+import java.util.ArrayList;
+import java.util.EnumSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Full-fidelity forwarding of remote subagent events: every {@link AgentEvent} survives the wire,
+ * either through its dedicated wire type or as an {@link RemoteEventType#AGENT_EVENT} passthrough.
+ */
+class RemoteEventCodecPassthroughTest {
+
+    /** One instance of every {@link AgentEvent} subclass registered on the base class. */
+    private static Map<AgentEventType, AgentEvent> sampleEvents() {
+        ToolUseBlock toolUse =
+                ToolUseBlock.builder()
+                        .id("call-1")
+                        .name("read_file")
+                        .input(Map.of("p", "a"))
+                        .build();
+        ToolResultBlock toolResult =
+                ToolResultBlock.builder()
+                        .id("call-1")
+                        .name("read_file")
+                        .output(TextBlock.builder().text("contents").build())
+                        .build();
+
+        Map<AgentEventType, AgentEvent> events = new LinkedHashMap<>();
+        events.put(AgentEventType.AGENT_START, new AgentStartEvent("sess", "reply", "researcher"));
+        events.put(AgentEventType.AGENT_END, new AgentEndEvent("reply"));
+        events.put(
+                AgentEventType.AGENT_RESULT,
+                new AgentResultEvent(
+                        Msg.builder().role(MsgRole.ASSISTANT).textContent("done").build()));
+        events.put(AgentEventType.MODEL_CALL_START, new ModelCallStartEvent("reply"));
+        events.put(
+                AgentEventType.MODEL_CALL_END,
+                new ModelCallEndEvent("reply", new ChatUsage(120, 45, 12, 1.5)));
+        events.put(AgentEventType.TEXT_BLOCK_START, new TextBlockStartEvent("reply", "b1"));
+        events.put(AgentEventType.TEXT_BLOCK_DELTA, new TextBlockDeltaEvent("reply", "b1", "hi"));
+        events.put(AgentEventType.TEXT_BLOCK_END, new TextBlockEndEvent("reply", "b1"));
+        events.put(AgentEventType.THINKING_BLOCK_START, new ThinkingBlockStartEvent("reply", "b2"));
+        events.put(
+                AgentEventType.THINKING_BLOCK_DELTA,
+                new ThinkingBlockDeltaEvent("reply", "b2", "hmm"));
+        events.put(AgentEventType.THINKING_BLOCK_END, new ThinkingBlockEndEvent("reply", "b2"));
+        events.put(AgentEventType.DATA_BLOCK_START, new DataBlockStartEvent("reply", "b3"));
+        events.put(AgentEventType.DATA_BLOCK_DELTA, new DataBlockDeltaEvent("reply", "b3", "{}"));
+        events.put(AgentEventType.DATA_BLOCK_END, new DataBlockEndEvent("reply", "b3"));
+        events.put(
+                AgentEventType.TOOL_CALL_START,
+                new ToolCallStartEvent("reply", "call-1", "read_file"));
+        events.put(
+                AgentEventType.TOOL_CALL_DELTA,
+                new ToolCallDeltaEvent("reply", "call-1", "read_file", "{\"p\":"));
+        events.put(
+                AgentEventType.TOOL_CALL_END, new ToolCallEndEvent("reply", "call-1", "read_file"));
+        events.put(
+                AgentEventType.TOOL_RESULT_START,
+                new ToolResultStartEvent("reply", "call-1", "read_file"));
+        events.put(
+                AgentEventType.TOOL_RESULT_TEXT_DELTA,
+                new ToolResultTextDeltaEvent("reply", "call-1", "read_file", "line one"));
+        events.put(
+                AgentEventType.TOOL_RESULT_DATA_DELTA,
+                new ToolResultDataDeltaEvent(
+                        "reply", "call-1", "read_file", TextBlock.builder().text("d").build()));
+        events.put(
+                AgentEventType.TOOL_RESULT_END,
+                new ToolResultEndEvent("reply", "call-1", "read_file", ToolResultState.SUCCESS));
+        events.put(AgentEventType.EXCEED_MAX_ITERS, new ExceedMaxItersEvent("reply", 10, 10));
+        events.put(
+                AgentEventType.REQUIRE_USER_CONFIRM,
+                new RequireUserConfirmEvent("reply", List.of(toolUse)));
+        events.put(
+                AgentEventType.REQUIRE_EXTERNAL_EXECUTION,
+                new RequireExternalExecutionEvent("reply", List.of(toolUse)));
+        events.put(
+                AgentEventType.USER_CONFIRM_RESULT,
+                new UserConfirmResultEvent("reply", List.of(new ConfirmResult(true, toolUse))));
+        events.put(
+                AgentEventType.EXTERNAL_EXECUTION_RESULT,
+                new ExternalExecutionResultEvent("reply", List.of(toolResult)));
+        events.put(
+                AgentEventType.REQUEST_STOP,
+                new RequestStopEvent("stop", GenerateReason.ALL_TOOLS_DENIED));
+        events.put(
+                AgentEventType.SUBAGENT_EXPOSED,
+                new SubagentExposedEvent("sub-1", "worker", "sess", "Worker"));
+        events.put(
+                AgentEventType.HINT_BLOCK,
+                new HintBlockEvent("reply", "b4", "tool_output", "note"));
+        events.put(AgentEventType.ALL_TOOLS_DENIED, new AllToolsDeniedEvent(List.of(toolUse)));
+        events.put(AgentEventType.CUSTOM, new CustomEvent("my_event", Map.of("k", "v")));
+        return events;
+    }
+
+    @Test
+    void everyEventTypeSurvivesTheRoundTrip() {
+        List<String> lost = new ArrayList<>();
+        sampleEvents()
+                .forEach(
+                        (type, event) -> {
+                            Optional<RemoteAgentEvent> dto = RemoteEventCodec.fromAgentEvent(event);
+                            if (dto.isEmpty()) {
+                                lost.add(type + " (not encoded)");
+                                return;
+                            }
+                            Optional<AgentEvent> back = RemoteEventCodec.toAgentEvent(dto.get());
+                            if (back.isEmpty()) {
+                                lost.add(type + " (not decoded)");
+                                return;
+                            }
+                            if (back.get().getType() != type) {
+                                lost.add(type + " (decoded as " + back.get().getType() + ")");
+                            }
+                        });
+        assertTrue(lost.isEmpty(), "events lost on the wire: " + lost);
+    }
+
+    @Test
+    void everyEventTypeIsCoveredBySamples() {
+        Set<AgentEventType> missing = EnumSet.allOf(AgentEventType.class);
+        missing.removeAll(sampleEvents().keySet());
+        assertTrue(missing.isEmpty(), "no sample for: " + missing);
+    }
+
+    @Test
+    void passthroughPreservesIdentityAndPayloadFields() {
+        ModelCallEndEvent original =
+                new ModelCallEndEvent("reply", new ChatUsage(120, 45, 12, 1.5));
+        original.withSource("parent/worker");
+        original.withMetadataEntry("keep", "me");
+
+        RemoteAgentEvent dto = RemoteEventCodec.fromAgentEvent(original).orElseThrow();
+        assertEquals(RemoteEventType.AGENT_EVENT, dto.getType());
+        assertEquals("MODEL_CALL_END", dto.getEventType());
+        assertNotNull(dto.getPayload());
+
+        ModelCallEndEvent back =
+                assertInstanceOf(
+                        ModelCallEndEvent.class, RemoteEventCodec.toAgentEvent(dto).orElseThrow());
+        assertEquals(original.getId(), back.getId());
+        assertEquals(original.getCreatedAt(), back.getCreatedAt());
+        assertEquals("reply", back.getReplyId());
+        assertEquals(120, back.getUsage().getInputTokens());
+        assertEquals(12, back.getUsage().getCachedTokens());
+        assertEquals("me", back.getMetadata().get("keep"));
+    }
+
+    @Test
+    void typedEventsAlsoDecodeFromPayloadWithoutLosingBlockIds() {
+        TextBlockDeltaEvent original = new TextBlockDeltaEvent("reply-7", "block-9", "hello");
+
+        RemoteAgentEvent dto = RemoteEventCodec.fromAgentEvent(original).orElseThrow();
+        assertEquals(
+                RemoteEventType.TEXT_DELTA, dto.getType(), "typed wire type stays for old clients");
+        assertEquals("hello", dto.getText());
+
+        TextBlockDeltaEvent back =
+                assertInstanceOf(
+                        TextBlockDeltaEvent.class,
+                        RemoteEventCodec.toAgentEvent(dto).orElseThrow());
+        assertEquals("hello", back.getDelta());
+        assertEquals("block-9", back.getBlockId());
+        assertEquals(original.getId(), back.getId());
+    }
+
+    @Test
+    void detailLevelsGateDeltasAndPassthrough() {
+        assertTrue(RemoteEventCodec.matchesDetail(RemoteEventType.RUN_STARTED, "status"));
+        assertFalse(RemoteEventCodec.matchesDetail(RemoteEventType.TEXT_DELTA, "status"));
+        assertFalse(RemoteEventCodec.matchesDetail(RemoteEventType.AGENT_EVENT, "status"));
+
+        assertTrue(RemoteEventCodec.matchesDetail(RemoteEventType.TEXT_DELTA, "full"));
+        assertTrue(RemoteEventCodec.matchesDetail(RemoteEventType.THINKING_DELTA, "full"));
+        assertFalse(RemoteEventCodec.matchesDetail(RemoteEventType.AGENT_EVENT, "full"));
+
+        assertTrue(RemoteEventCodec.matchesDetail(RemoteEventType.AGENT_EVENT, "verbose"));
+        assertTrue(RemoteEventCodec.matchesDetail(RemoteEventType.TEXT_DELTA, "verbose"));
+
+        assertFalse(RemoteEventCodec.matchesDetail((RemoteAgentEvent) null, "verbose"));
+        assertFalse(
+                RemoteEventCodec.matchesDetail(RemoteEventType.AGENT_EVENT, "unknown-level"),
+                "an unrecognized level is treated as status");
+    }
+
+    @Test
+    void eventFromAnOlderServerStillDecodesWithoutPayload() {
+        RemoteAgentEvent legacy = new RemoteAgentEvent();
+        legacy.setType(RemoteEventType.TOOL_CALL_START);
+        legacy.setToolCallId("call-1");
+        legacy.setToolName("read_file");
+        legacy.setTaskId("task_legacy");
+
+        ToolCallStartEvent back =
+                assertInstanceOf(
+                        ToolCallStartEvent.class,
+                        RemoteEventCodec.toAgentEvent(legacy).orElseThrow());
+        assertEquals("call-1", back.getToolCallId());
+        assertEquals("read_file", back.getToolCallName());
+        assertEquals("task_legacy", back.getMetadata().get(AgentEvent.METADATA_TASK_ID));
+    }
+
+    @Test
+    void payloadDecodesEvenWhenTheWireTypeIsUnknownToThisClient() {
+        RemoteAgentEvent dto =
+                RemoteEventCodec.fromAgentEvent(new HintBlockEvent("reply", "b1", "src", "note"))
+                        .orElseThrow();
+        dto.setType(null); // an unknown future type deserializes to null on an older client
+        dto.setTaskId("task_1");
+
+        AgentEvent back = RemoteEventCodec.toAgentEvent(dto).orElseThrow();
+        assertInstanceOf(HintBlockEvent.class, back);
+        assertEquals("task_1", back.getMetadata().get(AgentEvent.METADATA_TASK_ID));
+    }
+}

--- a/docs/v2/en/docs/harness/subagent.md
+++ b/docs/v2/en/docs/harness/subagent.md
@@ -338,6 +338,7 @@ Just set `url` + optional `headers` and the subagent runs through a remote HTTP 
     .url("http://agent-task-server:8080")
     .headers(Map.of("Authorization", "Bearer xxx"))
     .remoteStreaming(true)          // default when unset
+    .remoteStreamDetail(RemoteStreamDetail.VERBOSE)  // FULL when unset
     .remoteAskPolicy(RemoteAskPolicy.DENY)  // default
     .remoteContextAttributes(Map.of("region", "cn"))
     .build())
@@ -350,8 +351,23 @@ Declaration knobs specific to remote mode:
 | Field | Default | Notes |
 |-------|---------|-------|
 | `remoteStreaming` | `true` (when unset) | When the parent uses `streamEvents()`, forward remote task SSE events into the parent stream with a `source` tag plus `metadata.taskId` / `metadata.parentSessionId` (same ids as the harness `TaskRecord` / parent session) |
+| `remoteStreamDetail` | `FULL` | How much of the remote event stream to forward — see [Remote streaming detail](#remote-streaming-detail) |
 | `remoteAskPolicy` | `DENY` | How to resolve remote tool-confirmation (HITL) requests — see [Remote authorization](#remote-authorization) |
 | `remoteContextAttributes` | none | Static caller attributes sent as `context.attributes` on every submission. Merge per-call values by putting a map under `AgentSpawnTool.CTX_REMOTE_CONTEXT_ATTRIBUTES` on the parent's `RuntimeContext`; see [Context attributes](../../integration/protocol/agent-protocol.md#context-attributes) |
+
+### Remote streaming detail
+
+A local subagent forwards its child's events verbatim. A remote one has to cross the wire, and how much crosses is controlled by `remoteStreamDetail`, sent as `context.detail`:
+
+| Level | Forwards |
+|-------|----------|
+| `STATUS` | Run lifecycle, tool call boundaries, tool results, confirmation requests |
+| `FULL` (default) | `STATUS` plus text and thinking deltas |
+| `VERBOSE` | Every event the remote agent emits — block boundaries, tool argument deltas, **tool output deltas**, model calls with token usage, hints, agent results, custom events |
+
+Pick `VERBOSE` when the parent's stream should look the same whether the subagent is local or remote; that is the only level at which the remote subagent's tool output content and token usage reach the parent. It is not the default because the extra events are pure volume for callers that only render text.
+
+Events without a dedicated wire type travel as `AGENT_EVENT` with the original event serialized in the `payload` field, so the parent decodes the exact same class it would have received locally, ids, timestamps and metadata included. A client older than this field still reads the flat per-type fields and simply never sees the passthrough events.
 
 ### Remote authorization
 

--- a/docs/v2/en/integration/protocol/agent-protocol.md
+++ b/docs/v2/en/integration/protocol/agent-protocol.md
@@ -190,7 +190,7 @@ Optional `context` fields:
 | `user_id` | Forwarded into the remote agent's `RuntimeContext` |
 | `parent_session_id` | Parent session identity (for tracing / correlation) |
 | `stream` | Whether the caller intends to consume SSE events |
-| `detail` | `status` (default) or `full` — `full` includes text/thinking deltas on the event stream |
+| `detail` | `status` (default), `full` or `verbose` — see [Stream detail levels](#stream-detail-levels) |
 | `deny_rules` | Parent DENY permission rules to enforce on the remote side |
 | `attributes` | Caller-defined key/values for routing and for the run's `RuntimeContext`; see [Context attributes](#context-attributes) |
 
@@ -218,6 +218,27 @@ Reconnect / resume:
 - Header `Last-Event-ID` — used when `from_seq` is omitted (same meaning)
 
 Each SSE message uses the event seq as `id`, the remote event type as `event`, and a JSON body as `data`.
+
+#### Stream detail levels
+
+`context.detail` on submission decides how much of the run reaches subscribers. Each level is a superset of the previous one:
+
+| `detail` | Event types on the stream |
+|----------|---------------------------|
+| `status` (default) | `RUN_STARTED`, `RUN_FINISHED`, `RUN_ERROR`, `TOOL_CALL_START`, `TOOL_CALL_END`, `TOOL_RESULT`, `REQUIRE_CONFIRM`, `STATUS` |
+| `full` | plus `TEXT_DELTA`, `THINKING_DELTA` |
+| `verbose` | plus `AGENT_EVENT` — every remaining agent event, including block boundaries, tool argument and tool output deltas, model calls with token usage, agent results and custom events |
+
+Only `verbose` reproduces the agent's own event stream in full. An unrecognized value is treated as `status`.
+
+Every event body also carries two fields beyond its type-specific ones:
+
+| Field | Meaning |
+|-------|---------|
+| `eventType` | Name of the source `AgentEventType`, e.g. `MODEL_CALL_END`. Lets a client filter or log without parsing `payload` |
+| `payload` | The source `AgentEvent` serialized in full. Restores the original event with its id, timestamp and metadata intact, and is the only representation of an `AGENT_EVENT` |
+
+Both are additive: a client that ignores them keeps reading the flat fields (`text`, `toolCallId`, `status`, …) exactly as before, and one that predates `AGENT_EVENT` simply skips those messages.
 
 ### Resume after HITL
 

--- a/docs/v2/zh/docs/harness/subagent.md
+++ b/docs/v2/zh/docs/harness/subagent.md
@@ -338,6 +338,7 @@ ChatUiChannel chat = agent.channel(ChatUiChannel.create());  // 恢复能力自�
     .url("http://agent-task-server:8080")
     .headers(Map.of("Authorization", "Bearer xxx"))
     .remoteStreaming(true)          // 未设置时默认 true
+    .remoteStreamDetail(RemoteStreamDetail.VERBOSE)  // 未设置时为 FULL
     .remoteAskPolicy(RemoteAskPolicy.DENY)  // 默认
     .remoteContextAttributes(Map.of("region", "cn"))
     .build())
@@ -350,8 +351,23 @@ ChatUiChannel chat = agent.channel(ChatUiChannel.create());  // 恢复能力自�
 | 字段 | 默认 | 说明 |
 |------|------|------|
 | `remoteStreaming` | `true`（未设置时） | 父代理使用 `streamEvents()` 时，把远程任务的 SSE 事件转发进父流，并带 `source` 标记与 `metadata.taskId` / `metadata.parentSessionId`（与 harness `TaskRecord` / 父 session 一致） |
+| `remoteStreamDetail` | `FULL` | 回传多少远程事件——见[远程流式详细度](#远程流式详细度) |
 | `remoteAskPolicy` | `DENY` | 如何处理远程工具确认（HITL）请求——见 [远程授权](#远程授权) |
 | `remoteContextAttributes` | 无 | 每次提交都携带的静态调用方属性，写入 `context.attributes`。按次追加时，在父代理的 `RuntimeContext` 上用 `AgentSpawnTool.CTX_REMOTE_CONTEXT_ATTRIBUTES` 放一个 map；见[上下文属性](../../integration/protocol/agent-protocol.md#上下文属性contextattributes) |
+
+### 远程流式详细度
+
+本地子 agent 会把孩子的事件原样转发给父流。远程子 agent 的事件要过一趟网络，过多少由 `remoteStreamDetail` 决定，以 `context.detail` 发送：
+
+| 档位 | 回传内容 |
+|------|----------|
+| `STATUS` | 运行生命周期、工具调用起止、工具结果、确认请求 |
+| `FULL`（默认） | `STATUS` 之外再加文本与思考增量 |
+| `VERBOSE` | 远程 agent 发出的每一个事件——块边界、工具入参增量、**工具输出增量**、带 token usage 的模型调用、hint、agent 结果、自定义事件 |
+
+如果希望父流在子 agent 是本地还是远程时表现一致，选 `VERBOSE`——这是唯一能让远程子 agent 的工具输出内容和 token 用量到达父代理的档位。它不作为默认，是因为对只渲染文本的调用方来说这些事件纯粹是额外流量。
+
+没有专属 wire 类型的事件以 `AGENT_EVENT` 传输，原始事件完整序列化在 `payload` 字段里，父代理解出来的就是本地场景下同一个类，id、时间戳和 metadata 都在。不认识该字段的旧客户端仍读扁平字段，只是看不到这些透传事件。
 
 ### 远程授权
 

--- a/docs/v2/zh/integration/protocol/agent-protocol.md
+++ b/docs/v2/zh/integration/protocol/agent-protocol.md
@@ -190,7 +190,7 @@ RuntimeContext.builder()
 | `user_id` | 写入远程 agent 的 `RuntimeContext` |
 | `parent_session_id` | 父 session 标识（用于关联 / 追踪） |
 | `stream` | 调用方是否打算消费 SSE 事件 |
-| `detail` | `status`（默认）或 `full`——`full` 会在事件流中包含文本 / 思考增量 |
+| `detail` | `status`（默认）、`full` 或 `verbose`——见[事件流详细度](#事件流详细度) |
 | `deny_rules` | 父侧 DENY 权限规则，供远程侧执行 |
 | `attributes` | 调用方自定义键值，用于路由以及本次运行的 `RuntimeContext`；见[上下文属性](#上下文属性contextattributes) |
 
@@ -218,6 +218,27 @@ RuntimeContext.builder()
 - 请求头 `Last-Event-ID` —— 未传 `from_seq` 时使用（含义相同）
 
 每条 SSE 消息以事件序号为 `id`、远程事件类型为 `event`、JSON 正文为 `data`。
+
+#### 事件流详细度
+
+提交时的 `context.detail` 决定订阅方能收到多少事件，每一档都是前一档的超集：
+
+| `detail` | 事件流中的类型 |
+|----------|----------------|
+| `status`（默认） | `RUN_STARTED`、`RUN_FINISHED`、`RUN_ERROR`、`TOOL_CALL_START`、`TOOL_CALL_END`、`TOOL_RESULT`、`REQUIRE_CONFIRM`、`STATUS` |
+| `full` | 再加 `TEXT_DELTA`、`THINKING_DELTA` |
+| `verbose` | 再加 `AGENT_EVENT`——其余所有 agent 事件，包括块边界、工具入参与工具输出增量、带 token usage 的模型调用、agent 结果、自定义事件 |
+
+只有 `verbose` 能完整复现 agent 自身的事件流。无法识别的取值按 `status` 处理。
+
+除各类型专属字段外，每个事件正文还带两个字段：
+
+| 字段 | 含义 |
+|------|------|
+| `eventType` | 源 `AgentEventType` 的名字，如 `MODEL_CALL_END`。客户端可据此过滤或打日志，无需解析 `payload` |
+| `payload` | 源 `AgentEvent` 的完整序列化。可还原出原始事件，id、时间戳与 metadata 都保留；也是 `AGENT_EVENT` 的唯一表示形式 |
+
+两者都是增量字段：忽略它们的客户端照旧读扁平字段（`text`、`toolCallId`、`status` 等），早于 `AGENT_EVENT` 的客户端则直接跳过这类消息。
 
 ### HITL 恢复
 


### PR DESCRIPTION
## Summary

A local subagent forwards every child event into the parent's stream. A remote one (Agent Protocol) only delivered **8 of the 31** `AgentEvent` types — `RemoteEventCodec` mapped those by hand and its trailing `return Optional.empty()` silently dropped everything else. Users reported the gap as "the subagent doesn't send back the events the main agent has".

What was lost: tool output content (`ToolResultTextDeltaEvent`), token usage (`ModelCallEndEvent`), block boundaries, tool argument deltas, agent results, hints, external execution, and custom events. Even the 8 that did survive lost fidelity — decoding built `new TextBlockDeltaEvent(null, null, text)`, so `replyId`/`blockId` were always null and the event id and timestamp were regenerated despite the DTO carrying one.

`AgentEvent` is already polymorphic-serializable with stable `@JsonSubTypes` discriminators, so rather than hand-mapping the remaining 23 types (and every future one), each wire event now carries the source event serialized in a `payload` field. Types without a dedicated wire type travel as the new `AGENT_EVENT`. Decoding prefers the payload, restoring the exact class with ids, timestamps and metadata intact.

## Changes

- **Passthrough envelope** — `RemoteAgentEvent` gains `payload` (full serialization of the source event) and `eventType` (source `AgentEventType` name, for filtering and logging without parsing the payload). New `RemoteEventType.AGENT_EVENT` carries events with no dedicated wire type.
- **Three detail levels** — `RemoteStreamDetail` (`STATUS` / `FULL` / `VERBOSE`) sent as `context.detail`; passthrough events appear only at `VERBOSE`. `FULL` keeps its current semantics, so existing deployments see no volume change until they opt in via `SubagentDeclaration.remoteStreamDetail(VERBOSE)`.
- **Forward compatibility** — the client `ObjectMapper` now maps unknown enum values to null instead of failing the whole event, so a future wire type degrades gracefully (and still decodes when it carries a payload). The codec mapper ignores unknown properties, so a payload survives derived getters and fields added by a newer peer.
- **Two blockers found by the round-trip test** — `AllToolsDeniedEvent` was the only event class without a Jackson creator (added, matching its 30 siblings), and `ChatUsage.getTotalTokens()` is a derived getter no constructor parameter accepts, which broke `MODEL_CALL_END` decoding.

Both new fields are additive over `ignoreUnknown` DTOs: a client that ignores them keeps reading the flat fields exactly as before, and one predating `AGENT_EVENT` simply skips those messages.

## Test plan

- [x] `RemoteEventCodecPassthroughTest` walks the entire `AgentEventType` enum and asserts every type survives encode → decode as the same class; a second test fails if any enum constant lacks a sample, so a newly added core event type cannot silently regress this.
- [x] Fidelity assertions: passthrough preserves id, `createdAt`, metadata and nested `ChatUsage`; typed events now keep `blockId` and their original id.
- [x] Backward compatibility: a DTO without a payload still decodes via the per-type mapping (older server), and a payload still decodes when the wire type is unknown to the client (older client, newer server).
- [x] `AgentProtocolStreamDetailTest` drives the task store end to end and asserts what reaches a subscriber at each of `status` / `full` / `verbose`, including that the remote tool output content only arrives at `verbose`.
- [x] `agentscope-harness` 742 tests and `agentscope-extensions-agent-protocol` 26 tests pass; `spotless:check` clean. (`LocalFilesystemPersonalAssistantExampleTest` hit a flaky `@TempDir` cleanup error in the full run and passes in isolation — unrelated to this change.)
- [x] Docs updated in `zh` and `en` for both the subagent guide and the Agent Protocol reference.