### PR TITLE
fix(harness): propagate memoryConfig to general-purpose subagent

### DIFF
--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/HarnessAgentBuilderSupport.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/HarnessAgentBuilderSupport.java
@@ -36,6 +36,7 @@ import io.agentscope.harness.agent.filesystem.remote.store.BaseStore;
 import io.agentscope.harness.agent.filesystem.remote.store.NamespaceFactory;
 import io.agentscope.harness.agent.filesystem.sandbox.SandboxBackedFilesystem;
 import io.agentscope.harness.agent.filesystem.spec.LocalFilesystemSpec;
+import io.agentscope.harness.agent.memory.MemoryConfig;
 import io.agentscope.harness.agent.memory.compaction.CompactionConfig;
 import io.agentscope.harness.agent.memory.compaction.ToolResultEvictionConfig;
 import io.agentscope.harness.agent.middleware.DynamicSubagentsMiddleware;
@@ -311,6 +312,7 @@ final class HarnessAgentBuilderSupport {
         final boolean capturedAgentTracingLogEnabled = b.agentTracingLogEnabled;
         final List<String> capturedAdditionalContextFiles = List.copyOf(b.additionalContextFiles);
         final int capturedMaxContextTokens = b.maxContextTokens;
+        final MemoryConfig capturedMemoryConfig = b.memoryConfig;
         // Propagate the parent's (distributed) state store so an exposed subagent can be
         // re-materialized on another node / after a restart and still load its conversation
         // history by sessionId. Null in purely local default deployments — children then keep
@@ -356,6 +358,7 @@ final class HarnessAgentBuilderSupport {
             if (capturedModelExec != null) sub.modelExecutionConfig(capturedModelExec);
             if (capturedToolExec != null) sub.toolExecutionConfig(capturedToolExec);
             if (capturedGenOpts != null) sub.generateOptions(capturedGenOpts);
+            if (capturedMemoryConfig != null) sub.memory(capturedMemoryConfig);
             if (capturedDisableCompaction) {
                 sub.disableCompaction();
             } else if (capturedCompactionConfig != null) {

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/HarnessAgentBuilderSupport.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/HarnessAgentBuilderSupport.java
@@ -358,7 +358,7 @@ final class HarnessAgentBuilderSupport {
             if (capturedModelExec != null) sub.modelExecutionConfig(capturedModelExec);
             if (capturedToolExec != null) sub.toolExecutionConfig(capturedToolExec);
             if (capturedGenOpts != null) sub.generateOptions(capturedGenOpts);
-            if (capturedMemoryConfig != null) sub.memory(capturedMemoryConfig);
+            sub.memory(capturedMemoryConfig);
             if (capturedDisableCompaction) {
                 sub.disableCompaction();
             } else if (capturedCompactionConfig != null) {

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/HarnessAgentTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/HarnessAgentTest.java
@@ -52,12 +52,12 @@ import io.agentscope.harness.agent.filesystem.AbstractFilesystem;
 import io.agentscope.harness.agent.filesystem.local.LocalFilesystem;
 import io.agentscope.harness.agent.filesystem.remote.store.InMemoryStore;
 import io.agentscope.harness.agent.filesystem.spec.RemoteFilesystemSpec;
+import io.agentscope.harness.agent.memory.MemoryConfig;
 import io.agentscope.harness.agent.memory.compaction.CompactionConfig;
 import io.agentscope.harness.agent.middleware.AgentTraceMiddleware;
 import io.agentscope.harness.agent.middleware.SubagentEntry;
 import io.agentscope.harness.agent.middleware.WorkspaceContextMiddleware;
 import io.agentscope.harness.agent.sandbox.SandboxContext;
-import io.agentscope.harness.agent.memory.MemoryConfig;
 import io.agentscope.harness.agent.subagent.AgentSpecLoader;
 import io.agentscope.harness.agent.subagent.SubagentDeclaration;
 import io.agentscope.harness.agent.subagent.WorkspaceMode;
@@ -1176,7 +1176,10 @@ class HarnessAgentTest {
         when(memoryModel.stream(anyList(), anyList(), any())).thenReturn(Flux.just(memoryChunk));
 
         MemoryConfig memoryConfig =
-                MemoryConfig.builder().model(memoryModel).consolidationMinGap(Duration.ofMinutes(1)).build();
+                MemoryConfig.builder()
+                        .model(memoryModel)
+                        .consolidationMinGap(Duration.ofMinutes(1))
+                        .build();
 
         List<SubagentEntry> entries =
                 HarnessAgent.builder()

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/HarnessAgentTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/HarnessAgentTest.java
@@ -1197,9 +1197,7 @@ class HarnessAgentTest {
                                 .factory()
                                 .create(RuntimeContext.empty());
 
-        child
-                .call(userText("hi, keep this in memory"), RuntimeContext.empty())
-                .block();
+        child.call(userText("hi, keep this in memory"), RuntimeContext.empty()).block();
 
         verify(memoryModel).stream(anyList(), anyList(), any());
         verify(parentModel).stream(anyList(), anyList(), any());

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/HarnessAgentTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/HarnessAgentTest.java
@@ -57,6 +57,7 @@ import io.agentscope.harness.agent.middleware.AgentTraceMiddleware;
 import io.agentscope.harness.agent.middleware.SubagentEntry;
 import io.agentscope.harness.agent.middleware.WorkspaceContextMiddleware;
 import io.agentscope.harness.agent.sandbox.SandboxContext;
+import io.agentscope.harness.agent.memory.MemoryConfig;
 import io.agentscope.harness.agent.subagent.AgentSpecLoader;
 import io.agentscope.harness.agent.subagent.SubagentDeclaration;
 import io.agentscope.harness.agent.subagent.WorkspaceMode;
@@ -1156,6 +1157,49 @@ class HarnessAgentTest {
                                 .factory()
                                 .create(RuntimeContext.empty());
         assertNotNull(child.getCompactionHook(), "CompactionHook should be mirrored to GP child");
+    }
+
+    @Test
+    void generalPurpose_inheritsMemoryConfig_fromParent() throws Exception {
+        Files.createDirectories(workspace);
+
+        Model parentModel = stubModel("ok");
+        Model memoryModel = mock(Model.class);
+        when(memoryModel.getModelName()).thenReturn("memory-model");
+        ChatResponse memoryChunk =
+                new ChatResponse(
+                        "memory-id",
+                        List.of(TextBlock.builder().text("memory-done").build()),
+                        null,
+                        Map.of(),
+                        "stop");
+        when(memoryModel.stream(anyList(), anyList(), any())).thenReturn(Flux.just(memoryChunk));
+
+        MemoryConfig memoryConfig =
+                MemoryConfig.builder().model(memoryModel).consolidationMinGap(Duration.ofMinutes(1)).build();
+
+        List<SubagentEntry> entries =
+                HarnessAgent.builder()
+                        .model(parentModel)
+                        .workspace(workspace)
+                        .memory(memoryConfig)
+                        .buildSubagentEntries(workspace);
+
+        HarnessAgent child =
+                (HarnessAgent)
+                        entries.stream()
+                                .filter(e -> "general-purpose".equals(e.name()))
+                                .findFirst()
+                                .orElseThrow()
+                                .factory()
+                                .create(RuntimeContext.empty());
+
+        child
+                .call(userText("hi, keep this in memory"), RuntimeContext.empty())
+                .block();
+
+        verify(memoryModel).stream(anyList(), anyList(), any());
+        verify(parentModel).stream(anyList(), anyList(), any());
     }
 
     // =========================================================================

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/HarnessAgentTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/HarnessAgentTest.java
@@ -1226,7 +1226,7 @@ class HarnessAgentTest {
 
         child.call(userText("hi, no memory config"), RuntimeContext.empty()).block();
 
-        verify(parentModel).stream(any(), any(), any());
+        verify(parentModel, atLeast(1)).stream(any(), any(), any());
     }
 
     // =========================================================================

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/HarnessAgentTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/HarnessAgentTest.java
@@ -1200,7 +1200,7 @@ class HarnessAgentTest {
         child.call(userText("hi, keep this in memory"), RuntimeContext.empty()).block();
 
         verify(memoryModel).stream(any(), any(), any());
-        verify(parentModel).stream(any(), any(), any());
+        verify(parentModel, atLeast(2)).stream(any(), any(), any());
     }
 
     @Test

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/HarnessAgentTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/HarnessAgentTest.java
@@ -1203,6 +1203,32 @@ class HarnessAgentTest {
         verify(parentModel).stream(any(), any(), any());
     }
 
+    @Test
+    void generalPurpose_withoutMemoryConfig_usesParentModelOnly() throws Exception {
+        Files.createDirectories(workspace);
+
+        Model parentModel = stubModel("ok");
+
+        List<SubagentEntry> entries =
+                HarnessAgent.builder()
+                        .model(parentModel)
+                        .workspace(workspace)
+                        .buildSubagentEntries(workspace);
+
+        HarnessAgent child =
+                (HarnessAgent)
+                        entries.stream()
+                                .filter(e -> "general-purpose".equals(e.name()))
+                                .findFirst()
+                                .orElseThrow()
+                                .factory()
+                                .create(RuntimeContext.empty());
+
+        child.call(userText("hi, no memory config"), RuntimeContext.empty()).block();
+
+        verify(parentModel).stream(any(), any(), any());
+    }
+
     // =========================================================================
     // Multiple declarations → same definition workspace
     // =========================================================================

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/HarnessAgentTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/HarnessAgentTest.java
@@ -1199,8 +1199,8 @@ class HarnessAgentTest {
 
         child.call(userText("hi, keep this in memory"), RuntimeContext.empty()).block();
 
-        verify(memoryModel).stream(anyList(), anyList(), any());
-        verify(parentModel).stream(anyList(), anyList(), any());
+        verify(memoryModel).stream(any(), any(), any());
+        verify(parentModel).stream(any(), any(), any());
     }
 
     // =========================================================================

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/HarnessAgentTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/HarnessAgentTest.java
@@ -1200,7 +1200,7 @@ class HarnessAgentTest {
         child.call(userText("hi, keep this in memory"), RuntimeContext.empty()).block();
 
         verify(memoryModel).stream(any(), any(), any());
-        verify(parentModel, atLeast(2)).stream(any(), any(), any());
+        verify(parentModel, atLeast(1)).stream(any(), any(), any());
     }
 
     @Test


### PR DESCRIPTION
## Issue
Fixes #2549

## Describe the background, purpose, changes made, and how to test this PR
When building a general-purpose subagent, `HarnessAgentBuilderSupport` did not propagate `memoryConfig` from the root builder into the generated subagent factory. This causes behavior drift versus explicitly configured memory settings.

### Changes
- Capture `HarnessAgent.Builder#memoryConfig` into a local final variable.
- Pass the captured config into the general-purpose subagent via `sub.memory(capturedMemoryConfig)` during construction.

## Acceptance report
- [x] GitHub Java CI build passed on Ubuntu.
- [x] GitHub Java CI build passed on Windows.
- [x] Check License and Check Module Sync passed.
- [x] Codecov reports all modified and coverable lines covered by tests.
- [x] PR title follows the repository conventional-commit style: `fix(harness): propagate memoryConfig to general-purpose subagent`.
- [ ] `license/cla` remains pending until the contributor signs the CLA.

### How to test
- Create a harness with a general-purpose subagent and memory settings.
- Verify the general-purpose subagent observes the configured memory strategy and limits.

## Checklist
- [ ] Code has been formatted with `mvn spotless:apply`.
- [x] All GitHub CI tests are passing.
- [x] The changed behavior is covered by the passing CI and Codecov checks.
- [ ] Javadoc comments are complete and follow project conventions.
- [ ] Related documentation has been updated.
- [x] Code is ready for maintainer review.
