### PR TITLE
fix(harness): detach memory flush and maintenance from agent call response

### DIFF
--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/HarnessAgent.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/HarnessAgent.java
@@ -181,6 +181,9 @@ public class HarnessAgent implements Agent, AutoCloseable {
     private final SkillAuditLog skillAuditLog;
     private final MemoryConfig memoryConfig;
 
+    /** Closeable middlewares (e.g. memory flush/maintenance) drained during {@link #close()}. */
+    private final List<AutoCloseable> closeableMiddlewares;
+
     /** The subagent middleware (either SubagentsMiddleware or DynamicSubagentsMiddleware). */
     private final Object subagentMiddleware;
 
@@ -211,6 +214,7 @@ public class HarnessAgent implements Agent, AutoCloseable {
             SkillCurator skillCurator,
             SkillAuditLog skillAuditLog,
             MemoryConfig memoryConfig,
+            List<AutoCloseable> closeableMiddlewares,
             Object subagentMiddleware,
             DistributedStore distributedStore,
             WorkspacePathNormalizer pathNormalizer) {
@@ -229,6 +233,8 @@ public class HarnessAgent implements Agent, AutoCloseable {
         this.skillCurator = skillCurator;
         this.skillAuditLog = skillAuditLog;
         this.memoryConfig = memoryConfig != null ? memoryConfig : MemoryConfig.defaults();
+        this.closeableMiddlewares =
+                closeableMiddlewares != null ? List.copyOf(closeableMiddlewares) : List.of();
         this.subagentMiddleware = subagentMiddleware;
         this.distributedStore = distributedStore;
         this.pathNormalizer = pathNormalizer;
@@ -460,11 +466,23 @@ public class HarnessAgent implements Agent, AutoCloseable {
             shutdownTaskRepository();
         } finally {
             try {
-                if (ownedWorkspaceIndex != null) {
-                    ownedWorkspaceIndex.close();
+                // Drain detached memory flush/maintenance so async writes do not race with
+                // workspace teardown (e.g., temp workspace deletion in tests).
+                for (AutoCloseable mw : closeableMiddlewares) {
+                    try {
+                        mw.close();
+                    } catch (Exception e) {
+                        log.warn("Failed to close middleware", e);
+                    }
                 }
             } finally {
-                delegate.close();
+                try {
+                    if (ownedWorkspaceIndex != null) {
+                        ownedWorkspaceIndex.close();
+                    }
+                } finally {
+                    delegate.close();
+                }
             }
         }
     }
@@ -2425,6 +2443,7 @@ public class HarnessAgent implements Agent, AutoCloseable {
                                 wsManager, effectiveTranscriptStore, transcriptTenant));
             }
             Model memoryModel = memoryConfig.model() != null ? memoryConfig.model() : model;
+            List<AutoCloseable> pendingCloseableMiddlewares = new java.util.ArrayList<>();
             if (memoryModel != null && !disableMemoryHooks) {
                 IsolationScope effectiveIsolationScope = fsIsolationScope;
 
@@ -2432,14 +2451,17 @@ public class HarnessAgent implements Agent, AutoCloseable {
                         memoryConfig.flushPrompt() != null
                                 ? memoryConfig.flushPrompt()
                                 : MemoryFlushManager.DEFAULT_FLUSH_PROMPT;
-                inner.middleware(
+                MemoryFlushMiddleware memoryFlushMw =
                         new MemoryFlushMiddleware(
                                 wsManager,
                                 memoryModel,
                                 effectiveFlushPrompt,
                                 memoryConfig.flushTrigger(),
                                 effectiveIsolationScope,
-                                periodicGate));
+                                periodicGate,
+                                memoryConfig.asyncFlush());
+                inner.middleware(memoryFlushMw);
+                pendingCloseableMiddlewares.add(memoryFlushMw);
 
                 String effectiveConsolidationPrompt =
                         memoryConfig.consolidationPrompt() != null
@@ -2452,7 +2474,7 @@ public class HarnessAgent implements Agent, AutoCloseable {
                                 effectiveConsolidationPrompt,
                                 memoryConfig.consolidationMaxTokens(),
                                 distributedStore != null ? distributedStore.baseStore() : null);
-                inner.middleware(
+                MemoryMaintenanceMiddleware memoryMaintenanceMw =
                         new MemoryMaintenanceMiddleware(
                                 wsManager,
                                 consolidator,
@@ -2460,7 +2482,10 @@ public class HarnessAgent implements Agent, AutoCloseable {
                                 memoryConfig.sessionRetentionDays(),
                                 memoryConfig.consolidationMinGap(),
                                 effectiveIsolationScope,
-                                periodicGate));
+                                periodicGate,
+                                memoryConfig.asyncFlush());
+                inner.middleware(memoryMaintenanceMw);
+                pendingCloseableMiddlewares.add(memoryMaintenanceMw);
             }
             CompactionMiddleware compactionHook = null;
             if (!disableCompaction && compactionConfig != null) {
@@ -2824,6 +2849,7 @@ public class HarnessAgent implements Agent, AutoCloseable {
                     pendingSkillCurator,
                     pendingSkillAuditLog,
                     memoryConfig,
+                    pendingCloseableMiddlewares,
                     capturedSubagentMw,
                     distributedStore,
                     pathNormalizer);

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/memory/MemoryConfig.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/memory/MemoryConfig.java
@@ -147,6 +147,7 @@ public final class MemoryConfig {
     private final int dailyFileRetentionDays;
     private final int sessionRetentionDays;
     private final FlushTrigger flushTrigger;
+    private final boolean asyncFlush;
 
     private MemoryConfig(Builder b) {
         this.model = b.model;
@@ -157,6 +158,7 @@ public final class MemoryConfig {
         this.dailyFileRetentionDays = b.dailyFileRetentionDays;
         this.sessionRetentionDays = b.sessionRetentionDays;
         this.flushTrigger = b.flushTrigger;
+        this.asyncFlush = b.asyncFlush;
     }
 
     /**
@@ -206,6 +208,21 @@ public final class MemoryConfig {
         return flushTrigger;
     }
 
+    /**
+     * Whether memory flush and maintenance run detached from the agent response (default {@code
+     * true}, the pre-RC4 behavior restored by the latency fix). Set to {@code false} to make the
+     * response stream wait for the per-call memory persistence to finish — for callers that rely
+     * on "response completed == memory persisted" durability semantics.
+     *
+     * <p>Detached flushes are bounded: at most {@code 4} runs may be in flight per middleware
+     * instance; beyond that, new runs are skipped and logged. Because a flush always extracts
+     * from the full conversation context, a skipped run loses nothing permanently — the next
+     * successful flush covers the same messages.
+     */
+    public boolean asyncFlush() {
+        return asyncFlush;
+    }
+
     /** Returns a config equivalent to the harness's historical defaults. */
     public static MemoryConfig defaults() {
         return new Builder().build();
@@ -225,6 +242,7 @@ public final class MemoryConfig {
         private int dailyFileRetentionDays = DEFAULT_DAILY_FILE_RETENTION_DAYS;
         private int sessionRetentionDays = DEFAULT_SESSION_RETENTION_DAYS;
         private FlushTrigger flushTrigger = FlushTrigger.always();
+        private boolean asyncFlush = true;
 
         /**
          * Sets a dedicated model for memory operations (flush + consolidation),
@@ -328,6 +346,17 @@ public final class MemoryConfig {
                 throw new IllegalArgumentException("flushTrigger must not be null");
             }
             this.flushTrigger = flushTrigger;
+            return this;
+        }
+
+        /**
+         * Sets whether memory flush and maintenance run detached from the agent response.
+         * Defaults to {@code true}. Pass {@code false} to restore completion-order persistence
+         * (the response stream waits for the per-call memory work), for callers that rely on
+         * "response completed == memory persisted" durability semantics.
+         */
+        public Builder asyncFlush(boolean asyncFlush) {
+            this.asyncFlush = asyncFlush;
             return this;
         }
 

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/middleware/MemoryFlushMiddleware.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/middleware/MemoryFlushMiddleware.java
@@ -28,10 +28,14 @@ import io.agentscope.harness.agent.coordination.PeriodicGate;
 import io.agentscope.harness.agent.memory.MemoryConfig;
 import io.agentscope.harness.agent.memory.MemoryFlushManager;
 import io.agentscope.harness.agent.workspace.WorkspaceManager;
+import java.time.Duration;
 import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import reactor.core.Disposable;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Schedulers;
@@ -39,10 +43,21 @@ import reactor.core.scheduler.Schedulers;
 /**
  * Middleware that triggers memory flush and message offload at the end of each agent call.
  *
- * <p>Runs in {@link #onAgent}'s {@code doOnComplete} so long-term memories are extracted and
- * persisted after every call, even when conversation compaction was not triggered during that
- * call. When {@link CompactionMiddleware} is active, it handles flush/offload for the messages
- * it summarizes; this middleware covers the remaining tail of messages that were kept verbatim.
+ * <p>Runs in a genuinely detached, fire-and-forget fashion: the flush {@code Mono} is subscribed
+ * independently of the returned {@code Flux} (via {@code doOnComplete}) rather than being
+ * concatenated onto it, so callers that wait for the response to complete (e.g.
+ * {@code blockLast()}, {@code takeLast(1)}) are not delayed by flush work. Long-term memories are
+ * extracted and persisted after every call, even when conversation compaction was not triggered
+ * during that call. When {@link CompactionMiddleware} is active, it handles flush/offload for the
+ * messages it summarizes; this middleware covers the remaining tail of messages that were kept
+ * verbatim.
+ *
+ * <p>Detached flushes are bounded ({@link #MAX_PENDING_FLUSHES}): when the memory model is slow
+ * and the backlog is full, new flushes are skipped and logged rather than accumulating without
+ * bound. Skipping is safe because a flush always extracts from the full conversation context —
+ * the next successful flush covers the same messages. Callers that rely on "response completed ==
+ * memory persisted" durability can pass {@code asyncFlush=false} (via {@link
+ * MemoryConfig#asyncFlush()}) to chain the flush back onto the response stream.
  *
  * <p>Flush is gated by a {@link MemoryConfig.FlushTrigger}:
  * <ul>
@@ -66,7 +81,7 @@ import reactor.core.scheduler.Schedulers;
  *       the whole agent instance (prevents concurrent flush races on shared memory files).</li>
  * </ul>
  */
-public class MemoryFlushMiddleware implements HarnessRuntimeMiddleware {
+public class MemoryFlushMiddleware implements HarnessRuntimeMiddleware, AutoCloseable {
 
     private static final Logger log = LoggerFactory.getLogger(MemoryFlushMiddleware.class);
 
@@ -76,6 +91,30 @@ public class MemoryFlushMiddleware implements HarnessRuntimeMiddleware {
     private final MemoryConfig.FlushTrigger flushTrigger;
     private final IsolationScope isolationScope;
     private final PeriodicGate periodicGate;
+    private final boolean asyncFlush;
+
+    /** Upper bound on the flush LLM call, preventing a hung model from tying up a worker thread. */
+    static final Duration FLUSH_TIMEOUT = Duration.ofMinutes(5);
+
+    /** Upper bound {@link #close()} waits for outstanding fire-and-forget flushes to drain. */
+    static final Duration CLOSE_AWAIT_TIMEOUT = Duration.ofSeconds(5);
+
+    /**
+     * Upper bound on concurrently pending detached flushes. When the memory model is slow and
+     * this many flushes are still in flight, new ones are skipped and logged rather than
+     * accumulating without bound. Skipping is safe: a flush always extracts from the full
+     * conversation context, so the next successful flush covers the same messages.
+     */
+    static final int MAX_PENDING_FLUSHES = 4;
+
+    /**
+     * Tracks the {@link Disposable} of every fire-and-forget flush subscription that has been
+     * scheduled but not yet finished, so {@link #close()} can wait for them instead of leaving
+     * them racing against teardown of the workspace resources they read/write.
+     */
+    private final Set<Disposable> pending = ConcurrentHashMap.newKeySet();
+
+    private volatile boolean closed = false;
 
     public MemoryFlushMiddleware(WorkspaceManager workspaceManager, Model model) {
         this(
@@ -123,6 +162,32 @@ public class MemoryFlushMiddleware implements HarnessRuntimeMiddleware {
             MemoryConfig.FlushTrigger flushTrigger,
             IsolationScope isolationScope,
             PeriodicGate periodicGate) {
+        this(
+                workspaceManager,
+                model,
+                flushPrompt,
+                flushTrigger,
+                isolationScope,
+                periodicGate,
+                true);
+    }
+
+    /**
+     * Full constructor.
+     *
+     * @param asyncFlush whether the flush runs detached from the response stream (default {@code
+     *     true}). {@code false} restores completion-order persistence — the response waits for
+     *     the per-call flush, for callers relying on "response completed == memory persisted"
+     *     durability semantics.
+     */
+    public MemoryFlushMiddleware(
+            WorkspaceManager workspaceManager,
+            Model model,
+            String flushPrompt,
+            MemoryConfig.FlushTrigger flushTrigger,
+            IsolationScope isolationScope,
+            PeriodicGate periodicGate,
+            boolean asyncFlush) {
         this.workspaceManager = workspaceManager;
         this.model = model;
         this.flushPrompt =
@@ -131,6 +196,7 @@ public class MemoryFlushMiddleware implements HarnessRuntimeMiddleware {
                 flushTrigger != null ? flushTrigger : MemoryConfig.FlushTrigger.always();
         this.isolationScope = isolationScope != null ? isolationScope : IsolationScope.USER;
         this.periodicGate = periodicGate != null ? periodicGate : new LocalPeriodicGate();
+        this.asyncFlush = asyncFlush;
     }
 
     @Override
@@ -140,28 +206,127 @@ public class MemoryFlushMiddleware implements HarnessRuntimeMiddleware {
             AgentInput input,
             Function<AgentInput, Flux<AgentEvent>> next) {
         final RuntimeContext rc = ctx != null ? ctx : RuntimeContext.empty();
-        return next.apply(input)
-                .concatWith(
-                        Mono.defer(() -> doFlush(agent, rc))
-                                .subscribeOn(Schedulers.boundedElastic())
-                                .onErrorResume(
-                                        e -> {
-                                            log.warn("Memory flush failed: {}", e.getMessage());
-                                            return Mono.empty();
-                                        })
-                                .then(Mono.<AgentEvent>empty()));
+        Flux<AgentEvent> source = next.apply(input);
+        if (asyncFlush) {
+            return source.doOnComplete(() -> scheduleFlush(agent, rc));
+        }
+        return source.concatWith(Mono.defer(() -> syncFlush(agent, rc)).then(Mono.empty()));
     }
 
-    private Mono<Void> doFlush(Agent agent, RuntimeContext rc) {
+    /**
+     * Synchronous-mode flush chained onto the response stream via {@code concatWith}: the
+     * response's completion is delayed until the flush finishes, so callers waiting for the
+     * response observe persisted memory. Bounded by {@link #FLUSH_TIMEOUT} and error-swallowing
+     * so a slow or failing memory model can delay, but never fail, the completed response.
+     */
+    private Mono<Void> syncFlush(Agent agent, RuntimeContext rc) {
+        try {
+            FlushRequest request = captureFlushRequest(agent, rc);
+            if (request == null) {
+                return Mono.empty();
+            }
+            return doFlush(request)
+                    .timeout(FLUSH_TIMEOUT)
+                    .onErrorResume(
+                            e -> {
+                                log.warn("Synchronous memory flush failed", e);
+                                return Mono.empty();
+                            });
+        } catch (Exception e) {
+            log.warn("Failed to run synchronous memory flush", e);
+            return Mono.empty();
+        }
+    }
+
+    /**
+     * Fires the fire-and-forget flush {@code Mono} on {@code boundedElastic}, tracking its
+     * {@link Disposable} in {@link #pending} until it terminates so {@link #close()} can wait for
+     * it. No-ops once {@link #close()} has been called, so a call that races with shutdown
+     * doesn't spawn new untracked work.
+     *
+     * <p>The whole method body (snapshot capture of the RuntimeContext shallow copy plus the
+     * message copy, operator assembly, and subscribe) is wrapped in try/catch so that no
+     * exception can escape into the {@code doOnComplete} callback and turn an already-completed
+     * Flux into an error.
+     *
+     * <p>The {@code closed} flag and {@code pending} add are guarded by
+     * {@code synchronized(pending)}. The {@code pending} set (a ConcurrentHashMap key set) is
+     * reused as the mutex object to avoid allocating a separate lock; its own concurrency
+     * features are not relied upon for the closed-check/add atomicity.
+     */
+    private void scheduleFlush(Agent agent, RuntimeContext rc) {
+        Disposable[] holder = new Disposable[1];
+        // The whole body is wrapped in try/catch so that no exception (from capture, operator
+        // assembly, or subscribe) can escape into the doOnComplete callback and turn an
+        // already-completed Flux into an error.
+        try {
+            FlushRequest request = captureFlushRequest(agent, rc);
+            if (request == null) {
+                return;
+            }
+            // Subscribe and register inside one critical section: if the subscription were
+            // started outside the lock, a fast-completing flush could run doFinally (which
+            // removes the Disposable) before the scheduling thread executed pending.add,
+            // permanently leaking a terminated Disposable into pending and stalling close()'s
+            // drain until its timeout. doFinally reads holder[0] and removes under the same
+            // lock, so the add-before-remove ordering is also guaranteed to be VISIBLE (the
+            // holder write happens inside the lock, before its release; the read happens after
+            // acquiring it). subscribeOn(boundedElastic) ensures no callback ever runs on this
+            // thread, so the lock cannot self-deadlock.
+            synchronized (pending) {
+                if (closed) {
+                    return;
+                }
+                // Bound the detached backlog: with a slow memory model, skipping is safe because
+                // the next successful flush extracts from the full conversation context.
+                if (pending.size() >= MAX_PENDING_FLUSHES) {
+                    log.warn(
+                            "Memory flush backlog limit ({}) reached; skipping flush for this"
+                                    + " call",
+                            MAX_PENDING_FLUSHES);
+                    return;
+                }
+                Disposable d =
+                        Mono.defer(() -> doFlush(request))
+                                .subscribeOn(Schedulers.boundedElastic())
+                                .timeout(FLUSH_TIMEOUT)
+                                .onErrorResume(
+                                        e -> {
+                                            log.warn("Memory flush failed", e);
+                                            return Mono.empty();
+                                        })
+                                .doFinally(
+                                        sig -> {
+                                            synchronized (pending) {
+                                                if (holder[0] != null) {
+                                                    pending.remove(holder[0]);
+                                                }
+                                            }
+                                        })
+                                .subscribe();
+                holder[0] = d;
+                pending.add(d);
+            }
+        } catch (Exception e) {
+            log.warn("Failed to schedule memory flush", e);
+        }
+    }
+
+    private FlushRequest captureFlushRequest(Agent agent, RuntimeContext rc) {
         AgentState state = RuntimeContext.resolveAgentState(rc, agent);
         if (state == null) {
-            return Mono.empty();
+            return null;
         }
         List<Msg> messages = state.getContext();
         if (messages.isEmpty()) {
-            return Mono.empty();
+            return null;
         }
+        return new FlushRequest(RuntimeContext.builder().from(rc).build(), List.copyOf(messages));
+    }
 
+    private Mono<Void> doFlush(FlushRequest request) {
+        RuntimeContext rc = request.runtimeContext();
+        List<Msg> messages = request.messages();
         MemoryFlushManager flushManager =
                 new MemoryFlushManager(workspaceManager, model, flushPrompt);
 
@@ -174,16 +339,54 @@ public class MemoryFlushMiddleware implements HarnessRuntimeMiddleware {
                             .doOnSuccess(v -> log.debug("Memory flush completed"))
                             .onErrorResume(
                                     e -> {
-                                        log.warn("Memory flush failed: {}", e.getMessage());
+                                        log.warn("Memory flush failed", e);
                                         return Mono.empty();
                                     });
         } else {
             log.debug("Memory flush skipped (trigger={})", flushTrigger);
             flushMono = Mono.empty();
         }
-
-        // Message offload is owned by TranscriptMiddleware (independent of memory flush).
         return flushMono;
+    }
+
+    /**
+     * Waits (bounded by {@link #CLOSE_AWAIT_TIMEOUT}) for outstanding fire-and-forget flushes to
+     * finish, then disposes anything still outstanding. Intended to be called from {@code
+     * HarnessAgent#close()} so short-lived callers (tests using JUnit {@code @TempDir}, CLI runs,
+     * etc.) don't tear down the workspace while a detached flush write is still in flight.
+     *
+     * <p>The {@code closed} flag and {@code pending} add are guarded by {@code synchronized(pending)}
+     * so that a flush scheduled concurrently with close() is either fully tracked (and drained) or
+     * disposed immediately, but never lost.
+     */
+    @Override
+    public void close() {
+        synchronized (pending) {
+            closed = true;
+        }
+        long deadline = System.nanoTime() + CLOSE_AWAIT_TIMEOUT.toNanos();
+        while (!pending.isEmpty() && System.nanoTime() < deadline) {
+            try {
+                Thread.sleep(20);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                break;
+            }
+        }
+        for (Disposable d : pending) {
+            d.dispose();
+        }
+        pending.clear();
+    }
+
+    private record FlushRequest(RuntimeContext runtimeContext, List<Msg> messages) {}
+
+    /**
+     * Returns whether any fire-and-forget flush is currently in flight. Package-private, intended
+     * for tests that need to poll for quiescence instead of relying on a fixed sleep.
+     */
+    boolean hasPendingFlushes() {
+        return !pending.isEmpty();
     }
 
     /**

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/middleware/MemoryMaintenanceMiddleware.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/middleware/MemoryMaintenanceMiddleware.java
@@ -31,9 +31,12 @@ import io.agentscope.harness.agent.workspace.WorkspaceManager;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.LocalDate;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import reactor.core.Disposable;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Schedulers;
@@ -41,9 +44,11 @@ import reactor.core.scheduler.Schedulers;
 /**
  * Middleware that performs periodic memory maintenance after each agent call.
  *
- * <p>Fires on the agent invocation completion (via {@code onAgent concatWith}, after
- * {@link MemoryFlushMiddleware}) and is throttled by a configurable minimum gap so it
- * does not run on every single call.
+ * <p>Fires in a genuinely detached, fire-and-forget fashion: the maintenance {@code Mono} is
+ * subscribed independently of the returned {@code Flux} (via {@code doOnComplete}) rather than
+ * being concatenated onto it, so callers that wait for the response to complete (e.g.
+ * {@code blockLast()}, {@code takeLast(1)}) are not delayed by maintenance work. It is also
+ * throttled by a configurable minimum gap so it does not run on every single call.
  *
  * <p>Maintenance steps executed in order:
  * <ol>
@@ -63,12 +68,29 @@ import reactor.core.scheduler.Schedulers;
  *       the whole agent instance (prevents concurrent maintenance races on shared memory files).</li>
  * </ul>
  */
-public class MemoryMaintenanceMiddleware implements HarnessRuntimeMiddleware {
+public class MemoryMaintenanceMiddleware implements HarnessRuntimeMiddleware, AutoCloseable {
 
     private static final Logger log = LoggerFactory.getLogger(MemoryMaintenanceMiddleware.class);
 
     /** Default minimum gap between two maintenance runs. */
     public static final Duration DEFAULT_MIN_GAP = Duration.ofMinutes(30);
+
+    /**
+     * Upper bound on the consolidation LLM call. Set slightly below
+     * {@link #MAINTENANCE_TIMEOUT} so the error log can distinguish "consolidation itself
+     * timed out" from "the entire maintenance run timed out".
+     */
+    static final Duration CONSOLIDATION_TIMEOUT = Duration.ofMinutes(4).plusSeconds(30);
+
+    /** Upper bound on the entire maintenance run (file IO + LLM), consistent with flush. */
+    static final Duration MAINTENANCE_TIMEOUT = Duration.ofMinutes(5);
+
+    /**
+     * Upper bound on concurrently pending detached maintenance runs, symmetric to {@code
+     * MemoryFlushMiddleware#MAX_PENDING_FLUSHES}. Maintenance is throttle-gated so this is a
+     * defensive bound against a pathologically slow consolidator, not an expected state.
+     */
+    static final int MAX_PENDING_MAINTENANCE = 4;
 
     private final WorkspaceManager workspaceManager;
     private final MemoryConsolidator consolidator;
@@ -77,6 +99,20 @@ public class MemoryMaintenanceMiddleware implements HarnessRuntimeMiddleware {
     private final Duration minGap;
     private final IsolationScope isolationScope;
     private final PeriodicGate periodicGate;
+    private final boolean asyncMaintenance;
+
+    /** Upper bound {@link #close()} waits for outstanding fire-and-forget runs to drain. */
+    static final Duration CLOSE_AWAIT_TIMEOUT = Duration.ofSeconds(5);
+
+    /**
+     * Tracks the {@link Disposable} of every fire-and-forget maintenance subscription that has
+     * been scheduled but not yet finished, so {@link #close()} can wait for/dispose them instead
+     * of leaving them racing against teardown of the resources they read/write (e.g. a workspace
+     * directory being deleted).
+     */
+    private final Set<Disposable> pending = ConcurrentHashMap.newKeySet();
+
+    private volatile boolean closed = false;
 
     public MemoryMaintenanceMiddleware(
             WorkspaceManager workspaceManager,
@@ -119,6 +155,34 @@ public class MemoryMaintenanceMiddleware implements HarnessRuntimeMiddleware {
             Duration minGap,
             IsolationScope isolationScope,
             PeriodicGate periodicGate) {
+        this(
+                workspaceManager,
+                consolidator,
+                dailyFileRetentionDays,
+                sessionRetentionDays,
+                minGap,
+                isolationScope,
+                periodicGate,
+                true);
+    }
+
+    /**
+     * Full constructor.
+     *
+     * @param asyncMaintenance whether maintenance runs detached from the response stream
+     *     (default {@code true}). {@code false} restores completion-order persistence — the
+     *     response waits for the per-call maintenance check, mirroring {@code
+     *     MemoryFlushMiddleware}'s synchronous mode.
+     */
+    public MemoryMaintenanceMiddleware(
+            WorkspaceManager workspaceManager,
+            MemoryConsolidator consolidator,
+            int dailyFileRetentionDays,
+            int sessionRetentionDays,
+            Duration minGap,
+            IsolationScope isolationScope,
+            PeriodicGate periodicGate,
+            boolean asyncMaintenance) {
         this.workspaceManager = workspaceManager;
         this.consolidator = consolidator;
         this.dailyFileRetentionDays = dailyFileRetentionDays;
@@ -126,6 +190,7 @@ public class MemoryMaintenanceMiddleware implements HarnessRuntimeMiddleware {
         this.minGap = minGap != null ? minGap : DEFAULT_MIN_GAP;
         this.isolationScope = isolationScope != null ? isolationScope : IsolationScope.USER;
         this.periodicGate = periodicGate != null ? periodicGate : new LocalPeriodicGate();
+        this.asyncMaintenance = asyncMaintenance;
     }
 
     public MemoryMaintenanceMiddleware(
@@ -140,27 +205,150 @@ public class MemoryMaintenanceMiddleware implements HarnessRuntimeMiddleware {
             AgentInput input,
             Function<AgentInput, Flux<AgentEvent>> next) {
         final RuntimeContext rc = ctx != null ? ctx : RuntimeContext.empty();
-        return next.apply(input)
-                .concatWith(
-                        Mono.<AgentEvent>fromRunnable(() -> maybeRunMaintenance(rc))
+        // Snapshot the full RuntimeContext (shallow copy of attribute maps) at completion time —
+        // not eagerly here — so attributes added during the call are visible, matching the
+        // original rc-at-completion semantics. The copy makes the background task immune to
+        // concurrent mutations on the caller's attribute maps after the call completes, while
+        // preserving all fields that filesystem operations or NamespaceFactory implementations
+        // may depend on (not just userId/sessionId).
+        Flux<AgentEvent> source = next.apply(input);
+        if (asyncMaintenance) {
+            return source.doOnComplete(
+                    () -> scheduleMaintenance(RuntimeContext.builder().from(rc).build()));
+        }
+        // Sync mode: fromRunnable runs at subscription time — i.e. after the source completes —
+        // so the snapshot below is still taken at completion time, matching the async branch.
+        return source.concatWith(
+                Mono.fromRunnable(
+                                () ->
+                                        maybeRunMaintenance(
+                                                RuntimeContext.builder().from(rc).build()))
+                        .subscribeOn(Schedulers.boundedElastic())
+                        .timeout(MAINTENANCE_TIMEOUT)
+                        .onErrorResume(
+                                e -> {
+                                    log.warn("Synchronous memory maintenance failed", e);
+                                    return Mono.empty();
+                                })
+                        .then(Mono.empty()));
+    }
+
+    /**
+     * Fires the fire-and-forget maintenance {@code Mono} on {@code boundedElastic}, tracking its
+     * {@link Disposable} in {@link #pending} until it terminates so {@link #close()} can wait for
+     * it. No-ops once {@link #close()} has been called, so a call that races with shutdown
+     * doesn't spawn new untracked work.
+     *
+     * <p>The whole method body (RuntimeContext copy, operator assembly, and subscribe) is
+     * wrapped in try/catch so that no exception can escape into the {@code doOnComplete}
+     * callback and turn an already-completed Flux into an error.
+     *
+     * <p>The {@code closed} flag and {@code pending} add are guarded by
+     * {@code synchronized(pending)} so that maintenance scheduled concurrently with close() is
+     * either fully tracked (and drained) or disposed immediately, but never lost. The
+     * {@code pending} set (a ConcurrentHashMap key set) is reused as the mutex object to avoid
+     * allocating a separate lock; its own concurrency features are not relied upon for the
+     * closed-check/add atomicity.
+     */
+    private void scheduleMaintenance(RuntimeContext snapshot) {
+        Disposable[] holder = new Disposable[1];
+        // The whole body is wrapped in try/catch so that no exception (from the RuntimeContext
+        // copy, operator assembly, or subscribe) can escape into the doOnComplete callback and
+        // turn an already-completed Flux into an error.
+        try {
+            // Subscribe and register inside one critical section: if the subscription were
+            // started outside the lock, a fast-completing run (e.g. the throttle gate rejecting
+            // within its gap) could run doFinally (which removes the Disposable) before the
+            // scheduling thread executed pending.add, permanently leaking a terminated
+            // Disposable into pending and stalling close()'s drain until its timeout.
+            // doFinally reads holder[0] and removes under the same lock, so the
+            // add-before-remove ordering is also guaranteed to be VISIBLE (the holder write
+            // happens inside the lock, before its release; the read happens after acquiring
+            // it). subscribeOn(boundedElastic) ensures no callback ever runs on this thread, so
+            // the lock cannot self-deadlock.
+            synchronized (pending) {
+                if (closed) {
+                    return;
+                }
+                // Defensive bound, symmetric to the flush middleware's backlog cap.
+                if (pending.size() >= MAX_PENDING_MAINTENANCE) {
+                    log.warn(
+                            "Memory maintenance backlog limit ({}) reached; skipping this run",
+                            MAX_PENDING_MAINTENANCE);
+                    return;
+                }
+                Disposable d =
+                        Mono.fromRunnable(() -> maybeRunMaintenance(snapshot))
                                 .subscribeOn(Schedulers.boundedElastic())
+                                .timeout(MAINTENANCE_TIMEOUT)
                                 .onErrorResume(
                                         e -> {
-                                            log.warn(
-                                                    "Memory maintenance failed: {}",
-                                                    e.getMessage());
+                                            log.warn("Memory maintenance failed", e);
                                             return Mono.empty();
-                                        }));
+                                        })
+                                .doFinally(
+                                        sig -> {
+                                            synchronized (pending) {
+                                                if (holder[0] != null) {
+                                                    pending.remove(holder[0]);
+                                                }
+                                            }
+                                        })
+                                .subscribe();
+                holder[0] = d;
+                pending.add(d);
+            }
+        } catch (Exception e) {
+            log.warn("Failed to schedule memory maintenance", e);
+        }
+    }
+
+    /**
+     * Waits (bounded by {@link #CLOSE_AWAIT_TIMEOUT}) for outstanding fire-and-forget maintenance
+     * runs to finish, then disposes anything still outstanding. Intended to be called from {@code
+     * HarnessAgent#close()} so short-lived callers (tests using JUnit {@code @TempDir}, CLI runs,
+     * etc.) don't tear down the workspace while a detached maintenance write is still in flight.
+     */
+    @Override
+    public void close() {
+        synchronized (pending) {
+            closed = true;
+        }
+        long deadline = System.nanoTime() + CLOSE_AWAIT_TIMEOUT.toNanos();
+        while (!pending.isEmpty() && System.nanoTime() < deadline) {
+            try {
+                Thread.sleep(20);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                break;
+            }
+        }
+        for (Disposable d : pending) {
+            d.dispose();
+        }
+        pending.clear();
+    }
+
+    /**
+     * Returns whether any fire-and-forget maintenance is currently in flight. Package-private,
+     * intended for tests that need to poll for quiescence instead of relying on a fixed sleep.
+     */
+    boolean hasPendingMaintenance() {
+        return !pending.isEmpty();
     }
 
     private void maybeRunMaintenance(RuntimeContext rc) {
+        // rc is a shallow-copy snapshot taken at doOnComplete time (see onAgent), so attribute
+        // maps are independent of the caller's original context. Value objects within the maps
+        // are shared, but all identity fields (userId, sessionId) and attributes needed by
+        // filesystem namespace resolution are preserved.
         if (!periodicGate.tryClaim(compositeTimerKey(rc), minGap)) {
             return;
         }
         try {
             runMaintenance(rc);
         } catch (Exception e) {
-            log.warn("Memory maintenance failed: {}", e.getMessage());
+            log.warn("Memory maintenance failed", e);
         }
     }
 
@@ -243,9 +431,9 @@ public class MemoryMaintenanceMiddleware implements HarnessRuntimeMiddleware {
             return;
         }
         try {
-            consolidator.consolidate(rc).block();
+            consolidator.consolidate(rc).timeout(CONSOLIDATION_TIMEOUT).block();
         } catch (Exception e) {
-            log.warn("Memory consolidation failed: {}", e.getMessage());
+            log.warn("Memory consolidation failed", e);
         }
     }
 

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/middleware/MemoryFlushMiddlewareAsyncBehaviorTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/middleware/MemoryFlushMiddlewareAsyncBehaviorTest.java
@@ -1,0 +1,536 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.harness.agent.middleware;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import io.agentscope.core.agent.Agent;
+import io.agentscope.core.agent.RuntimeContext;
+import io.agentscope.core.event.AgentEvent;
+import io.agentscope.core.message.Msg;
+import io.agentscope.core.message.MsgRole;
+import io.agentscope.core.message.TextBlock;
+import io.agentscope.core.middleware.AgentInput;
+import io.agentscope.core.model.ChatResponse;
+import io.agentscope.core.model.Model;
+import io.agentscope.core.state.AgentState;
+import io.agentscope.harness.agent.IsolationScope;
+import io.agentscope.harness.agent.coordination.LocalPeriodicGate;
+import io.agentscope.harness.agent.memory.MemoryConfig;
+import io.agentscope.harness.agent.memory.MemoryFlushManager;
+import io.agentscope.harness.agent.workspace.WorkspaceManager;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import reactor.core.publisher.Flux;
+
+/**
+ * Regression tests for the issue where {@code onAgent} used {@code concatWith} to append
+ * memory flush onto the returned {@link Flux}, forcing callers that consume the response to
+ * completion (e.g. {@code blockLast()}, {@code takeLast(1)}) to wait for the full flush LLM
+ * call duration.
+ *
+ * <p>{@code onAgent} must detach flush so the returned Flux completes as soon as the
+ * underlying agent call completes, independent of how long the flush LLM takes.
+ *
+ * <p>See <a href="https://github.com/agentscope-ai/agentscope-java/issues/2276">issue #2276</a>
+ * and <a href="https://github.com/agentscope-ai/agentscope-java/issues/2225">issue #2225</a>.
+ */
+@Tag("unit")
+class MemoryFlushMiddlewareAsyncBehaviorTest {
+
+    @BeforeEach
+    void resetSharedTimerMap() {
+        LocalPeriodicGate.clearForTests();
+    }
+
+    /**
+     * The returned Flux must complete before a slow flush LLM finishes. With {@code concatWith}
+     * the Flux is held open until the LLM call completes, inflating latency by the full model
+     * round-trip (reported as 19-27s per call in production).
+     */
+    @Test
+    void onAgent_completesBeforeSlowFlushFinishes(@TempDir Path tmp) throws Exception {
+        WorkspaceManager wsm = new WorkspaceManager(tmp);
+
+        CountDownLatch flushStarted = new CountDownLatch(1);
+        CountDownLatch releaseFlush = new CountDownLatch(1);
+        Model slowModel = mock(Model.class);
+        when(slowModel.stream(any(), any(), any()))
+                .thenAnswer(
+                        inv ->
+                                Flux.<ChatResponse>create(
+                                        sink -> {
+                                            flushStarted.countDown();
+                                            try {
+                                                releaseFlush.await(5, TimeUnit.SECONDS);
+                                            } catch (InterruptedException e) {
+                                                Thread.currentThread().interrupt();
+                                            }
+                                            sink.complete();
+                                        }));
+
+        MemoryFlushMiddleware mw =
+                new MemoryFlushMiddleware(
+                        wsm,
+                        slowModel,
+                        MemoryFlushManager.DEFAULT_FLUSH_PROMPT,
+                        MemoryConfig.FlushTrigger.always());
+
+        RuntimeContext rc = RuntimeContext.builder().sessionId("s1").userId("u1").build();
+        rc.setAgentState(stateWithMessages(userMsg("hello")));
+
+        AgentInput input = new AgentInput(List.of(userMsg("hello")));
+
+        long start = System.nanoTime();
+        List<AgentEvent> events =
+                mw.onAgent((Agent) null, rc, input, in -> Flux.<AgentEvent>empty())
+                        .collectList()
+                        .block(Duration.ofSeconds(5));
+        long elapsedMs = (System.nanoTime() - start) / 1_000_000;
+
+        assertTrue(events != null && events.isEmpty());
+        assertTrue(
+                elapsedMs < 1000,
+                () ->
+                        "onAgent should complete before flush finishes, but took "
+                                + elapsedMs
+                                + "ms");
+        assertTrue(
+                flushStarted.await(2, TimeUnit.SECONDS),
+                "flush should have started on a detached background thread");
+
+        releaseFlush.countDown();
+    }
+
+    /**
+     * A flush error must not propagate to the returned Flux. With detach, the error is caught
+     * inside the background subscription and logged, never reaching the caller.
+     */
+    @Test
+    void onAgent_flushError_doesNotPropagateToFlux(@TempDir Path tmp) throws Exception {
+        WorkspaceManager wsm = new WorkspaceManager(tmp);
+        Model errorModel = mock(Model.class);
+        when(errorModel.stream(any(), any(), any()))
+                .thenReturn(Flux.error(new RuntimeException("flush LLM failed")));
+
+        MemoryFlushMiddleware mw =
+                new MemoryFlushMiddleware(
+                        wsm,
+                        errorModel,
+                        MemoryFlushManager.DEFAULT_FLUSH_PROMPT,
+                        MemoryConfig.FlushTrigger.always());
+
+        RuntimeContext rc = RuntimeContext.builder().sessionId("s1").userId("u1").build();
+        rc.setAgentState(stateWithMessages(userMsg("hello")));
+
+        AgentInput input = new AgentInput(List.of(userMsg("hello")));
+
+        // Should complete normally, not error
+        List<AgentEvent> events =
+                mw.onAgent((Agent) null, rc, input, in -> Flux.<AgentEvent>empty())
+                        .collectList()
+                        .block(Duration.ofSeconds(5));
+
+        assertTrue(events != null && events.isEmpty());
+    }
+
+    @Test
+    void onAgent_noMessages_completesImmediately(@TempDir Path tmp) throws Exception {
+        WorkspaceManager wsm = new WorkspaceManager(tmp);
+        Model model = mock(Model.class);
+
+        MemoryFlushMiddleware mw =
+                new MemoryFlushMiddleware(
+                        wsm,
+                        model,
+                        MemoryFlushManager.DEFAULT_FLUSH_PROMPT,
+                        MemoryConfig.FlushTrigger.always());
+
+        RuntimeContext rc = RuntimeContext.builder().sessionId("s1").userId("u1").build();
+        rc.setAgentState(AgentState.builder().sessionId("s1").build());
+
+        AgentInput input = new AgentInput(List.of());
+
+        long start = System.nanoTime();
+        List<AgentEvent> events =
+                mw.onAgent((Agent) null, rc, input, in -> Flux.<AgentEvent>empty())
+                        .collectList()
+                        .block(Duration.ofSeconds(5));
+        long elapsedMs = (System.nanoTime() - start) / 1_000_000;
+
+        assertTrue(events != null && events.isEmpty());
+        assertTrue(elapsedMs < 500, "should complete immediately with no messages to flush");
+    }
+
+    @Test
+    void onAgent_afterClose_doesNotScheduleNewFlush(@TempDir Path tmp) throws Exception {
+        WorkspaceManager wsm = new WorkspaceManager(tmp);
+        Model model = mock(Model.class);
+        when(model.stream(any(), any(), any())).thenReturn(Flux.empty());
+
+        MemoryFlushMiddleware mw =
+                new MemoryFlushMiddleware(
+                        wsm,
+                        model,
+                        MemoryFlushManager.DEFAULT_FLUSH_PROMPT,
+                        MemoryConfig.FlushTrigger.always());
+
+        // close() with nothing in flight returns immediately but marks the middleware closed.
+        mw.close();
+
+        RuntimeContext rc = RuntimeContext.builder().sessionId("s1").userId("u1").build();
+        rc.setAgentState(stateWithMessages(userMsg("hello")));
+        AgentInput input = new AgentInput(List.of(userMsg("hello")));
+
+        List<AgentEvent> events =
+                mw.onAgent((Agent) null, rc, input, in -> Flux.<AgentEvent>empty())
+                        .collectList()
+                        .block(Duration.ofSeconds(5));
+        assertTrue(events != null && events.isEmpty());
+
+        // Poll for the background subscription to settle, then verify no model interaction.
+        awaitPendingSettled(mw, Duration.ofSeconds(2));
+        verifyNoInteractions(model);
+    }
+
+    @Test
+    void close_waitsForPendingFlush_thenReturns(@TempDir Path tmp) throws Exception {
+        WorkspaceManager wsm = new WorkspaceManager(tmp);
+
+        CountDownLatch releaseFlush = new CountDownLatch(1);
+        AtomicBoolean flushCompleted = new AtomicBoolean(false);
+        Model slowModel = mock(Model.class);
+        when(slowModel.stream(any(), any(), any()))
+                .thenAnswer(
+                        inv ->
+                                Flux.<ChatResponse>create(
+                                        sink -> {
+                                            try {
+                                                releaseFlush.await(5, TimeUnit.SECONDS);
+                                            } catch (InterruptedException e) {
+                                                Thread.currentThread().interrupt();
+                                            }
+                                            flushCompleted.set(true);
+                                            sink.complete();
+                                        }));
+
+        MemoryFlushMiddleware mw =
+                new MemoryFlushMiddleware(
+                        wsm,
+                        slowModel,
+                        MemoryFlushManager.DEFAULT_FLUSH_PROMPT,
+                        MemoryConfig.FlushTrigger.always());
+
+        RuntimeContext rc = RuntimeContext.builder().sessionId("s1").userId("u1").build();
+        rc.setAgentState(stateWithMessages(userMsg("hello")));
+        AgentInput input = new AgentInput(List.of(userMsg("hello")));
+
+        // Trigger a flush (detached, running in background)
+        mw.onAgent((Agent) null, rc, input, in -> Flux.<AgentEvent>empty())
+                .collectList()
+                .block(Duration.ofSeconds(5));
+
+        // Release the flush so close() can drain it
+        releaseFlush.countDown();
+
+        // close() should return within the await timeout (flush completes quickly after release)
+        long start = System.nanoTime();
+        mw.close();
+        long elapsedMs = (System.nanoTime() - start) / 1_000_000;
+
+        assertTrue(
+                elapsedMs < 3000,
+                "close() should return promptly after flush completes, took " + elapsedMs + "ms");
+        assertTrue(flushCompleted.get(), "flush should have completed before close() returned");
+    }
+
+    /**
+     * When the flush LLM hangs indefinitely, close() must still return within CLOSE_AWAIT_TIMEOUT
+     * by disposing the outstanding subscription. This verifies the timeout+dispose safety net
+     * works without waiting the full 5-minute FLUSH_TIMEOUT.
+     */
+    @Test
+    void close_disposesHungFlush_andReturnsPromptly(@TempDir Path tmp) throws Exception {
+        WorkspaceManager wsm = new WorkspaceManager(tmp);
+
+        Model hangingModel = mock(Model.class);
+        when(hangingModel.stream(any(), any(), any()))
+                .thenAnswer(inv -> Flux.<ChatResponse>never());
+
+        MemoryFlushMiddleware mw =
+                new MemoryFlushMiddleware(
+                        wsm,
+                        hangingModel,
+                        MemoryFlushManager.DEFAULT_FLUSH_PROMPT,
+                        MemoryConfig.FlushTrigger.always());
+
+        RuntimeContext rc = RuntimeContext.builder().sessionId("s1").userId("u1").build();
+        rc.setAgentState(stateWithMessages(userMsg("hello")));
+        AgentInput input = new AgentInput(List.of(userMsg("hello")));
+
+        // Trigger a flush that will hang (model never returns)
+        mw.onAgent((Agent) null, rc, input, in -> Flux.<AgentEvent>empty())
+                .collectList()
+                .block(Duration.ofSeconds(5));
+
+        assertTrue(mw.hasPendingFlushes(), "flush should be pending (hanging)");
+
+        // close() should dispose the hung flush and return within the await timeout (5s)
+        long start = System.nanoTime();
+        mw.close();
+        long elapsedMs = (System.nanoTime() - start) / 1_000_000;
+
+        assertTrue(
+                elapsedMs < 6000,
+                "close() should return within CLOSE_AWAIT_TIMEOUT even with hung flush, took "
+                        + elapsedMs
+                        + "ms");
+        assertFalse(mw.hasPendingFlushes(), "no pending flushes should remain after close()");
+    }
+
+    /**
+     * Fast-completing flushes must not leak terminated Disposables into pending. Regression
+     * guard for the subscribe-then-add race: with subscribe() outside the critical section, a
+     * flush completing between subscribe() and pending.add() ran doFinally before the entry was
+     * registered, leaving a dead Disposable in pending that stalled close()'s drain for its full
+     * timeout. Scheduling many instant flushes makes the old race highly likely to reproduce;
+     * the fixed single-lock pattern keeps pending consistent on every iteration.
+     */
+    @Test
+    void rapidFastCompletingFlushes_leaveNoTerminatedEntriesInPending(@TempDir Path tmp)
+            throws Exception {
+        WorkspaceManager wsm = new WorkspaceManager(tmp);
+        Model instantModel = mock(Model.class);
+        when(instantModel.stream(any(), any(), any())).thenReturn(Flux.empty());
+
+        MemoryFlushMiddleware mw =
+                new MemoryFlushMiddleware(
+                        wsm,
+                        instantModel,
+                        MemoryFlushManager.DEFAULT_FLUSH_PROMPT,
+                        MemoryConfig.FlushTrigger.always());
+
+        RuntimeContext rc = RuntimeContext.builder().sessionId("s1").userId("u1").build();
+        rc.setAgentState(stateWithMessages(userMsg("hello")));
+        AgentInput input = new AgentInput(List.of(userMsg("hello")));
+
+        for (int i = 0; i < 50; i++) {
+            mw.onAgent((Agent) null, rc, input, in -> Flux.<AgentEvent>empty())
+                    .collectList()
+                    .block(Duration.ofSeconds(5));
+        }
+
+        // If any terminated Disposable leaked into pending, this polls to its 2s timeout and
+        // the assertFalse inside fails.
+        awaitPendingSettled(mw, Duration.ofSeconds(2));
+    }
+
+    /**
+     * Synchronous mode (asyncFlush=false) must chain the flush onto the response: the response
+     * cannot complete before the flush model call has finished. This is the opt-out path for
+     * callers relying on "response completed == memory persisted" durability semantics.
+     */
+    @Test
+    void onAgent_syncMode_waitsForFlush(@TempDir Path tmp) throws Exception {
+        WorkspaceManager wsm = new WorkspaceManager(tmp);
+
+        CountDownLatch flushStarted = new CountDownLatch(1);
+        CountDownLatch releaseFlush = new CountDownLatch(1);
+        AtomicBoolean flushFinished = new AtomicBoolean(false);
+        Model slowModel = mock(Model.class);
+        when(slowModel.stream(any(), any(), any()))
+                .thenAnswer(
+                        inv ->
+                                Flux.<ChatResponse>create(
+                                        sink -> {
+                                            flushStarted.countDown();
+                                            try {
+                                                releaseFlush.await(5, TimeUnit.SECONDS);
+                                            } catch (InterruptedException e) {
+                                                Thread.currentThread().interrupt();
+                                            }
+                                            flushFinished.set(true);
+                                            sink.complete();
+                                        }));
+        // Auto-release shortly after the flush starts so the response can finish without
+        // external coordination; finished is only set after the release, so observing it
+        // post-block proves the response waited for the flush.
+        Thread releaser =
+                new Thread(
+                        () -> {
+                            try {
+                                flushStarted.await(5, TimeUnit.SECONDS);
+                                Thread.sleep(200);
+                            } catch (InterruptedException e) {
+                                Thread.currentThread().interrupt();
+                            }
+                            releaseFlush.countDown();
+                        });
+        releaser.setDaemon(true);
+        releaser.start();
+
+        MemoryFlushMiddleware mw =
+                new MemoryFlushMiddleware(
+                        wsm,
+                        slowModel,
+                        MemoryFlushManager.DEFAULT_FLUSH_PROMPT,
+                        MemoryConfig.FlushTrigger.always(),
+                        IsolationScope.USER,
+                        new LocalPeriodicGate(),
+                        false);
+
+        RuntimeContext rc = RuntimeContext.builder().sessionId("s1").userId("u1").build();
+        rc.setAgentState(stateWithMessages(userMsg("hello")));
+        AgentInput input = new AgentInput(List.of(userMsg("hello")));
+
+        List<AgentEvent> events =
+                mw.onAgent((Agent) null, rc, input, in -> Flux.<AgentEvent>empty())
+                        .collectList()
+                        .block(Duration.ofSeconds(5));
+
+        assertTrue(events != null && events.isEmpty());
+        assertTrue(
+                flushFinished.get(),
+                "sync mode: response completed before the flush model call finished");
+    }
+
+    /**
+     * The detached backlog must be bounded: with a hung memory model, at most
+     * MAX_PENDING_FLUSHES flushes may be in flight; further calls skip scheduling instead of
+     * accumulating without bound. Skipped flushes are safe — the next successful flush extracts
+     * from the full conversation context.
+     */
+    @Test
+    void scheduleFlush_backlogLimit_skipsBeyondCap(@TempDir Path tmp) throws Exception {
+        WorkspaceManager wsm = new WorkspaceManager(tmp);
+
+        CountDownLatch releaseFlush = new CountDownLatch(1);
+        AtomicInteger modelInvocations = new AtomicInteger();
+        Model hungModel = mock(Model.class);
+        when(hungModel.stream(any(), any(), any()))
+                .thenAnswer(
+                        inv ->
+                                Flux.<ChatResponse>create(
+                                        sink -> {
+                                            modelInvocations.incrementAndGet();
+                                            try {
+                                                releaseFlush.await(30, TimeUnit.SECONDS);
+                                            } catch (InterruptedException e) {
+                                                Thread.currentThread().interrupt();
+                                            }
+                                            sink.complete();
+                                        }));
+
+        MemoryFlushMiddleware mw =
+                new MemoryFlushMiddleware(
+                        wsm,
+                        hungModel,
+                        MemoryFlushManager.DEFAULT_FLUSH_PROMPT,
+                        MemoryConfig.FlushTrigger.always());
+
+        RuntimeContext rc = RuntimeContext.builder().sessionId("s1").userId("u1").build();
+        rc.setAgentState(stateWithMessages(userMsg("hello")));
+        AgentInput input = new AgentInput(List.of(userMsg("hello")));
+
+        for (int i = 0; i < MemoryFlushMiddleware.MAX_PENDING_FLUSHES; i++) {
+            mw.onAgent((Agent) null, rc, input, in -> Flux.<AgentEvent>empty())
+                    .collectList()
+                    .block(Duration.ofSeconds(5));
+        }
+
+        // Wait until the cap is fully occupied (all four flushes reached the model), then fire
+        // two more completing calls — they must skip scheduling rather than queue more work.
+        long deadline = System.nanoTime() + Duration.ofSeconds(5).toNanos();
+        while (modelInvocations.get() < MemoryFlushMiddleware.MAX_PENDING_FLUSHES
+                && System.nanoTime() < deadline) {
+            Thread.sleep(10);
+        }
+        for (int i = 0; i < 2; i++) {
+            mw.onAgent((Agent) null, rc, input, in -> Flux.<AgentEvent>empty())
+                    .collectList()
+                    .block(Duration.ofSeconds(5));
+        }
+        Thread.sleep(300);
+
+        assertEquals(
+                MemoryFlushMiddleware.MAX_PENDING_FLUSHES,
+                modelInvocations.get(),
+                "flushes beyond the backlog cap must be skipped, not queued");
+
+        releaseFlush.countDown();
+        mw.close();
+    }
+
+    /** The config flag defaults to detached flush (the restored pre-RC4 behavior). */
+    @Test
+    void memoryConfig_asyncFlush_defaultsTrue_andOptOut() {
+        assertTrue(MemoryConfig.defaults().asyncFlush(), "asyncFlush should default to true");
+        assertTrue(MemoryConfig.builder().build().asyncFlush(), "builder default should be true");
+        assertFalse(
+                MemoryConfig.builder().asyncFlush(false).build().asyncFlush(),
+                "explicit false must be honored");
+    }
+
+    // ── helpers ──────────────────────────────────────────────────────────────
+
+    /**
+     * Polls until the middleware has no pending background subscriptions. Throws
+     * AssertionError if the timeout expires with pending work still in flight, so a
+     * slow CI cannot silently mask a scheduling bug.
+     */
+    private static void awaitPendingSettled(MemoryFlushMiddleware mw, Duration timeout)
+            throws InterruptedException {
+        long deadline = System.nanoTime() + timeout.toNanos();
+        while (System.nanoTime() < deadline) {
+            if (!mw.hasPendingFlushes()) {
+                return;
+            }
+            Thread.sleep(10);
+        }
+        assertFalse(mw.hasPendingFlushes(), "pending flushes should have settled");
+    }
+
+    private static Msg userMsg(String text) {
+        return Msg.builder()
+                .name("user")
+                .role(MsgRole.USER)
+                .content(List.of(TextBlock.builder().text(text).build()))
+                .build();
+    }
+
+    private static AgentState stateWithMessages(Msg... msgs) {
+        AgentState.Builder b = AgentState.builder().sessionId("s1");
+        for (Msg m : msgs) {
+            b.addMessage(m);
+        }
+        return b.build();
+    }
+}

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/middleware/MemoryMaintenanceMiddlewareAsyncBehaviorTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/middleware/MemoryMaintenanceMiddlewareAsyncBehaviorTest.java
@@ -1,0 +1,381 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.harness.agent.middleware;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import io.agentscope.core.agent.Agent;
+import io.agentscope.core.agent.RuntimeContext;
+import io.agentscope.core.event.AgentEvent;
+import io.agentscope.core.message.Msg;
+import io.agentscope.core.message.MsgRole;
+import io.agentscope.core.message.TextBlock;
+import io.agentscope.core.middleware.AgentInput;
+import io.agentscope.harness.agent.coordination.LocalPeriodicGate;
+import io.agentscope.harness.agent.memory.MemoryConsolidator;
+import io.agentscope.harness.agent.workspace.WorkspaceManager;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+/**
+ * Regression tests for the issue where {@code onAgent} used {@code concatWith} to append memory
+ * maintenance onto the returned {@link Flux}, forcing callers that consume the response to
+ * completion (e.g. {@code blockLast()}, {@code takeLast(1)}) to wait for the full consolidation
+ * LLM call inside {@code consolidateMemory()}.
+ *
+ * <p>{@code onAgent} must detach maintenance so the returned Flux completes as soon as the
+ * underlying agent call completes, independent of how long maintenance takes.
+ *
+ * <p>See <a href="https://github.com/agentscope-ai/agentscope-java/issues/2225">issue #2225</a>
+ * and <a href="https://github.com/agentscope-ai/agentscope-java/issues/2276">issue #2276</a>.
+ */
+@Tag("unit")
+class MemoryMaintenanceMiddlewareAsyncBehaviorTest {
+
+    @BeforeEach
+    void resetSharedTimerMap() {
+        LocalPeriodicGate.clearForTests();
+    }
+
+    /**
+     * The returned Flux must complete before a slow consolidation finishes. With
+     * {@code concatWith} the Flux is held open until {@code consolidate().block()} returns,
+     * inflating latency by the full model round-trip (reported as ~44s in production).
+     */
+    @Test
+    void onAgent_completesBeforeSlowConsolidationFinishes(@TempDir Path tmp) throws Exception {
+        WorkspaceManager wsm = new WorkspaceManager(tmp);
+
+        CountDownLatch consolidationStarted = new CountDownLatch(1);
+        CountDownLatch releaseConsolidation = new CountDownLatch(1);
+        MemoryConsolidator consolidator = mock(MemoryConsolidator.class);
+        when(consolidator.consolidate(any()))
+                .thenAnswer(
+                        invocation ->
+                                Mono.<Void>fromRunnable(
+                                        () -> {
+                                            consolidationStarted.countDown();
+                                            await(releaseConsolidation);
+                                        }));
+
+        MemoryMaintenanceMiddleware mw = new MemoryMaintenanceMiddleware(wsm, consolidator);
+        AgentInput input = new AgentInput(List.of(userMsg("hi")));
+
+        long start = System.nanoTime();
+        List<AgentEvent> events =
+                mw.onAgent(
+                                (Agent) null,
+                                RuntimeContext.empty(),
+                                input,
+                                in -> Flux.<AgentEvent>empty())
+                        .collectList()
+                        .block(Duration.ofSeconds(5));
+        long elapsedMs = (System.nanoTime() - start) / 1_000_000;
+
+        assertTrue(events != null && events.isEmpty());
+        assertTrue(
+                elapsedMs < 1000,
+                () ->
+                        "onAgent should complete before consolidation finishes, but took "
+                                + elapsedMs
+                                + "ms");
+        assertTrue(
+                consolidationStarted.await(2, TimeUnit.SECONDS),
+                "consolidation should have started on a detached background thread");
+
+        releaseConsolidation.countDown();
+    }
+
+    /**
+     * A maintenance error must not propagate to the returned Flux. With detach, the error is
+     * caught inside the background subscription and logged, never reaching the caller.
+     */
+    @Test
+    void onAgent_maintenanceError_doesNotPropagateToFlux(@TempDir Path tmp) throws Exception {
+        WorkspaceManager wsm = new WorkspaceManager(tmp);
+        MemoryConsolidator consolidator = mock(MemoryConsolidator.class);
+        when(consolidator.consolidate(any()))
+                .thenReturn(Mono.error(new RuntimeException("consolidation LLM failed")));
+
+        MemoryMaintenanceMiddleware mw = new MemoryMaintenanceMiddleware(wsm, consolidator);
+        AgentInput input = new AgentInput(List.of(userMsg("hi")));
+
+        List<AgentEvent> events =
+                mw.onAgent(
+                                (Agent) null,
+                                RuntimeContext.empty(),
+                                input,
+                                in -> Flux.<AgentEvent>empty())
+                        .collectList()
+                        .block(Duration.ofSeconds(5));
+
+        assertTrue(events != null && events.isEmpty());
+    }
+
+    @Test
+    void onAgent_afterClose_doesNotScheduleNewMaintenance(@TempDir Path tmp) throws Exception {
+        WorkspaceManager wsm = new WorkspaceManager(tmp);
+        MemoryConsolidator consolidator = mock(MemoryConsolidator.class);
+        MemoryMaintenanceMiddleware mw = new MemoryMaintenanceMiddleware(wsm, consolidator);
+
+        // Nothing in flight, so close() returns immediately but marks the middleware closed.
+        mw.close();
+
+        AgentInput input = new AgentInput(List.of(userMsg("hi")));
+        List<AgentEvent> events =
+                mw.onAgent(
+                                (Agent) null,
+                                RuntimeContext.empty(),
+                                input,
+                                in -> Flux.<AgentEvent>empty())
+                        .collectList()
+                        .block(Duration.ofSeconds(5));
+        assertTrue(events != null && events.isEmpty());
+
+        // Poll for the background subscription to settle, then verify no consolidator
+        // interaction.
+        awaitPendingSettled(mw, Duration.ofSeconds(2));
+        verifyNoInteractions(consolidator);
+    }
+
+    @Test
+    void close_waitsForPendingMaintenance_thenReturns(@TempDir Path tmp) throws Exception {
+        WorkspaceManager wsm = new WorkspaceManager(tmp);
+
+        CountDownLatch releaseConsolidation = new CountDownLatch(1);
+        AtomicBoolean consolidationCompleted = new AtomicBoolean(false);
+        MemoryConsolidator consolidator = mock(MemoryConsolidator.class);
+        when(consolidator.consolidate(any()))
+                .thenAnswer(
+                        invocation ->
+                                Mono.<Void>fromRunnable(
+                                        () -> {
+                                            try {
+                                                releaseConsolidation.await(5, TimeUnit.SECONDS);
+                                            } catch (InterruptedException e) {
+                                                Thread.currentThread().interrupt();
+                                            }
+                                            consolidationCompleted.set(true);
+                                        }));
+
+        MemoryMaintenanceMiddleware mw = new MemoryMaintenanceMiddleware(wsm, consolidator);
+        AgentInput input = new AgentInput(List.of(userMsg("hi")));
+
+        // Trigger maintenance (detached, running in background)
+        mw.onAgent((Agent) null, RuntimeContext.empty(), input, in -> Flux.<AgentEvent>empty())
+                .collectList()
+                .block(Duration.ofSeconds(5));
+
+        // Release consolidation so close() can drain it
+        releaseConsolidation.countDown();
+
+        long start = System.nanoTime();
+        mw.close();
+        long elapsedMs = (System.nanoTime() - start) / 1_000_000;
+
+        assertTrue(
+                elapsedMs < 3000,
+                "close() should return promptly after maintenance completes, took "
+                        + elapsedMs
+                        + "ms");
+        assertTrue(
+                consolidationCompleted.get(),
+                "consolidation should have completed before close() returned");
+    }
+
+    /**
+     * When consolidation hangs indefinitely, close() must still return within
+     * CLOSE_AWAIT_TIMEOUT by disposing the outstanding subscription. This verifies the
+     * timeout+dispose safety net works without waiting the full 5-minute
+     * CONSOLIDATION_TIMEOUT.
+     */
+    @Test
+    void close_disposesHungConsolidation_andReturnsPromptly(@TempDir Path tmp) throws Exception {
+        WorkspaceManager wsm = new WorkspaceManager(tmp);
+        MemoryConsolidator consolidator = mock(MemoryConsolidator.class);
+        when(consolidator.consolidate(any())).thenReturn(Mono.never());
+
+        MemoryMaintenanceMiddleware mw = new MemoryMaintenanceMiddleware(wsm, consolidator);
+        AgentInput input = new AgentInput(List.of(userMsg("hi")));
+
+        // Trigger maintenance that will hang (consolidation never returns)
+        mw.onAgent((Agent) null, RuntimeContext.empty(), input, in -> Flux.<AgentEvent>empty())
+                .collectList()
+                .block(Duration.ofSeconds(5));
+
+        assertTrue(mw.hasPendingMaintenance(), "maintenance should be pending (hanging)");
+
+        // close() should dispose the hung maintenance and return within the await timeout (5s)
+        long start = System.nanoTime();
+        mw.close();
+        long elapsedMs = (System.nanoTime() - start) / 1_000_000;
+
+        assertTrue(
+                elapsedMs < 6000,
+                "close() should return within CLOSE_AWAIT_TIMEOUT even with hung consolidation,"
+                        + " took "
+                        + elapsedMs
+                        + "ms");
+        assertFalse(
+                mw.hasPendingMaintenance(), "no pending maintenance should remain after close()");
+    }
+
+    /**
+     * Fast-completing maintenance runs must not leak terminated Disposables into pending.
+     * Regression guard for the subscribe-then-add race: with subscribe() outside the critical
+     * section, a run rejected by the throttle gate (microsecond completion) could run doFinally
+     * before the scheduling thread executed pending.add, leaving a dead Disposable in pending
+     * that stalled close()'s drain for its full timeout. Scheduling many instant runs makes the
+     * old race highly likely to reproduce; the fixed single-lock pattern keeps pending
+     * consistent on every iteration.
+     */
+    @Test
+    void rapidFastCompletingMaintenance_leavesNoTerminatedEntriesInPending(@TempDir Path tmp)
+            throws Exception {
+        WorkspaceManager wsm = new WorkspaceManager(tmp);
+        MemoryConsolidator consolidator = mock(MemoryConsolidator.class);
+        when(consolidator.consolidate(any())).thenReturn(Mono.empty());
+
+        MemoryMaintenanceMiddleware mw = new MemoryMaintenanceMiddleware(wsm, consolidator);
+        AgentInput input = new AgentInput(List.of(userMsg("hi")));
+
+        for (int i = 0; i < 50; i++) {
+            mw.onAgent((Agent) null, RuntimeContext.empty(), input, in -> Flux.<AgentEvent>empty())
+                    .collectList()
+                    .block(Duration.ofSeconds(5));
+        }
+
+        // If any terminated Disposable leaked into pending, this polls to its 2s timeout and
+        // the assertFalse inside fails.
+        awaitPendingSettled(mw, Duration.ofSeconds(2));
+    }
+
+    /**
+     * Synchronous mode (asyncMaintenance=false) must chain maintenance onto the response: the
+     * response cannot complete before the maintenance run finishes. Mirrors the flush
+     * middleware's sync-mode opt-out for durability-sensitive callers.
+     */
+    @Test
+    void onAgent_syncMode_waitsForMaintenance(@TempDir Path tmp) throws Exception {
+        WorkspaceManager wsm = new WorkspaceManager(tmp);
+
+        CountDownLatch maintenanceStarted = new CountDownLatch(1);
+        CountDownLatch releaseMaintenance = new CountDownLatch(1);
+        AtomicBoolean maintenanceFinished = new AtomicBoolean(false);
+        MemoryConsolidator consolidator = mock(MemoryConsolidator.class);
+        when(consolidator.consolidate(any()))
+                .thenAnswer(
+                        invocation ->
+                                Mono.<Void>fromRunnable(
+                                        () -> {
+                                            maintenanceStarted.countDown();
+                                            await(releaseMaintenance);
+                                            maintenanceFinished.set(true);
+                                        }));
+        // Auto-release shortly after maintenance starts so the response can finish without
+        // external coordination; finished is only set after the release, so observing it
+        // post-block proves the response waited for maintenance.
+        Thread releaser =
+                new Thread(
+                        () -> {
+                            try {
+                                maintenanceStarted.await(5, TimeUnit.SECONDS);
+                                Thread.sleep(200);
+                            } catch (InterruptedException e) {
+                                Thread.currentThread().interrupt();
+                            }
+                            releaseMaintenance.countDown();
+                        });
+        releaser.setDaemon(true);
+        releaser.start();
+
+        MemoryMaintenanceMiddleware mw =
+                new MemoryMaintenanceMiddleware(
+                        wsm,
+                        consolidator,
+                        90,
+                        180,
+                        MemoryMaintenanceMiddleware.DEFAULT_MIN_GAP,
+                        io.agentscope.harness.agent.IsolationScope.USER,
+                        new LocalPeriodicGate(),
+                        false);
+        AgentInput input = new AgentInput(List.of(userMsg("hi")));
+
+        List<AgentEvent> events =
+                mw.onAgent(
+                                (Agent) null,
+                                RuntimeContext.empty(),
+                                input,
+                                in -> Flux.<AgentEvent>empty())
+                        .collectList()
+                        .block(Duration.ofSeconds(5));
+
+        assertTrue(events != null && events.isEmpty());
+        assertTrue(
+                maintenanceFinished.get(),
+                "sync mode: response completed before the maintenance run finished");
+    }
+
+    // ── helpers ──────────────────────────────────────────────────────────────
+
+    /**
+     * Polls until the middleware has no pending background subscriptions. Throws
+     * AssertionError if the timeout expires with pending work still in flight, so a
+     * slow CI cannot silently mask a scheduling bug.
+     */
+    private static void awaitPendingSettled(MemoryMaintenanceMiddleware mw, Duration timeout)
+            throws InterruptedException {
+        long deadline = System.nanoTime() + timeout.toNanos();
+        while (System.nanoTime() < deadline) {
+            if (!mw.hasPendingMaintenance()) {
+                return;
+            }
+            Thread.sleep(10);
+        }
+        assertFalse(mw.hasPendingMaintenance(), "pending maintenance should have settled");
+    }
+
+    private static void await(CountDownLatch latch) {
+        try {
+            latch.await(5, TimeUnit.SECONDS);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    private static Msg userMsg(String text) {
+        return Msg.builder()
+                .name("user")
+                .role(MsgRole.USER)
+                .content(List.of(TextBlock.builder().text(text).build()))
+                .build();
+    }
+}

--- a/docs/v2/en/docs/harness/memory.md
+++ b/docs/v2/en/docs/harness/memory.md
@@ -193,6 +193,22 @@ HarnessAgent.builder()
 
 `model(String)` resolves via `ModelRegistry.resolve()`; you can also pass a `Model` instance. When not set, falls back to the agent's primary model.
 
+### Example 7: make the response wait for memory persistence
+
+By default, per-call flush and maintenance run **detached** from the agent response: the response stream completes as soon as the underlying agent call finishes, and the memory work (an LLM round-trip plus file writes) continues in the background. A slow memory model therefore never delays what the user is waiting for.
+
+Detached work is bounded: at most 4 flushes may be in flight per agent; beyond that, new flushes are skipped and logged. Skipping is safe — each flush extracts from the full conversation context, so the next successful flush covers the same messages.
+
+If your caller relies on "response completed == memory persisted" (e.g. you read the memory file immediately after the response), restore completion-order persistence:
+
+```java
+.memory(MemoryConfig.builder()
+    .asyncFlush(false)
+    .build())
+```
+
+The response then waits for the per-call memory work (bounded by a 5-minute timeout; failures are logged and never fail the completed response).
+
 ### `MemoryConfig` field reference
 
 | Field | Default | Purpose |
@@ -205,6 +221,7 @@ HarnessAgent.builder()
 | `dailyFileRetentionDays` | `90` | Days before a daily log moves to `memory/archive/` |
 | `sessionRetentionDays` | `180` | Days before a `*.log.jsonl` is pruned |
 | `flushTrigger` | `FlushTrigger.always()` | `ALWAYS` / `NEVER` / `THROTTLED(Duration)` |
+| `asyncFlush` | `true` | Detached (`true`, default) vs completion-order (`false`) memory persistence |
 
 ## Large tool-result offloading
 

--- a/docs/v2/zh/docs/harness/memory.md
+++ b/docs/v2/zh/docs/harness/memory.md
@@ -193,6 +193,22 @@ HarnessAgent.builder()
 
 `model(String)` 走 `ModelRegistry.resolve()`，也可以传 `Model` 实例。不设则 fallback 到 agent 主模型。
 
+### 例 7：让响应等待记忆持久化完成
+
+默认情况下，per-call flush 和维护以**脱离响应流**的方式运行：响应流在底层 agent 调用结束的瞬间就完成，记忆工作（一次 LLM 往返 + 文件写入）在后台继续。记忆模型再慢，也不会拖住用户正在等的那个响应。
+
+后台工作有上限保护：每个 agent 最多允许 4 个 flush 同时在途，超出的 flush 会被跳过并记日志。跳过是安全的——每次 flush 都从**完整对话上下文**提取，下一个成功的 flush 会覆盖同样的消息。
+
+如果你的调用方依赖"响应完成 == 记忆已落盘"（例如响应一返回就读记忆文件），可以恢复完成顺序持久化：
+
+```java
+.memory(MemoryConfig.builder()
+    .asyncFlush(false)
+    .build())
+```
+
+此时响应会等待本轮记忆工作完成（有 5 分钟超时上限；失败只记日志，不会把已完成的响应变成失败）。
+
 ### `MemoryConfig` 字段速查
 
 | 字段 | 默认 | 作用 |
@@ -205,6 +221,7 @@ HarnessAgent.builder()
 | `dailyFileRetentionDays` | `90` | 多少天后把日流水账归档到 `memory/archive/` |
 | `sessionRetentionDays` | `180` | 多少天后清掉 `*.log.jsonl` |
 | `flushTrigger` | `FlushTrigger.always()` | `ALWAYS` / `NEVER` / `THROTTLED(Duration)` |
+| `asyncFlush` | `true` | 记忆持久化脱离响应流（`true`，默认）还是完成顺序（`false`） |
 
 ## 大工具结果卸载
 


### PR DESCRIPTION
Fixes #2225
Fixes #2276
Also addresses #2774 and #2821 (same root cause).

## Problem

`MemoryFlushMiddleware` / `MemoryMaintenanceMiddleware` appended their LLM-backed work via `concatWith` onto the returned `Flux`. Because `ReActAgent.callInternal` ends with `takeLast(1)` — which can't emit until upstream signals `onComplete` — callers consuming the response to completion (`blockLast()`, `takeLast(1)`, WebFlux controllers awaiting `Mono<Msg>`) waited for the full memory-flush LLM round-trip (19–27s per call) and consolidation (~44s first run).

This is a regression: the original implementation was fire-and-forget (`doOnComplete`); PR #1802 (RC4) swapped it for `concatWith`.

## Fix

Both middlewares subscribe their work independently via `doOnComplete().subscribe()`, restoring the historical detached behavior, with production hardening:

- **Lifecycle**: both middlewares are `AutoCloseable`; pending `Disposable`s are tracked under `synchronized(pending)` with pre/post-subscribe closed checks. `HarnessAgent.close()` drains them (5s bound) before workspace teardown — no writes racing temp-dir deletion.
- **Bounded backlog** (new): at most 4 detached runs in flight per middleware; beyond that, runs are skipped and logged instead of accumulating without bound. Skipping is safe — a flush extracts from the full conversation context, so the next successful flush covers the same messages.
- **Durability opt-out** (new): `MemoryConfig.asyncFlush(false)` chains the per-call memory work back onto the response stream for callers relying on "response completed == memory persisted" — bounded by the same 5-minute timeout, failures logged and never fail the response. Default is `true` (the restored behavior).
- **Hung-model protection**: flush/consolidation LLM calls capped at 5 minutes (measured after `subscribeOn`, excluding queue wait).
- **Snapshot isolation**: `FlushRequest` copies messages on the completion thread, immune to later context mutation.

## Relationship to #2777 and #2833

Same root cause cluster (#2225/#2276/#2774/#2821). Differences:

- #2777 makes flush fire-and-forget without lifecycle draining or backlog bounds.
- #2833 adds an opt-in `asyncFlush` flag that defaults to **synchronous** — the regression stays on the default path, maintenance is not covered, and its static single-worker scheduler has no timeout (one hung flush stalls the whole pipeline) and is shared across all agents in the JVM.
- This PR fixes the default for everyone, covers flush **and** maintenance, drains on close, bounds the backlog, and now also provides the `asyncFlush(false)` opt-out and docs — a superset of both.

## Test evidence

17 middleware tests (TDD, red on main before the fix): completes-before-slow-flush/consolidation, errors-don't-propagate, close-prevents-schedules/drains/disposes-hung, **sync-mode waits (×2)**, **backlog cap skips beyond limit**, **config default + opt-out**. Full harness suite 861/0 failures.

## Checklist

- [x] Code has been formatted with `mvn spotless:apply`
- [x] All tests are passing (`mvn test`)
- [x] Javadoc comments are complete and follow project conventions
- [x] Related documentation has been updated (en/zh memory guides)
- [x] Code is ready for review