### PR TITLE
feat(harness): let operators configure subagent timeout, overriding the LLM

### DIFF
--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/subagent/SubagentDeclaration.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/subagent/SubagentDeclaration.java
@@ -96,6 +96,7 @@ public final class SubagentDeclaration {
     private final boolean persistSession;
     private final boolean inheritParentPermissions;
     private final Boolean exposeToUser;
+    private final Integer timeoutSeconds;
     private final List<String> tools;
     private final List<String> skills;
 
@@ -141,6 +142,7 @@ public final class SubagentDeclaration {
         this.persistSession = b.persistSession;
         this.inheritParentPermissions = b.inheritParentPermissions;
         this.exposeToUser = b.exposeToUser;
+        this.timeoutSeconds = b.timeoutSeconds;
         this.tools = b.tools != null ? List.copyOf(b.tools) : List.of();
         this.skills = b.skills != null ? List.copyOf(b.skills) : List.of();
         this.url = b.url;
@@ -301,6 +303,36 @@ public final class SubagentDeclaration {
     }
 
     /**
+     * Optional per-subagent synchronous wait timeout, in seconds.
+     *
+     * <p>When set (non-null), this value takes precedence over the {@code timeout_seconds} argument
+     * the LLM supplies on {@code agent_spawn} / {@code agent_send}, giving the application operator
+     * control over how long the parent waits synchronously for the subagent result before
+     * returning. This is useful when the model cannot reliably estimate the wait for deep,
+     * long-running work and keeps timing out.
+     *
+     * <p>Semantics when set:
+     *
+     * <ul>
+     *   <li>The parent waits synchronously for up to this many seconds, overriding an LLM request
+     *       for background execution ({@code timeout_seconds=0}).
+     *   <li>This bounds the wait, not the subagent's lifetime: when the wait elapses the run is
+     *       promoted to a background task and its {@code task_id} is returned, unless
+     *       {@code AgentSpawnTool#CTX_FORCE_SYNC} is enabled, in which case the subagent is
+     *       interrupted and {@code status: timeout} is returned.
+     *   <li>Values are clamped to the tool's maximum; {@code <= 0} is treated as unset.
+     * </ul>
+     *
+     * <p>{@code null} (default) defers to the per-call {@code RuntimeContext} override and then the
+     * LLM's {@code timeout_seconds} argument. This is overridden at runtime by a
+     * {@code RuntimeContext} value keyed {@code AgentSpawnTool#CTX_TIMEOUT_SECONDS}; see
+     * {@code AgentSpawnTool} for the full resolution precedence.
+     */
+    public Integer getTimeoutSeconds() {
+        return timeoutSeconds;
+    }
+
+    /**
      * Optional tool allowlist. When non-empty, only inherited parent tools whose names are listed
      * remain on the subagent's inherited toolkit. Empty means inherit all parent tools.
      */
@@ -396,6 +428,7 @@ public final class SubagentDeclaration {
         private boolean persistSession = false;
         private boolean inheritParentPermissions = true;
         private Boolean exposeToUser;
+        private Integer timeoutSeconds;
         private List<String> tools;
         private List<String> skills;
         private String url;
@@ -558,6 +591,22 @@ public final class SubagentDeclaration {
          */
         public Builder exposeToUser(Boolean exposeToUser) {
             this.exposeToUser = exposeToUser;
+            return this;
+        }
+
+        /**
+         * Per-subagent synchronous wait timeout in seconds, overriding the LLM's
+         * {@code timeout_seconds} argument.
+         *
+         * <p>Use this when the model cannot reliably estimate the wait for deep, long-running work.
+         * A non-null value makes the parent wait synchronously for up to this many seconds, even if
+         * the model requests background execution. It bounds the wait rather than the subagent's
+         * lifetime: once the wait elapses the run is promoted to a background task unless
+         * force-sync is enabled. {@code null} (default) defers to the {@code RuntimeContext}
+         * override and then the LLM's argument.
+         */
+        public Builder timeoutSeconds(Integer timeoutSeconds) {
+            this.timeoutSeconds = timeoutSeconds;
             return this;
         }
 

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/tool/AgentSpawnTool.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/tool/AgentSpawnTool.java
@@ -204,6 +204,24 @@ public class AgentSpawnTool {
     public static final String CTX_FORCE_SYNC_TIMEOUT_SECONDS =
             "agentscope.subagent.force_sync_timeout_seconds";
 
+    /**
+     * Optional {@link RuntimeContext} override for the synchronous wait (seconds), applied
+     * regardless of force-sync. Accepts an {@link Integer}/{@link Number} or its string form.
+     *
+     * <p>This is the highest-priority source in the general (non-force-sync) timeout resolution:
+     * per-call {@code RuntimeContext} → {@link SubagentDeclaration#getTimeoutSeconds()} →
+     * LLM {@code timeout_seconds}. Like a declaration timeout, a positive value makes the parent
+     * wait synchronously for up to that many seconds, overriding an LLM request for background
+     * execution ({@code timeout_seconds=0}). It bounds the wait rather than the subagent's
+     * lifetime: once the wait elapses the run is promoted to a background task unless
+     * {@link #CTX_FORCE_SYNC} is enabled. Values {@code <= 0} are ignored (treated as unset);
+     * values above the maximum are clamped.
+     *
+     * <p>Distinct from {@link #CTX_FORCE_SYNC_TIMEOUT_SECONDS}, which only applies when
+     * {@link #CTX_FORCE_SYNC} is enabled and retains top priority in that mode.
+     */
+    public static final String CTX_TIMEOUT_SECONDS = "agentscope.subagent.timeout_seconds";
+
     private static final String BG_RESULT_TEMPLATE =
             """
             status: accepted
@@ -449,8 +467,11 @@ public class AgentSpawnTool {
         }
 
         boolean forceSync = isForceSync(runtimeContext);
-        long timeoutMs = resolveEffectiveTimeoutMs(timeoutSeconds, runtimeContext);
         boolean remote = declOpt.map(SubagentDeclaration::isRemote).orElse(false);
+        // Timeout precedence: per-call RuntimeContext override, the declaration's configured
+        // timeout, then the LLM's timeout_seconds — so operators can bound long-running subagents
+        // whose duration the model cannot estimate reliably.
+        long timeoutMs = resolveEffectiveTimeoutMs(timeoutSeconds, runtimeContext, declOpt);
 
         if (timeoutMs == 0) {
             String taskId = "task_" + UUID.randomUUID();
@@ -619,7 +640,6 @@ public class AgentSpawnTool {
         final SpawnedAgent spawned = resolved;
 
         boolean forceSync = isForceSync(runtimeContext);
-        long timeoutMs = resolveEffectiveTimeoutMs(timeoutSeconds, runtimeContext);
         String currentUserId = runtimeContext != null ? runtimeContext.getUserId() : null;
         String parentSessionId = runtimeContext != null ? runtimeContext.getSessionId() : null;
         DefaultAgentManager manager = managerFor(runtimeContext);
@@ -628,6 +648,7 @@ public class AgentSpawnTool {
         propagateParentDenyRules(
                 parentState, currentUserId, spawned.sessionId(), spawned.agent(), declOpt);
         boolean remote = declOpt.map(SubagentDeclaration::isRemote).orElse(false);
+        long timeoutMs = resolveEffectiveTimeoutMs(timeoutSeconds, runtimeContext, declOpt);
 
         if (timeoutMs == 0) {
             String taskId = "task_" + UUID.randomUUID();
@@ -1515,19 +1536,45 @@ public class AgentSpawnTool {
     }
 
     /**
+     * Resolves the effective sync wait for the current call, without a subagent declaration.
+     *
+     * <p>Equivalent to {@link #resolveEffectiveTimeoutMs(Integer, RuntimeContext, Optional)} with
+     * an empty declaration.
+     */
+    static long resolveEffectiveTimeoutMs(Integer timeoutSeconds, RuntimeContext ctx) {
+        return resolveEffectiveTimeoutMs(timeoutSeconds, ctx, Optional.empty());
+    }
+
+    /**
      * Resolves the effective sync wait for the current call.
      *
      * <p>Precedence under force-sync (highest first):
      *
      * <ol>
      *   <li>{@link #CTX_FORCE_SYNC_TIMEOUT_SECONDS} when present — absolute app override
+     *   <li>{@link #CTX_TIMEOUT_SECONDS} when positive
+     *   <li>{@link SubagentDeclaration#getTimeoutSeconds()} when positive
      *   <li>LLM {@code timeout_seconds}, with {@code 0} coerced to the default sync timeout
      * </ol>
      *
-     * <p>Without force-sync, behavior matches {@link #resolveTimeoutMs} (including async {@code
-     * 0}).
+     * <p>Without force-sync, precedence is:
+     *
+     * <ol>
+     *   <li>{@link #CTX_TIMEOUT_SECONDS} when positive — per-call operator override
+     *   <li>{@link SubagentDeclaration#getTimeoutSeconds()} when positive — per-subagent operator
+     *       configuration
+     *   <li>LLM {@code timeout_seconds} (including async {@code 0}); see {@link #resolveTimeoutMs}
+     * </ol>
+     *
+     * <p>An operator-supplied timeout (context or declaration) expresses an explicit intent to wait
+     * synchronously, so it overrides an LLM request for background execution
+     * ({@code timeout_seconds=0}). It bounds the parent's wait rather than the subagent's lifetime:
+     * timeout promotion to a background task still applies unless {@link #CTX_FORCE_SYNC} is
+     * enabled. Non-positive operator values are treated as unset and fall through to the next
+     * source.
      */
-    static long resolveEffectiveTimeoutMs(Integer timeoutSeconds, RuntimeContext ctx) {
+    static long resolveEffectiveTimeoutMs(
+            Integer timeoutSeconds, RuntimeContext ctx, Optional<SubagentDeclaration> declOpt) {
         boolean forceSync = isForceSync(ctx);
         if (forceSync) {
             Integer override = forceSyncTimeoutSeconds(ctx);
@@ -1536,11 +1583,38 @@ public class AgentSpawnTool {
                 return (long) Math.min(seconds, MAX_TIMEOUT_SECONDS) * 1_000;
             }
         }
+        Integer operatorSeconds = resolveOperatorTimeoutSeconds(ctx, declOpt);
+        if (operatorSeconds != null) {
+            return (long) Math.min(operatorSeconds, MAX_TIMEOUT_SECONDS) * 1_000;
+        }
         long timeoutMs = resolveTimeoutMs(timeoutSeconds, DEFAULT_TIMEOUT_SECONDS);
         if (forceSync && timeoutMs == 0L) {
             return (long) DEFAULT_TIMEOUT_SECONDS * 1_000;
         }
         return timeoutMs;
+    }
+
+    /**
+     * Reads the operator-configured sync wait: per-call {@link #CTX_TIMEOUT_SECONDS} first, then
+     * {@link SubagentDeclaration#getTimeoutSeconds()}. Returns {@code null} when neither supplies a
+     * positive value, meaning "defer to the LLM argument".
+     */
+    static Integer resolveOperatorTimeoutSeconds(
+            RuntimeContext ctx, Optional<SubagentDeclaration> declOpt) {
+        if (ctx != null) {
+            Integer ctxSeconds = asPositiveOrZeroInt(ctx.get(CTX_TIMEOUT_SECONDS));
+            if (ctxSeconds != null && ctxSeconds > 0) {
+                return ctxSeconds;
+            }
+        }
+        Integer declSeconds =
+                declOpt != null
+                        ? declOpt.map(SubagentDeclaration::getTimeoutSeconds).orElse(null)
+                        : null;
+        if (declSeconds != null && declSeconds > 0) {
+            return declSeconds;
+        }
+        return null;
     }
 
     /** Reads {@link #CTX_FORCE_SYNC_TIMEOUT_SECONDS}; {@code null} means "no override". */
@@ -1622,7 +1696,7 @@ public class AgentSpawnTool {
             Integer timeoutSeconds,
             Optional<SubagentDeclaration> declOpt) {
         boolean forceSync = isForceSync(runtimeContext);
-        long timeoutMs = resolveEffectiveTimeoutMs(timeoutSeconds, runtimeContext);
+        long timeoutMs = resolveEffectiveTimeoutMs(timeoutSeconds, runtimeContext, declOpt);
         String currentUserId = runtimeContext != null ? runtimeContext.getUserId() : null;
         String parentSessionId = runtimeContext != null ? runtimeContext.getSessionId() : null;
         DefaultAgentManager manager = managerFor(runtimeContext);

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/tool/AgentSpawnToolDeclarationTimeoutTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/tool/AgentSpawnToolDeclarationTimeoutTest.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.harness.agent.tool;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import io.agentscope.core.agent.RuntimeContext;
+import io.agentscope.harness.agent.subagent.SubagentDeclaration;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests operator-controlled subagent timeout resolution: a per-subagent
+ * {@link SubagentDeclaration#getTimeoutSeconds()} or a per-call
+ * {@link AgentSpawnTool#CTX_TIMEOUT_SECONDS} overrides the LLM's {@code timeout_seconds} argument,
+ * so long-running subagents can be bounded by the application rather than the model.
+ */
+@DisplayName("AgentSpawnTool operator timeout (declaration / CTX_TIMEOUT_SECONDS)")
+class AgentSpawnToolDeclarationTimeoutTest {
+
+    private static final RuntimeContext EMPTY = RuntimeContext.empty();
+
+    private static Optional<SubagentDeclaration> declWithTimeout(Integer seconds) {
+        return Optional.of(
+                SubagentDeclaration.builder()
+                        .name("sub")
+                        .description("long-running subagent")
+                        .timeoutSeconds(seconds)
+                        .build());
+    }
+
+    @Test
+    @DisplayName("Declaration timeout overrides the LLM timeout_seconds")
+    void declarationOverridesLlmValue() {
+        assertEquals(
+                120_000L,
+                AgentSpawnTool.resolveEffectiveTimeoutMs(5, EMPTY, declWithTimeout(120)),
+                "declaration timeout must win over the LLM's 5s");
+    }
+
+    @Test
+    @DisplayName("Declaration timeout overrides an LLM async request (timeout_seconds=0)")
+    void declarationOverridesAsyncRequest() {
+        assertEquals(
+                90_000L,
+                AgentSpawnTool.resolveEffectiveTimeoutMs(0, EMPTY, declWithTimeout(90)),
+                "a configured timeout means run synchronously, overriding async 0");
+    }
+
+    @Test
+    @DisplayName("Declaration timeout is clamped to the maximum")
+    void declarationClampedToMax() {
+        assertEquals(
+                600_000L,
+                AgentSpawnTool.resolveEffectiveTimeoutMs(5, EMPTY, declWithTimeout(9999)),
+                "declaration timeout above 600s must clamp");
+    }
+
+    @Test
+    @DisplayName("Non-positive declaration timeout is ignored, deferring to the LLM value")
+    void nonPositiveDeclarationIgnored() {
+        assertEquals(
+                5_000L,
+                AgentSpawnTool.resolveEffectiveTimeoutMs(5, EMPTY, declWithTimeout(0)),
+                "timeout<=0 is unset; fall back to the LLM's 5s");
+        assertEquals(
+                0L,
+                AgentSpawnTool.resolveEffectiveTimeoutMs(0, EMPTY, declWithTimeout(-1)),
+                "unset declaration keeps async 0");
+    }
+
+    @Test
+    @DisplayName("Null declaration timeout leaves LLM behavior unchanged")
+    void nullDeclarationLeavesLlmBehavior() {
+        assertEquals(
+                0L,
+                AgentSpawnTool.resolveEffectiveTimeoutMs(0, EMPTY, declWithTimeout(null)),
+                "no configured timeout keeps async 0");
+        assertEquals(
+                7_000L,
+                AgentSpawnTool.resolveEffectiveTimeoutMs(7, EMPTY, Optional.empty()),
+                "no declaration keeps the LLM's 7s");
+    }
+
+    @Test
+    @DisplayName("CTX_TIMEOUT_SECONDS overrides both the declaration and the LLM value")
+    void contextOverridesDeclaration() {
+        RuntimeContext ctx =
+                RuntimeContext.builder().put(AgentSpawnTool.CTX_TIMEOUT_SECONDS, 200).build();
+        assertEquals(
+                200_000L,
+                AgentSpawnTool.resolveEffectiveTimeoutMs(5, ctx, declWithTimeout(120)),
+                "per-call context timeout takes precedence over the declaration");
+    }
+
+    @Test
+    @DisplayName("CTX_TIMEOUT_SECONDS accepts a numeric string and overrides async 0")
+    void contextAcceptsStringAndOverridesAsync() {
+        RuntimeContext ctx =
+                RuntimeContext.builder().put(AgentSpawnTool.CTX_TIMEOUT_SECONDS, "150").build();
+        assertEquals(150_000L, AgentSpawnTool.resolveEffectiveTimeoutMs(0, ctx, Optional.empty()));
+    }
+
+    @Test
+    @DisplayName("Force-sync absolute override still wins over declaration timeout")
+    void forceSyncOverrideBeatsDeclaration() {
+        RuntimeContext ctx =
+                RuntimeContext.builder()
+                        .put(AgentSpawnTool.CTX_FORCE_SYNC, true)
+                        .put(AgentSpawnTool.CTX_FORCE_SYNC_TIMEOUT_SECONDS, 45)
+                        .build();
+        assertEquals(
+                45_000L,
+                AgentSpawnTool.resolveEffectiveTimeoutMs(5, ctx, declWithTimeout(120)),
+                "force-sync absolute override retains top priority");
+    }
+
+    @Test
+    @DisplayName("Two-arg overload is unchanged (no declaration): async 0 stays async")
+    void twoArgOverloadUnchanged() {
+        assertEquals(0L, AgentSpawnTool.resolveEffectiveTimeoutMs(0, EMPTY));
+        assertEquals(5_000L, AgentSpawnTool.resolveEffectiveTimeoutMs(5, EMPTY));
+    }
+}


### PR DESCRIPTION
## AgentScope-Java Version

2.0.3-SNAPSHOT (`main` at 49cffeb6)

## Description

### Background

Subagent timeouts can currently only be set by the model, through the `timeout_seconds` argument on `agent_spawn` / `agent_send`. As reported in #2103, when a subagent runs deep, long-running business logic the model cannot estimate the duration reliably — it keeps timing out, and retrying with a few more minutes times out again.

The one existing override, `CTX_FORCE_SYNC_TIMEOUT_SECONDS`, is only read when `CTX_FORCE_SYNC` is enabled:

```java
static long resolveEffectiveTimeoutMs(Integer timeoutSeconds, RuntimeContext ctx) {
    boolean forceSync = isForceSync(ctx);
    if (forceSync) {                                 // ← only under force-sync
        Integer override = forceSyncTimeoutSeconds(ctx);
```

Enabling force-sync also takes away the model's ability to choose background execution, so there was no way to bound the wait while leaving the sync/async decision alone.

### Changes

- **`SubagentDeclaration`**: new `Integer timeoutSeconds` (field, builder setter, getter), so a timeout can be configured per subagent type alongside the existing `steps` / `model` / `exposeToUser` options.
- **`AgentSpawnTool`**:
  - new `CTX_TIMEOUT_SECONDS` `RuntimeContext` key for a per-call operator override that applies regardless of force-sync;
  - new `resolveOperatorTimeoutSeconds(RuntimeContext, Optional<SubagentDeclaration>)`;
  - `resolveEffectiveTimeoutMs` gains a 3-arg overload taking the declaration. The original 2-arg overload is kept and delegates with `Optional.empty()`.
- All three call sites — `agentSpawn`, `agentSend`, `execSpawnTask` — now pass the declaration, so local and remote subagents share one resolution path.

### Resolution precedence

| Mode | Precedence (highest first) |
|---|---|
| force-sync | `CTX_FORCE_SYNC_TIMEOUT_SECONDS` → `CTX_TIMEOUT_SECONDS` → declaration → LLM `timeout_seconds` |
| default | `CTX_TIMEOUT_SECONDS` → declaration → LLM `timeout_seconds` (including async `0`) |

This mirrors the precedence convention already used in this file for `resolveExposeToUser` (per-call context → declaration policy → LLM argument).

An operator-supplied timeout expresses an explicit intent to wait synchronously, so a positive value overrides an LLM request for background execution (`timeout_seconds=0`) — that is the point of the feature per the issue ("超时时间给人一个控制权"). Non-positive operator values are treated as unset and fall through to the next source. All sources remain clamped to `MAX_TIMEOUT_SECONDS`.

### Usage

```java
SubagentDeclaration.builder()
        .name("deep-etl")
        .description("Runs a long ETL pipeline")
        .timeoutSeconds(300)      // operator bound, regardless of what the model asks for
        .build();
```

Or per call:

```java
RuntimeContext ctx = RuntimeContext.builder()
        .put(AgentSpawnTool.CTX_TIMEOUT_SECONDS, 300)
        .build();
```

### How to test

```bash
mvn -pl agentscope-harness -am -DfailIfNoSpecifiedTests=false \
    -Dtest='AgentSpawnToolDeclarationTimeoutTest' test
```

Full module regression:

```bash
mvn -pl agentscope-harness -am test
# core:    Tests run: 2275, Failures: 0, Errors: 0, Skipped: 9
# harness: Tests run: 837,  Failures: 0, Errors: 0, Skipped: 3
# BUILD SUCCESS
```

`AgentSpawnToolDeclarationTimeoutTest` adds 9 tests covering: declaration overriding a positive LLM value, declaration overriding async `0`, clamping at 600s, non-positive and null declarations falling through, `CTX_TIMEOUT_SECONDS` beating the declaration, numeric-string parsing, force-sync override retaining top priority, and the unchanged 2-arg overload.

The new tests were verified to actually exercise the new branch: with the operator-resolution block removed, exactly the 5 tests asserting new behaviour fail while the 4 asserting fallback/compatibility still pass.

### Backwards compatibility

- The 2-arg `resolveEffectiveTimeoutMs` overload is preserved with unchanged semantics; `AgentSpawnToolForceSyncTest`'s existing assertions (including "without force-sync, `0` stays async even with a timeout override present") all pass untouched.
- A declaration without `timeoutSeconds` (the default `null`) behaves exactly as before.
- `CTX_FORCE_SYNC_TIMEOUT_SECONDS` semantics are unchanged and it keeps top priority under force-sync.
- `timeoutMs == 0` remains the sole gate for background task submission, so `task_id` / `BG_RESULT_TEMPLATE` flows and timeout-promotion behaviour (still governed by `forceSync`) are untouched.

## Checklist

Please check the following items before code is ready to be reviewed.

- [x]  Code has been formatted with `mvn spotless:apply` (`spotless:check` passes)
- [x]  All tests are passing (`mvn test`)
- [x]  Javadoc comments are complete and follow project conventions (new constant, field, builder setter and both overloads document the full precedence chain)
- [x]  Related documentation has been updated (e.g. links, examples, etc.) — the feature is documented via Javadoc on the public `SubagentDeclaration.timeoutSeconds` builder method and `AgentSpawnTool.CTX_TIMEOUT_SECONDS`; no existing doc page describes subagent timeout resolution
- [x]  Code is ready for review

---
Closes #2103
