### PR TITLE
fix(harness): 不将用户中断会话降级为会话压缩失败

### DIFF
--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/memory/compaction/ConversationCompactor.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/memory/compaction/ConversationCompactor.java
@@ -29,6 +29,7 @@ import io.agentscope.harness.agent.middleware.CompactionMiddleware;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -138,6 +139,9 @@ public class ConversationCompactor {
                                 .doOnSuccess(v -> log.debug("Memory flush before compaction done"))
                                 .onErrorResume(
                                         e -> {
+                                            if (containsInterruptedException(e)) {
+                                                return Mono.error(e);
+                                            }
                                             log.warn(
                                                     "Memory flush before compaction failed: {}",
                                                     e.getMessage());
@@ -166,6 +170,9 @@ public class ConversationCompactor {
                                                     path))
                             .onErrorResume(
                                     e -> {
+                                        if (containsInterruptedException(e)) {
+                                            return Mono.error(e);
+                                        }
                                         log.warn(
                                                 "Message offload before compaction failed: {}",
                                                 e.getMessage());
@@ -368,9 +375,24 @@ public class ConversationCompactor {
                 .defaultIfEmpty("(Summary unavailable)")
                 .onErrorResume(
                         e -> {
+                            if (containsInterruptedException(e)) {
+                                return Mono.error(e);
+                            }
                             log.warn("Summarization LLM call failed: {}", e.getMessage());
                             return Mono.just("(Summarization failed: " + e.getMessage() + ")");
                         });
+    }
+
+    private static boolean containsInterruptedException(Throwable error) {
+        IdentityHashMap<Throwable, Boolean> visited = new IdentityHashMap<>();
+        Throwable current = error;
+        while (current != null && visited.put(current, Boolean.TRUE) == null) {
+            if (current instanceof InterruptedException) {
+                return true;
+            }
+            current = current.getCause();
+        }
+        return false;
     }
 
     /**

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/middleware/CompactionMiddleware.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/middleware/CompactionMiddleware.java
@@ -61,39 +61,15 @@ public class CompactionMiddleware implements HarnessRuntimeMiddleware {
 
     private static final Logger log = LoggerFactory.getLogger(CompactionMiddleware.class);
 
+    private final WorkspaceManager workspaceManager;
     private final Model model;
     private final CompactionConfig config;
-    private final CompactionExecutor compactionExecutor;
 
     public CompactionMiddleware(
             WorkspaceManager workspaceManager, Model model, CompactionConfig config) {
-        this(
-                workspaceManager,
-                model,
-                config,
-                (runtimeContext, conversation, effectiveConfig, agentId, sessionId) ->
-                        new ConversationCompactor(
-                                        model, new MemoryFlushManager(workspaceManager, model))
-                                .compactIfNeeded(
-                                        runtimeContext,
-                                        conversation,
-                                        effectiveConfig,
-                                        agentId,
-                                        sessionId));
-    }
-
-    /**
-     * Allows package-local tests to replace the compaction step and isolate its failure boundary
-     * from downstream reasoning.
-     */
-    CompactionMiddleware(
-            WorkspaceManager workspaceManager,
-            Model model,
-            CompactionConfig config,
-            CompactionExecutor compactionExecutor) {
+        this.workspaceManager = workspaceManager;
         this.model = model;
         this.config = config;
-        this.compactionExecutor = compactionExecutor;
     }
 
     @Override
@@ -127,10 +103,14 @@ public class CompactionMiddleware implements HarnessRuntimeMiddleware {
 
                     CompactionConfig effectiveConfig = resolveEffectiveConfig();
 
+                    MemoryFlushManager flushManager =
+                            new MemoryFlushManager(workspaceManager, model);
+                    ConversationCompactor compactor =
+                            new ConversationCompactor(model, flushManager);
                     final Msg sys = systemMsg;
 
                     // Only compaction may degrade; downstream reasoning errors must propagate.
-                    return compactionExecutor
+                    return compactor
                             .compactIfNeeded(rc, conversation, effectiveConfig, agentId, sessionId)
                             .onErrorResume(
                                     error -> {
@@ -169,11 +149,7 @@ public class CompactionMiddleware implements HarnessRuntimeMiddleware {
                 });
     }
 
-    /**
-     * Recognizes interruptions wrapped by Reactor or application exceptions so compaction fallback
-     * does not swallow a user interrupt.
-     */
-    private boolean containsInterruptedException(Throwable error) {
+    private static boolean containsInterruptedException(Throwable error) {
         IdentityHashMap<Throwable, Boolean> visited = new IdentityHashMap<>();
         Throwable current = error;
         while (current != null && visited.put(current, Boolean.TRUE) == null) {
@@ -183,21 +159,6 @@ public class CompactionMiddleware implements HarnessRuntimeMiddleware {
             current = current.getCause();
         }
         return false;
-    }
-
-    /**
-     * Defines a replaceable compaction step; production continues to use ConversationCompactor.
-     */
-    @FunctionalInterface
-    interface CompactionExecutor {
-
-        /** Performs one optional conversation compaction. */
-        Mono<Optional<List<Msg>>> compactIfNeeded(
-                RuntimeContext runtimeContext,
-                List<Msg> conversation,
-                CompactionConfig effectiveConfig,
-                String agentId,
-                String sessionId);
     }
 
     /**

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/middleware/CompactionMiddleware.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/middleware/CompactionMiddleware.java
@@ -29,11 +29,14 @@ import io.agentscope.harness.agent.memory.compaction.CompactionConfig;
 import io.agentscope.harness.agent.memory.compaction.ConversationCompactor;
 import io.agentscope.harness.agent.workspace.WorkspaceManager;
 import java.util.ArrayList;
+import java.util.IdentityHashMap;
 import java.util.List;
+import java.util.Optional;
 import java.util.function.Function;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 
 /**
  * Middleware that performs conversation compaction before each LLM reasoning call.
@@ -58,15 +61,39 @@ public class CompactionMiddleware implements HarnessRuntimeMiddleware {
 
     private static final Logger log = LoggerFactory.getLogger(CompactionMiddleware.class);
 
-    private final WorkspaceManager workspaceManager;
     private final Model model;
     private final CompactionConfig config;
+    private final CompactionExecutor compactionExecutor;
 
     public CompactionMiddleware(
             WorkspaceManager workspaceManager, Model model, CompactionConfig config) {
-        this.workspaceManager = workspaceManager;
+        this(
+                workspaceManager,
+                model,
+                config,
+                (runtimeContext, conversation, effectiveConfig, agentId, sessionId) ->
+                        new ConversationCompactor(
+                                        model, new MemoryFlushManager(workspaceManager, model))
+                                .compactIfNeeded(
+                                        runtimeContext,
+                                        conversation,
+                                        effectiveConfig,
+                                        agentId,
+                                        sessionId));
+    }
+
+    /**
+     * Allows package-local tests to replace the compaction step and isolate its failure boundary
+     * from downstream reasoning.
+     */
+    CompactionMiddleware(
+            WorkspaceManager workspaceManager,
+            Model model,
+            CompactionConfig config,
+            CompactionExecutor compactionExecutor) {
         this.model = model;
         this.config = config;
+        this.compactionExecutor = compactionExecutor;
     }
 
     @Override
@@ -100,14 +127,22 @@ public class CompactionMiddleware implements HarnessRuntimeMiddleware {
 
                     CompactionConfig effectiveConfig = resolveEffectiveConfig();
 
-                    MemoryFlushManager flushManager =
-                            new MemoryFlushManager(workspaceManager, model);
-                    ConversationCompactor compactor =
-                            new ConversationCompactor(model, flushManager);
                     final Msg sys = systemMsg;
 
-                    return compactor
+                    // Only compaction may degrade; downstream reasoning errors must propagate.
+                    return compactionExecutor
                             .compactIfNeeded(rc, conversation, effectiveConfig, agentId, sessionId)
+                            .onErrorResume(
+                                    error -> {
+                                        if (containsInterruptedException(error)) {
+                                            return Mono.error(error);
+                                        }
+                                        log.warn(
+                                                "Compaction failed, continuing without compaction:"
+                                                        + " {}",
+                                                error.getMessage());
+                                        return Mono.just(Optional.empty());
+                                    })
                             .flatMapMany(
                                     optResult -> {
                                         if (optResult.isEmpty()) {
@@ -130,16 +165,39 @@ public class CompactionMiddleware implements HarnessRuntimeMiddleware {
                                                         newMessages,
                                                         input.tools(),
                                                         input.options()));
-                                    })
-                            .onErrorResume(
-                                    e -> {
-                                        log.warn(
-                                                "Compaction failed, continuing without compaction:"
-                                                        + " {}",
-                                                e.getMessage());
-                                        return next.apply(input);
                                     });
                 });
+    }
+
+    /**
+     * Recognizes interruptions wrapped by Reactor or application exceptions so compaction fallback
+     * does not swallow a user interrupt.
+     */
+    private boolean containsInterruptedException(Throwable error) {
+        IdentityHashMap<Throwable, Boolean> visited = new IdentityHashMap<>();
+        Throwable current = error;
+        while (current != null && visited.put(current, Boolean.TRUE) == null) {
+            if (current instanceof InterruptedException) {
+                return true;
+            }
+            current = current.getCause();
+        }
+        return false;
+    }
+
+    /**
+     * Defines a replaceable compaction step; production continues to use ConversationCompactor.
+     */
+    @FunctionalInterface
+    interface CompactionExecutor {
+
+        /** Performs one optional conversation compaction. */
+        Mono<Optional<List<Msg>>> compactIfNeeded(
+                RuntimeContext runtimeContext,
+                List<Msg> conversation,
+                CompactionConfig effectiveConfig,
+                String agentId,
+                String sessionId);
     }
 
     /**

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/memory/compaction/ConversationCompactorTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/memory/compaction/ConversationCompactorTest.java
@@ -20,6 +20,8 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -38,6 +40,7 @@ import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
 
 /** Tests message routing between summarization, memory flushing, and the preserved tail. */
 class ConversationCompactorTest {
@@ -143,6 +146,53 @@ class ConversationCompactorTest {
         assertTrue(fixture.flushInputs.isEmpty());
     }
 
+    /** Verifies that memory-flush fallback does not swallow a user interruption. */
+    @Test
+    void compactIfNeeded_propagatesInterruptedMemoryFlush() {
+        RecordingModel model = new RecordingModel();
+        MemoryFlushManager flushManager = mock(MemoryFlushManager.class);
+        when(flushManager.flushMemories(any(RuntimeContext.class), anyList()))
+                .thenReturn(Mono.error(new InterruptedException("interrupted while flushing")));
+        ConversationCompactor compactor = new ConversationCompactor(model, flushManager);
+
+        StepVerifier.create(
+                        compactor.compactIfNeeded(
+                                mock(RuntimeContext.class),
+                                compactableMessages(),
+                                config(true, false),
+                                "agent-id",
+                                "session-id"))
+                .expectError(InterruptedException.class)
+                .verify();
+    }
+
+    /** Verifies that message-offload fallback does not swallow a wrapped interruption. */
+    @Test
+    void compactIfNeeded_propagatesInterruptedMessageOffload() {
+        RecordingModel model = new RecordingModel();
+        MemoryFlushManager flushManager = mock(MemoryFlushManager.class);
+        doThrow(
+                        new IllegalStateException(
+                                "offload wrapper",
+                                new InterruptedException("interrupted while offloading")))
+                .when(flushManager)
+                .offloadMessages(any(RuntimeContext.class), anyList(), anyString(), anyString());
+        ConversationCompactor compactor = new ConversationCompactor(model, flushManager);
+
+        StepVerifier.create(
+                        compactor.compactIfNeeded(
+                                mock(RuntimeContext.class),
+                                compactableMessages(),
+                                config(false, true),
+                                "agent-id",
+                                "session-id"))
+                .expectErrorMatches(
+                        error ->
+                                error instanceof IllegalStateException
+                                        && error.getCause() instanceof InterruptedException)
+                .verify();
+    }
+
     /** Creates a regular user message. */
     private static Msg message(String text) {
         return Msg.builder()
@@ -157,6 +207,27 @@ class ConversationCompactorTest {
                 .role(MsgRole.USER)
                 .name(ConversationCompactor.SUMMARY_MSG_NAME)
                 .content(TextBlock.builder().text(text).build())
+                .build();
+    }
+
+    /** Creates an input that always triggers compaction and retains a two-message tail. */
+    private static List<Msg> compactableMessages() {
+        return List.of(message("M1"), message("M2"), message("TAIL_1"), message("TAIL_2"));
+    }
+
+    /** Creates focused compaction configuration for fallback-boundary tests. */
+    private static CompactionConfig config(
+            boolean flushBeforeCompact, boolean offloadBeforeCompact) {
+        return CompactionConfig.builder()
+                .triggerMessages(3)
+                .triggerTokens(0)
+                .keepMessages(2)
+                .keepTokens(0)
+                .summaryPrompt("SUMMARY_INPUT:\n{messages}")
+                .flushBeforeCompact(flushBeforeCompact)
+                .offloadBeforeCompact(offloadBeforeCompact)
+                .truncateArgs(null)
+                .prune(null)
                 .build();
     }
 
@@ -195,18 +266,7 @@ class ConversationCompactorTest {
                                 return Mono.empty();
                             });
             compactor = new ConversationCompactor(model, flushManager);
-            config =
-                    CompactionConfig.builder()
-                            .triggerMessages(3)
-                            .triggerTokens(0)
-                            .keepMessages(2)
-                            .keepTokens(0)
-                            .summaryPrompt("SUMMARY_INPUT:\n{messages}")
-                            .flushBeforeCompact(flushBeforeCompact)
-                            .offloadBeforeCompact(false)
-                            .truncateArgs(null)
-                            .prune(null)
-                            .build();
+            config = config(flushBeforeCompact, false);
         }
 
         /** Runs compaction and requires the supplied input to trigger it. */

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/middleware/CompactionMiddlewareTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/middleware/CompactionMiddlewareTest.java
@@ -16,7 +16,7 @@
 package io.agentscope.harness.agent.middleware;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -32,22 +32,17 @@ import io.agentscope.core.middleware.ReasoningInput;
 import io.agentscope.core.model.ChatModelBase;
 import io.agentscope.core.model.ChatResponse;
 import io.agentscope.core.model.GenerateOptions;
-import io.agentscope.core.model.Model;
 import io.agentscope.core.model.ToolSchema;
 import io.agentscope.harness.agent.memory.compaction.CompactionConfig;
 import java.time.Duration;
 import java.util.List;
-import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.Test;
 import reactor.core.publisher.Flux;
-import reactor.core.publisher.Mono;
-import reactor.core.publisher.Sinks;
 import reactor.core.scheduler.Schedulers;
 import reactor.test.StepVerifier;
 
@@ -59,10 +54,11 @@ class CompactionMiddlewareTest {
     void ordinaryCompactionFailureFallsBackToOriginalInputOnce() {
         AtomicInteger nextCalls = new AtomicInteger();
         CompactionMiddleware middleware =
-                middleware(
-                        (ctx, messages, config, agentId, sessionId) ->
-                                Mono.error(
-                                        new IllegalStateException("summary provider unavailable")));
+                new CompactionMiddleware(
+                        null,
+                        new SynchronousFailingSummaryModel(
+                                new IllegalStateException("summary provider unavailable")),
+                        fixedConfig());
 
         StepVerifier.create(
                         middleware.onReasoning(
@@ -78,15 +74,47 @@ class CompactionMiddlewareTest {
         assertEquals(1, nextCalls.get());
     }
 
-    /** An interrupt during compaction must propagate without entering downstream reasoning. */
+    /** A normal summary failure is still best-effort and continues with a failed-summary message. */
     @Test
-    void interruptedCompactionPropagatesWithoutCallingNext() {
+    void ordinarySummaryFailureContinuesWithCompactedInput() {
         AtomicInteger nextCalls = new AtomicInteger();
         CompactionMiddleware middleware =
-                middleware(
-                        (ctx, messages, config, agentId, sessionId) ->
-                                Mono.error(
-                                        new InterruptedException("interrupted while compacting")));
+                new CompactionMiddleware(
+                        null,
+                        new FailingSummaryModel(
+                                new IllegalStateException("summary provider unavailable")),
+                        fixedConfig());
+
+        StepVerifier.create(
+                        middleware.onReasoning(
+                                agent(),
+                                context("user", "session"),
+                                input(),
+                                next -> {
+                                    nextCalls.incrementAndGet();
+                                    assertEquals(2, next.messages().size());
+                                    assertTrue(
+                                            next.messages()
+                                                    .get(0)
+                                                    .getTextContent()
+                                                    .contains("Summarization failed"));
+                                    return Flux.empty();
+                                }))
+                .verifyComplete();
+
+        assertEquals(1, nextCalls.get());
+    }
+
+    /** An interrupt during real compaction summarization must propagate without entering reasoning. */
+    @Test
+    void interruptedSummaryCompactionPropagatesWithoutCallingNext() {
+        AtomicInteger nextCalls = new AtomicInteger();
+        CompactionMiddleware middleware =
+                new CompactionMiddleware(
+                        null,
+                        new FailingSummaryModel(
+                                new InterruptedException("interrupted while compacting")),
+                        fixedConfig());
 
         StepVerifier.create(
                         middleware.onReasoning(
@@ -103,38 +131,29 @@ class CompactionMiddlewareTest {
         assertEquals(0, nextCalls.get());
     }
 
-    /** An interrupt received after asynchronous compaction starts must not degrade to reasoning. */
+    /** An async interrupt from real compaction summarization must not degrade to reasoning. */
     @Test
-    void interruptedInFlightCompactionPropagatesWithoutCallingNext() throws Exception {
+    void asynchronousInterruptedSummaryCompactionPropagatesWithoutCallingNext() {
         AtomicInteger nextCalls = new AtomicInteger();
-        CountDownLatch compactionStarted = new CountDownLatch(1);
-        Sinks.One<Optional<List<Msg>>> compactionResult = Sinks.one();
         CompactionMiddleware middleware =
-                middleware(
-                        (ctx, messages, config, agentId, sessionId) ->
-                                compactionResult
-                                        .asMono()
-                                        .doOnSubscribe(ignored -> compactionStarted.countDown()));
+                new CompactionMiddleware(
+                        null,
+                        new AsyncFailingSummaryModel(
+                                new InterruptedException("interrupted while compacting")),
+                        fixedConfig());
 
-        var result =
-                middleware
-                        .onReasoning(
+        StepVerifier.create(
+                        middleware.onReasoning(
                                 agent(),
                                 context("user", "session"),
                                 input(),
                                 next -> {
                                     nextCalls.incrementAndGet();
                                     return Flux.empty();
-                                })
-                        .subscribeOn(Schedulers.parallel())
-                        .collectList()
-                        .toFuture();
-        assertTrue(compactionStarted.await(5, TimeUnit.SECONDS), "compaction should start");
-        compactionResult.tryEmitError(new InterruptedException("interrupted while compacting"));
+                                }))
+                .expectError(InterruptedException.class)
+                .verify();
 
-        ExecutionException error =
-                assertThrows(ExecutionException.class, () -> result.get(5, TimeUnit.SECONDS));
-        assertTrue(error.getCause() instanceof InterruptedException);
         assertEquals(0, nextCalls.get());
     }
 
@@ -143,13 +162,13 @@ class CompactionMiddlewareTest {
     void wrappedInterruptedCompactionPropagatesWithoutCallingNext() {
         AtomicInteger nextCalls = new AtomicInteger();
         CompactionMiddleware middleware =
-                middleware(
-                        (ctx, messages, config, agentId, sessionId) ->
-                                Mono.error(
-                                        new IllegalStateException(
-                                                "compaction wrapper",
-                                                new InterruptedException(
-                                                        "interrupted while compacting"))));
+                new CompactionMiddleware(
+                        null,
+                        new FailingSummaryModel(
+                                new IllegalStateException(
+                                        "compaction wrapper",
+                                        new InterruptedException("interrupted while compacting"))),
+                        fixedConfig());
 
         StepVerifier.create(
                         middleware.onReasoning(
@@ -174,9 +193,8 @@ class CompactionMiddlewareTest {
     void cyclicCompactionFailureCauseFallsBackWithoutLooping() {
         AtomicInteger nextCalls = new AtomicInteger();
         CompactionMiddleware middleware =
-                middleware(
-                        (ctx, messages, config, agentId, sessionId) ->
-                                Mono.error(new CyclicCauseException()));
+                new CompactionMiddleware(
+                        null, new FailingSummaryModel(new CyclicCauseException()), fixedConfig());
 
         StepVerifier.create(
                         middleware.onReasoning(
@@ -197,8 +215,7 @@ class CompactionMiddlewareTest {
     void interruptedDownstreamPropagatesWithoutRetryingNext() {
         AtomicInteger nextCalls = new AtomicInteger();
         CompactionMiddleware middleware =
-                middleware(
-                        (ctx, messages, config, agentId, sessionId) -> Mono.just(Optional.empty()));
+                new CompactionMiddleware(null, new SuccessfulSummaryModel(), fixedConfig());
 
         StepVerifier.create(
                         middleware.onReasoning(
@@ -224,23 +241,14 @@ class CompactionMiddlewareTest {
         AtomicInteger activeNextCalls = new AtomicInteger();
         Set<String> compactedSessions = ConcurrentHashMap.newKeySet();
         CompactionMiddleware middleware =
-                middleware(
-                        (ctx, messages, config, agentId, sessionId) ->
-                                Mono.defer(
-                                        () -> {
-                                            compactedSessions.add(ctx.getSessionId());
-                                            return "session-a".equals(ctx.getSessionId())
-                                                    ? Mono.error(
-                                                            new InterruptedException(
-                                                                    "interrupted session-a"))
-                                                    : Mono.just(Optional.empty());
-                                        }));
+                new CompactionMiddleware(
+                        null, new PerSessionSummaryModel(compactedSessions), fixedConfig());
 
         Flux<AgentEvent> interrupted =
                 middleware.onReasoning(
                         agent(),
                         context("user-a", "session-a"),
-                        input(),
+                        input("session-a previous", "session-a latest"),
                         next -> {
                             interruptedNextCalls.incrementAndGet();
                             return Flux.empty();
@@ -249,7 +257,7 @@ class CompactionMiddlewareTest {
                 middleware.onReasoning(
                         agent(),
                         context("user-b", "session-b"),
-                        input(),
+                        input("session-b previous", "session-b latest"),
                         next -> {
                             activeNextCalls.incrementAndGet();
                             return Flux.empty();
@@ -274,11 +282,7 @@ class CompactionMiddlewareTest {
         CountDownLatch subscribed = new CountDownLatch(1);
         CountingDelayedFirstChunkModel model = new CountingDelayedFirstChunkModel(subscribed);
         CompactionMiddleware middleware =
-                new CompactionMiddleware(
-                        null,
-                        model,
-                        fixedConfig(),
-                        (ctx, messages, config, agentId, sessionId) -> Mono.just(Optional.empty()));
+                new CompactionMiddleware(null, model, noCompactionConfig());
         ReActAgent agent =
                 ReActAgent.builder()
                         .name("compaction-test-agent")
@@ -312,11 +316,7 @@ class CompactionMiddlewareTest {
         CountDownLatch subscribed = new CountDownLatch(2);
         CountingDelayedFirstChunkModel model = new CountingDelayedFirstChunkModel(subscribed);
         CompactionMiddleware middleware =
-                new CompactionMiddleware(
-                        null,
-                        model,
-                        fixedConfig(),
-                        (ctx, messages, config, agentId, sessionId) -> Mono.just(Optional.empty()));
+                new CompactionMiddleware(null, model, noCompactionConfig());
         ReActAgent agent =
                 ReActAgent.builder()
                         .name("compaction-test-agent")
@@ -341,20 +341,30 @@ class CompactionMiddlewareTest {
         assertEquals(
                 GenerateReason.INTERRUPTED,
                 interruptedReply.get(5, TimeUnit.SECONDS).getGenerateReason());
-        assertTrue(
+        assertFalse(
                 activeReply.get(5, TimeUnit.SECONDS).getGenerateReason()
-                        != GenerateReason.INTERRUPTED);
+                        == GenerateReason.INTERRUPTED);
         assertEquals(2, model.callCount.get());
-    }
-
-    /** Creates middleware with an explicit compaction executor, avoiding real model or filesystem dependencies. */
-    private CompactionMiddleware middleware(CompactionMiddleware.CompactionExecutor executor) {
-        return new CompactionMiddleware(null, mock(Model.class), fixedConfig(), executor);
     }
 
     /** Creates stable configuration that enters the compaction branch. */
     private CompactionConfig fixedConfig() {
-        return CompactionConfig.builder().triggerTokens(1).keepTokens(1).build();
+        return CompactionConfig.builder()
+                .triggerTokens(1)
+                .keepTokens(1)
+                .flushBeforeCompact(false)
+                .offloadBeforeCompact(false)
+                .prune(null)
+                .build();
+    }
+
+    /** Creates stable configuration that bypasses compaction for model-stream interrupt tests. */
+    private CompactionConfig noCompactionConfig() {
+        return CompactionConfig.builder()
+                .triggerMessages(0)
+                .triggerTokens(Integer.MAX_VALUE)
+                .keepTokens(0)
+                .build();
     }
 
     /** Creates the ReActAgent test double required by the middleware. */
@@ -371,12 +381,120 @@ class CompactionMiddlewareTest {
 
     /** Creates the minimal input containing one user message. */
     private ReasoningInput input() {
-        return new ReasoningInput(List.of(userMessage("test")), List.of(), null);
+        return input("previous context", "latest request");
+    }
+
+    /** Creates input with enough conversation messages for compaction to cut a prefix. */
+    private ReasoningInput input(String first, String second) {
+        return new ReasoningInput(
+                List.of(userMessage(first), userMessage(second)), List.of(), null);
     }
 
     /** Creates a minimal user message shared by single-session and concurrent-session tests. */
     private Msg userMessage(String text) {
         return Msg.builder().role(MsgRole.USER).textContent(text).build();
+    }
+
+    /** Throws while creating the summary publisher, exercising the outer compaction fallback. */
+    private static final class SynchronousFailingSummaryModel extends ChatModelBase {
+        private final RuntimeException error;
+
+        private SynchronousFailingSummaryModel(RuntimeException error) {
+            this.error = error;
+        }
+
+        @Override
+        public String getModelName() {
+            return "synchronous-failing-summary";
+        }
+
+        @Override
+        protected Flux<ChatResponse> doStream(
+                List<Msg> messages, List<ToolSchema> tools, GenerateOptions options) {
+            throw error;
+        }
+    }
+
+    /** Provides a summary model that emits one successful summary chunk. */
+    private static final class SuccessfulSummaryModel extends ChatModelBase {
+
+        @Override
+        public String getModelName() {
+            return "successful-summary";
+        }
+
+        @Override
+        protected Flux<ChatResponse> doStream(
+                List<Msg> messages, List<ToolSchema> tools, GenerateOptions options) {
+            return Flux.just(
+                    ChatResponse.builder()
+                            .content(List.of(TextBlock.builder().text("summary").build()))
+                            .build());
+        }
+    }
+
+    /** Provides a real summary-model failure for compaction boundary tests. */
+    private static class FailingSummaryModel extends ChatModelBase {
+        private final Throwable error;
+
+        private FailingSummaryModel(Throwable error) {
+            this.error = error;
+        }
+
+        @Override
+        public String getModelName() {
+            return "failing-summary";
+        }
+
+        @Override
+        protected Flux<ChatResponse> doStream(
+                List<Msg> messages, List<ToolSchema> tools, GenerateOptions options) {
+            return Flux.error(error);
+        }
+    }
+
+    /** Provides an asynchronous summary-model failure for in-flight interrupt coverage. */
+    private static final class AsyncFailingSummaryModel extends FailingSummaryModel {
+
+        private AsyncFailingSummaryModel(Throwable error) {
+            super(error);
+        }
+
+        @Override
+        protected Flux<ChatResponse> doStream(
+                List<Msg> messages, List<ToolSchema> tools, GenerateOptions options) {
+            return super.doStream(messages, tools, options)
+                    .delaySubscription(Duration.ofMillis(20));
+        }
+    }
+
+    /** Fails one session's summary while allowing another to complete. */
+    private static final class PerSessionSummaryModel extends ChatModelBase {
+        private final Set<String> compactedSessions;
+
+        private PerSessionSummaryModel(Set<String> compactedSessions) {
+            this.compactedSessions = compactedSessions;
+        }
+
+        @Override
+        public String getModelName() {
+            return "per-session-summary";
+        }
+
+        @Override
+        protected Flux<ChatResponse> doStream(
+                List<Msg> messages, List<ToolSchema> tools, GenerateOptions options) {
+            String rendered = messages.get(0).getTextContent();
+            if (rendered.contains("session-a")) {
+                compactedSessions.add("session-a");
+                return Flux.error(new InterruptedException("interrupted session-a"));
+            }
+            compactedSessions.add("session-b");
+            return Flux.just(
+                    ChatResponse.builder()
+                            .content(List.of(TextBlock.builder().text("summary").build()))
+                            .build());
+        }
     }
 
     /** Provides a model interruptible before its first chunk to verify real ReAct stream request counts. */

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/middleware/CompactionMiddlewareTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/middleware/CompactionMiddlewareTest.java
@@ -1,0 +1,392 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.harness.agent.middleware;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.agentscope.core.ReActAgent;
+import io.agentscope.core.agent.RuntimeContext;
+import io.agentscope.core.event.AgentEvent;
+import io.agentscope.core.message.GenerateReason;
+import io.agentscope.core.message.Msg;
+import io.agentscope.core.message.MsgRole;
+import io.agentscope.core.message.TextBlock;
+import io.agentscope.core.middleware.ReasoningInput;
+import io.agentscope.core.model.ChatModelBase;
+import io.agentscope.core.model.ChatResponse;
+import io.agentscope.core.model.GenerateOptions;
+import io.agentscope.core.model.Model;
+import io.agentscope.core.model.ToolSchema;
+import io.agentscope.harness.agent.memory.compaction.CompactionConfig;
+import java.time.Duration;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.core.publisher.Sinks;
+import reactor.core.scheduler.Schedulers;
+import reactor.test.StepVerifier;
+
+/** Verifies that compaction fallback does not swallow interrupts or rerun downstream reasoning. */
+class CompactionMiddlewareTest {
+
+    /** An ordinary compaction failure skips compaction and invokes original reasoning once. */
+    @Test
+    void ordinaryCompactionFailureFallsBackToOriginalInputOnce() {
+        AtomicInteger nextCalls = new AtomicInteger();
+        CompactionMiddleware middleware =
+                middleware(
+                        (ctx, messages, config, agentId, sessionId) ->
+                                Mono.error(
+                                        new IllegalStateException("summary provider unavailable")));
+
+        StepVerifier.create(
+                        middleware.onReasoning(
+                                agent(),
+                                context("user", "session"),
+                                input(),
+                                next -> {
+                                    nextCalls.incrementAndGet();
+                                    return Flux.empty();
+                                }))
+                .verifyComplete();
+
+        assertEquals(1, nextCalls.get());
+    }
+
+    /** An interrupt during compaction must propagate without entering downstream reasoning. */
+    @Test
+    void interruptedCompactionPropagatesWithoutCallingNext() {
+        AtomicInteger nextCalls = new AtomicInteger();
+        CompactionMiddleware middleware =
+                middleware(
+                        (ctx, messages, config, agentId, sessionId) ->
+                                Mono.error(
+                                        new InterruptedException("interrupted while compacting")));
+
+        StepVerifier.create(
+                        middleware.onReasoning(
+                                agent(),
+                                context("user", "session"),
+                                input(),
+                                next -> {
+                                    nextCalls.incrementAndGet();
+                                    return Flux.empty();
+                                }))
+                .expectError(InterruptedException.class)
+                .verify();
+
+        assertEquals(0, nextCalls.get());
+    }
+
+    /** An interrupt received after asynchronous compaction starts must not degrade to reasoning. */
+    @Test
+    void interruptedInFlightCompactionPropagatesWithoutCallingNext() throws Exception {
+        AtomicInteger nextCalls = new AtomicInteger();
+        CountDownLatch compactionStarted = new CountDownLatch(1);
+        Sinks.One<Optional<List<Msg>>> compactionResult = Sinks.one();
+        CompactionMiddleware middleware =
+                middleware(
+                        (ctx, messages, config, agentId, sessionId) ->
+                                compactionResult
+                                        .asMono()
+                                        .doOnSubscribe(ignored -> compactionStarted.countDown()));
+
+        var result =
+                middleware
+                        .onReasoning(
+                                agent(),
+                                context("user", "session"),
+                                input(),
+                                next -> {
+                                    nextCalls.incrementAndGet();
+                                    return Flux.empty();
+                                })
+                        .subscribeOn(Schedulers.parallel())
+                        .collectList()
+                        .toFuture();
+        assertTrue(compactionStarted.await(5, TimeUnit.SECONDS), "compaction should start");
+        compactionResult.tryEmitError(new InterruptedException("interrupted while compacting"));
+
+        ExecutionException error =
+                assertThrows(ExecutionException.class, () -> result.get(5, TimeUnit.SECONDS));
+        assertTrue(error.getCause() instanceof InterruptedException);
+        assertEquals(0, nextCalls.get());
+    }
+
+    /** A user interrupt wrapped by Reactor or application exceptions must also propagate. */
+    @Test
+    void wrappedInterruptedCompactionPropagatesWithoutCallingNext() {
+        AtomicInteger nextCalls = new AtomicInteger();
+        CompactionMiddleware middleware =
+                middleware(
+                        (ctx, messages, config, agentId, sessionId) ->
+                                Mono.error(
+                                        new IllegalStateException(
+                                                "compaction wrapper",
+                                                new InterruptedException(
+                                                        "interrupted while compacting"))));
+
+        StepVerifier.create(
+                        middleware.onReasoning(
+                                agent(),
+                                context("user", "session"),
+                                input(),
+                                next -> {
+                                    nextCalls.incrementAndGet();
+                                    return Flux.empty();
+                                }))
+                .expectErrorMatches(
+                        error ->
+                                error instanceof IllegalStateException
+                                        && error.getCause() instanceof InterruptedException)
+                .verify();
+
+        assertEquals(0, nextCalls.get());
+    }
+
+    /** An interrupt from downstream reasoning must propagate without a fallback retry. */
+    @Test
+    void interruptedDownstreamPropagatesWithoutRetryingNext() {
+        AtomicInteger nextCalls = new AtomicInteger();
+        CompactionMiddleware middleware =
+                middleware(
+                        (ctx, messages, config, agentId, sessionId) -> Mono.just(Optional.empty()));
+
+        StepVerifier.create(
+                        middleware.onReasoning(
+                                agent(),
+                                context("user", "session"),
+                                input(),
+                                next -> {
+                                    nextCalls.incrementAndGet();
+                                    return Flux.error(
+                                            new InterruptedException(
+                                                    "interrupted while reasoning"));
+                                }))
+                .expectError(InterruptedException.class)
+                .verify();
+
+        assertEquals(1, nextCalls.get());
+    }
+
+    /** An interrupted concurrent session must not prevent another session from entering reasoning. */
+    @Test
+    void concurrentSessionInterruptDoesNotAffectOtherSession() {
+        AtomicInteger interruptedNextCalls = new AtomicInteger();
+        AtomicInteger activeNextCalls = new AtomicInteger();
+        Set<String> compactedSessions = ConcurrentHashMap.newKeySet();
+        CompactionMiddleware middleware =
+                middleware(
+                        (ctx, messages, config, agentId, sessionId) ->
+                                Mono.defer(
+                                        () -> {
+                                            compactedSessions.add(ctx.getSessionId());
+                                            return "session-a".equals(ctx.getSessionId())
+                                                    ? Mono.error(
+                                                            new InterruptedException(
+                                                                    "interrupted session-a"))
+                                                    : Mono.just(Optional.empty());
+                                        }));
+
+        Flux<AgentEvent> interrupted =
+                middleware.onReasoning(
+                        agent(),
+                        context("user-a", "session-a"),
+                        input(),
+                        next -> {
+                            interruptedNextCalls.incrementAndGet();
+                            return Flux.empty();
+                        });
+        Flux<AgentEvent> active =
+                middleware.onReasoning(
+                        agent(),
+                        context("user-b", "session-b"),
+                        input(),
+                        next -> {
+                            activeNextCalls.incrementAndGet();
+                            return Flux.empty();
+                        });
+
+        Flux.mergeDelayError(
+                        2,
+                        interrupted.materialize().subscribeOn(Schedulers.parallel()),
+                        active.materialize().subscribeOn(Schedulers.parallel()))
+                .collectList()
+                .block();
+
+        assertEquals(Set.of("session-a", "session-b"), compactedSessions);
+        assertEquals(0, interruptedNextCalls.get());
+        assertEquals(1, activeNextCalls.get());
+        assertTrue(compactedSessions.contains("session-b"));
+    }
+
+    /** An interrupt in a regular model stream must make one request and end as INTERRUPTED. */
+    @Test
+    void modelStreamInterruptProducesOneCallAndInterruptedTerminalReason() throws Exception {
+        CountDownLatch subscribed = new CountDownLatch(1);
+        CountingDelayedFirstChunkModel model = new CountingDelayedFirstChunkModel(subscribed);
+        CompactionMiddleware middleware =
+                new CompactionMiddleware(
+                        null,
+                        model,
+                        fixedConfig(),
+                        (ctx, messages, config, agentId, sessionId) -> Mono.just(Optional.empty()));
+        ReActAgent agent =
+                ReActAgent.builder()
+                        .name("compaction-test-agent")
+                        .sysPrompt("test")
+                        .model(model)
+                        .middleware(middleware)
+                        .build();
+        RuntimeContext context = context("user", "session");
+
+        var reply =
+                agent.call(
+                                List.of(
+                                        Msg.builder()
+                                                .role(MsgRole.USER)
+                                                .textContent("test")
+                                                .build()),
+                                context)
+                        .subscribeOn(Schedulers.parallel())
+                        .toFuture();
+        assertTrue(subscribed.await(5, TimeUnit.SECONDS), "model stream should start");
+        agent.interrupt(context);
+
+        assertEquals(
+                GenerateReason.INTERRUPTED, reply.get(5, TimeUnit.SECONDS).getGenerateReason());
+        assertEquals(1, model.callCount.get());
+    }
+
+    /** Interrupting one concurrent user session must not cancel the other session's model stream. */
+    @Test
+    void interruptingOneSessionDoesNotCancelConcurrentSession() throws Exception {
+        CountDownLatch subscribed = new CountDownLatch(2);
+        CountingDelayedFirstChunkModel model = new CountingDelayedFirstChunkModel(subscribed);
+        CompactionMiddleware middleware =
+                new CompactionMiddleware(
+                        null,
+                        model,
+                        fixedConfig(),
+                        (ctx, messages, config, agentId, sessionId) -> Mono.just(Optional.empty()));
+        ReActAgent agent =
+                ReActAgent.builder()
+                        .name("compaction-test-agent")
+                        .sysPrompt("test")
+                        .model(model)
+                        .middleware(middleware)
+                        .build();
+        RuntimeContext interruptedContext = context("user-a", "session-a");
+        RuntimeContext activeContext = context("user-b", "session-b");
+
+        var interruptedReply =
+                agent.call(List.of(userMessage("interrupt me")), interruptedContext)
+                        .subscribeOn(Schedulers.parallel())
+                        .toFuture();
+        var activeReply =
+                agent.call(List.of(userMessage("finish normally")), activeContext)
+                        .subscribeOn(Schedulers.parallel())
+                        .toFuture();
+        assertTrue(subscribed.await(5, TimeUnit.SECONDS), "both model streams should start");
+        agent.interrupt(interruptedContext);
+
+        assertEquals(
+                GenerateReason.INTERRUPTED,
+                interruptedReply.get(5, TimeUnit.SECONDS).getGenerateReason());
+        assertTrue(
+                activeReply.get(5, TimeUnit.SECONDS).getGenerateReason()
+                        != GenerateReason.INTERRUPTED);
+        assertEquals(2, model.callCount.get());
+    }
+
+    /** Creates middleware with an explicit compaction executor, avoiding real model or filesystem dependencies. */
+    private CompactionMiddleware middleware(CompactionMiddleware.CompactionExecutor executor) {
+        return new CompactionMiddleware(null, mock(Model.class), fixedConfig(), executor);
+    }
+
+    /** Creates stable configuration that enters the compaction branch. */
+    private CompactionConfig fixedConfig() {
+        return CompactionConfig.builder().triggerTokens(1).keepTokens(1).build();
+    }
+
+    /** Creates the ReActAgent test double required by the middleware. */
+    private ReActAgent agent() {
+        ReActAgent agent = mock(ReActAgent.class);
+        when(agent.getName()).thenReturn("compaction-test-agent");
+        return agent;
+    }
+
+    /** Creates a runtime context isolated by user and session. */
+    private RuntimeContext context(String userId, String sessionId) {
+        return RuntimeContext.builder().userId(userId).sessionId(sessionId).build();
+    }
+
+    /** Creates the minimal input containing one user message. */
+    private ReasoningInput input() {
+        return new ReasoningInput(List.of(userMessage("test")), List.of(), null);
+    }
+
+    /** Creates a minimal user message shared by single-session and concurrent-session tests. */
+    private Msg userMessage(String text) {
+        return Msg.builder().role(MsgRole.USER).textContent(text).build();
+    }
+
+    /** Provides a model interruptible before its first chunk to verify real ReAct stream request counts. */
+    private static final class CountingDelayedFirstChunkModel extends ChatModelBase {
+        private final CountDownLatch subscribed;
+        private final AtomicInteger callCount = new AtomicInteger();
+
+        private CountingDelayedFirstChunkModel(CountDownLatch subscribed) {
+            this.subscribed = subscribed;
+        }
+
+        @Override
+        public String getModelName() {
+            return "counting-delayed-first-chunk";
+        }
+
+        @Override
+        protected Flux<ChatResponse> doStream(
+                List<Msg> messages, List<ToolSchema> tools, GenerateOptions options) {
+            return Flux.defer(
+                    () -> {
+                        callCount.incrementAndGet();
+                        subscribed.countDown();
+                        return Flux.just(
+                                        ChatResponse.builder()
+                                                .content(
+                                                        List.of(
+                                                                TextBlock.builder()
+                                                                        .text("reply")
+                                                                        .build()))
+                                                .build())
+                                .delaySubscription(Duration.ofMillis(200));
+                    });
+        }
+    }
+}

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/middleware/CompactionMiddlewareTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/middleware/CompactionMiddlewareTest.java
@@ -169,6 +169,29 @@ class CompactionMiddlewareTest {
         assertEquals(0, nextCalls.get());
     }
 
+    /** A cyclic exception cause chain must terminate and retain ordinary compaction fallback. */
+    @Test
+    void cyclicCompactionFailureCauseFallsBackWithoutLooping() {
+        AtomicInteger nextCalls = new AtomicInteger();
+        CompactionMiddleware middleware =
+                middleware(
+                        (ctx, messages, config, agentId, sessionId) ->
+                                Mono.error(new CyclicCauseException()));
+
+        StepVerifier.create(
+                        middleware.onReasoning(
+                                agent(),
+                                context("user", "session"),
+                                input(),
+                                next -> {
+                                    nextCalls.incrementAndGet();
+                                    return Flux.empty();
+                                }))
+                .verifyComplete();
+
+        assertEquals(1, nextCalls.get());
+    }
+
     /** An interrupt from downstream reasoning must propagate without a fallback retry. */
     @Test
     void interruptedDownstreamPropagatesWithoutRetryingNext() {
@@ -387,6 +410,15 @@ class CompactionMiddlewareTest {
                                                 .build())
                                 .delaySubscription(Duration.ofMillis(200));
                     });
+        }
+    }
+
+    /** Supplies a malformed cause chain to verify cycle-safe interruption detection. */
+    private static final class CyclicCauseException extends RuntimeException {
+
+        @Override
+        public synchronized Throwable getCause() {
+            return this;
         }
     }
 }


### PR DESCRIPTION
## 关联问题
#2658 
- Fixes: `CompactionMiddleware` 将中断错误纳入 fallback，导致重复执行下游 reasoning

## AgentScope-Java Version

`2.0.3-SNAPSHOT`。

## 背景

`CompactionMiddleware` 原本使用一个覆盖整个处理链的 `onErrorResume`。这使得压缩失败和下游 reasoning 失败共享同一降级逻辑。

用户中断时，`InterruptedException` 被错误记录为 `Compaction failed`，然后 fallback 再次执行 `next.apply(input)`。该第二次 reasoning 已越过 `ReActAgent` 本轮入口的中断检查，可能额外发起模型请求，并使取消终态等待模型首个 chunk。

## 变更内容

1. 将 `onErrorResume` 收窄到 `compactIfNeeded(...)`：
   - 普通压缩异常降级为 `Optional.empty()`，随后仅调用一次 `next.apply(originalInput)`。
   - `InterruptedException` 及其 cause 链中的包装异常直接 `Mono.error(...)` 透传。
2. 将 `next.apply(...)` 置于压缩 fallback 作用域之外：
   - 下游 reasoning 的中断和其他异常不再被误判为压缩失败；
   - 下游不会被 fallback 再次调用。

## Checklist

- [x] 已执行 `mvn spotless:apply`
- [x] 已运行本次改动对应的聚焦测试
- [x] 无需更新公开使用文档
- [x] 代码可供审查
