### PR TITLE
fix(harness): resolve sandbox workspace root from state instead of hardcoding /workspace

### DIFF
--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/middleware/WorkspaceContextMiddleware.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/middleware/WorkspaceContextMiddleware.java
@@ -23,6 +23,9 @@ import io.agentscope.harness.agent.filesystem.OverlayFilesystem;
 import io.agentscope.harness.agent.filesystem.ProjectAwareOverlay;
 import io.agentscope.harness.agent.filesystem.local.LocalFilesystemWithShell;
 import io.agentscope.harness.agent.filesystem.sandbox.AbstractSandboxFilesystem;
+import io.agentscope.harness.agent.sandbox.Sandbox;
+import io.agentscope.harness.agent.sandbox.SandboxAware;
+import io.agentscope.harness.agent.sandbox.SandboxState;
 import io.agentscope.harness.agent.workspace.LocalFsMode;
 import io.agentscope.harness.agent.workspace.PathPolicy;
 import io.agentscope.harness.agent.workspace.WorkspaceManager;
@@ -340,7 +343,9 @@ public class WorkspaceContextMiddleware implements HarnessRuntimeMiddleware {
             sb.append("Shell commands run with `pwd` set to the project directory.\n");
         } else if (fs instanceof AbstractSandboxFilesystem sandbox
                 && !(fs instanceof OverlayFilesystem)) {
-            sb.append("Sandbox root: /workspace (container id: ")
+            sb.append("Sandbox root: ")
+                    .append(resolveSandboxRoot(fs))
+                    .append(" (container id: ")
                     .append(sandbox.id())
                     .append(")\n");
             sb.append(
@@ -367,6 +372,30 @@ public class WorkspaceContextMiddleware implements HarnessRuntimeMiddleware {
                 "AGENTS.md defines persona and local conventions — honor them when consistent"
                         + " with safety and policy.\n");
         return sb.toString();
+    }
+
+    /**
+     * Resolves the sandbox workspace root from the active sandbox's persisted state.
+     *
+     * <p>The workspace root is written into each sandbox backend's state object when the sandbox
+     * is created (e.g. {@code DockerSandboxState}, {@code E2bSandboxState}), and is the
+     * authoritative source for the path the container exposes to the model. This method
+     * reads it via the base-class accessor {@link SandboxState#getWorkspaceRoot()} introduced
+     * for this purpose.
+     *
+     * <p>Falls back to {@code /workspace} when the filesystem is not sandbox-aware, no sandbox
+     * is attached, or the state has not yet been initialised.
+     */
+    private static String resolveSandboxRoot(AbstractFilesystem fs) {
+        if (fs instanceof SandboxAware aware) {
+            Sandbox sandbox = aware.getSandbox();
+            SandboxState state = sandbox != null ? sandbox.getState() : null;
+            String root = state != null ? state.getWorkspaceRoot() : null;
+            if (root != null && !root.isBlank()) {
+                return root;
+            }
+        }
+        return "/workspace";
     }
 
     /**

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/sandbox/SandboxState.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/sandbox/SandboxState.java
@@ -82,4 +82,18 @@ public abstract class SandboxState {
     public void setWorkspaceRootReady(boolean workspaceRootReady) {
         this.workspaceRootReady = workspaceRootReady;
     }
+
+    /**
+     * Returns the absolute path of the workspace root inside the sandbox container.
+     *
+     * <p>Each backend stores this value in its concrete state subclass. This base-class accessor
+     * provides a polymorphic read path for code that only holds a {@code SandboxState} reference
+     * (e.g. middleware prompt builders). Subclasses that define a {@code workspaceRoot} field
+     * override this method with their own getter.
+     *
+     * @return the workspace root path, or {@code null} when the backend has not yet initialised it
+     */
+    public String getWorkspaceRoot() {
+        return null;
+    }
 }

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/middleware/WorkspaceContextMiddlewareSandboxRootTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/middleware/WorkspaceContextMiddlewareSandboxRootTest.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.harness.agent.middleware;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.agentscope.core.agent.RuntimeContext;
+import io.agentscope.harness.agent.filesystem.sandbox.SandboxBackedFilesystem;
+import io.agentscope.harness.agent.sandbox.ExecResult;
+import io.agentscope.harness.agent.sandbox.Sandbox;
+import io.agentscope.harness.agent.sandbox.SandboxState;
+import io.agentscope.harness.agent.sandbox.WorkspaceSpec;
+import io.agentscope.harness.agent.workspace.WorkspaceManager;
+import java.io.InputStream;
+import java.nio.file.Path;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Ensures the {@code ## Workspace} paragraph advertises the sandbox's real workspace root
+ * (from {@link SandboxState#getWorkspaceRoot()}) instead of the hard-coded {@code /workspace}.
+ */
+class WorkspaceContextMiddlewareSandboxRootTest {
+
+    @TempDir Path workspace;
+
+    private WorkspaceManager wm;
+
+    @AfterEach
+    void tearDown() {
+        if (wm != null) {
+            wm.close();
+        }
+    }
+
+    @Test
+    @DisplayName("Sandbox prompt advertises the configured non-default workspace root")
+    void advertisesConfiguredRoot() {
+        SandboxBackedFilesystem fs = fsWithWorkspaceRoot("/home/agentscope/workspace");
+        wm = new WorkspaceManager(workspace, fs);
+        WorkspaceContextMiddleware mw = new WorkspaceContextMiddleware(wm);
+
+        String prompt = mw.onSystemPrompt(null, RuntimeContext.empty(), "BASE\n").block();
+
+        assertNotNull(prompt);
+        assertTrue(
+                prompt.contains("Sandbox root: /home/agentscope/workspace"),
+                "prompt must advertise configured root, got:\n" + prompt);
+    }
+
+    @Test
+    @DisplayName("Sandbox prompt keeps default /workspace when state has null workspaceRoot")
+    void fallsBackWhenWorkspaceRootNull() {
+        SandboxBackedFilesystem fs = fsWithWorkspaceRoot(null);
+        wm = new WorkspaceManager(workspace, fs);
+        WorkspaceContextMiddleware mw = new WorkspaceContextMiddleware(wm);
+
+        String prompt = mw.onSystemPrompt(null, RuntimeContext.empty(), "BASE\n").block();
+
+        assertNotNull(prompt);
+        assertTrue(
+                prompt.contains("Sandbox root: /workspace"),
+                "prompt must fall back to /workspace, got:\n" + prompt);
+    }
+
+    @Test
+    @DisplayName("Blank workspaceRoot falls back to /workspace")
+    void fallsBackOnBlankRoot() {
+        SandboxBackedFilesystem fs = fsWithWorkspaceRoot("   ");
+        wm = new WorkspaceManager(workspace, fs);
+        WorkspaceContextMiddleware mw = new WorkspaceContextMiddleware(wm);
+
+        String prompt = mw.onSystemPrompt(null, RuntimeContext.empty(), "BASE\n").block();
+
+        assertNotNull(prompt);
+        assertTrue(
+                prompt.contains("Sandbox root: /workspace"),
+                "prompt must fall back to /workspace, got:\n" + prompt);
+    }
+
+    private static SandboxBackedFilesystem fsWithWorkspaceRoot(String root) {
+        SandboxBackedFilesystem fs = new SandboxBackedFilesystem();
+        FakeSandbox sandbox = new FakeSandbox(root);
+        fs.setSandbox(sandbox);
+        return fs;
+    }
+
+    /** Minimal Sandbox whose state exposes a configurable workspaceRoot. */
+    private static final class FakeSandbox implements Sandbox {
+
+        private final FakeState state;
+
+        FakeSandbox(String workspaceRoot) {
+            this.state = new FakeState(workspaceRoot);
+        }
+
+        @Override
+        public void start() {}
+
+        @Override
+        public void stop() {}
+
+        @Override
+        public void shutdown() {}
+
+        @Override
+        public void close() {}
+
+        @Override
+        public boolean isRunning() {
+            return true;
+        }
+
+        @Override
+        public SandboxState getState() {
+            return state;
+        }
+
+        @Override
+        public ExecResult exec(
+                RuntimeContext runtimeContext, String command, Integer timeoutSeconds) {
+            return new ExecResult(0, "", "", false);
+        }
+
+        @Override
+        public InputStream persistWorkspace() {
+            return InputStream.nullInputStream();
+        }
+
+        @Override
+        public void hydrateWorkspace(InputStream archive) {}
+    }
+
+    /**
+     * SandboxState subclass that overrides {@link #getWorkspaceRoot()} with the test value,
+     * matching how real backends (Docker/E2b/AgentRun/...) store it.
+     */
+    private static final class FakeState extends SandboxState {
+
+        private final String workspaceRoot;
+
+        FakeState(String workspaceRoot) {
+            this.workspaceRoot = workspaceRoot;
+            setWorkspaceSpec(new WorkspaceSpec());
+        }
+
+        @Override
+        public String getWorkspaceRoot() {
+            return workspaceRoot;
+        }
+    }
+}


### PR DESCRIPTION
## AgentScope-Java Version

2.0.3-SNAPSHOT (`main` at 49cffeb6)

## Description

### Background

`WorkspaceContextMiddleware.buildWorkspaceParagraph()` hardcodes `"/workspace"` in the system prompt for sandbox-backed filesystems:

```java
sb.append("Sandbox root: /workspace (container id: ")
```

But different sandbox backends mount the workspace at different paths:
- Docker: `/workspace` (default)
- E2b: `/home/user`
- AgentRun: `/home/agentscope/workspace`
- Daytona: `/home/daytona/workspace`

The authoritative workspace root lives in each `SandboxState` subclass — written by `SandboxClient.create()` from `SandboxClientOptions.workspaceRoot` at sandbox creation time, and used by all sandbox exec/hydrate/persist operations at runtime. The hardcoded value gives the model incorrect path context when any non-default root is configured.

**Note on `WorkspaceSpec.root`**: this is a *separate* declarative field for workspace projection (initial entries, environment). It may diverge from the actual container path because it comes from a different input source. The fix reads the state field, not the spec, because the state is what the sandbox runtime actually uses.

### Changes

- **`SandboxState.java`**: add `public String getWorkspaceRoot()` returning `null`. All 5 existing backend subclasses (`DockerSandboxState`, `E2bSandboxState`, `AgentRunSandboxState`, `DaytonaSandboxState`, `KubernetesSandboxState`) already have their own `public String getWorkspaceRoot()` with their own field — those automatically become overrides, requiring zero changes to extension modules.
- **`WorkspaceContextMiddleware.java`**: new `resolveSandboxRoot(AbstractFilesystem)` helper reads `SandboxAware.getSandbox().getState().getWorkspaceRoot()`, falling back to `/workspace` when unavailable. The sandbox prompt branch calls it instead of the hardcoded string.
- **`WorkspaceContextMiddlewareSandboxRootTest.java`** (new): 3 tests with a `FakeState` subclass that overrides `getWorkspaceRoot()` — matching exactly how real backends store the value.

### How to test

```bash
mvn -pl agentscope-harness -am -DfailIfNoSpecifiedTests=false \
    -Dtest='WorkspaceContextMiddlewareSandboxRootTest' test
```

Full regression including sandbox extension serde tests:
```bash
mvn -pl agentscope-harness,agentscope-extensions/agentscope-extensions-sandbox/agentscope-extensions-sandbox-agentrun,agentscope-extensions/agentscope-extensions-sandbox/agentscope-extensions-sandbox-e2b,agentscope-extensions/agentscope-extensions-sandbox/agentscope-extensions-sandbox-kubernetes -am test
# Tests run: 3156, Failures: 0, Errors: 0
# BUILD SUCCESS
```

### Jackson serialization safety

The base-class getter has **no `@JsonIgnore`** — that was tested and found to *break* subclass serialization (Jackson inherits ignore annotations downward). Without the annotation, Jackson correctly resolves the property from each subclass's own field+getter+setter, ignoring the base-class getter entirely. Verified by running `AgentRunSandboxStateSerializationTest` (round-trip serde with explicit `workspaceRoot` assertion).

---
Closes #2647