### PR TITLE
fix(postgresql): remove path-separator check from PostgresAgentStateStore session id validation

### DIFF
--- a/agentscope-extensions/agentscope-extensions-postgresql/src/main/java/io/agentscope/extensions/postgresql/state/PostgresAgentStateStore.java
+++ b/agentscope-extensions/agentscope-extensions-postgresql/src/main/java/io/agentscope/extensions/postgresql/state/PostgresAgentStateStore.java
@@ -717,9 +717,6 @@ public class PostgresAgentStateStore implements AgentStateStore {
         if (sessionId == null || sessionId.trim().isEmpty()) {
             throw new IllegalArgumentException("AgentStateStore ID cannot be null or empty");
         }
-        if (sessionId.contains("/") || sessionId.contains("\\")) {
-            throw new IllegalArgumentException("AgentStateStore ID cannot contain path separators");
-        }
         if (sessionId.length() > 255) {
             throw new IllegalArgumentException("AgentStateStore ID cannot exceed 255 characters");
         }

--- a/agentscope-extensions/agentscope-extensions-postgresql/src/test/java/io/agentscope/extensions/postgresql/state/PostgresAgentStateStoreTest.java
+++ b/agentscope-extensions/agentscope-extensions-postgresql/src/test/java/io/agentscope/extensions/postgresql/state/PostgresAgentStateStoreTest.java
@@ -15,6 +15,7 @@
  */
 package io.agentscope.extensions.postgresql.state;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -384,15 +385,15 @@ class PostgresAgentStateStoreTest {
     }
 
     @Test
-    void rejectsSessionIdWithPathSeparators() {
+    void acceptsSessionIdWithPathSeparators() {
         PostgresAgentStateStore store =
                 PostgresAgentStateStore.builder(dataSource).createIfNotExist(false).build();
-        assertThrows(
-                IllegalArgumentException.class,
-                () -> store.save("user", "a/b", "key", new TestState("v")));
-        assertThrows(
-                IllegalArgumentException.class,
-                () -> store.save("user", "a\\b", "key", new TestState("v")));
+        // Harness packs the sandbox isolation scope into the session id, e.g.
+        // "sandbox/session/<sessionId>". Path separators carry no meaning for a relational
+        // store, so they must not be rejected.
+        assertDoesNotThrow(
+                () -> store.save(null, "sandbox/session/conv-1", "key", new TestState("v")));
+        assertDoesNotThrow(() -> store.save("user", "a\\b", "key", new TestState("v")));
     }
 
     @Test


### PR DESCRIPTION
## AgentScope-Java Version

2.0.3-SNAPSHOT (rebased onto current `main`, at 48b62328)

## Description

### Background

`PostgresAgentStateStore.validateSessionId()` rejects any session id containing `/` or `\`:

```java
if (sessionId.contains("/") || sessionId.contains("\\")) {
    throw new IllegalArgumentException("AgentStateStore ID cannot contain path separators");
}
```

Harness packs the sandbox isolation scope into the session id, so `SessionSandboxStateStore.slotSessionId()` produces values such as `sandbox/session/<sessionId>`. Persisting sandbox state through `PostgresAgentStateStore` therefore fails with:

```
java.lang.IllegalArgumentException: AgentStateStore ID cannot contain path separators
    at PostgresAgentStateStore.validateSessionId(PostgresAgentStateStore.java:721)
    at PostgresAgentStateStore.save(PostgresAgentStateStore.java:265)
```

Call chain: `SandboxManager.persistState(...)` → `SessionSandboxStateStore.save(...)` → `slotSessionId(...)` → `PostgresAgentStateStore.save(...)` → `validateSessionId(...)`.

### Why removing the check is the right fix

This is a filesystem-oriented constraint that has no meaning for a relational store:

- The value is bound as a `PreparedStatement` parameter (`stmt.setString(1, slotId)`) and is never used as a filesystem path, so `/` poses no injection or traversal risk.
- `PostgresAgentStateStore` already joins `userId` and `sessionId` with `:` internally (`slotId(...)`), confirming that `/` carries no special meaning at this layer.
- The identical check was removed from `MysqlAgentStateStore` in 769eac17 for exactly this reason.
- `JsonFileAgentStateStore` — the implementation where the constraint genuinely matters — protects itself instead of rejecting: ids that do not match `^[a-zA-Z0-9_\-.]+$` are Base64-URL encoded.

`PostgresAgentStateStore` was the last `AgentStateStore` implementation still enforcing it (verified by grepping the whole repository), so the implementations were behaving inconsistently.

### Changes

- `PostgresAgentStateStore.validateSessionId()`: drop the path-separator rejection (null/blank and 255-character checks are unchanged).
- `PostgresAgentStateStoreTest`: the existing `rejectsSessionIdWithPathSeparators` asserted the buggy behaviour; it is replaced by `acceptsSessionIdWithPathSeparators`, which uses the real sandbox slot id (`sandbox/session/conv-1`) as input.

### How to test

```bash
mvn -pl agentscope-extensions/agentscope-extensions-postgresql -am \
    -DfailIfNoSpecifiedTests=false -Dtest='Postgres*' test
```

Before the fix, the new test fails with the exception quoted above. After the fix, the whole module passes:

```
Tests run: 144, Failures: 0, Errors: 0, Skipped: 0
BUILD SUCCESS
```

The tests use a Mockito-mocked `DataSource`, so no live PostgreSQL instance is required.

### Relationship to existing issues and PRs

- Completes the Postgres half of #2583. The MySQL half was already fixed by 769eac17.
- #2336 proposes an alternative approach on the Harness side (replacing `/` with `:` in the sandbox slot id). The two are not mutually exclusive: even if #2336 lands, `PostgresAgentStateStore` would still be inconsistent with `MysqlAgentStateStore` and `JsonFileAgentStateStore`, and would still reject session ids that callers are free to choose under the `AgentStateStore` contract. Happy to defer or rebase if maintainers prefer to converge on one approach.

## Checklist

Please check the following items before code is ready to be reviewed.

- [x]  Code has been formatted with `mvn spotless:apply` (`spotless:check` passes on all five reactor modules)
- [x]  All tests are passing (`mvn test`)
- [x]  Javadoc comments are complete and follow project conventions (no signature or contract documentation changed)
- [x]  Related documentation has been updated (e.g. links, examples, etc.) — no documentation references this validation rule; the only mention of path separators is `docs/v1/en/docs/task/session.md`, which concerns the filesystem-backed `JsonSession` and is unaffected
- [x]  Code is ready for review
