### PR TITLE
fix(harness): reclaim .skills-cache orphans when repositories return no skills

### DIFF
--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/middleware/HarnessSkillMiddleware.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/middleware/HarnessSkillMiddleware.java
@@ -208,12 +208,25 @@ public class HarnessSkillMiddleware implements HarnessRuntimeMiddleware {
         }
         Map<String, RepoBound> merged = skillsForCall(ctx);
         if (merged.isEmpty()) {
+            reclaimStagedSkills();
             return;
         }
         List<RepoBound> visible = applyVisibility(merged.values(), ctx);
         List<RepoBound> enabled = applySkillFilter(visible, effectiveFilter(ctx));
-        if (!enabled.isEmpty()) {
-            stager.stage(enabled, sourceNamespaces);
+        stager.stage(enabled, sourceNamespaces);
+    }
+
+    /**
+     * Rebuilds the staged white-list from an empty visible set so that orphaned
+     * {@code .skills-cache} directories are reclaimed even when no skill is staged.
+     *
+     * <p>Orphan GC only runs inside {@link MarketplaceStager#stage}, so the empty case must
+     * still reach it: otherwise skills deleted from their repository keep their staged files on
+     * the host workspace and stay visible through sandbox workspace projection.
+     */
+    private void reclaimStagedSkills() {
+        if (stager != null) {
+            stager.stage(List.of(), sourceNamespaces);
         }
     }
 
@@ -227,6 +240,7 @@ public class HarnessSkillMiddleware implements HarnessRuntimeMiddleware {
 
         Map<String, RepoBound> merged = skillsForCall(ctx);
         if (merged.isEmpty()) {
+            reclaimStagedSkills();
             runtime.install(SkillCatalog.empty(), ctx, agentToolkit);
             return Mono.just(currentPrompt);
         }
@@ -234,6 +248,7 @@ public class HarnessSkillMiddleware implements HarnessRuntimeMiddleware {
         List<RepoBound> visible = applyVisibility(merged.values(), ctx);
         List<RepoBound> enabled = applySkillFilter(visible, effectiveFilter(ctx));
         if (enabled.isEmpty()) {
+            reclaimStagedSkills();
             runtime.install(SkillCatalog.empty(), ctx, agentToolkit);
             return Mono.just(currentPrompt);
         }

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/middleware/HarnessSkillMiddlewareCacheGcTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/middleware/HarnessSkillMiddlewareCacheGcTest.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.harness.agent.middleware;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.agentscope.core.agent.RuntimeContext;
+import io.agentscope.core.skill.AgentSkill;
+import io.agentscope.core.skill.repository.AgentSkillRepository;
+import io.agentscope.core.skill.repository.AgentSkillRepositoryInfo;
+import io.agentscope.core.tool.Toolkit;
+import io.agentscope.harness.agent.skill.runtime.MarketplaceStager;
+import io.agentscope.harness.agent.skill.runtime.ShellPathPolicy;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Regression tests for orphan reclamation of {@code .skills-cache} when the skill repositories
+ * stop publishing skills.
+ *
+ * <p>Orphan GC lives inside {@link MarketplaceStager#stage}, so any early return that skips
+ * staging also skips reclamation: previously staged directories then stay on the host workspace
+ * and keep being projected into the sandbox even though no skill exists any more.
+ */
+class HarnessSkillMiddlewareCacheGcTest {
+
+    @TempDir Path workspace;
+
+    @Test
+    @DisplayName("onSystemPrompt reclaims staged skills once repositories return empty")
+    void onSystemPromptReclaimsOrphansWhenRepositoryBecomesEmpty() throws IOException {
+        Path staged = stalePreviouslyStagedSkill();
+
+        HarnessSkillMiddleware middleware = middlewareWithEmptyRepository();
+        middleware.onSystemPrompt(null, RuntimeContext.empty(), "").block();
+
+        assertFalse(Files.exists(staged), "stale staged skill must be reclaimed: " + staged);
+    }
+
+    @Test
+    @DisplayName("prestageMarketplaceSkills reclaims staged skills once repositories return empty")
+    void prestageReclaimsOrphansWhenRepositoryBecomesEmpty() throws IOException {
+        Path staged = stalePreviouslyStagedSkill();
+
+        HarnessSkillMiddleware middleware = middlewareWithEmptyRepository();
+        middleware.prestageMarketplaceSkills(RuntimeContext.empty());
+
+        assertFalse(Files.exists(staged), "stale staged skill must be reclaimed: " + staged);
+    }
+
+    private HarnessSkillMiddleware middlewareWithEmptyRepository() {
+        return new HarnessSkillMiddleware(
+                List.of(new EmptySkillRepository()),
+                new Toolkit(),
+                null,
+                null,
+                new MarketplaceStager(workspace),
+                ShellPathPolicy.noShell());
+    }
+
+    /** Simulates content left behind by an earlier call, before the skill was deleted. */
+    private Path stalePreviouslyStagedSkill() throws IOException {
+        Path staged =
+                workspace
+                        .resolve(MarketplaceStager.CACHE_DIR)
+                        .resolve("mysql")
+                        .resolve("demo-skill");
+        Files.createDirectories(staged);
+        Files.writeString(staged.resolve("SKILL.md"), "---\nname: demo-skill\n---\n# demo\n");
+        Files.writeString(staged.resolve("run.sh"), "#!/bin/bash\necho hello\n");
+        assertTrue(Files.exists(staged), "precondition: staged skill exists");
+        return staged;
+    }
+
+    /** A repository that no longer publishes any skill (e.g. rows deleted from the database). */
+    private static final class EmptySkillRepository implements AgentSkillRepository {
+
+        @Override
+        public AgentSkill getSkill(String name) {
+            return null;
+        }
+
+        @Override
+        public List<String> getAllSkillNames() {
+            return List.of();
+        }
+
+        @Override
+        public List<AgentSkill> getAllSkills() {
+            return List.of();
+        }
+
+        @Override
+        public boolean save(List<AgentSkill> skills, boolean force) {
+            return false;
+        }
+
+        @Override
+        public boolean delete(String skillName) {
+            return false;
+        }
+
+        @Override
+        public boolean skillExists(String skillName) {
+            return false;
+        }
+
+        @Override
+        public AgentSkillRepositoryInfo getRepositoryInfo() {
+            return new AgentSkillRepositoryInfo("mysql", "test", false);
+        }
+
+        @Override
+        public String getSource() {
+            return "mysql";
+        }
+
+        @Override
+        public void setWriteable(boolean writeable) {}
+
+        @Override
+        public boolean isWriteable() {
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
## AgentScope-Java Version

2.0.3-SNAPSHOT (`main` at 49cffeb6)

## Description

### Background

Orphan reclamation for `.skills-cache` lives entirely inside `MarketplaceStager.stage()`:

```java
garbageCollectOrphans(cacheRoot, retained);   // MarketplaceStager.java:146
```

But `HarnessSkillMiddleware` returned early without ever reaching `stage()` whenever no skill was left to stage:

- `prestageMarketplaceSkills()` — returned on `merged.isEmpty()`, and guarded `stage()` behind `if (!enabled.isEmpty())`
- `onSystemPrompt()` — returned on `merged.isEmpty()` and again on `enabled.isEmpty()`

So once a repository stopped publishing a skill — for example after the rows were deleted from `MysqlSkillRepository` — the directories staged by earlier calls were never reclaimed.

Because `.skills-cache` is part of `SandboxFilesystemSpec.DEFAULT_WORKSPACE_PROJECTION_ROOTS`, those stale `SKILL.md` files and scripts kept being hydrated into every freshly started sandbox. The model could still browse them with its file/shell tools and kept reporting skills that no longer existed anywhere in the repository. Nothing threw, so the divergence was silent.

### Fix

The empty case now still calls `stage()` with an empty visible set, via a small `reclaimStagedSkills()` helper.

This needs no new mechanism, because it is precisely what `stage()` already documents about itself:

> The white-list of staged directories is rebuilt every call; any pre-existing directory under `.skills-cache/<source-ns>/` not in the white-list is removed.

With an empty white-list, every staged directory is an orphan and gets reclaimed. Staging itself is a no-op in that case, and `garbageCollectOrphans()` already returns immediately when the cache directory does not exist, so the added call is cheap and safe when there is nothing to clean.

### Changes

- `HarnessSkillMiddleware`: the three early-return paths (`prestageMarketplaceSkills()` on empty merged view, `onSystemPrompt()` on empty merged and empty enabled views) now reclaim staged orphans before returning. `prestageMarketplaceSkills()` also drops the `!enabled.isEmpty()` guard so an empty enabled view reaches `stage()` as well.
- `HarnessSkillMiddlewareCacheGcTest` (new): regression coverage for both entry points, driven by a stub repository that returns an empty collection.

### How to test

```bash
mvn -pl agentscope-harness -am -DfailIfNoSpecifiedTests=false \
    -Dtest='HarnessSkillMiddlewareCacheGcTest' test
```

Both new tests fail on `main` exactly as reported in the issue — the staged directory survives the call:

```
AssertionFailedError: stale staged skill must be reclaimed:
  .../.skills-cache/mysql/demo-skill ==> expected: <false> but was: <true>
Tests run: 2, Failures: 2
```

After the fix, the full `agentscope-harness` module passes:

```
Tests run: 830, Failures: 0, Errors: 0, Skipped: 3
BUILD SUCCESS
```

(The 3 skips are pre-existing and unrelated.) The tests use `@TempDir` only — no database, sandbox or network required.

## Checklist

Please check the following items before code is ready to be reviewed.

- [x]  Code has been formatted with `mvn spotless:apply` (`spotless:check` passes for parent, core and harness)
- [x]  All tests are passing (`mvn test`)
- [x]  Javadoc comments are complete and follow project conventions (the new private helper documents why the empty case must still reach `stage()`)
- [x]  Related documentation has been updated (e.g. links, examples, etc.) — none needed; no documented behaviour or public API changes, the fix restores the reclamation contract already stated in `MarketplaceStager.stage()`'s Javadoc
- [x]  Code is ready for review
