### PR TITLE
fix(core): include field path in tool validation error messages

### DIFF
--- a/agentscope-core/src/main/java/io/agentscope/core/tool/ToolValidator.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/tool/ToolValidator.java
@@ -95,8 +95,10 @@ public final class ToolValidator {
                 return null; // Validation passed
             }
 
-            // Format error messages
-            return errors.stream().map(Error::getMessage).collect(Collectors.joining("; "));
+            // Format error messages, prefixing each with its field path so failures are actionable
+            return errors.stream()
+                    .map(e -> e.getInstanceLocation() + ": " + e.getMessage())
+                    .collect(Collectors.joining("\n"));
 
         } catch (Exception e) {
             return "Schema validation error: " + e.getMessage();

--- a/agentscope-core/src/test/java/io/agentscope/core/tool/ToolValidatorTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/tool/ToolValidatorTest.java
@@ -272,6 +272,32 @@ class ToolValidatorTest {
     }
 
     @Nested
+    @DisplayName("validateInput - Error Message Includes Field Name")
+    class ValidateInputErrorIncludesFieldName {
+
+        @Test
+        @DisplayName("Should include the field name in type validation errors")
+        void testErrorIncludesFieldName() {
+            Map<String, Object> schema =
+                    Map.of(
+                            "type",
+                            "object",
+                            "properties",
+                            Map.of(
+                                    "name", Map.of("type", "string"),
+                                    "age", Map.of("type", "integer")));
+
+            Map<String, Object> input = Map.of("name", 123, "age", "not a number");
+            String result =
+                    ToolValidator.validateInput(JsonUtils.getJsonCodec().toJson(input), schema);
+
+            assertNotNull(result);
+            assertTrue(result.contains("name"), "Error should mention field 'name': " + result);
+            assertTrue(result.contains("age"), "Error should mention field 'age': " + result);
+        }
+    }
+
+    @Nested
     @DisplayName("validateInput - Enum Validation")
     class ValidateInputEnumValidation {
 

--- a/agentscope-core/src/test/java/io/agentscope/core/tool/ToolValidatorTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/tool/ToolValidatorTest.java
@@ -272,28 +272,35 @@ class ToolValidatorTest {
     }
 
     @Nested
-    @DisplayName("validateInput - Error Message Includes Field Name")
-    class ValidateInputErrorIncludesFieldName {
+    @DisplayName("validateInput - Error Message Includes Field Path")
+    class ValidateInputErrorIncludesFieldPath {
 
         @Test
-        @DisplayName("Should include the field name in type validation errors")
-        void testErrorIncludesFieldName() {
+        @DisplayName("Should include JSON Pointer paths in type validation errors")
+        void testErrorIncludesFieldPath() {
+            Map<String, Object> addressSchema =
+                    Map.of(
+                            "type",
+                            "object",
+                            "properties",
+                            Map.of("city", Map.of("type", "string")));
+
             Map<String, Object> schema =
                     Map.of(
                             "type",
                             "object",
                             "properties",
-                            Map.of(
-                                    "name", Map.of("type", "string"),
-                                    "age", Map.of("type", "integer")));
+                            Map.of("name", Map.of("type", "string"), "address", addressSchema));
 
-            Map<String, Object> input = Map.of("name", 123, "age", "not a number");
+            Map<String, Object> input = Map.of("name", 123, "address", Map.of("city", 456));
             String result =
                     ToolValidator.validateInput(JsonUtils.getJsonCodec().toJson(input), schema);
 
             assertNotNull(result);
-            assertTrue(result.contains("name"), "Error should mention field 'name': " + result);
-            assertTrue(result.contains("age"), "Error should mention field 'age': " + result);
+            assertTrue(result.contains("/name"), "Error should include path '/name': " + result);
+            assertTrue(
+                    result.contains("/address/city"),
+                    "Error should include nested path '/address/city': " + result);
         }
     }
 

--- a/agentscope-dependencies-bom/pom.xml
+++ b/agentscope-dependencies-bom/pom.xml
@@ -105,7 +105,7 @@
         <spring.version>7.0.7</spring.version>
         <spring-boot.version>4.0.4</spring-boot.version>
         <nacos-client.version>3.2.1-2026.03.30</nacos-client.version>
-        <json-schema-validator.version>2.0.0</json-schema-validator.version>
+        <json-schema-validator.version>3.0.6</json-schema-validator.version>
         <jsonschema-generator.version>4.38.0</jsonschema-generator.version>
         <snakeyaml.version>2.6</snakeyaml.version>
         <tree-sitter.version>0.24.4</tree-sitter.version>

--- a/agentscope-dependencies-bom/pom.xml
+++ b/agentscope-dependencies-bom/pom.xml
@@ -105,7 +105,7 @@
         <spring.version>7.0.7</spring.version>
         <spring-boot.version>4.0.4</spring-boot.version>
         <nacos-client.version>3.2.1-2026.03.30</nacos-client.version>
-        <json-schema-validator.version>3.0.6</json-schema-validator.version>
+        <json-schema-validator.version>2.0.0</json-schema-validator.version>
         <jsonschema-generator.version>4.38.0</jsonschema-generator.version>
         <snakeyaml.version>2.6</snakeyaml.version>
         <tree-sitter.version>0.24.4</tree-sitter.version>


### PR DESCRIPTION
## Summary

修复 `ToolValidator.validateInput` 返回的校验错误丢失字段路径的问题。

之前只使用 `Error.getMessage()` 拼装错误，多个字段同时失败时会返回一串完全相同的消息（如「已找到 null，必须是 string」），无法定位具体字段。

## Changes

- 在校验错误前拼接 `Error.getInstanceLocation()` 的字段路径，例如 `$.name: ...`
- 新增单元测试 `ValidateInputErrorIncludesFieldName`，断言错误信息包含字段名

问题详见 ISSUE https://github.com/agentscope-ai/agentscope-java/issues/2717
