### PR TITLE
fix(agui): stop emitting RUN_FINISHED after RUN_ERROR by default

### DIFF
--- a/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/main/java/io/agentscope/core/agui/adapter/AguiAdapterConfig.java
+++ b/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/main/java/io/agentscope/core/agui/adapter/AguiAdapterConfig.java
@@ -37,6 +37,7 @@ public class AguiAdapterConfig {
     private final boolean emitToolCallArgs;
     private final boolean emitTokenUsage;
     private final boolean enableReasoning;
+    private final boolean emitRunFinishedAfterError;
     private final Duration runTimeout;
     private final String defaultAgentId;
     private final List<AgentEventConverter> eventConverters;
@@ -50,6 +51,7 @@ public class AguiAdapterConfig {
         this.emitToolCallArgs = builder.emitToolCallArgs;
         this.emitTokenUsage = builder.emitTokenUsage;
         this.enableReasoning = builder.enableReasoning;
+        this.emitRunFinishedAfterError = builder.emitRunFinishedAfterError;
         this.runTimeout = builder.runTimeout;
         this.defaultAgentId = builder.defaultAgentId;
         this.eventConverters = List.copyOf(builder.eventConverters);
@@ -108,6 +110,19 @@ public class AguiAdapterConfig {
      */
     public boolean isEnableReasoning() {
         return enableReasoning;
+    }
+
+    /**
+     * Check whether {@code RUN_FINISHED} should be emitted after {@code RUN_ERROR}.
+     *
+     * <p>AG-UI treats {@code RUN_ERROR} and {@code RUN_FINISHED} as mutually exclusive terminal
+     * events. Default is {@code false} (standard AG-UI). Set {@code true} only for legacy clients
+     * that still expect a finish event after an error.
+     *
+     * @return true if {@code RUN_FINISHED} should follow {@code RUN_ERROR}
+     */
+    public boolean isEmitRunFinishedAfterError() {
+        return emitRunFinishedAfterError;
     }
 
     /**
@@ -204,6 +219,7 @@ public class AguiAdapterConfig {
         private boolean emitToolCallArgs = true;
         private boolean emitTokenUsage = false;
         private boolean enableReasoning = false;
+        private boolean emitRunFinishedAfterError = false;
         private Duration runTimeout = Duration.ofMinutes(10);
         private String defaultAgentId;
         private final List<AgentEventConverter> eventConverters = new ArrayList<>();
@@ -270,6 +286,22 @@ public class AguiAdapterConfig {
          */
         public Builder enableReasoning(boolean enableReasoning) {
             this.enableReasoning = enableReasoning;
+            return this;
+        }
+
+        /**
+         * Set whether to emit {@code RUN_FINISHED} after {@code RUN_ERROR}.
+         *
+         * <p>Default is {@code false} to match the AG-UI invariant of a single terminal event
+         * ({@code RUN_ERROR} alone). Set {@code true} for legacy clients that expect a finish
+         * event even on failure.
+         *
+         * @param emitRunFinishedAfterError true to emit {@code RUN_FINISHED} after {@code
+         *     RUN_ERROR}
+         * @return This builder
+         */
+        public Builder emitRunFinishedAfterError(boolean emitRunFinishedAfterError) {
+            this.emitRunFinishedAfterError = emitRunFinishedAfterError;
             return this;
         }
 

--- a/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/main/java/io/agentscope/core/agui/adapter/AguiAgentAdapter.java
+++ b/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/main/java/io/agentscope/core/agui/adapter/AguiAgentAdapter.java
@@ -394,7 +394,9 @@ public class AguiAgentAdapter {
                         mapErrorCode(error),
                         System.currentTimeMillis(),
                         null));
-        events.add(new AguiEvent.RunFinished(threadId, runId));
+        if (config.isEmitRunFinishedAfterError()) {
+            events.add(new AguiEvent.RunFinished(threadId, runId));
+        }
         return Flux.fromIterable(events);
     }
 

--- a/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/main/java/io/agentscope/core/agui/processor/AguiRequestProcessor.java
+++ b/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/main/java/io/agentscope/core/agui/processor/AguiRequestProcessor.java
@@ -23,6 +23,7 @@ import io.agentscope.core.agui.adapter.AguiAgentAdapterFactory;
 import io.agentscope.core.agui.event.AguiEvent;
 import io.agentscope.core.agui.model.AguiMessage;
 import io.agentscope.core.agui.model.RunAgentInput;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -132,7 +133,9 @@ public class AguiRequestProcessor {
                             if (beginResult.isError()) {
                                 return Flux.fromIterable(
                                         resumeCoordinator.contractErrorEvents(
-                                                input, beginResult.message()));
+                                                input,
+                                                beginResult.message(),
+                                                config.isEmitRunFinishedAfterError()));
                             }
 
                             try {
@@ -183,16 +186,20 @@ public class AguiRequestProcessor {
     private Flux<AguiEvent> processorErrorEvents(RunAgentInput input, Throwable error) {
         String errorMessage =
                 error.getMessage() != null ? error.getMessage() : error.getClass().getSimpleName();
-        return Flux.just(
-                new AguiEvent.RunStarted(input.getThreadId(), input.getRunId(), null, input),
+        List<AguiEvent> events = new ArrayList<>();
+        events.add(new AguiEvent.RunStarted(input.getThreadId(), input.getRunId(), null, input));
+        events.add(
                 new AguiEvent.RunError(
                         input.getThreadId(),
                         input.getRunId(),
                         errorMessage,
                         mapErrorCode(error),
                         System.currentTimeMillis(),
-                        null),
-                new AguiEvent.RunFinished(input.getThreadId(), input.getRunId()));
+                        null));
+        if (config.isEmitRunFinishedAfterError()) {
+            events.add(new AguiEvent.RunFinished(input.getThreadId(), input.getRunId()));
+        }
+        return Flux.fromIterable(events);
     }
 
     private static String mapErrorCode(Throwable error) {

--- a/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/main/java/io/agentscope/core/agui/processor/AguiResumeCoordinator.java
+++ b/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/main/java/io/agentscope/core/agui/processor/AguiResumeCoordinator.java
@@ -205,6 +205,8 @@ final class AguiResumeCoordinator {
      *
      * @param input The invalid run input
      * @param message The validation error message
+     * @param emitRunFinishedAfterError true to append {@code RUN_FINISHED} after {@code RUN_ERROR}
+     *     for legacy clients
      * @return The protocol error lifecycle events
      */
     List<AguiEvent> contractErrorEvents(

--- a/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/main/java/io/agentscope/core/agui/processor/AguiResumeCoordinator.java
+++ b/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/main/java/io/agentscope/core/agui/processor/AguiResumeCoordinator.java
@@ -22,6 +22,7 @@ import io.agentscope.core.agui.adapter.AguiAgentAdapter;
 import io.agentscope.core.agui.event.AguiEvent;
 import io.agentscope.core.agui.model.AguiResume;
 import io.agentscope.core.agui.model.RunAgentInput;
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -206,17 +207,22 @@ final class AguiResumeCoordinator {
      * @param message The validation error message
      * @return The protocol error lifecycle events
      */
-    List<AguiEvent> contractErrorEvents(RunAgentInput input, String message) {
-        return List.of(
-                new AguiEvent.RunStarted(input.getThreadId(), input.getRunId(), null, input),
+    List<AguiEvent> contractErrorEvents(
+            RunAgentInput input, String message, boolean emitRunFinishedAfterError) {
+        List<AguiEvent> events = new ArrayList<>();
+        events.add(new AguiEvent.RunStarted(input.getThreadId(), input.getRunId(), null, input));
+        events.add(
                 new AguiEvent.RunError(
                         input.getThreadId(),
                         input.getRunId(),
                         message,
                         CONTRACT_ERROR_CODE,
                         System.currentTimeMillis(),
-                        null),
-                new AguiEvent.RunFinished(input.getThreadId(), input.getRunId()));
+                        null));
+        if (emitRunFinishedAfterError) {
+            events.add(new AguiEvent.RunFinished(input.getThreadId(), input.getRunId()));
+        }
+        return List.copyOf(events);
     }
 
     private ResumeContractResult validateResumeStatuses(List<AguiResume> resumes) {

--- a/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/test/java/io/agentscope/core/agui/adapter/AguiAdapterConfigTest.java
+++ b/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/test/java/io/agentscope/core/agui/adapter/AguiAdapterConfigTest.java
@@ -47,6 +47,7 @@ class AguiAdapterConfigTest {
         assertTrue(config.isEmitToolCallArgs());
         assertFalse(config.isEmitTokenUsage());
         assertFalse(config.isEnableReasoning()); // Default should be false
+        assertFalse(config.isEmitRunFinishedAfterError()); // Default should be false
         assertEquals(Duration.ofMinutes(10), config.getRunTimeout());
         assertNull(config.getDefaultAgentId());
         assertFalse(config.isBaseEventPropertiesEnricherEnabled());
@@ -160,6 +161,7 @@ class AguiAdapterConfigTest {
                         .emitToolCallArgs(false)
                         .emitTokenUsage(true)
                         .enableReasoning(true)
+                        .emitRunFinishedAfterError(true)
                         .runTimeout(Duration.ofHours(1))
                         .defaultAgentId("my-agent")
                         .baseEventPropertiesEnricherEnabled(false)
@@ -170,6 +172,7 @@ class AguiAdapterConfigTest {
         assertFalse(config.isEmitToolCallArgs());
         assertTrue(config.isEmitTokenUsage());
         assertTrue(config.isEnableReasoning());
+        assertTrue(config.isEmitRunFinishedAfterError());
         assertEquals(Duration.ofHours(1), config.getRunTimeout());
         assertEquals("my-agent", config.getDefaultAgentId());
         assertFalse(config.isBaseEventPropertiesEnricherEnabled());

--- a/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/test/java/io/agentscope/core/agui/adapter/AguiAgentAdapterTest.java
+++ b/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/test/java/io/agentscope/core/agui/adapter/AguiAgentAdapterTest.java
@@ -197,15 +197,12 @@ class AguiAgentAdapterTest {
         List<AguiEvent> events = adapter.run(input).collectList().block();
 
         assertNotNull(events);
-        assertEquals(3, events.size());
+        assertEquals(2, events.size());
         assertInstanceOf(AguiEvent.RunStarted.class, events.get(0));
         AguiEvent.RunError runError = assertInstanceOf(AguiEvent.RunError.class, events.get(1));
         assertEquals("RuntimeException", runError.message());
         assertEquals("INTERNAL_ERROR", runError.code());
         assertNotNull(runError.timestamp());
-        AguiEvent.RunFinished finished =
-                assertInstanceOf(AguiEvent.RunFinished.class, events.get(2));
-        assertNull(finished.timestamp());
     }
 
     @Test
@@ -719,8 +716,8 @@ class AguiAgentAdapterTest {
 
         assertNotNull(events);
 
-        // Should have: RunStarted, RunError, RunFinished
-        assertTrue(events.size() >= 3);
+        // Should have: RunStarted, RunError
+        assertEquals(2, events.size());
         assertInstanceOf(AguiEvent.RunStarted.class, events.get(0));
 
         // Find RunError event
@@ -733,8 +730,7 @@ class AguiAgentAdapterTest {
 
         assertNotNull(errorEvent, "Should have RunError event");
         assertTrue(errorEvent.message().contains("Agent error"));
-
-        assertInstanceOf(AguiEvent.RunFinished.class, events.get(events.size() - 1));
+        assertInstanceOf(AguiEvent.RunError.class, events.get(events.size() - 1));
     }
 
     @Test

--- a/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/test/java/io/agentscope/core/agui/adapter/AguiAgentAdapterV2Test.java
+++ b/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/test/java/io/agentscope/core/agui/adapter/AguiAgentAdapterV2Test.java
@@ -792,13 +792,9 @@ class AguiAgentAdapterV2Test {
                             new AgentEndEvent("reply-suspended"));
 
             assertEquals(
-                    List.of(
-                            AguiEventType.RUN_STARTED,
-                            AguiEventType.RUN_ERROR,
-                            AguiEventType.RUN_FINISHED),
-                    types(events));
+                    List.of(AguiEventType.RUN_STARTED, AguiEventType.RUN_ERROR), types(events));
             assertErrorRun(
-                    events.subList(1, 3),
+                    events.subList(1, 2),
                     "TOOL_SUSPENDED result contains a suspended tool result without a stable id",
                     "INVALID_INPUT_ERROR");
         }
@@ -970,13 +966,9 @@ class AguiAgentAdapterV2Test {
                             new AgentEndEvent("reply-confirm"));
 
             assertEquals(
-                    List.of(
-                            AguiEventType.RUN_STARTED,
-                            AguiEventType.RUN_ERROR,
-                            AguiEventType.RUN_FINISHED),
-                    types(events));
+                    List.of(AguiEventType.RUN_STARTED, AguiEventType.RUN_ERROR), types(events));
             assertErrorRun(
-                    events.subList(1, 3),
+                    events.subList(1, 2),
                     "RequireUserConfirmEvent contains a tool call without a stable id",
                     "INVALID_INPUT_ERROR");
         }
@@ -1489,12 +1481,29 @@ class AguiAgentAdapterV2Test {
                                     Flux.error(new RuntimeException("boom"))));
 
             assertEquals(
+                    List.of(AguiEventType.RUN_STARTED, AguiEventType.RUN_ERROR), types(events));
+            assertErrorRun(events.subList(1, 2), "boom", "INTERNAL_ERROR");
+        }
+
+        @Test
+        void testRunEmitsRunFinishedAfterErrorWhenEnabled() {
+            List<AguiEvent> events =
+                    runReActFlux(
+                            AguiAdapterConfig.builder().emitRunFinishedAfterError(true).build(),
+                            Flux.concat(
+                                    Flux.just(new AgentStartEvent("thread-v2", "reply", "react")),
+                                    Flux.error(new RuntimeException("boom"))));
+
+            assertEquals(
                     List.of(
                             AguiEventType.RUN_STARTED,
                             AguiEventType.RUN_ERROR,
                             AguiEventType.RUN_FINISHED),
                     types(events));
-            assertErrorRun(events.subList(1, 3), "boom", "INTERNAL_ERROR");
+            AguiEvent.RunError runError = assertInstanceOf(AguiEvent.RunError.class, events.get(1));
+            assertEquals("boom", runError.message());
+            assertEquals("INTERNAL_ERROR", runError.code());
+            assertInstanceOf(AguiEvent.RunFinished.class, events.get(2));
         }
 
         @Test
@@ -1522,8 +1531,7 @@ class AguiAgentAdapterV2Test {
                             AguiEventType.TEXT_MESSAGE_START,
                             AguiEventType.TEXT_MESSAGE_CONTENT,
                             AguiEventType.TEXT_MESSAGE_END,
-                            AguiEventType.RUN_ERROR,
-                            AguiEventType.RUN_FINISHED),
+                            AguiEventType.RUN_ERROR),
                     types(events));
         }
 
@@ -1543,8 +1551,7 @@ class AguiAgentAdapterV2Test {
                             AguiEventType.REASONING_MESSAGE_START,
                             AguiEventType.REASONING_MESSAGE_CONTENT,
                             AguiEventType.REASONING_MESSAGE_END,
-                            AguiEventType.RUN_ERROR,
-                            AguiEventType.RUN_FINISHED),
+                            AguiEventType.RUN_ERROR),
                     types(events));
         }
 
@@ -1565,8 +1572,7 @@ class AguiAgentAdapterV2Test {
                             AguiEventType.TOOL_CALL_START,
                             AguiEventType.TOOL_CALL_ARGS,
                             AguiEventType.TOOL_CALL_END,
-                            AguiEventType.RUN_ERROR,
-                            AguiEventType.RUN_FINISHED),
+                            AguiEventType.RUN_ERROR),
                     types(events));
         }
 
@@ -1584,8 +1590,7 @@ class AguiAgentAdapterV2Test {
                     List.of(
                             AguiEventType.TOOL_CALL_START,
                             AguiEventType.TOOL_CALL_END,
-                            AguiEventType.RUN_ERROR,
-                            AguiEventType.RUN_FINISHED),
+                            AguiEventType.RUN_ERROR),
                     types(events));
         }
 
@@ -1606,12 +1611,10 @@ class AguiAgentAdapterV2Test {
                             AguiEventType.TEXT_MESSAGE_START,
                             AguiEventType.TEXT_MESSAGE_CONTENT,
                             AguiEventType.TEXT_MESSAGE_END,
-                            AguiEventType.RUN_ERROR,
-                            AguiEventType.RUN_FINISHED),
+                            AguiEventType.RUN_ERROR),
                     types(events));
             assertNotNull(events.get(2).timestamp());
             assertNotNull(events.get(3).timestamp());
-            assertNull(events.get(4).timestamp());
         }
     }
 
@@ -1798,27 +1801,21 @@ class AguiAgentAdapterV2Test {
 
     private static void assertStartedErrorRun(List<AguiEvent> events, String message, String code) {
         assertNotNull(events);
-        assertEquals(3, events.size());
+        assertEquals(2, events.size());
         assertInstanceOf(AguiEvent.RunStarted.class, events.get(0));
         AguiEvent.RunError runError = assertInstanceOf(AguiEvent.RunError.class, events.get(1));
         assertEquals(message, runError.message());
         assertEquals(code, runError.code());
         assertNotNull(runError.timestamp());
-        AguiEvent.RunFinished finished =
-                assertInstanceOf(AguiEvent.RunFinished.class, events.get(2));
-        assertNull(finished.timestamp());
     }
 
     private static void assertErrorRun(List<AguiEvent> events, String message, String code) {
         assertNotNull(events);
-        assertEquals(2, events.size());
+        assertEquals(1, events.size());
         AguiEvent.RunError runError = assertInstanceOf(AguiEvent.RunError.class, events.get(0));
         assertEquals(message, runError.message());
         assertEquals(code, runError.code());
         assertNotNull(runError.timestamp());
-        AguiEvent.RunFinished finished =
-                assertInstanceOf(AguiEvent.RunFinished.class, events.get(1));
-        assertNull(finished.timestamp());
     }
 
     private static void assertToolCallId(AguiEvent event, String expectedToolCallId) {

--- a/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/test/java/io/agentscope/core/agui/processor/AguiRequestProcessorTest.java
+++ b/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/test/java/io/agentscope/core/agui/processor/AguiRequestProcessorTest.java
@@ -536,10 +536,7 @@ class AguiRequestProcessorTest {
 
     private static void assertResumeContractErrorLifecycle(List<AguiEvent> events) {
         assertEquals(
-                List.of(
-                        AguiEventType.RUN_STARTED,
-                        AguiEventType.RUN_ERROR,
-                        AguiEventType.RUN_FINISHED),
+                List.of(AguiEventType.RUN_STARTED, AguiEventType.RUN_ERROR),
                 events.stream().map(AguiEvent::getType).toList());
         AguiEvent.RunError error = assertInstanceOf(AguiEvent.RunError.class, events.get(1));
         assertEquals("AGUI_INTERRUPT_CONTRACT_ERROR", error.code());
@@ -549,10 +546,7 @@ class AguiRequestProcessorTest {
     private static void assertProcessorErrorLifecycle(
             List<AguiEvent> events, String message, String code) {
         assertEquals(
-                List.of(
-                        AguiEventType.RUN_STARTED,
-                        AguiEventType.RUN_ERROR,
-                        AguiEventType.RUN_FINISHED),
+                List.of(AguiEventType.RUN_STARTED, AguiEventType.RUN_ERROR),
                 events.stream().map(AguiEvent::getType).toList());
         AguiEvent.RunError error = assertInstanceOf(AguiEvent.RunError.class, events.get(1));
         assertEquals(message, error.message());

--- a/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/test/java/io/agentscope/core/agui/processor/AguiResumeCoordinatorTest.java
+++ b/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/test/java/io/agentscope/core/agui/processor/AguiResumeCoordinatorTest.java
@@ -238,7 +238,23 @@ class AguiResumeCoordinatorTest {
         AguiResumeCoordinator coordinator = new AguiResumeCoordinator();
 
         List<AguiEvent> events =
-                coordinator.contractErrorEvents(input("run-1"), "resume contract failed");
+                coordinator.contractErrorEvents(input("run-1"), "resume contract failed", false);
+
+        assertEquals(
+                List.of(AguiEventType.RUN_STARTED, AguiEventType.RUN_ERROR),
+                events.stream().map(AguiEvent::getType).toList());
+        AguiEvent.RunError error = (AguiEvent.RunError) events.get(1);
+        assertEquals(AguiResumeCoordinator.CONTRACT_ERROR_CODE, error.code());
+        assertEquals("resume contract failed", error.message());
+        assertNotNull(error.timestamp());
+    }
+
+    @Test
+    void contractErrorEventsEmitRunFinishedWhenEnabled() {
+        AguiResumeCoordinator coordinator = new AguiResumeCoordinator();
+
+        List<AguiEvent> events =
+                coordinator.contractErrorEvents(input("run-1"), "resume contract failed", true);
 
         assertEquals(
                 List.of(
@@ -246,10 +262,6 @@ class AguiResumeCoordinatorTest {
                         AguiEventType.RUN_ERROR,
                         AguiEventType.RUN_FINISHED),
                 events.stream().map(AguiEvent::getType).toList());
-        AguiEvent.RunError error = (AguiEvent.RunError) events.get(1);
-        assertEquals(AguiResumeCoordinator.CONTRACT_ERROR_CODE, error.code());
-        assertEquals("resume contract failed", error.message());
-        assertNotNull(error.timestamp());
     }
 
     private static void track(

--- a/agentscope-extensions/agentscope-spring-boot-starters/agentscope-agui-spring-boot-starter/src/main/java/io/agentscope/spring/boot/agui/common/AguiProperties.java
+++ b/agentscope-extensions/agentscope-spring-boot-starters/agentscope-agui-spring-boot-starter/src/main/java/io/agentscope/spring/boot/agui/common/AguiProperties.java
@@ -39,6 +39,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
  *     enable-path-routing: true
  *     enable-reasoning: false
  *     emit-token-usage: false
+ *     emit-run-finished-after-error: false
  * </pre>
  */
 @ConfigurationProperties(prefix = "agentscope.agui")
@@ -76,6 +77,14 @@ public class AguiProperties {
      * backward compatibility and privacy compliance.
      */
     private boolean enableReasoning = false;
+
+    /**
+     * Whether to emit {@code RUN_FINISHED} after {@code RUN_ERROR}.
+     *
+     * <p>Default is {@code false} (standard AG-UI). Set {@code true} for legacy clients that expect
+     * a finish event after an error.
+     */
+    private boolean emitRunFinishedAfterError = false;
 
     /** Default agent ID to use when not specified in the request. */
     private String defaultAgentId = "default";
@@ -186,6 +195,14 @@ public class AguiProperties {
 
     public void setEnableReasoning(boolean enableReasoning) {
         this.enableReasoning = enableReasoning;
+    }
+
+    public boolean isEmitRunFinishedAfterError() {
+        return emitRunFinishedAfterError;
+    }
+
+    public void setEmitRunFinishedAfterError(boolean emitRunFinishedAfterError) {
+        this.emitRunFinishedAfterError = emitRunFinishedAfterError;
     }
 
     public String getDefaultAgentId() {

--- a/agentscope-extensions/agentscope-spring-boot-starters/agentscope-agui-spring-boot-starter/src/main/java/io/agentscope/spring/boot/agui/mvc/AgentscopeAguiMvcAutoConfiguration.java
+++ b/agentscope-extensions/agentscope-spring-boot-starters/agentscope-agui-spring-boot-starter/src/main/java/io/agentscope/spring/boot/agui/mvc/AgentscopeAguiMvcAutoConfiguration.java
@@ -93,6 +93,7 @@ public class AgentscopeAguiMvcAutoConfiguration {
                         .emitToolCallArgs(props.isEmitToolCallArgs())
                         .emitTokenUsage(props.isEmitTokenUsage())
                         .enableReasoning(props.isEnableReasoning())
+                        .emitRunFinishedAfterError(props.isEmitRunFinishedAfterError())
                         .defaultAgentId(props.getDefaultAgentId())
                         .eventConverters(eventConvertersProvider.orderedStream().toList())
                         .eventEnrichers(eventEnrichersProvider.orderedStream().toList())

--- a/agentscope-extensions/agentscope-spring-boot-starters/agentscope-agui-spring-boot-starter/src/main/java/io/agentscope/spring/boot/agui/webflux/AgentscopeAguiWebFluxAutoConfiguration.java
+++ b/agentscope-extensions/agentscope-spring-boot-starters/agentscope-agui-spring-boot-starter/src/main/java/io/agentscope/spring/boot/agui/webflux/AgentscopeAguiWebFluxAutoConfiguration.java
@@ -96,6 +96,7 @@ public class AgentscopeAguiWebFluxAutoConfiguration {
                         .emitToolCallArgs(props.isEmitToolCallArgs())
                         .emitTokenUsage(props.isEmitTokenUsage())
                         .enableReasoning(props.isEnableReasoning())
+                        .emitRunFinishedAfterError(props.isEmitRunFinishedAfterError())
                         .defaultAgentId(props.getDefaultAgentId())
                         .eventConverters(eventConvertersProvider.orderedStream().toList())
                         .eventEnrichers(eventEnrichersProvider.orderedStream().toList())

--- a/agentscope-extensions/agentscope-spring-boot-starters/agentscope-agui-spring-boot-starter/src/test/java/io/agentscope/spring/boot/agui/common/AguiAdapterConfigAutoConfigurationTest.java
+++ b/agentscope-extensions/agentscope-spring-boot-starters/agentscope-agui-spring-boot-starter/src/test/java/io/agentscope/spring/boot/agui/common/AguiAdapterConfigAutoConfigurationTest.java
@@ -115,6 +115,42 @@ class AguiAdapterConfigAutoConfigurationTest {
     }
 
     @Test
+    @DisplayName("Should default emit-run-finished-after-error to false")
+    void testDefaultEmitRunFinishedAfterError() {
+        mvcContextRunner.run(
+                ctx -> {
+                    AguiAdapterConfig config = mvcConfig(ctx.getBean(AguiMvcController.class));
+                    assertFalse(config.isEmitRunFinishedAfterError());
+                });
+    }
+
+    @Test
+    @DisplayName("Should bind emit-run-finished-after-error property for MVC")
+    void testMvcEmitRunFinishedAfterErrorProperty() {
+        mvcContextRunner
+                .withPropertyValues("agentscope.agui.emit-run-finished-after-error=true")
+                .run(
+                        ctx -> {
+                            AguiAdapterConfig config =
+                                    mvcConfig(ctx.getBean(AguiMvcController.class));
+                            assertTrue(config.isEmitRunFinishedAfterError());
+                        });
+    }
+
+    @Test
+    @DisplayName("Should bind emit-run-finished-after-error property for WebFlux")
+    void testWebFluxEmitRunFinishedAfterErrorProperty() {
+        webFluxContextRunner
+                .withPropertyValues("agentscope.agui.emit-run-finished-after-error=true")
+                .run(
+                        ctx -> {
+                            AguiAdapterConfig config =
+                                    webFluxConfig(ctx.getBean(AguiWebFluxHandler.class));
+                            assertTrue(config.isEmitRunFinishedAfterError());
+                        });
+    }
+
+    @Test
     @DisplayName("Should register ordered converter and enricher beans for MVC")
     void testMvcRegistersOrderedExtensions() {
         mvcContextRunner

--- a/docs/v2/en/integration/protocol/agui.md
+++ b/docs/v2/en/integration/protocol/agui.md
@@ -4,6 +4,8 @@
 
 `agentscope-extensions-agui` converts AgentScope v2 `AgentEvent` streams into [AG-UI Protocol](https://github.com/ag-ui-protocol/ag-ui) events so front-end UIs can render an agent run in real time, including text, reasoning, tool calls, state, custom events, token usage, and HITL interrupts.
 
+`RUN_ERROR` and `RUN_FINISHED` are mutually exclusive terminal events. Set `emitRunFinishedAfterError=true` only if you still need the legacy `RUN_ERROR` + `RUN_FINISHED` sequence.
+
 `AguiMessage.content` is represented as typed message content. For text-only code paths, use `getTextContent()`.
 
 Multimodal input is supported, but document types are not supported yet.
@@ -77,7 +79,7 @@ The v2 path consumes `AgentEvent`. Built-in converters handle semantic mapping, 
 | token usage (`emitTokenUsage=true`)    | `CUSTOM`, `name=token_usage` |
 | Unmapped `AgentEvent`                  | `RAW`, with official `event` and `source` fields |
 
-Normal `RUN_STARTED` and `RUN_FINISHED` events are driven by upstream `AgentStartEvent` and `AgentEndEvent`. If a normal stream completes without an upstream `AgentEndEvent`, the adapter does not synthesize `RUN_FINISHED`. On errors, the adapter emits a `RUN_ERROR` with a `timestamp`, then emits a fallback `RUN_FINISHED`.
+Normal `RUN_STARTED` and `RUN_FINISHED` events are driven by upstream `AgentStartEvent` and `AgentEndEvent`. If a normal stream completes without an upstream `AgentEndEvent`, the adapter does not synthesize `RUN_FINISHED`. On errors, the adapter emits a `RUN_ERROR` with a `timestamp`. `RUN_ERROR` and `RUN_FINISHED` are mutually exclusive terminal events. Set `emitRunFinishedAfterError=true` (or Spring Boot `agentscope.agui.emit-run-finished-after-error=true`) only for legacy clients that still expect a finish event after an error.
 
 ## Subagent events
 
@@ -216,6 +218,7 @@ agentscope:
     emit-tool-call-args: true
     emit-token-usage: false
     enable-reasoning: false
+    emit-run-finished-after-error: false
     server-side-memory: false
 ```
 

--- a/docs/v2/zh/integration/protocol/agui.md
+++ b/docs/v2/zh/integration/protocol/agui.md
@@ -4,6 +4,8 @@
 
 `agentscope-extensions-agui` 把 AgentScope v2 的 `AgentEvent` 流转换为 [AG-UI Protocol](https://github.com/ag-ui-protocol/ag-ui) 事件，让前端 UI 可以实时渲染 agent 的运行过程，包括文本、推理内容、工具调用、状态、自定义事件、token usage 和 HITL interrupt。
 
+`RUN_ERROR` 和 `RUN_FINISHED` 是互斥终态事件。只有还需要旧版 `RUN_ERROR` + `RUN_FINISHED` 序列时，才开启 `emitRunFinishedAfterError=true`。
+
 `AguiMessage.content` 现在使用类型化消息内容表示。仅处理纯文本时，请使用 `getTextContent()`。
 
 已支持多模态输入，但是暂不支持文档类型。
@@ -77,7 +79,7 @@ v2 正常链路以 `AgentEvent` 为输入，内置 converter 负责语义映射�
 | token usage（`emitTokenUsage=true`） | `CUSTOM`，`name=token_usage` |
 | 未映射 `AgentEvent`                 | `RAW`，包含官方 `event` 和 `source` 字段 |
 
-正常运行的 `RUN_STARTED` 和 `RUN_FINISHED` 由上游 `AgentStartEvent` / `AgentEndEvent` 决定。正常流结束但上游没有发 `AgentEndEvent` 时，adapter 不会额外补 `RUN_FINISHED`。异常路径会输出带 `timestamp` 的 `RUN_ERROR`，并补发一个 `RUN_FINISHED`。
+正常运行的 `RUN_STARTED` 和 `RUN_FINISHED` 由上游 `AgentStartEvent` / `AgentEndEvent` 决定。正常流结束但上游没有发 `AgentEndEvent` 时，adapter 不会额外补 `RUN_FINISHED`。异常路径会输出带 `timestamp` 的 `RUN_ERROR`。 `RUN_ERROR` 和 `RUN_FINISHED` 是互斥终态事件。只有旧客户端仍依赖错误后补发完成事件时，才设置 `emitRunFinishedAfterError=true`（Spring Boot 配置为 `agentscope.agui.emit-run-finished-after-error=true`）。
 
 ## 子 agent 事件
 
@@ -216,6 +218,7 @@ agentscope:
     emit-tool-call-args: true
     emit-token-usage: false
     enable-reasoning: false
+    emit-run-finished-after-error: false
     server-side-memory: false
 ```
 


### PR DESCRIPTION
## Summary
- Treat `RUN_ERROR` as the terminal event by default, matching AG-UI lifecycle semantics (`RUN_ERROR` and `RUN_FINISHED` are mutually exclusive).
- Add `emitRunFinishedAfterError` (default `false`) so legacy clients can still opt into the previous `RUN_ERROR` + `RUN_FINISHED` behavior.
- Wire the flag through adapter/processor/resume error paths and Spring Boot `agentscope.agui.emit-run-finished-after-error`.

Fixes https://github.com/agentscope-ai/agentscope-java/issues/2642

## Test plan
- [x] `mvn -pl agentscope-extensions-agui,agentscope-agui-spring-boot-starter spotless:check test`
- [x] Verify default error lifecycle ends at `RUN_ERROR` without `RUN_FINISHED`
- [x] Verify `emitRunFinishedAfterError=true` still emits both events