### PR TITLE
feat(core): expose tool call ID from ToolEmitter

### DIFF
--- a/agentscope-core/src/main/java/io/agentscope/core/tool/DefaultToolEmitter.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/tool/DefaultToolEmitter.java
@@ -57,4 +57,14 @@ class DefaultToolEmitter implements ToolEmitter {
             chunkCallback.accept(toolUseBlock, chunk);
         }
     }
+
+    /**
+     * Returns the ID of the tool call associated with this emitter.
+     *
+     * @return The tool call ID, or {@code null} if no tool call is available
+     */
+    @Override
+    public String getToolCallId() {
+        return toolUseBlock != null ? toolUseBlock.getId() : null;
+    }
 }

--- a/agentscope-core/src/main/java/io/agentscope/core/tool/ToolEmitter.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/tool/ToolEmitter.java
@@ -68,4 +68,16 @@ public interface ToolEmitter {
      * @param chunk The chunk to emit
      */
     void emit(ToolResultBlock chunk);
+
+    /**
+     * Returns the ID of the tool call associated with this emitter.
+     *
+     * <p>The default implementation returns {@code null} so custom emitters without tool call
+     * context remain compatible.
+     *
+     * @return The tool call ID, or {@code null} if it is not available
+     */
+    default String getToolCallId() {
+        return null;
+    }
 }

--- a/agentscope-core/src/test/java/io/agentscope/core/tool/DefaultToolEmitterTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/tool/DefaultToolEmitterTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.core.tool;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import io.agentscope.core.message.ToolUseBlock;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/** Tests for DefaultToolEmitter. */
+@DisplayName("DefaultToolEmitter Tests")
+class DefaultToolEmitterTest {
+
+    @Test
+    @DisplayName("getToolCallId() should return the associated tool call ID")
+    void testGetToolCallId() {
+        ToolUseBlock toolUseBlock =
+                ToolUseBlock.builder().id("call-123").name("test_tool").input(Map.of()).build();
+        ToolEmitter emitter = new DefaultToolEmitter(toolUseBlock, null);
+
+        assertEquals("call-123", emitter.getToolCallId());
+    }
+
+    @Test
+    @DisplayName("getToolCallId() should return null when no tool call is available")
+    void testGetToolCallIdWithoutToolUseBlock() {
+        ToolEmitter emitter = new DefaultToolEmitter(null, null);
+
+        assertNull(emitter.getToolCallId());
+    }
+}

--- a/agentscope-core/src/test/java/io/agentscope/core/tool/NoOpToolEmitterTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/tool/NoOpToolEmitterTest.java
@@ -17,6 +17,7 @@ package io.agentscope.core.tool;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 
 import io.agentscope.core.message.ToolResultBlock;
@@ -39,6 +40,12 @@ class NoOpToolEmitterTest {
     void testImplementsToolEmitter() {
         ToolEmitter emitter = NoOpToolEmitter.INSTANCE;
         assertNotNull(emitter);
+    }
+
+    @Test
+    @DisplayName("getToolCallId() should return null when no tool call is available")
+    void testGetToolCallId() {
+        assertNull(NoOpToolEmitter.INSTANCE.getToolCallId());
     }
 
     @Test

--- a/docs/v2/en/docs/building-blocks/tool.md
+++ b/docs/v2/en/docs/building-blocks/tool.md
@@ -225,12 +225,27 @@ Inside a `@Tool` method, any parameter **without `@ToolParam`** is treated as fr
 
 | Parameter type | Source |
 |----------------|--------|
-| `ToolEmitter` | Streaming emitter (no-op when none configured) |
+| `ToolEmitter` | Streaming emitter and tool call context (no-op when none configured) |
 | `Agent` | The current agent instance |
 | `AgentState` | The per-session state for the current call (via `RuntimeContext.getAgentState()`) |
 | `RuntimeContext` | The current per-call context |
 | `ToolExecutionContext` | `runtimeContext.asToolExecutionContext()` (compatibility shim, deprecated) |
 | Any other user POJO type | `runtimeContext.get(ParamType.class)` — i.e. an object the caller registered via `RuntimeContext.builder().put(ParamType.class, value)` |
+
+An injected `ToolEmitter` exposes the current tool call ID, which can be used to correlate progress with frontend state or another shared store:
+
+```java
+@Tool(name = "run_task", description = "Run a long-running task")
+public String runTask(ToolEmitter emitter) {
+    String toolCallId = emitter.getToolCallId();
+    if (toolCallId != null) {
+        progressByToolCall.put(toolCallId, "running");
+    }
+    return "done";
+}
+```
+
+`getToolCallId()` returns `null` when the emitter has no tool call context, such as a no-op or custom emitter.
 
 "User POJO" means: no `@ToolParam`, not primitive, not `ContentBlock` / `Msg`, not under `java.*` / `javax.*`. Every other parameter (those with `@ToolParam`, or that fall outside the above types) is read from the LLM-supplied JSON by name.
 

--- a/docs/v2/zh/docs/building-blocks/tool.md
+++ b/docs/v2/zh/docs/building-blocks/tool.md
@@ -225,12 +225,27 @@ public class HumanApprovalTool extends ToolBase {
 
 | 参数类型 | 注入来源 |
 |---------|---------|
-| `ToolEmitter` | 流式中间产物 emitter（无配置时为 no-op） |
+| `ToolEmitter` | 流式中间产物 emitter 和工具调用上下文（无配置时为 no-op） |
 | `Agent` | 当前 agent 实例 |
 | `AgentState` | 当前 call 的 per-session 状态（通过 `RuntimeContext.getAgentState()` 获取） |
 | `RuntimeContext` | 当前 per-call 上下文 |
 | `ToolExecutionContext` | `runtimeContext.asToolExecutionContext()`（兼容层，已 deprecated） |
 | 其它用户自定义 POJO 类型 | `runtimeContext.get(ParamType.class)` —— 即调用方在 `RuntimeContext.builder().put(ParamType.class, value)` 注册的对象 |
+
+注入的 `ToolEmitter` 会提供当前工具调用 ID，可用于把进度与前端状态或其它共享存储关联起来：
+
+```java
+@Tool(name = "run_task", description = "Run a long-running task")
+public String runTask(ToolEmitter emitter) {
+    String toolCallId = emitter.getToolCallId();
+    if (toolCallId != null) {
+        progressByToolCall.put(toolCallId, "running");
+    }
+    return "done";
+}
+```
+
+当 emitter 没有工具调用上下文时（例如 no-op 或自定义 emitter），`getToolCallId()` 返回 `null`。
 
 「用户自定义 POJO」的判定：参数没有 `@ToolParam`、不是基本类型、不是 `ContentBlock` / `Msg`、不在 `java.*` / `javax.*` 包下。其余参数（带 `@ToolParam` 或属于上述兜底类型）从 LLM 提供的 JSON 输入按名称取值。
 


### PR DESCRIPTION
## AgentScope-Java Version

2.0.3-SNAPSHOT

## Description

Adds a backward-compatible way for streaming tools to access the ID of the current tool call.

- Add the default `ToolEmitter#getToolCallId()` method, returning `null` when call context is unavailable.
- Return the associated `ToolUseBlock` ID from `DefaultToolEmitter`.
- Add focused regression tests for associated and unavailable tool call IDs.
- Document the API and nullable behavior in the English and Chinese v2 tool guides.

Closes #695.

### Testing

- `mvn -pl agentscope-core -Dtest=DefaultToolEmitterTest,NoOpToolEmitterTest test`
- `mvn -pl agentscope-core test`
- Full reactor `mvn test`, completed with Maven `-rf` resumes after transient Maven Central and npm registry connection failures
- `mvn spotless:check`

All reactor modules completed successfully; the interrupted runs failed only while downloading dependencies, with no test failures.

## Checklist

Please check the following items before code is ready to be reviewed.

- [x]  Code has been formatted with `mvn spotless:apply`
- [x]  All tests are passing (`mvn test`)
- [x]  Javadoc comments are complete and follow project conventions
- [x]  Related documentation has been updated (e.g. links, examples, etc.)
- [x]  Code is ready for review
