### PR TITLE
feat(console): transcript overhaul - ordered content blocks, markdown, tool UX

### DIFF
--- a/agentscope-service/frontend/package.json
+++ b/agentscope-service/frontend/package.json
@@ -22,8 +22,10 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^1.27.0",
+    "prism-react-renderer": "^2.4.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
+    "react-markdown": "^10.1.0",
     "react-router-dom": "^6.28.0",
     "tailwind-merge": "^3.6.0"
   },

--- a/agentscope-service/frontend/src/api/managedSessions.ts
+++ b/agentscope-service/frontend/src/api/managedSessions.ts
@@ -204,67 +204,93 @@ export interface EventStreamHandle {
   close: () => void;
 }
 
+const sleep = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
+
 /**
- * Subscribes to session events over SSE. Uses fetch (not native EventSource) so JWT Bearer auth works.
+ * Subscribes to session events over SSE. Uses fetch (not native EventSource) so JWT Bearer auth
+ * works. Reconnects automatically when the stream ends or fails, resuming from the last seen
+ * sequence via {@code getAfter} so no events are lost across plane restarts or network drops.
  */
 export function streamEvents(
   sessionId: string,
   onEvent: (event: SessionEvent) => void,
   onError?: (err: Error) => void,
-  options?: { eventDeltas?: string[]; after?: number },
+  options?: {
+    eventDeltas?: string[];
+    after?: number;
+    /** Called before each (re)connect to compute the resume cursor. */
+    getAfter?: () => number | undefined;
+    /** Base reconnect delay; doubles up to {@link maxRetryMs} and resets on progress. */
+    retryMs?: number;
+    maxRetryMs?: number;
+  },
 ): EventStreamHandle {
   const token = getToken();
   const controller = new AbortController();
   let closed = false;
+  let backoffMs = Math.max(500, options?.retryMs ?? 2000);
+  const maxRetryMs = options?.maxRetryMs ?? 30000;
 
-  (async () => {
-    try {
-      const params = new URLSearchParams();
-      if (options?.after != null && options.after > 0) {
-        params.set('after', String(options.after));
-      }
-      for (const t of options?.eventDeltas ?? []) {
-        params.append('event_deltas', t);
-      }
-      const qs = params.toString();
-      const res = await fetch(
-        `/api/sessions/${encodeURIComponent(sessionId)}/events/stream${qs ? `?${qs}` : ''}`,
-        {
-          headers: token ? { Authorization: `Bearer ${token}` } : {},
-          signal: controller.signal,
-        },
-      );
-      if (!res.ok || !res.body) {
-        throw new Error(`Event stream failed: ${res.status}`);
-      }
-      const reader = res.body.getReader();
-      const dec = new TextDecoder();
-      let buf = '';
-      while (!closed) {
-        const { value, done } = await reader.read();
-        if (done) break;
-        buf += dec.decode(value, { stream: true });
-        let idx;
-        while ((idx = buf.indexOf('\n\n')) >= 0) {
-          const block = buf.slice(0, idx);
-          buf = buf.slice(idx + 2);
-          const lines = block.split('\n');
-          let data = '';
-          for (const ln of lines) {
-            if (ln.startsWith('data:')) data += ln.slice(5).trim();
-          }
-          if (!data) continue;
-          try {
-            onEvent(JSON.parse(data) as SessionEvent);
-          } catch {
-            // ignore malformed frames
-          }
+  async function connect(): Promise<void> {
+    const after = options?.getAfter ? options.getAfter() : options?.after;
+    const params = new URLSearchParams();
+    if (after != null && after > 0) {
+      params.set('after', String(after));
+    }
+    for (const t of options?.eventDeltas ?? []) {
+      params.append('event_deltas', t);
+    }
+    const qs = params.toString();
+    const res = await fetch(
+      `/api/sessions/${encodeURIComponent(sessionId)}/events/stream${qs ? `?${qs}` : ''}`,
+      {
+        headers: token ? { Authorization: `Bearer ${token}` } : {},
+        signal: controller.signal,
+      },
+    );
+    if (!res.ok || !res.body) {
+      throw new Error(`Event stream failed: ${res.status}`);
+    }
+    const reader = res.body.getReader();
+    const dec = new TextDecoder();
+    let buf = '';
+    while (!closed) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      buf += dec.decode(value, { stream: true });
+      let idx;
+      while ((idx = buf.indexOf('\n\n')) >= 0) {
+        const block = buf.slice(0, idx);
+        buf = buf.slice(idx + 2);
+        let data = '';
+        for (const ln of block.split('\n')) {
+          if (ln.startsWith('data:')) data += ln.slice(5).trim();
+        }
+        if (!data) continue;
+        try {
+          onEvent(JSON.parse(data) as SessionEvent);
+          // Any delivered event means the connection is healthy; reset backoff.
+          backoffMs = Math.max(500, options?.retryMs ?? 2000);
+        } catch {
+          // ignore malformed frames
         }
       }
-    } catch (e: unknown) {
+    }
+  }
+
+  (async () => {
+    while (!closed) {
+      try {
+        await connect();
+      } catch (e: unknown) {
+        if (closed) return;
+        if (e instanceof Error && e.name === 'AbortError') return;
+        onError?.(e instanceof Error ? e : new Error(String(e)));
+      }
       if (closed) return;
-      if (e instanceof Error && e.name === 'AbortError') return;
-      onError?.(e instanceof Error ? e : new Error(String(e)));
+      const delayMs = backoffMs;
+      backoffMs = Math.min(maxRetryMs, backoffMs * 2);
+      await sleep(delayMs);
     }
   })();
 

--- a/agentscope-service/frontend/src/components/ChatPanel.tsx
+++ b/agentscope-service/frontend/src/components/ChatPanel.tsx
@@ -27,23 +27,17 @@ import {
   SessionEvent,
   streamEvents,
 } from '../api/managedSessions';
-import MessageBlock from './MessageBlock';
+import MessageBlock, { ContentBlock } from './MessageBlock';
 
 type Role = 'user' | 'assistant' | 'system' | 'error';
-
-interface ToolEntry {
-  id: string;
-  name: string;
-  input?: string;
-  result?: string;
-}
 
 interface Message {
   id: string;
   role: Role;
-  text: string;
-  tools: ToolEntry[];
+  blocks: ContentBlock[];
   pending?: boolean;
+  /** Turn finished: no more blocks are appended to this bubble. */
+  closed?: boolean;
 }
 
 interface PendingConfirmation {
@@ -135,23 +129,46 @@ function errorText(evt: SessionEvent): string {
 
 function eventsToMessages(events: SessionEvent[]): Message[] {
   const out: Message[] = [];
+  // Index of the current assistant turn bubble; content appends into it until
+  // a status/error event closes the turn.
+  let open = -1;
+  const closeOpen = () => {
+    if (open >= 0 && out[open].role === 'assistant') {
+      out[open].pending = false;
+      out[open].closed = true;
+    }
+    open = -1;
+  };
+  const ensureOpen = (seedId: string): Message => {
+    if (open >= 0 && !out[open].closed) {
+      return out[open];
+    }
+    const msg: Message = { id: `${seedId}-turn`, role: 'assistant', blocks: [], pending: true };
+    out.push(msg);
+    open = out.length - 1;
+    return msg;
+  };
   for (const evt of events) {
     if (evt.type === 'user.message') {
-      out.push({ id: evt.id, role: 'user', text: payloadText(evt.payload), tools: [] });
+      closeOpen();
+      out.push({
+        id: evt.id,
+        role: 'user',
+        blocks: [{ kind: 'text', id: evt.id, text: payloadText(evt.payload) }],
+      });
     } else if (evt.type === 'agent.turn_stub' || evt.type === 'agent.message') {
-      out.push({ id: evt.id, role: 'assistant', text: payloadText(evt.payload) || '[agent response]', tools: [] });
+      ensureOpen(evt.id).blocks.push({
+        kind: 'text',
+        id: evt.id,
+        text: payloadText(evt.payload) || '[agent response]',
+      });
     } else if (evt.type === 'agent.tool_use') {
-      const tool: ToolEntry = {
+      ensureOpen(evt.id).blocks.push({
+        kind: 'tool',
         id: String(evt.payload?.id ?? evt.payload?.toolCallId ?? evt.payload?.toolUseId ?? evt.id),
-        name: String(evt.payload?.name ?? evt.payload?.toolName ?? 'tool'),
-        input: evt.payload?.input != null ? JSON.stringify(evt.payload.input) : undefined,
-      };
-      const last = out[out.length - 1];
-      if (last?.role === 'assistant') {
-        last.tools = [...last.tools, tool];
-      } else {
-        out.push({ id: `${evt.id}-host`, role: 'assistant', text: '', tools: [tool] });
-      }
+        toolName: String(evt.payload?.name ?? evt.payload?.toolName ?? 'tool'),
+        text: evt.payload?.input != null ? JSON.stringify(evt.payload.input) : undefined,
+      });
     } else if (evt.type === 'agent.tool_result') {
       const toolUseId = String(
         evt.payload?.tool_use_id ?? evt.payload?.toolCallId ?? evt.payload?.id ?? '',
@@ -160,17 +177,28 @@ function eventsToMessages(events: SessionEvent[]): Message[] {
         ? String(evt.payload.output)
         : payloadText(evt.payload);
       if (!toolUseId) continue;
-      for (let i = out.length - 1; i >= 0; i--) {
-        const m = out[i];
-        if (m.role !== 'assistant') continue;
-        const idx = m.tools.findIndex(t => t.id === toolUseId);
+      for (const m of out) {
+        const idx = m.blocks.findIndex(b => b.kind === 'tool' && b.id === toolUseId);
         if (idx >= 0) {
-          m.tools = m.tools.map((t, j) => (j === idx ? { ...t, result: output } : t));
+          m.blocks = m.blocks.map((b, i) => (i === idx ? { ...b, result: output } : b));
           break;
         }
       }
     } else if (evt.type === 'session.error') {
-      out.push({ id: evt.id, role: 'error', text: errorText(evt), tools: [] });
+      closeOpen();
+      out.push({
+        id: evt.id,
+        role: 'error',
+        blocks: [{ kind: 'text', id: evt.id, text: errorText(evt) }],
+      });
+    } else if (evt.type.startsWith('session.status')) {
+      // Status events do not end the turn bubble: the backend may emit
+      // status_idle between model iterations of one user question, followed
+      // by more tool calls and the final text. Only user.message / session.error
+      // (or a later user.message) close the bubble.
+      if (open >= 0 && out[open].role === 'assistant') {
+        out[open].pending = false;
+      }
     }
   }
   return out;
@@ -260,8 +288,9 @@ export default function ChatPanel({
   const threadRef = useRef<HTMLDivElement | null>(null);
   const inputRef = useRef<HTMLTextAreaElement | null>(null);
   const streamHandleRef = useRef<EventStreamHandle | null>(null);
-  const replyMsgIdRef = useRef<string | null>(null);
   const pendingUserMsgIdRef = useRef<string | null>(null);
+  /** Id of the current open assistant turn bubble; null when no turn is active. */
+  const openMsgIdRef = useRef<string | null>(null);
   const seenEventIdsRef = useRef<Set<string>>(new Set());
   const lastSeqRef = useRef(0);
   /** When true, keep pinned to latest message as stream grows. */
@@ -285,21 +314,35 @@ export default function ChatPanel({
     const confirm = extractConfirmation(evt);
     if (confirm) setPendingConfirm(confirm);
 
+    const closeOpen = (prev: Message[]): Message[] => {
+      const id = openMsgIdRef.current;
+      openMsgIdRef.current = null;
+      if (!id) return prev;
+      return prev.map(m => (m.id === id ? { ...m, pending: false, closed: true } : m));
+    };
+    const append = (prev: Message[], seedId: string, block: ContentBlock): Message[] => {
+      const cur = openMsgIdRef.current;
+      if (cur) {
+        const existing = prev.find(m => m.id === cur);
+        if (existing && !existing.closed) {
+          // Avoid duplicate blocks for the same event id (preview vs persisted).
+          if (existing.blocks.some(
+            b => b.kind === block.kind && (b.id === block.id || b.id === seedId),
+          )) return prev;
+          return prev.map(m =>
+            m.id === cur ? { ...m, blocks: [...m.blocks, block], pending: true } : m);
+        }
+      }
+      openMsgIdRef.current = `${seedId}-turn`;
+      return [...prev, { id: `${seedId}-turn`, role: 'assistant', blocks: [block], pending: true }];
+    };
+
     if (evt.type === 'event_start') {
       const targetType = String(evt.payload?.type ?? '');
       const eventId = String(evt.payload?.event_id ?? '');
-      if (!eventId) return;
-      if (targetType === 'agent.message') {
-        const localReply = replyMsgIdRef.current;
-        replyMsgIdRef.current = eventId;
-        setMessages(prev => {
-          if (prev.some(m => m.id === eventId)) return prev;
-          if (localReply) {
-            return prev.map(m => (m.id === localReply ? { ...m, id: eventId, pending: true } : m));
-          }
-          return [...prev, { id: eventId, role: 'assistant', text: '', tools: [], pending: true }];
-        });
-      }
+      if (!eventId || targetType !== 'agent.message') return;
+      // Reserve the turn bubble so deltas stream into it.
+      setMessages(prev => append(prev, eventId, { kind: 'text', id: eventId, text: '' }));
       return;
     }
 
@@ -309,104 +352,111 @@ export default function ChatPanel({
       const delta = evt.payload?.delta != null ? String(evt.payload.delta) : '';
       if (!eventId || !delta) return;
       if (targetType === 'agent.message') {
-        const localReply = replyMsgIdRef.current;
-        replyMsgIdRef.current = eventId;
         setMessages(prev => {
-          if (prev.some(m => m.id === eventId)) {
-            return prev.map(m => (m.id === eventId ? { ...m, text: m.text + delta, pending: true } : m));
+          const cur = openMsgIdRef.current;
+          if (cur) {
+            const existing = prev.find(m => m.id === cur);
+            if (existing && !existing.closed) {
+              return prev.map(m => {
+                if (m.id !== cur) return m;
+                const idx = m.blocks.findIndex(b => b.kind === 'text' && b.id === eventId);
+                if (idx >= 0) {
+                  return {
+                    ...m,
+                    blocks: m.blocks.map((b, i) =>
+                      i === idx ? { ...b, text: (b.text ?? '') + delta } : b),
+                    pending: true,
+                  };
+                }
+                return { ...m, blocks: [...m.blocks, { kind: 'text', id: eventId, text: delta }], pending: true };
+              });
+            }
           }
-          if (localReply && localReply !== eventId && prev.some(m => m.id === localReply)) {
-            return prev.map(m =>
-              m.id === localReply ? { ...m, id: eventId, text: m.text + delta, pending: true } : m);
-          }
-          return [...prev, { id: eventId, role: 'assistant', text: delta, tools: [], pending: true }];
+          return append(prev, eventId, { kind: 'text', id: eventId, text: delta });
         });
       } else if (targetType === 'agent.tool_use') {
-        setMessages(prev => {
-          const lastAssistantIdx = [...prev].map((m, i) => ({ m, i })).reverse()
-            .find(x => x.m.role === 'assistant')?.i;
-          if (lastAssistantIdx == null) {
-            return [...prev, {
-              id: `${eventId}-host`,
-              role: 'assistant',
-              text: '',
-              tools: [{ id: eventId, name: 'tool', input: delta }],
-              pending: true,
-            }];
-          }
-          return prev.map((m, i) => {
-            if (i !== lastAssistantIdx) return m;
-            const existing = m.tools.find(t => t.id === eventId);
-            const tools = existing
-              ? m.tools.map(t => (t.id === eventId ? { ...t, input: (t.input ?? '') + delta } : t))
-              : [...m.tools, { id: eventId, name: 'tool', input: delta }];
-            return { ...m, tools, pending: true };
-          });
-        });
+        setMessages(prev => append(prev, eventId, { kind: 'tool', id: eventId, toolName: 'tool', text: delta }));
       }
       return;
     }
 
     if (evt.type === 'user.message') {
       const text = payloadText(evt.payload);
-      if (text) {
-        const localUser = pendingUserMsgIdRef.current;
-        pendingUserMsgIdRef.current = null;
-        setMessages(prev => {
-          if (prev.some(m => m.id === evt.id)) return prev;
-          // Adopt the server id onto the optimistic bubble instead of appending a twin.
-          if (localUser && prev.some(m => m.id === localUser)) {
-            return prev.map(m => (m.id === localUser ? { ...m, id: evt.id, text } : m));
-          }
-          return [...prev, { id: evt.id, role: 'user', text, tools: [] }];
-        });
-      }
-    } else if (evt.type === 'agent.message' || evt.type === 'agent.turn_stub') {
-      const text = payloadText(evt.payload);
-      const replyId = replyMsgIdRef.current;
-      replyMsgIdRef.current = null;
+      if (!text) return;
+      const localUser = pendingUserMsgIdRef.current;
+      pendingUserMsgIdRef.current = null;
       setMessages(prev => {
-        if (prev.some(m => m.id === evt.id)) {
-          return prev.map(m =>
-            m.id === evt.id ? { ...m, text: text || m.text || '[agent response]', pending: false } : m);
-        }
-        if (replyId && prev.some(m => m.id === replyId)) {
-          return prev.map(m =>
-            m.id === replyId
-              ? { ...m, id: evt.id, text: text || m.text || '[agent response]', pending: false }
+        let next = closeOpen(prev);
+        if (next.some(m => m.id === evt.id)) return next;
+        if (localUser && next.some(m => m.id === localUser)) {
+          return next.map(m =>
+            m.id === localUser
+              ? { ...m, id: evt.id, blocks: [{ kind: 'text', id: evt.id, text }] }
               : m);
         }
-        return [...prev, { id: evt.id, role: 'assistant', text: text || '[agent response]', tools: [] }];
+        return [...next, { id: evt.id, role: 'user', blocks: [{ kind: 'text', id: evt.id, text }] }];
       });
-    } else if (evt.type === 'agent.tool_use') {
-      const tool: ToolEntry = {
-        id: String(evt.payload?.id ?? evt.payload?.toolCallId ?? evt.payload?.toolUseId ?? evt.id),
-        name: String(evt.payload?.name ?? evt.payload?.toolName ?? 'tool'),
-        input: evt.payload?.input != null ? JSON.stringify(evt.payload.input) : undefined,
-      };
-      const previewKey = evt.id;
+      return;
+    }
+
+    if (evt.type === 'agent.message' || evt.type === 'agent.turn_stub') {
+      const text = payloadText(evt.payload) || '[agent response]';
       setMessages(prev => {
-        let matched = false;
-        const next = prev.map(m => {
-          if (m.role !== 'assistant') return m;
-          const tools = m.tools.map(t => {
-            if (t.id === previewKey || t.id === tool.id) {
-              matched = true;
-              return { ...tool, id: tool.id };
+        // The final persisted event carries the full text: replace the streamed
+        // preview block instead of appending a duplicate.
+        const cur = openMsgIdRef.current;
+        if (cur) {
+          const existing = prev.find(m => m.id === cur);
+          if (existing && !existing.closed) {
+            const idx = existing.blocks.findIndex(b => b.kind === 'text' && b.id === evt.id);
+            if (idx >= 0) {
+              return prev.map(m =>
+                m.id === cur
+                  ? { ...m, blocks: m.blocks.map((b, i) => (i === idx ? { ...b, text } : b)) }
+                  : m);
             }
-            return t;
-          });
-          return matched ? { ...m, tools, pending: false } : m;
-        });
-        if (matched) return next;
-        const last = next[next.length - 1];
-        if (last?.role === 'assistant') {
-          return next.map((m, i) =>
-            i === next.length - 1 ? { ...m, tools: [...m.tools, tool], pending: false } : m);
+          }
         }
-        return [...next, { id: `${evt.id}-host`, role: 'assistant', text: '', tools: [tool] }];
+        return append(prev, evt.id, { kind: 'text', id: evt.id, text });
       });
-    } else if (evt.type === 'agent.tool_result') {
+      return;
+    }
+
+    if (evt.type === 'agent.tool_use') {
+      const toolId = String(
+        evt.payload?.id ?? evt.payload?.toolCallId ?? evt.payload?.toolUseId ?? evt.id,
+      );
+      const toolName = String(evt.payload?.name ?? evt.payload?.toolName ?? 'tool');
+      const input = evt.payload?.input != null ? JSON.stringify(evt.payload.input) : undefined;
+      setMessages(prev => {
+        // Adopt the preview block (id = the event id) and finalize its id to the
+        // tool-call id so tool_result can match it later.
+        const cur = openMsgIdRef.current;
+        if (cur) {
+          const existing = prev.find(m => m.id === cur);
+          if (existing && !existing.closed) {
+            const idx = existing.blocks.findIndex(
+              b => b.kind === 'tool' && (b.id === toolId || b.id === evt.id),
+            );
+            if (idx >= 0) {
+              return prev.map(m =>
+                m.id === cur
+                  ? {
+                      ...m,
+                      blocks: m.blocks.map((b, i) =>
+                        i === idx ? { ...b, id: toolId, toolName, text: b.text ?? input } : b),
+                      pending: false,
+                    }
+                  : m);
+            }
+          }
+        }
+        return append(prev, evt.id, { kind: 'tool', id: toolId, toolName, text: input });
+      });
+      return;
+    }
+
+    if (evt.type === 'agent.tool_result') {
       const toolUseId = String(
         evt.payload?.tool_use_id ?? evt.payload?.toolCallId ?? evt.payload?.id ?? '',
       );
@@ -414,29 +464,40 @@ export default function ChatPanel({
         ? String(evt.payload.output)
         : payloadText(evt.payload);
       if (!toolUseId) return;
-      setMessages(prev => prev.map(m => {
-        if (m.role !== 'assistant') return m;
-        if (!m.tools.some(t => t.id === toolUseId)) return m;
-        return {
-          ...m,
-          tools: m.tools.map(t => (t.id === toolUseId ? { ...t, result: output } : t)),
-        };
-      }));
-    } else if (evt.type === 'session.status_idle' && !confirm) {
-      const replyId = replyMsgIdRef.current;
-      if (replyId) {
-        setMessages(prev => prev.map(m => m.id === replyId ? { ...m, pending: false } : m));
-        replyMsgIdRef.current = null;
-      }
-    } else if (evt.type === 'session.error') {
       setMessages(prev => {
-        if (prev.some(m => m.id === evt.id)) return prev;
-        const replyId = replyMsgIdRef.current;
-        replyMsgIdRef.current = null;
-        return [
-          ...prev.map(m => (m.id === replyId ? { ...m, pending: false } : m)),
-          { id: evt.id, role: 'error', text: errorText(evt), tools: [] },
-        ];
+        let updated = false;
+        const next = prev.map(m => {
+          const idx = m.blocks.findIndex(b => b.kind === 'tool' && b.id === toolUseId);
+          if (idx < 0) return m;
+          updated = true;
+          return { ...m, blocks: m.blocks.map((b, i) => (i === idx ? { ...b, result: output } : b)) };
+        });
+        return updated ? next : prev;
+      });
+      return;
+    }
+
+    if (evt.type.startsWith('session.status')) {
+      // Keep the turn bubble open across status events (the backend may emit
+      // status_idle between model iterations of one user question); only
+      // user.message / session.error close it.
+      setMessages(prev => {
+        const id = openMsgIdRef.current;
+        if (!id) return prev;
+        return prev.map(m => (m.id === id ? { ...m, pending: false } : m));
+      });
+      return;
+    }
+
+    if (evt.type === 'session.error') {
+      setMessages(prev => {
+        const next = closeOpen(prev);
+        if (next.some(m => m.id === evt.id)) return next;
+        return [...next, {
+          id: evt.id,
+          role: 'error',
+          blocks: [{ kind: 'text', id: evt.id, text: errorText(evt) }],
+        }];
       });
     }
   }, []);
@@ -451,7 +512,7 @@ export default function ChatPanel({
     setManagedSession(null);
     seenEventIdsRef.current = new Set();
     lastSeqRef.current = 0;
-    replyMsgIdRef.current = null;
+    openMsgIdRef.current = null;
     pendingUserMsgIdRef.current = null;
     stickToBottomRef.current = true;
     streamHandleRef.current?.close();
@@ -478,6 +539,9 @@ export default function ChatPanel({
           {
             after: lastSeqRef.current,
             eventDeltas: ['agent.message', 'agent.thinking', 'agent.tool_use'],
+            // Resume from the last seen sequence on automatic reconnects.
+            getAfter: () => lastSeqRef.current,
+            retryMs: 2000,
           },
         );
       } catch (e: unknown) {
@@ -548,8 +612,9 @@ export default function ChatPanel({
 
   /**
    * Relabels the optimistic user bubble with the server event id so the same event
-   * arriving over the stream is dropped by the seen-id guard. No-op when the stream
-   * already won the race and reconciled it.
+   * arriving over the stream reconciles instead of appending a twin. The stream is
+   * deliberately NOT pre-deduped: the user.message handler must run so it closes the
+   * previous turn bubble before the next reply is appended.
    */
   function adoptRecordedUserEvent(recorded: SessionEvent[]) {
     const localUser = pendingUserMsgIdRef.current;
@@ -557,7 +622,6 @@ export default function ChatPanel({
     const serverEvent = recorded.find(e => e.type === 'user.message' && e.id);
     if (!serverEvent) return;
     pendingUserMsgIdRef.current = null;
-    seenEventIdsRef.current.add(serverEvent.id);
     if (typeof serverEvent.seq === 'number' && serverEvent.seq > lastSeqRef.current) {
       lastSeqRef.current = serverEvent.seq;
     }
@@ -573,21 +637,24 @@ export default function ChatPanel({
     setInput('');
     setBusy(true);
     stickToBottomRef.current = true;
-    const userMsg: Message = { id: nextId(), role: 'user', text, tools: [] };
-    const replyMsg: Message = { id: nextId(), role: 'assistant', text: '', tools: [], pending: true };
-    replyMsgIdRef.current = replyMsg.id;
+    const userMsg: Message = {
+      id: nextId(),
+      role: 'user',
+      blocks: [{ kind: 'text', id: nextId(), text }],
+    };
     pendingUserMsgIdRef.current = userMsg.id;
-    setMessages(prev => [...prev, userMsg, replyMsg]);
+    setMessages(prev => [...prev, userMsg]);
 
     try {
       const recorded = await postUserMessage(sessionId, text);
       adoptRecordedUserEvent(recorded);
     } catch (e: unknown) {
       const msg = e instanceof Error ? e.message : 'send failed';
-      setMessages(prev => prev.map(m => m.id === replyMsg.id
-        ? { ...m, pending: false, text: `[error] ${msg}` }
-        : m));
-      replyMsgIdRef.current = null;
+      setMessages(prev => [...prev, {
+        id: nextId(),
+        role: 'system',
+        blocks: [{ kind: 'text', id: nextId(), text: `[error] ${msg}` }],
+      }]);
       pendingUserMsgIdRef.current = null;
     } finally {
       setBusy(false);
@@ -610,12 +677,19 @@ export default function ChatPanel({
       setMessages(prev => [...prev, {
         id: nextId(),
         role: 'system',
-        text: allow ? `Tool "${pendingConfirm.toolName}" allowed.` : `Tool "${pendingConfirm.toolName}" denied.`,
-        tools: [],
+        blocks: [{
+          kind: 'text',
+          id: nextId(),
+          text: allow ? `Tool "${pendingConfirm.toolName}" allowed.` : `Tool "${pendingConfirm.toolName}" denied.`,
+        }],
       }]);
     } catch (e: unknown) {
       const msg = e instanceof Error ? e.message : 'confirmation failed';
-      setMessages(prev => [...prev, { id: nextId(), role: 'system', text: `[error] ${msg}`, tools: [] }]);
+      setMessages(prev => [...prev, {
+        id: nextId(),
+        role: 'system',
+        blocks: [{ kind: 'text', id: nextId(), text: `[error] ${msg}` }],
+      }]);
     } finally {
       setBusy(false);
     }
@@ -712,15 +786,26 @@ export default function ChatPanel({
             Session ready. Send a message to start the first turn — events stay empty until then.
           </div>
         )}
-        {messages.map(m => (
-          <MessageBlock
-            key={m.id}
-            role={m.role}
-            text={m.text}
-            tools={m.tools}
-            pending={m.pending}
-          />
-        ))}
+        {(() => {
+          // Auto-expand the latest assistant turn bubble (even when a follow-up
+          // user message sits after it) so replies and tool calls are readable.
+          let lastAssistant = -1;
+          for (let i = messages.length - 1; i >= 0; i--) {
+            if (messages[i].role === 'assistant') {
+              lastAssistant = i;
+              break;
+            }
+          }
+          return messages.map((m, i) => (
+            <MessageBlock
+              key={m.id}
+              role={m.role}
+              blocks={m.blocks}
+              pending={m.pending}
+              defaultOpen={i === lastAssistant}
+            />
+          ));
+        })()}
         {pendingConfirm && !readOnly && (
           <div style={S.confirmCard}>
             <div style={{ fontWeight: 700, color: '#92400e', marginBottom: 8 }}>

--- a/agentscope-service/frontend/src/components/MessageBlock.tsx
+++ b/agentscope-service/frontend/src/components/MessageBlock.tsx
@@ -15,19 +15,22 @@
  */
 
 import React, { useMemo, useState } from 'react';
+import ReactMarkdown from 'react-markdown';
 import ToolCallBlock from './ToolCallBlock';
 
-export interface MessageBlockTool {
+/** Ordered content inside one assistant turn bubble (text and tool calls interleaved). */
+export interface ContentBlock {
+  kind: 'text' | 'tool';
   id: string;
-  name: string;
-  input?: string;
+  /** Text content, or the tool-call input when kind === 'tool'. */
+  text?: string;
+  toolName?: string;
   result?: string;
 }
 
 export interface MessageBlockProps {
   role: 'user' | 'assistant' | 'system' | 'error';
-  text: string;
-  tools: MessageBlockTool[];
+  blocks: ContentBlock[];
   pending?: boolean;
   /** Soft auto-expand while actively streaming once the user opens it — not forced. */
   defaultOpen?: boolean;
@@ -156,18 +159,20 @@ const s: Record<string, React.CSSProperties> = {
 
 export default function MessageBlock({
   role,
-  text,
-  tools,
+  blocks,
   pending,
   defaultOpen = false,
 }: MessageBlockProps) {
   const [open, setOpen] = useState(defaultOpen);
+  const text = useMemo(
+    () => blocks.filter(b => b.kind === 'text').map(b => b.text ?? '').join(''),
+    [blocks],
+  );
+  const toolCount = useMemo(() => blocks.filter(b => b.kind === 'tool').length, [blocks]);
   const preview = useMemo(() => messagePreviewLine(text, pending), [text, pending]);
-  const toolHint = tools.length > 0
-    ? `${tools.length} tool${tools.length === 1 ? '' : 's'}`
-    : '';
+  const toolHint = toolCount > 0 ? `${toolCount} tool${toolCount === 1 ? '' : 's'}` : '';
 
-  const empty = !text && tools.length === 0;
+  const empty = blocks.length === 0;
 
   return (
     <div style={{ ...s.root, ...roleStyles[role] }}>
@@ -193,25 +198,34 @@ export default function MessageBlock({
 
       {open && (
         <div style={s.body}>
-          {tools.length > 0 && (
-            <div>
-              {tools.map((t) => (
+          {blocks.map(b => (
+            b.kind === 'text'
+              ? (
+                role === 'assistant'
+                  ? (
+                    <div key={b.id} className="md-text" style={{ wordBreak: 'break-word' }}>
+                      <ReactMarkdown>{b.text}</ReactMarkdown>
+                    </div>
+                  )
+                  : (
+                    <div key={b.id} style={s.text}>{b.text}</div>
+                  )
+              )
+              : (
                 <ToolCallBlock
-                  key={t.id}
-                  toolName={t.name}
-                  toolCallId={t.id}
-                  result={t.result}
+                  key={b.id}
+                  toolName={b.toolName ?? 'tool'}
+                  toolCallId={b.id}
+                  input={b.text}
+                  result={b.result}
                 />
-              ))}
-            </div>
-          )}
-          {text ? (
-            <div style={s.text}>{text}</div>
-          ) : pending ? (
+              )
+          ))}
+          {empty && pending && <div style={{ ...s.text, ...s.pending }}>…</div>}
+          {empty && !pending && <div style={{ ...s.text, ...s.pending }}>—</div>}
+          {!empty && pending && text.trim() === '' && toolCount === 0 && (
             <div style={{ ...s.text, ...s.pending }}>…</div>
-          ) : empty ? (
-            <div style={{ ...s.text, ...s.pending }}>—</div>
-          ) : null}
+          )}
         </div>
       )}
     </div>

--- a/agentscope-service/frontend/src/components/ToolCallBlock.tsx
+++ b/agentscope-service/frontend/src/components/ToolCallBlock.tsx
@@ -14,12 +14,50 @@
  * limitations under the License.
  */
 
-import React, { useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
+import { Highlight, themes } from 'prism-react-renderer';
 
 interface Props {
   toolName: string;
   toolCallId: string;
+  /** Serialized tool-call input (JSON args). */
+  input?: string;
   result?: string;
+}
+
+/** Unescapes residual \\n / \\t / \\" sequences from double-encoded tool output. */
+function unescapeText(s: string): string {
+  return s
+    .replace(/\\n/g, '\n')
+    .replace(/\\t/g, '\t')
+    .replace(/\\r/g, '')
+    .replace(/\\"/g, '"')
+    .replace(/\\\\/g, '\\');
+}
+
+/** Unescapes JSON-encoded tool payloads and pretty-prints JSON for readability. */
+function formatToolContent(raw?: string): string {
+  if (raw == null) return '';
+  const trimmed = raw.trim();
+  if (trimmed.startsWith('"')) {
+    try {
+      const parsed = JSON.parse(trimmed);
+      if (typeof parsed === 'string') {
+        return /\\[ntr"\\]/.test(parsed) ? unescapeText(parsed) : parsed;
+      }
+      return JSON.stringify(parsed, null, 2);
+    } catch {
+      // fall through to raw display
+    }
+  }
+  if (trimmed.startsWith('{') || trimmed.startsWith('[')) {
+    try {
+      return JSON.stringify(JSON.parse(trimmed), null, 2);
+    } catch {
+      // fall through to raw display
+    }
+  }
+  return raw;
 }
 
 const s: Record<string, React.CSSProperties> = {
@@ -30,6 +68,9 @@ const s: Record<string, React.CSSProperties> = {
     margin: '0.5rem 0',
     overflow: 'hidden',
     fontSize: '0.9rem',
+    // Keep the block at natural height so the parent bubble body scrolls
+    // instead of compressing this card (flex-shrink would clip content).
+    flexShrink: 0,
   },
   header: {
     display: 'flex',
@@ -55,10 +96,111 @@ const s: Record<string, React.CSSProperties> = {
     fontSize: '0.85rem',
     lineHeight: 1.55,
   },
+  label: {
+    fontSize: '0.72rem',
+    fontWeight: 700,
+    textTransform: 'uppercase',
+    letterSpacing: '0.06em',
+    color: '#94a3b8',
+    marginBottom: 4,
+  },
+  inputSection: {
+    padding: '0.7rem 1rem 0.3rem',
+  },
+  resultSection: {
+    padding: '0.3rem 1rem 0.85rem',
+  },
 };
 
-export default function ToolCallBlock({ toolName, toolCallId, result }: Props) {
-  const [open, setOpen] = useState(false);
+/** Renders tool output with grep-style `file:line:content` lines cleaned up. */
+function renderOutput(text: string): React.ReactNode[] {
+  const lines = text.split('\n');
+  return lines.map((line, i) => {
+    const m = line.match(/^(?:\.\.\/)+([^:]+?):(\d+):(.*)$/);
+    if (m) {
+      return (
+        <div key={i} style={{ display: 'flex' }}>
+          <span style={{ color: '#6366f1', fontWeight: 600 }}>{m[1]}</span>
+          <span style={{ color: '#94a3b8' }}>:{m[2]}:</span>
+          <span style={{ flex: 1 }}>{m[3]}</span>
+        </div>
+      );
+    }
+    return (
+      <div key={i} style={{ display: 'flex' }}>
+        <span style={{
+          color: '#cbd5e1', minWidth: '2.4em', textAlign: 'right',
+          paddingRight: 10, userSelect: 'none', flexShrink: 0,
+        }}>
+          {i + 1}
+        </span>
+        <span style={{ flex: 1, whiteSpace: 'pre-wrap', wordBreak: 'break-all' }}>
+          {line || '\u00a0'}
+        </span>
+      </div>
+    );
+  });
+}
+
+const GUTTER: React.CSSProperties = {
+  color: '#cbd5e1', minWidth: '2.4em', textAlign: 'right',
+  paddingRight: 10, userSelect: 'none', flexShrink: 0,
+};
+
+/** Heuristic language detection for syntax-highlightable tool content. */
+function detectCodeLanguage(text: string): string | null {
+  const t = text.trimStart();
+  if (t.startsWith('{') || t.startsWith('[')) return 'json';
+  if (t.startsWith('<')) return 'xml';
+  if (t.startsWith('package ') || t.startsWith('import java') || t.startsWith('public ') || t.startsWith('@Override')) return 'java';
+  if (t.startsWith('#!/')) return 'bash';
+  if (t.startsWith('function ') || t.startsWith('const ') || t.startsWith('let ') || t.startsWith('export ')) return 'javascript';
+  return null;
+}
+
+function CodeBlock({ code, language }: { code: string; language: string }) {
+  return (
+    <div style={{
+      maxHeight: 320, overflowY: 'auto', fontSize: '0.85rem', lineHeight: 1.55,
+      fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace',
+    }}>
+      <Highlight theme={themes.github} code={code} language={language}>
+        {({ style, tokens, getTokenProps }) => (
+          <div style={{ ...style, margin: 0, padding: '0.6rem 1rem', backgroundColor: 'transparent' }}>
+            {tokens.map((line, i) => (
+              <div key={i} style={{ display: 'flex' }}>
+                <span style={GUTTER}>{i + 1}</span>
+                <span style={{ flex: 1, whiteSpace: 'pre-wrap', wordBreak: 'break-all' }}>
+                  {line.map((token, key) => (
+                    <span key={key} {...getTokenProps({ token })} />
+                  ))}
+                </span>
+              </div>
+            ))}
+          </div>
+        )}
+      </Highlight>
+    </div>
+  );
+}
+
+/** Picks syntax highlighting for code-like content, else the plain/grep renderer. */
+function renderContent(text: string): React.ReactNode {
+  const lang = detectCodeLanguage(text);
+  if (lang) {
+    return <CodeBlock code={text} language={lang} />;
+  }
+  return <div style={s.body}>{renderOutput(text)}</div>;
+}
+
+export default function ToolCallBlock({ toolName, toolCallId, input, result }: Props) {
+  // Open while the tool is producing output, collapse once the result lands.
+  const [open, setOpen] = useState(result == null);
+  useEffect(() => {
+    if (result != null) setOpen(false);
+  }, [result]);
+  const inputText = useMemo(() => formatToolContent(input), [input]);
+  const resultText = useMemo(() => formatToolContent(result), [result]);
   return (
     <div style={s.wrapper}>
       <div style={s.header} onClick={() => setOpen(o => !o)}>
@@ -66,8 +208,23 @@ export default function ToolCallBlock({ toolName, toolCallId, result }: Props) {
         <span style={s.name}>Tool: {toolName}</span>
         <span style={s.id}>{toolCallId.slice(0, 10)}</span>
       </div>
-      {open && result && <div style={s.body}>{result}</div>}
-      {open && !result && (
+      {open && (inputText || resultText) && (
+        <>
+          {inputText != null && (
+            <div style={s.inputSection}>
+              <div style={s.label}>Input</div>
+              {renderContent(inputText)}
+            </div>
+          )}
+          {resultText != null && (
+            <div style={s.resultSection}>
+              <div style={s.label}>Result</div>
+              {renderContent(resultText)}
+            </div>
+          )}
+        </>
+      )}
+      {open && !inputText && !resultText && (
         <div style={{ ...s.body, color: '#94a3b8' }}>Running…</div>
       )}
     </div>

--- a/agentscope-service/frontend/src/index.css
+++ b/agentscope-service/frontend/src/index.css
@@ -106,3 +106,101 @@ select:focus {
 .font-mono {
   font-family: var(--font-mono);
 }
+
+/* Markdown-rendered assistant text inside chat bubbles */
+.md-text {
+  font-size: 0.95rem;
+  line-height: 1.65;
+}
+.md-text > *:first-child {
+  margin-top: 0;
+}
+.md-text > *:last-child {
+  margin-bottom: 0;
+}
+.md-text p {
+  margin: 0.5em 0;
+}
+.md-text h1,
+.md-text h2,
+.md-text h3,
+.md-text h4 {
+  margin: 0.9em 0 0.4em;
+  font-weight: 700;
+  line-height: 1.3;
+}
+.md-text h1 {
+  font-size: 1.25rem;
+}
+.md-text h2 {
+  font-size: 1.12rem;
+}
+.md-text h3 {
+  font-size: 1.02rem;
+}
+.md-text ul,
+.md-text ol {
+  margin: 0.5em 0;
+  padding-left: 1.5em;
+}
+.md-text li {
+  margin: 0.2em 0;
+}
+.md-text li > ul,
+.md-text li > ol {
+  margin: 0.2em 0;
+}
+.md-text a {
+  color: #4338ca;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+.md-text code {
+  font-family: var(--font-mono);
+  font-size: 0.85em;
+  background: #f1f5f9;
+  border: 1px solid #e2e8f0;
+  border-radius: 4px;
+  padding: 0.1em 0.35em;
+}
+.md-text pre {
+  background: #0f172a;
+  color: #e2e8f0;
+  border-radius: 8px;
+  padding: 10px 12px;
+  overflow: auto;
+  font-size: 0.85rem;
+  line-height: 1.55;
+  margin: 0.6em 0;
+}
+.md-text pre code {
+  background: none;
+  border: none;
+  padding: 0;
+  font-size: inherit;
+}
+.md-text blockquote {
+  margin: 0.6em 0;
+  padding-left: 12px;
+  border-left: 3px solid #cbd5e1;
+  color: #64748b;
+}
+.md-text table {
+  border-collapse: collapse;
+  margin: 0.6em 0;
+  font-size: 0.9rem;
+}
+.md-text th,
+.md-text td {
+  border: 1px solid #e2e8f0;
+  padding: 5px 10px;
+  text-align: left;
+}
+.md-text th {
+  background: #f8fafc;
+  font-weight: 600;
+}
+.md-text img {
+  max-width: 100%;
+  border-radius: 8px;
+}


### PR DESCRIPTION
## Summary

Reworks the managed-session chat transcript around **one bubble per user question**, with text and tool calls rendered as ordered content blocks in chronological order.

**ChatPanel.tsx**
- Block-based message model (`ContentBlock[]`): `agent.message` / `agent.tool_use` / `agent.tool_result` append ordered blocks into the current turn bubble; `user.message` / `session.error` close it
- Turn bubbles stay open across `session.status_*` events — the backend emits `status_idle` between model iterations of one user question, which previously split one answer into multiple bubbles
- Auto-expand the latest assistant turn bubble (even when a follow-up user message sits after it)
- Renders `session.error` as a red bubble (fixes #2596)
- Fixed the send path: optimistic user bubble + SSE reconciliation now correctly closes the previous turn (the `seen-id` pre-dedupe was eating the streamed `user.message`, so the next reply appended to the old bubble)
- Removed vestigial `replyMsgIdRef` (it crashed sends after the block refactor)

**managedSessions.ts**
- SSE auto-reconnect with exponential backoff (2s → 30s cap, resets on progress), resuming from the last seen sequence via `getAfter` so no events are lost across plane restarts

**MessageBlock.tsx**
- Renders ordered content blocks; assistant text via `react-markdown` with `.md-text` styles (headings, lists, code blocks, tables, blockquote, images)

**ToolCallBlock.tsx**
- Input / Result sections with labels
- JSON pretty-printing + residual escape unescaping (`\\n` from double-encoded tool output)
- Grep-style `file:line:content` rows highlighted (relative-path prefix stripped)
- Line numbers for plain/file dumps; `prism-react-renderer` syntax highlighting for XML/JSON/Java/Bash/JS
- Tool card opens while the tool is running and collapses once the result lands

Dependencies added: `react-markdown`, `prism-react-renderer` (package.json only; `package-lock.json` was not regenerated locally — CI may want to run `npm install --package-lock`).

## Test plan

- [x] `vite build` succeeds
- [x] Verified via headless Chrome: sequential user messages produce separate assistant bubbles; multi-tool turns render as one bubble in event order; markdown renders; tool Input/Result display formatted content; SSE reconnect resumes from cursor
- [x] Send-path regression: user message → agent reply loop works end-to-end (DeepSeek model)

Supersedes #2598 (session.error rendering was folded into the block model).