### PR TITLE
fix(core): propagate acting middleware result rewrites

### DIFF
--- a/agentscope-core/src/main/java/io/agentscope/core/ReActAgent.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/ReActAgent.java
@@ -2732,8 +2732,16 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
                     .firePreActing(pendingToolCalls, toolkit)
                     .flatMap(
                             toolCalls -> {
+                                List<AgentEvent> coreToolResultEvents = new ArrayList<>();
+                                List<AgentEvent> transformedToolResultEvents = new ArrayList<>();
                                 Function<ActingInput, Flux<AgentEvent>> actingCore =
-                                        ai -> actingStream(ai.toolCalls(), replyId, resultHolder);
+                                        ai ->
+                                                actingStream(ai.toolCalls(), replyId, resultHolder)
+                                                        .doOnNext(
+                                                                event ->
+                                                                        addToolResultEvent(
+                                                                                coreToolResultEvents,
+                                                                                event));
                                 Flux<AgentEvent> stream =
                                         MiddlewareChain.build(
                                                         middlewares,
@@ -2744,11 +2752,20 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
                                                 .apply(new ActingInput(toolCalls));
                                 return stream.doOnNext(
                                                 ev -> {
+                                                    addToolResultEvent(
+                                                            transformedToolResultEvents, ev);
+                                                    publishEvent(ev);
                                                     if (ev instanceof RequestStopEvent rs) {
                                                         actingStopRequested.compareAndSet(null, rs);
                                                     }
                                                 })
-                                        .then(Mono.defer(() -> Mono.just(resultHolder.get())));
+                                        .then(
+                                                Mono.fromSupplier(
+                                                        () ->
+                                                                applyToolResultTransformations(
+                                                                        resultHolder.get(),
+                                                                        coreToolResultEvents,
+                                                                        transformedToolResultEvents)));
                             })
                     .flatMap(
                             results -> {
@@ -2807,6 +2824,107 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
                                                     return executeIteration(iter + 1);
                                                 });
                             });
+        }
+
+        private void addToolResultEvent(List<AgentEvent> events, AgentEvent event) {
+            if (event instanceof ToolResultTextDeltaEvent
+                    || event instanceof ToolResultDataDeltaEvent
+                    || event instanceof ToolResultEndEvent) {
+                events.add(event);
+            }
+        }
+
+        private List<Map.Entry<ToolUseBlock, ToolResultBlock>> applyToolResultTransformations(
+                List<Map.Entry<ToolUseBlock, ToolResultBlock>> results,
+                List<AgentEvent> coreEvents,
+                List<AgentEvent> transformedEvents) {
+            List<Map.Entry<ToolUseBlock, ToolResultBlock>> updated = new ArrayList<>();
+            for (Map.Entry<ToolUseBlock, ToolResultBlock> entry : results) {
+                String toolCallId = entry.getKey().getId();
+                List<AgentEvent> coreForTool = toolResultEventsFor(toolCallId, coreEvents);
+                List<AgentEvent> transformedForTool =
+                        toolResultEventsFor(toolCallId, transformedEvents);
+
+                if (sameEventInstances(coreForTool, transformedForTool)) {
+                    updated.add(entry);
+                    continue;
+                }
+
+                ToolResultBlock original = entry.getValue();
+                List<ContentBlock> output = new ArrayList<>();
+                StringBuilder text = new StringBuilder();
+                Map<String, Object> metadata = original.getMetadata();
+                ToolResultState state = original.getState();
+                for (AgentEvent event : transformedForTool) {
+                    if (event instanceof ToolResultTextDeltaEvent textDelta) {
+                        if (textDelta.getDelta() != null) {
+                            text.append(textDelta.getDelta());
+                        }
+                        if (textDelta.getMetadata() != null) {
+                            metadata = textDelta.getMetadata();
+                        }
+                    } else if (event instanceof ToolResultDataDeltaEvent dataDelta) {
+                        flushToolResultText(output, text);
+                        if (dataDelta.getData() != null) {
+                            output.add(dataDelta.getData());
+                        }
+                        if (dataDelta.getMetadata() != null) {
+                            metadata = dataDelta.getMetadata();
+                        }
+                    } else if (event instanceof ToolResultEndEvent endEvent) {
+                        if (endEvent.getState() != null) {
+                            state = endEvent.getState();
+                        }
+                        if (endEvent.getMetadata() != null) {
+                            metadata = endEvent.getMetadata();
+                        }
+                    }
+                }
+                flushToolResultText(output, text);
+                ToolResultBlock transformed =
+                        new ToolResultBlock(
+                                original.getId(), original.getName(), output, metadata, state);
+                updated.add(Map.entry(entry.getKey(), transformed));
+            }
+            return updated;
+        }
+
+        private List<AgentEvent> toolResultEventsFor(String toolCallId, List<AgentEvent> events) {
+            return events.stream()
+                    .filter(event -> Objects.equals(toolCallId, toolResultCallId(event)))
+                    .toList();
+        }
+
+        private String toolResultCallId(AgentEvent event) {
+            if (event instanceof ToolResultTextDeltaEvent textDelta) {
+                return textDelta.getToolCallId();
+            }
+            if (event instanceof ToolResultDataDeltaEvent dataDelta) {
+                return dataDelta.getToolCallId();
+            }
+            if (event instanceof ToolResultEndEvent endEvent) {
+                return endEvent.getToolCallId();
+            }
+            return null;
+        }
+
+        private boolean sameEventInstances(List<AgentEvent> left, List<AgentEvent> right) {
+            if (left.size() != right.size()) {
+                return false;
+            }
+            for (int i = 0; i < left.size(); i++) {
+                if (left.get(i) != right.get(i)) {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        private void flushToolResultText(List<ContentBlock> output, StringBuilder text) {
+            if (!text.isEmpty()) {
+                output.add(TextBlock.builder().text(text.toString()).build());
+                text.setLength(0);
+            }
         }
 
         /**
@@ -2882,8 +3000,7 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
                                         new RequestStopEvent(
                                                 "permission asking",
                                                 GenerateReason.PERMISSION_ASKING));
-                            })
-                    .doOnNext(this::publishEvent);
+                            });
         }
 
         /**

--- a/agentscope-core/src/main/java/io/agentscope/core/ReActAgent.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/ReActAgent.java
@@ -143,6 +143,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
@@ -2732,8 +2733,10 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
                     .firePreActing(pendingToolCalls, toolkit)
                     .flatMap(
                             toolCalls -> {
-                                List<AgentEvent> coreToolResultEvents = new ArrayList<>();
-                                List<AgentEvent> transformedToolResultEvents = new ArrayList<>();
+                                List<AgentEvent> coreToolResultEvents =
+                                        new CopyOnWriteArrayList<>();
+                                List<AgentEvent> transformedToolResultEvents =
+                                        new CopyOnWriteArrayList<>();
                                 Function<ActingInput, Flux<AgentEvent>> actingCore =
                                         ai ->
                                                 actingStream(ai.toolCalls(), replyId, resultHolder)

--- a/agentscope-core/src/main/java/io/agentscope/core/middleware/MiddlewareBase.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/middleware/MiddlewareBase.java
@@ -109,6 +109,9 @@ public interface MiddlewareBase {
     /**
      * Intercept the tool-call execution phase.
      *
+     * <p>Transformations to tool-result delta events in the returned stream are reflected in the
+     * result message passed to the next model iteration.
+     *
      * @param agent the agent instance
      * @param ctx   per-call runtime context (session, user, attributes)
      * @param input acting input (the tool calls)

--- a/agentscope-core/src/test/java/io/agentscope/core/agent/ReActAgentNewLoopE2ETest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/agent/ReActAgentNewLoopE2ETest.java
@@ -16,6 +16,7 @@
 package io.agentscope.core.agent;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -69,6 +70,7 @@ class ReActAgentNewLoopE2ETest {
         private final List<Supplier<Flux<ChatResponse>>> scripts;
         private final AtomicInteger idx = new AtomicInteger(0);
         final AtomicInteger calls = new AtomicInteger(0);
+        final List<List<Msg>> requests = new ArrayList<>();
 
         ScriptedModel(List<Supplier<Flux<ChatResponse>>> scripts) {
             this.scripts = scripts;
@@ -83,6 +85,7 @@ class ReActAgentNewLoopE2ETest {
         protected Flux<ChatResponse> doStream(
                 List<Msg> messages, List<ToolSchema> tools, GenerateOptions options) {
             calls.incrementAndGet();
+            requests.add(List.copyOf(messages));
             int i = idx.getAndIncrement();
             if (i >= scripts.size()) {
                 return Flux.just(textResponse(""));
@@ -415,5 +418,75 @@ class ReActAgentNewLoopE2ETest {
         assertEquals(1L, events.stream().filter(ToolResultEndEvent.class::isInstance).count());
         assertTrue(events.get(0) instanceof AgentStartEvent);
         assertTrue(events.get(events.size() - 1) instanceof AgentEndEvent);
+    }
+
+    @Test
+    void actingMiddlewareCanRewriteToolResultForEventsAndNextModelCall() {
+        ScriptedModel model =
+                new ScriptedModel(
+                        List.of(
+                                () -> Flux.just(toolUseResponse("c1", "search", "alpha")),
+                                () -> Flux.just(textResponse("done"))));
+        Toolkit tk = new Toolkit();
+        tk.registerAgentTool(new AlwaysAllowTool("search"));
+
+        MiddlewareBase rewritingMiddleware =
+                new MiddlewareBase() {
+                    @Override
+                    public Flux<AgentEvent> onActing(
+                            Agent agent,
+                            RuntimeContext ctx,
+                            ActingInput input,
+                            Function<ActingInput, Flux<AgentEvent>> next) {
+                        return next.apply(input)
+                                .map(
+                                        event -> {
+                                            if (!(event
+                                                    instanceof
+                                                    ToolResultTextDeltaEvent textDelta)) {
+                                                return event;
+                                            }
+                                            ToolResultTextDeltaEvent rewritten =
+                                                    new ToolResultTextDeltaEvent(
+                                                            textDelta.getReplyId(),
+                                                            textDelta.getToolCallId(),
+                                                            textDelta.getToolCallName(),
+                                                            "rewritten");
+                                            rewritten.withMetadata(textDelta.getMetadata());
+                                            return rewritten;
+                                        });
+                    }
+                };
+
+        ReActAgent agent =
+                ReActAgent.builder()
+                        .name("asst")
+                        .sysPrompt("you are helpful")
+                        .model(model)
+                        .toolkit(tk)
+                        .middleware(rewritingMiddleware)
+                        .build();
+
+        List<AgentEvent> events = agent.streamEvents(List.of()).collectList().block();
+        assertNotNull(events);
+
+        List<String> streamedResults =
+                events.stream()
+                        .filter(ToolResultTextDeltaEvent.class::isInstance)
+                        .map(ToolResultTextDeltaEvent.class::cast)
+                        .map(ToolResultTextDeltaEvent::getDelta)
+                        .toList();
+        assertEquals(List.of("rewritten"), streamedResults);
+
+        List<String> nextModelToolResults =
+                model.requests.get(1).stream()
+                        .flatMap(msg -> msg.getContentBlocks(ToolResultBlock.class).stream())
+                        .flatMap(result -> result.getOutput().stream())
+                        .filter(TextBlock.class::isInstance)
+                        .map(TextBlock.class::cast)
+                        .map(TextBlock::getText)
+                        .toList();
+        assertEquals(List.of("rewritten"), nextModelToolResults);
+        assertFalse(nextModelToolResults.contains("search:alpha"));
     }
 }

--- a/agentscope-extensions/agentscope-extensions-rag/agentscope-extensions-rag-simple/src/test/java/io/agentscope/core/embedding/openai/OpenAITextEmbeddingEmbedTest.java
+++ b/agentscope-extensions/agentscope-extensions-rag/agentscope-extensions-rag-simple/src/test/java/io/agentscope/core/embedding/openai/OpenAITextEmbeddingEmbedTest.java
@@ -84,7 +84,7 @@ class OpenAITextEmbeddingEmbedTest {
             EmbeddingService mockEmbeddings = mock(EmbeddingService.class);
 
             when(mockBuilder.build()).thenReturn(mockOpenAIClient);
-            when(mockBuilder.apiKey(any())).thenReturn(mockBuilder);
+            when(mockBuilder.apiKey(any(String.class))).thenReturn(mockBuilder);
             when(mockBuilder.baseUrl(any(String.class))).thenReturn(mockBuilder);
             when(mockBuilder.putHeader(any(), any())).thenReturn(mockBuilder);
 
@@ -121,7 +121,7 @@ class OpenAITextEmbeddingEmbedTest {
             EmbeddingService mockEmbeddings = mock(EmbeddingService.class);
 
             when(mockBuilder.build()).thenReturn(mockOpenAIClient);
-            when(mockBuilder.apiKey(any())).thenReturn(mockBuilder);
+            when(mockBuilder.apiKey(any(String.class))).thenReturn(mockBuilder);
             when(mockBuilder.baseUrl(any(String.class))).thenReturn(mockBuilder);
             when(mockBuilder.putHeader(any(), any())).thenReturn(mockBuilder);
 
@@ -163,7 +163,7 @@ class OpenAITextEmbeddingEmbedTest {
             EmbeddingService mockEmbeddings = mock(EmbeddingService.class);
 
             when(mockBuilder.build()).thenReturn(mockOpenAIClient);
-            when(mockBuilder.apiKey(any())).thenReturn(mockBuilder);
+            when(mockBuilder.apiKey(any(String.class))).thenReturn(mockBuilder);
             when(mockBuilder.baseUrl(any(String.class))).thenReturn(mockBuilder);
             when(mockBuilder.putHeader(any(), any())).thenReturn(mockBuilder);
 
@@ -205,7 +205,7 @@ class OpenAITextEmbeddingEmbedTest {
             EmbeddingService mockEmbeddings = mock(EmbeddingService.class);
 
             when(mockBuilder.build()).thenReturn(mockOpenAIClient);
-            when(mockBuilder.apiKey(any())).thenReturn(mockBuilder);
+            when(mockBuilder.apiKey(any(String.class))).thenReturn(mockBuilder);
             when(mockBuilder.baseUrl(any(String.class))).thenReturn(mockBuilder);
             when(mockBuilder.putHeader(any(), any())).thenReturn(mockBuilder);
 
@@ -248,7 +248,7 @@ class OpenAITextEmbeddingEmbedTest {
             EmbeddingService mockEmbeddings = mock(EmbeddingService.class);
 
             when(mockBuilder.build()).thenReturn(mockOpenAIClient);
-            when(mockBuilder.apiKey(any())).thenReturn(mockBuilder);
+            when(mockBuilder.apiKey(any(String.class))).thenReturn(mockBuilder);
             when(mockBuilder.baseUrl(any(String.class))).thenReturn(mockBuilder);
             when(mockBuilder.putHeader(any(), any())).thenReturn(mockBuilder);
 
@@ -291,7 +291,7 @@ class OpenAITextEmbeddingEmbedTest {
             EmbeddingService mockEmbeddings = mock(EmbeddingService.class);
 
             when(mockBuilder.build()).thenReturn(mockOpenAIClient);
-            when(mockBuilder.apiKey(any())).thenReturn(mockBuilder);
+            when(mockBuilder.apiKey(any(String.class))).thenReturn(mockBuilder);
             when(mockBuilder.baseUrl(any(String.class))).thenReturn(mockBuilder);
             when(mockBuilder.putHeader(any(), any())).thenReturn(mockBuilder);
 


### PR DESCRIPTION
## AgentScope-Java Version

2.0.3-SNAPSHOT

## Description

Fixes #2672.

`ReActAgent.actingStream` published raw tool-result events before the `onActing` middleware chain. The acting phase then discarded the post-middleware events and continued with the raw `resultHolder`, so a middleware rewrite was visible neither to event consumers nor to the next model call.

This change:

- publishes acting events after the middleware chain;
- detects tool-result delta/end events that middleware replaced or filtered;
- rebuilds only the affected `ToolResultBlock` values from the transformed stream;
- preserves the original result object when middleware passes all result events through unchanged.

The new end-to-end regression test rewrites `search:alpha` to `rewritten`. On current main it failed because the public stream returned `search:alpha`; with this change both the public stream and the second model request contain only `rewritten`.

## Tests

- `mvn -pl agentscope-core -Dtest=ReActAgentNewLoopE2ETest#actingMiddlewareCanRewriteToolResultForEventsAndNextModelCall test` — 1 passed
- `mvn -pl agentscope-core -Dtest=ReActAgentNewLoopE2ETest,ReActAgentMiddlewareIntegrationTest test` — 12 passed
- `mvn -pl agentscope-core test` — 2275 passed, 9 skipped
- Spotless check passed as part of the Maven builds

## Compatibility and risk

No public API signatures change. Existing tool results retain their original `ToolResultBlock` instance unless middleware actually changes the tool-result event sequence. Text and data deltas, metadata, and end state are retained when rebuilding a transformed result.

## Checklist

- [x] Code has been formatted with `mvn spotless:apply`
- [x] All relevant tests are passing
- [x] Javadoc comments are complete and follow project conventions
- [x] Related middleware documentation has been updated
- [x] Code is ready for review
