### PR TITLE
feat(agent-protocol): decouple TaskStore from execution WorkspaceManager

### DIFF
--- a/agentscope-examples/documentation/src/main/java/io/agentscope/examples/documentation2/harness/channel/ChannelSendExample.java
+++ b/agentscope-examples/documentation/src/main/java/io/agentscope/examples/documentation2/harness/channel/ChannelSendExample.java
@@ -87,8 +87,7 @@ public class ChannelSendExample {
         // Attach application context (attributes / force-sync) via SendOptions.
         Msg withCtx =
                 chat.send(
-                                SendOptions.userId("user-1")
-                                        .withAttribute("tenant", "demo"),
+                                SendOptions.userId("user-1").withAttribute("tenant", "demo"),
                                 "Reply with a short hello.")
                         .block();
         System.out.println(
@@ -111,10 +110,8 @@ public class ChannelSendExample {
                                                         .build())
                                         .build())
                         .build();
-        Msg vision =
-                chat.send(SendOptions.userId("user-1"), multimodal).block();
-        System.out.println(
-                "Multimodal: " + (vision != null ? vision.getTextContent() : "(null)"));
+        Msg vision = chat.send(SendOptions.userId("user-1"), multimodal).block();
+        System.out.println("Multimodal: " + (vision != null ? vision.getTextContent() : "(null)"));
         // Equivalent list form:
         chat.send(SendOptions.userId("user-1"), List.of(multimodal)).block();
 

--- a/agentscope-extensions/agentscope-extensions-channel/agentscope-extensions-channel-dingtalk/src/main/java/io/agentscope/extensions/channel/dingtalk/DingTalkChannel.java
+++ b/agentscope-extensions/agentscope-extensions-channel/agentscope-extensions-channel-dingtalk/src/main/java/io/agentscope/extensions/channel/dingtalk/DingTalkChannel.java
@@ -155,11 +155,11 @@ public final class DingTalkChannel implements Channel {
         }
         RouteResult route = router.resolveRoute(config, message);
         return g.run(
-                route.context(),
-                message.messages(),
-                route.outboundAddress(),
-                message.runtimeContext(),
-                message)
+                        route.context(),
+                        message.messages(),
+                        route.outboundAddress(),
+                        message.runtimeContext(),
+                        message)
                 .flatMap(reply -> sendReply(route.outboundAddress(), reply).thenReturn(reply));
     }
 

--- a/agentscope-extensions/agentscope-extensions-channel/agentscope-extensions-channel-feishu/src/main/java/io/agentscope/extensions/channel/feishu/FeishuChannel.java
+++ b/agentscope-extensions/agentscope-extensions-channel/agentscope-extensions-channel-feishu/src/main/java/io/agentscope/extensions/channel/feishu/FeishuChannel.java
@@ -160,11 +160,11 @@ public final class FeishuChannel implements Channel {
         }
         RouteResult route = router.resolveRoute(config, message);
         return g.run(
-                route.context(),
-                message.messages(),
-                route.outboundAddress(),
-                message.runtimeContext(),
-                message)
+                        route.context(),
+                        message.messages(),
+                        route.outboundAddress(),
+                        message.runtimeContext(),
+                        message)
                 .flatMap(reply -> sendReply(route.outboundAddress(), reply).thenReturn(reply));
     }
 

--- a/agentscope-extensions/agentscope-extensions-channel/agentscope-extensions-channel-github/src/main/java/io/agentscope/extensions/channel/github/GitHubChannel.java
+++ b/agentscope-extensions/agentscope-extensions-channel/agentscope-extensions-channel-github/src/main/java/io/agentscope/extensions/channel/github/GitHubChannel.java
@@ -157,11 +157,11 @@ public final class GitHubChannel implements Channel {
         }
         RouteResult route = router.resolveRoute(config, message);
         return g.run(
-                route.context(),
-                message.messages(),
-                route.outboundAddress(),
-                message.runtimeContext(),
-                message)
+                        route.context(),
+                        message.messages(),
+                        route.outboundAddress(),
+                        message.runtimeContext(),
+                        message)
                 .flatMap(reply -> sendReply(route.outboundAddress(), reply).thenReturn(reply));
     }
 

--- a/agentscope-extensions/agentscope-extensions-channel/agentscope-extensions-channel-gitlab/src/main/java/io/agentscope/extensions/channel/gitlab/GitLabChannel.java
+++ b/agentscope-extensions/agentscope-extensions-channel/agentscope-extensions-channel-gitlab/src/main/java/io/agentscope/extensions/channel/gitlab/GitLabChannel.java
@@ -150,11 +150,11 @@ public final class GitLabChannel implements Channel {
         }
         RouteResult route = router.resolveRoute(config, message);
         return g.run(
-                route.context(),
-                message.messages(),
-                route.outboundAddress(),
-                message.runtimeContext(),
-                message)
+                        route.context(),
+                        message.messages(),
+                        route.outboundAddress(),
+                        message.runtimeContext(),
+                        message)
                 .flatMap(reply -> sendReply(route.outboundAddress(), reply).thenReturn(reply));
     }
 

--- a/agentscope-extensions/agentscope-extensions-channel/agentscope-extensions-channel-wecom/src/main/java/io/agentscope/extensions/channel/wecom/WeComChannel.java
+++ b/agentscope-extensions/agentscope-extensions-channel/agentscope-extensions-channel-wecom/src/main/java/io/agentscope/extensions/channel/wecom/WeComChannel.java
@@ -168,11 +168,11 @@ public final class WeComChannel implements Channel {
         }
         RouteResult route = router.resolveRoute(config, message);
         return g.run(
-                route.context(),
-                message.messages(),
-                route.outboundAddress(),
-                message.runtimeContext(),
-                message)
+                        route.context(),
+                        message.messages(),
+                        route.outboundAddress(),
+                        message.runtimeContext(),
+                        message)
                 .flatMap(reply -> sendReply(route.outboundAddress(), reply).thenReturn(reply));
     }
 

--- a/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agent-protocol/src/main/java/io/agentscope/extensions/agentprotocol/AgentProtocolAutoConfiguration.java
+++ b/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agent-protocol/src/main/java/io/agentscope/extensions/agentprotocol/AgentProtocolAutoConfiguration.java
@@ -16,7 +16,7 @@
 package io.agentscope.extensions.agentprotocol;
 
 import io.agentscope.harness.agent.HarnessAgent;
-import io.agentscope.harness.agent.workspace.WorkspaceManager;
+import java.nio.file.Path;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
@@ -35,6 +35,10 @@ import org.springframework.context.annotation.Bean;
  * <p>Agent selection goes through {@link AgentFactory}. Without a user-defined bean, the default
  * factory resolves the single {@link HarnessAgent} bean for every task; define an
  * {@link AgentFactory} bean to route per {@code agent_id} or submission context.
+ *
+ * <p>Protocol task metadata is persisted through {@link ProtocolTaskRepository},
+ * rooted at {@link AgentProtocolProperties#getTaskStorePath()} by default — not through any
+ * execution agent's workspace.
  *
  * <p>All {@link RuntimeContextCustomizer} beans are applied, in {@code @Order}, to the runtime
  * context of every task run.
@@ -61,16 +65,22 @@ public class AgentProtocolAutoConfiguration {
     }
 
     @Bean
-    @ConditionalOnBean({AgentFactory.class, WorkspaceManager.class})
+    @ConditionalOnMissingBean(ProtocolTaskRepository.class)
+    public ProtocolTaskRepository agentProtocolTaskRepository(AgentProtocolProperties properties) {
+        return new WorkspaceProtocolTaskRepository(Path.of(properties.getTaskStorePath()));
+    }
+
+    @Bean
+    @ConditionalOnBean({AgentFactory.class, ProtocolTaskRepository.class})
     public AgentProtocolTaskStore agentProtocolTaskStore(
             AgentFactory agentFactory,
-            WorkspaceManager workspaceManager,
+            ProtocolTaskRepository taskRepository,
             AgentProtocolTaskEventBus eventBus,
             AgentProtocolProperties properties,
             ObjectProvider<RuntimeContextCustomizer> runtimeContextCustomizers) {
         return new AgentProtocolTaskStore(
                 agentFactory,
-                workspaceManager,
+                taskRepository,
                 eventBus,
                 properties,
                 runtimeContextCustomizers.orderedStream().toList());

--- a/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agent-protocol/src/main/java/io/agentscope/extensions/agentprotocol/AgentProtocolProperties.java
+++ b/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agent-protocol/src/main/java/io/agentscope/extensions/agentprotocol/AgentProtocolProperties.java
@@ -15,6 +15,7 @@
  */
 package io.agentscope.extensions.agentprotocol;
 
+import java.nio.file.Path;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 /** Configuration for the AgentScope task HTTP protocol endpoints. */
@@ -35,6 +36,13 @@ public class AgentProtocolProperties {
 
     /** Client idle timeout hint for SSE (ms); not enforced server-side by default. */
     private long sseTimeoutMs = 10_800_000L;
+
+    /**
+     * Dedicated control-plane directory for protocol task-record persistence. Independent of any
+     * execution agent's workspace. When null/blank, defaults to {@code
+     * ${user.dir}/.agentscope/agent-protocol}.
+     */
+    private String taskStorePath;
 
     public boolean isEnabled() {
         return enabled;
@@ -74,5 +82,21 @@ public class AgentProtocolProperties {
 
     public void setSseTimeoutMs(long sseTimeoutMs) {
         this.sseTimeoutMs = sseTimeoutMs;
+    }
+
+    /**
+     * Resolved control-plane path. Never blank after this getter — falls back to {@code
+     * ${user.dir}/.agentscope/agent-protocol}.
+     */
+    public String getTaskStorePath() {
+        if (taskStorePath == null || taskStorePath.isBlank()) {
+            return Path.of(System.getProperty("user.dir"), ".agentscope", "agent-protocol")
+                    .toString();
+        }
+        return taskStorePath;
+    }
+
+    public void setTaskStorePath(String taskStorePath) {
+        this.taskStorePath = taskStorePath;
     }
 }

--- a/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agent-protocol/src/main/java/io/agentscope/extensions/agentprotocol/AgentProtocolTaskStore.java
+++ b/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agent-protocol/src/main/java/io/agentscope/extensions/agentprotocol/AgentProtocolTaskStore.java
@@ -34,7 +34,6 @@ import io.agentscope.harness.agent.subagent.protocol.RemoteEventType;
 import io.agentscope.harness.agent.subagent.protocol.RemotePendingConfirm;
 import io.agentscope.harness.agent.subagent.task.TaskRecord;
 import io.agentscope.harness.agent.subagent.task.TaskStatus;
-import io.agentscope.harness.agent.workspace.WorkspaceManager;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -61,9 +60,8 @@ import reactor.core.publisher.Flux;
  * to be configured with {@code checkRunning(false)}.
  *
  * <p>Task metadata is stored via {@link ProtocolTaskRepository} (a dedicated control-plane path),
- * not via any execution agent's {@link WorkspaceManager}. Caller-supplied {@code context.attributes}
- * reach the run through its {@link RuntimeContext}; see {@link RuntimeContextCustomizer} for
- * controlling how.
+ * not via any execution agent's workspace. Caller-supplied {@code context.attributes} reach the
+ * run through its {@link RuntimeContext}; see {@link RuntimeContextCustomizer} for controlling how.
  */
 public final class AgentProtocolTaskStore {
 
@@ -126,62 +124,6 @@ public final class AgentProtocolTaskStore {
     public AgentProtocolTaskStore(
             HarnessAgent harnessAgent, ProtocolTaskRepository taskRepository) {
         this(AgentFactory.fixed(harnessAgent), taskRepository);
-    }
-
-    /**
-     * @deprecated Prefer {@link #AgentProtocolTaskStore(AgentFactory, ProtocolTaskRepository,
-     *     AgentProtocolTaskEventBus, AgentProtocolProperties)}. The workspace manager is wrapped as
-     *     a control-plane repository only — do not pass an execution agent's workspace.
-     */
-    @Deprecated
-    public AgentProtocolTaskStore(
-            AgentFactory agentFactory,
-            WorkspaceManager workspaceManager,
-            AgentProtocolTaskEventBus eventBus,
-            AgentProtocolProperties properties) {
-        this(
-                agentFactory,
-                new WorkspaceProtocolTaskRepository(workspaceManager),
-                eventBus,
-                properties,
-                List.of());
-    }
-
-    /**
-     * @deprecated Prefer {@link #AgentProtocolTaskStore(AgentFactory, ProtocolTaskRepository,
-     *     AgentProtocolTaskEventBus, AgentProtocolProperties, List)}.
-     */
-    @Deprecated
-    public AgentProtocolTaskStore(
-            AgentFactory agentFactory,
-            WorkspaceManager workspaceManager,
-            AgentProtocolTaskEventBus eventBus,
-            AgentProtocolProperties properties,
-            List<RuntimeContextCustomizer> runtimeContextCustomizers) {
-        this(
-                agentFactory,
-                new WorkspaceProtocolTaskRepository(workspaceManager),
-                eventBus,
-                properties,
-                runtimeContextCustomizers);
-    }
-
-    /**
-     * @deprecated Prefer {@link #AgentProtocolTaskStore(AgentFactory, ProtocolTaskRepository)}.
-     */
-    @Deprecated
-    public AgentProtocolTaskStore(AgentFactory agentFactory, WorkspaceManager workspaceManager) {
-        this(agentFactory, new WorkspaceProtocolTaskRepository(workspaceManager));
-    }
-
-    /**
-     * @deprecated Prefer {@link #AgentProtocolTaskStore(HarnessAgent, ProtocolTaskRepository)}.
-     */
-    @Deprecated
-    public AgentProtocolTaskStore(HarnessAgent harnessAgent, WorkspaceManager workspaceManager) {
-        this(
-                AgentFactory.fixed(harnessAgent),
-                new WorkspaceProtocolTaskRepository(workspaceManager));
     }
 
     public AgentProtocolTaskEventBus eventBus() {

--- a/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agent-protocol/src/main/java/io/agentscope/extensions/agentprotocol/AgentProtocolTaskStore.java
+++ b/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agent-protocol/src/main/java/io/agentscope/extensions/agentprotocol/AgentProtocolTaskStore.java
@@ -53,15 +53,17 @@ import org.slf4j.LoggerFactory;
 import reactor.core.publisher.Flux;
 
 /**
- * In-memory execution handles with workspace-backed {@link TaskRecord} persistence.
+ * In-memory execution handles with control-plane {@link TaskRecord} persistence.
  *
  * <p>Each run resolves its {@link HarnessAgent} through the {@link AgentFactory}, which receives
  * the submission context and can therefore route per task. For concurrent task execution, return a
  * new instance per call (e.g. a Spring prototype-scoped bean); a shared instance requires the agent
  * to be configured with {@code checkRunning(false)}.
  *
- * <p>Caller-supplied {@code context.attributes} reach the run through its {@link RuntimeContext};
- * see {@link RuntimeContextCustomizer} for controlling how.
+ * <p>Task metadata is stored via {@link ProtocolTaskRepository} (a dedicated control-plane path),
+ * not via any execution agent's {@link WorkspaceManager}. Caller-supplied {@code context.attributes}
+ * reach the run through its {@link RuntimeContext}; see {@link RuntimeContextCustomizer} for
+ * controlling how.
  */
 public final class AgentProtocolTaskStore {
 
@@ -72,7 +74,7 @@ public final class AgentProtocolTaskStore {
     static final String AWAITING_CONFIRM_SENTINEL = "__awaiting_confirm__";
 
     private final AgentFactory agentFactory;
-    private final WorkspaceManager workspaceManager;
+    private final ProtocolTaskRepository taskRepository;
     private final AgentProtocolTaskEventBus eventBus;
     private final AgentProtocolProperties properties;
     private final List<RuntimeContextCustomizer> runtimeContextCustomizers;
@@ -90,20 +92,20 @@ public final class AgentProtocolTaskStore {
 
     public AgentProtocolTaskStore(
             AgentFactory agentFactory,
-            WorkspaceManager workspaceManager,
+            ProtocolTaskRepository taskRepository,
             AgentProtocolTaskEventBus eventBus,
             AgentProtocolProperties properties) {
-        this(agentFactory, workspaceManager, eventBus, properties, List.of());
+        this(agentFactory, taskRepository, eventBus, properties, List.of());
     }
 
     public AgentProtocolTaskStore(
             AgentFactory agentFactory,
-            WorkspaceManager workspaceManager,
+            ProtocolTaskRepository taskRepository,
             AgentProtocolTaskEventBus eventBus,
             AgentProtocolProperties properties,
             List<RuntimeContextCustomizer> runtimeContextCustomizers) {
         this.agentFactory = Objects.requireNonNull(agentFactory, "agentFactory");
-        this.workspaceManager = Objects.requireNonNull(workspaceManager, "workspaceManager");
+        this.taskRepository = Objects.requireNonNull(taskRepository, "taskRepository");
         this.eventBus = eventBus != null ? eventBus : new AgentProtocolTaskEventBus();
         this.properties = properties != null ? properties : new AgentProtocolProperties();
         this.runtimeContextCustomizers =
@@ -112,16 +114,74 @@ public final class AgentProtocolTaskStore {
                         : List.copyOf(runtimeContextCustomizers);
     }
 
-    public AgentProtocolTaskStore(AgentFactory agentFactory, WorkspaceManager workspaceManager) {
+    public AgentProtocolTaskStore(
+            AgentFactory agentFactory, ProtocolTaskRepository taskRepository) {
         this(
                 agentFactory,
-                workspaceManager,
+                taskRepository,
                 new AgentProtocolTaskEventBus(),
                 new AgentProtocolProperties());
     }
 
+    public AgentProtocolTaskStore(
+            HarnessAgent harnessAgent, ProtocolTaskRepository taskRepository) {
+        this(AgentFactory.fixed(harnessAgent), taskRepository);
+    }
+
+    /**
+     * @deprecated Prefer {@link #AgentProtocolTaskStore(AgentFactory, ProtocolTaskRepository,
+     *     AgentProtocolTaskEventBus, AgentProtocolProperties)}. The workspace manager is wrapped as
+     *     a control-plane repository only — do not pass an execution agent's workspace.
+     */
+    @Deprecated
+    public AgentProtocolTaskStore(
+            AgentFactory agentFactory,
+            WorkspaceManager workspaceManager,
+            AgentProtocolTaskEventBus eventBus,
+            AgentProtocolProperties properties) {
+        this(
+                agentFactory,
+                new WorkspaceProtocolTaskRepository(workspaceManager),
+                eventBus,
+                properties,
+                List.of());
+    }
+
+    /**
+     * @deprecated Prefer {@link #AgentProtocolTaskStore(AgentFactory, ProtocolTaskRepository,
+     *     AgentProtocolTaskEventBus, AgentProtocolProperties, List)}.
+     */
+    @Deprecated
+    public AgentProtocolTaskStore(
+            AgentFactory agentFactory,
+            WorkspaceManager workspaceManager,
+            AgentProtocolTaskEventBus eventBus,
+            AgentProtocolProperties properties,
+            List<RuntimeContextCustomizer> runtimeContextCustomizers) {
+        this(
+                agentFactory,
+                new WorkspaceProtocolTaskRepository(workspaceManager),
+                eventBus,
+                properties,
+                runtimeContextCustomizers);
+    }
+
+    /**
+     * @deprecated Prefer {@link #AgentProtocolTaskStore(AgentFactory, ProtocolTaskRepository)}.
+     */
+    @Deprecated
+    public AgentProtocolTaskStore(AgentFactory agentFactory, WorkspaceManager workspaceManager) {
+        this(agentFactory, new WorkspaceProtocolTaskRepository(workspaceManager));
+    }
+
+    /**
+     * @deprecated Prefer {@link #AgentProtocolTaskStore(HarnessAgent, ProtocolTaskRepository)}.
+     */
+    @Deprecated
     public AgentProtocolTaskStore(HarnessAgent harnessAgent, WorkspaceManager workspaceManager) {
-        this(AgentFactory.fixed(harnessAgent), workspaceManager);
+        this(
+                AgentFactory.fixed(harnessAgent),
+                new WorkspaceProtocolTaskRepository(workspaceManager));
     }
 
     public AgentProtocolTaskEventBus eventBus() {
@@ -139,12 +199,7 @@ public final class AgentProtocolTaskStore {
     }
 
     public void submit(String taskId, String agentId, String input, Map<String, Object> context) {
-        Optional<TaskRecord> existing =
-                workspaceManager.readTaskRecord(
-                        RuntimeContext.empty(),
-                        AgentProtocolConstants.PROTOCOL_AGENT_ID,
-                        AgentProtocolConstants.PROTOCOL_SESSION_ID,
-                        taskId);
+        Optional<TaskRecord> existing = taskRepository.find(taskId);
         if (existing.isPresent() && existing.get().getStatus().isTerminal()) {
             throw new IllegalStateException("task_id already finished: " + taskId);
         }
@@ -182,12 +237,7 @@ public final class AgentProtocolTaskStore {
         if (!properties.isHitlEnabled()) {
             throw new IllegalStateException("HITL is disabled on this server");
         }
-        Optional<TaskRecord> existing =
-                workspaceManager.readTaskRecord(
-                        RuntimeContext.empty(),
-                        AgentProtocolConstants.PROTOCOL_AGENT_ID,
-                        AgentProtocolConstants.PROTOCOL_SESSION_ID,
-                        taskId);
+        Optional<TaskRecord> existing = taskRepository.find(taskId);
         if (existing.isEmpty() || !existing.get().isAwaitingConfirm()) {
             throw new IllegalStateException("task is not awaiting confirmation: " + taskId);
         }
@@ -343,12 +393,7 @@ public final class AgentProtocolTaskStore {
 
     private void markAwaitingConfirm(
             String taskId, String agentId, List<RemotePendingConfirm> pending) {
-        Optional<TaskRecord> prev =
-                workspaceManager.readTaskRecord(
-                        RuntimeContext.empty(),
-                        AgentProtocolConstants.PROTOCOL_AGENT_ID,
-                        AgentProtocolConstants.PROTOCOL_SESSION_ID,
-                        taskId);
+        Optional<TaskRecord> prev = taskRepository.find(taskId);
         TaskRecord r =
                 prev.orElseGet(
                         () ->
@@ -411,11 +456,7 @@ public final class AgentProtocolTaskStore {
     }
 
     private void persist(TaskRecord r) {
-        workspaceManager.writeTaskRecord(
-                RuntimeContext.empty(),
-                AgentProtocolConstants.PROTOCOL_AGENT_ID,
-                AgentProtocolConstants.PROTOCOL_SESSION_ID,
-                r);
+        taskRepository.save(r);
     }
 
     private void updateRunning(String taskId, String agentId) {
@@ -430,12 +471,7 @@ public final class AgentProtocolTaskStore {
             String agentId,
             boolean awaitingConfirm,
             List<RemotePendingConfirm> pendingConfirms) {
-        Optional<TaskRecord> prev =
-                workspaceManager.readTaskRecord(
-                        RuntimeContext.empty(),
-                        AgentProtocolConstants.PROTOCOL_AGENT_ID,
-                        AgentProtocolConstants.PROTOCOL_SESSION_ID,
-                        taskId);
+        Optional<TaskRecord> prev = taskRepository.find(taskId);
         TaskRecord r =
                 prev.orElseGet(
                         () ->
@@ -461,12 +497,7 @@ public final class AgentProtocolTaskStore {
     public Map<String, Object> snapshot(String taskId) {
         Map<String, Object> m = new LinkedHashMap<>();
         m.put("task_id", taskId);
-        Optional<TaskRecord> rec =
-                workspaceManager.readTaskRecord(
-                        RuntimeContext.empty(),
-                        AgentProtocolConstants.PROTOCOL_AGENT_ID,
-                        AgentProtocolConstants.PROTOCOL_SESSION_ID,
-                        taskId);
+        Optional<TaskRecord> rec = taskRepository.find(taskId);
         if (rec.isEmpty()) {
             m.put("status", "error");
             m.put("error", "task not found");
@@ -520,12 +551,7 @@ public final class AgentProtocolTaskStore {
 
         int attempt = 0;
         while (System.currentTimeMillis() < deadline) {
-            Optional<TaskRecord> rec =
-                    workspaceManager.readTaskRecord(
-                            RuntimeContext.empty(),
-                            AgentProtocolConstants.PROTOCOL_AGENT_ID,
-                            AgentProtocolConstants.PROTOCOL_SESSION_ID,
-                            taskId);
+            Optional<TaskRecord> rec = taskRepository.find(taskId);
             if (rec.isEmpty()) {
                 Map<String, Object> err = new LinkedHashMap<>();
                 err.put("status", "error");
@@ -571,12 +597,7 @@ public final class AgentProtocolTaskStore {
         if (f != null) {
             f.cancel(true);
         }
-        Optional<TaskRecord> rec =
-                workspaceManager.readTaskRecord(
-                        RuntimeContext.empty(),
-                        AgentProtocolConstants.PROTOCOL_AGENT_ID,
-                        AgentProtocolConstants.PROTOCOL_SESSION_ID,
-                        taskId);
+        Optional<TaskRecord> rec = taskRepository.find(taskId);
         if (rec.isPresent()) {
             TaskRecord r = rec.get();
             r.setCancelRequested(true);

--- a/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agent-protocol/src/main/java/io/agentscope/extensions/agentprotocol/ProtocolTaskRepository.java
+++ b/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agent-protocol/src/main/java/io/agentscope/extensions/agentprotocol/ProtocolTaskRepository.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.extensions.agentprotocol;
+
+import io.agentscope.harness.agent.subagent.task.TaskRecord;
+import java.util.Optional;
+
+/**
+ * Control-plane persistence for Agent Protocol {@link TaskRecord}s.
+ *
+ * <p>This store is <strong>not</strong> an execution agent's workspace. Task HTTP endpoints need a
+ * global {@code task_id} lookup independent of which {@link
+ * io.agentscope.harness.agent.HarnessAgent} ran the task; records therefore live under a dedicated
+ * protocol bucket (see {@link AgentProtocolConstants#PROTOCOL_AGENT_ID}). Each agent's own {@link
+ * io.agentscope.harness.agent.workspace.WorkspaceManager} continues to own MEMORY / sessions /
+ * skills for that agent only.
+ */
+public interface ProtocolTaskRepository {
+
+    /** Upserts the given task record. */
+    void save(TaskRecord record);
+
+    /** Returns the task with the given id, or empty if unknown. */
+    Optional<TaskRecord> find(String taskId);
+}

--- a/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agent-protocol/src/main/java/io/agentscope/extensions/agentprotocol/WorkspaceProtocolTaskRepository.java
+++ b/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agent-protocol/src/main/java/io/agentscope/extensions/agentprotocol/WorkspaceProtocolTaskRepository.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.extensions.agentprotocol;
+
+import io.agentscope.core.agent.RuntimeContext;
+import io.agentscope.harness.agent.subagent.task.TaskRecord;
+import io.agentscope.harness.agent.workspace.WorkspaceManager;
+import java.nio.file.Path;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * {@link ProtocolTaskRepository} backed by a dedicated {@link WorkspaceManager} writing into the
+ * synthetic {@link AgentProtocolConstants#PROTOCOL_AGENT_ID} /
+ * {@link AgentProtocolConstants#PROTOCOL_SESSION_ID} bucket.
+ *
+ * <p>Pass a manager rooted at the protocol control-plane path (not an execution agent's
+ * workspace) so multi-agent deployments keep task metadata separate from each agent's files.
+ */
+public final class WorkspaceProtocolTaskRepository implements ProtocolTaskRepository {
+
+    private final WorkspaceManager workspaceManager;
+
+    public WorkspaceProtocolTaskRepository(WorkspaceManager workspaceManager) {
+        this.workspaceManager = Objects.requireNonNull(workspaceManager, "workspaceManager");
+    }
+
+    /** Creates a repository rooted at {@code taskStorePath} with a fresh local workspace manager. */
+    public WorkspaceProtocolTaskRepository(Path taskStorePath) {
+        this(new WorkspaceManager(Objects.requireNonNull(taskStorePath, "taskStorePath")));
+    }
+
+    /** Returns the underlying workspace manager (control-plane root only). */
+    public WorkspaceManager workspaceManager() {
+        return workspaceManager;
+    }
+
+    @Override
+    public void save(TaskRecord record) {
+        Objects.requireNonNull(record, "record");
+        workspaceManager.writeTaskRecord(
+                RuntimeContext.empty(),
+                AgentProtocolConstants.PROTOCOL_AGENT_ID,
+                AgentProtocolConstants.PROTOCOL_SESSION_ID,
+                record);
+    }
+
+    @Override
+    public Optional<TaskRecord> find(String taskId) {
+        if (taskId == null || taskId.isBlank()) {
+            return Optional.empty();
+        }
+        return workspaceManager.readTaskRecord(
+                RuntimeContext.empty(),
+                AgentProtocolConstants.PROTOCOL_AGENT_ID,
+                AgentProtocolConstants.PROTOCOL_SESSION_ID,
+                taskId);
+    }
+}

--- a/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agent-protocol/src/test/java/io/agentscope/extensions/agentprotocol/AgentProtocolAgentFactoryTest.java
+++ b/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agent-protocol/src/test/java/io/agentscope/extensions/agentprotocol/AgentProtocolAgentFactoryTest.java
@@ -30,7 +30,6 @@ import io.agentscope.core.event.AgentStartEvent;
 import io.agentscope.core.message.Msg;
 import io.agentscope.core.message.MsgRole;
 import io.agentscope.harness.agent.HarnessAgent;
-import io.agentscope.harness.agent.workspace.WorkspaceManager;
 import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.List;
@@ -49,14 +48,14 @@ class AgentProtocolAgentFactoryTest {
 
     @TempDir Path tempDir;
 
-    private WorkspaceManager workspaceManager;
+    private ProtocolTaskRepository taskRepository;
     private HarnessAgent researcher;
     private HarnessAgent writer;
     private final List<AgentRequest> seenRequests = new CopyOnWriteArrayList<>();
 
     @BeforeEach
     void setUp() {
-        workspaceManager = new WorkspaceManager(tempDir);
+        taskRepository = new WorkspaceProtocolTaskRepository(tempDir);
         researcher = agentReplying("researched");
         writer = agentReplying("written");
     }
@@ -130,7 +129,7 @@ class AgentProtocolAgentFactoryTest {
                 };
         return new AgentProtocolTaskStore(
                 factory,
-                workspaceManager,
+                taskRepository,
                 new AgentProtocolTaskEventBus(),
                 new AgentProtocolProperties());
     }

--- a/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agent-protocol/src/test/java/io/agentscope/extensions/agentprotocol/AgentProtocolContextAttributesTest.java
+++ b/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agent-protocol/src/test/java/io/agentscope/extensions/agentprotocol/AgentProtocolContextAttributesTest.java
@@ -29,7 +29,6 @@ import io.agentscope.core.event.AgentStartEvent;
 import io.agentscope.core.message.Msg;
 import io.agentscope.core.message.MsgRole;
 import io.agentscope.harness.agent.HarnessAgent;
-import io.agentscope.harness.agent.workspace.WorkspaceManager;
 import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.List;
@@ -49,12 +48,12 @@ class AgentProtocolContextAttributesTest {
 
     @TempDir Path tempDir;
 
-    private WorkspaceManager workspaceManager;
+    private ProtocolTaskRepository taskRepository;
     private final AtomicReference<RuntimeContext> executed = new AtomicReference<>();
 
     @BeforeEach
     void setUp() {
-        workspaceManager = new WorkspaceManager(tempDir);
+        taskRepository = new WorkspaceProtocolTaskRepository(tempDir);
     }
 
     @Test
@@ -155,7 +154,7 @@ class AgentProtocolContextAttributesTest {
     private AgentProtocolTaskStore store(List<RuntimeContextCustomizer> customizers) {
         return new AgentProtocolTaskStore(
                 AgentFactory.fixed(recordingAgent()),
-                workspaceManager,
+                taskRepository,
                 new AgentProtocolTaskEventBus(),
                 new AgentProtocolProperties(),
                 customizers);

--- a/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agent-protocol/src/test/java/io/agentscope/extensions/agentprotocol/AgentProtocolStreamDetailTest.java
+++ b/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agent-protocol/src/test/java/io/agentscope/extensions/agentprotocol/AgentProtocolStreamDetailTest.java
@@ -39,7 +39,6 @@ import io.agentscope.harness.agent.HarnessAgent;
 import io.agentscope.harness.agent.subagent.protocol.RemoteAgentEvent;
 import io.agentscope.harness.agent.subagent.protocol.RemoteEventCodec;
 import io.agentscope.harness.agent.subagent.protocol.RemoteEventType;
-import io.agentscope.harness.agent.workspace.WorkspaceManager;
 import java.nio.file.Path;
 import java.time.Duration;
 import java.util.List;
@@ -60,12 +59,12 @@ class AgentProtocolStreamDetailTest {
 
     @TempDir Path tempDir;
 
-    private WorkspaceManager workspaceManager;
+    private ProtocolTaskRepository taskRepository;
     private HarnessAgent agent;
 
     @BeforeEach
     void setUp() {
-        workspaceManager = new WorkspaceManager(tempDir);
+        taskRepository = new WorkspaceProtocolTaskRepository(tempDir);
         agent = mock(HarnessAgent.class);
         when(agent.streamEvents(any(Msg.class), any(RuntimeContext.class)))
                 .thenReturn(Flux.fromIterable(agentRun()));
@@ -141,7 +140,7 @@ class AgentProtocolStreamDetailTest {
         AgentProtocolTaskStore store =
                 new AgentProtocolTaskStore(
                         AgentFactory.fixed(agent),
-                        workspaceManager,
+                        taskRepository,
                         bus,
                         new AgentProtocolProperties());
 

--- a/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agent-protocol/src/test/java/io/agentscope/extensions/agentprotocol/AgentProtocolTaskStoreHitlTest.java
+++ b/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agent-protocol/src/test/java/io/agentscope/extensions/agentprotocol/AgentProtocolTaskStoreHitlTest.java
@@ -37,7 +37,6 @@ import io.agentscope.core.message.ToolUseBlock;
 import io.agentscope.harness.agent.HarnessAgent;
 import io.agentscope.harness.agent.subagent.protocol.RemoteConfirmDecision;
 import io.agentscope.harness.agent.subagent.protocol.RemotePendingConfirm;
-import io.agentscope.harness.agent.workspace.WorkspaceManager;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
@@ -56,21 +55,21 @@ class AgentProtocolTaskStoreHitlTest {
     @TempDir Path tempDir;
 
     private HarnessAgent agent;
-    private WorkspaceManager workspaceManager;
+    private ProtocolTaskRepository taskRepository;
     private AgentProtocolTaskStore store;
     private final AtomicInteger streamCalls = new AtomicInteger();
 
     @BeforeEach
     void setUp() {
         agent = mock(HarnessAgent.class);
-        workspaceManager = new WorkspaceManager(tempDir);
+        taskRepository = new WorkspaceProtocolTaskRepository(tempDir);
         AgentProtocolProperties props = new AgentProtocolProperties();
         props.setHitlEnabled(true);
         props.setStreamingEnabled(true);
         store =
                 new AgentProtocolTaskStore(
                         AgentFactory.fixed(agent),
-                        workspaceManager,
+                        taskRepository,
                         new AgentProtocolTaskEventBus(),
                         props);
 

--- a/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agent-protocol/src/test/java/io/agentscope/extensions/agentprotocol/WorkspaceProtocolTaskRepositoryTest.java
+++ b/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agent-protocol/src/test/java/io/agentscope/extensions/agentprotocol/WorkspaceProtocolTaskRepositoryTest.java
@@ -120,16 +120,6 @@ class WorkspaceProtocolTaskRepositoryTest {
                         .normalize());
     }
 
-    @Test
-    @Deprecated
-    @DisplayName("deprecated WorkspaceManager ctor still wraps as control-plane repo")
-    void deprecatedCtorStillWorks() {
-        WorkspaceManager wm = new WorkspaceManager(controlPlane);
-        AgentProtocolTaskStore store =
-                new AgentProtocolTaskStore(AgentFactory.fixed(mock(HarnessAgent.class)), wm);
-        assertEquals("error", store.snapshot("missing").get("status"));
-    }
-
     private static void awaitStatus(AgentProtocolTaskStore store, String taskId, String status)
             throws Exception {
         long deadline = System.currentTimeMillis() + 5_000L;

--- a/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agent-protocol/src/test/java/io/agentscope/extensions/agentprotocol/WorkspaceProtocolTaskRepositoryTest.java
+++ b/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agent-protocol/src/test/java/io/agentscope/extensions/agentprotocol/WorkspaceProtocolTaskRepositoryTest.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.extensions.agentprotocol;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.agentscope.core.agent.RuntimeContext;
+import io.agentscope.core.event.AgentEndEvent;
+import io.agentscope.core.event.AgentResultEvent;
+import io.agentscope.core.event.AgentStartEvent;
+import io.agentscope.core.message.Msg;
+import io.agentscope.core.message.MsgRole;
+import io.agentscope.harness.agent.HarnessAgent;
+import io.agentscope.harness.agent.subagent.task.TaskRecord;
+import io.agentscope.harness.agent.subagent.task.TaskStatus;
+import io.agentscope.harness.agent.workspace.WorkspaceManager;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import reactor.core.publisher.Flux;
+
+/** Control-plane ProtocolTaskRepository vs execution-agent WorkspaceManager. */
+@DisplayName("ProtocolTaskRepository control-plane isolation")
+class WorkspaceProtocolTaskRepositoryTest {
+
+    @TempDir Path tempDir;
+
+    private Path controlPlane;
+    private Path agentWorkspace;
+    private ProtocolTaskRepository taskRepository;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        controlPlane = tempDir.resolve("protocol-control");
+        agentWorkspace = tempDir.resolve("agent-a");
+        Files.createDirectories(controlPlane);
+        Files.createDirectories(agentWorkspace);
+        taskRepository = new WorkspaceProtocolTaskRepository(controlPlane);
+    }
+
+    @Test
+    @DisplayName("save/find round-trip under PROTOCOL_* bucket")
+    void saveFindRoundTrip() {
+        TaskRecord record =
+                new TaskRecord(
+                        "task-1",
+                        "worker",
+                        AgentProtocolConstants.PROTOCOL_AGENT_ID,
+                        AgentProtocolConstants.PROTOCOL_SESSION_ID,
+                        null);
+        record.setStatus(TaskStatus.COMPLETED);
+        record.setResult("done");
+
+        taskRepository.save(record);
+
+        assertTrue(taskRepository.find("task-1").isPresent());
+        assertEquals(TaskStatus.COMPLETED, taskRepository.find("task-1").get().getStatus());
+        assertEquals("done", taskRepository.find("task-1").get().getResult());
+    }
+
+    @Test
+    @DisplayName("TaskStore writes protocol records outside the execution agent workspace")
+    void taskStoreUsesControlPlaneNotAgentWorkspace() throws Exception {
+        HarnessAgent agent = mock(HarnessAgent.class);
+        WorkspaceManager agentWm = new WorkspaceManager(agentWorkspace);
+        when(agent.getWorkspaceManager()).thenReturn(agentWm);
+        when(agent.streamEvents(any(Msg.class), any(RuntimeContext.class)))
+                .thenReturn(
+                        Flux.just(
+                                new AgentStartEvent("sess", null, "worker"),
+                                new AgentResultEvent(
+                                        Msg.builder()
+                                                .role(MsgRole.ASSISTANT)
+                                                .textContent("ok")
+                                                .build()),
+                                new AgentEndEvent(null)));
+
+        AgentProtocolTaskStore store =
+                new AgentProtocolTaskStore(AgentFactory.fixed(agent), taskRepository);
+
+        store.submit("t-ctrl", "worker", "hello");
+        awaitStatus(store, "t-ctrl", "success");
+
+        assertTrue(taskRepository.find("t-ctrl").isPresent());
+        assertTrue(
+                agentWm.readTaskRecord(
+                                RuntimeContext.empty(),
+                                AgentProtocolConstants.PROTOCOL_AGENT_ID,
+                                AgentProtocolConstants.PROTOCOL_SESSION_ID,
+                                "t-ctrl")
+                        .isEmpty(),
+                "execution agent workspace must not hold protocol TaskRecords");
+        assertNotEquals(
+                agentWm.getWorkspace().normalize(),
+                ((WorkspaceProtocolTaskRepository) taskRepository)
+                        .workspaceManager()
+                        .getWorkspace()
+                        .normalize());
+    }
+
+    @Test
+    @Deprecated
+    @DisplayName("deprecated WorkspaceManager ctor still wraps as control-plane repo")
+    void deprecatedCtorStillWorks() {
+        WorkspaceManager wm = new WorkspaceManager(controlPlane);
+        AgentProtocolTaskStore store =
+                new AgentProtocolTaskStore(AgentFactory.fixed(mock(HarnessAgent.class)), wm);
+        assertEquals("error", store.snapshot("missing").get("status"));
+    }
+
+    private static void awaitStatus(AgentProtocolTaskStore store, String taskId, String status)
+            throws Exception {
+        long deadline = System.currentTimeMillis() + 5_000L;
+        while (System.currentTimeMillis() < deadline) {
+            if (status.equals(store.snapshot(taskId).get("status"))) {
+                return;
+            }
+            TimeUnit.MILLISECONDS.sleep(50);
+        }
+        throw new AssertionError(
+                "timed out waiting for status=" + status + " got=" + store.snapshot(taskId));
+    }
+}

--- a/docs/v2/en/integration/protocol/agent-protocol.md
+++ b/docs/v2/en/integration/protocol/agent-protocol.md
@@ -57,10 +57,9 @@ This path is **independent** of each `HarnessAgent`'s own `WorkspaceManager` (ME
 skills). Multi-agent factories may give each agent a different `.workspace(...)`; protocol
 `task_id` lookup always goes through the control-plane repository.
 
-You may supply your own `ProtocolTaskRepository` bean to override the default. Do **not** inject an
-execution agent's `WorkspaceManager` into the task store unless you intentionally want protocol
-metadata co-located with that agent's files (legacy deprecated constructors still wrap a
-`WorkspaceManager` as a control-plane repo for compatibility).
+You may supply your own `ProtocolTaskRepository` bean to override the default. Construct
+`AgentProtocolTaskStore` with a `ProtocolTaskRepository` only — do not pass an execution agent's
+`WorkspaceManager`.
 
 ## Concurrent execution
 

--- a/docs/v2/en/integration/protocol/agent-protocol.md
+++ b/docs/v2/en/integration/protocol/agent-protocol.md
@@ -33,16 +33,34 @@ AgentScope uses different protocols for different trust / UX boundaries:
 
 The module is delivered as a Spring Boot auto-configuration. In a Spring Boot app:
 
-1. Provide a `HarnessAgent` bean and a `WorkspaceManager` bean.
+1. Provide a `HarnessAgent` bean (or a custom `AgentFactory`).
 2. Enable in `application.yml`:
 
 ```yaml
 agentscope:
   agent-protocol:
     enabled: true
+    # optional — control-plane TaskRecord directory (not an execution agent's workspace)
+    # task-store-path: ${user.dir}/.agentscope/agent-protocol
 ```
 
 The `/tasks` REST endpoints are then registered automatically.
+
+### Control-plane vs execution workspace
+
+`AgentProtocolTaskStore` persists protocol task metadata (`TaskRecord` for submit / resume /
+snapshot) through a dedicated `ProtocolTaskRepository`. By default that repository is rooted at
+`agentscope.agent-protocol.task-store-path` (`${user.dir}/.agentscope/agent-protocol`), under the
+synthetic bucket `agents/_agentscope_protocol/tasks/`.
+
+This path is **independent** of each `HarnessAgent`'s own `WorkspaceManager` (MEMORY, sessions,
+skills). Multi-agent factories may give each agent a different `.workspace(...)`; protocol
+`task_id` lookup always goes through the control-plane repository.
+
+You may supply your own `ProtocolTaskRepository` bean to override the default. Do **not** inject an
+execution agent's `WorkspaceManager` into the task store unless you intentionally want protocol
+metadata co-located with that agent's files (legacy deprecated constructors still wrap a
+`WorkspaceManager` as a control-plane repo for compatibility).
 
 ## Concurrent execution
 

--- a/docs/v2/zh/integration/protocol/agent-protocol.md
+++ b/docs/v2/zh/integration/protocol/agent-protocol.md
@@ -57,9 +57,8 @@ snapshot 用的 `TaskRecord`）。默认根目录为 `agentscope.agent-protocol.
 多 agent 的 `AgentFactory` 可以为每个 agent 配置不同的 `.workspace(...)`；协议侧按 `task_id`
 查找始终走控制面仓库。
 
-也可以自行提供 `ProtocolTaskRepository` Bean 覆盖默认实现。**不要**把执行 Agent 的
-`WorkspaceManager` 注入 TaskStore，除非你有意把协议元数据与该 Agent 文件放在一起（遗留的
-已废弃构造仍会把 `WorkspaceManager` 包成控制面 repo，仅作兼容）。
+也可以自行提供 `ProtocolTaskRepository` Bean 覆盖默认实现。`AgentProtocolTaskStore` 只接受
+`ProtocolTaskRepository`，不要传入执行 Agent 的 `WorkspaceManager`。
 
 ## 并发执行
 

--- a/docs/v2/zh/integration/protocol/agent-protocol.md
+++ b/docs/v2/zh/integration/protocol/agent-protocol.md
@@ -33,16 +33,33 @@ AgentScope 用不同协议覆盖不同信任边界 / 交互面：
 
 模块以 Spring Boot 自动配置形式提供，所以仅需在 Spring Boot 应用里：
 
-1. 注入一个 `HarnessAgent` Bean 和一个 `WorkspaceManager` Bean。
+1. 注入一个 `HarnessAgent` Bean（或自定义 `AgentFactory`）。
 2. 在 `application.yml` 里启用：
 
 ```yaml
 agentscope:
   agent-protocol:
     enabled: true
+    # 可选 —— 协议控制面 TaskRecord 目录（不是执行 Agent 的 workspace）
+    # task-store-path: ${user.dir}/.agentscope/agent-protocol
 ```
 
 随后会自动注册 `/tasks` 系列 REST 接口。
+
+### 控制面 vs 执行 workspace
+
+`AgentProtocolTaskStore` 通过独立的 `ProtocolTaskRepository` 持久化协议任务元数据（submit / resume /
+snapshot 用的 `TaskRecord`）。默认根目录为 `agentscope.agent-protocol.task-store-path`
+（`${user.dir}/.agentscope/agent-protocol`），落在合成桶
+`agents/_agentscope_protocol/tasks/` 下。
+
+该路径与每个 `HarnessAgent` 自己的 `WorkspaceManager`（MEMORY、sessions、skills）**相互独立**。
+多 agent 的 `AgentFactory` 可以为每个 agent 配置不同的 `.workspace(...)`；协议侧按 `task_id`
+查找始终走控制面仓库。
+
+也可以自行提供 `ProtocolTaskRepository` Bean 覆盖默认实现。**不要**把执行 Agent 的
+`WorkspaceManager` 注入 TaskStore，除非你有意把协议元数据与该 Agent 文件放在一起（遗留的
+已废弃构造仍会把 `WorkspaceManager` 包成控制面 repo，仅作兼容）。
 
 ## 并发执行
 


### PR DESCRIPTION
## Summary
- Introduce `ProtocolTaskRepository` / `WorkspaceProtocolTaskRepository` as the control-plane store for protocol `TaskRecord`s (synthetic `PROTOCOL_*` bucket).
- `AgentProtocolTaskStore` depends on the repository instead of a shared execution `WorkspaceManager`; legacy WM constructors are deprecated wrappers.
- Spring autoconfig no longer requires a `WorkspaceManager` bean; default path is `agentscope.agent-protocol.task-store-path` (`${user.dir}/.agentscope/agent-protocol`). Docs (EN/ZH) clarify control-plane vs agent workspace.

## Test plan
- [ ] `mvn -pl agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agent-protocol -am test`
- [ ] Enable agent-protocol with only a `HarnessAgent` bean (no `WorkspaceManager` bean) and confirm `/tasks` registers
- [ ] Multi-agent `AgentFactory` with different `.workspace(...)` — protocol records land under `task-store-path`, not agent workspaces