### PR TITLE
fix(harness): recover from unavailable historical media

### DIFF
--- a/agentscope-core/src/main/java/io/agentscope/core/model/ModelMediaException.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/model/ModelMediaException.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.core.model;
+
+/**
+ * Exception contract for model providers that can classify failures caused by unavailable media.
+ *
+ * <p>This keeps recovery logic provider-neutral while allowing extension modules to preserve
+ * provider-specific exception types and diagnostics.
+ */
+public interface ModelMediaException {
+
+    /**
+     * Returns whether the model provider failed because it could not access referenced media.
+     *
+     * @return true when referenced media is unavailable
+     */
+    boolean isMediaUnavailable();
+}

--- a/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-dashscope/src/main/java/io/agentscope/extensions/model/dashscope/DashScopeHttpClient.java
+++ b/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-dashscope/src/main/java/io/agentscope/extensions/model/dashscope/DashScopeHttpClient.java
@@ -17,6 +17,7 @@ package io.agentscope.extensions.model.dashscope;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import io.agentscope.core.Version;
+import io.agentscope.core.model.ModelMediaException;
 import io.agentscope.core.model.transport.HttpRequest;
 import io.agentscope.core.model.transport.HttpResponse;
 import io.agentscope.core.model.transport.HttpTransport;
@@ -840,7 +841,11 @@ public class DashScopeHttpClient {
     /**
      * Exception thrown when DashScope HTTP operations fail.
      */
-    public static class DashScopeHttpException extends RuntimeException {
+    public static class DashScopeHttpException extends RuntimeException
+            implements ModelMediaException {
+        private static final String MEDIA_UNAVAILABLE_MESSAGE =
+                "failed to download multimodal content";
+
         private final Integer statusCode;
         private final String errorCode;
         private final String responseBody;
@@ -883,6 +888,18 @@ public class DashScopeHttpClient {
 
         public String getResponseBody() {
             return responseBody;
+        }
+
+        @Override
+        public boolean isMediaUnavailable() {
+            return containsMediaUnavailableMessage(getMessage())
+                    || containsMediaUnavailableMessage(errorCode)
+                    || containsMediaUnavailableMessage(responseBody);
+        }
+
+        private static boolean containsMediaUnavailableMessage(String value) {
+            return value != null
+                    && value.toLowerCase(java.util.Locale.ROOT).contains(MEDIA_UNAVAILABLE_MESSAGE);
         }
     }
 }

--- a/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-dashscope/src/test/java/io/agentscope/extensions/model/dashscope/DashScopeHttpClientTest.java
+++ b/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-dashscope/src/test/java/io/agentscope/extensions/model/dashscope/DashScopeHttpClientTest.java
@@ -476,6 +476,33 @@ class DashScopeHttpClientTest {
                         () -> client.call(request, null, null, null));
 
         assertTrue(exception.getMessage().contains("Invalid API key"));
+        assertFalse(exception.isMediaUnavailable());
+    }
+
+    @Test
+    void testApiErrorClassifiesUnavailableMedia() {
+        String errorJson =
+                """
+                {
+                  "request_id": "error-request",
+                  "code": "InvalidParameter",
+                  "message": "<400> InternalError.Algo.InvalidParameter: Failed to download multimodal content."
+                }
+                """;
+
+        mockServer.enqueue(
+                new MockResponse()
+                        .setResponseCode(200)
+                        .setBody(errorJson)
+                        .setHeader("Content-Type", "application/json"));
+
+        DashScopeRequest request = createTestRequest("qwen-vl-plus", "test");
+        DashScopeHttpClient.DashScopeHttpException exception =
+                assertThrows(
+                        DashScopeHttpClient.DashScopeHttpException.class,
+                        () -> client.call(request, null, null, null));
+
+        assertTrue(exception.isMediaUnavailable());
     }
 
     @Test
@@ -494,6 +521,27 @@ class DashScopeHttpClientTest {
                         () -> client.call(request, null, null, null));
 
         assertEquals(500, exception.getStatusCode());
+        assertFalse(exception.isMediaUnavailable());
+    }
+
+    @Test
+    void testHttpErrorBodyClassifiesUnavailableMedia() {
+        mockServer.enqueue(
+                new MockResponse()
+                        .setResponseCode(400)
+                        .setBody(
+                                "{\"code\":\"InvalidParameter\",\"message\":\"Failed to"
+                                        + " download multimodal content\"}")
+                        .setHeader("Content-Type", "application/json"));
+
+        DashScopeRequest request = createTestRequest("qwen-vl-plus", "test");
+        DashScopeHttpClient.DashScopeHttpException exception =
+                assertThrows(
+                        DashScopeHttpClient.DashScopeHttpException.class,
+                        () -> client.call(request, null, null, null));
+
+        assertEquals(400, exception.getStatusCode());
+        assertTrue(exception.isMediaUnavailable());
     }
 
     @Test
@@ -667,6 +715,32 @@ class DashScopeHttpClientTest {
     }
 
     @Test
+    void testStreamClassifiesUnavailableMedia() {
+        String errorMessage =
+                "<400> InternalError.Algo.InvalidParameter: Failed to download multimodal"
+                        + " content.";
+        mockServer.enqueue(
+                new MockResponse()
+                        .setResponseCode(200)
+                        .setBody(
+                                "data: {\"code\":\"InvalidParameter\",\"message\":\""
+                                        + errorMessage
+                                        + "\",\"request_id\":\"request_id_123\"}")
+                        .setHeader("Content-Type", "text/event-stream"));
+
+        DashScopeRequest request = createTestRequest("qwen-vl-plus", "test");
+
+        StepVerifier.create(client.stream(request, null, null, null))
+                .expectErrorMatches(
+                        error ->
+                                error
+                                                instanceof
+                                                DashScopeHttpClient.DashScopeHttpException exception
+                                        && exception.isMediaUnavailable())
+                .verify();
+    }
+
+    @Test
     void testStreamIgnoresMalformedSseData() {
         mockServer.enqueue(
                 new MockResponse()
@@ -800,6 +874,7 @@ class DashScopeHttpClientTest {
         assertNull(exception.getStatusCode());
         assertEquals("InvalidAPIKey", exception.getErrorCode());
         assertEquals("{\"error\":\"invalid key\"}", exception.getResponseBody());
+        assertFalse(exception.isMediaUnavailable());
     }
 
     @Test

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/HarnessAgent.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/HarnessAgent.java
@@ -71,6 +71,8 @@ import io.agentscope.harness.agent.middleware.CompactionMiddleware;
 import io.agentscope.harness.agent.middleware.DynamicSubagentsMiddleware;
 import io.agentscope.harness.agent.middleware.HarnessRuntimeMiddleware;
 import io.agentscope.harness.agent.middleware.HarnessSkillMiddleware;
+import io.agentscope.harness.agent.middleware.HistoricalMediaRecoveryConfig;
+import io.agentscope.harness.agent.middleware.HistoricalMediaRecoveryMiddleware;
 import io.agentscope.harness.agent.middleware.InboxMiddleware;
 import io.agentscope.harness.agent.middleware.MemoryFlushMiddleware;
 import io.agentscope.harness.agent.middleware.MemoryMaintenanceMiddleware;
@@ -668,7 +670,8 @@ public class HarnessAgent implements Agent, AutoCloseable {
     @Deprecated(since = "2.2.0")
     @Override
     public Mono<Msg> call(List<Msg> msgs) {
-        return wrappedCall(msgs, RuntimeContext.empty(), () -> delegate.call(msgs));
+        RuntimeContext effective = ensureSessionDefaults(RuntimeContext.empty());
+        return wrappedCall(msgs, effective, () -> delegate.call(msgs, effective));
     }
 
     /**
@@ -677,8 +680,8 @@ public class HarnessAgent implements Agent, AutoCloseable {
     @Deprecated(since = "2.2.0")
     @Override
     public Mono<Msg> call(List<Msg> msgs, Class<?> structuredModel) {
-        return wrappedCall(
-                msgs, RuntimeContext.empty(), () -> delegate.call(msgs, structuredModel));
+        RuntimeContext effective = ensureSessionDefaults(RuntimeContext.empty());
+        return wrappedCall(msgs, effective, () -> delegate.call(msgs, structuredModel, effective));
     }
 
     /**
@@ -687,7 +690,8 @@ public class HarnessAgent implements Agent, AutoCloseable {
     @Deprecated(since = "2.2.0")
     @Override
     public Mono<Msg> call(List<Msg> msgs, JsonNode schema) {
-        return wrappedCall(msgs, RuntimeContext.empty(), () -> delegate.call(msgs, schema));
+        RuntimeContext effective = ensureSessionDefaults(RuntimeContext.empty());
+        return wrappedCall(msgs, effective, () -> delegate.call(msgs, schema, effective));
     }
 
     public Mono<Msg> call(Msg msg, RuntimeContext ctx) {
@@ -730,7 +734,8 @@ public class HarnessAgent implements Agent, AutoCloseable {
     @Deprecated(since = "2.0.0", forRemoval = true)
     @Override
     public Flux<Event> stream(List<Msg> msgs, StreamOptions options) {
-        return wrappedStream(RuntimeContext.empty(), () -> delegate.stream(msgs, options));
+        RuntimeContext effective = ensureSessionDefaults(RuntimeContext.empty());
+        return wrappedStream(effective, () -> delegate.stream(msgs, options, effective));
     }
 
     /**
@@ -740,8 +745,9 @@ public class HarnessAgent implements Agent, AutoCloseable {
     @Deprecated(since = "2.0.0", forRemoval = true)
     @Override
     public Flux<Event> stream(List<Msg> msgs, StreamOptions options, Class<?> structuredModel) {
+        RuntimeContext effective = ensureSessionDefaults(RuntimeContext.empty());
         return wrappedStream(
-                RuntimeContext.empty(), () -> delegate.stream(msgs, options, structuredModel));
+                effective, () -> delegate.stream(msgs, options, structuredModel, effective));
     }
 
     /**
@@ -751,7 +757,8 @@ public class HarnessAgent implements Agent, AutoCloseable {
     @Deprecated(since = "2.0.0", forRemoval = true)
     @Override
     public Flux<Event> stream(List<Msg> msgs, StreamOptions options, JsonNode schema) {
-        return wrappedStream(RuntimeContext.empty(), () -> delegate.stream(msgs, options, schema));
+        RuntimeContext effective = ensureSessionDefaults(RuntimeContext.empty());
+        return wrappedStream(effective, () -> delegate.stream(msgs, options, schema, effective));
     }
 
     /**
@@ -1177,8 +1184,11 @@ public class HarnessAgent implements Agent, AutoCloseable {
         CompactionConfig compactionConfig = CompactionConfig.builder().build();
         MemoryConfig memoryConfig = MemoryConfig.defaults();
         ToolResultEvictionConfig toolResultEvictionConfig = ToolResultEvictionConfig.defaults();
+        HistoricalMediaRecoveryConfig historicalMediaRecoveryConfig =
+                HistoricalMediaRecoveryConfig.defaults();
         boolean disableCompaction = false;
         boolean disableToolResultEviction = false;
+        boolean disableHistoricalMediaRecovery = false;
 
         final List<SubagentDeclaration> subagentDeclarations = new ArrayList<>();
         final List<HarnessAgentBuilderSupport.SubagentFactoryEntry> customSubagentFactories =
@@ -1795,6 +1805,24 @@ public class HarnessAgent implements Agent, AutoCloseable {
         /** Disables the {@link CompactionMiddleware} entirely. */
         public Builder disableCompaction() {
             this.disableCompaction = true;
+            return this;
+        }
+
+        /**
+         * Overrides the default historical-media recovery configuration. Recovery is enabled by
+         * default and retries once after replacing unavailable URL-backed media in historical
+         * messages. Pass {@code null}, or call {@link #disableHistoricalMediaRecovery()}, to turn
+         * it off.
+         */
+        public Builder historicalMediaRecovery(HistoricalMediaRecoveryConfig config) {
+            this.historicalMediaRecoveryConfig = config;
+            this.disableHistoricalMediaRecovery = (config == null);
+            return this;
+        }
+
+        /** Disables historical-media recovery entirely. */
+        public Builder disableHistoricalMediaRecovery() {
+            this.disableHistoricalMediaRecovery = true;
             return this;
         }
 
@@ -2451,6 +2479,12 @@ public class HarnessAgent implements Agent, AutoCloseable {
                                 memoryConfig.consolidationMinGap(),
                                 effectiveIsolationScope,
                                 periodicGate));
+            }
+            if (!disableHistoricalMediaRecovery && historicalMediaRecoveryConfig != null) {
+                // Register before compaction so recovery wraps compaction fallback and the normal
+                // downstream model call.
+                inner.middleware(
+                        new HistoricalMediaRecoveryMiddleware(historicalMediaRecoveryConfig));
             }
             CompactionMiddleware compactionHook = null;
             if (!disableCompaction && compactionConfig != null) {

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/HarnessAgentBuilderSupport.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/HarnessAgentBuilderSupport.java
@@ -40,6 +40,7 @@ import io.agentscope.harness.agent.memory.MemoryConfig;
 import io.agentscope.harness.agent.memory.compaction.CompactionConfig;
 import io.agentscope.harness.agent.memory.compaction.ToolResultEvictionConfig;
 import io.agentscope.harness.agent.middleware.DynamicSubagentsMiddleware;
+import io.agentscope.harness.agent.middleware.HistoricalMediaRecoveryConfig;
 import io.agentscope.harness.agent.middleware.SubagentEntry;
 import io.agentscope.harness.agent.middleware.SubagentsMiddleware;
 import io.agentscope.harness.agent.subagent.AgentSpecLoader;
@@ -310,6 +311,9 @@ final class HarnessAgentBuilderSupport {
         final ToolResultEvictionConfig capturedToolResultEvictionConfig =
                 b.toolResultEvictionConfig;
         final boolean capturedDisableToolResultEviction = b.disableToolResultEviction;
+        final HistoricalMediaRecoveryConfig capturedHistoricalMediaRecoveryConfig =
+                b.historicalMediaRecoveryConfig;
+        final boolean capturedDisableHistoricalMediaRecovery = b.disableHistoricalMediaRecovery;
         final boolean capturedAgentTracingLogEnabled = b.agentTracingLogEnabled;
         final List<String> capturedAdditionalContextFiles = List.copyOf(b.additionalContextFiles);
         final int capturedMaxContextTokens = b.maxContextTokens;
@@ -368,6 +372,11 @@ final class HarnessAgentBuilderSupport {
                 sub.disableToolResultEviction();
             } else if (capturedToolResultEvictionConfig != null) {
                 sub.toolResultEviction(capturedToolResultEvictionConfig);
+            }
+            if (capturedDisableHistoricalMediaRecovery) {
+                sub.disableHistoricalMediaRecovery();
+            } else if (capturedHistoricalMediaRecoveryConfig != null) {
+                sub.historicalMediaRecovery(capturedHistoricalMediaRecoveryConfig);
             }
 
             sub.middlewares(capturedMiddlewares);

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/middleware/HistoricalMediaRecoveryConfig.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/middleware/HistoricalMediaRecoveryConfig.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.harness.agent.middleware;
+
+/** Configuration for recovering from unavailable URL-backed media in conversation history. */
+public final class HistoricalMediaRecoveryConfig {
+
+    public static final String DEFAULT_REPLACEMENT_TEXT =
+            "[Historical media omitted because its source URL is no longer available]";
+
+    private final String replacementText;
+
+    private HistoricalMediaRecoveryConfig(Builder builder) {
+        this.replacementText = builder.replacementText;
+    }
+
+    /** Creates a configuration with the default historical-media placeholder. */
+    public static HistoricalMediaRecoveryConfig defaults() {
+        return builder().build();
+    }
+
+    /** Creates a builder for historical-media recovery configuration. */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /** Text used in place of each unavailable historical URL-backed media block. */
+    public String getReplacementText() {
+        return replacementText;
+    }
+
+    /** Builder for {@link HistoricalMediaRecoveryConfig}. */
+    public static final class Builder {
+
+        private String replacementText = DEFAULT_REPLACEMENT_TEXT;
+
+        /** Sets the non-blank text used to replace unavailable historical media. */
+        public Builder replacementText(String replacementText) {
+            this.replacementText = replacementText;
+            return this;
+        }
+
+        public HistoricalMediaRecoveryConfig build() {
+            if (replacementText == null || replacementText.isBlank()) {
+                throw new IllegalArgumentException("replacementText must not be blank");
+            }
+            return new HistoricalMediaRecoveryConfig(this);
+        }
+    }
+}

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/middleware/HistoricalMediaRecoveryMiddleware.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/middleware/HistoricalMediaRecoveryMiddleware.java
@@ -1,0 +1,315 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.harness.agent.middleware;
+
+import io.agentscope.core.agent.Agent;
+import io.agentscope.core.agent.RuntimeContext;
+import io.agentscope.core.event.AgentEvent;
+import io.agentscope.core.event.ModelCallStartEvent;
+import io.agentscope.core.message.AudioBlock;
+import io.agentscope.core.message.ContentBlock;
+import io.agentscope.core.message.DataBlock;
+import io.agentscope.core.message.ImageBlock;
+import io.agentscope.core.message.Msg;
+import io.agentscope.core.message.TextBlock;
+import io.agentscope.core.message.ToolResultBlock;
+import io.agentscope.core.message.URLSource;
+import io.agentscope.core.message.VideoBlock;
+import io.agentscope.core.middleware.AgentInput;
+import io.agentscope.core.middleware.ReasoningInput;
+import io.agentscope.core.model.ModelMediaException;
+import io.agentscope.core.state.AgentState;
+import java.util.ArrayList;
+import java.util.IdentityHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Function;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import reactor.core.publisher.Flux;
+
+/**
+ * Recovers a Harness conversation when a model provider can no longer fetch URL-backed media from
+ * historical messages.
+ *
+ * <p>The current call's messages are never modified. On a classified media-unavailable failure,
+ * historical URL-backed media is replaced with text and reasoning is retried exactly once. The
+ * canonical {@link AgentState} is updated only after that retry completes successfully.
+ */
+public final class HistoricalMediaRecoveryMiddleware implements HarnessRuntimeMiddleware {
+
+    private static final Logger log =
+            LoggerFactory.getLogger(HistoricalMediaRecoveryMiddleware.class);
+
+    private final HistoricalMediaRecoveryConfig config;
+
+    public HistoricalMediaRecoveryMiddleware(HistoricalMediaRecoveryConfig config) {
+        this.config = config != null ? config : HistoricalMediaRecoveryConfig.defaults();
+    }
+
+    @Override
+    public Flux<AgentEvent> onAgent(
+            Agent agent,
+            RuntimeContext ctx,
+            AgentInput input,
+            Function<AgentInput, Flux<AgentEvent>> next) {
+        if (ctx == null) {
+            return next.apply(input);
+        }
+        return Flux.defer(
+                () -> {
+                    CurrentInputMessageIds previous = ctx.get(CurrentInputMessageIds.class);
+                    CurrentInputMessageIds current = currentInputMessageIds(input.msgs());
+                    ctx.put(CurrentInputMessageIds.class, current);
+                    return next.apply(input)
+                            .doFinally(ignored -> ctx.put(CurrentInputMessageIds.class, previous));
+                });
+    }
+
+    @Override
+    public Flux<AgentEvent> onReasoning(
+            Agent agent,
+            RuntimeContext ctx,
+            ReasoningInput input,
+            Function<ReasoningInput, Flux<AgentEvent>> next) {
+        return Flux.defer(
+                () -> {
+                    CurrentInputMessageIds current =
+                            ctx != null ? ctx.get(CurrentInputMessageIds.class) : null;
+                    if (current == null || !current.safeToRecover()) {
+                        return next.apply(input);
+                    }
+
+                    AtomicBoolean sawStart = new AtomicBoolean(false);
+                    AtomicBoolean sawOutput = new AtomicBoolean(false);
+                    return Flux.defer(() -> next.apply(input))
+                            .doOnNext(
+                                    event -> {
+                                        if (event instanceof ModelCallStartEvent) {
+                                            sawStart.set(true);
+                                        } else {
+                                            sawOutput.set(true);
+                                        }
+                                    })
+                            .onErrorResume(
+                                    error -> {
+                                        if (sawOutput.get() || !isMediaUnavailable(error)) {
+                                            return Flux.error(error);
+                                        }
+                                        SanitizationResult sanitized =
+                                                sanitizeMessages(
+                                                        input.messages(), current.ids(), null);
+                                        if (!sanitized.changed()) {
+                                            return Flux.error(error);
+                                        }
+
+                                        String sessionId =
+                                                ctx != null && ctx.getSessionId() != null
+                                                        ? ctx.getSessionId()
+                                                        : "default";
+                                        log.warn(
+                                                "[{}] Retrying after replacing {} unavailable"
+                                                        + " historical media block(s) for session"
+                                                        + " {}",
+                                                agent.getName(),
+                                                sanitized.replacementCount(),
+                                                sessionId);
+
+                                        ReasoningInput retryInput =
+                                                new ReasoningInput(
+                                                        sanitized.messages(),
+                                                        input.tools(),
+                                                        input.options());
+                                        return Flux.defer(() -> next.apply(retryInput))
+                                                .filter(
+                                                        event ->
+                                                                !(sawStart.get()
+                                                                        && event
+                                                                                instanceof
+                                                                                ModelCallStartEvent))
+                                                .doOnComplete(
+                                                        () -> {
+                                                            commitSanitizedHistory(
+                                                                    agent,
+                                                                    ctx,
+                                                                    current.ids(),
+                                                                    sanitized.changedMessageIds());
+                                                            log.info(
+                                                                    "[{}] Recovered unavailable"
+                                                                            + " historical media"
+                                                                            + " for session {}",
+                                                                    agent.getName(),
+                                                                    sessionId);
+                                                        })
+                                                .doOnError(
+                                                        retryError ->
+                                                                log.warn(
+                                                                        "[{}] Historical media"
+                                                                            + " recovery retry"
+                                                                            + " failed for session"
+                                                                            + " {}",
+                                                                        agent.getName(),
+                                                                        sessionId));
+                                    });
+                });
+    }
+
+    private CurrentInputMessageIds currentInputMessageIds(List<Msg> messages) {
+        if (messages == null || messages.isEmpty()) {
+            return new CurrentInputMessageIds(Set.of(), true);
+        }
+        Set<String> ids = new LinkedHashSet<>();
+        for (Msg message : messages) {
+            if (message == null || message.getId() == null) {
+                return new CurrentInputMessageIds(Set.of(), false);
+            }
+            ids.add(message.getId());
+        }
+        return new CurrentInputMessageIds(Set.copyOf(ids), true);
+    }
+
+    private boolean isMediaUnavailable(Throwable error) {
+        IdentityHashMap<Throwable, Boolean> visited = new IdentityHashMap<>();
+        Throwable current = error;
+        while (current != null && visited.put(current, Boolean.TRUE) == null) {
+            if (current instanceof ModelMediaException mediaError
+                    && mediaError.isMediaUnavailable()) {
+                return true;
+            }
+            current = current.getCause();
+        }
+        return false;
+    }
+
+    private void commitSanitizedHistory(
+            Agent agent,
+            RuntimeContext ctx,
+            Set<String> currentInputIds,
+            Set<String> changedMessageIds) {
+        AgentState state = RuntimeContext.resolveAgentState(ctx, agent);
+        if (state == null || changedMessageIds.isEmpty()) {
+            return;
+        }
+        List<Msg> context = state.contextMutable();
+        SanitizationResult result = sanitizeMessages(context, currentInputIds, changedMessageIds);
+        if (!result.changed()) {
+            return;
+        }
+        for (int i = 0; i < context.size(); i++) {
+            context.set(i, result.messages().get(i));
+        }
+    }
+
+    private SanitizationResult sanitizeMessages(
+            List<Msg> messages, Set<String> currentInputIds, Set<String> allowedMessageIds) {
+        if (messages == null || messages.isEmpty()) {
+            return new SanitizationResult(
+                    messages != null ? messages : List.of(), false, 0, Set.of());
+        }
+
+        List<Msg> rebuiltMessages = new ArrayList<>(messages.size());
+        Set<String> changedMessageIds = new LinkedHashSet<>();
+        int replacementCount = 0;
+        for (Msg message : messages) {
+            if (message == null
+                    || currentInputIds.contains(message.getId())
+                    || (allowedMessageIds != null
+                            && !allowedMessageIds.contains(message.getId()))) {
+                rebuiltMessages.add(message);
+                continue;
+            }
+            BlockSanitization sanitized = sanitizeBlocks(message.getContent());
+            if (!sanitized.changed()) {
+                rebuiltMessages.add(message);
+                continue;
+            }
+            rebuiltMessages.add(rebuildMessage(message, sanitized.blocks()));
+            changedMessageIds.add(message.getId());
+            replacementCount += sanitized.replacementCount();
+        }
+        boolean changed = !changedMessageIds.isEmpty();
+        return new SanitizationResult(
+                changed ? rebuiltMessages : messages,
+                changed,
+                replacementCount,
+                changed ? Set.copyOf(changedMessageIds) : Set.of());
+    }
+
+    private BlockSanitization sanitizeBlocks(List<ContentBlock> blocks) {
+        if (blocks == null || blocks.isEmpty()) {
+            return new BlockSanitization(blocks != null ? blocks : List.of(), false, 0);
+        }
+        List<ContentBlock> rebuilt = new ArrayList<>(blocks.size());
+        boolean changed = false;
+        int replacementCount = 0;
+        for (ContentBlock block : blocks) {
+            if (isUrlBackedMedia(block)) {
+                rebuilt.add(TextBlock.builder().text(config.getReplacementText()).build());
+                changed = true;
+                replacementCount++;
+                continue;
+            }
+            if (block instanceof ToolResultBlock toolResult) {
+                BlockSanitization nested = sanitizeBlocks(toolResult.getOutput());
+                if (nested.changed()) {
+                    rebuilt.add(
+                            new ToolResultBlock(
+                                    toolResult.getId(),
+                                    toolResult.getName(),
+                                    nested.blocks(),
+                                    toolResult.getMetadata(),
+                                    toolResult.getState()));
+                    changed = true;
+                    replacementCount += nested.replacementCount();
+                    continue;
+                }
+            }
+            rebuilt.add(block);
+        }
+        return new BlockSanitization(changed ? rebuilt : blocks, changed, replacementCount);
+    }
+
+    private boolean isUrlBackedMedia(ContentBlock block) {
+        return block instanceof ImageBlock image && image.getSource() instanceof URLSource
+                || block instanceof AudioBlock audio && audio.getSource() instanceof URLSource
+                || block instanceof VideoBlock video && video.getSource() instanceof URLSource
+                || block instanceof DataBlock data && data.getSource() instanceof URLSource;
+    }
+
+    private Msg rebuildMessage(Msg message, List<ContentBlock> content) {
+        return Msg.builderForRole(message.getRole())
+                .id(message.getId())
+                .name(message.getName())
+                .content(content)
+                .metadata(message.getMetadata())
+                .timestamp(message.getTimestamp())
+                .usage(message.getUsage())
+                .build();
+    }
+
+    private record CurrentInputMessageIds(Set<String> ids, boolean safeToRecover) {}
+
+    private record BlockSanitization(
+            List<ContentBlock> blocks, boolean changed, int replacementCount) {}
+
+    private record SanitizationResult(
+            List<Msg> messages,
+            boolean changed,
+            int replacementCount,
+            Set<String> changedMessageIds) {}
+}

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/HarnessAgentTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/HarnessAgentTest.java
@@ -58,6 +58,8 @@ import io.agentscope.harness.agent.filesystem.spec.RemoteFilesystemSpec;
 import io.agentscope.harness.agent.memory.MemoryConfig;
 import io.agentscope.harness.agent.memory.compaction.CompactionConfig;
 import io.agentscope.harness.agent.middleware.AgentTraceMiddleware;
+import io.agentscope.harness.agent.middleware.CompactionMiddleware;
+import io.agentscope.harness.agent.middleware.HistoricalMediaRecoveryMiddleware;
 import io.agentscope.harness.agent.middleware.SubagentEntry;
 import io.agentscope.harness.agent.middleware.WorkspaceContextMiddleware;
 import io.agentscope.harness.agent.sandbox.SandboxContext;
@@ -151,6 +153,79 @@ class HarnessAgentTest {
         assertFalse(toolNames.contains("memory_search"));
         assertFalse(toolNames.contains("memory_get"));
         assertFalse(toolNames.contains("session_search"));
+    }
+
+    @Test
+    void historicalMediaRecoveryIsEnabledOutsideCompactionByDefault() throws Exception {
+        Files.createDirectories(workspace);
+        HarnessAgent agent =
+                HarnessAgent.builder()
+                        .name("t")
+                        .model(stubModel("ok"))
+                        .workspace(workspace)
+                        .abstractFilesystem(new LocalFilesystem(workspace))
+                        .build();
+
+        List<MiddlewareBase> middlewares = agent.getDelegate().getMiddlewares();
+        int recoveryIndex = indexOf(middlewares, HistoricalMediaRecoveryMiddleware.class);
+        int compactionIndex = indexOf(middlewares, CompactionMiddleware.class);
+        assertTrue(recoveryIndex >= 0, "historical media recovery should be enabled by default");
+        assertTrue(compactionIndex >= 0, "compaction should be enabled by default");
+        assertTrue(
+                recoveryIndex < compactionIndex,
+                "historical media recovery must wrap compaction fallback");
+    }
+
+    @Test
+    void historicalMediaRecoveryCanBeDisabled() throws Exception {
+        Files.createDirectories(workspace);
+        HarnessAgent agent =
+                HarnessAgent.builder()
+                        .name("t")
+                        .model(stubModel("ok"))
+                        .workspace(workspace)
+                        .abstractFilesystem(new LocalFilesystem(workspace))
+                        .disableHistoricalMediaRecovery()
+                        .build();
+
+        assertFalse(
+                agent.getDelegate().getMiddlewares().stream()
+                        .anyMatch(HistoricalMediaRecoveryMiddleware.class::isInstance));
+    }
+
+    @SuppressWarnings("deprecation")
+    @Test
+    void compatibilityCallPassesDefaultedRuntimeContextToOnAgent() throws Exception {
+        Files.createDirectories(workspace);
+        AtomicReference<RuntimeContext> seen = new AtomicReference<>();
+        HarnessAgent agent =
+                HarnessAgent.builder()
+                        .name("t")
+                        .model(stubModel("ok"))
+                        .workspace(workspace)
+                        .abstractFilesystem(new LocalFilesystem(workspace))
+                        .middleware(
+                                new MiddlewareBase() {
+                                    @Override
+                                    public Flux<AgentEvent> onAgent(
+                                            Agent agent,
+                                            RuntimeContext ctx,
+                                            io.agentscope.core.middleware.AgentInput input,
+                                            java.util.function.Function<
+                                                            io.agentscope.core.middleware
+                                                                    .AgentInput,
+                                                            Flux<AgentEvent>>
+                                                    next) {
+                                        seen.set(ctx);
+                                        return next.apply(input);
+                                    }
+                                })
+                        .build();
+
+        agent.call(List.of(userText("hi"))).block();
+
+        assertNotNull(seen.get());
+        assertEquals("t", seen.get().getSessionId());
     }
 
     @Test
@@ -912,6 +987,16 @@ class HarnessAgentTest {
                 .build();
     }
 
+    private static int indexOf(
+            List<MiddlewareBase> middlewares, Class<? extends MiddlewareBase> type) {
+        for (int i = 0; i < middlewares.size(); i++) {
+            if (type.isInstance(middlewares.get(i))) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
     private static String joinAllText(List<Msg> msgs) {
         return msgs.stream().map(Msg::getTextContent).collect(Collectors.joining("\n"));
     }
@@ -1220,6 +1305,29 @@ class HarnessAgentTest {
                                 .factory()
                                 .create(RuntimeContext.empty());
         assertNotNull(child.getCompactionHook(), "CompactionHook should be mirrored to GP child");
+    }
+
+    @Test
+    void generalPurposeMirrorsDisabledHistoricalMediaRecovery() throws Exception {
+        Files.createDirectories(workspace);
+        List<SubagentEntry> entries =
+                HarnessAgent.builder()
+                        .model(stubModel("ok"))
+                        .workspace(workspace)
+                        .disableHistoricalMediaRecovery()
+                        .buildSubagentEntries(workspace);
+
+        HarnessAgent child =
+                (HarnessAgent)
+                        entries.stream()
+                                .filter(e -> "general-purpose".equals(e.name()))
+                                .findFirst()
+                                .orElseThrow()
+                                .factory()
+                                .create(RuntimeContext.empty());
+        assertFalse(
+                child.getDelegate().getMiddlewares().stream()
+                        .anyMatch(HistoricalMediaRecoveryMiddleware.class::isInstance));
     }
 
     @Test

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/middleware/HistoricalMediaRecoveryMiddlewareTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/middleware/HistoricalMediaRecoveryMiddlewareTest.java
@@ -1,0 +1,573 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.harness.agent.middleware;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.agentscope.core.ReActAgent;
+import io.agentscope.core.agent.Agent;
+import io.agentscope.core.agent.AgentBase;
+import io.agentscope.core.agent.RuntimeContext;
+import io.agentscope.core.event.AgentEvent;
+import io.agentscope.core.event.ModelCallStartEvent;
+import io.agentscope.core.event.TextBlockDeltaEvent;
+import io.agentscope.core.interruption.InterruptContext;
+import io.agentscope.core.message.AudioBlock;
+import io.agentscope.core.message.Base64Source;
+import io.agentscope.core.message.ContentBlock;
+import io.agentscope.core.message.DataBlock;
+import io.agentscope.core.message.ImageBlock;
+import io.agentscope.core.message.Msg;
+import io.agentscope.core.message.MsgRole;
+import io.agentscope.core.message.TextBlock;
+import io.agentscope.core.message.ToolResultBlock;
+import io.agentscope.core.message.ToolResultState;
+import io.agentscope.core.message.URLSource;
+import io.agentscope.core.message.VideoBlock;
+import io.agentscope.core.middleware.AgentInput;
+import io.agentscope.core.middleware.ReasoningInput;
+import io.agentscope.core.model.ChatModelBase;
+import io.agentscope.core.model.ChatResponse;
+import io.agentscope.core.model.GenerateOptions;
+import io.agentscope.core.model.ModelMediaException;
+import io.agentscope.core.model.ToolSchema;
+import io.agentscope.core.state.AgentState;
+import io.agentscope.harness.agent.memory.compaction.CompactionConfig;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Function;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
+import reactor.test.StepVerifier;
+
+class HistoricalMediaRecoveryMiddlewareTest {
+
+    private static final String PLACEHOLDER = "[expired historical media]";
+
+    @Test
+    void replacesHistoricalUrlMediaRetriesOnceAndCommitsState() {
+        HistoricalMediaRecoveryMiddleware middleware = middleware();
+        Msg history = mixedHistoricalMedia("history");
+        Msg toolHistory = toolHistory("tool-history");
+        Msg current = textMessage("current", "continue");
+        AgentState state =
+                AgentState.builder()
+                        .addMessage(history)
+                        .addMessage(toolHistory)
+                        .addMessage(current)
+                        .build();
+        RuntimeContext ctx = context("session", state);
+        AtomicInteger calls = new AtomicInteger();
+        AtomicReference<ReasoningInput> retryInput = new AtomicReference<>();
+
+        List<AgentEvent> events =
+                invoke(
+                                middleware,
+                                ctx,
+                                List.of(current),
+                                new ReasoningInput(
+                                        List.of(history, toolHistory, current), List.of(), null),
+                                input -> {
+                                    if (calls.incrementAndGet() == 1) {
+                                        return Flux.concat(
+                                                Flux.just(new ModelCallStartEvent("first")),
+                                                Flux.error(
+                                                        new RuntimeException(
+                                                                new TestMediaException(true))));
+                                    }
+                                    retryInput.set(input);
+                                    return Flux.just(new ModelCallStartEvent("retry"));
+                                })
+                        .collectList()
+                        .block();
+
+        assertEquals(2, calls.get());
+        assertEquals(1, events.size());
+        assertTrue(events.get(0) instanceof ModelCallStartEvent);
+        assertEquals("first", ((ModelCallStartEvent) events.get(0)).getReplyId());
+
+        Msg retriedHistory = retryInput.get().messages().get(0);
+        assertEquals(history.getId(), retriedHistory.getId());
+        assertEquals(history.getRole(), retriedHistory.getRole());
+        assertEquals(history.getTimestamp(), retriedHistory.getTimestamp());
+        assertEquals(history.getUsage(), retriedHistory.getUsage());
+        assertEquals("preserve", retriedHistory.getMetadata().get("marker"));
+        assertEquals(4, countTopLevelPlaceholders(retriedHistory));
+        assertEquals(1, retriedHistory.getContentBlocks(ImageBlock.class).size());
+        assertTrue(
+                retriedHistory.getContentBlocks(ImageBlock.class).get(0).getSource()
+                        instanceof Base64Source);
+        assertFalse(hasUrlMedia(retriedHistory));
+
+        Msg retriedTool = retryInput.get().messages().get(1);
+        assertFalse(hasUrlMedia(retriedTool));
+        ToolResultBlock retryToolResult =
+                retriedTool.getContentBlocks(ToolResultBlock.class).get(0);
+        assertEquals(ToolResultState.SUCCESS, retryToolResult.getState());
+        assertEquals("preserve", retryToolResult.getMetadata().get("marker"));
+
+        assertFalse(hasUrlMedia(state.getContext().get(0)));
+        assertFalse(hasUrlMedia(state.getContext().get(1)));
+        assertSame(current, state.getContext().get(2));
+
+        Msg nextCurrent = textMessage("next-current", "continue again");
+        AtomicInteger nextCalls = new AtomicInteger();
+        StepVerifier.create(
+                        invoke(
+                                middleware,
+                                ctx,
+                                List.of(nextCurrent),
+                                new ReasoningInput(
+                                        List.of(
+                                                state.getContext().get(0),
+                                                state.getContext().get(1),
+                                                current,
+                                                nextCurrent),
+                                        List.of(),
+                                        null),
+                                ignored -> {
+                                    nextCalls.incrementAndGet();
+                                    return Flux.error(new TestMediaException(true));
+                                }))
+                .expectError(TestMediaException.class)
+                .verify();
+        assertEquals(1, nextCalls.get(), "cleaned history must not trigger recovery again");
+    }
+
+    @Test
+    void currentInputMediaFailureIsPropagatedWithoutRetry() {
+        HistoricalMediaRecoveryMiddleware middleware = middleware();
+        Msg current = imageMessage("current", "https://example.invalid/current.png");
+        AgentState state = AgentState.builder().addMessage(current).build();
+        RuntimeContext ctx = context("session", state);
+        AtomicInteger calls = new AtomicInteger();
+
+        StepVerifier.create(
+                        invoke(
+                                middleware,
+                                ctx,
+                                List.of(current),
+                                new ReasoningInput(List.of(current), List.of(), null),
+                                input -> {
+                                    calls.incrementAndGet();
+                                    return Flux.concat(
+                                            Flux.just(new ModelCallStartEvent("first")),
+                                            Flux.error(new TestMediaException(true)));
+                                }))
+                .expectNextCount(1)
+                .expectError(TestMediaException.class)
+                .verify();
+
+        assertEquals(1, calls.get());
+        assertSame(current, state.getContext().get(0));
+        assertTrue(hasUrlMedia(state.getContext().get(0)));
+    }
+
+    @Test
+    void retryFailureDoesNotCommitHistoricalSanitization() {
+        HistoricalMediaRecoveryMiddleware middleware = middleware();
+        Msg history = imageMessage("history", "https://example.invalid/history.png");
+        Msg current = imageMessage("current", "https://example.invalid/current.png");
+        AgentState state = AgentState.builder().addMessage(history).addMessage(current).build();
+        RuntimeContext ctx = context("session", state);
+        AtomicInteger calls = new AtomicInteger();
+        TestMediaException retryError = new TestMediaException(true);
+
+        StepVerifier.create(
+                        invoke(
+                                middleware,
+                                ctx,
+                                List.of(current),
+                                new ReasoningInput(List.of(history, current), List.of(), null),
+                                input -> {
+                                    int call = calls.incrementAndGet();
+                                    return Flux.concat(
+                                            Flux.just(new ModelCallStartEvent("call-" + call)),
+                                            Flux.error(
+                                                    call == 1
+                                                            ? new TestMediaException(true)
+                                                            : retryError));
+                                }))
+                .expectNextCount(1)
+                .expectErrorMatches(error -> error == retryError)
+                .verify();
+
+        assertEquals(2, calls.get());
+        assertSame(history, state.getContext().get(0));
+        assertTrue(hasUrlMedia(state.getContext().get(0)));
+        assertSame(current, state.getContext().get(1));
+    }
+
+    @Test
+    void outputBeforeFailurePreventsRetry() {
+        HistoricalMediaRecoveryMiddleware middleware = middleware();
+        Msg history = imageMessage("history", "https://example.invalid/history.png");
+        Msg current = textMessage("current", "continue");
+        AgentState state = AgentState.builder().addMessage(history).addMessage(current).build();
+        RuntimeContext ctx = context("session", state);
+        AtomicInteger calls = new AtomicInteger();
+
+        StepVerifier.create(
+                        invoke(
+                                middleware,
+                                ctx,
+                                List.of(current),
+                                new ReasoningInput(List.of(history, current), List.of(), null),
+                                input -> {
+                                    calls.incrementAndGet();
+                                    return Flux.concat(
+                                            Flux.just(
+                                                    new ModelCallStartEvent("first"),
+                                                    new TextBlockDeltaEvent(
+                                                            "first", "text", "partial")),
+                                            Flux.error(new TestMediaException(true)));
+                                }))
+                .expectNextCount(2)
+                .expectError(TestMediaException.class)
+                .verify();
+
+        assertEquals(1, calls.get());
+        assertSame(history, state.getContext().get(0));
+    }
+
+    @Test
+    void unrelatedErrorIsNotRetried() {
+        HistoricalMediaRecoveryMiddleware middleware = middleware();
+        Msg history = imageMessage("history", "https://example.invalid/history.png");
+        Msg current = textMessage("current", "continue");
+        AgentState state = AgentState.builder().addMessage(history).addMessage(current).build();
+        RuntimeContext ctx = context("session", state);
+        AtomicInteger calls = new AtomicInteger();
+
+        StepVerifier.create(
+                        invoke(
+                                middleware,
+                                ctx,
+                                List.of(current),
+                                new ReasoningInput(List.of(history, current), List.of(), null),
+                                input -> {
+                                    calls.incrementAndGet();
+                                    return Flux.error(new IllegalArgumentException("bad request"));
+                                }))
+                .expectError(IllegalArgumentException.class)
+                .verify();
+
+        assertEquals(1, calls.get());
+        assertSame(history, state.getContext().get(0));
+    }
+
+    @Test
+    void recoversAfterCompactionFailureFallsBackToOriginalReasoning() {
+        HistoricalMediaRecoveryMiddleware recovery = middleware();
+        CompactionMiddleware compaction =
+                new CompactionMiddleware(
+                        null,
+                        new SynchronousFailingModel(),
+                        CompactionConfig.builder()
+                                .triggerTokens(1)
+                                .keepTokens(1)
+                                .flushBeforeCompact(false)
+                                .offloadBeforeCompact(false)
+                                .prune(null)
+                                .build());
+        ReActAgent agent =
+                ReActAgent.builder()
+                        .name("test-agent")
+                        .model(new SynchronousFailingModel())
+                        .build();
+        Msg history = imageMessage("history", "https://example.invalid/history.png");
+        Msg current = textMessage("current", "continue");
+        AgentState state = AgentState.builder().addMessage(history).addMessage(current).build();
+        RuntimeContext ctx = context("session", state);
+        ReasoningInput input = new ReasoningInput(List.of(history, current), List.of(), null);
+        AtomicInteger reasoningCalls = new AtomicInteger();
+
+        List<AgentEvent> events =
+                recovery.onAgent(
+                                agent,
+                                ctx,
+                                new AgentInput(List.of(current)),
+                                ignored ->
+                                        recovery.onReasoning(
+                                                agent,
+                                                ctx,
+                                                input,
+                                                compactInput ->
+                                                        compaction.onReasoning(
+                                                                agent,
+                                                                ctx,
+                                                                compactInput,
+                                                                reasoningInput -> {
+                                                                    if (reasoningCalls
+                                                                                    .incrementAndGet()
+                                                                            == 1) {
+                                                                        return Flux.error(
+                                                                                new TestMediaException(
+                                                                                        true));
+                                                                    }
+                                                                    return Flux.empty();
+                                                                })))
+                        .collectList()
+                        .block();
+
+        assertTrue(events.isEmpty());
+        assertEquals(2, reasoningCalls.get());
+        assertFalse(hasUrlMedia(state.getContext().get(0)));
+        assertSame(current, state.getContext().get(1));
+    }
+
+    @Test
+    void concurrentSessionsKeepCurrentInputMarkersIsolated() {
+        HistoricalMediaRecoveryMiddleware middleware = middleware();
+        RecoveryCall first = recoveryCall("a");
+        RecoveryCall second = recoveryCall("b");
+
+        Flux.merge(
+                        first.invoke(middleware).subscribeOn(Schedulers.parallel()),
+                        second.invoke(middleware).subscribeOn(Schedulers.parallel()))
+                .collectList()
+                .block();
+
+        assertEquals(2, first.calls().get());
+        assertEquals(2, second.calls().get());
+        assertFalse(hasUrlMedia(first.state().getContext().get(0)));
+        assertSame(first.current(), first.state().getContext().get(1));
+        assertFalse(hasUrlMedia(second.state().getContext().get(0)));
+        assertSame(second.current(), second.state().getContext().get(1));
+    }
+
+    @Test
+    void configRejectsBlankReplacementText() {
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> HistoricalMediaRecoveryConfig.builder().replacementText("  ").build());
+        assertEquals(
+                HistoricalMediaRecoveryConfig.DEFAULT_REPLACEMENT_TEXT,
+                HistoricalMediaRecoveryConfig.defaults().getReplacementText());
+    }
+
+    private HistoricalMediaRecoveryMiddleware middleware() {
+        return new HistoricalMediaRecoveryMiddleware(
+                HistoricalMediaRecoveryConfig.builder().replacementText(PLACEHOLDER).build());
+    }
+
+    private Flux<AgentEvent> invoke(
+            HistoricalMediaRecoveryMiddleware middleware,
+            RuntimeContext ctx,
+            List<Msg> currentMessages,
+            ReasoningInput reasoningInput,
+            Function<ReasoningInput, Flux<AgentEvent>> next) {
+        Agent agent = agent();
+        return middleware.onAgent(
+                agent,
+                ctx,
+                new AgentInput(currentMessages),
+                ignored -> middleware.onReasoning(agent, ctx, reasoningInput, next));
+    }
+
+    private RecoveryCall recoveryCall(String suffix) {
+        Msg history =
+                imageMessage(
+                        "history-" + suffix, "https://example.invalid/history-" + suffix + ".png");
+        Msg current = textMessage("current-" + suffix, "continue " + suffix);
+        AgentState state = AgentState.builder().addMessage(history).addMessage(current).build();
+        RuntimeContext ctx = context("session-" + suffix, state);
+        AtomicInteger calls = new AtomicInteger();
+        return new RecoveryCall(history, current, state, ctx, calls);
+    }
+
+    private Msg mixedHistoricalMedia(String id) {
+        return Msg.builder()
+                .id(id)
+                .role(MsgRole.USER)
+                .content(
+                        List.of(
+                                TextBlock.builder().text("keep text").build(),
+                                ImageBlock.builder()
+                                        .source(new URLSource("https://example.invalid/image.png"))
+                                        .build(),
+                                AudioBlock.builder()
+                                        .source(new URLSource("https://example.invalid/audio.mp3"))
+                                        .build(),
+                                VideoBlock.builder()
+                                        .source(new URLSource("https://example.invalid/video.mp4"))
+                                        .build(),
+                                DataBlock.builder()
+                                        .id("data")
+                                        .name("file.pdf")
+                                        .source(new URLSource("https://example.invalid/file.pdf"))
+                                        .build(),
+                                ImageBlock.builder()
+                                        .source(new Base64Source("image/png", "aGVsbG8="))
+                                        .build()))
+                .metadata(Map.of("marker", "preserve"))
+                .build();
+    }
+
+    private Msg toolHistory(String id) {
+        ToolResultBlock result =
+                new ToolResultBlock(
+                        "call-1",
+                        "download",
+                        List.of(
+                                TextBlock.builder().text("keep tool text").build(),
+                                DataBlock.builder()
+                                        .id("tool-data")
+                                        .source(new URLSource("https://example.invalid/tool.bin"))
+                                        .build()),
+                        Map.of("marker", "preserve"),
+                        ToolResultState.SUCCESS);
+        return Msg.builder().id(id).role(MsgRole.TOOL).content(result).build();
+    }
+
+    private Msg imageMessage(String id, String url) {
+        return Msg.builder()
+                .id(id)
+                .role(MsgRole.USER)
+                .content(ImageBlock.builder().source(new URLSource(url)).build())
+                .build();
+    }
+
+    private Msg textMessage(String id, String text) {
+        return Msg.builder().id(id).role(MsgRole.USER).textContent(text).build();
+    }
+
+    private RuntimeContext context(String sessionId, AgentState state) {
+        return RuntimeContext.builder().sessionId(sessionId).agentState(state).build();
+    }
+
+    private Agent agent() {
+        return new AgentBase("test-agent") {
+            @Override
+            protected Mono<Msg> doCall(List<Msg> msgs) {
+                return Mono.empty();
+            }
+
+            @Override
+            protected Mono<Msg> handleInterrupt(InterruptContext context, Msg... originalArgs) {
+                return Mono.empty();
+            }
+        };
+    }
+
+    private int countTopLevelPlaceholders(Msg message) {
+        return (int)
+                message.getContent().stream()
+                        .filter(
+                                block ->
+                                        block instanceof TextBlock text
+                                                && PLACEHOLDER.equals(text.getText()))
+                        .count();
+    }
+
+    private boolean hasUrlMedia(Msg message) {
+        return hasUrlMedia(message.getContent());
+    }
+
+    private boolean hasUrlMedia(List<ContentBlock> blocks) {
+        for (ContentBlock block : blocks) {
+            if (block instanceof ImageBlock image && image.getSource() instanceof URLSource
+                    || block instanceof AudioBlock audio && audio.getSource() instanceof URLSource
+                    || block instanceof VideoBlock video && video.getSource() instanceof URLSource
+                    || block instanceof DataBlock data && data.getSource() instanceof URLSource) {
+                return true;
+            }
+            if (block instanceof ToolResultBlock toolResult
+                    && hasUrlMedia(toolResult.getOutput())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private record RecoveryCall(
+            Msg history,
+            Msg current,
+            AgentState state,
+            RuntimeContext context,
+            AtomicInteger calls) {
+
+        private Flux<AgentEvent> invoke(HistoricalMediaRecoveryMiddleware middleware) {
+            Agent testAgent =
+                    new AgentBase("test-agent-" + current.getId()) {
+                        @Override
+                        protected Mono<Msg> doCall(List<Msg> msgs) {
+                            return Mono.empty();
+                        }
+
+                        @Override
+                        protected Mono<Msg> handleInterrupt(
+                                InterruptContext interruptContext, Msg... originalArgs) {
+                            return Mono.empty();
+                        }
+                    };
+            ReasoningInput input = new ReasoningInput(List.of(history, current), List.of(), null);
+            return middleware.onAgent(
+                    testAgent,
+                    context,
+                    new AgentInput(List.of(current)),
+                    ignored ->
+                            middleware.onReasoning(
+                                    testAgent,
+                                    context,
+                                    input,
+                                    reasoning -> {
+                                        if (calls.incrementAndGet() == 1) {
+                                            return Flux.error(new TestMediaException(true));
+                                        }
+                                        return Flux.empty();
+                                    }));
+        }
+    }
+
+    private static final class TestMediaException extends RuntimeException
+            implements ModelMediaException {
+
+        private final boolean mediaUnavailable;
+
+        private TestMediaException(boolean mediaUnavailable) {
+            super("media unavailable");
+            this.mediaUnavailable = mediaUnavailable;
+        }
+
+        @Override
+        public boolean isMediaUnavailable() {
+            return mediaUnavailable;
+        }
+    }
+
+    private static final class SynchronousFailingModel extends ChatModelBase {
+
+        @Override
+        public String getModelName() {
+            return "failing-compaction-model";
+        }
+
+        @Override
+        protected Flux<ChatResponse> doStream(
+                List<Msg> messages, List<ToolSchema> tools, GenerateOptions options) {
+            throw new IllegalStateException("compaction unavailable");
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- add a provider-neutral `ModelMediaException` contract and classify DashScope's unavailable multimodal URL failures from synchronous, streaming, and HTTP error responses
- enable historical media recovery by default for `HarnessAgent`, outside compaction, while leaving bare `ReActAgent` behavior unchanged
- replace URL-backed media in historical messages with a configurable text placeholder, retry reasoning once, and commit the repaired history only after a successful retry
- preserve current-turn media errors, Base64 content, message identity/metadata, nested tool-result structure, and the single visible model-call start event

## Behavior and limitations

- recovery only runs for classified media-unavailable errors and only before model output has been emitted
- because DashScope does not identify the failed URL, one recovery attempt removes all URL-backed media from historical messages in that request
- current-turn URL media is never removed; retry failure propagates without mutating persisted agent state
- this does not probe or refresh URLs, re-upload media, clean Base64 content, or address transcript/media persistence from #2701

## Testing

- `mvn -pl :agentscope-core,:agentscope-harness,:agentscope-extensions-model-dashscope -am test`
- `mvn spotless:check`
- `mvn test`
- `git diff --check`

All commands passed on JDK 17. The repository does not contain a Maven wrapper, so the equivalent system Maven commands were used.

Fixes #2700
