### PR TITLE
fix(harness): expose shared knowledge to isolated users

### DIFF
--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/filesystem/LocalWorkspaceOverlay.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/filesystem/LocalWorkspaceOverlay.java
@@ -1,0 +1,225 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.harness.agent.filesystem;
+
+import io.agentscope.core.agent.RuntimeContext;
+import io.agentscope.harness.agent.filesystem.model.EditResult;
+import io.agentscope.harness.agent.filesystem.model.ExecuteResponse;
+import io.agentscope.harness.agent.filesystem.model.FileDownloadResponse;
+import io.agentscope.harness.agent.filesystem.model.FileInfo;
+import io.agentscope.harness.agent.filesystem.model.GlobResult;
+import io.agentscope.harness.agent.filesystem.model.GrepMatch;
+import io.agentscope.harness.agent.filesystem.model.GrepResult;
+import io.agentscope.harness.agent.filesystem.model.LsResult;
+import io.agentscope.harness.agent.filesystem.model.ReadResult;
+import io.agentscope.harness.agent.filesystem.model.WriteResult;
+import io.agentscope.harness.agent.filesystem.sandbox.AbstractSandboxFilesystem;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Local filesystem overlay that exposes agent-level knowledge as a read-only baseline beneath
+ * the isolated user/session layer.
+ *
+ * <p>Knowledge reads use {@code isolated workspace > agent workspace > project}. Other paths keep
+ * the standard {@link OverlayFilesystem} ordering ({@code isolated workspace > project}), so a
+ * caller cannot traverse another user's namespace through the agent workspace fallback. Writes
+ * always target the isolated upper layer and edits of shared knowledge use copy-on-write.
+ */
+public class LocalWorkspaceOverlay extends OverlayFilesystem implements AbstractSandboxFilesystem {
+
+    private static final String KNOWLEDGE = "knowledge";
+
+    private final AbstractSandboxFilesystem shellBackend;
+    private final AbstractFilesystem sharedWorkspace;
+
+    public LocalWorkspaceOverlay(
+            AbstractSandboxFilesystem upper,
+            AbstractFilesystem sharedWorkspace,
+            AbstractFilesystem project) {
+        super(upper, project);
+        this.shellBackend = upper;
+        this.sharedWorkspace = sharedWorkspace;
+    }
+
+    @Override
+    public String id() {
+        return shellBackend.id();
+    }
+
+    @Override
+    public ExecuteResponse execute(
+            RuntimeContext runtimeContext, String command, Integer timeoutSeconds) {
+        return shellBackend.execute(runtimeContext, command, timeoutSeconds);
+    }
+
+    @Override
+    public ReadResult read(RuntimeContext rc, String filePath, int offset, int limit) {
+        if (!isKnowledgePath(filePath) || upper().exists(rc, filePath)) {
+            return super.read(rc, filePath, offset, limit);
+        }
+        if (sharedWorkspace.exists(rc, filePath)) {
+            return sharedWorkspace.read(rc, filePath, offset, limit);
+        }
+        return lower().read(rc, filePath, offset, limit);
+    }
+
+    @Override
+    public LsResult ls(RuntimeContext rc, String path) {
+        if (!isKnowledgePath(path)) {
+            return super.ls(rc, path);
+        }
+        Map<String, FileInfo> merged = new LinkedHashMap<>();
+        mergeFileInfo(merged, lower().ls(rc, path));
+        mergeFileInfo(merged, sharedWorkspace.ls(rc, path));
+        mergeFileInfo(merged, upper().ls(rc, path));
+        return LsResult.success(new ArrayList<>(merged.values()));
+    }
+
+    @Override
+    public GlobResult glob(RuntimeContext rc, String pattern, String path) {
+        if (!isKnowledgePath(path)) {
+            return super.glob(rc, pattern, path);
+        }
+        Map<String, FileInfo> merged = new LinkedHashMap<>();
+        mergeFileInfo(merged, lower().glob(rc, pattern, path));
+        mergeFileInfo(merged, sharedWorkspace.glob(rc, pattern, path));
+        mergeFileInfo(merged, upper().glob(rc, pattern, path));
+        return GlobResult.success(new ArrayList<>(merged.values()));
+    }
+
+    @Override
+    public GrepResult grep(RuntimeContext rc, String pattern, String path, String glob) {
+        if (!isKnowledgePath(path)) {
+            return super.grep(rc, pattern, path, glob);
+        }
+        Map<String, GrepMatch> merged = new LinkedHashMap<>();
+        mergeGrep(merged, lower().grep(rc, pattern, path, glob));
+        mergeGrep(merged, sharedWorkspace.grep(rc, pattern, path, glob));
+        mergeGrep(merged, upper().grep(rc, pattern, path, glob));
+        return GrepResult.success(new ArrayList<>(merged.values()));
+    }
+
+    @Override
+    public EditResult edit(
+            RuntimeContext rc,
+            String filePath,
+            String oldString,
+            String newString,
+            boolean replaceAll) {
+        if (!isKnowledgePath(filePath) || upper().exists(rc, filePath)) {
+            return super.edit(rc, filePath, oldString, newString, replaceAll);
+        }
+        AbstractFilesystem source =
+                sharedWorkspace.exists(rc, filePath) ? sharedWorkspace : lower();
+        if (!source.exists(rc, filePath)) {
+            return EditResult.fail("File not found: " + filePath);
+        }
+        ReadResult read = source.read(rc, filePath, 0, Integer.MAX_VALUE);
+        if (!read.isSuccess()) {
+            return EditResult.fail("Cannot read shared file for copy-on-write: " + filePath);
+        }
+        WriteResult write = upper().write(rc, filePath, read.fileData().content());
+        if (!write.isSuccess()) {
+            return EditResult.fail("Cannot copy shared file for editing: " + filePath);
+        }
+        return upper().edit(rc, filePath, oldString, newString, replaceAll);
+    }
+
+    @Override
+    public List<FileDownloadResponse> downloadFiles(RuntimeContext rc, List<String> paths) {
+        List<FileDownloadResponse> results = new ArrayList<>();
+        for (String path : paths) {
+            if (!isKnowledgePath(path) || upper().exists(rc, path)) {
+                results.addAll(super.downloadFiles(rc, List.of(path)));
+            } else if (sharedWorkspace.exists(rc, path)) {
+                results.addAll(sharedWorkspace.downloadFiles(rc, List.of(path)));
+            } else {
+                results.addAll(lower().downloadFiles(rc, List.of(path)));
+            }
+        }
+        return results;
+    }
+
+    @Override
+    public WriteResult delete(RuntimeContext rc, String path) {
+        if (!isKnowledgePath(path) || upper().exists(rc, path)) {
+            return super.delete(rc, path);
+        }
+        if (sharedWorkspace.exists(rc, path)) {
+            return WriteResult.fail("Cannot delete shared file: " + path);
+        }
+        return super.delete(rc, path);
+    }
+
+    @Override
+    public WriteResult move(RuntimeContext rc, String fromPath, String toPath) {
+        if (!isKnowledgePath(fromPath) || upper().exists(rc, fromPath)) {
+            return super.move(rc, fromPath, toPath);
+        }
+        if (!sharedWorkspace.exists(rc, fromPath)) {
+            return super.move(rc, fromPath, toPath);
+        }
+        ReadResult read = sharedWorkspace.read(rc, fromPath, 0, Integer.MAX_VALUE);
+        if (!read.isSuccess()) {
+            return WriteResult.fail("Cannot read source for move: " + fromPath);
+        }
+        return upper().write(rc, toPath, read.fileData().content());
+    }
+
+    @Override
+    public boolean exists(RuntimeContext rc, String path) {
+        return super.exists(rc, path)
+                || (isKnowledgePath(path) && sharedWorkspace.exists(rc, path));
+    }
+
+    private static boolean isKnowledgePath(String path) {
+        if (path == null || path.isBlank()) {
+            return false;
+        }
+        String normalized = path.replace('\\', '/').strip();
+        while (normalized.startsWith("/")) {
+            normalized = normalized.substring(1);
+        }
+        return normalized.equals(KNOWLEDGE) || normalized.startsWith(KNOWLEDGE + "/");
+    }
+
+    private static void mergeFileInfo(Map<String, FileInfo> merged, LsResult result) {
+        if (result.isSuccess() && result.entries() != null) {
+            for (FileInfo info : result.entries()) {
+                merged.put(info.path(), info);
+            }
+        }
+    }
+
+    private static void mergeFileInfo(Map<String, FileInfo> merged, GlobResult result) {
+        if (result.isSuccess() && result.matches() != null) {
+            for (FileInfo info : result.matches()) {
+                merged.put(info.path(), info);
+            }
+        }
+    }
+
+    private static void mergeGrep(Map<String, GrepMatch> merged, GrepResult result) {
+        if (result.isSuccess() && result.matches() != null) {
+            for (GrepMatch match : result.matches()) {
+                merged.put(match.path() + ":" + match.line(), match);
+            }
+        }
+    }
+}

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/filesystem/LocalWorkspaceOverlay.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/filesystem/LocalWorkspaceOverlay.java
@@ -27,6 +27,7 @@ import io.agentscope.harness.agent.filesystem.model.LsResult;
 import io.agentscope.harness.agent.filesystem.model.ReadResult;
 import io.agentscope.harness.agent.filesystem.model.WriteResult;
 import io.agentscope.harness.agent.filesystem.sandbox.AbstractSandboxFilesystem;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -167,6 +168,10 @@ public class LocalWorkspaceOverlay extends OverlayFilesystem implements Abstract
         return super.delete(rc, path);
     }
 
+    /**
+     * Moves an isolated file normally. Moving shared knowledge creates an isolated copy at the
+     * destination because the shared layer is a read-only baseline; the shared source remains.
+     */
     @Override
     public WriteResult move(RuntimeContext rc, String fromPath, String toPath) {
         if (!isKnowledgePath(fromPath) || upper().exists(rc, fromPath)) {
@@ -196,6 +201,7 @@ public class LocalWorkspaceOverlay extends OverlayFilesystem implements Abstract
         while (normalized.startsWith("/")) {
             normalized = normalized.substring(1);
         }
+        normalized = Path.of(normalized).normalize().toString().replace('\\', '/');
         return normalized.equals(KNOWLEDGE) || normalized.startsWith(KNOWLEDGE + "/");
     }
 

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/filesystem/ProjectAwareOverlay.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/filesystem/ProjectAwareOverlay.java
@@ -18,7 +18,6 @@ package io.agentscope.harness.agent.filesystem;
 import io.agentscope.core.agent.RuntimeContext;
 import io.agentscope.harness.agent.filesystem.local.LocalFilesystem;
 import io.agentscope.harness.agent.filesystem.model.EditResult;
-import io.agentscope.harness.agent.filesystem.model.ExecuteResponse;
 import io.agentscope.harness.agent.filesystem.model.FileUploadResponse;
 import io.agentscope.harness.agent.filesystem.model.WriteResult;
 import io.agentscope.harness.agent.filesystem.sandbox.AbstractSandboxFilesystem;
@@ -36,10 +35,10 @@ import java.util.Set;
  * when {@code projectWritable(true)} is set. Other filesystem specs ({@code RemoteFilesystemSpec},
  * {@code SandboxFilesystemSpec}) are not affected.
  *
- * <p>Read operations retain standard overlay semantics: check upper (workspace) first, fall back
- * to lower (project). Shell {@code execute()} delegates to the upper layer as before.
+ * <p>Read operations use the same layered knowledge fallback as {@link LocalWorkspaceOverlay}.
+ * Shell execution continues to delegate to the upper layer.
  */
-public class ProjectAwareOverlay extends OverlayFilesystem implements AbstractSandboxFilesystem {
+public class ProjectAwareOverlay extends LocalWorkspaceOverlay {
 
     private static final Set<String> WORKSPACE_PREFIXES =
             Set.of(
@@ -57,7 +56,6 @@ public class ProjectAwareOverlay extends OverlayFilesystem implements AbstractSa
                     ".skills-cache",
                     "large_tool_results");
 
-    private final AbstractSandboxFilesystem shellBackend;
     private final LocalFilesystem projectFs;
     private final Path workspaceRoot;
 
@@ -69,24 +67,26 @@ public class ProjectAwareOverlay extends OverlayFilesystem implements AbstractSa
      */
     public ProjectAwareOverlay(
             AbstractSandboxFilesystem upper,
+            AbstractFilesystem sharedWorkspace,
             AbstractFilesystem lower,
             LocalFilesystem projectFs,
             Path workspaceRoot) {
-        super(upper, lower);
-        this.shellBackend = upper;
+        super(upper, sharedWorkspace, lower);
         this.projectFs = projectFs;
         this.workspaceRoot = workspaceRoot.toAbsolutePath().normalize();
     }
 
-    @Override
-    public String id() {
-        return shellBackend.id();
-    }
-
-    @Override
-    public ExecuteResponse execute(
-            RuntimeContext runtimeContext, String command, Integer timeoutSeconds) {
-        return shellBackend.execute(runtimeContext, command, timeoutSeconds);
+    public ProjectAwareOverlay(
+            AbstractSandboxFilesystem upper,
+            AbstractFilesystem lower,
+            LocalFilesystem projectFs,
+            Path workspaceRoot) {
+        this(
+                upper,
+                new LocalFilesystem(workspaceRoot, true, 10, null),
+                lower,
+                projectFs,
+                workspaceRoot);
     }
 
     // ==================== Write routing ====================

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/filesystem/spec/LocalFilesystemSpec.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/filesystem/spec/LocalFilesystemSpec.java
@@ -17,7 +17,7 @@ package io.agentscope.harness.agent.filesystem.spec;
 
 import io.agentscope.harness.agent.IsolationScope;
 import io.agentscope.harness.agent.filesystem.AbstractFilesystem;
-import io.agentscope.harness.agent.filesystem.OverlayFilesystem;
+import io.agentscope.harness.agent.filesystem.LocalWorkspaceOverlay;
 import io.agentscope.harness.agent.filesystem.ProjectAwareOverlay;
 import io.agentscope.harness.agent.filesystem.local.LocalFilesystem;
 import io.agentscope.harness.agent.filesystem.local.LocalFilesystemWithShell;
@@ -305,13 +305,18 @@ public class LocalFilesystemSpec {
                         localNamespaceFactory,
                         effectiveProject);
         LocalFilesystem lower = new LocalFilesystem(effectiveProject, true, 10, null);
+        LocalFilesystem sharedWorkspace = new LocalFilesystem(workspace, true, 10, null);
         if (projectWritable) {
             LocalFilesystem projectFs =
                     new LocalFilesystem(
                             effectiveProject, mode, pathPolicy, 10, localNamespaceFactory);
             return new ProjectAwareOverlay(
-                    (AbstractSandboxFilesystem) upper, lower, projectFs, workspace);
+                    (AbstractSandboxFilesystem) upper,
+                    sharedWorkspace,
+                    lower,
+                    projectFs,
+                    workspace);
         }
-        return OverlayFilesystem.of(upper, lower);
+        return new LocalWorkspaceOverlay(upper, sharedWorkspace, lower);
     }
 }

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/filesystem/spec/LocalFilesystemSpec.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/filesystem/spec/LocalFilesystemSpec.java
@@ -245,7 +245,7 @@ public class LocalFilesystemSpec {
 
     /**
      * Sets the user project root used as the lower layer of the resulting
-     * {@link OverlayFilesystem}. Reads of {@code AGENTS.md}, {@code knowledge/}, {@code skills/}
+     * {@link LocalWorkspaceOverlay}. Reads of {@code AGENTS.md}, {@code knowledge/}, {@code skills/}
      * etc. fall back to this directory when the agent {@code workspace} does not contain them;
      * shell {@code execute()} runs with {@code pwd} set to this directory.
      *

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/filesystem/LocalFilesystemSpecTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/filesystem/LocalFilesystemSpecTest.java
@@ -17,6 +17,7 @@ package io.agentscope.harness.agent.filesystem;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.agentscope.core.agent.RuntimeContext;
@@ -102,6 +103,25 @@ class LocalFilesystemSpecTest {
 
         assertFalse(filesystem.exists(alice, "bob/knowledge/private.md"));
         assertFalse(filesystem.read(alice, "bob/knowledge/private.md", 0, 100).isSuccess());
+    }
+
+    @Test
+    void sharedFallbackDoesNotAllowTraversalOutsideKnowledge() throws Exception {
+        Path workspace = Files.createDirectories(tempDir.resolve("workspace"));
+        Path project = Files.createDirectories(tempDir.resolve("project"));
+        Files.writeString(workspace.resolve("MEMORY.md"), "shared root secret");
+
+        AbstractFilesystem filesystem =
+                new LocalFilesystemSpec()
+                        .project(project)
+                        .toFilesystem(workspace, rc -> List.of(rc.getUserId()));
+        RuntimeContext alice = RuntimeContext.builder().userId("alice").build();
+
+        String traversalPath = "knowledge/../MEMORY.md";
+        assertThrows(IllegalArgumentException.class, () -> filesystem.exists(alice, traversalPath));
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> filesystem.read(alice, traversalPath, 0, 100));
     }
 
     @Test

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/filesystem/LocalFilesystemSpecTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/filesystem/LocalFilesystemSpecTest.java
@@ -21,12 +21,21 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.agentscope.core.agent.RuntimeContext;
 import io.agentscope.harness.agent.filesystem.model.EditResult;
+import io.agentscope.harness.agent.filesystem.model.FileDownloadResponse;
+import io.agentscope.harness.agent.filesystem.model.FileInfo;
+import io.agentscope.harness.agent.filesystem.model.GlobResult;
+import io.agentscope.harness.agent.filesystem.model.GrepResult;
+import io.agentscope.harness.agent.filesystem.model.LsResult;
 import io.agentscope.harness.agent.filesystem.model.ReadResult;
+import io.agentscope.harness.agent.filesystem.model.WriteResult;
 import io.agentscope.harness.agent.filesystem.sandbox.AbstractSandboxFilesystem;
 import io.agentscope.harness.agent.filesystem.spec.LocalFilesystemSpec;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -106,8 +115,140 @@ class LocalFilesystemSpecTest {
         assertTrue(filesystem instanceof AbstractSandboxFilesystem);
     }
 
+    @Test
+    void knowledgeListingAndSearchMergeAllThreeLayers() throws Exception {
+        Path workspace = Files.createDirectories(tempDir.resolve("workspace"));
+        Path project = Files.createDirectories(tempDir.resolve("project"));
+        Files.createDirectories(project.resolve("knowledge"));
+        Files.writeString(project.resolve("knowledge/project.md"), "needle from project");
+        Files.createDirectories(workspace.resolve("knowledge"));
+        Files.writeString(workspace.resolve("knowledge/shared.md"), "needle from shared");
+        Files.createDirectories(workspace.resolve("alice/knowledge"));
+        Files.writeString(workspace.resolve("alice/knowledge/personal.md"), "needle from alice");
+
+        AbstractFilesystem filesystem =
+                new LocalFilesystemSpec()
+                        .project(project)
+                        .toFilesystem(workspace, rc -> List.of(rc.getUserId()));
+        RuntimeContext alice = RuntimeContext.builder().userId("alice").build();
+
+        LsResult ls = filesystem.ls(alice, "knowledge");
+        GlobResult glob = filesystem.glob(alice, "*.md", "knowledge");
+        GrepResult grep = filesystem.grep(alice, "needle", "knowledge", "*.md");
+
+        assertTrue(ls.isSuccess());
+        assertPathsContain(
+                ls.entries(),
+                "knowledge/project.md",
+                "knowledge/shared.md",
+                "knowledge/personal.md");
+        assertTrue(glob.isSuccess());
+        assertPathsContain(
+                glob.matches(),
+                "knowledge/project.md",
+                "knowledge/shared.md",
+                "knowledge/personal.md");
+        assertTrue(grep.isSuccess());
+        Set<String> grepPaths =
+                grep.matches().stream().map(match -> match.path()).collect(Collectors.toSet());
+        assertTrue(grepPaths.stream().anyMatch(path -> path.endsWith("knowledge/project.md")));
+        assertTrue(grepPaths.stream().anyMatch(path -> path.endsWith("knowledge/shared.md")));
+        assertTrue(grepPaths.stream().anyMatch(path -> path.endsWith("knowledge/personal.md")));
+    }
+
+    @Test
+    void downloadsResolveKnowledgeInLayerOrderAndKeepRegularOverlayBehavior() throws Exception {
+        Path workspace = Files.createDirectories(tempDir.resolve("workspace"));
+        Path project = Files.createDirectories(tempDir.resolve("project"));
+        Files.createDirectories(project.resolve("knowledge"));
+        Files.writeString(project.resolve("knowledge/project.txt"), "project");
+        Files.createDirectories(project.resolve("docs"));
+        Files.writeString(project.resolve("docs/regular.txt"), "regular");
+        Files.createDirectories(workspace.resolve("knowledge"));
+        Files.writeString(workspace.resolve("knowledge/shared.txt"), "shared");
+        Files.createDirectories(workspace.resolve("alice/knowledge"));
+        Files.writeString(workspace.resolve("alice/knowledge/personal.txt"), "personal");
+
+        AbstractFilesystem filesystem =
+                new LocalFilesystemSpec()
+                        .project(project)
+                        .toFilesystem(workspace, rc -> List.of(rc.getUserId()));
+        RuntimeContext alice = RuntimeContext.builder().userId("alice").build();
+
+        List<FileDownloadResponse> downloads =
+                filesystem.downloadFiles(
+                        alice,
+                        List.of(
+                                "knowledge/personal.txt",
+                                "knowledge/shared.txt",
+                                "knowledge/project.txt",
+                                "docs/regular.txt"));
+
+        assertEquals(4, downloads.size());
+        assertEquals("personal", content(downloads.get(0)));
+        assertEquals("shared", content(downloads.get(1)));
+        assertEquals("project", content(downloads.get(2)));
+        assertEquals("regular", content(downloads.get(3)));
+    }
+
+    @Test
+    void sharedKnowledgeMoveCopiesToIsolatedLayerAndDeleteCannotRemoveBaseline() throws Exception {
+        Path workspace = Files.createDirectories(tempDir.resolve("workspace"));
+        Path project = Files.createDirectories(tempDir.resolve("project"));
+        Files.createDirectories(workspace.resolve("knowledge"));
+        Files.writeString(workspace.resolve("knowledge/reference.md"), "shared reference");
+        Files.createDirectories(workspace.resolve("alice/knowledge"));
+        Files.writeString(workspace.resolve("alice/knowledge/personal.md"), "personal reference");
+
+        AbstractFilesystem filesystem =
+                new LocalFilesystemSpec()
+                        .project(project)
+                        .toFilesystem(workspace, rc -> List.of(rc.getUserId()));
+        RuntimeContext alice = RuntimeContext.builder().userId("alice").build();
+
+        WriteResult sharedDelete = filesystem.delete(alice, "knowledge/reference.md");
+        WriteResult move = filesystem.move(alice, "knowledge/reference.md", "knowledge/copied.md");
+        WriteResult personalDelete = filesystem.delete(alice, "knowledge/personal.md");
+
+        assertFalse(sharedDelete.isSuccess());
+        assertTrue(move.isSuccess());
+        assertEquals(
+                "shared reference",
+                Files.readString(workspace.resolve("alice/knowledge/copied.md")));
+        assertEquals(
+                "shared reference", Files.readString(workspace.resolve("knowledge/reference.md")));
+        assertTrue(personalDelete.isSuccess());
+        assertFalse(Files.exists(workspace.resolve("alice/knowledge/personal.md")));
+    }
+
+    @Test
+    void localOverlayDelegatesIdAndShellExecution() throws Exception {
+        Path workspace = Files.createDirectories(tempDir.resolve("workspace"));
+        Path project = Files.createDirectories(tempDir.resolve("project"));
+        AbstractFilesystem filesystem =
+                new LocalFilesystemSpec().project(project).toFilesystem(workspace, rc -> List.of());
+        AbstractSandboxFilesystem sandbox = (AbstractSandboxFilesystem) filesystem;
+
+        assertFalse(sandbox.id().isBlank());
+        var result = sandbox.execute(RuntimeContext.empty(), "printf local-overlay", 10);
+        assertEquals(0, result.exitCode());
+        assertEquals("local-overlay", result.output());
+    }
+
     private static void assertContent(ReadResult result, String expected) {
         assertTrue(result.isSuccess());
         assertEquals(expected, result.fileData().content());
+    }
+
+    private static void assertPathsContain(List<FileInfo> entries, String... expectedPaths) {
+        Set<String> paths = entries.stream().map(FileInfo::path).collect(Collectors.toSet());
+        for (String expectedPath : expectedPaths) {
+            assertTrue(paths.stream().anyMatch(path -> path.endsWith(expectedPath)));
+        }
+    }
+
+    private static String content(FileDownloadResponse response) {
+        assertTrue(response.isSuccess());
+        return new String(response.content(), StandardCharsets.UTF_8);
     }
 }

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/filesystem/LocalFilesystemSpecTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/filesystem/LocalFilesystemSpecTest.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.harness.agent.filesystem;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.agentscope.core.agent.RuntimeContext;
+import io.agentscope.harness.agent.filesystem.model.EditResult;
+import io.agentscope.harness.agent.filesystem.model.ReadResult;
+import io.agentscope.harness.agent.filesystem.sandbox.AbstractSandboxFilesystem;
+import io.agentscope.harness.agent.filesystem.spec.LocalFilesystemSpec;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class LocalFilesystemSpecTest {
+
+    @TempDir Path tempDir;
+
+    @Test
+    void isolatedKnowledgeOverridesSharedKnowledgeAndFallsBackWhenMissing() throws Exception {
+        Path workspace = Files.createDirectories(tempDir.resolve("workspace"));
+        Path project = Files.createDirectories(tempDir.resolve("project"));
+        Files.createDirectories(workspace.resolve("knowledge"));
+        Files.writeString(workspace.resolve("knowledge/shared.md"), "shared baseline");
+        Files.writeString(workspace.resolve("knowledge/overridden.md"), "shared version");
+        Files.createDirectories(workspace.resolve("alice/knowledge"));
+        Files.writeString(workspace.resolve("alice/knowledge/overridden.md"), "alice version");
+
+        AbstractFilesystem filesystem =
+                new LocalFilesystemSpec()
+                        .project(project)
+                        .toFilesystem(workspace, rc -> List.of(rc.getUserId()));
+        RuntimeContext alice = RuntimeContext.builder().userId("alice").build();
+
+        assertContent(filesystem.read(alice, "knowledge/shared.md", 0, 100), "shared baseline");
+        assertContent(filesystem.read(alice, "knowledge/overridden.md", 0, 100), "alice version");
+        assertTrue(filesystem.exists(alice, "knowledge/shared.md"));
+    }
+
+    @Test
+    void editingSharedKnowledgeCopiesItIntoIsolatedWorkspace() throws Exception {
+        Path workspace = Files.createDirectories(tempDir.resolve("workspace"));
+        Path project = Files.createDirectories(tempDir.resolve("project"));
+        Files.createDirectories(workspace.resolve("knowledge"));
+        Files.writeString(workspace.resolve("knowledge/reference.md"), "shared text");
+
+        AbstractFilesystem filesystem =
+                new LocalFilesystemSpec()
+                        .project(project)
+                        .toFilesystem(workspace, rc -> List.of(rc.getUserId()));
+        RuntimeContext alice = RuntimeContext.builder().userId("alice").build();
+
+        EditResult result =
+                filesystem.edit(alice, "knowledge/reference.md", "shared", "personal", false);
+
+        assertTrue(result.isSuccess());
+        assertEquals("shared text", Files.readString(workspace.resolve("knowledge/reference.md")));
+        assertEquals(
+                "personal text",
+                Files.readString(workspace.resolve("alice/knowledge/reference.md")));
+    }
+
+    @Test
+    void sharedFallbackDoesNotExposeOtherUserNamespaces() throws Exception {
+        Path workspace = Files.createDirectories(tempDir.resolve("workspace"));
+        Path project = Files.createDirectories(tempDir.resolve("project"));
+        Files.createDirectories(workspace.resolve("bob/knowledge"));
+        Files.writeString(workspace.resolve("bob/knowledge/private.md"), "bob secret");
+
+        AbstractFilesystem filesystem =
+                new LocalFilesystemSpec()
+                        .project(project)
+                        .toFilesystem(workspace, rc -> List.of(rc.getUserId()));
+        RuntimeContext alice = RuntimeContext.builder().userId("alice").build();
+
+        assertFalse(filesystem.exists(alice, "bob/knowledge/private.md"));
+        assertFalse(filesystem.read(alice, "bob/knowledge/private.md", 0, 100).isSuccess());
+    }
+
+    @Test
+    void localOverlayKeepsShellCapability() throws Exception {
+        Path workspace = Files.createDirectories(tempDir.resolve("workspace"));
+        Path project = Files.createDirectories(tempDir.resolve("project"));
+
+        AbstractFilesystem filesystem =
+                new LocalFilesystemSpec().project(project).toFilesystem(workspace, rc -> List.of());
+
+        assertTrue(filesystem instanceof AbstractSandboxFilesystem);
+    }
+
+    private static void assertContent(ReadResult result, String expected) {
+        assertTrue(result.isSuccess());
+        assertEquals(expected, result.fileData().content());
+    }
+}


### PR DESCRIPTION
## What changed

- add a local workspace overlay that resolves knowledge files in this order: isolated user/session workspace, shared agent workspace, then project
- preserve copy-on-write behavior when editing shared knowledge
- keep shell execution and project-writable routing intact
- add regression coverage for shared fallback, isolated overrides, copy-on-write, shell capability, and cross-user isolation

## Root cause

The local filesystem upper layer applies the user/session namespace to every relative path. Once isolation is enabled, `knowledge/foo.md` resolves only under `<workspace>/<namespace>/knowledge/foo.md`; the overlay then falls back directly to the project filesystem and never checks the agent-level `<workspace>/knowledge/foo.md` baseline that was already injected into the prompt.

## Validation

- `mvn -pl agentscope-harness -am test`
- core: 2,274 tests, 0 failures, 0 errors
- harness: 832 tests, 0 failures, 0 errors

Fixes #2683
