### PR TITLE
fix(core): 将用户拒绝工具执行原因写入模型上下文

### DIFF
--- a/agentscope-core/src/main/java/io/agentscope/core/ReActAgent.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/ReActAgent.java
@@ -1963,8 +1963,9 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
          */
         private void applyConfirmResults(List<ConfirmResult> results) {
             // Replace ASKING ToolUseBlocks with possibly-modified ones from the user, and
-            // promote them to ALLOWED. Collect denied ones for separate handling.
-            List<ToolUseBlock> deniedToolCalls = new ArrayList<>();
+            // promote them to ALLOWED. Collect denied results for separate handling so any
+            // user-supplied reason can be included in the denied tool result.
+            List<ConfirmResult> deniedResults = new ArrayList<>();
             Map<String, ToolUseBlock> replacements = new HashMap<>();
             for (ConfirmResult r : results) {
                 ToolUseBlock target = r.getToolCall();
@@ -1981,18 +1982,25 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
                         }
                     }
                 } else {
-                    deniedToolCalls.add(target);
+                    deniedResults.add(r);
                 }
             }
             applyToolUseBlockReplacements(replacements);
-            for (ToolUseBlock denied : deniedToolCalls) {
-                ToolResultBlock deniedResult =
-                        ToolResultBlock.text("Permission denied by user")
+            for (ConfirmResult deniedResult : deniedResults) {
+                ToolUseBlock denied = deniedResult.getToolCall();
+                String reason = deniedResult.getReason();
+                String message =
+                        reason == null || reason.isBlank()
+                                ? "Permission denied by user"
+                                : "Permission denied by user. User-provided reason: "
+                                        + reason.strip();
+                ToolResultBlock deniedToolResult =
+                        ToolResultBlock.text(message)
                                 .withIdAndName(denied.getId(), denied.getName())
                                 .withState(ToolResultState.DENIED);
                 Msg deniedMsg =
                         ToolResultMessageBuilder.buildToolResultMsg(
-                                deniedResult, denied, getName());
+                                deniedToolResult, denied, getName());
                 state.contextMutable().add(deniedMsg);
             }
         }

--- a/agentscope-core/src/main/java/io/agentscope/core/ReActAgent.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/ReActAgent.java
@@ -217,6 +217,7 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
     private static final Logger log = LoggerFactory.getLogger(ReActAgent.class);
     private static final GracefulShutdownManager shutdownManager =
             GracefulShutdownManager.getInstance();
+    private static final int MAX_CONFIRM_REASON_CODE_POINTS = 500;
 
     /** Tool name used for the per-call structured-output {@code generate_response} tool. */
     public static final String STRUCTURED_OUTPUT_TOOL_NAME = "generate_response";
@@ -1989,11 +1990,18 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
             for (ConfirmResult deniedResult : deniedResults) {
                 ToolUseBlock denied = deniedResult.getToolCall();
                 String reason = deniedResult.getReason();
+                String normalizedReason = reason == null ? "" : reason.strip();
+                if (normalizedReason.codePointCount(0, normalizedReason.length())
+                        > MAX_CONFIRM_REASON_CODE_POINTS) {
+                    int endIndex =
+                            normalizedReason.offsetByCodePoints(0, MAX_CONFIRM_REASON_CODE_POINTS);
+                    normalizedReason = normalizedReason.substring(0, endIndex) + " <truncated>";
+                }
                 String message =
-                        reason == null || reason.isBlank()
+                        normalizedReason.isEmpty()
                                 ? "Permission denied by user"
                                 : "Permission denied by user. User-provided reason: "
-                                        + reason.strip();
+                                        + normalizedReason;
                 ToolResultBlock deniedToolResult =
                         ToolResultBlock.text(message)
                                 .withIdAndName(denied.getId(), denied.getName())

--- a/agentscope-core/src/main/java/io/agentscope/core/event/ConfirmResult.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/event/ConfirmResult.java
@@ -16,6 +16,7 @@
 package io.agentscope.core.event;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.agentscope.core.message.ToolUseBlock;
 import io.agentscope.core.permission.PermissionRule;
@@ -33,20 +34,28 @@ public class ConfirmResult {
     private final boolean confirmed;
     private final ToolUseBlock toolCall;
     private final List<PermissionRule> rules;
+    private final String reason;
 
     @JsonCreator
     public ConfirmResult(
             @JsonProperty("confirmed") boolean confirmed,
             @JsonProperty("toolCall") ToolUseBlock toolCall,
-            @JsonProperty("rules") List<PermissionRule> rules) {
+            @JsonProperty("rules") List<PermissionRule> rules,
+            @JsonProperty("reason") String reason) {
         this.confirmed = confirmed;
         this.toolCall = toolCall;
         this.rules = rules;
+        this.reason = reason;
+    }
+
+    /** Backward-compatible constructor without a decision reason. */
+    public ConfirmResult(boolean confirmed, ToolUseBlock toolCall, List<PermissionRule> rules) {
+        this(confirmed, toolCall, rules, null);
     }
 
     /** Convenience constructor without rules. */
     public ConfirmResult(boolean confirmed, ToolUseBlock toolCall) {
-        this(confirmed, toolCall, null);
+        this(confirmed, toolCall, null, null);
     }
 
     public boolean isConfirmed() {
@@ -65,5 +74,19 @@ public class ConfirmResult {
      */
     public List<PermissionRule> getRules() {
         return rules;
+    }
+
+    /**
+     * Optional user-supplied reason for the confirmation decision.
+     *
+     * <p>When {@link #confirmed} is false, the agent includes this reason in the denied tool result
+     * that is added to model context. It is otherwise retained on the confirmation event for
+     * callers that need to inspect it.
+     *
+     * @return decision reason, or null if none was supplied
+     */
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public String getReason() {
+        return reason;
     }
 }

--- a/agentscope-core/src/test/java/io/agentscope/core/agent/ReActAgentHitlTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/agent/ReActAgentHitlTest.java
@@ -46,6 +46,7 @@ import io.agentscope.core.state.AgentState;
 import io.agentscope.core.tool.ToolBase;
 import io.agentscope.core.tool.ToolCallParam;
 import io.agentscope.core.tool.Toolkit;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -70,6 +71,7 @@ class ReActAgentHitlTest {
     private static final class ScriptedModel extends ChatModelBase {
         private final List<Supplier<Flux<ChatResponse>>> scripts;
         private final AtomicInteger idx = new AtomicInteger(0);
+        private final List<List<Msg>> invocations = new ArrayList<>();
 
         ScriptedModel(List<Supplier<Flux<ChatResponse>>> scripts) {
             this.scripts = scripts;
@@ -83,11 +85,16 @@ class ReActAgentHitlTest {
         @Override
         protected Flux<ChatResponse> doStream(
                 List<Msg> messages, List<ToolSchema> tools, GenerateOptions options) {
+            invocations.add(List.copyOf(messages));
             int i = idx.getAndIncrement();
             if (i >= scripts.size()) {
                 return Flux.just(textResponse(""));
             }
             return scripts.get(i).get();
+        }
+
+        List<List<Msg>> getInvocations() {
+            return List.copyOf(invocations);
         }
     }
 
@@ -406,6 +413,53 @@ class ReActAgentHitlTest {
                                         "tc1".equals(tr.getId())
                                                 && tr.getState() == ToolResultState.DENIED);
         assertTrue(foundDenied, "expected a DENIED ToolResultBlock for the rejected tool");
+
+        ToolResultBlock deniedResult =
+                agent.getAgentState().getContext().stream()
+                        .flatMap(m -> m.getContentBlocks(ToolResultBlock.class).stream())
+                        .filter(tr -> "tc1".equals(tr.getId()))
+                        .findFirst()
+                        .orElseThrow();
+        assertEquals(
+                "Permission denied by user",
+                ((TextBlock) deniedResult.getOutput().get(0)).getText());
+    }
+
+    @Test
+    void deniedConfirmationReasonIsIncludedInNextModelInput() {
+        ScriptedModel model =
+                new ScriptedModel(
+                        List.of(
+                                () -> Flux.just(toolUseResponse("tc1", "ask", "x")),
+                                () -> Flux.just(textResponse("done"))));
+        ReActAgent agent = buildAgent(model, toolkitWith(new AskingTool("ask")));
+
+        Msg first = agent.call(List.of()).block();
+        assertNotNull(first);
+        ToolUseBlock pending = first.getContentBlocks(ToolUseBlock.class).get(0);
+
+        Msg resume =
+                confirmMsg(
+                        List.of(
+                                new ConfirmResult(
+                                        false,
+                                        pending,
+                                        null,
+                                        "The file is still needed by another task.")));
+        agent.call(List.of(resume)).block();
+
+        assertEquals(2, model.getInvocations().size());
+        ToolResultBlock deniedResult =
+                model.getInvocations().get(1).stream()
+                        .flatMap(m -> m.getContentBlocks(ToolResultBlock.class).stream())
+                        .filter(tr -> "tc1".equals(tr.getId()))
+                        .findFirst()
+                        .orElseThrow();
+        assertEquals(ToolResultState.DENIED, deniedResult.getState());
+        assertEquals(
+                "Permission denied by user. User-provided reason: The file is still needed by"
+                        + " another task.",
+                ((TextBlock) deniedResult.getOutput().get(0)).getText());
     }
 
     @Test

--- a/agentscope-core/src/test/java/io/agentscope/core/agent/ReActAgentHitlTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/agent/ReActAgentHitlTest.java
@@ -222,7 +222,7 @@ class ReActAgentHitlTest {
     }
 
     private static Msg confirmMsg(boolean confirmed, ToolUseBlock toolCall) {
-        return confirmMsg(List.of(new ConfirmResult(confirmed, toolCall, null)));
+        return confirmMsg(List.of(new ConfirmResult(confirmed, toolCall)));
     }
 
     private static Msg confirmMsg(List<ConfirmResult> confirmResults) {
@@ -401,7 +401,8 @@ class ReActAgentHitlTest {
         ToolUseBlock pending = lastAssistant.getContentBlocks(ToolUseBlock.class).get(0);
 
         // Second call → deny
-        Msg second = agent.call(List.of(confirmMsg(false, pending))).block();
+        Msg confirmation = confirmMsg(List.of(new ConfirmResult(false, pending, null, "  ")));
+        Msg second = agent.call(List.of(confirmation)).block();
         assertNotNull(second);
 
         // Context should contain a DENIED ToolResultBlock for tc1
@@ -459,6 +460,36 @@ class ReActAgentHitlTest {
         assertEquals(
                 "Permission denied by user. User-provided reason: The file is still needed by"
                         + " another task.",
+                ((TextBlock) deniedResult.getOutput().get(0)).getText());
+    }
+
+    @Test
+    void deniedConfirmationReasonIsTruncatedBeforeEnteringModelInput() {
+        ScriptedModel model =
+                new ScriptedModel(
+                        List.of(
+                                () -> Flux.just(toolUseResponse("tc1", "ask", "x")),
+                                () -> Flux.just(textResponse("done"))));
+        ReActAgent agent = buildAgent(model, toolkitWith(new AskingTool("ask")));
+
+        Msg first = agent.call(List.of()).block();
+        assertNotNull(first);
+        ToolUseBlock pending = first.getContentBlocks(ToolUseBlock.class).get(0);
+        String reason = "a".repeat(499) + "😀ignored";
+
+        Msg resume = confirmMsg(List.of(new ConfirmResult(false, pending, null, reason)));
+        agent.call(List.of(resume)).block();
+
+        ToolResultBlock deniedResult =
+                model.getInvocations().get(1).stream()
+                        .flatMap(m -> m.getContentBlocks(ToolResultBlock.class).stream())
+                        .filter(tr -> "tc1".equals(tr.getId()))
+                        .findFirst()
+                        .orElseThrow();
+        assertEquals(
+                "Permission denied by user. User-provided reason: "
+                        + "a".repeat(499)
+                        + "😀 <truncated>",
                 ((TextBlock) deniedResult.getOutput().get(0)).getText());
     }
 

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/subagent/protocol/RemoteEventCodecPassthroughTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/subagent/protocol/RemoteEventCodecPassthroughTest.java
@@ -217,6 +217,30 @@ class RemoteEventCodecPassthroughTest {
     }
 
     @Test
+    void userConfirmationReasonSurvivesTheRoundTrip() {
+        ToolUseBlock toolUse =
+                ToolUseBlock.builder()
+                        .id("call-1")
+                        .name("delete_file")
+                        .input(Map.of("path", "important.txt"))
+                        .build();
+        UserConfirmResultEvent original =
+                new UserConfirmResultEvent(
+                        "reply",
+                        List.of(
+                                new ConfirmResult(
+                                        false, toolUse, null, "The file is still needed.")));
+
+        RemoteAgentEvent dto = RemoteEventCodec.fromAgentEvent(original).orElseThrow();
+        UserConfirmResultEvent back =
+                assertInstanceOf(
+                        UserConfirmResultEvent.class,
+                        RemoteEventCodec.toAgentEvent(dto).orElseThrow());
+
+        assertEquals("The file is still needed.", back.getConfirmResults().get(0).getReason());
+    }
+
+    @Test
     void typedEventsAlsoDecodeFromPayloadWithoutLosingBlockIds() {
         TextBlockDeltaEvent original = new TextBlockDeltaEvent("reply-7", "block-9", "hello");
 


### PR DESCRIPTION
## 背景

现在`ReactAgent`和`HarnessAgent`已经有工具审批逻辑，发出 `RequireUserConfirmEvent` 和 `UserConfirmResultEvent`事件，用户可以选择通过或者拒绝，但是没有渠道可以把用户主动提供的拒绝调用的原因。已合并的 #2511 建立了工具审批结果的事件和恢复链路，但 `ConfirmResult` 只能表达通过或拒绝，拒绝时写入模型上下文的仍是固定文案，无法携带用户主动提供的原因。这个PR拓展了一下工具调用审批需要的 `ConfirmResult`，加入了可选的`reason`字段，并且将原因加入到了对应的ToolResultBlock里面。

## 改动

- 为 `ConfirmResult` 增加可选 `reason`，保留旧构造函数。
- 拒绝时将原因追加到 `DENIED` 工具结果，使模型下一轮可见。
- 补充 ReActAgent 上下文测试和 Harness 远程事件编解码测试。

## 测试

`ReActAgentHitlTest`、`RemoteEventCodecPassthroughTest` 通过。