### PR TITLE
fix(middleware): normalize model call tools

### DIFF
--- a/agentscope-core/src/main/java/io/agentscope/core/ReActAgent.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/ReActAgent.java
@@ -3534,7 +3534,7 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
                             rc,
                             MiddlewareBase::onModelCall,
                             summaryModelCallCore)
-                    .apply(new ModelCallInput(messages, null, options, model))
+                    .apply(new ModelCallInput(messages, List.of(), options, model))
                     .doOnNext(this::publishEvent);
         }
 

--- a/agentscope-core/src/test/java/io/agentscope/core/agent/ReActAgentNewLoopReplyTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/agent/ReActAgentNewLoopReplyTest.java
@@ -46,6 +46,8 @@ import io.agentscope.core.message.ThinkingBlock;
 import io.agentscope.core.message.ToolResultBlock;
 import io.agentscope.core.message.ToolResultState;
 import io.agentscope.core.message.ToolUseBlock;
+import io.agentscope.core.middleware.MiddlewareBase;
+import io.agentscope.core.middleware.ModelCallInput;
 import io.agentscope.core.model.ChatModelBase;
 import io.agentscope.core.model.ChatResponse;
 import io.agentscope.core.model.GenerateOptions;
@@ -58,6 +60,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Function;
 import java.util.function.Supplier;
 import org.junit.jupiter.api.Test;
 import reactor.core.publisher.Flux;
@@ -553,6 +557,47 @@ class ReActAgentNewLoopReplyTest {
         assertTrue(summaryTextStart > summaryThinkingEnd);
         assertTrue(summaryTextEnd > summaryTextStart);
         assertTrue(summaryModelEnd > summaryTextEnd);
+    }
+
+    @Test
+    void summaryModelCallExposesEmptyToolsToMiddleware() {
+        AtomicInteger modelCallCount = new AtomicInteger();
+        AtomicReference<List<ToolSchema>> summaryTools = new AtomicReference<>();
+        MiddlewareBase middleware =
+                new MiddlewareBase() {
+                    @Override
+                    public Flux<AgentEvent> onModelCall(
+                            Agent agent,
+                            RuntimeContext ctx,
+                            ModelCallInput input,
+                            Function<ModelCallInput, Flux<AgentEvent>> next) {
+                        if (modelCallCount.incrementAndGet() == 2) {
+                            summaryTools.set(List.copyOf(input.tools()));
+                        }
+                        return next.apply(input);
+                    }
+                };
+        ChatModelBase model =
+                new ScriptedModel(
+                        List.of(
+                                () -> Flux.just(toolUseResponse("tc", "echo", "x")),
+                                () -> Flux.just(textResponse("summary"))));
+        ReActAgent agent =
+                ReActAgent.builder()
+                        .name("asst")
+                        .model(model)
+                        .toolkit(toolkitWith(new EchoTool()))
+                        .middlewares(List.of(middleware))
+                        .maxIters(1)
+                        .build();
+
+        List<AgentEvent> events = agent.streamEvents(List.of()).collectList().block();
+
+        assertNotNull(events);
+        assertEquals(List.of(), summaryTools.get());
+        AgentResultEvent resultEvent =
+                (AgentResultEvent) events.get(indexOf(events, AgentResultEvent.class));
+        assertEquals("summary", resultEvent.getResult().getTextContent());
     }
 
     private static int indexOf(List<AgentEvent> events, Class<?> type) {

--- a/agentscope-core/src/test/java/io/agentscope/core/middleware/ModelCallInputTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/middleware/ModelCallInputTest.java
@@ -15,24 +15,19 @@
  */
 package io.agentscope.core.middleware;
 
-import io.agentscope.core.message.Msg;
-import io.agentscope.core.model.GenerateOptions;
-import io.agentscope.core.model.Model;
-import io.agentscope.core.model.ToolSchema;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import java.util.List;
+import org.junit.jupiter.api.Test;
 
-/**
- * Input context for {@link MiddlewareBase#onModelCall}.
- *
- * @param messages the messages to send to the model
- * @param tools    the non-null tool schemas, empty when no tools are available
- * @param options  generation options
- * @param model    the model instance to call
- */
-public record ModelCallInput(
-        List<Msg> messages, List<ToolSchema> tools, GenerateOptions options, Model model) {
+class ModelCallInputTest {
 
-    public ModelCallInput {
-        tools = tools == null ? List.of() : tools;
+    @Test
+    void nullToolsAreNormalizedToEmptyList() {
+        ModelCallInput input = new ModelCallInput(List.of(), null, null, null);
+
+        assertNotNull(input.tools());
+        assertTrue(input.tools().isEmpty());
     }
 }


### PR DESCRIPTION
## AgentScope-Java Version

2.0.3-SNAPSHOT

## Description

Summary model calls do not expose tools, but they currently pass `null` to middleware through `ModelCallInput`. Middleware that treats `tools()` as a collection can therefore fail only on the summary path.

This change:

- passes an empty tool list from `ReActAgent.summaryStream()`
- normalizes legacy/null inputs at the `ModelCallInput` boundary
- documents the non-null tools contract
- adds regression coverage for summary middleware and direct construction

Fixes #2753

### Testing

- `mvn -pl agentscope-core clean test`: 2277 tests passed, 9 skipped
- focused regression tests: 14 tests passed

## Checklist

- [x] Code has been formatted with `mvn spotless:apply`
- [x] All tests are passing (`mvn test`)
- [x] Javadoc comments are complete and follow project conventions
- [x] Related documentation has been updated (Javadoc contract; no external docs required)
- [x] Code is ready for review