### PR TITLE
fix(harness): close test agents before temp workspace cleanup

### DIFF
--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/HarnessAgentDynamicHookBuilderTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/HarnessAgentDynamicHookBuilderTest.java
@@ -44,11 +44,13 @@ import io.agentscope.harness.agent.middleware.DynamicSubagentsMiddleware;
 import io.agentscope.harness.agent.middleware.SubagentsMiddleware;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.mockito.ArgumentCaptor;
@@ -75,17 +77,29 @@ import reactor.core.publisher.Flux;
 class HarnessAgentDynamicHookBuilderTest {
 
     @TempDir Path workspace;
+    private final List<HarnessAgent> agents = new ArrayList<>();
+
+    @AfterEach
+    void closeAgents() {
+        agents.forEach(HarnessAgent::close);
+    }
+
+    private HarnessAgent track(HarnessAgent agent) {
+        agents.add(agent);
+        return agent;
+    }
 
     @Test
     void defaultBuild_registersDynamicSkillAndSubagentMiddlewares() throws Exception {
         Files.createDirectories(workspace);
         HarnessAgent agent =
-                HarnessAgent.builder()
-                        .name("t")
-                        .model(stubModel("ok"))
-                        .workspace(workspace)
-                        .abstractFilesystem(new LocalFilesystem(workspace))
-                        .build();
+                track(
+                        HarnessAgent.builder()
+                                .name("t")
+                                .model(stubModel("ok"))
+                                .workspace(workspace)
+                                .abstractFilesystem(new LocalFilesystem(workspace))
+                                .build());
 
         List<MiddlewareBase> mws = agent.getDelegate().getMiddlewares();
         assertTrue(
@@ -108,13 +122,14 @@ class HarnessAgentDynamicHookBuilderTest {
         AgentSkillRepository emptyRepo = new EmptySkillRepository();
 
         HarnessAgent agent =
-                HarnessAgent.builder()
-                        .name("t")
-                        .model(stubModel("ok"))
-                        .workspace(workspace)
-                        .abstractFilesystem(new LocalFilesystem(workspace))
-                        .skillRepository(emptyRepo)
-                        .build();
+                track(
+                        HarnessAgent.builder()
+                                .name("t")
+                                .model(stubModel("ok"))
+                                .workspace(workspace)
+                                .abstractFilesystem(new LocalFilesystem(workspace))
+                                .skillRepository(emptyRepo)
+                                .build());
 
         List<MiddlewareBase> mws = agent.getDelegate().getMiddlewares();
         assertTrue(
@@ -126,13 +141,14 @@ class HarnessAgentDynamicHookBuilderTest {
     void disableDynamicSkills_skipsDynamicSkillMiddleware() throws Exception {
         Files.createDirectories(workspace);
         HarnessAgent agent =
-                HarnessAgent.builder()
-                        .name("t")
-                        .model(stubModel("ok"))
-                        .workspace(workspace)
-                        .abstractFilesystem(new LocalFilesystem(workspace))
-                        .disableDynamicSkills()
-                        .build();
+                track(
+                        HarnessAgent.builder()
+                                .name("t")
+                                .model(stubModel("ok"))
+                                .workspace(workspace)
+                                .abstractFilesystem(new LocalFilesystem(workspace))
+                                .disableDynamicSkills()
+                                .build());
 
         List<MiddlewareBase> mws = agent.getDelegate().getMiddlewares();
         assertFalse(
@@ -154,14 +170,15 @@ class HarnessAgentDynamicHookBuilderTest {
                                         null)));
 
         HarnessAgent agent =
-                HarnessAgent.builder()
-                        .name("t")
-                        .model(model)
-                        .workspace(workspace)
-                        .abstractFilesystem(new LocalFilesystem(workspace))
-                        .skillRepository(repository)
-                        .disableDynamicSkills()
-                        .build();
+                track(
+                        HarnessAgent.builder()
+                                .name("t")
+                                .model(model)
+                                .workspace(workspace)
+                                .abstractFilesystem(new LocalFilesystem(workspace))
+                                .skillRepository(repository)
+                                .disableDynamicSkills()
+                                .build());
 
         assertEquals(
                 1,
@@ -223,21 +240,27 @@ class HarnessAgentDynamicHookBuilderTest {
                                 skill("gamma", "gamma description")));
 
         HarnessAgent agent =
-                HarnessAgent.builder()
-                        .name("t")
-                        .model(model)
-                        .workspace(workspace)
-                        .abstractFilesystem(new LocalFilesystem(workspace))
-                        .skillRepository(repository)
-                        .enableSkills("alpha", "beta")
-                        .enableSkillPromotionGate(
-                                null,
-                                (skills, ctx) ->
-                                        skills.stream()
-                                                .filter(skill -> !"alpha".equals(skill.getName()))
-                                                .toList())
-                        .disableDynamicSkills()
-                        .build();
+                track(
+                        HarnessAgent.builder()
+                                .name("t")
+                                .model(model)
+                                .workspace(workspace)
+                                .abstractFilesystem(new LocalFilesystem(workspace))
+                                .skillRepository(repository)
+                                .enableSkills("alpha", "beta")
+                                .enableSkillPromotionGate(
+                                        null,
+                                        (skills, ctx) ->
+                                                skills.stream()
+                                                        .filter(
+                                                                skill ->
+                                                                        !"alpha"
+                                                                                .equals(
+                                                                                        skill
+                                                                                                .getName()))
+                                                        .toList())
+                                .disableDynamicSkills()
+                                .build());
 
         RuntimeContext ctx = RuntimeContext.builder().sessionId("filtered-static").build();
         agent.call("hello", ctx).block();
@@ -266,15 +289,16 @@ class HarnessAgentDynamicHookBuilderTest {
                 new CountingSkillRepository(List.of(skill("disabled", "must stay hidden")));
 
         HarnessAgent agent =
-                HarnessAgent.builder()
-                        .name("t")
-                        .model(model)
-                        .workspace(workspace)
-                        .abstractFilesystem(new LocalFilesystem(workspace))
-                        .skillRepository(repository)
-                        .skillsEnabled(false)
-                        .disableDynamicSkills()
-                        .build();
+                track(
+                        HarnessAgent.builder()
+                                .name("t")
+                                .model(model)
+                                .workspace(workspace)
+                                .abstractFilesystem(new LocalFilesystem(workspace))
+                                .skillRepository(repository)
+                                .skillsEnabled(false)
+                                .disableDynamicSkills()
+                                .build());
 
         RuntimeContext ctx = RuntimeContext.builder().sessionId("no-static-skills").build();
         agent.call("hello", ctx).block();
@@ -294,13 +318,14 @@ class HarnessAgentDynamicHookBuilderTest {
         Files.writeString(skillDir.resolve("references/guide.md"), "lazy reference body");
 
         HarnessAgent agent =
-                HarnessAgent.builder()
-                        .name("t")
-                        .model(stubModel("ok"))
-                        .workspace(workspace)
-                        .abstractFilesystem(new LocalFilesystem(workspace))
-                        .disableDynamicSkills()
-                        .build();
+                track(
+                        HarnessAgent.builder()
+                                .name("t")
+                                .model(stubModel("ok"))
+                                .workspace(workspace)
+                                .abstractFilesystem(new LocalFilesystem(workspace))
+                                .disableDynamicSkills()
+                                .build());
 
         RuntimeContext ctx = RuntimeContext.builder().sessionId("lazy-static").build();
         agent.call("hello", ctx).block();
@@ -332,13 +357,14 @@ class HarnessAgentDynamicHookBuilderTest {
         AgentSkillRepository custom = new EmptySkillRepository();
 
         HarnessAgent agent =
-                HarnessAgent.builder()
-                        .name("t")
-                        .model(stubModel("ok"))
-                        .workspace(workspace)
-                        .abstractFilesystem(new LocalFilesystem(workspace))
-                        .skillRepository(custom)
-                        .build();
+                track(
+                        HarnessAgent.builder()
+                                .name("t")
+                                .model(stubModel("ok"))
+                                .workspace(workspace)
+                                .abstractFilesystem(new LocalFilesystem(workspace))
+                                .skillRepository(custom)
+                                .build());
 
         List<AgentSkillRepository> repos = agent.getSkillRepositories();
         assertNotNull(repos, "getSkillRepositories() must never return null");
@@ -357,13 +383,14 @@ class HarnessAgentDynamicHookBuilderTest {
     void getSkillRepositories_isEmptyWhenNothingComposed() throws Exception {
         Files.createDirectories(workspace);
         HarnessAgent agent =
-                HarnessAgent.builder()
-                        .name("t")
-                        .model(stubModel("ok"))
-                        .workspace(workspace)
-                        .abstractFilesystem(new LocalFilesystem(workspace))
-                        .disableDynamicSkills()
-                        .build();
+                track(
+                        HarnessAgent.builder()
+                                .name("t")
+                                .model(stubModel("ok"))
+                                .workspace(workspace)
+                                .abstractFilesystem(new LocalFilesystem(workspace))
+                                .disableDynamicSkills()
+                                .build());
 
         assertNotNull(agent.getSkillRepositories());
     }
@@ -372,12 +399,13 @@ class HarnessAgentDynamicHookBuilderTest {
     void getSkillRepositories_returnsImmutableList() throws Exception {
         Files.createDirectories(workspace);
         HarnessAgent agent =
-                HarnessAgent.builder()
-                        .name("t")
-                        .model(stubModel("ok"))
-                        .workspace(workspace)
-                        .abstractFilesystem(new LocalFilesystem(workspace))
-                        .build();
+                track(
+                        HarnessAgent.builder()
+                                .name("t")
+                                .model(stubModel("ok"))
+                                .workspace(workspace)
+                                .abstractFilesystem(new LocalFilesystem(workspace))
+                                .build());
 
         List<AgentSkillRepository> first = agent.getSkillRepositories();
         List<AgentSkillRepository> second = agent.getSkillRepositories();
@@ -395,13 +423,14 @@ class HarnessAgentDynamicHookBuilderTest {
     void disableDynamicSubagents_fallsBackToStaticSubagentsMiddleware() throws Exception {
         Files.createDirectories(workspace);
         HarnessAgent agent =
-                HarnessAgent.builder()
-                        .name("t")
-                        .model(stubModel("ok"))
-                        .workspace(workspace)
-                        .abstractFilesystem(new LocalFilesystem(workspace))
-                        .disableDynamicSubagents()
-                        .build();
+                track(
+                        HarnessAgent.builder()
+                                .name("t")
+                                .model(stubModel("ok"))
+                                .workspace(workspace)
+                                .abstractFilesystem(new LocalFilesystem(workspace))
+                                .disableDynamicSubagents()
+                                .build());
 
         List<MiddlewareBase> mws = agent.getDelegate().getMiddlewares();
         assertFalse(

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/HarnessAgentSubagentStreamTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/HarnessAgentSubagentStreamTest.java
@@ -39,6 +39,7 @@ import io.agentscope.core.model.Model;
 import io.agentscope.harness.agent.filesystem.local.LocalFilesystem;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -69,6 +70,7 @@ class HarnessAgentSubagentStreamTest {
     // "parent" agent's persisted AgentState from leaking between cases.
     @TempDir Path stateHome;
 
+    private final List<HarnessAgent> agents = new ArrayList<>();
     private String previousStateHome;
 
     @BeforeEach
@@ -78,12 +80,21 @@ class HarnessAgentSubagentStreamTest {
     }
 
     @AfterEach
-    void restoreStateHome() {
-        if (previousStateHome != null) {
-            System.setProperty("agentscope.state.home", previousStateHome);
-        } else {
-            System.clearProperty("agentscope.state.home");
+    void cleanup() {
+        try {
+            agents.forEach(HarnessAgent::close);
+        } finally {
+            if (previousStateHome != null) {
+                System.setProperty("agentscope.state.home", previousStateHome);
+            } else {
+                System.clearProperty("agentscope.state.home");
+            }
         }
+    }
+
+    private HarnessAgent track(HarnessAgent agent) {
+        agents.add(agent);
+        return agent;
     }
 
     // -----------------------------------------------------------------
@@ -177,12 +188,13 @@ class HarnessAgentSubagentStreamTest {
                 .thenReturn(Flux.just(stopChunk("p2", "summary done")));
 
         HarnessAgent parent =
-                HarnessAgent.builder()
-                        .name("parent")
-                        .model(model)
-                        .workspace(workspace)
-                        .abstractFilesystem(new LocalFilesystem(workspace))
-                        .build();
+                track(
+                        HarnessAgent.builder()
+                                .name("parent")
+                                .model(model)
+                                .workspace(workspace)
+                                .abstractFilesystem(new LocalFilesystem(workspace))
+                                .build());
 
         RuntimeContext ctx = RuntimeContext.builder().sessionId("sess-stream").build();
 
@@ -274,12 +286,13 @@ class HarnessAgentSubagentStreamTest {
                 .thenReturn(Flux.just(stopChunk("p2", "all done")));
 
         HarnessAgent parent =
-                HarnessAgent.builder()
-                        .name("parent")
-                        .model(model)
-                        .workspace(workspace)
-                        .abstractFilesystem(new LocalFilesystem(workspace))
-                        .build();
+                track(
+                        HarnessAgent.builder()
+                                .name("parent")
+                                .model(model)
+                                .workspace(workspace)
+                                .abstractFilesystem(new LocalFilesystem(workspace))
+                                .build());
 
         List<Event> events =
                 parent.stream(
@@ -358,12 +371,13 @@ class HarnessAgentSubagentStreamTest {
                 .thenReturn(Flux.just(stopChunk("p2", "result obtained")));
 
         HarnessAgent parent =
-                HarnessAgent.builder()
-                        .name("parent")
-                        .model(model)
-                        .workspace(workspace)
-                        .abstractFilesystem(new LocalFilesystem(workspace))
-                        .build();
+                track(
+                        HarnessAgent.builder()
+                                .name("parent")
+                                .model(model)
+                                .workspace(workspace)
+                                .abstractFilesystem(new LocalFilesystem(workspace))
+                                .build());
 
         Msg reply =
                 parent.call(
@@ -451,12 +465,13 @@ class HarnessAgentSubagentStreamTest {
         when(model.getModelName()).thenReturn("stub");
 
         HarnessAgent agent =
-                HarnessAgent.builder()
-                        .name("diag-parent")
-                        .model(model)
-                        .workspace(workspace)
-                        .abstractFilesystem(new LocalFilesystem(workspace))
-                        .build();
+                track(
+                        HarnessAgent.builder()
+                                .name("diag-parent")
+                                .model(model)
+                                .workspace(workspace)
+                                .abstractFilesystem(new LocalFilesystem(workspace))
+                                .build());
 
         // After the HarnessAgent → ReActAgent unification the inner agent is exposed via
         // getDelegate(); toolkit is reachable through the public getToolkit() accessor.


### PR DESCRIPTION
## AgentScope-Java Version

2.0.1-SNAPSHOT

## Description

Fixes flaky GitHub Actions failures in Harness tests caused by JUnit deleting `@TempDir` workspaces while `HarnessAgent` background session/transcript writes are still draining.

- Track each `HarnessAgent` created by the affected tests.
- Close tracked agents in `@AfterEach` before JUnit cleans temporary directories.
- Preserve restoration of `agentscope.state.home` in subagent stream tests.

## Testing

- `mvn -pl agentscope-harness -am -Dtest=HarnessAgentSubagentStreamTest,HarnessAgentDynamicHookBuilderTest test`
- `./.github/scripts/check-shade-and-bom-sync.sh`
- `mvn -T1 clean verify` (in progress)

## Checklist

- [x] Code has been formatted with `mvn spotless:apply`
- [x] Targeted Harness tests are passing
- [x] Module shade/BOM synchronization check is passing
- [x] No documentation update is required for this test lifecycle fix
- [x] Code is ready for review