### PR TITLE
fix(agui-example): configure Spring Boot 4 example to decode AG-UI requests with Jackson 2

### DIFF
--- a/agentscope-examples/agui/pom.xml
+++ b/agentscope-examples/agui/pom.xml
@@ -65,6 +65,10 @@
             <artifactId>agentscope-agui-spring-boot-starter</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-webflux</artifactId>
         </dependency>

--- a/agentscope-examples/agui/src/main/java/io/agentscope/examples/agui/config/Jackson2Configuration.java
+++ b/agentscope-examples/agui/src/main/java/io/agentscope/examples/agui/config/Jackson2Configuration.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.examples.agui.config;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class Jackson2Configuration {
+
+    @Bean
+    @ConditionalOnMissingBean(ObjectMapper.class)
+    public ObjectMapper jackson2ObjectMapper() {
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+        return mapper;
+    }
+}

--- a/agentscope-examples/agui/src/main/resources/application.yml
+++ b/agentscope-examples/agui/src/main/resources/application.yml
@@ -20,6 +20,10 @@ server:
 spring:
   main:
     banner-mode: off
+  http:
+    codecs:
+      # AG-UI models use Jackson 2 annotations and custom serializers.
+      preferred-json-mapper: jackson2
   web:
     resources:
       cache:


### PR DESCRIPTION
## Description

Spring Boot 4 默认使用 Jackson 3，而 AG-UI 的 `MessageContent` 模型依赖 Jackson 2 注解和自定义反序列化器，导致 agui-example 示例前端发送请求时 WebFlux 无法解析 `RunAgentInput`：
`Type definition error: [simple type, class io.agentscope.core.agui.model.MessageContent]`

## Change

- 在 AG-UI 示例模块中显式引入 Jackson 2 依赖。
- 提供 Jackson 2 `ObjectMapper` Bean。
- 配置 Spring WebFlux 使用 Jackson 2 JSON codecs。
- 保留 Spring Boot 4 默认 Jackson 3 依赖，避免影响其他组件。

## Checklist

Please check the following items before code is ready to be reviewed.

- [ ]  Code has been formatted with `mvn spotless:apply`
- [ ]  All tests are passing (`mvn test`)
- [ ]  Javadoc comments are complete and follow project conventions
- [ ]  Related documentation has been updated (e.g. links, examples, etc.)
- [ ]  Code is ready for review
