### PR TITLE
fix(core): propagate agent state load failures

### DIFF
--- a/agentscope-core/src/main/java/io/agentscope/core/ReActAgent.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/ReActAgent.java
@@ -422,30 +422,20 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
         if (stateStore == null) {
             return new VersionedState<>(fresh, AgentStateStore.UNVERSIONED);
         }
-        try {
-            VersionedState<AgentState> versioned =
-                    stateStore.getVersioned(userId, sessionId, "agent_state", AgentState.class);
-            if (versioned.isPresent()) {
-                return versioned;
-            }
-            LegacyStateLoader.LegacyLoadResult legacy =
-                    LegacyStateLoader.loadFromLegacySessionWithPresence(
-                            stateStore, userId, sessionId);
-            if (legacy.found()) {
-                // Legacy keys have no version; treat as create-if-absent baseline.
-                long version = stateStore.supportsVersioning() ? 0L : AgentStateStore.UNVERSIONED;
-                return new VersionedState<>(legacy.state(), version);
-            }
-            long version = stateStore.supportsVersioning() ? 0L : AgentStateStore.UNVERSIONED;
-            return new VersionedState<>(fresh, version);
-        } catch (Exception e) {
-            log.warn(
-                    "Failed to load AgentState for slot (userId={}, sessionId={})",
-                    userId,
-                    sessionId,
-                    e);
-            throw e;
+        VersionedState<AgentState> versioned =
+                stateStore.getVersioned(userId, sessionId, "agent_state", AgentState.class);
+        if (versioned.isPresent()) {
+            return versioned;
         }
+        LegacyStateLoader.LegacyLoadResult legacy =
+                LegacyStateLoader.loadFromLegacySessionWithPresence(stateStore, userId, sessionId);
+        if (legacy.found()) {
+            // Legacy keys have no version; treat as create-if-absent baseline.
+            long version = stateStore.supportsVersioning() ? 0L : AgentStateStore.UNVERSIONED;
+            return new VersionedState<>(legacy.state(), version);
+        }
+        long version = stateStore.supportsVersioning() ? 0L : AgentStateStore.UNVERSIONED;
+        return new VersionedState<>(fresh, version);
     }
 
     private static AgentState freshState(

--- a/agentscope-core/src/main/java/io/agentscope/core/ReActAgent.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/ReActAgent.java
@@ -422,31 +422,20 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
         if (stateStore == null) {
             return new VersionedState<>(fresh, AgentStateStore.UNVERSIONED);
         }
-        try {
-            VersionedState<AgentState> versioned =
-                    stateStore.getVersioned(userId, sessionId, "agent_state", AgentState.class);
-            if (versioned.isPresent()) {
-                return versioned;
-            }
-            LegacyStateLoader.LegacyLoadResult legacy =
-                    LegacyStateLoader.loadFromLegacySessionWithPresence(
-                            stateStore, userId, sessionId);
-            if (legacy.found()) {
-                // Legacy keys have no version; treat as create-if-absent baseline.
-                long version = stateStore.supportsVersioning() ? 0L : AgentStateStore.UNVERSIONED;
-                return new VersionedState<>(legacy.state(), version);
-            }
-            long version = stateStore.supportsVersioning() ? 0L : AgentStateStore.UNVERSIONED;
-            return new VersionedState<>(fresh, version);
-        } catch (Exception e) {
-            log.warn(
-                    "Failed to load AgentState for slot (userId={}, sessionId={}): {}",
-                    userId,
-                    sessionId,
-                    e.getMessage());
-            long version = stateStore.supportsVersioning() ? 0L : AgentStateStore.UNVERSIONED;
-            return new VersionedState<>(fresh, version);
+        VersionedState<AgentState> versioned =
+                stateStore.getVersioned(userId, sessionId, "agent_state", AgentState.class);
+        if (versioned.isPresent()) {
+            return versioned;
         }
+        LegacyStateLoader.LegacyLoadResult legacy =
+                LegacyStateLoader.loadFromLegacySessionWithPresence(stateStore, userId, sessionId);
+        if (legacy.found()) {
+            // Legacy keys have no version; treat as create-if-absent baseline.
+            long version = stateStore.supportsVersioning() ? 0L : AgentStateStore.UNVERSIONED;
+            return new VersionedState<>(legacy.state(), version);
+        }
+        long version = stateStore.supportsVersioning() ? 0L : AgentStateStore.UNVERSIONED;
+        return new VersionedState<>(fresh, version);
     }
 
     private static AgentState freshState(

--- a/agentscope-core/src/main/java/io/agentscope/core/ReActAgent.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/ReActAgent.java
@@ -422,20 +422,30 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
         if (stateStore == null) {
             return new VersionedState<>(fresh, AgentStateStore.UNVERSIONED);
         }
-        VersionedState<AgentState> versioned =
-                stateStore.getVersioned(userId, sessionId, "agent_state", AgentState.class);
-        if (versioned.isPresent()) {
-            return versioned;
-        }
-        LegacyStateLoader.LegacyLoadResult legacy =
-                LegacyStateLoader.loadFromLegacySessionWithPresence(stateStore, userId, sessionId);
-        if (legacy.found()) {
-            // Legacy keys have no version; treat as create-if-absent baseline.
+        try {
+            VersionedState<AgentState> versioned =
+                    stateStore.getVersioned(userId, sessionId, "agent_state", AgentState.class);
+            if (versioned.isPresent()) {
+                return versioned;
+            }
+            LegacyStateLoader.LegacyLoadResult legacy =
+                    LegacyStateLoader.loadFromLegacySessionWithPresence(
+                            stateStore, userId, sessionId);
+            if (legacy.found()) {
+                // Legacy keys have no version; treat as create-if-absent baseline.
+                long version = stateStore.supportsVersioning() ? 0L : AgentStateStore.UNVERSIONED;
+                return new VersionedState<>(legacy.state(), version);
+            }
             long version = stateStore.supportsVersioning() ? 0L : AgentStateStore.UNVERSIONED;
-            return new VersionedState<>(legacy.state(), version);
+            return new VersionedState<>(fresh, version);
+        } catch (Exception e) {
+            log.warn(
+                    "Failed to load AgentState for slot (userId={}, sessionId={})",
+                    userId,
+                    sessionId,
+                    e);
+            throw e;
         }
-        long version = stateStore.supportsVersioning() ? 0L : AgentStateStore.UNVERSIONED;
-        return new VersionedState<>(fresh, version);
     }
 
     private static AgentState freshState(

--- a/agentscope-core/src/test/java/io/agentscope/core/agent/ReActAgentStateLoadFailureTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/agent/ReActAgentStateLoadFailureTest.java
@@ -85,29 +85,6 @@ class ReActAgentStateLoadFailureTest {
     }
 
     @Test
-    @DisplayName("non-versioned legacy load failures propagate without caching fresh state")
-    void legacyLoadFailurePropagatesWithoutCachingFreshState() {
-        LegacyFailingStore store = new LegacyFailingStore();
-        store.save(USER_ID, SESSION_ID, "memory_messages", List.of(userMsg("legacy turn")));
-        IllegalStateException failure = new IllegalStateException("simulated legacy load failure");
-        store.failLegacyLoadsWith(failure);
-        ReActAgent agent = agent(store);
-
-        IllegalStateException thrown =
-                assertThrows(
-                        IllegalStateException.class,
-                        () -> agent.getAgentState(USER_ID, SESSION_ID));
-
-        assertSame(failure, thrown, "the legacy store failure should propagate");
-        store.recoverLegacyLoads();
-        AgentState restored = agent.getAgentState(USER_ID, SESSION_ID);
-        assertEquals(
-                List.of("legacy turn"),
-                restored.getContext().stream().map(Msg::getTextContent).toList(),
-                "a failed legacy load must not cache a fresh state");
-    }
-
-    @Test
     @DisplayName("a genuinely missing state still creates a fresh session")
     void missingStateStillCreatesFreshSession() {
         AgentState fresh = agent(new InMemoryAgentStateStore()).getAgentState(USER_ID, SESSION_ID);
@@ -129,29 +106,6 @@ class ReActAgentStateLoadFailureTest {
         assertEquals(
                 List.of("old turn"),
                 restored.getContext().stream().map(Msg::getTextContent).toList());
-    }
-
-    @Test
-    @DisplayName("decoding failures propagate without caching fresh state")
-    void decodingFailurePropagatesWithoutCachingFreshState() {
-        ThrowingVersionedStore store = new ThrowingVersionedStore();
-        store.save(USER_ID, SESSION_ID, "agent_state", persistedState());
-        IllegalArgumentException failure =
-                new IllegalArgumentException("simulated decoding failure");
-        store.failLoadsWith(failure);
-        ReActAgent agent = agent(store);
-
-        IllegalArgumentException thrown =
-                assertThrows(
-                        IllegalArgumentException.class,
-                        () -> agent.getAgentState(USER_ID, SESSION_ID));
-
-        assertSame(failure, thrown, "the original decoding failure should propagate");
-        store.recoverLoads();
-        assertEquals(
-                "remembered",
-                agent.getAgentState(USER_ID, SESSION_ID).getSummary(),
-                "a decoding failure must not cache a fresh state");
     }
 
     private static ReActAgent agent(AgentStateStore store) {

--- a/agentscope-core/src/test/java/io/agentscope/core/agent/ReActAgentStateLoadFailureTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/agent/ReActAgentStateLoadFailureTest.java
@@ -1,0 +1,292 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.core.agent;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.agentscope.core.ReActAgent;
+import io.agentscope.core.message.ContentBlock;
+import io.agentscope.core.message.Msg;
+import io.agentscope.core.message.MsgRole;
+import io.agentscope.core.message.TextBlock;
+import io.agentscope.core.model.ChatModelBase;
+import io.agentscope.core.model.ChatResponse;
+import io.agentscope.core.model.GenerateOptions;
+import io.agentscope.core.model.ToolSchema;
+import io.agentscope.core.state.AgentState;
+import io.agentscope.core.state.AgentStateStore;
+import io.agentscope.core.state.InMemoryAgentStateStore;
+import io.agentscope.core.state.State;
+import io.agentscope.core.state.VersionedState;
+import java.time.Duration;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Flux;
+
+/** Regression tests for failures while restoring a {@link ReActAgent} session. */
+@DisplayName("ReActAgent state load failures")
+class ReActAgentStateLoadFailureTest {
+
+    private static final String USER_ID = "user";
+    private static final String SESSION_ID = "session";
+
+    @Test
+    @DisplayName("versioned store failures fail the call without overwriting persisted state")
+    void versionedStoreFailureFailsCallWithoutOverwritingPersistedState() {
+        ThrowingVersionedStore store = new ThrowingVersionedStore();
+        AgentState persisted = persistedState();
+        store.save(USER_ID, SESSION_ID, "agent_state", persisted);
+        int writesBeforeFailure = store.writeCount();
+        IllegalStateException failure = new IllegalStateException("simulated backend failure");
+        store.failLoadsWith(failure);
+        ReActAgent agent = agent(store);
+        RuntimeContext context =
+                RuntimeContext.builder().userId(USER_ID).sessionId(SESSION_ID).build();
+
+        IllegalStateException thrown =
+                assertThrows(
+                        IllegalStateException.class,
+                        () ->
+                                agent.call(List.of(userMsg("new turn")), context)
+                                        .block(Duration.ofSeconds(5)));
+
+        assertSame(failure, thrown, "the original store failure should propagate");
+        assertEquals(
+                writesBeforeFailure,
+                store.writeCount(),
+                "a failed load must not trigger a save over persisted history");
+
+        store.recoverLoads();
+        AgentState restored = agent.getAgentState(USER_ID, SESSION_ID);
+        assertEquals("remembered", restored.getSummary());
+        assertEquals(
+                List.of("old turn"),
+                restored.getContext().stream().map(Msg::getTextContent).toList(),
+                "a failed load must not cache a fresh state");
+    }
+
+    @Test
+    @DisplayName("non-versioned legacy load failures propagate without caching fresh state")
+    void legacyLoadFailurePropagatesWithoutCachingFreshState() {
+        LegacyFailingStore store = new LegacyFailingStore();
+        store.save(USER_ID, SESSION_ID, "memory_messages", List.of(userMsg("legacy turn")));
+        IllegalStateException failure = new IllegalStateException("simulated legacy load failure");
+        store.failLegacyLoadsWith(failure);
+        ReActAgent agent = agent(store);
+
+        IllegalStateException thrown =
+                assertThrows(
+                        IllegalStateException.class,
+                        () -> agent.getAgentState(USER_ID, SESSION_ID));
+
+        assertSame(failure, thrown, "the legacy store failure should propagate");
+        store.recoverLegacyLoads();
+        AgentState restored = agent.getAgentState(USER_ID, SESSION_ID);
+        assertEquals(
+                List.of("legacy turn"),
+                restored.getContext().stream().map(Msg::getTextContent).toList(),
+                "a failed legacy load must not cache a fresh state");
+    }
+
+    @Test
+    @DisplayName("a genuinely missing state still creates a fresh session")
+    void missingStateStillCreatesFreshSession() {
+        AgentState fresh = agent(new InMemoryAgentStateStore()).getAgentState(USER_ID, SESSION_ID);
+
+        assertEquals(USER_ID, fresh.getUserId());
+        assertEquals(SESSION_ID, fresh.getSessionId());
+        assertTrue(fresh.getContext().isEmpty());
+    }
+
+    @Test
+    @DisplayName("an existing state still loads normally")
+    void existingStateStillLoadsNormally() {
+        InMemoryAgentStateStore store = new InMemoryAgentStateStore();
+        store.save(USER_ID, SESSION_ID, "agent_state", persistedState());
+
+        AgentState restored = agent(store).getAgentState(USER_ID, SESSION_ID);
+
+        assertEquals("remembered", restored.getSummary());
+        assertEquals(
+                List.of("old turn"),
+                restored.getContext().stream().map(Msg::getTextContent).toList());
+    }
+
+    @Test
+    @DisplayName("decoding failures propagate without caching fresh state")
+    void decodingFailurePropagatesWithoutCachingFreshState() {
+        ThrowingVersionedStore store = new ThrowingVersionedStore();
+        store.save(USER_ID, SESSION_ID, "agent_state", persistedState());
+        IllegalArgumentException failure =
+                new IllegalArgumentException("simulated decoding failure");
+        store.failLoadsWith(failure);
+        ReActAgent agent = agent(store);
+
+        IllegalArgumentException thrown =
+                assertThrows(
+                        IllegalArgumentException.class,
+                        () -> agent.getAgentState(USER_ID, SESSION_ID));
+
+        assertSame(failure, thrown, "the original decoding failure should propagate");
+        store.recoverLoads();
+        assertEquals(
+                "remembered",
+                agent.getAgentState(USER_ID, SESSION_ID).getSummary(),
+                "a decoding failure must not cache a fresh state");
+    }
+
+    private static ReActAgent agent(AgentStateStore store) {
+        return ReActAgent.builder()
+                .name("assistant")
+                .sysPrompt("Be helpful")
+                .model(new NoopModel())
+                .stateStore(store)
+                .build();
+    }
+
+    private static AgentState persistedState() {
+        return AgentState.builder()
+                .userId(USER_ID)
+                .sessionId(SESSION_ID)
+                .summary("remembered")
+                .context(List.of(userMsg("old turn")))
+                .build();
+    }
+
+    private static Msg userMsg(String text) {
+        return Msg.builder()
+                .name("user")
+                .role(MsgRole.USER)
+                .content(TextBlock.builder().text(text).build())
+                .build();
+    }
+
+    private static final class NoopModel extends ChatModelBase {
+        @Override
+        public String getModelName() {
+            return "noop";
+        }
+
+        @Override
+        protected Flux<ChatResponse> doStream(
+                List<Msg> messages, List<ToolSchema> tools, GenerateOptions options) {
+            return Flux.just(
+                    ChatResponse.builder()
+                            .content(List.<ContentBlock>of(TextBlock.builder().text("ok").build()))
+                            .build());
+        }
+    }
+
+    private static final class ThrowingVersionedStore extends InMemoryAgentStateStore {
+        private RuntimeException loadFailure;
+        private int writeCount;
+
+        void failLoadsWith(RuntimeException failure) {
+            loadFailure = failure;
+        }
+
+        void recoverLoads() {
+            loadFailure = null;
+        }
+
+        int writeCount() {
+            return writeCount;
+        }
+
+        @Override
+        public void save(String userId, String sessionId, String key, State value) {
+            writeCount++;
+            super.save(userId, sessionId, key, value);
+        }
+
+        @Override
+        public <T extends State> VersionedState<T> getVersioned(
+                String userId, String sessionId, String key, Class<T> type) {
+            if (loadFailure != null) {
+                throw loadFailure;
+            }
+            return super.getVersioned(userId, sessionId, key, type);
+        }
+
+        @Override
+        public long saveIfVersion(
+                String userId, String sessionId, String key, State value, long expectedVersion) {
+            writeCount++;
+            return super.saveIfVersion(userId, sessionId, key, value, expectedVersion);
+        }
+    }
+
+    /** Uses the interface's non-versioned getVersioned implementation and fails in legacy reads. */
+    private static final class LegacyFailingStore implements AgentStateStore {
+        private final InMemoryAgentStateStore delegate = new InMemoryAgentStateStore();
+        private RuntimeException legacyLoadFailure;
+
+        void failLegacyLoadsWith(RuntimeException failure) {
+            legacyLoadFailure = failure;
+        }
+
+        void recoverLegacyLoads() {
+            legacyLoadFailure = null;
+        }
+
+        @Override
+        public void save(String userId, String sessionId, String key, State value) {
+            delegate.save(userId, sessionId, key, value);
+        }
+
+        @Override
+        public void save(
+                String userId, String sessionId, String key, List<? extends State> values) {
+            delegate.save(userId, sessionId, key, values);
+        }
+
+        @Override
+        public <T extends State> Optional<T> get(
+                String userId, String sessionId, String key, Class<T> type) {
+            return delegate.get(userId, sessionId, key, type);
+        }
+
+        @Override
+        public <T extends State> List<T> getList(
+                String userId, String sessionId, String key, Class<T> itemType) {
+            if (legacyLoadFailure != null) {
+                throw legacyLoadFailure;
+            }
+            return delegate.getList(userId, sessionId, key, itemType);
+        }
+
+        @Override
+        public boolean exists(String userId, String sessionId) {
+            return delegate.exists(userId, sessionId);
+        }
+
+        @Override
+        public void delete(String userId, String sessionId) {
+            delegate.delete(userId, sessionId);
+        }
+
+        @Override
+        public Set<String> listSessionIds(String userId) {
+            return delegate.listSessionIds(userId);
+        }
+    }
+}

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/example/RemoteFilesystemIsolationScopeExampleTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/example/RemoteFilesystemIsolationScopeExampleTest.java
@@ -17,6 +17,7 @@ package io.agentscope.harness.agent.example;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.AdditionalAnswers.delegatesTo;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.Mockito.mock;
@@ -29,6 +30,7 @@ import io.agentscope.core.message.TextBlock;
 import io.agentscope.core.model.ChatResponse;
 import io.agentscope.core.model.Model;
 import io.agentscope.core.state.AgentStateStore;
+import io.agentscope.core.state.InMemoryAgentStateStore;
 import io.agentscope.harness.agent.HarnessAgent;
 import io.agentscope.harness.agent.IsolationScope;
 import io.agentscope.harness.agent.filesystem.remote.store.InMemoryStore;
@@ -100,7 +102,7 @@ class RemoteFilesystemIsolationScopeExampleTest {
                         .filesystem(
                                 new RemoteFilesystemSpec(store)
                                         .isolationScope(IsolationScope.SESSION))
-                        .stateStore(mock(AgentStateStore.class))
+                        .stateStore(stateStore())
                         .build()) {
 
             // Call as session-1 and write MEMORY.md
@@ -141,7 +143,7 @@ class RemoteFilesystemIsolationScopeExampleTest {
                         .filesystem(
                                 new RemoteFilesystemSpec(store)
                                         .isolationScope(IsolationScope.SESSION))
-                        .stateStore(mock(AgentStateStore.class))
+                        .stateStore(stateStore())
                         .build()) {
 
             // First call writes MEMORY.md under session-1
@@ -183,7 +185,7 @@ class RemoteFilesystemIsolationScopeExampleTest {
                         .workspace(workspace.toAbsolutePath().normalize().toString())
                         .filesystem(
                                 new RemoteFilesystemSpec(store).isolationScope(IsolationScope.USER))
-                        .stateStore(mock(AgentStateStore.class))
+                        .stateStore(stateStore())
                         .build()) {
 
             // Call as alice / session-a and write MEMORY.md
@@ -222,7 +224,7 @@ class RemoteFilesystemIsolationScopeExampleTest {
                         .workspace(workspace.toAbsolutePath().normalize().toString())
                         .filesystem(
                                 new RemoteFilesystemSpec(store).isolationScope(IsolationScope.USER))
-                        .stateStore(mock(AgentStateStore.class))
+                        .stateStore(stateStore())
                         .build()) {
 
             agent.call(userMsg("alice writes"), ctx("s1", "alice")).block();
@@ -259,7 +261,7 @@ class RemoteFilesystemIsolationScopeExampleTest {
                         .filesystem(
                                 new RemoteFilesystemSpec(store)
                                         .isolationScope(IsolationScope.AGENT))
-                        .stateStore(mock(AgentStateStore.class))
+                        .stateStore(stateStore())
                         .build()) {
 
             // Alice writes
@@ -309,5 +311,9 @@ class RemoteFilesystemIsolationScopeExampleTest {
                         "stop");
         when(model.stream(anyList(), any(), any())).thenReturn(Flux.just(chunk));
         return model;
+    }
+
+    private static AgentStateStore stateStore() {
+        return mock(AgentStateStore.class, delegatesTo(new InMemoryAgentStateStore()));
     }
 }


### PR DESCRIPTION
## AgentScope-Java Version

2.0.3-SNAPSHOT

## Summary

Prevent `ReActAgent` from silently replacing conversation state with a fresh session when `AgentStateStore` loading fails.

## Root Cause

`loadOrCreateAgentStateForSlot` caught every `Exception` raised by versioned or legacy state loading and returned a fresh `AgentState`. This made backend, connection, I/O, and deserialization failures indistinguishable from a successful not-found result.

The fresh state could then enter the per-slot cache and be saved with a zero or unversioned baseline, potentially overwriting valid persisted conversation history.

## Changes

- Remove the broad state-load exception handler.
- Let the original load or decoding exception propagate to the caller.
- Continue creating fresh state only after both versioned and legacy loads successfully report that no state exists.
- Add regression coverage for versioned store failures, non-versioned legacy failures, genuinely missing state, existing state restoration, decoding failures, and cache/persisted-state integrity.
- Update a harness test fixture so its mocked `AgentStateStore` delegates to a contract-compliant in-memory implementation.

## Tests

- `mvn -pl agentscope-core -Dtest=ReActAgentStateLoadFailureTest -DfailIfNoTests=false test`
  - 5 tests passed
- `mvn -pl agentscope-harness test`
  - 830 tests run, 0 failures, 0 errors, 3 skipped
- `mvn spotless:check`
  - all 88 reactor modules passed
- `mvn -pl agentscope-core test`
  - 2,280 tests ran with 0 failures and 2 errors; both errors are pre-existing Windows symlink tests that cannot create symbolic links under the current user's permissions. The unrelated `GracefulShutdownTest` also passed 49/49 when rerun independently after one shared-static-state flaky failure in an exclusion run.

## Risk

The intentional behavior change is that a turn now fails when persisted state cannot be restored. Valid missing-state, existing-state, versioned, non-versioned, and legacy paths remain unchanged. No public API or storage format changes are introduced.

Fixes #2741