### PR TITLE
feat(harness): add description field to SubagentFactoryEntry

### DIFF
--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/HarnessAgent.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/HarnessAgent.java
@@ -1846,10 +1846,33 @@ public class HarnessAgent implements Agent, AutoCloseable {
             return this;
         }
 
-        /** Adds a fully custom subagent factory for a given agent id. */
+        /**
+         * Adds a fully custom subagent factory for a given agent id, advertising {@code name} as
+         * the subagent's description.
+         *
+         * <p>Prefer {@link #subagentFactory(String, String, Function)}: the description is what
+         * this agent's model reads when deciding which subagent to delegate to, and a bare name
+         * carries no routing signal.
+         */
         public Builder subagentFactory(String name, Function<String, Agent> factory) {
             this.customSubagentFactories.add(
                     new HarnessAgentBuilderSupport.SubagentFactoryEntry(name, factory));
+            return this;
+        }
+
+        /**
+         * Adds a fully custom subagent factory for a given agent id, with the description this
+         * agent's model sees when choosing a delegate.
+         *
+         * @param name        the subagent's agent id
+         * @param description what the subagent is for; falls back to {@code name} when null or blank
+         * @param factory     creates the subagent from its agent id
+         */
+        public Builder subagentFactory(
+                String name, String description, Function<String, Agent> factory) {
+            this.customSubagentFactories.add(
+                    new HarnessAgentBuilderSupport.SubagentFactoryEntry(
+                            name, description, factory));
             return this;
         }
 

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/HarnessAgentBuilderSupport.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/HarnessAgentBuilderSupport.java
@@ -128,8 +128,26 @@ final class HarnessAgentBuilderSupport {
         return base.isEmpty() ? SUBAGENT_CONTEXT_SECTION : base + "\n\n" + SUBAGENT_CONTEXT_SECTION;
     }
 
-    /** Custom-supplied subagent factory entry: name + factory function from name to Agent. */
-    record SubagentFactoryEntry(String name, Function<String, Agent> factory) {}
+    /**
+     * Custom-supplied subagent factory entry: name + description + factory function from name to
+     * Agent.
+     *
+     * <p>{@code description} is what the parent agent's model sees when choosing which subagent to
+     * delegate to, so a blank value degrades routing quality. When callers do not supply one it
+     * falls back to {@code name}, preserving the behaviour of the two-argument
+     * {@link HarnessAgent.Builder#subagentFactory(String, Function)} overload.
+     */
+    record SubagentFactoryEntry(String name, String description, Function<String, Agent> factory) {
+
+        SubagentFactoryEntry(String name, Function<String, Agent> factory) {
+            this(name, null, factory);
+        }
+
+        /** The description to advertise, falling back to {@link #name()} when none was supplied. */
+        String effectiveDescription() {
+            return (description != null && !description.isBlank()) ? description : name;
+        }
+    }
 
     // -----------------------------------------------------------------
     //  Filesystem
@@ -220,7 +238,7 @@ final class HarnessAgentBuilderSupport {
             entries.add(
                     new SubagentEntry(
                             custom.name(),
-                            custom.name(),
+                            custom.effectiveDescription(),
                             // custom factory uses Function<String, Agent> — pre-B-0 signature
                             // doesn't accept RuntimeContext. Bridge by ignoring rc here; users
                             // that need parent-aware isolation should register a programmatic
@@ -263,7 +281,7 @@ final class HarnessAgentBuilderSupport {
             entries.add(
                     new SubagentEntry(
                             custom.name(),
-                            custom.name(),
+                            custom.effectiveDescription(),
                             // custom factory uses Function<String, Agent> — pre-B-0 signature
                             // doesn't accept RuntimeContext. Bridge by ignoring rc here; users
                             // that need parent-aware isolation should register a programmatic

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/SubagentFactoryDescriptionTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/SubagentFactoryDescriptionTest.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.harness.agent;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.agentscope.core.agent.Agent;
+import io.agentscope.core.model.Model;
+import io.agentscope.harness.agent.middleware.SubagentEntry;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.function.Function;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Covers the description advertised for subagents registered through
+ * {@link HarnessAgent.Builder#subagentFactory(String, String, Function)}.
+ *
+ * <p>The description is the routing signal the parent agent's model reads when choosing a
+ * delegate, so it must be the caller-supplied text when one is given.
+ */
+class SubagentFactoryDescriptionTest {
+
+    @TempDir Path workspace;
+
+    private Model model;
+
+    @BeforeEach
+    void setUp() {
+        model = mock(Model.class);
+        when(model.getModelName()).thenReturn("stub-model");
+    }
+
+    @Test
+    @DisplayName("subagentFactory(name, description, factory) advertises the given description")
+    void suppliedDescriptionIsAdvertised() {
+        List<SubagentEntry> entries =
+                HarnessAgent.builder()
+                        .model(model)
+                        .workspace(workspace)
+                        .subagentFactory(
+                                "code-reviewer", "Reviews diffs for defects", stubFactory())
+                        .buildSubagentEntries(workspace);
+
+        assertEquals("Reviews diffs for defects", descriptionOf(entries, "code-reviewer"));
+    }
+
+    @Test
+    @DisplayName("Blank description falls back to the subagent name")
+    void blankDescriptionFallsBackToName() {
+        List<SubagentEntry> entries =
+                HarnessAgent.builder()
+                        .model(model)
+                        .workspace(workspace)
+                        .subagentFactory("blank-desc", "   ", stubFactory())
+                        .subagentFactory("null-desc", null, stubFactory())
+                        .buildSubagentEntries(workspace);
+
+        assertEquals("blank-desc", descriptionOf(entries, "blank-desc"));
+        assertEquals("null-desc", descriptionOf(entries, "null-desc"));
+    }
+
+    @Test
+    @DisplayName("Two-argument overload keeps advertising the name, unchanged")
+    void twoArgOverloadKeepsNameAsDescription() {
+        List<SubagentEntry> entries =
+                HarnessAgent.builder()
+                        .model(model)
+                        .workspace(workspace)
+                        .subagentFactory("legacy-agent", stubFactory())
+                        .buildSubagentEntries(workspace);
+
+        assertEquals("legacy-agent", descriptionOf(entries, "legacy-agent"));
+    }
+
+    @Test
+    @DisplayName("Description also reaches the static entry path used when sandboxed")
+    void staticEntryPathCarriesDescription() {
+        HarnessAgent.Builder builder =
+                HarnessAgent.builder()
+                        .model(model)
+                        .workspace(workspace)
+                        .subagentFactory("doc-writer", "Writes user-facing docs", stubFactory());
+
+        List<SubagentEntry> entries =
+                HarnessAgentBuilderSupport.buildStaticSubagentEntries(builder, workspace, null);
+
+        assertEquals("Writes user-facing docs", descriptionOf(entries, "doc-writer"));
+    }
+
+    private Function<String, Agent> stubFactory() {
+        return name -> HarnessAgent.builder().name(name).model(model).workspace(workspace).build();
+    }
+
+    private static String descriptionOf(List<SubagentEntry> entries, String name) {
+        return entries.stream()
+                .filter(e -> name.equals(e.name()))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("missing subagent entry: " + name))
+                .description();
+    }
+}


### PR DESCRIPTION
## AgentScope-Java Version

2.0.3-SNAPSHOT (`main` at 49cffeb6)

## Description

### Background

`HarnessAgent.Builder.subagentFactory(String name, Function<String, Agent> factory)` registers a custom subagent, but `SubagentFactoryEntry` only carries `(name, factory)`. When building the `SubagentEntry` list, both `buildSubagentEntries` and `buildStaticSubagentEntries` pass `name` as the description:

```java
new SubagentEntry(
        custom.name(),
        custom.name(),   // ← description slot filled with name
        ...);
```

The description is the routing signal the parent agent's model reads when choosing which subagent to delegate to. A bare name such as `"code-reviewer"` gives no task-selection context, degrading delegation accuracy.

By contrast, `SubagentDeclaration` (the declarative `.md`-based path) does carry a real description (`decl.getDescription()`), and the built-in `general-purpose` entry has a full sentence — only the programmatic factory path is missing this capability.

### Changes

- **`SubagentFactoryEntry`**: extended from `(name, factory)` to `(name, description, factory)`. Added a compact constructor `SubagentFactoryEntry(name, factory)` that sets `description = null` for backwards compatibility, and `effectiveDescription()` that falls back to `name` when description is null or blank.
- **`HarnessAgent.Builder`**: new three-argument overload `subagentFactory(String name, String description, Function<String, Agent> factory)`. The original two-argument overload is preserved with unchanged behaviour (advertises name as description).
- **Both `build*SubagentEntries` methods**: switched from `custom.name()` to `custom.effectiveDescription()` in the description slot.
- **`SubagentFactoryDescriptionTest`** (new): 4 tests covering supplied description, blank/null fallback, two-argument legacy behaviour, and the static-entry path.

### How to test

```bash
mvn -pl agentscope-harness -am -DfailIfNoSpecifiedTests=false \
    -Dtest='SubagentFactoryDescriptionTest' test
```

Full module regression (832 harness tests + spotless):

```bash
mvn -pl agentscope-harness -am test
# Tests run: 832, Failures: 0, Errors: 0, Skipped: 3
# BUILD SUCCESS
```

### Backwards compatibility

The original `subagentFactory(name, factory)` API is fully preserved. Its behaviour is unchanged — description is advertised as the name, identical to the pre-fix state. Only callers that opt in to the new three-argument overload get custom descriptions.

`SubagentFactoryEntry` is a package-private record (not public API), so adding a field does not affect external consumers.

## Checklist

Please check the following items before code is ready to be reviewed.

- [x]  Code has been formatted with `mvn spotless:apply` (`spotless:check` passes)
- [x]  All tests are passing (`mvn test`)
- [x]  Javadoc comments are complete and follow project conventions
- [x]  Related documentation has been updated (e.g. links, examples, etc.) — no external doc references this internal type; the Builder's new overload is self-documenting via Javadoc
- [x]  Code is ready for review

---
Closes #2739