### PR TITLE
fix(agui): parse request bodies with Jackson 2 codec

### DIFF
--- a/agentscope-extensions/agentscope-spring-boot-starters/agentscope-agui-spring-boot-starter/src/main/java/io/agentscope/spring/boot/agui/common/AguiRequestBodyParser.java
+++ b/agentscope-extensions/agentscope-spring-boot-starters/agentscope-agui-spring-boot-starter/src/main/java/io/agentscope/spring/boot/agui/common/AguiRequestBodyParser.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.spring.boot.agui.common;
+
+import io.agentscope.core.agui.model.RunAgentInput;
+import io.agentscope.core.util.JsonUtils;
+import java.util.Objects;
+
+/**
+ * Parses AG-UI request bodies with AgentScope's JSON codec.
+ *
+ * <p>The default AgentScope codec is Jackson 2. Keeping this conversion at the AG-UI boundary
+ * avoids selecting Spring Boot 4's Jackson 3 codec for AG-UI's Jackson 2-annotated models, while
+ * leaving the application's other HTTP converters unchanged.
+ */
+public final class AguiRequestBodyParser {
+
+    private AguiRequestBodyParser() {}
+
+    /**
+     * Parses a JSON request body into {@link RunAgentInput}.
+     *
+     * @param body the raw JSON request body
+     * @return the parsed AG-UI input
+     */
+    public static RunAgentInput parse(String body) {
+        Objects.requireNonNull(body, "body cannot be null");
+        return JsonUtils.getJsonCodec().fromJson(body, RunAgentInput.class);
+    }
+}

--- a/agentscope-extensions/agentscope-spring-boot-starters/agentscope-agui-spring-boot-starter/src/main/java/io/agentscope/spring/boot/agui/mvc/AguiRestController.java
+++ b/agentscope-extensions/agentscope-spring-boot-starters/agentscope-agui-spring-boot-starter/src/main/java/io/agentscope/spring/boot/agui/mvc/AguiRestController.java
@@ -15,10 +15,16 @@
  */
 package io.agentscope.spring.boot.agui.mvc;
 
+import io.agentscope.core.agui.encoder.AguiEventEncoder;
+import io.agentscope.core.agui.event.AguiEvent;
 import io.agentscope.core.agui.model.RunAgentInput;
+import io.agentscope.core.util.JsonException;
 import io.agentscope.spring.boot.agui.common.AguiRequestBodyParser;
 import jakarta.servlet.http.HttpServletRequest;
+import java.util.Map;
 import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -36,6 +42,7 @@ import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 public class AguiRestController {
 
     private final AguiMvcController aguiMvcController;
+    private final AguiEventEncoder encoder = new AguiEventEncoder();
     private final String pathPrefix;
     private final boolean enablePathRouting;
 
@@ -64,7 +71,7 @@ public class AguiRestController {
      *   <li>"default"</li>
      * </ol>
      *
-     * @param body The run agent input
+     * @param body The raw run agent input JSON
      * @param agentIdHeader The agent ID from HTTP header (optional)
      * @return An SseEmitter for streaming AG-UI events
      */
@@ -89,7 +96,7 @@ public class AguiRestController {
      * <p>The path variable takes highest priority for agent resolution.
      *
      * @param agentId The agent ID from path variable
-     * @param body The run agent input
+     * @param body The raw run agent input JSON
      * @param agentIdHeader The agent ID from HTTP header (optional)
      * @return An SseEmitter for streaming AG-UI events
      */
@@ -107,5 +114,29 @@ public class AguiRestController {
             HttpServletRequest request) {
         RunAgentInput input = AguiRequestBodyParser.parse(body);
         return aguiMvcController.handleWithAgentId(input, agentIdHeader, agentId, request);
+    }
+
+    /**
+     * Return HTTP 400 for AG-UI request body parsing failures.
+     *
+     * @param error the JSON parse failure
+     * @return an SSE-compatible bad request response
+     */
+    @ExceptionHandler(JsonException.class)
+    public ResponseEntity<String> handleParseError(JsonException error) {
+        String errorEvent =
+                encoder.encodeToJson(
+                                new AguiEvent.Raw(
+                                        "unknown",
+                                        "unknown",
+                                        Map.of(
+                                                "error",
+                                                "Failed to parse request: " + error.getMessage())))
+                        .trim();
+        String finishEvent =
+                encoder.encodeToJson(new AguiEvent.RunFinished("unknown", "unknown")).trim();
+        return ResponseEntity.badRequest()
+                .contentType(MediaType.TEXT_EVENT_STREAM)
+                .body("data: " + errorEvent + "\n\n" + "data: " + finishEvent + "\n\n");
     }
 }

--- a/agentscope-extensions/agentscope-spring-boot-starters/agentscope-agui-spring-boot-starter/src/main/java/io/agentscope/spring/boot/agui/mvc/AguiRestController.java
+++ b/agentscope-extensions/agentscope-spring-boot-starters/agentscope-agui-spring-boot-starter/src/main/java/io/agentscope/spring/boot/agui/mvc/AguiRestController.java
@@ -16,6 +16,7 @@
 package io.agentscope.spring.boot.agui.mvc;
 
 import io.agentscope.core.agui.model.RunAgentInput;
+import io.agentscope.spring.boot.agui.common.AguiRequestBodyParser;
 import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -63,7 +64,7 @@ public class AguiRestController {
      *   <li>"default"</li>
      * </ol>
      *
-     * @param input The run agent input
+     * @param body The run agent input
      * @param agentIdHeader The agent ID from HTTP header (optional)
      * @return An SseEmitter for streaming AG-UI events
      */
@@ -72,12 +73,13 @@ public class AguiRestController {
             consumes = MediaType.APPLICATION_JSON_VALUE,
             produces = MediaType.TEXT_EVENT_STREAM_VALUE)
     public SseEmitter run(
-            @RequestBody RunAgentInput input,
+            @RequestBody String body,
             @RequestHeader(
                             value = "${agentscope.agui.agent-id-header:X-Agent-Id}",
                             required = false)
                     String agentIdHeader,
             HttpServletRequest request) {
+        RunAgentInput input = AguiRequestBodyParser.parse(body);
         return aguiMvcController.handle(input, agentIdHeader, request);
     }
 
@@ -87,7 +89,7 @@ public class AguiRestController {
      * <p>The path variable takes highest priority for agent resolution.
      *
      * @param agentId The agent ID from path variable
-     * @param input The run agent input
+     * @param body The run agent input
      * @param agentIdHeader The agent ID from HTTP header (optional)
      * @return An SseEmitter for streaming AG-UI events
      */
@@ -97,12 +99,13 @@ public class AguiRestController {
             produces = MediaType.TEXT_EVENT_STREAM_VALUE)
     public SseEmitter runWithAgentId(
             @PathVariable String agentId,
-            @RequestBody RunAgentInput input,
+            @RequestBody String body,
             @RequestHeader(
                             value = "${agentscope.agui.agent-id-header:X-Agent-Id}",
                             required = false)
                     String agentIdHeader,
             HttpServletRequest request) {
+        RunAgentInput input = AguiRequestBodyParser.parse(body);
         return aguiMvcController.handleWithAgentId(input, agentIdHeader, agentId, request);
     }
 }

--- a/agentscope-extensions/agentscope-spring-boot-starters/agentscope-agui-spring-boot-starter/src/main/java/io/agentscope/spring/boot/agui/webflux/AguiWebFluxHandler.java
+++ b/agentscope-extensions/agentscope-spring-boot-starters/agentscope-agui-spring-boot-starter/src/main/java/io/agentscope/spring/boot/agui/webflux/AguiWebFluxHandler.java
@@ -24,6 +24,7 @@ import io.agentscope.core.agui.event.AguiEvent;
 import io.agentscope.core.agui.model.RunAgentInput;
 import io.agentscope.core.agui.processor.AguiRequestProcessor;
 import io.agentscope.core.agui.registry.AguiAgentRegistry;
+import io.agentscope.spring.boot.agui.common.AguiRequestBodyParser;
 import io.agentscope.spring.boot.agui.common.AguiRuntimeContextRequest;
 import io.agentscope.spring.boot.agui.common.AguiRuntimeContextResolver;
 import io.agentscope.spring.boot.agui.common.DefaultAgentResolver;
@@ -112,7 +113,8 @@ public class AguiWebFluxHandler {
      * @return A Mono containing the server response with SSE stream
      */
     public Mono<ServerResponse> handle(ServerRequest request) {
-        return request.bodyToMono(RunAgentInput.class)
+        return request.bodyToMono(String.class)
+                .map(AguiRequestBodyParser::parse)
                 .flatMap(input -> processInput(input, request, null))
                 .onErrorResume(this::handleParseError);
     }
@@ -128,7 +130,8 @@ public class AguiWebFluxHandler {
      */
     public Mono<ServerResponse> handleWithAgentId(ServerRequest request) {
         String pathAgentId = request.pathVariable(AGENT_ID_PATH_VARIABLE);
-        return request.bodyToMono(RunAgentInput.class)
+        return request.bodyToMono(String.class)
+                .map(AguiRequestBodyParser::parse)
                 .flatMap(input -> processInput(input, request, pathAgentId))
                 .onErrorResume(this::handleParseError);
     }

--- a/agentscope-extensions/agentscope-spring-boot-starters/agentscope-agui-spring-boot-starter/src/test/java/io/agentscope/spring/boot/agui/common/AguiRequestBodyParserTest.java
+++ b/agentscope-extensions/agentscope-spring-boot-starters/agentscope-agui-spring-boot-starter/src/test/java/io/agentscope/spring/boot/agui/common/AguiRequestBodyParserTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.spring.boot.agui.common;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.agentscope.core.agui.model.MessageContent;
+import io.agentscope.core.agui.model.RunAgentInput;
+import org.junit.jupiter.api.Test;
+
+class AguiRequestBodyParserTest {
+
+    @Test
+    void shouldParseTextContentWithAgentScopeCodec() {
+        String body =
+                """
+                {
+                  "threadId": "thread-1",
+                  "runId": "run-1",
+                  "messages": [
+                    {"id": "message-1", "role": "user", "content": "Hello!"}
+                  ]
+                }
+                """;
+
+        RunAgentInput input = AguiRequestBodyParser.parse(body);
+
+        assertEquals("Hello!", input.getMessages().get(0).getTextContent());
+    }
+
+    @Test
+    void shouldParseMultimodalContentWithAgentScopeCodec() {
+        String body =
+                """
+                {
+                  "threadId": "thread-1",
+                  "runId": "run-1",
+                  "messages": [
+                    {
+                      "id": "message-1",
+                      "role": "user",
+                      "content": [
+                        {"type": "text", "text": "Describe this"},
+                        {
+                          "type": "image",
+                          "source": {
+                            "type": "url",
+                            "value": "https://example.com/image.png"
+                          }
+                        }
+                      ]
+                    }
+                  ]
+                }
+                """;
+
+        RunAgentInput input = AguiRequestBodyParser.parse(body);
+        MessageContent.Blocks content =
+                assertInstanceOf(
+                        MessageContent.Blocks.class, input.getMessages().get(0).getContent());
+
+        assertEquals(2, content.parts().size());
+        assertTrue(input.getMessages().get(0).hasBlocks());
+    }
+
+    @Test
+    void shouldRejectNullBody() {
+        assertThrows(NullPointerException.class, () -> AguiRequestBodyParser.parse(null));
+    }
+}

--- a/agentscope-extensions/agentscope-spring-boot-starters/agentscope-agui-spring-boot-starter/src/test/java/io/agentscope/spring/boot/agui/mvc/AguiRestControllerTest.java
+++ b/agentscope-extensions/agentscope-spring-boot-starters/agentscope-agui-spring-boot-starter/src/test/java/io/agentscope/spring/boot/agui/mvc/AguiRestControllerTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.spring.boot.agui.mvc;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.agentscope.core.util.JsonException;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+
+class AguiRestControllerTest {
+
+    @Test
+    void shouldReturnBadRequestSseForParseErrors() {
+        AguiRestController controller = new AguiRestController(null, "/agui", true);
+
+        ResponseEntity<String> response =
+                controller.handleParseError(new JsonException("bad json"));
+
+        assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+        assertEquals(MediaType.TEXT_EVENT_STREAM, response.getHeaders().getContentType());
+        assertNotNull(response.getBody());
+        assertTrue(response.getBody().contains("Failed to parse request: bad json"));
+        assertTrue(response.getBody().contains("data: "));
+    }
+}


### PR DESCRIPTION
## 背景

AG-UI 的 `MessageContent` 依赖 Jackson 2 注解和自定义反序列化器。Spring Boot 4 默认使用 Jackson 3 解析请求体时，会导致 AG-UI 请求反序列化失败。

## 修改内容

- `AguiWebFluxHandler` 改为先读取原始 JSON，再使用 AgentScope JSON codec（默认jackson2）解析。
- `AguiRestController` 改用相同的请求体解析逻辑。
- 增加文本和多模态 `MessageContent` 解析测试。
- 不修改 Spring Boot 全局 Jackson 配置。

## 兼容性影响

默认情况下使用 AgentScope 的 Jackson 2 codec，可避免 Jackson 3 与 AG-UI 模型不兼容的问题。

如果用户通过 `JsonUtils.setJsonCodec(...)` 配置了自定义 codec，AG-UI 请求解析仍会遵循该全局配置。HTTP 请求格式、接口路径和 SSE 响应行为保持不变。

## Checklist

Please check the following items before code is ready to be reviewed.

- [ ]  Code has been formatted with `mvn spotless:apply`
- [ ]  All tests are passing (`mvn test`)
- [ ]  Javadoc comments are complete and follow project conventions
- [ ]  Related documentation has been updated (e.g. links, examples, etc.)
- [ ]  Code is ready for review
