### PR TITLE
feat(example): add user binding preferences API

### DIFF
--- a/agentscope-examples/agents/agentscope-dataagent/src/main/java/io/agentscope/dataagent/web/api/ChatController.java
+++ b/agentscope-examples/agents/agentscope-dataagent/src/main/java/io/agentscope/dataagent/web/api/ChatController.java
@@ -25,6 +25,8 @@ import io.agentscope.dataagent.runtime.session.SessionEntry;
 import io.agentscope.dataagent.runtime.session.SessionKind;
 import io.agentscope.dataagent.web.audit.ActivityEvent;
 import io.agentscope.dataagent.web.audit.AgentActivityStore;
+import io.agentscope.dataagent.web.binding.UserBinding;
+import io.agentscope.dataagent.web.binding.UserBindingStore;
 import io.agentscope.dataagent.web.catalog.AgentCatalogService;
 import io.agentscope.dataagent.web.catalog.AgentDefinition;
 import io.agentscope.dataagent.web.identity.IdentityLinkStore;
@@ -37,6 +39,7 @@ import io.agentscope.harness.agent.gateway.channel.InboundMessage;
 import io.agentscope.harness.agent.gateway.channel.Peer;
 import io.agentscope.harness.agent.gateway.channel.chatui.ChatUiChannel;
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -87,6 +90,7 @@ public class ChatController {
     private final ToolEventBus toolEventBus;
     private final AgentAccessGuard guard;
     private final AgentActivityStore activity;
+    private final UserBindingStore userBindings;
 
     /**
      * AgentStateStore keys for which we have already recorded a RUN_SESSION event. Each (userId, agentId)
@@ -103,7 +107,8 @@ public class ChatController {
             UsageStore usageStore,
             ToolEventBus toolEventBus,
             AgentAccessGuard guard,
-            AgentActivityStore activity) {
+            AgentActivityStore activity,
+            UserBindingStore userBindings) {
         this.chatUiChannel = chatUiChannel;
         this.sessionAgentManager = builderBootstrap.gateway().sessionAgentManager();
         this.catalogService = catalogService;
@@ -112,6 +117,7 @@ public class ChatController {
         this.toolEventBus = toolEventBus;
         this.guard = guard;
         this.activity = activity;
+        this.userBindings = userBindings;
     }
 
     /**
@@ -486,6 +492,42 @@ public class ChatController {
     private record CommandResult(String message, String newSessionKey) {}
 
     /**
+     * Builds the inbound message list for a chat turn, applying stored {@link UserBinding}
+     * preferences that can be honoured at the dispatch entry point.
+     *
+     * <p>Currently only {@code language} is wired - it is injected as a {@link MsgRole#SYSTEM}
+     * instruction so the agent actually replies in the requested language. The remaining fields
+     * ({@code enabledSkills}, {@code sessionScope}) require deeper, architecturally-scoped hooks
+     * and are intentionally left as follow-ups:
+     *
+     * <ul>
+     *   <li>{@code enabledSkills} filters the skills loaded by the agent, which happens at agent
+     *       construction time (see {@code DataAgentBootstrap} / {@code SkillRepositorySupport}),
+     *       not at the dispatch entry point.
+     *   <li>{@code sessionScope} overrides per-session key derivation performed by the
+     *       {@code ChannelRouter}, which is outside this controller's responsibility.
+     * </ul>
+     */
+    static List<Msg> shapeInboundMessages(
+            List<UserBinding> preferences, String channelId, String message) {
+        UserBinding pref =
+                preferences.stream()
+                        .filter(b -> channelId.equals(b.channelId()))
+                        .findFirst()
+                        .orElse(null);
+        List<Msg> msgs = new ArrayList<>();
+        if (pref != null && pref.language() != null) {
+            msgs.add(
+                    Msg.builder()
+                            .role(MsgRole.SYSTEM)
+                            .textContent("Reply to the user in " + pref.language() + ".")
+                            .build());
+        }
+        msgs.add(Msg.builder().role(MsgRole.USER).textContent(message).build());
+        return msgs;
+    }
+
+    /**
      * Core dispatch logic. Always routes through {@link ChatUiChannel#dispatch} so that the
      * {@link io.agentscope.harness.agent.gateway.channel.ChannelRouter} runs uniformly — including for
      * the path-mapped Web UI calls. The URL-supplied {@code agentId} is passed as
@@ -498,18 +540,22 @@ public class ChatController {
      */
     private Mono<Msg> executeChat(
             String userId, String agentId, String message, String conversationId) {
-        Msg userMsg = Msg.builder().role(MsgRole.USER).textContent(message).build();
         long startMs = System.currentTimeMillis();
+
+        List<Msg> msgs =
+                shapeInboundMessages(userBindings.list(userId), ChatUiChannel.CHANNEL_ID, message);
 
         InboundMessage inbound;
         if (agentId == null || agentId.isBlank()) {
             // No agent override and no conversation scoping — pure binding-driven routing.
-            inbound = InboundMessage.dm(ChatUiChannel.CHANNEL_ID, userId, List.of(userMsg));
+            inbound = InboundMessage.dm(ChatUiChannel.CHANNEL_ID, userId, List.copyOf(msgs));
         } else {
             String gatewayAgentId = catalogService.resolveGatewayAgentId(userId, agentId);
             inbound =
                     InboundMessage.builder(
-                                    ChatUiChannel.CHANNEL_ID, Peer.direct(userId), List.of(userMsg))
+                                    ChatUiChannel.CHANNEL_ID,
+                                    Peer.direct(userId),
+                                    List.copyOf(msgs))
                             .preferredAgentId(gatewayAgentId)
                             .accountId(conversationId)
                             .build();

--- a/agentscope-examples/agents/agentscope-dataagent/src/main/java/io/agentscope/dataagent/web/api/UserBindingController.java
+++ b/agentscope-examples/agents/agentscope-dataagent/src/main/java/io/agentscope/dataagent/web/api/UserBindingController.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.dataagent.web.api;
+
+import io.agentscope.dataagent.web.binding.UserBinding;
+import io.agentscope.dataagent.web.binding.UserBindingStore;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
+
+/** CRUD API for channel preferences scoped to the authenticated user. */
+@RestController
+@RequestMapping("/api/user/bindings")
+public class UserBindingController {
+
+    private static final int MAX_ENABLED_SKILLS = 100;
+
+    private final UserBindingStore store;
+
+    public UserBindingController(UserBindingStore store) {
+        this.store = store;
+    }
+
+    @GetMapping
+    public Mono<List<UserBinding>> list(Authentication authentication) {
+        String userId = authentication.getName();
+        return Mono.fromCallable(() -> store.list(userId)).subscribeOn(Schedulers.boundedElastic());
+    }
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public Mono<UserBinding> add(@RequestBody UserBinding request, Authentication authentication) {
+        String userId = authentication.getName();
+        return Mono.fromCallable(() -> store.add(userId, normalize(request)))
+                .subscribeOn(Schedulers.boundedElastic());
+    }
+
+    @PutMapping("/{index}")
+    public Mono<UserBinding> update(
+            @PathVariable int index,
+            @RequestBody UserBinding request,
+            Authentication authentication) {
+        String userId = authentication.getName();
+        return Mono.fromCallable(
+                        () ->
+                                store.update(userId, index, normalize(request))
+                                        .orElseThrow(() -> bindingNotFound(index)))
+                .subscribeOn(Schedulers.boundedElastic());
+    }
+
+    @DeleteMapping("/{index}")
+    public Mono<RemoveResponse> remove(@PathVariable int index, Authentication authentication) {
+        String userId = authentication.getName();
+        return Mono.fromCallable(
+                        () -> {
+                            store.remove(userId, index).orElseThrow(() -> bindingNotFound(index));
+                            return new RemoveResponse(true);
+                        })
+                .subscribeOn(Schedulers.boundedElastic());
+    }
+
+    static UserBinding normalize(UserBinding request) {
+        if (request == null) {
+            throw badRequest("Request body is required");
+        }
+        String channelId = required(request.channelId(), "channelId", 128);
+        String displayLabel = optional(request.displayLabel(), "displayLabel", 255);
+        String sessionScope = optional(request.sessionScope(), "sessionScope", 128);
+        String language = optional(request.language(), "language", 35);
+        if (language != null && !isLanguageTag(language)) {
+            throw badRequest("language must be a valid BCP-47 language tag");
+        }
+        List<String> enabledSkills = normalizeSkills(request.enabledSkills());
+        return new UserBinding(channelId, displayLabel, sessionScope, language, enabledSkills);
+    }
+
+    private static List<String> normalizeSkills(List<String> skills) {
+        if (skills == null || skills.isEmpty()) {
+            return null;
+        }
+        Set<String> normalized = new LinkedHashSet<>();
+        for (String skill : skills) {
+            String value = optional(skill, "enabledSkills entry", 128);
+            if (value != null) {
+                normalized.add(value);
+            }
+        }
+        if (normalized.size() > MAX_ENABLED_SKILLS) {
+            throw badRequest(
+                    "enabledSkills must contain at most " + MAX_ENABLED_SKILLS + " entries");
+        }
+        return normalized.isEmpty() ? null : new ArrayList<>(normalized);
+    }
+
+    private static boolean isLanguageTag(String language) {
+        Locale locale = Locale.forLanguageTag(language);
+        return !locale.getLanguage().isBlank() && !"und".equals(locale.toLanguageTag());
+    }
+
+    private static String required(String value, String field, int maxLength) {
+        String normalized = optional(value, field, maxLength);
+        if (normalized == null) {
+            throw badRequest(field + " must not be blank");
+        }
+        return normalized;
+    }
+
+    private static String optional(String value, String field, int maxLength) {
+        if (value == null || value.isBlank()) {
+            return null;
+        }
+        String normalized = value.trim();
+        if (normalized.length() > maxLength) {
+            throw badRequest(field + " must not exceed " + maxLength + " characters");
+        }
+        return normalized;
+    }
+
+    private static ResponseStatusException bindingNotFound(int index) {
+        return new ResponseStatusException(
+                HttpStatus.NOT_FOUND, "User binding index out of range: " + index);
+    }
+
+    private static ResponseStatusException badRequest(String reason) {
+        return new ResponseStatusException(HttpStatus.BAD_REQUEST, reason);
+    }
+
+    public record RemoveResponse(boolean removed) {}
+}

--- a/agentscope-examples/agents/agentscope-dataagent/src/main/java/io/agentscope/dataagent/web/binding/UserBinding.java
+++ b/agentscope-examples/agents/agentscope-dataagent/src/main/java/io/agentscope/dataagent/web/binding/UserBinding.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.dataagent.web.binding;
+
+import java.util.List;
+
+/** User-scoped preferences applied when interacting through a channel. */
+public record UserBinding(
+        String channelId,
+        String displayLabel,
+        String sessionScope,
+        String language,
+        List<String> enabledSkills) {
+
+    public UserBinding {
+        enabledSkills = enabledSkills != null ? List.copyOf(enabledSkills) : null;
+    }
+}

--- a/agentscope-examples/agents/agentscope-dataagent/src/main/java/io/agentscope/dataagent/web/binding/UserBindingStore.java
+++ b/agentscope-examples/agents/agentscope-dataagent/src/main/java/io/agentscope/dataagent/web/binding/UserBindingStore.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.dataagent.web.binding;
+
+import java.util.List;
+import java.util.Optional;
+
+/** Durable storage for ordered channel preferences belonging to one user. */
+public interface UserBindingStore {
+
+    List<UserBinding> list(String userId);
+
+    UserBinding add(String userId, UserBinding binding);
+
+    Optional<UserBinding> update(String userId, int index, UserBinding binding);
+
+    Optional<UserBinding> remove(String userId, int index);
+}

--- a/agentscope-examples/agents/agentscope-dataagent/src/main/java/io/agentscope/dataagent/web/persistence/jpa/JpaPersistenceConfig.java
+++ b/agentscope-examples/agents/agentscope-dataagent/src/main/java/io/agentscope/dataagent/web/persistence/jpa/JpaPersistenceConfig.java
@@ -15,7 +15,9 @@
  */
 package io.agentscope.dataagent.web.persistence.jpa;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.agentscope.dataagent.web.auth.UserStore;
+import io.agentscope.dataagent.web.binding.UserBindingStore;
 import io.agentscope.dataagent.web.catalog.UserAgentDefinitionStore;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -68,6 +70,13 @@ public class JpaPersistenceConfig {
     public UserStore jpaUserStore(UserEntityRepository repository) {
         log.info("Persistence: user store backed by JPA");
         return new JpaUserStore(repository);
+    }
+
+    @Bean
+    public UserBindingStore jpaUserBindingStore(
+            UserEntityRepository repository, ObjectMapper objectMapper) {
+        log.info("Persistence: user binding store backed by JPA");
+        return new JpaUserBindingStore(repository, objectMapper);
     }
 
     @Bean

--- a/agentscope-examples/agents/agentscope-dataagent/src/main/java/io/agentscope/dataagent/web/persistence/jpa/JpaUserBindingStore.java
+++ b/agentscope-examples/agents/agentscope-dataagent/src/main/java/io/agentscope/dataagent/web/persistence/jpa/JpaUserBindingStore.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.dataagent.web.persistence.jpa;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.agentscope.dataagent.web.binding.UserBinding;
+import io.agentscope.dataagent.web.binding.UserBindingStore;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.transaction.annotation.Transactional;
+
+/** JPA-backed {@link UserBindingStore} persisted on the owning user row. */
+@Transactional
+public class JpaUserBindingStore implements UserBindingStore {
+
+    private static final TypeReference<List<UserBinding>> BINDING_LIST_TYPE =
+            new TypeReference<>() {};
+
+    private final UserEntityRepository repository;
+    private final ObjectMapper objectMapper;
+
+    public JpaUserBindingStore(UserEntityRepository repository, ObjectMapper objectMapper) {
+        this.repository = repository;
+        this.objectMapper = objectMapper;
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<UserBinding> list(String userId) {
+        return repository
+                .findById(userId)
+                .map(UserEntity::getBindingsJson)
+                .map(this::deserialize)
+                .orElseGet(List::of);
+    }
+
+    @Override
+    public UserBinding add(String userId, UserBinding binding) {
+        UserEntity user = requireUserForUpdate(userId);
+        List<UserBinding> bindings = mutableBindings(user);
+        bindings.add(binding);
+        persist(user, bindings);
+        return binding;
+    }
+
+    @Override
+    public Optional<UserBinding> update(String userId, int index, UserBinding binding) {
+        UserEntity user = requireUserForUpdate(userId);
+        List<UserBinding> bindings = mutableBindings(user);
+        if (index < 0 || index >= bindings.size()) {
+            return Optional.empty();
+        }
+        bindings.set(index, binding);
+        persist(user, bindings);
+        return Optional.of(binding);
+    }
+
+    @Override
+    public Optional<UserBinding> remove(String userId, int index) {
+        UserEntity user = requireUserForUpdate(userId);
+        List<UserBinding> bindings = mutableBindings(user);
+        if (index < 0 || index >= bindings.size()) {
+            return Optional.empty();
+        }
+        UserBinding removed = bindings.remove(index);
+        persist(user, bindings);
+        return Optional.of(removed);
+    }
+
+    private UserEntity requireUserForUpdate(String userId) {
+        return repository
+                .findByIdForUpdate(userId)
+                .orElseThrow(
+                        () -> new IllegalStateException("Authenticated user not found: " + userId));
+    }
+
+    private List<UserBinding> mutableBindings(UserEntity user) {
+        return new ArrayList<>(deserialize(user.getBindingsJson()));
+    }
+
+    private List<UserBinding> deserialize(String json) {
+        if (json == null || json.isBlank()) {
+            return List.of();
+        }
+        try {
+            List<UserBinding> bindings = objectMapper.readValue(json, BINDING_LIST_TYPE);
+            return bindings != null ? List.copyOf(bindings) : List.of();
+        } catch (JsonProcessingException e) {
+            throw new IllegalStateException("Failed to deserialize user channel preferences", e);
+        }
+    }
+
+    private void persist(UserEntity user, List<UserBinding> bindings) {
+        try {
+            user.setBindingsJson(objectMapper.writeValueAsString(bindings));
+            repository.save(user);
+        } catch (JsonProcessingException e) {
+            throw new IllegalStateException("Failed to serialize user channel preferences", e);
+        }
+    }
+}

--- a/agentscope-examples/agents/agentscope-dataagent/src/main/java/io/agentscope/dataagent/web/persistence/jpa/UserEntity.java
+++ b/agentscope-examples/agents/agentscope-dataagent/src/main/java/io/agentscope/dataagent/web/persistence/jpa/UserEntity.java
@@ -19,6 +19,7 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.Index;
+import jakarta.persistence.Lob;
 import jakarta.persistence.Table;
 import java.time.Instant;
 
@@ -58,6 +59,10 @@ public class UserEntity {
 
     @Column(name = "created_at")
     private Instant createdAt = Instant.now();
+
+    @Lob
+    @Column(name = "bindings_json")
+    private String bindingsJson;
 
     public UserEntity() {}
 
@@ -106,5 +111,13 @@ public class UserEntity {
 
     public void setCreatedAt(Instant createdAt) {
         this.createdAt = createdAt;
+    }
+
+    public String getBindingsJson() {
+        return bindingsJson;
+    }
+
+    public void setBindingsJson(String bindingsJson) {
+        this.bindingsJson = bindingsJson;
     }
 }

--- a/agentscope-examples/agents/agentscope-dataagent/src/main/java/io/agentscope/dataagent/web/persistence/jpa/UserEntityRepository.java
+++ b/agentscope-examples/agents/agentscope-dataagent/src/main/java/io/agentscope/dataagent/web/persistence/jpa/UserEntityRepository.java
@@ -15,13 +15,21 @@
  */
 package io.agentscope.dataagent.web.persistence.jpa;
 
+import jakarta.persistence.LockModeType;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 /** Spring Data repository for {@link UserEntity}. */
 public interface UserEntityRepository extends JpaRepository<UserEntity, String> {
 
     Optional<UserEntity> findByUsernameIgnoreCase(String username);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("select u from UserEntity u where u.userId = :userId")
+    Optional<UserEntity> findByIdForUpdate(@Param("userId") String userId);
 
     boolean existsByUsernameIgnoreCase(String username);
 }

--- a/agentscope-examples/agents/agentscope-dataagent/src/test/java/io/agentscope/dataagent/web/api/ChatControllerLanguagePreferenceTest.java
+++ b/agentscope-examples/agents/agentscope-dataagent/src/test/java/io/agentscope/dataagent/web/api/ChatControllerLanguagePreferenceTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.dataagent.web.api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.agentscope.core.message.Msg;
+import io.agentscope.core.message.MsgRole;
+import io.agentscope.dataagent.web.binding.UserBinding;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies {@link ChatController} applies stored user preferences when shaping inbound messages.
+ */
+class ChatControllerLanguagePreferenceTest {
+
+    @Test
+    void injectsLanguageSystemInstructionWhenChatuiPreferenceExists() {
+        UserBinding pref = new UserBinding("chatui", null, null, "zh-CN", null);
+        List<Msg> msgs = ChatController.shapeInboundMessages(List.of(pref), "chatui", "hello");
+        assertThat(msgs).hasSize(2);
+        assertThat(msgs.get(0).getRole()).isEqualTo(MsgRole.SYSTEM);
+        assertThat(msgs.get(0).getTextContent()).contains("zh-CN");
+        assertThat(msgs.get(1).getRole()).isEqualTo(MsgRole.USER);
+    }
+
+    @Test
+    void omitsSystemInstructionWhenNoPreference() {
+        List<Msg> msgs = ChatController.shapeInboundMessages(List.of(), "chatui", "hello");
+        assertThat(msgs).hasSize(1);
+        assertThat(msgs.get(0).getRole()).isEqualTo(MsgRole.USER);
+    }
+
+    @Test
+    void ignoresPreferenceForOtherChannel() {
+        UserBinding pref = new UserBinding("slack", null, null, "en", null);
+        List<Msg> msgs = ChatController.shapeInboundMessages(List.of(pref), "chatui", "hello");
+        assertThat(msgs).hasSize(1);
+        assertThat(msgs.get(0).getRole()).isEqualTo(MsgRole.USER);
+    }
+
+    @Test
+    void omitsSystemInstructionWhenLanguageBlank() {
+        UserBinding pref = new UserBinding("chatui", null, null, null, null);
+        List<Msg> msgs = ChatController.shapeInboundMessages(List.of(pref), "chatui", "hello");
+        assertThat(msgs).hasSize(1);
+        assertThat(msgs.get(0).getRole()).isEqualTo(MsgRole.USER);
+    }
+}

--- a/agentscope-examples/agents/agentscope-dataagent/src/test/java/io/agentscope/dataagent/web/api/UserBindingControllerTest.java
+++ b/agentscope-examples/agents/agentscope-dataagent/src/test/java/io/agentscope/dataagent/web/api/UserBindingControllerTest.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.dataagent.web.api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.agentscope.dataagent.web.binding.UserBinding;
+import io.agentscope.dataagent.web.binding.UserBindingStore;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.authentication.TestingAuthenticationToken;
+import org.springframework.web.server.ResponseStatusException;
+import reactor.test.StepVerifier;
+
+class UserBindingControllerTest {
+
+    private final InMemoryStore store = new InMemoryStore();
+    private final UserBindingController controller = new UserBindingController(store);
+
+    @Test
+    void supportsUserScopedCrudWithFrontendContract() {
+        TestingAuthenticationToken alice = new TestingAuthenticationToken("alice", "n/a");
+        UserBinding request =
+                new UserBinding(
+                        " chatui ",
+                        " My default session ",
+                        " MAIN ",
+                        "zh-CN",
+                        List.of("sql-analysis", "chart-rendering", "sql-analysis"));
+
+        UserBinding created = controller.add(request, alice).block();
+
+        assertThat(created.channelId()).isEqualTo("chatui");
+        assertThat(created.displayLabel()).isEqualTo("My default session");
+        assertThat(created.enabledSkills()).containsExactly("sql-analysis", "chart-rendering");
+        assertThat(controller.list(alice).block()).containsExactly(created);
+        assertThat(controller.list(new TestingAuthenticationToken("bob", "n/a")).block()).isEmpty();
+
+        UserBinding replacement =
+                new UserBinding("slack", null, null, "en", List.of("sql-analysis"));
+        assertThat(controller.update(0, replacement, alice).block()).isEqualTo(replacement);
+        assertThat(controller.remove(0, alice).block().removed()).isTrue();
+        assertThat(controller.list(alice).block()).isEmpty();
+    }
+
+    @Test
+    void rejectsInvalidInputAndMissingIndexes() {
+        TestingAuthenticationToken alice = new TestingAuthenticationToken("alice", "n/a");
+
+        StepVerifier.create(controller.add(new UserBinding(" ", null, null, null, null), alice))
+                .expectErrorSatisfies(
+                        error -> {
+                            assertThat(error).isInstanceOf(ResponseStatusException.class);
+                            assertThat(((ResponseStatusException) error).getStatusCode())
+                                    .isEqualTo(HttpStatus.BAD_REQUEST);
+                        })
+                .verify();
+
+        StepVerifier.create(controller.remove(0, alice))
+                .expectErrorSatisfies(
+                        error -> {
+                            assertThat(error).isInstanceOf(ResponseStatusException.class);
+                            assertThat(((ResponseStatusException) error).getStatusCode())
+                                    .isEqualTo(HttpStatus.NOT_FOUND);
+                        })
+                .verify();
+    }
+
+    private static final class InMemoryStore implements UserBindingStore {
+
+        private final Map<String, List<UserBinding>> bindingsByUser = new LinkedHashMap<>();
+
+        @Override
+        public synchronized List<UserBinding> list(String userId) {
+            return List.copyOf(bindingsByUser.getOrDefault(userId, List.of()));
+        }
+
+        @Override
+        public synchronized UserBinding add(String userId, UserBinding binding) {
+            bindingsByUser.computeIfAbsent(userId, ignored -> new ArrayList<>()).add(binding);
+            return binding;
+        }
+
+        @Override
+        public synchronized Optional<UserBinding> update(
+                String userId, int index, UserBinding binding) {
+            List<UserBinding> bindings = bindingsByUser.get(userId);
+            if (bindings == null || index < 0 || index >= bindings.size()) {
+                return Optional.empty();
+            }
+            bindings.set(index, binding);
+            return Optional.of(binding);
+        }
+
+        @Override
+        public synchronized Optional<UserBinding> remove(String userId, int index) {
+            List<UserBinding> bindings = bindingsByUser.get(userId);
+            if (bindings == null || index < 0 || index >= bindings.size()) {
+                return Optional.empty();
+            }
+            return Optional.of(bindings.remove(index));
+        }
+    }
+}

--- a/agentscope-examples/agents/agentscope-dataagent/src/test/java/io/agentscope/dataagent/web/persistence/jpa/JpaUserBindingStoreTest.java
+++ b/agentscope-examples/agents/agentscope-dataagent/src/test/java/io/agentscope/dataagent/web/persistence/jpa/JpaUserBindingStoreTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.dataagent.web.persistence.jpa;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.agentscope.dataagent.web.binding.UserBinding;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
+
+@DataJpaTest
+class JpaUserBindingStoreTest {
+
+    @Autowired private UserEntityRepository repository;
+
+    private JpaUserBindingStore store;
+
+    @BeforeEach
+    void setUp() {
+        repository.save(new UserEntity("alice", "alice", "hash", "user"));
+        store = new JpaUserBindingStore(repository, new ObjectMapper());
+    }
+
+    @Test
+    void persistsOrderedBindingsOnUserRow() {
+        UserBinding first = new UserBinding("chatui", "Main", "MAIN", "zh-CN", null);
+        UserBinding second = new UserBinding("slack", "Slack", null, "en", List.of("sql-analysis"));
+
+        store.add("alice", first);
+        store.add("alice", second);
+
+        assertThat(store.list("alice")).containsExactly(first, second);
+        assertThat(store.update("alice", 0, second)).contains(second);
+        assertThat(store.remove("alice", 1)).contains(second);
+        assertThat(store.list("alice")).containsExactly(second);
+        assertThat(repository.findById("alice").orElseThrow().getBindingsJson()).isNotBlank();
+    }
+}


### PR DESCRIPTION
## AgentScope-Java Version

`2.0.3-SNAPSHOT`

## Description


### Background

The DataAgent frontend `/bindings` page requests `/api/user/bindings`, but the backend did not provide this API, causing the request to return `404 Not Found`.

### Purpose

Add authenticated user-binding preference APIs and persist each user's binding configuration.

### Changes

- Added authenticated user-binding CRUD APIs:
  - `GET /api/user/bindings`
  - `POST /api/user/bindings`
  - `PUT /api/user/bindings/{index}`
  - `DELETE /api/user/bindings/{index}`
- Added the `UserBinding` model with the following fields:
  - `channelId`
  - `displayLabel`
  - `sessionScope`
  - `language`
  - `enabledSkills`
- Added `UserBindingStore` and its JPA implementation.




## Checklist

Please check the following items before code is ready to be reviewed.

- [ x]  Code has been formatted with `mvn spotless:apply`
- [x]  All tests are passing (`mvn test`)
- [ ]  Javadoc comments are complete and follow project conventions
- [ ]  Related documentation has been updated (e.g. links, examples, etc.)
- [x]  Code is ready for review
