### PR TITLE
fix(core): retry empty final responses instead of finishing silently

### DIFF
--- a/agentscope-core/src/main/java/io/agentscope/core/ReActAgent.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/ReActAgent.java
@@ -2435,10 +2435,7 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
                                 // Empty final response: no tool calls and no visible content
                                 // (e.g. a reasoning model that wrote its whole answer into the
                                 // reasoning channel and left the content channel empty). Loop
-                                // back to reasoning with a synthetic reminder — mirroring the
-                                // "Tool not found" feedback given for hallucinated tool calls —
-                                // bounded by maxIters, instead of silently finishing with an
-                                // empty reply (#2750).
+                                // back to reasoning with a synthetic reminder.
                                 if (!hasToolCalls(eventMsg)) {
                                     log.warn(
                                             "Final response has no visible content (empty reply),"
@@ -3698,8 +3695,7 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
         /**
          * Check if the ReAct loop should terminate.
          *
-         * <p>A response with tool calls (even non-existent ones) continues to the acting phase
-         * where ToolExecutor returns "Tool not found" for the model to see. A tool-free response
+         * <p>A response with tool calls continues to the acting phase. A tool-free response
          * finishes only when it carries visible content: empty or thinking-only responses (the
          * entire answer in the reasoning channel) loop back to reasoning, bounded by {@code
          * maxIters}, instead of silently ending the agent with an empty reply.
@@ -3716,28 +3712,14 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
                 return false;
             }
 
-            return hasVisibleText(msg);
-        }
-
-        /**
-         * Check whether the given message requests tool execution. Shared by {@link #isFinished}
-         * and the empty-final-response guard so both derive "tool-free" from one place.
-         */
-        private static boolean hasToolCalls(Msg msg) {
-            return !msg.getContentBlocks(ToolUseBlock.class).isEmpty();
-        }
-
-        /**
-         * Check whether the given message carries user-visible content: a {@link TextBlock}
-         * with non-blank text. Text is the only channel consumers render as the assistant's
-         * visible reply (thinking never counts; tool calls are handled by the caller before
-         * this check; images and other data enter through tool results, not final responses).
-         */
-        private static boolean hasVisibleText(Msg msg) {
             return msg.getContentBlocks(TextBlock.class).stream()
                     .anyMatch(
                             textBlock ->
                                     textBlock.getText() != null && !textBlock.getText().isBlank());
+        }
+
+        private static boolean hasToolCalls(Msg msg) {
+            return !msg.getContentBlocks(ToolUseBlock.class).isEmpty();
         }
 
         /**

--- a/agentscope-core/src/main/java/io/agentscope/core/ReActAgent.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/ReActAgent.java
@@ -3716,7 +3716,7 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
                 return false;
             }
 
-            return hasVisibleContent(msg);
+            return hasVisibleText(msg);
         }
 
         /**
@@ -3728,24 +3728,16 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
         }
 
         /**
-         * Check whether the given message carries any user-visible content: any non-thinking
-         * block, where a {@link TextBlock} counts only when its text is non-blank. Blank text,
-         * thinking-only and fully-empty responses carry no visible content; tool-call-only
-         * responses are handled by the caller before this check.
+         * Check whether the given message carries user-visible content: a {@link TextBlock}
+         * with non-blank text. Text is the only channel consumers render as the assistant's
+         * visible reply (thinking never counts; tool calls are handled by the caller before
+         * this check; images and other data enter through tool results, not final responses).
          */
-        private static boolean hasVisibleContent(Msg msg) {
-            return msg.getContent().stream()
+        private static boolean hasVisibleText(Msg msg) {
+            return msg.getContentBlocks(TextBlock.class).stream()
                     .anyMatch(
-                            block -> {
-                                if (block instanceof ThinkingBlock) {
-                                    return false;
-                                }
-                                if (block instanceof TextBlock textBlock) {
-                                    return textBlock.getText() != null
-                                            && !textBlock.getText().isBlank();
-                                }
-                                return true;
-                            });
+                            textBlock ->
+                                    textBlock.getText() != null && !textBlock.getText().isBlank());
         }
 
         /**

--- a/agentscope-core/src/main/java/io/agentscope/core/ReActAgent.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/ReActAgent.java
@@ -313,6 +313,12 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
      */
     private static final String EVENT_SINK_KEY = "io.agentscope.core.ReActAgent.eventSink";
 
+    /** Synthetic reminder injected when looping back to reasoning for an empty final response. */
+    private static final String EMPTY_RESPONSE_REMINDER_TEXT =
+            "<system-reminder>Your previous reply had empty content - the full answer was written"
+                    + " to the reasoning channel only. Reply again and write the final answer into"
+                    + " the content channel.</system-reminder>";
+
     @SuppressWarnings("deprecation")
     private final LegacyHookDispatcher hookDispatcher;
 
@@ -2426,6 +2432,22 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
                                     return Mono.justOrEmpty(eventMsg);
                                 }
 
+                                // Empty final response: no tool calls and no visible content
+                                // (e.g. a reasoning model that wrote its whole answer into the
+                                // reasoning channel and left the content channel empty). Loop
+                                // back to reasoning with a synthetic reminder — mirroring the
+                                // "Tool not found" feedback given for hallucinated tool calls —
+                                // bounded by maxIters, instead of silently finishing with an
+                                // empty reply (#2750).
+                                if (!hasToolCalls(eventMsg)) {
+                                    log.warn(
+                                            "Final response has no visible content (empty reply),"
+                                                    + " model: {}, iter: {}",
+                                            model.getModelName(),
+                                            iter);
+                                    state.contextMutable().add(buildEmptyResponseReminder());
+                                }
+
                                 // Continue to acting
                                 return checkInterrupted().then(acting(iter));
                             })
@@ -3676,6 +3698,12 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
         /**
          * Check if the ReAct loop should terminate.
          *
+         * <p>A response with tool calls (even non-existent ones) continues to the acting phase
+         * where ToolExecutor returns "Tool not found" for the model to see. A tool-free response
+         * finishes only when it carries visible content: empty or thinking-only responses (the
+         * entire answer in the reasoning channel) loop back to reasoning, bounded by {@code
+         * maxIters}, instead of silently ending the agent with an empty reply.
+         *
          * @param msg The reasoning message
          * @return true if should finish, false if should continue to acting
          */
@@ -3684,12 +3712,63 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
                 return true;
             }
 
-            List<ToolUseBlock> toolCalls = msg.getContentBlocks(ToolUseBlock.class);
+            if (hasToolCalls(msg)) {
+                return false;
+            }
 
-            // No tool calls - finished
-            // If there are tool calls (even non-existent ones), continue to acting phase
-            // where ToolExecutor will return "Tool not found" error for the model to see
-            return toolCalls.isEmpty();
+            return hasVisibleContent(msg);
+        }
+
+        /**
+         * Check whether the given message requests tool execution. Shared by {@link #isFinished}
+         * and the empty-final-response guard so both derive "tool-free" from one place.
+         */
+        private static boolean hasToolCalls(Msg msg) {
+            return !msg.getContentBlocks(ToolUseBlock.class).isEmpty();
+        }
+
+        /**
+         * Check whether the given message carries any user-visible content: any non-thinking
+         * block, where a {@link TextBlock} counts only when its text is non-blank. Blank text,
+         * thinking-only and fully-empty responses carry no visible content; tool-call-only
+         * responses are handled by the caller before this check.
+         */
+        private static boolean hasVisibleContent(Msg msg) {
+            return msg.getContent().stream()
+                    .anyMatch(
+                            block -> {
+                                if (block instanceof ThinkingBlock) {
+                                    return false;
+                                }
+                                if (block instanceof TextBlock textBlock) {
+                                    return textBlock.getText() != null
+                                            && !textBlock.getText().isBlank();
+                                }
+                                return true;
+                            });
+        }
+
+        /**
+         * Build the synthetic {@code system} reminder injected before looping back to reasoning
+         * after an empty final response.
+         *
+         * <p>Unlike {@code TaskReminderMiddleware}'s transient todo reminder, this reminder is
+         * written into the agent context and persists in the session state (like {@code
+         * SubagentsMiddleware}'s task-delivery reminder): the corrective signal stays visible to
+         * later turns. Accumulation is bounded by {@code maxIters} per call.
+         */
+        private static Msg buildEmptyResponseReminder() {
+            return Msg.builder()
+                    .role(MsgRole.USER)
+                    .name("system")
+                    .content(TextBlock.builder().text(EMPTY_RESPONSE_REMINDER_TEXT).build())
+                    .metadata(
+                            Map.of(
+                                    Msg.METADATA_SYNTHETIC,
+                                    true,
+                                    Msg.METADATA_REMINDER_KIND,
+                                    "empty_response"))
+                    .build();
         }
 
         /**

--- a/agentscope-core/src/test/java/io/agentscope/core/agent/ReActAgentEmptyResponseRetryTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/agent/ReActAgentEmptyResponseRetryTest.java
@@ -1,0 +1,204 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.core.agent;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.agentscope.core.ReActAgent;
+import io.agentscope.core.agent.test.TestUtils;
+import io.agentscope.core.message.Msg;
+import io.agentscope.core.message.MsgRole;
+import io.agentscope.core.message.TextBlock;
+import io.agentscope.core.message.ThinkingBlock;
+import io.agentscope.core.message.ToolUseBlock;
+import io.agentscope.core.model.ChatResponse;
+import io.agentscope.core.model.Model;
+import io.agentscope.core.tool.Toolkit;
+import io.agentscope.core.util.JsonUtils;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import reactor.core.publisher.Flux;
+
+/**
+ * Tests for the empty-final-response guard: a finished response with no tool calls and no
+ * visible content (e.g. a reasoning model that wrote its whole answer into the reasoning
+ * channel) loops back to reasoning — bounded by {@code maxIters} — instead of silently
+ * ending with an empty reply.
+ */
+class ReActAgentEmptyResponseRetryTest {
+
+    private static final Duration TEST_TIMEOUT = Duration.ofSeconds(10);
+
+    private Model mockModel;
+    private Toolkit toolkit;
+
+    @BeforeEach
+    void setUp() {
+        mockModel = mock(Model.class);
+        when(mockModel.getModelName()).thenReturn("test-model");
+        toolkit = new Toolkit();
+    }
+
+    @Test
+    @DisplayName("Thinking-only final response loops back and the retry carries a reminder")
+    void retriesThinkingOnlyFinalResponse() {
+        when(mockModel.stream(anyList(), anyList(), any()))
+                .thenReturn(fluxOf(TestUtils.createThinkingMessage("assistant", "thinking only")))
+                .thenReturn(fluxOf(TestUtils.createAssistantMessage("assistant", "final answer")));
+
+        ReActAgent agent = buildAgent(10);
+        Msg result = agent.call(TestUtils.createUserMessage("user", "hello")).block(TEST_TIMEOUT);
+
+        assertNotNull(result);
+        assertTrue(result.hasContentBlocks(TextBlock.class), "Retry should produce visible text");
+        verify(mockModel, times(2)).stream(anyList(), anyList(), any());
+
+        // The re-entered reasoning call must carry the synthetic reminder as its last message
+        ArgumentCaptor<List<Msg>> msgsCaptor = ArgumentCaptor.forClass(List.class);
+        verify(mockModel, times(2)).stream(msgsCaptor.capture(), anyList(), any());
+        List<Msg> secondCallMsgs = msgsCaptor.getAllValues().get(1);
+        Msg lastMsg = secondCallMsgs.get(secondCallMsgs.size() - 1);
+        assertEquals(Boolean.TRUE, lastMsg.getMetadata().get(Msg.METADATA_SYNTHETIC));
+        assertEquals("empty_response", lastMsg.getMetadata().get(Msg.METADATA_REMINDER_KIND));
+        TextBlock reminderText = lastMsg.getFirstContentBlock(TextBlock.class);
+        assertNotNull(reminderText);
+        assertTrue(
+                reminderText.getText().startsWith("<system-reminder>"),
+                "Reminder should be a system reminder");
+    }
+
+    @Test
+    @DisplayName("A model that keeps returning thinking-only stops at maxIters")
+    void loopIsBoundedByMaxIters() {
+        // tools matcher is any(): the summarizing path passes null tool schemas
+        when(mockModel.stream(anyList(), any(), any()))
+                .thenAnswer(
+                        invocation ->
+                                fluxOf(TestUtils.createThinkingMessage("assistant", "thinking")));
+
+        ReActAgent agent = buildAgent(1);
+        Msg result = agent.call(TestUtils.createUserMessage("user", "hello")).block(TEST_TIMEOUT);
+
+        assertNotNull(result);
+        assertFalse(
+                result.hasContentBlocks(TextBlock.class),
+                "Exhausted iterations return the empty response as-is");
+        // One reasoning round at iter 0, then summarizing() at iter 1 (which calls the model
+        // again via the summary path) — never an unbounded loop
+        verify(mockModel, times(2)).stream(anyList(), any(), any());
+    }
+
+    @Test
+    @DisplayName("Blank text counts as no visible content")
+    void blankTextTriggersRetry() {
+        when(mockModel.stream(anyList(), anyList(), any()))
+                .thenReturn(fluxOf(blankTextMsg()))
+                .thenReturn(fluxOf(TestUtils.createAssistantMessage("assistant", "final answer")));
+
+        ReActAgent agent = buildAgent(10);
+        Msg result = agent.call(TestUtils.createUserMessage("user", "hello")).block(TEST_TIMEOUT);
+
+        assertNotNull(result);
+        assertTrue(result.hasContentBlocks(TextBlock.class));
+        verify(mockModel, times(2)).stream(anyList(), anyList(), any());
+    }
+
+    @Test
+    @DisplayName("Responses with tool calls do not trigger the guard")
+    void toolCallResponsesAreNotRetried() {
+        when(mockModel.stream(anyList(), anyList(), any()))
+                .thenReturn(fluxOf(toolUseMsg()))
+                .thenReturn(fluxOf(TestUtils.createAssistantMessage("assistant", "final answer")));
+
+        ReActAgent agent = buildAgent(10);
+        Msg result = agent.call(TestUtils.createUserMessage("user", "hello")).block(TEST_TIMEOUT);
+
+        assertNotNull(result);
+        assertTrue(result.hasContentBlocks(TextBlock.class));
+        // Exactly one acting round: 2 model calls total, no guard-triggered extra call
+        verify(mockModel, times(2)).stream(anyList(), anyList(), any());
+    }
+
+    @Test
+    @DisplayName("Normal text responses are not retried")
+    void textResponsesAreNotRetried() {
+        when(mockModel.stream(anyList(), anyList(), any()))
+                .thenReturn(fluxOf(TestUtils.createAssistantMessage("assistant", "hello back")));
+
+        ReActAgent agent = buildAgent(10);
+        Msg result = agent.call(TestUtils.createUserMessage("user", "hello")).block(TEST_TIMEOUT);
+
+        assertNotNull(result);
+        assertTrue(result.hasContentBlocks(TextBlock.class));
+        verify(mockModel, times(1)).stream(anyList(), anyList(), any());
+    }
+
+    private ReActAgent buildAgent(int maxIters) {
+        return ReActAgent.builder()
+                .name("test-agent")
+                .model(mockModel)
+                .toolkit(toolkit)
+                .checkRunning(false)
+                .maxIters(maxIters)
+                .build();
+    }
+
+    private Flux<ChatResponse> fluxOf(Msg msg) {
+        ChatResponse response =
+                ChatResponse.builder().id("test-id").content(msg.getContent()).build();
+        return Flux.just(response);
+    }
+
+    private Msg blankTextMsg() {
+        return Msg.builder()
+                .name("assistant")
+                .role(MsgRole.ASSISTANT)
+                .content(
+                        ThinkingBlock.builder().thinking("thinking").build(),
+                        TextBlock.builder().text("   ").build())
+                .build();
+    }
+
+    private Msg toolUseMsg() {
+        Map<String, Object> input = Map.of("query", "test");
+        return Msg.builder()
+                .name("assistant")
+                .role(MsgRole.ASSISTANT)
+                .content(
+                        ThinkingBlock.builder().thinking("call the tool").build(),
+                        ToolUseBlock.builder()
+                                .id("t1")
+                                .name("search")
+                                .input(input)
+                                .content(JsonUtils.getJsonCodec().toJson(input))
+                                .build())
+                .build();
+    }
+}

--- a/agentscope-core/src/test/java/io/agentscope/core/agent/ReActAgentThinkingCumulativeTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/agent/ReActAgentThinkingCumulativeTest.java
@@ -86,14 +86,7 @@ class ReActAgentThinkingCumulativeTest {
                 };
 
         // Create agent with the hook
-        ReActAgent agent =
-                ReActAgent.builder()
-                        .name("TestAgent")
-                        .sysPrompt("You are a test agent")
-                        .model(mockModel)
-                        .toolkit(new EmptyToolkit())
-                        .hook(cumulativeHook)
-                        .build();
+        ReActAgent agent = buildAgent(mockModel, cumulativeHook);
 
         // Execute agent call
         Msg userMsg = TestUtils.createUserMessage("User", "Hello");
@@ -141,14 +134,7 @@ class ReActAgentThinkingCumulativeTest {
                 };
 
         // Create agent with the hook
-        ReActAgent agent =
-                ReActAgent.builder()
-                        .name("TestAgent")
-                        .sysPrompt("You are a test agent")
-                        .model(mockModel)
-                        .toolkit(new EmptyToolkit())
-                        .hook(incrementalHook)
-                        .build();
+        ReActAgent agent = buildAgent(mockModel, incrementalHook);
 
         // Execute agent call
         Msg userMsg = TestUtils.createUserMessage("User", "Hello");
@@ -163,6 +149,22 @@ class ReActAgentThinkingCumulativeTest {
         assertEquals(
                 "this is ", receivedThinkingChunks.get(1), "Second chunk should be 'this is '");
         assertEquals("correct.", receivedThinkingChunks.get(2), "Third chunk should be 'correct.'");
+    }
+
+    /**
+     * Build an agent around the given chunk-collecting hook. The model streams thinking-only
+     * chunks, so iterations are capped at 1: the empty-final-response loop-back goes straight to
+     * summarizing and the chunk-mechanics assertions stay deterministic.
+     */
+    private ReActAgent buildAgent(Model model, Hook hook) {
+        return ReActAgent.builder()
+                .name("TestAgent")
+                .sysPrompt("You are a test agent")
+                .model(model)
+                .toolkit(new EmptyToolkit())
+                .maxIters(1)
+                .hook(hook)
+                .build();
     }
 
     /**


### PR DESCRIPTION
Fixes #2750

## Summary

A reasoning model occasionally emits its entire final answer into the `reasoning_content` channel with an empty `content` (`finish_reason=stop`, no tool calls). `ReActAgent.isFinished()` only checked `toolCalls.isEmpty()`, so such a response terminated the ReAct loop **silently**: zero `TEXT_MESSAGE_*` events downstream, empty assistant turn in session history, and nothing logged at WARN/ERROR — an invisible failure for both the user and ops. Verified in production with kimi-k2.6 (DashScope OpenAI-compatible endpoint); any reasoning model over the OpenAI-compatible path using `reasoning_content` is exposed (DeepSeek-R1-class included).

## Root cause chain (main @ 49cffeb6)

| Link | Location | Behavior |
|---|---|---|
| Response parsing | `OpenAIResponseParser.java:431-466` | `reasoning_content` → `ThinkingBlock`; empty `content` → no `TextBlock` (faithful, unchanged) |
| Event emission | `ReActAgent.emitBlockEvents` | no `TextBlock` → no `TextBlock*Event` |
| Finish check | `ReActAgent.isFinished()` | `toolCalls.isEmpty()` only — never checked for visible content |
| AG-UI conversion | `TextBlockEventConverter` | `TextMessage*` events sourced exclusively from `TextBlock*` events |

## The fix

1. **`isFinished()` strengthened** — a tool-free response finishes only when it carries visible content: any non-`ThinkingBlock` block counts, a `TextBlock` only when non-blank. `msg == null` still finishes (unchanged).
2. **Empty final responses loop back through the existing natural path** — `runPostReasoningPipeline` → `acting(iter)` → (empty pending branch) → `executeIteration(iter + 1)` → `reasoning(iter + 1, false)`. The retry therefore **consumes iteration budget and is bounded by `maxIters`** — exactly the semantics the loop already applies to hallucinated tool calls ("Tool not found" loops). No new config, no new per-call state, honest iteration accounting.
3. **Feedback per loop-back** — a WARN is logged unconditionally (observability even when iterations exhaust), and a synthetic reminder (`role=USER`, `name="system"`, `METADATA_SYNTHETIC`, reminder kind `"empty_response"`) is injected, mirroring the "Tool not found" feedback given for hallucinated tools. Construction follows the existing `TaskReminderMiddleware` / `SubagentsMiddleware` synthetic-reminder convention; unlike the transient todo reminder it is deliberately written into the agent context (like `SubagentsMiddleware`'s task-delivery reminder) so the corrective signal stays visible to later turns, bounded by `maxIters` per call.

## Behavior change

Models that legitimately end with empty or thinking-only final responses now trigger additional model calls (bounded by `maxIters`) instead of finishing silently. When iterations exhaust, the existing `summarizing()` safety net applies. The only in-repo test relying on silent thinking-only completion (`ReActAgentThinkingCumulativeTest`, a chunk-mechanics test whose mock model streams thinking-only chunks) was adapted with `.maxIters(1)`.

## Tests

New `ReActAgentEmptyResponseRetryTest`:
- thinking-only first response → retry produces text; 2 model calls; second call's last message is the synthetic reminder (asserts `METADATA_SYNTHETIC`, reminder kind `"empty_response"`, `<system-reminder>` prefix)
- a model that always returns thinking-only with `maxIters=1` → bounded (1 reasoning call + 1 summary call), never an unbounded loop
- blank-text-only response triggers the retry
- tool-call responses do **not** trigger the guard
- normal text responses do **not** trigger a retry (1 call)

Verification: `agentscope-core` (2280 tests) and `agentscope-harness` (828 tests) full suites green; Spotless clean.

## Follow-up (out of scope here)

The synthetic-reminder construction shape now exists in three places (`ReActAgent`, `TaskReminderMiddleware`, `SubagentsMiddleware`); a shared factory (e.g. `Msg.syntheticReminder(kind, text)`) would be a worthwhile standalone cleanup PR.
