### PR TITLE
fix(core): simplify ReActAgent pending tool and error result handling

### DIFF
--- a/agentscope-core/src/main/java/io/agentscope/core/ReActAgent.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/ReActAgent.java
@@ -1937,7 +1937,6 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
             // promote them to ALLOWED. Collect denied ones for separate handling.
             List<ToolUseBlock> deniedToolCalls = new ArrayList<>();
             Map<String, ToolUseBlock> replacements = new HashMap<>();
-            Map<String, ToolCallState> stateUpdates = new HashMap<>();
             for (ConfirmResult r : results) {
                 ToolUseBlock target = r.getToolCall();
                 if (target == null) {
@@ -1945,7 +1944,6 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
                 }
                 if (r.isConfirmed()) {
                     replacements.put(target.getId(), target.withState(ToolCallState.ALLOWED));
-                    stateUpdates.put(target.getId(), ToolCallState.ALLOWED);
                     if (r.getRules() != null) {
                         for (PermissionRule rule : r.getRules()) {
                             if (rule != null) {
@@ -2036,7 +2034,7 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
                     pendingToolCalls.stream().map(ToolUseBlock::getId).toList());
             for (ToolUseBlock toolCall : pendingToolCalls) {
                 ToolResultBlock errorResult =
-                        buildErrorToolResult(
+                        ToolResultBlock.error(
                                 toolCall.getId(),
                                 "[ERROR] Previous tool execution failed or was interrupted. Tool: "
                                         + toolCall.getName());
@@ -2072,7 +2070,7 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
             }
             for (ToolUseBlock toolCall : pendingToolCalls) {
                 ToolResultBlock errorResult =
-                        buildErrorToolResult(
+                        ToolResultBlock.error(
                                 toolCall.getId(),
                                 "Tool execution was interrupted before it could run. Tool: "
                                         + toolCall.getName());
@@ -2094,21 +2092,6 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
             } else if (externalEventEmitter != null) {
                 externalEventEmitter.emit(event);
             }
-        }
-
-        /**
-         * Build a {@link ToolResultBlock} representing a tool execution error.
-         *
-         * @param toolId the id of the tool call that failed
-         * @param errorMessage the human-readable error description
-         * @return a {@link ToolResultBlock} containing the formatted error message
-         */
-        private static ToolResultBlock buildErrorToolResult(String toolId, String errorMessage) {
-            return ToolResultBlock.builder()
-                    .id(toolId)
-                    .output(List.of(TextBlock.builder().text("[ERROR] " + errorMessage).build()))
-                    .state(ToolResultState.ERROR)
-                    .build();
         }
 
         /**
@@ -3303,7 +3286,7 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
                                                 .map(
                                                         toolCall -> {
                                                             ToolResultBlock errorResult =
-                                                                    buildErrorToolResult(
+                                                                    ToolResultBlock.error(
                                                                             toolCall.getId(),
                                                                             "Tool execution failed:"
                                                                                     + " "
@@ -3366,7 +3349,7 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
                                                 ToolResultBlock result = byId.get(use.getId());
                                                 if (result == null) {
                                                     return Mono.just(
-                                                            buildErrorToolResult(
+                                                            ToolResultBlock.error(
                                                                     use.getId(),
                                                                     "Internal error: missing tool"
                                                                             + " result for '"
@@ -3387,7 +3370,7 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
                     ToolValidator.validateInput(use.getContent(), soTool.getParameters());
             if (validationError != null) {
                 return Mono.just(
-                        buildErrorToolResult(
+                        ToolResultBlock.error(
                                 use.getId(),
                                 "Parameter validation failed for tool '"
                                         + STRUCTURED_OUTPUT_TOOL_NAME
@@ -3447,15 +3430,15 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
             log.debug("Maximum iterations reached. Generating summary...");
 
             // Handle pending tool calls that were not completed before max iterations
-            if (hasPendingToolUse()) {
-                List<ToolUseBlock> pendingTools = extractPendingToolCalls();
+            List<ToolUseBlock> pendingTools = extractPendingToolCalls();
+            if (!pendingTools.isEmpty()) {
                 log.warn(
                         "Max iterations reached with {} pending tool calls. Adding error results.",
                         pendingTools.size());
 
                 for (ToolUseBlock toolUse : pendingTools) {
                     ToolResultBlock errorResult =
-                            buildErrorToolResult(
+                            ToolResultBlock.error(
                                     toolUse.getId(),
                                     "Tool execution cancelled because maximum iterations limit ("
                                             + maxIters

--- a/agentscope-core/src/main/java/io/agentscope/core/ReActAgent.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/ReActAgent.java
@@ -2036,7 +2036,7 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
                 ToolResultBlock errorResult =
                         ToolResultBlock.error(
                                 toolCall.getId(),
-                                "[ERROR] Previous tool execution failed or was interrupted. Tool: "
+                                "Previous tool execution failed or was interrupted. Tool: "
                                         + toolCall.getName());
                 Msg toolResultMsg =
                         ToolResultMessageBuilder.buildToolResultMsg(

--- a/agentscope-core/src/main/java/io/agentscope/core/message/ToolResultBlock.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/message/ToolResultBlock.java
@@ -212,6 +212,25 @@ public final class ToolResultBlock extends ContentBlock {
     }
 
     /**
+     * Create an error result for a tool call.
+     *
+     * <p>The {@code [ERROR]} prefix is used by the agent runtime to preserve the error marker in
+     * generated tool results.
+     *
+     * @param toolId Tool call ID
+     * @param errorMessage Error message
+     * @return Error ToolResultBlock for use in a message
+     */
+    public static ToolResultBlock error(String toolId, String errorMessage) {
+        return new ToolResultBlock(
+                toolId,
+                null,
+                List.of(TextBlock.builder().text("[ERROR] " + errorMessage).build()),
+                null,
+                ToolResultState.ERROR);
+    }
+
+    /**
      * Create a result with output only (for tool method return values).
      *
      * @param output Content block output

--- a/agentscope-core/src/test/java/io/agentscope/core/message/ToolResultBlockTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/message/ToolResultBlockTest.java
@@ -30,4 +30,14 @@ class ToolResultBlockTest {
         TextBlock output = assertInstanceOf(TextBlock.class, result.getOutput().get(0));
         assertEquals("Error: probe failed", output.getText());
     }
+
+    @Test
+    void toolCallErrorFactoryPreservesToolIdAndRuntimeErrorMarker() {
+        ToolResultBlock result = ToolResultBlock.error("tool-1", "probe failed");
+
+        assertEquals("tool-1", result.getId());
+        assertEquals(ToolResultState.ERROR, result.getState());
+        TextBlock output = assertInstanceOf(TextBlock.class, result.getOutput().get(0));
+        assertEquals("[ERROR] probe failed", output.getText());
+    }
 }


### PR DESCRIPTION
## Summary

- Simplify `ReActAgent.summarizing()` by directly checking the extracted pending tool calls.
- Move tool execution error-result construction into `ToolResultBlock`.
- Remove the unused `stateUpdates` map from `applyConfirmResults`.
- Preserve the existing error state and `[ERROR]` marker behavior.

## Checklist

Please check the following items before code is ready to be reviewed.

- [ ]  Code has been formatted with `mvn spotless:apply`
- [ ]  All tests are passing (`mvn test`)
- [ ]  Javadoc comments are complete and follow project conventions
- [ ]  Related documentation has been updated (e.g. links, examples, etc.)
- [ ]  Code is ready for review
