### PR TITLE
fix(demo): agui demo access return error Failed to parse request: Type definition error: [simple type, class io.agentscope.core.agui.model.MessageContent]

### DIFF
--- a/agentscope-extensions/agentscope-spring-boot-starters/agentscope-agui-spring-boot-starter/src/main/java/io/agentscope/spring/boot/agui/mvc/AgentscopeAguiMvcAutoConfiguration.java
+++ b/agentscope-extensions/agentscope-spring-boot-starters/agentscope-agui-spring-boot-starter/src/main/java/io/agentscope/spring/boot/agui/mvc/AgentscopeAguiMvcAutoConfiguration.java
@@ -32,6 +32,8 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
+import org.springframework.http.converter.HttpMessageConverters;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 /**
@@ -53,6 +55,27 @@ import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 @ConditionalOnWebApplication(type = ConditionalOnWebApplication.Type.SERVLET)
 @EnableConfigurationProperties(AguiProperties.class)
 public class AgentscopeAguiMvcAutoConfiguration {
+
+    /**
+     * Adds a Jackson 2 converter for AG-UI run input.
+     *
+     * <p>AG-UI models use Jackson 2 custom deserializers, while Spring Boot 4 uses Jackson 3 by
+     * default. Limiting this converter to {@code RunAgentInput} preserves the application's default
+     * Jackson 3 behavior for all other request and response types.
+     *
+     * @return The AG-UI MVC message converter configurer
+     */
+    @Bean
+    public WebMvcConfigurer aguiRunAgentInputWebMvcConfigurer() {
+        return new WebMvcConfigurer() {
+            @Override
+            public void configureMessageConverters(
+                    HttpMessageConverters.ServerBuilder messageConverters) {
+                messageConverters.configureMessageConvertersList(
+                        converters -> converters.add(0, new RunAgentInputHttpMessageConverter()));
+            }
+        };
+    }
 
     /**
      * Creates the thread session manager bean.

--- a/agentscope-extensions/agentscope-spring-boot-starters/agentscope-agui-spring-boot-starter/src/main/java/io/agentscope/spring/boot/agui/mvc/RunAgentInputHttpMessageConverter.java
+++ b/agentscope-extensions/agentscope-spring-boot-starters/agentscope-agui-spring-boot-starter/src/main/java/io/agentscope/spring/boot/agui/mvc/RunAgentInputHttpMessageConverter.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.spring.boot.agui.mvc;
+
+import io.agentscope.core.agui.model.RunAgentInput;
+import java.lang.reflect.Type;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+
+@SuppressWarnings("removal")
+final class RunAgentInputHttpMessageConverter extends MappingJackson2HttpMessageConverter {
+
+    @Override
+    public boolean canRead(Class<?> clazz, MediaType mediaType) {
+        return RunAgentInput.class.isAssignableFrom(clazz) && super.canRead(clazz, mediaType);
+    }
+
+    @Override
+    public boolean canRead(Type type, Class<?> contextClass, MediaType mediaType) {
+        return type instanceof Class<?> clazz
+                && RunAgentInput.class.isAssignableFrom(clazz)
+                && super.canRead(type, contextClass, mediaType);
+    }
+
+    @Override
+    public boolean canWrite(Class<?> clazz, MediaType mediaType) {
+        return false;
+    }
+
+    @Override
+    public boolean canWrite(Type type, Class<?> clazz, MediaType mediaType) {
+        return false;
+    }
+}

--- a/agentscope-extensions/agentscope-spring-boot-starters/agentscope-agui-spring-boot-starter/src/main/java/io/agentscope/spring/boot/agui/webflux/AgentscopeAguiWebFluxAutoConfiguration.java
+++ b/agentscope-extensions/agentscope-spring-boot-starters/agentscope-agui-spring-boot-starter/src/main/java/io/agentscope/spring/boot/agui/webflux/AgentscopeAguiWebFluxAutoConfiguration.java
@@ -32,6 +32,8 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
+import org.springframework.http.codec.ServerCodecConfigurer;
+import org.springframework.web.reactive.config.WebFluxConfigurer;
 import org.springframework.web.reactive.function.server.RouterFunction;
 import org.springframework.web.reactive.function.server.RouterFunctions;
 import org.springframework.web.reactive.function.server.ServerResponse;
@@ -56,6 +58,25 @@ import org.springframework.web.reactive.function.server.ServerResponse;
 @ConditionalOnWebApplication(type = ConditionalOnWebApplication.Type.REACTIVE)
 @EnableConfigurationProperties(AguiProperties.class)
 public class AgentscopeAguiWebFluxAutoConfiguration {
+
+    /**
+     * Adds a Jackson 2 decoder for AG-UI run input.
+     *
+     * <p>AG-UI models use Jackson 2 custom deserializers, while Spring Boot 4 uses Jackson 3 by
+     * default. Limiting this decoder to {@code RunAgentInput} preserves the application's default
+     * Jackson 3 behavior for all other request and response types.
+     *
+     * @return The AG-UI WebFlux codec configurer
+     */
+    @Bean
+    public WebFluxConfigurer aguiRunAgentInputWebFluxConfigurer() {
+        return new WebFluxConfigurer() {
+            @Override
+            public void configureHttpMessageCodecs(ServerCodecConfigurer configurer) {
+                configurer.customCodecs().register(new RunAgentInputJsonDecoder());
+            }
+        };
+    }
 
     /**
      * Creates the thread session manager bean.

--- a/agentscope-extensions/agentscope-spring-boot-starters/agentscope-agui-spring-boot-starter/src/main/java/io/agentscope/spring/boot/agui/webflux/RunAgentInputJsonDecoder.java
+++ b/agentscope-extensions/agentscope-spring-boot-starters/agentscope-agui-spring-boot-starter/src/main/java/io/agentscope/spring/boot/agui/webflux/RunAgentInputJsonDecoder.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.spring.boot.agui.webflux;
+
+import io.agentscope.core.agui.model.RunAgentInput;
+import org.springframework.core.ResolvableType;
+import org.springframework.http.codec.json.Jackson2JsonDecoder;
+import org.springframework.util.MimeType;
+
+@SuppressWarnings("removal")
+final class RunAgentInputJsonDecoder extends Jackson2JsonDecoder {
+
+    @Override
+    public boolean canDecode(ResolvableType elementType, MimeType mimeType) {
+        Class<?> resolvedType = elementType.resolve();
+        return resolvedType != null
+                && RunAgentInput.class.isAssignableFrom(resolvedType)
+                && super.canDecode(elementType, mimeType);
+    }
+}

--- a/agentscope-extensions/agentscope-spring-boot-starters/agentscope-agui-spring-boot-starter/src/test/java/io/agentscope/spring/boot/agui/mvc/RunAgentInputHttpMessageConverterTest.java
+++ b/agentscope-extensions/agentscope-spring-boot-starters/agentscope-agui-spring-boot-starter/src/test/java/io/agentscope/spring/boot/agui/mvc/RunAgentInputHttpMessageConverterTest.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.spring.boot.agui.mvc;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.request;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import io.agentscope.core.agui.model.MessageContent;
+import io.agentscope.core.agui.model.RunAgentInput;
+import jakarta.servlet.http.HttpServletRequest;
+import java.nio.charset.StandardCharsets;
+import java.util.stream.StreamSupport;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.HttpMessageConverter;
+import org.springframework.http.converter.HttpMessageConverters;
+import org.springframework.mock.http.MockHttpInputMessage;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+class RunAgentInputHttpMessageConverterTest {
+
+    private static final String REQUEST_BODY =
+            """
+            {
+              "threadId": "thread-1",
+              "runId": "run-1",
+              "messages": [
+                {
+                  "id": "message-1",
+                  "role": "user",
+                  "content": "Hello"
+                }
+              ],
+              "tools": []
+            }
+            """;
+
+    private final RunAgentInputHttpMessageConverter converter =
+            new RunAgentInputHttpMessageConverter();
+
+    @Test
+    void shouldDeserializeRunAgentInputWithTextMessage() throws Exception {
+        MockHttpInputMessage message =
+                new MockHttpInputMessage(REQUEST_BODY.getBytes(StandardCharsets.UTF_8));
+        message.getHeaders().setContentType(MediaType.APPLICATION_JSON);
+
+        RunAgentInput input = (RunAgentInput) converter.read(RunAgentInput.class, message);
+
+        assertEquals("thread-1", input.getThreadId());
+        assertEquals("run-1", input.getRunId());
+        assertEquals(1, input.getMessages().size());
+        MessageContent.Text content =
+                assertInstanceOf(
+                        MessageContent.Text.class, input.getMessages().get(0).getContent());
+        assertEquals("Hello", content.value());
+    }
+
+    @Test
+    void shouldOnlyReadRunAgentInput() {
+        assertTrue(converter.canRead(RunAgentInput.class, MediaType.APPLICATION_JSON));
+        assertFalse(converter.canRead(String.class, MediaType.APPLICATION_JSON));
+        assertFalse(converter.canWrite(RunAgentInput.class, MediaType.APPLICATION_JSON));
+    }
+
+    @Test
+    void shouldBindRunAgentInputForAgentIdEndpoint() throws Exception {
+        AguiMvcController aguiMvcController = mock(AguiMvcController.class);
+        when(aguiMvcController.handleWithAgentId(
+                        any(RunAgentInput.class),
+                        isNull(),
+                        eq("test-agent"),
+                        any(HttpServletRequest.class)))
+                .thenReturn(new SseEmitter());
+
+        HttpMessageConverters.ServerBuilder messageConverters =
+                HttpMessageConverters.forServer().registerDefaults();
+        WebMvcConfigurer configurer =
+                new AgentscopeAguiMvcAutoConfiguration().aguiRunAgentInputWebMvcConfigurer();
+        configurer.configureMessageConverters(messageConverters);
+        HttpMessageConverter<?>[] converterArray =
+                StreamSupport.stream(messageConverters.build().spliterator(), false)
+                        .toArray(HttpMessageConverter<?>[]::new);
+
+        MockMvc mockMvc =
+                MockMvcBuilders.standaloneSetup(
+                                new AguiRestController(aguiMvcController, "/agui", true))
+                        .addPlaceholderValue("agentscope.agui.path-prefix", "/agui")
+                        .addPlaceholderValue("agentscope.agui.agent-id-header", "X-Agent-Id")
+                        .setMessageConverters(converterArray)
+                        .build();
+
+        mockMvc.perform(
+                        post("/agui/run/test-agent")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .accept(MediaType.TEXT_EVENT_STREAM)
+                                .content(REQUEST_BODY))
+                .andExpect(status().isOk())
+                .andExpect(request().asyncStarted());
+
+        ArgumentCaptor<RunAgentInput> inputCaptor = ArgumentCaptor.forClass(RunAgentInput.class);
+        verify(aguiMvcController)
+                .handleWithAgentId(
+                        inputCaptor.capture(),
+                        isNull(),
+                        eq("test-agent"),
+                        any(HttpServletRequest.class));
+        assertEquals("thread-1", inputCaptor.getValue().getThreadId());
+        assertInstanceOf(
+                MessageContent.Text.class,
+                inputCaptor.getValue().getMessages().get(0).getContent());
+    }
+}

--- a/agentscope-extensions/agentscope-spring-boot-starters/agentscope-agui-spring-boot-starter/src/test/java/io/agentscope/spring/boot/agui/webflux/RunAgentInputJsonDecoderTest.java
+++ b/agentscope-extensions/agentscope-spring-boot-starters/agentscope-agui-spring-boot-starter/src/test/java/io/agentscope/spring/boot/agui/webflux/RunAgentInputJsonDecoderTest.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.spring.boot.agui.webflux;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.springframework.web.reactive.function.server.RequestPredicates.POST;
+import static org.springframework.web.reactive.function.server.RouterFunctions.route;
+
+import io.agentscope.core.agui.model.MessageContent;
+import io.agentscope.core.agui.model.RunAgentInput;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.Test;
+import org.springframework.core.ResolvableType;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.reactive.server.WebTestClient;
+import org.springframework.web.reactive.config.WebFluxConfigurer;
+import org.springframework.web.reactive.function.server.HandlerStrategies;
+import org.springframework.web.reactive.function.server.RouterFunction;
+import org.springframework.web.reactive.function.server.ServerResponse;
+
+class RunAgentInputJsonDecoderTest {
+
+    private static final String REQUEST_BODY =
+            """
+            {
+              "threadId": "thread-1",
+              "runId": "run-1",
+              "messages": [
+                {
+                  "id": "message-1",
+                  "role": "user",
+                  "content": "Hello"
+                }
+              ],
+              "tools": []
+            }
+            """;
+
+    private final RunAgentInputJsonDecoder decoder = new RunAgentInputJsonDecoder();
+
+    @Test
+    void shouldOnlyDecodeRunAgentInput() {
+        assertTrue(
+                decoder.canDecode(
+                        ResolvableType.forClass(RunAgentInput.class), MediaType.APPLICATION_JSON));
+        assertFalse(
+                decoder.canDecode(
+                        ResolvableType.forClass(String.class), MediaType.APPLICATION_JSON));
+    }
+
+    @Test
+    void shouldBindRunAgentInputThroughWebFluxBodyToMono() {
+        AtomicReference<RunAgentInput> capturedInput = new AtomicReference<>();
+        RouterFunction<ServerResponse> routes =
+                route(
+                        POST("/agui/run"),
+                        request ->
+                                request.bodyToMono(RunAgentInput.class)
+                                        .doOnNext(capturedInput::set)
+                                        .then(ServerResponse.noContent().build()));
+        WebFluxConfigurer configurer =
+                new AgentscopeAguiWebFluxAutoConfiguration().aguiRunAgentInputWebFluxConfigurer();
+        HandlerStrategies strategies =
+                HandlerStrategies.builder().codecs(configurer::configureHttpMessageCodecs).build();
+        WebTestClient client =
+                WebTestClient.bindToRouterFunction(routes).handlerStrategies(strategies).build();
+
+        client.post()
+                .uri("/agui/run")
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue(REQUEST_BODY)
+                .exchange()
+                .expectStatus()
+                .isNoContent();
+
+        RunAgentInput input = capturedInput.get();
+        assertNotNull(input);
+        assertEquals("thread-1", input.getThreadId());
+        assertEquals("run-1", input.getRunId());
+        MessageContent.Text content =
+                assertInstanceOf(
+                        MessageContent.Text.class, input.getMessages().get(0).getContent());
+        assertEquals("Hello", content.value());
+    }
+}


### PR DESCRIPTION
- 新增MVC消息转换器和WebFlux解码器
- 在自动配置类中注册自定义反序列化组件
- 兼容Spring Boot 4默认Jackson3，仅针对RunAgentInput使用Jackson2
- 新增对应单元测试验证功能正确性

## AgentScope-Java Version

[The version of AgentScope-Java you are working on, e.g. 1.0.12, check your pom.xml dependency version or run `mvn dependency:tree | grep agentscope-parent:pom`(only mac/linux)]

## Description

[Please describe the background, purpose, changes made, and how to test this PR]

## Checklist

Please check the following items before code is ready to be reviewed.

- [ ]  Code has been formatted with `mvn spotless:apply`
- [ ]  All tests are passing (`mvn test`)
- [ ]  Javadoc comments are complete and follow project conventions
- [ ]  Related documentation has been updated (e.g. links, examples, etc.)
- [ ]  Code is ready for review
