### PR TITLE
fix(core): 异常终止时保存 ReActAgent 状态

### DIFF
--- a/agentscope-core/src/main/java/io/agentscope/core/ReActAgent.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/ReActAgent.java
@@ -486,24 +486,49 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
         if (stateStore == null) {
             return Mono.empty();
         }
+        return Mono.<Void>fromRunnable(() -> persistState(scope))
+                .subscribeOn(Schedulers.boundedElastic());
+    }
+
+    private void persistState(CallExecution scope) {
         syncToolkitToState(scope.state);
         SlotRef ref = SlotRef.parse(scope.slotKey);
-        AgentState toSave = scope.state;
-        return Mono.<Void>fromRunnable(
-                        () -> {
-                            long newVersion =
-                                    persistAgentStateCas(
-                                            ref.userId,
-                                            ref.sessionId,
-                                            scope.slotKey,
-                                            toSave,
-                                            scope.loadedVersion,
-                                            scope.loadedContextSize);
-                            if (newVersion != AgentStateStore.UNVERSIONED) {
-                                scope.loadedVersion = newVersion;
-                            }
-                        })
-                .subscribeOn(Schedulers.boundedElastic());
+        long newVersion =
+                persistAgentStateCas(
+                        ref.userId,
+                        ref.sessionId,
+                        scope.slotKey,
+                        scope.state,
+                        scope.loadedVersion,
+                        scope.loadedContextSize);
+        if (newVersion != AgentStateStore.UNVERSIONED) {
+            scope.loadedVersion = newVersion;
+        }
+    }
+
+    private void repairStateBeforeAbnormalCheckpoint(CallExecution scope) {
+        try {
+            scope.dropUncommittedToolCallsFromCurrentCall();
+        } catch (RuntimeException repairError) {
+            log.warn("Failed to repair agent state before checkpoint", repairError);
+        }
+    }
+
+    private void checkpointStateAfterCancellation(CallExecution scope) {
+        repairStateBeforeAbnormalCheckpoint(scope);
+        try {
+            if (stateStore != null) {
+                persistState(scope);
+            }
+        } catch (RuntimeException saveError) {
+            log.warn("Failed to save agent state after abnormal termination", saveError);
+        }
+    }
+
+    private <T> Mono<T> checkpointOnAbnormalTermination(CallExecution scope, Mono<T> execution) {
+        return execution
+                .doOnCancel(() -> checkpointStateAfterCancellation(scope))
+                .onErrorResume(error -> saveStateAfterCallFailure(scope, error));
     }
 
     /**
@@ -522,6 +547,7 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
         if (ExceptionUtils.containsInterruptedException(callFailure)) {
             return Mono.error(callFailure);
         }
+        repairStateBeforeAbnormalCheckpoint(scope);
         return saveStateToSession(scope)
                 .onErrorResume(
                         saveFailure -> {
@@ -1223,8 +1249,7 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
                         AgentEventEmitter.fromForwardingContext(cv)
                                 .ifPresent(ae -> scope.externalEventEmitter = ae);
                     }
-                    return scope.doCallInner(msgs)
-                            .onErrorResume(error -> saveStateAfterCallFailure(scope, error))
+                    return checkpointOnAbnormalTermination(scope, scope.doCallInner(msgs))
                             .flatMap(result -> saveStateToSession(scope).thenReturn(result));
                 });
     }
@@ -1265,20 +1290,25 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
                 hasTools
                         ? model.supportsNativeStructuredOutputWithTools()
                         : model.supportsNativeStructuredOutput();
+        Mono<Msg> execution;
         if (useNative) {
-            return doNativeStructuredCall(msgs, jsonSchema)
-                    .onErrorResume(
-                            e -> {
-                                log.warn(
-                                        "Native structured output failed ({}) — falling back to"
-                                                + " synthetic tool path",
-                                        e.getMessage() != null
-                                                ? e.getMessage()
-                                                : e.getClass().getSimpleName());
-                                return doFallbackStructuredCall(msgs, jsonSchema);
-                            });
+            execution =
+                    doNativeStructuredCall(msgs, jsonSchema)
+                            .onErrorResume(
+                                    e -> {
+                                        log.warn(
+                                                "Native structured output failed ({}) — falling"
+                                                        + " back to synthetic tool path",
+                                                e.getMessage() != null
+                                                        ? e.getMessage()
+                                                        : e.getClass().getSimpleName());
+                                        return doFallbackStructuredCall(msgs, jsonSchema);
+                                    });
+        } else {
+            execution = doFallbackStructuredCall(msgs, jsonSchema);
         }
-        return doFallbackStructuredCall(msgs, jsonSchema);
+        return Mono.deferContextual(
+                cv -> checkpointOnAbnormalTermination(scopeFrom(cv), execution));
     }
 
     /**
@@ -1359,7 +1389,6 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
                     scope.soTool = createStructuredOutputTool(jsonSchema);
 
                     return scope.doCallInner(msgs)
-                            .onErrorResume(error -> saveStateAfterCallFailure(scope, error))
                             .flatMap(
                                     result -> {
                                         Msg out = result;
@@ -2121,6 +2150,40 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
                         "Synthesized interrupted-result for pending tool call: {} ({})",
                         toolCall.getName(),
                         toolCall.getId());
+            }
+        }
+
+        /** Remove current-call PENDING tool calls that never produced results. */
+        private void dropUncommittedToolCallsFromCurrentCall() {
+            Set<String> pendingIds = getPendingToolUseIds();
+            if (pendingIds.isEmpty()) {
+                return;
+            }
+            List<Msg> context = state.contextMutable();
+            for (int i = context.size() - 1; i >= loadedContextSize; i--) {
+                Msg message = context.get(i);
+                if (message.getRole() != MsgRole.ASSISTANT
+                        || !message.hasContentBlocks(ToolUseBlock.class)) {
+                    continue;
+                }
+                List<ContentBlock> retained =
+                        message.getContent().stream()
+                                .filter(
+                                        block ->
+                                                !(block instanceof ToolUseBlock toolUse)
+                                                        || toolUse.getState()
+                                                                != ToolCallState.PENDING
+                                                        || !pendingIds.contains(toolUse.getId()))
+                                .toList();
+                if (retained.size() == message.getContent().size()) {
+                    return;
+                }
+                if (retained.isEmpty()) {
+                    context.remove(i);
+                } else {
+                    context.set(i, message.withContent(retained));
+                }
+                return;
             }
         }
 

--- a/agentscope-core/src/test/java/io/agentscope/core/agent/ReActAgentPerSessionStateTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/agent/ReActAgentPerSessionStateTest.java
@@ -19,6 +19,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.agentscope.core.ReActAgent;
@@ -30,6 +31,9 @@ import io.agentscope.core.message.GenerateReason;
 import io.agentscope.core.message.Msg;
 import io.agentscope.core.message.MsgRole;
 import io.agentscope.core.message.TextBlock;
+import io.agentscope.core.message.ToolUseBlock;
+import io.agentscope.core.middleware.ActingInput;
+import io.agentscope.core.middleware.MiddlewareBase;
 import io.agentscope.core.model.ChatModelBase;
 import io.agentscope.core.model.ChatResponse;
 import io.agentscope.core.model.GenerateOptions;
@@ -51,11 +55,13 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import reactor.core.Disposable;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Schedulers;
@@ -63,6 +69,10 @@ import reactor.core.scheduler.Schedulers;
 /** Per-(userId, sessionId) state access / persistence API on {@link ReActAgent}. */
 @DisplayName("ReActAgent per-session state API")
 class ReActAgentPerSessionStateTest {
+
+    static class StructuredResponse {
+        public String value;
+    }
 
     private static final class NoopModel extends ChatModelBase {
         @Override
@@ -435,6 +445,141 @@ class ReActAgentPerSessionStateTest {
         assertEquals(GenerateReason.INTERRUPTED, restoredRecovery.getGenerateReason());
     }
 
+    @Test
+    @DisplayName("model errors checkpoint committed context without partial output")
+    void modelErrorCheckpointsCommittedContext() {
+        InMemoryAgentStateStore store = new InMemoryAgentStateStore();
+        RuntimeContext ctx = RuntimeContext.builder().userId("u1").sessionId("model-error").build();
+        ReActAgent first =
+                ReActAgent.builder()
+                        .name("asst")
+                        .sysPrompt("hi")
+                        .model(failingReasoningModel())
+                        .stateStore(store)
+                        .build();
+        IllegalStateException error =
+                assertThrows(
+                        IllegalStateException.class,
+                        () ->
+                                first.streamEvents(List.of(userMsg("hello")), ctx)
+                                        .blockLast(Duration.ofSeconds(5)));
+
+        assertEquals("model stream failed", error.getMessage());
+        AgentState restored = agent(store).getAgentState("u1", "model-error");
+        assertTrue(allText(restored).contains("hello"));
+        assertFalse(allText(restored).contains("visible before error"));
+        assertFalse(hasToolUse(restored, "call-malformed"));
+    }
+
+    @Test
+    @DisplayName("acting errors remove newly persisted tool calls without results")
+    void actingErrorDropsUncommittedToolCallBeforeCheckpoint() {
+        InMemoryAgentStateStore store = new InMemoryAgentStateStore();
+        RuntimeContext ctx =
+                RuntimeContext.builder().userId("u1").sessionId("acting-error").build();
+        ReActAgent first =
+                ReActAgent.builder()
+                        .name("asst")
+                        .sysPrompt("hi")
+                        .model(completedToolCallModel())
+                        .stateStore(store)
+                        .middleware(new FailingActingMiddleware())
+                        .build();
+
+        IllegalStateException error =
+                assertThrows(
+                        IllegalStateException.class,
+                        () ->
+                                first.streamEvents(List.of(userMsg("hello")), ctx)
+                                        .blockLast(Duration.ofSeconds(5)));
+
+        assertEquals("acting failed", error.getMessage());
+        AgentState restored = agent(store).getAgentState("u1", "acting-error");
+        assertTrue(allText(restored).contains("completed response"));
+        assertFalse(hasToolUse(restored, "call-complete"));
+    }
+
+    @Test
+    @DisplayName("stream cancellation checkpoints committed context")
+    void cancellationCheckpointsCommittedContext() throws Exception {
+        InMemoryAgentStateStore store = new InMemoryAgentStateStore();
+        CountDownLatch chunksEmitted = new CountDownLatch(1);
+        ChatModelBase model =
+                model(
+                        Flux.just(
+                                        response(
+                                                TextBlock.builder()
+                                                        .text("visible before cancel")
+                                                        .build()),
+                                        response(
+                                                ToolUseBlock.builder()
+                                                        .id("call-cancelled")
+                                                        .name("echo")
+                                                        .content("{\"value\":")
+                                                        .build()))
+                                .doOnComplete(chunksEmitted::countDown)
+                                .concatWith(Flux.never()));
+        RuntimeContext ctx = RuntimeContext.builder().userId("u1").sessionId("cancelled").build();
+        ReActAgent first =
+                ReActAgent.builder()
+                        .name("asst")
+                        .sysPrompt("hi")
+                        .model(model)
+                        .stateStore(store)
+                        .build();
+
+        Disposable subscription =
+                first.streamEvents(List.of(userMsg("hello")), ctx).subscribe(event -> {});
+        assertTrue(
+                chunksEmitted.await(5, TimeUnit.SECONDS),
+                "visible chunks should be consumed before cancellation");
+
+        subscription.dispose();
+
+        AgentState restored = agent(store).getAgentState("u1", "cancelled");
+        assertTrue(allText(restored).contains("hello"));
+        assertFalse(allText(restored).contains("visible before cancel"));
+        assertFalse(hasToolUse(restored, "call-cancelled"));
+    }
+
+    @Test
+    @DisplayName("native structured-output cancellation checkpoints committed context")
+    void nativeStructuredOutputCancellationCheckpointsCommittedContext() throws Exception {
+        InMemoryAgentStateStore store = new InMemoryAgentStateStore();
+        CountDownLatch chunkEmitted = new CountDownLatch(1);
+        ChatModelBase model =
+                model(
+                        Flux.just(
+                                        response(
+                                                TextBlock.builder()
+                                                        .text("visible before cancel")
+                                                        .build()))
+                                .doOnComplete(chunkEmitted::countDown)
+                                .concatWith(Flux.never()),
+                        true);
+        RuntimeContext ctx =
+                RuntimeContext.builder().userId("u1").sessionId("structured-cancel").build();
+        ReActAgent first =
+                ReActAgent.builder()
+                        .name("asst")
+                        .sysPrompt("hi")
+                        .model(model)
+                        .stateStore(store)
+                        .build();
+
+        Disposable subscription =
+                first.call(List.of(userMsg("hello")), StructuredResponse.class, ctx).subscribe();
+        assertTrue(
+                chunkEmitted.await(5, TimeUnit.SECONDS),
+                "visible chunk should be consumed before cancellation");
+
+        subscription.dispose();
+
+        AgentState restored = agent(store).getAgentState("u1", "structured-cancel");
+        assertTrue(allText(restored).contains("hello"));
+        assertFalse(allText(restored).contains("visible before cancel"));
+    }
+
     private static final class DelayedFirstChunkModel extends ChatModelBase {
         private final CountDownLatch subscribed;
 
@@ -466,12 +611,84 @@ class ReActAgentPerSessionStateTest {
         }
     }
 
+    private static ChatModelBase completedToolCallModel() {
+        return model(
+                Flux.just(
+                        response(
+                                TextBlock.builder().text("completed response").build(),
+                                ToolUseBlock.builder()
+                                        .id("call-complete")
+                                        .name("echo")
+                                        .input(java.util.Map.of("value", "done"))
+                                        .build())));
+    }
+
+    private static ChatModelBase failingReasoningModel() {
+        return model(
+                Flux.concat(
+                        Flux.just(
+                                response(TextBlock.builder().text("visible before error").build()),
+                                response(
+                                        ToolUseBlock.builder()
+                                                .id("call-malformed")
+                                                .name("echo")
+                                                .content("{\"value\":")
+                                                .build())),
+                        Flux.error(new IllegalStateException("model stream failed"))));
+    }
+
+    private static ChatModelBase model(Flux<ChatResponse> responses) {
+        return model(responses, false);
+    }
+
+    private static ChatModelBase model(
+            Flux<ChatResponse> responses, boolean supportsNativeStructuredOutput) {
+        return new ChatModelBase() {
+            @Override
+            public String getModelName() {
+                return "test";
+            }
+
+            @Override
+            protected Flux<ChatResponse> doStream(
+                    List<Msg> messages, List<ToolSchema> tools, GenerateOptions options) {
+                return responses;
+            }
+
+            @Override
+            public boolean supportsNativeStructuredOutput() {
+                return supportsNativeStructuredOutput;
+            }
+        };
+    }
+
+    private static final class FailingActingMiddleware implements MiddlewareBase {
+        @Override
+        public Flux<AgentEvent> onActing(
+                Agent agent,
+                RuntimeContext ctx,
+                ActingInput input,
+                Function<ActingInput, Flux<AgentEvent>> next) {
+            return Flux.error(new IllegalStateException("acting failed"));
+        }
+    }
+
+    private static ChatResponse response(ContentBlock... blocks) {
+        return ChatResponse.builder().content(List.of(blocks)).build();
+    }
+
     private static Msg userMsg(String text) {
         return Msg.builder()
                 .name("user")
                 .role(MsgRole.USER)
                 .content(TextBlock.builder().text(text).build())
                 .build();
+    }
+
+    private static boolean hasToolUse(AgentState state, String id) {
+        return state.getContext().stream()
+                .flatMap(msg -> msg.getContentBlocks(ToolUseBlock.class).stream())
+                .anyMatch(block -> id.equals(block.getId()));
     }
 
     private static List<String> allText(AgentState state) {


### PR DESCRIPTION
## AgentScope-Java Version

2.0.3-SNAPSHOT

## Description

### 背景

`ReActAgent` 目前只在正常结束和用户 interrupt 后保存状态。模型、工具或 middleware 报错，以及流被取消时，本轮已经写入内存的用户消息和已完成上下文不会保存到 `AgentStateStore`，Agent 重建后会回退到旧状态。

另外，如果 reasoning 已经产生 tool call，但在 acting 写入结果前异常结束，直接保存会留下没有对应结果的 `PENDING` tool call，影响下一轮恢复。应用层因此需要额外实现异常保存和状态修复逻辑。

### 改动

- 在普通和 structured-output 执行报错或取消时，尽力保存当前已提交的 `AgentState`，且不覆盖原始异常。
- 保存前只移除本轮没有结果的 `PENDING` tool call，保留文本、thinking、`ALLOWED` 和 `ASKING` 状态。
- 复用现有状态保存和冲突处理逻辑，保持原有 interrupt 流程不变。
- 补充普通及 structured-output 报错、取消、未完成 tool call 和保存失败场景的测试。

### 测试

`mvn -pl agentscope-core test`

2298 tests passed，8 skipped。

## Checklist

- [x] Code has been formatted with `mvn spotless:apply`
- [x] All tests are passing (`mvn test`)
- [x] Javadoc comments are complete and follow project conventions
- [x] Related documentation has been updated (no documentation change required)
- [x] Code is ready for review
