### PR TITLE
fix(harness): align skill prompt with shell tool name

### DIFF
--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/skill/runtime/SkillPromptBuilder.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/skill/runtime/SkillPromptBuilder.java
@@ -17,6 +17,7 @@ package io.agentscope.harness.agent.skill.runtime;
 
 import io.agentscope.core.skill.AgentSkill;
 import io.agentscope.core.skill.SkillFilter;
+import io.agentscope.harness.agent.tool.ShellExecuteTool;
 import java.util.Collection;
 import java.util.Map;
 import java.util.regex.Pattern;
@@ -79,7 +80,7 @@ public final class SkillPromptBuilder {
             ## Code Execution
 
             <code_execution>
-            You have access to the execute_shell_command tool. Each skill in <available_skills>
+            You have access to the %s tool. Each skill in <available_skills>
             includes a <files-root> element giving the absolute path to that skill's files.
 
             Workflow:
@@ -89,7 +90,8 @@ public final class SkillPromptBuilder {
             4. Always use absolute paths derived from <files-root>; never invent paths
             5. If a script exists for the task, run it directly — do not rewrite its logic inline
             </code_execution>
-            """;
+            """
+                    .formatted(ShellExecuteTool.NAME);
 
     private final String header;
     private final String codeExecutionInstruction;

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/skill/runtime/SkillRuntimeTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/skill/runtime/SkillRuntimeTest.java
@@ -32,6 +32,7 @@ import io.agentscope.core.tool.ToolCallParam;
 import io.agentscope.core.tool.Toolkit;
 import io.agentscope.harness.agent.skill.SkillResources;
 import io.agentscope.harness.agent.skill.runtime.MarketplaceStager.StageResult;
+import io.agentscope.harness.agent.tool.ShellExecuteTool;
 import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.List;
@@ -175,6 +176,7 @@ class SkillRuntimeTest {
             assertTrue(out.contains("<files-root>/workspace/skills/alpha</files-root>"));
             assertTrue(out.contains("## Code Execution"));
             assertTrue(out.contains("<files-root>"));
+            assertTrue(out.contains("access to the " + ShellExecuteTool.NAME + " tool"));
         }
 
         @Test

--- a/docs/v2/en/docs/harness/skill.md
+++ b/docs/v2/en/docs/harness/skill.md
@@ -307,7 +307,7 @@ The agent doesn't see this difference — `load_skill_through_path` always works
 
 ### `<files-root>` and shell execution
 
-When a skill ships scripts (e.g. `scripts/run-checks.sh`), the agent needs an absolute path to invoke them via `execute_shell_command`. That path comes from the `<files-root>` element on each skill entry. Resolution depends on the filesystem mode:
+When a skill ships scripts (e.g. `scripts/run-checks.sh`), the agent needs an absolute path to invoke them via `execute`. That path comes from the `<files-root>` element on each skill entry. Resolution depends on the filesystem mode:
 
 | FS mode (shell available?) | Workspace skill `<files-root>` | Marketplace skill `<files-root>` |
 |----------------------------|--------------------------------|-----------------------------------|
@@ -315,7 +315,7 @@ When a skill ships scripts (e.g. `scripts/run-checks.sh`), the agent needs an ab
 | Local-with-shell | `<wsRoot>/skills/<name>` | `<wsRoot>/.skills-cache/<source>/<name>` |
 | Local without shell / Composite | (not rendered — no shell tool registered) | (not rendered) |
 
-So the agent's shell call is always `execute_shell_command("python3 <files-root>/scripts/foo.py")` — no path guessing, no per-source variations to remember.
+So the agent's shell call is always `execute("python3 <files-root>/scripts/foo.py")` — no path guessing, no per-source variations to remember.
 
 ### Where marketplace files actually live
 
@@ -381,7 +381,7 @@ In sandbox mode, each skill's `<files-root>` in the `<available_skills>` block i
 So the agent simply issues:
 
 ```
-execute_shell_command("python3 /workspace/skills/code-reviewer/scripts/run-checks.sh <target>")
+execute("python3 /workspace/skills/code-reviewer/scripts/run-checks.sh <target>")
 ```
 
 That command runs in the container and reads exactly the file that was projected in. The agent doesn't need to know which layer a skill came from — the framework computes the prefix.

--- a/docs/v2/en/docs/harness/workspace.md
+++ b/docs/v2/en/docs/harness/workspace.md
@@ -386,7 +386,7 @@ A skill is a packaged capability — a directory containing `SKILL.md` (descript
 skills/code-reviewer/
 ├── SKILL.md               ← YAML frontmatter (name + description) + instructions
 ├── references/style-guide.md   ← optional, agent reads on demand
-└── scripts/run-checks.sh       ← optional, agent invokes via execute_shell_command
+└── scripts/run-checks.sh       ← optional, agent invokes via execute
 ```
 
 There are four registration layers (low → high priority):

--- a/docs/v2/zh/docs/harness/skill.md
+++ b/docs/v2/zh/docs/harness/skill.md
@@ -307,7 +307,7 @@ agent 感知不到这种差异，`load_skill_through_path` 调起来都一样。
 
 ### `<files-root>` 和 shell 执行
 
-当一个 skill 自带脚本（例如 `scripts/run-checks.sh`），agent 需要绝对路径才能通过 `execute_shell_command` 调用它。这个绝对路径就是 skill 条目里的 `<files-root>`。它怎么算出来取决于文件系统模式：
+当一个 skill 自带脚本（例如 `scripts/run-checks.sh`），agent 需要绝对路径才能通过 `execute` 调用它。这个绝对路径就是 skill 条目里的 `<files-root>`。它怎么算出来取决于文件系统模式：
 
 | 文件系统模式（是否有 shell） | 工作区 skill 的 `<files-root>` | 市场 skill 的 `<files-root>` |
 |---------------------------|----------------------------|---------------------------|
@@ -315,7 +315,7 @@ agent 感知不到这种差异，`load_skill_through_path` 调起来都一样。
 | Local-with-shell | `<wsRoot>/skills/<name>` | `<wsRoot>/.skills-cache/<source>/<name>` |
 | Local 不带 shell / Composite | （不渲染——没注册 shell 工具） | （不渲染） |
 
-所以 agent 发出来的 shell 命令永远是 `execute_shell_command("python3 <files-root>/scripts/foo.py")`——不用猜路径，不用记每种来源对应哪个前缀。
+所以 agent 发出来的 shell 命令永远是 `execute("python3 <files-root>/scripts/foo.py")`——不用猜路径，不用记每种来源对应哪个前缀。
 
 ### 市场 skill 文件实际落在哪儿
 
@@ -381,7 +381,7 @@ AGENTS.md  skills/  subagents/  knowledge/  .skills-cache/
 于是 agent 直接发：
 
 ```
-execute_shell_command("python3 /workspace/skills/code-reviewer/scripts/run-checks.sh <目标路径>")
+execute("python3 /workspace/skills/code-reviewer/scripts/run-checks.sh <目标路径>")
 ```
 
 这条命令在容器里跑，读到的就是投影进来的那份文件。agent 不用知道 skill 来自哪一层，前缀由框架算好。

--- a/docs/v2/zh/docs/harness/workspace.md
+++ b/docs/v2/zh/docs/harness/workspace.md
@@ -383,7 +383,7 @@ workspace/
 skills/code-reviewer/
 ├── SKILL.md               ← YAML frontmatter (name + description) + 指令
 ├── references/style-guide.md   ← 可选，agent 按需 read_file
-└── scripts/run-checks.sh       ← 可选，agent 通过 execute_shell_command 调
+└── scripts/run-checks.sh       ← 可选，agent 通过 execute 调
 ```
 
 注册路径有四层（低 → 高优先级）：


### PR DESCRIPTION
## Summary

- render the Harness skill code-execution prompt with the registered `ShellExecuteTool.NAME`
- prevent the prompt from directing models to the unavailable `execute_shell_command` tool
- add a focused regression assertion to keep the prompt and tool registration aligned
- update the English and Chinese Harness skill/workspace docs to use the registered `execute` tool name

## Reproduction

On current `main`, the new assertion failed because the rendered prompt did not contain the registered shell tool name `execute`:

- `SkillRuntimeTest`: 27 tests run, 1 failure
- failing test: `rendersFilesRootAndCodeExecutionWhenAvailable`

## Validation

- `mvn -pl agentscope-harness -am -Dtest=SkillRuntimeTest -Dsurefire.failIfNoSpecifiedTests=false test` — 27 passed
- `mvn -pl agentscope-harness -am test` — Core 2274 passed, 9 skipped; Harness 828 passed, 3 skipped
- Spotless checks passed as part of both Maven runs
- `git diff --check`
- verified no stale `execute_shell_command` reference remains under `agentscope-harness` or `docs`

Fixes #2644