### PR TITLE
Introduce AgentProtocolEventBus for pluggable SSE event handling

### DIFF
--- a/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agent-protocol/src/main/java/io/agentscope/extensions/agentprotocol/AgentProtocolAutoConfiguration.java
+++ b/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agent-protocol/src/main/java/io/agentscope/extensions/agentprotocol/AgentProtocolAutoConfiguration.java
@@ -53,7 +53,8 @@ import org.springframework.context.annotation.Bean;
 public class AgentProtocolAutoConfiguration {
 
     @Bean
-    public AgentProtocolTaskEventBus agentProtocolTaskEventBus(AgentProtocolProperties properties) {
+    @ConditionalOnMissingBean(AgentProtocolEventBus.class)
+    public AgentProtocolEventBus agentProtocolEventBus(AgentProtocolProperties properties) {
         return new AgentProtocolTaskEventBus(properties.getSseReplayBufferSize());
     }
 
@@ -75,7 +76,7 @@ public class AgentProtocolAutoConfiguration {
     public AgentProtocolTaskStore agentProtocolTaskStore(
             AgentFactory agentFactory,
             ProtocolTaskRepository taskRepository,
-            AgentProtocolTaskEventBus eventBus,
+            AgentProtocolEventBus eventBus,
             AgentProtocolProperties properties,
             ObjectProvider<RuntimeContextCustomizer> runtimeContextCustomizers) {
         return new AgentProtocolTaskStore(

--- a/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agent-protocol/src/main/java/io/agentscope/extensions/agentprotocol/AgentProtocolEventBus.java
+++ b/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agent-protocol/src/main/java/io/agentscope/extensions/agentprotocol/AgentProtocolEventBus.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.extensions.agentprotocol;
+
+import io.agentscope.harness.agent.subagent.protocol.RemoteAgentEvent;
+import reactor.core.publisher.Flux;
+
+/**
+ * Event bus abstraction used by Agent Protocol task SSE endpoints.
+ *
+ * <p>Implementations are responsible for assigning a monotonically increasing sequence per task,
+ * publishing events, and replaying events after {@code fromSeq}. The default implementation is
+ * {@link AgentProtocolTaskEventBus}, which keeps the replay buffer in process memory. Applications
+ * that need cross-instance streaming can provide a shared implementation, such as a Redis Streams
+ * adapter, as the {@code AgentProtocolEventBus} bean.
+ */
+public interface AgentProtocolEventBus {
+
+    /** Publishes an event for a task and returns the event after protocol fields are assigned. */
+    RemoteAgentEvent publish(String taskId, RemoteAgentEvent event);
+
+    /**
+     * Subscribes to a task's event stream, replaying only events whose sequence is greater than
+     * {@code fromSeq}.
+     */
+    Flux<RemoteAgentEvent> subscribe(String taskId, long fromSeq);
+
+    /** Completes and releases the event stream for a terminal task. */
+    void complete(String taskId);
+}

--- a/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agent-protocol/src/main/java/io/agentscope/extensions/agentprotocol/AgentProtocolTaskEventBus.java
+++ b/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agent-protocol/src/main/java/io/agentscope/extensions/agentprotocol/AgentProtocolTaskEventBus.java
@@ -28,7 +28,7 @@ import reactor.core.publisher.Sinks;
  * Per-task event bus for Agent Protocol SSE streaming. Uses a replay buffer so late subscribers /
  * reconnects can catch up from {@code fromSeq}.
  */
-public final class AgentProtocolTaskEventBus {
+public final class AgentProtocolTaskEventBus implements AgentProtocolEventBus {
 
     private static final Logger log = LoggerFactory.getLogger(AgentProtocolTaskEventBus.class);
 
@@ -44,6 +44,7 @@ public final class AgentProtocolTaskEventBus {
     }
 
     /** Publishes an event, assigning a monotonic {@code seq}. */
+    @Override
     public RemoteAgentEvent publish(String taskId, RemoteAgentEvent event) {
         Channel ch = channels.computeIfAbsent(taskId, id -> new Channel(replayBufferSize));
         long seq = ch.seq.incrementAndGet();
@@ -60,6 +61,7 @@ public final class AgentProtocolTaskEventBus {
      * Subscribes to events for {@code taskId}, optionally skipping those with {@code seq <=
      * fromSeq}.
      */
+    @Override
     public Flux<RemoteAgentEvent> subscribe(String taskId, long fromSeq) {
         Channel ch = channels.computeIfAbsent(taskId, id -> new Channel(replayBufferSize));
         Flux<RemoteAgentEvent> flux = ch.sink.asFlux();
@@ -70,6 +72,7 @@ public final class AgentProtocolTaskEventBus {
     }
 
     /** Completes and removes the channel after a terminal event has been published. */
+    @Override
     public void complete(String taskId) {
         Channel ch = channels.remove(taskId);
         if (ch != null) {

--- a/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agent-protocol/src/main/java/io/agentscope/extensions/agentprotocol/AgentProtocolTaskStore.java
+++ b/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agent-protocol/src/main/java/io/agentscope/extensions/agentprotocol/AgentProtocolTaskStore.java
@@ -73,7 +73,7 @@ public final class AgentProtocolTaskStore {
 
     private final AgentFactory agentFactory;
     private final ProtocolTaskRepository taskRepository;
-    private final AgentProtocolTaskEventBus eventBus;
+    private final AgentProtocolEventBus eventBus;
     private final AgentProtocolProperties properties;
     private final List<RuntimeContextCustomizer> runtimeContextCustomizers;
     private final ExecutorService executor =
@@ -91,7 +91,7 @@ public final class AgentProtocolTaskStore {
     public AgentProtocolTaskStore(
             AgentFactory agentFactory,
             ProtocolTaskRepository taskRepository,
-            AgentProtocolTaskEventBus eventBus,
+            AgentProtocolEventBus eventBus,
             AgentProtocolProperties properties) {
         this(agentFactory, taskRepository, eventBus, properties, List.of());
     }
@@ -99,7 +99,7 @@ public final class AgentProtocolTaskStore {
     public AgentProtocolTaskStore(
             AgentFactory agentFactory,
             ProtocolTaskRepository taskRepository,
-            AgentProtocolTaskEventBus eventBus,
+            AgentProtocolEventBus eventBus,
             AgentProtocolProperties properties,
             List<RuntimeContextCustomizer> runtimeContextCustomizers) {
         this.agentFactory = Objects.requireNonNull(agentFactory, "agentFactory");
@@ -126,7 +126,7 @@ public final class AgentProtocolTaskStore {
         this(AgentFactory.fixed(harnessAgent), taskRepository);
     }
 
-    public AgentProtocolTaskEventBus eventBus() {
+    public AgentProtocolEventBus eventBus() {
         return eventBus;
     }
 

--- a/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agent-protocol/src/test/java/io/agentscope/extensions/agentprotocol/AgentProtocolAutoConfigurationTest.java
+++ b/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agent-protocol/src/test/java/io/agentscope/extensions/agentprotocol/AgentProtocolAutoConfigurationTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.extensions.agentprotocol;
+
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+import io.agentscope.harness.agent.subagent.protocol.RemoteAgentEvent;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import reactor.core.publisher.Flux;
+
+class AgentProtocolAutoConfigurationTest {
+
+    private final ApplicationContextRunner contextRunner =
+            new ApplicationContextRunner()
+                    .withConfiguration(AutoConfigurations.of(AgentProtocolAutoConfiguration.class))
+                    .withPropertyValues("agentscope.agent-protocol.enabled=true");
+
+    @Test
+    void createsInMemoryEventBusByDefault() {
+        contextRunner.run(
+                context ->
+                        assertInstanceOf(
+                                AgentProtocolTaskEventBus.class,
+                                context.getBean(AgentProtocolEventBus.class)));
+    }
+
+    @Test
+    void keepsUserEventBusWhenOneIsProvided() {
+        AgentProtocolEventBus customEventBus = new TestEventBus();
+
+        contextRunner
+                .withBean(AgentProtocolEventBus.class, () -> customEventBus)
+                .run(
+                        context ->
+                                assertSame(
+                                        customEventBus,
+                                        context.getBean(AgentProtocolEventBus.class)));
+    }
+
+    private static final class TestEventBus implements AgentProtocolEventBus {
+
+        @Override
+        public RemoteAgentEvent publish(String taskId, RemoteAgentEvent event) {
+            return event;
+        }
+
+        @Override
+        public Flux<RemoteAgentEvent> subscribe(String taskId, long fromSeq) {
+            return Flux.fromIterable(List.of());
+        }
+
+        @Override
+        public void complete(String taskId) {}
+    }
+}

--- a/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agent-protocol/src/test/java/io/agentscope/extensions/agentprotocol/AgentProtocolTaskEventBusTest.java
+++ b/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agent-protocol/src/test/java/io/agentscope/extensions/agentprotocol/AgentProtocolTaskEventBusTest.java
@@ -26,6 +26,7 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.LongStream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import reactor.core.Disposable;
@@ -51,6 +52,32 @@ class AgentProtocolTaskEventBusTest {
         assertEquals("task-a", second.getTaskId());
         assertEquals(1L, other.getSeq());
         assertEquals("task-b", other.getTaskId());
+    }
+
+    @Test
+    void implementsEventBusContract() {
+        assertTrue(bus instanceof AgentProtocolEventBus);
+    }
+
+    @Test
+    void publish_assignsUniqueSequencesForConcurrentPublishers() {
+        int eventCount = 200;
+
+        List<RemoteAgentEvent> published =
+                LongStream.range(0, eventCount)
+                        .parallel()
+                        .mapToObj(
+                                ignored ->
+                                        bus.publish(
+                                                "task-concurrent", event(RemoteEventType.STATUS)))
+                        .toList();
+
+        assertEquals(
+                eventCount, published.stream().map(RemoteAgentEvent::getSeq).distinct().count());
+        assertEquals(
+                LongStream.rangeClosed(1, eventCount).boxed().toList(),
+                published.stream().map(RemoteAgentEvent::getSeq).sorted().toList());
+        assertTrue(published.stream().allMatch(e -> "task-concurrent".equals(e.getTaskId())));
     }
 
     @Test


### PR DESCRIPTION
AgentScope-Java Version

2.0.3-SNAPSHOT（pom.xml 中的 <revision>）

Description

背景： 当前 Agent Protocol 的 SSE 事件流由 AgentProtocolTaskEventBus 直接提供，回放缓冲保存在进程内存中，且 TaskStore、自动配置与具体实现类强耦合。对于需要跨实例（多副本）流式输出的场景（例如基于 Redis Streams 的共享事件总线），只能复制代码改造，无法通过配置替换实现。

改动内容：

新增 AgentProtocolEventBus 接口，抽象事件总线能力（publish / subscribe / complete），由实现方负责单调递增 seq 的分配与回放
AgentProtocolTaskEventBus 实现该接口，保持原有进程内回放缓冲行为不变（默认实现）
AgentProtocolAutoConfiguration 改为声明 AgentProtocolEventBus bean，并加上 @ConditionalOnMissingBean，允许应用提供自定义实现（如 Redis Streams 适配器）自动覆盖默认实现
AgentProtocolTaskStore 依赖接口 AgentProtocolEventBus 而非具体类
新增测试：
AgentProtocolAutoConfigurationTest：默认创建内存实现；用户提供自定义 bean 时保留自定义实现
AgentProtocolTaskEventBusTest 新增用例：验证并发 publish 时 seq 单调唯一

如何测试：

# 格式检查
mvn spotless:check

# 相关测试（注意：本机需 JDK 17+ 运行 Maven，默认 JDK 8 与 spotless 3.4.0 不兼容）
mvn test -pl agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agent-protocol \
  -Dtest='AgentProtocolTaskEventBusTest,AgentProtocolAutoConfigurationTest'

验证结果：spotless:check 通过；7 个测试（AgentProtocolTaskEventBusTest 5 + AgentProtocolAutoConfigurationTest 2）全部通过，BUILD SUCCESS。

破坏性变更： 无。仅新增接口与抽象，默认行为不变。

Checklist

 Code has been formatted with mvn spotless:apply（已验证 spotless:check 通过）
 All tests are passing (mvn test)（已跑改动模块相关测试，7 个全部通过；全量 mvn test 未执行）
 Javadoc comments are complete and follow project conventions（新增接口含完整 Javadoc）
 Related documentation has been updated (e.g. links, examples, etc.)（本次未更新文档；如需可补充自定义 EventBus 的使用说明）
 Code is ready for review