### PR TITLE
fix(harness): target active session in HarnessAgent interrupt API

### DIFF
--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/HarnessAgent.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/HarnessAgent.java
@@ -575,6 +575,7 @@ public class HarnessAgent implements Agent, AutoCloseable {
 
     @Override
     public void interrupt() {
+        // get the active runtime context
         RuntimeContext active = delegate.getRuntimeContext();
         if (active != null) {
             delegate.interrupt(active);

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/HarnessAgent.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/HarnessAgent.java
@@ -575,12 +575,47 @@ public class HarnessAgent implements Agent, AutoCloseable {
 
     @Override
     public void interrupt() {
-        delegate.interrupt();
+        RuntimeContext active = delegate.getRuntimeContext();
+        if (active != null) {
+            delegate.interrupt(active);
+        } else {
+            delegate.interrupt();
+        }
     }
 
     @Override
     public void interrupt(Msg msg) {
-        delegate.interrupt(msg);
+        RuntimeContext active = delegate.getRuntimeContext();
+        if (active != null) {
+            delegate.interrupt(active, msg);
+        } else {
+            delegate.interrupt(msg);
+        }
+    }
+
+    /**
+     * Interrupts the in-flight call identified by the given {@link RuntimeContext}.
+     *
+     * <p>Unlike {@link #interrupt()}, this targets the exact {@code (userId, sessionId)} slot
+     * carried by {@code ctx}, so it works for sessions started via
+     * {@link #streamEvents(List, RuntimeContext)} with a custom {@code sessionId} (see issue
+     * #2610). Safe under concurrency: each caller supplies the session it wants to cancel.
+     *
+     * @param ctx the runtime context identifying the session to interrupt
+     */
+    public void interrupt(RuntimeContext ctx) {
+        delegate.interrupt(ctx);
+    }
+
+    /**
+     * Interrupts the in-flight call identified by the given {@link RuntimeContext} with an
+     * associated user message.
+     *
+     * @param ctx the runtime context identifying the session to interrupt
+     * @param msg optional user message to attach to the interrupt signal
+     */
+    public void interrupt(RuntimeContext ctx, Msg msg) {
+        delegate.interrupt(ctx, msg);
     }
 
     // -----------------------------------------------------------------

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/HarnessAgentInterruptTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/HarnessAgentInterruptTest.java
@@ -1,0 +1,210 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.harness.agent;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.agentscope.core.agent.RuntimeContext;
+import io.agentscope.core.event.AgentResultEvent;
+import io.agentscope.core.message.GenerateReason;
+import io.agentscope.core.message.Msg;
+import io.agentscope.core.message.MsgRole;
+import io.agentscope.core.message.TextBlock;
+import io.agentscope.core.message.UserMessage;
+import io.agentscope.core.model.ChatModelBase;
+import io.agentscope.core.model.ChatResponse;
+import io.agentscope.core.model.GenerateOptions;
+import io.agentscope.core.model.ToolSchema;
+import io.agentscope.core.state.InMemoryAgentStateStore;
+import io.agentscope.harness.agent.filesystem.local.LocalFilesystem;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import reactor.core.publisher.Flux;
+
+/**
+ * Tests for {@link HarnessAgent} interrupt targeting: the {@code interrupt(RuntimeContext[, Msg])}
+ * overloads must cancel the in-flight stream running under the custom {@code sessionId} carried by
+ * that context, and the context-free {@code interrupt()} / {@code interrupt(Msg)} overloads must
+ * prefer the active call's runtime context when one exists. See issue #2610.
+ */
+class HarnessAgentInterruptTest {
+
+    @TempDir Path workspace;
+
+    /**
+     * Model whose first call blocks until released, so the test thread can fire an interrupt
+     * while the agent's stream is in flight.
+     */
+    private static final class BlockingModel extends ChatModelBase {
+        private final CountDownLatch called = new CountDownLatch(1);
+        private final CountDownLatch release = new CountDownLatch(1);
+
+        @Override
+        public String getModelName() {
+            return "blocking-model";
+        }
+
+        @Override
+        protected Flux<ChatResponse> doStream(
+                List<Msg> messages, List<ToolSchema> tools, GenerateOptions options) {
+            called.countDown();
+            try {
+                if (!release.await(10, TimeUnit.SECONDS)) {
+                    throw new IllegalStateException("test interrupt never released the model");
+                }
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new IllegalStateException("interrupted while waiting for release", e);
+            }
+            return Flux.just(textResponse("done"));
+        }
+
+        boolean awaitCalled(long timeout, TimeUnit unit) throws InterruptedException {
+            return called.await(timeout, unit);
+        }
+
+        void release() {
+            release.countDown();
+        }
+    }
+
+    private static ChatResponse textResponse(String text) {
+        return new ChatResponse(
+                "stub-id", List.of(TextBlock.builder().text(text).build()), null, Map.of(), "stop");
+    }
+
+    private static Msg userMsg(String text) {
+        return Msg.builder().role(MsgRole.USER).textContent(text).build();
+    }
+
+    private static HarnessAgent buildAgent(ChatModelBase model, Path workspace) {
+        return HarnessAgent.builder()
+                .name("coding-assistant")
+                .model(model)
+                .workspace(workspace)
+                .abstractFilesystem(new LocalFilesystem(workspace))
+                .stateStore(new InMemoryAgentStateStore())
+                .build();
+    }
+
+    private static Msg runStreamAndInterrupt(
+            HarnessAgent agent, RuntimeContext ctx, BlockingModel model, Runnable interruptAction)
+            throws Exception {
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        try {
+            Future<Msg> future =
+                    executor.submit(
+                            () ->
+                                    agent.streamEvents(List.of(userMsg("hello")), ctx)
+                                            .filter(e -> e instanceof AgentResultEvent)
+                                            .cast(AgentResultEvent.class)
+                                            .next()
+                                            .map(AgentResultEvent::getResult)
+                                            .block());
+            assertTrue(
+                    model.awaitCalled(5, TimeUnit.SECONDS),
+                    "agent stream should have started a model call");
+            interruptAction.run();
+            model.release();
+            return future.get(10, TimeUnit.SECONDS);
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
+    @Test
+    void interruptWithRuntimeContext_targetsCustomSessionStream() throws Exception {
+        Files.createDirectories(workspace);
+        BlockingModel model = new BlockingModel();
+        try (HarnessAgent agent = buildAgent(model, workspace)) {
+            RuntimeContext ctx =
+                    RuntimeContext.builder().userId("user-1").sessionId("conversation-123").build();
+            Msg result =
+                    runStreamAndInterrupt(
+                            agent, ctx, model, () -> agent.interrupt(ctx, new UserMessage("用户取消")));
+            assertNotNull(result);
+            assertEquals(GenerateReason.INTERRUPTED, result.getGenerateReason());
+        }
+    }
+
+    @Test
+    void interruptWithRuntimeContextWithoutMsg_targetsCustomSessionStream() throws Exception {
+        Files.createDirectories(workspace);
+        BlockingModel model = new BlockingModel();
+        try (HarnessAgent agent = buildAgent(model, workspace)) {
+            RuntimeContext ctx =
+                    RuntimeContext.builder().userId("user-1").sessionId("conversation-123").build();
+            Msg result = runStreamAndInterrupt(agent, ctx, model, () -> agent.interrupt(ctx));
+            assertNotNull(result);
+            assertEquals(GenerateReason.INTERRUPTED, result.getGenerateReason());
+        }
+    }
+
+    @Test
+    void interruptWithoutContext_prefersActiveCallSession() throws Exception {
+        Files.createDirectories(workspace);
+        BlockingModel model = new BlockingModel();
+        try (HarnessAgent agent = buildAgent(model, workspace)) {
+            RuntimeContext ctx =
+                    RuntimeContext.builder().userId("user-1").sessionId("conversation-123").build();
+            Msg result =
+                    runStreamAndInterrupt(
+                            agent, ctx, model, () -> agent.interrupt(new UserMessage("用户取消")));
+            assertNotNull(result);
+            assertEquals(GenerateReason.INTERRUPTED, result.getGenerateReason());
+        }
+    }
+
+    @Test
+    void interruptWithoutContext_defaultSessionStreamStillInterruptible() throws Exception {
+        Files.createDirectories(workspace);
+        BlockingModel model = new BlockingModel();
+        try (HarnessAgent agent = buildAgent(model, workspace)) {
+            // No sessionId on the context: the stream runs under the default session
+            // (the agent name), which the context-free interrupt must keep targeting.
+            Msg result =
+                    runStreamAndInterrupt(
+                            agent,
+                            RuntimeContext.empty(),
+                            model,
+                            () -> agent.interrupt(new UserMessage("用户取消")));
+            assertNotNull(result);
+            assertEquals(GenerateReason.INTERRUPTED, result.getGenerateReason());
+        }
+    }
+
+    @Test
+    void interruptWithoutActiveCall_fallsBackToDefaultSessionWithoutThrowing() throws Exception {
+        Files.createDirectories(workspace);
+        try (HarnessAgent agent = buildAgent(new BlockingModel(), workspace)) {
+            // No in-flight call: the context-free overloads must keep their legacy fallback
+            // (interrupting the default session slot) instead of failing.
+            agent.interrupt();
+            agent.interrupt(new UserMessage("用户取消"));
+        }
+    }
+}

--- a/docs/v2/en/docs/building-blocks/agent.md
+++ b/docs/v2/en/docs/building-blocks/agent.md
@@ -220,6 +220,34 @@ agent.interrupt("alice", "session-001");
 agent.interrupt("alice", "session-001", interruptMsg);
 ```
 
+### HarnessAgent: targeting the active call
+
+On [`HarnessAgent`](../harness/architecture.md), the context-free `interrupt()` / `interrupt(Msg)`
+overloads prefer the **active call's** `RuntimeContext` — the session currently running on the
+agent — and only fall back to the builder-time default session when no call is in flight. Streams
+started via `streamEvents(msgs, ctx)` with a custom `sessionId` are therefore cancelled correctly
+(see issue #2610).
+
+When several sessions run concurrently on the same `HarnessAgent`, target the exact session with
+the `RuntimeContext` overloads — each caller supplies the session it wants to cancel, so this is
+safe under concurrency:
+
+```java
+HarnessAgent agent = ...;  // streamEvents(msgs, ctx) and interrupt(RuntimeContext[, Msg]) are HarnessAgent-specific
+
+RuntimeContext ctx = RuntimeContext.builder()
+        .userId("alice")
+        .sessionId("conversation-123")
+        .build();
+
+// start a stream under the custom sessionId
+agent.streamEvents(List.of(new UserMessage("Hello")), ctx).subscribe(...);
+
+// later, from any thread:
+agent.interrupt(ctx);                                     // cancels that stream only
+agent.interrupt(ctx, new UserMessage("User cancelled"));  // with an injected message
+```
+
 ## Running an agent
 
 `call` and `streamEvents` accept the same input messages and drive the same reasoning-acting loop. They differ in how the result is delivered.

--- a/docs/v2/en/docs/building-blocks/context.md
+++ b/docs/v2/en/docs/building-blocks/context.md
@@ -223,7 +223,7 @@ agent.interrupt("alice", "session-001", Msg.userMsg("Please stop and summarise."
 
 The reasoning loop checks `state.interruptControl().isInterrupted()` before each iteration. When triggered, the loop enters the `handleInterrupt` path, which saves state and returns the partial result.
 
-The legacy no-arg `interrupt()` still works for single-session scenarios — it routes to the currently active session's `InterruptControl`.
+The legacy no-arg `interrupt()` still works for single-session scenarios — it routes to the currently active session's `InterruptControl`. `HarnessAgent` behaves the same way: its context-free `interrupt()` / `interrupt(Msg)` prefer the active call's `RuntimeContext` (so streams started via `streamEvents(msgs, ctx)` with a custom `sessionId` can be cancelled), and it additionally exposes `interrupt(RuntimeContext[, Msg])` overloads for targeting an explicit session (see [Agent — Interrupt](./agent.md)).
 
 :::{note}
 `InterruptControl` is a runtime-only signal; it is never persisted. If a session resumes on a different node after failover, the interrupt flag starts cleared. The separate `AgentState.shutdownInterrupted` flag (which **is** persisted) records whether the session was interrupted by graceful shutdown — the agent can detect and recover from that on next load.

--- a/docs/v2/zh/docs/building-blocks/agent.md
+++ b/docs/v2/zh/docs/building-blocks/agent.md
@@ -220,6 +220,28 @@ agent.interrupt("alice", "session-001");
 agent.interrupt("alice", "session-001", interruptMsg);
 ```
 
+### HarnessAgent：定位活跃调用
+
+对于 [`HarnessAgent`](../harness/architecture.md)，无上下文的 `interrupt()` / `interrupt(Msg)` 重载会**优先路由到活跃调用（active call）的 `RuntimeContext`**——即当前正在该 agent 上运行的会话；只有当没有调用在飞时才回退到 builder 上配置的默认会话。因此，通过 `streamEvents(msgs, ctx)` 以自定义 `sessionId` 启动的流现在可以被正确取消（参见 issue #2610）。
+
+当同一 `HarnessAgent` 上有多个会话并发运行时，请使用带 `RuntimeContext` 的重载精确命中目标会话——每个调用者自己指定要取消的会话，因此在并发下是安全的：
+
+```java
+HarnessAgent agent = ...;  // streamEvents(msgs, ctx) 与 interrupt(RuntimeContext[, Msg]) 是 HarnessAgent 特有 API
+
+RuntimeContext ctx = RuntimeContext.builder()
+        .userId("alice")
+        .sessionId("conversation-123")
+        .build();
+
+// 以自定义 sessionId 启动流
+agent.streamEvents(List.of(new UserMessage("你好")), ctx).subscribe(...);
+
+// 之后从任意线程：
+agent.interrupt(ctx);                                      // 只取消该流
+agent.interrupt(ctx, new UserMessage("用户取消了操作"));   // 带注入消息
+```
+
 ## 运行智能体
 
 `call` 和 `streamEvents` 都接受相同的输入消息列表，驱动相同的推理-行动循环，区别在于结果的交付方式。

--- a/docs/v2/zh/docs/building-blocks/context.md
+++ b/docs/v2/zh/docs/building-blocks/context.md
@@ -221,7 +221,7 @@ agent.interrupt("alice", "session-001", Msg.userMsg("请停下来做个总结。
 
 推理循环在每次迭代前检查 `state.interruptControl().isInterrupted()`。被触发后,循环进入 `handleInterrupt` 路径,保存状态并返回部分结果。
 
-旧的无参 `interrupt()` 在单 session 场景下仍然有效——它会路由到当前活跃会话的 `InterruptControl`。
+旧的无参 `interrupt()` 在单 session 场景下仍然有效——它会路由到当前活跃会话的 `InterruptControl`。`HarnessAgent` 的行为一致：其无上下文的 `interrupt()` / `interrupt(Msg)` 会优先活跃调用的 `RuntimeContext`（因此通过 `streamEvents(msgs, ctx)` 以自定义 `sessionId` 启动的流可以被取消），并且额外提供了 `interrupt(RuntimeContext[, Msg])` 重载用于精确命中目标会话（参见 [Agent — 中断执行](./agent.md)）。
 
 :::{note}
 `InterruptControl` 是纯运行时信号,不会被持久化。如果某个 session 在故障转移后恢复到另一台机器,中断标志从清零状态开始。另一个 `AgentState.shutdownInterrupted` 标志(是**会被持久化**的)记录了该 session 是否被优雅停机中断——agent 可以在下次加载时检测并恢复。


### PR DESCRIPTION
### Background

Issue #2610: `HarnessAgent.interrupt()` / `interrupt(Msg)` unconditionally resolved the default
session id (the agent name), so streams started via `streamEvents(List, RuntimeContext)` with a
custom `sessionId` could never be cancelled — the interrupt signal was always sent to the wrong
session slot.

### Purpose

Make the interrupt API target the session that is actually running:

1. The context-free overloads now prefer the active call's `RuntimeContext` (obtained from the
   delegate's current runtime context) when one exists, while keeping the legacy default-session
   fallback when no call is in flight.
2. New `interrupt(RuntimeContext)` / `interrupt(RuntimeContext, Msg)` overloads let callers target
   an explicit `(userId, sessionId)` slot. Because each caller supplies the session it wants to
   cancel, this is safe under concurrency (multiple sessions running in parallel).

### Changes

- `agentscope-harness/src/main/java/io/agentscope/harness/agent/HarnessAgent.java`:
  - `interrupt()` and `interrupt(Msg)` now prefer the active call's runtime context when present,
    and fall back to the default session otherwise.
  - Added `interrupt(RuntimeContext ctx)` and `interrupt(RuntimeContext ctx, Msg msg)` overloads
    that delegate directly to the target session (with Javadoc documenting the issue context).
- `agentscope-harness/src/test/java/io/agentscope/harness/agent/HarnessAgentInterruptTest.java`
  (new): a blocking model is used to keep a stream in flight while an interrupt is fired. Covers:
  - `interrupt(ctx, msg)` cancels a stream running under a custom `sessionId` → `GenerateReason.INTERRUPTED`
  - `interrupt(ctx)` cancels a custom-session stream without a message
  - context-free `interrupt(msg)` prefers the active call's custom session
  - context-free `interrupt(msg)` still works for streams under the default session (backward compat)
  - context-free `interrupt()` / `interrupt(msg)` with no active call fall back to the default
    session without throwing (backward compat)

### How to Test
All five test cases in `HarnessAgentInterruptTest` should pass; no existing tests are affected.

## Checklist

Please check the following items before code is ready to be reviewed.

- [x] Code has been formatted with `mvn spotless:apply`
- [x] All tests are passing (`mvn test`)
- [x] Javadoc comments are complete and follow project conventions
- [x] Related documentation has been updated (e.g. links, examples, etc.)
- [x] Code is ready for review