### PR TITLE
fix(sandbox): make concurrent sandbox uploads safe (unique hydrate temp names, native transfer for relative paths)

### DIFF
--- a/agentscope-extensions/agentscope-extensions-sandbox/agentscope-extensions-sandbox-kubernetes/src/main/java/io/agentscope/extensions/sandbox/kubernetes/KubernetesSandbox.java
+++ b/agentscope-extensions/agentscope-extensions-sandbox/agentscope-extensions-sandbox-kubernetes/src/main/java/io/agentscope/extensions/sandbox/kubernetes/KubernetesSandbox.java
@@ -27,6 +27,7 @@ import io.agentscope.harness.agent.sandbox.WorkspaceMountSupport;
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.time.Duration;
+import java.util.UUID;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -121,7 +122,7 @@ public class KubernetesSandbox extends AbstractBaseSandbox implements SandboxFil
     }
 
     private InputStream persistViaFileApi(String root, String tarArgs) throws Exception {
-        String tmpRel = TMP_DIR_REL + "/ws-persist-" + sessionHash() + ".tar";
+        String tmpRel = TMP_DIR_REL + "/" + tempArchiveName("ws-persist") + ".tar";
         String tmpAbs = fileApiPath(tmpRel);
         String tarCmd =
                 "mkdir -p "
@@ -174,7 +175,7 @@ public class KubernetesSandbox extends AbstractBaseSandbox implements SandboxFil
     }
 
     private void hydrateViaFileApi(String root, byte[] tarBytes) throws Exception {
-        String tmpRel = TMP_DIR_REL + "/ws-hydrate-" + sessionHash() + ".tar";
+        String tmpRel = TMP_DIR_REL + "/" + tempArchiveName("ws-hydrate") + ".tar";
         String tmpAbs = fileApiPath(tmpRel);
         sdkSandbox.files().write(tmpRel, tarBytes);
         try {
@@ -186,7 +187,7 @@ public class KubernetesSandbox extends AbstractBaseSandbox implements SandboxFil
 
     private void hydrateViaExec(String root, byte[] tarBytes) throws Exception {
         String b64 = java.util.Base64.getEncoder().encodeToString(tarBytes);
-        String tmpTar = "/tmp/ws-hydrate-" + sessionHash() + ".tar";
+        String tmpTar = "/tmp/" + tempArchiveName("ws-hydrate") + ".tar";
 
         String writeCmd = "echo '" + b64 + "' | base64 -d > " + tmpTar;
         ExecutionResult writeResult = sdkSandbox.commands().run(writeCmd);
@@ -330,6 +331,16 @@ public class KubernetesSandbox extends AbstractBaseSandbox implements SandboxFil
 
     private String sessionHash() {
         return Integer.toHexString(Math.abs(k8sState.getSessionId().hashCode()));
+    }
+
+    /**
+     * Temp archive name unique per transfer. Concurrent hydrate/persist calls on the same
+     * sandbox must not share a name: with a deterministic name, one call's {@code rm -f}
+     * cleanup deletes another call's archive between its upload and {@code tar -xf},
+     * failing the extraction with "Cannot open: No such file or directory".
+     */
+    private String tempArchiveName(String prefix) {
+        return prefix + "-" + sessionHash() + "-" + UUID.randomUUID();
     }
 
     private static String shellQuote(String s) {

--- a/agentscope-extensions/agentscope-extensions-sandbox/agentscope-extensions-sandbox-kubernetes/src/test/java/io/agentscope/extensions/sandbox/kubernetes/KubernetesSandboxTest.java
+++ b/agentscope-extensions/agentscope-extensions-sandbox/agentscope-extensions-sandbox-kubernetes/src/test/java/io/agentscope/extensions/sandbox/kubernetes/KubernetesSandboxTest.java
@@ -107,6 +107,24 @@ class KubernetesSandboxTest {
     }
 
     @Test
+    void hydrateUsesUniqueTempArchivePerCall() throws Exception {
+        when(commands.run(anyString())).thenReturn(new ExecutionResult("", "", 0));
+
+        sandbox.doHydrateWorkspace(new ByteArrayInputStream("tar-one".getBytes()));
+        sandbox.doHydrateWorkspace(new ByteArrayInputStream("tar-two".getBytes()));
+
+        // Concurrent transfers must never share a temp archive: a deterministic name lets
+        // one call's rm -f cleanup delete another call's archive before tar -xf runs.
+        ArgumentCaptor<String> path = ArgumentCaptor.forClass(String.class);
+        verify(files, org.mockito.Mockito.times(2)).write(path.capture(), any(byte[].class));
+        String first = path.getAllValues().get(0);
+        String second = path.getAllValues().get(1);
+        assertTrue(first.startsWith(".agentscope-tmp/ws-hydrate-"));
+        assertTrue(second.startsWith(".agentscope-tmp/ws-hydrate-"));
+        assertTrue(!first.equals(second));
+    }
+
+    @Test
     void persistUsesFileApiWhenConfigured() throws Exception {
         when(commands.run(anyString())).thenReturn(new ExecutionResult("", "", 0));
         byte[] tar = "fake-tar".getBytes();

--- a/agentscope-extensions/agentscope-extensions-sandbox/agentscope-extensions-sandbox-kubernetes/src/test/java/io/agentscope/extensions/sandbox/kubernetes/KubernetesSandboxTest.java
+++ b/agentscope-extensions/agentscope-extensions-sandbox/agentscope-extensions-sandbox-kubernetes/src/test/java/io/agentscope/extensions/sandbox/kubernetes/KubernetesSandboxTest.java
@@ -125,6 +125,25 @@ class KubernetesSandboxTest {
     }
 
     @Test
+    void persistUsesUniqueTempArchivePerCall() throws Exception {
+        when(commands.run(anyString())).thenReturn(new ExecutionResult("", "", 0));
+        when(files.read(startsWith(".agentscope-tmp/ws-persist-")))
+                .thenReturn("fake-tar".getBytes());
+
+        sandbox.doPersistWorkspace();
+        sandbox.doPersistWorkspace();
+
+        // Same uniqueness contract as hydrate: concurrent persists must not share a
+        // temp archive, even if a future refactor splits the naming method.
+        ArgumentCaptor<String> path = ArgumentCaptor.forClass(String.class);
+        verify(files, org.mockito.Mockito.times(2)).read(path.capture());
+        String first = path.getAllValues().get(0);
+        String second = path.getAllValues().get(1);
+        assertTrue(first.startsWith(".agentscope-tmp/ws-persist-"));
+        assertTrue(!first.equals(second));
+    }
+
+    @Test
     void persistUsesFileApiWhenConfigured() throws Exception {
         when(commands.run(anyString())).thenReturn(new ExecutionResult("", "", 0));
         byte[] tar = "fake-tar".getBytes();

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/filesystem/sandbox/SandboxBackedFilesystem.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/filesystem/sandbox/SandboxBackedFilesystem.java
@@ -107,16 +107,30 @@ public class SandboxBackedFilesystem extends BaseSandboxFilesystem implements Sa
             String path = file.getKey();
             byte[] content = file.getValue();
 
-            if (active instanceof SandboxFileTransfer transfer
-                    && transfer.supportsFileTransfer(path)) {
+            if (active instanceof SandboxFileTransfer transfer) {
+                String transferPath = null;
                 try {
-                    transfer.uploadFile(path, content);
-                    results.add(FileUploadResponse.success(path));
-                } catch (Exception e) {
-                    log.warn("[sandbox-fs] native upload failed for path: {}", path, e);
+                    transferPath = resolveTransferPath(active, path);
+                } catch (IllegalArgumentException e) {
+                    // Same contract as the archive fallback: an invalid path fails this file.
+                    log.warn("[sandbox-fs] uploadFiles failed for path: {}", path, e);
                     results.add(FileUploadResponse.fail(path, e.getMessage()));
+                    continue;
+                } catch (IOException e) {
+                    log.debug(
+                            "[sandbox-fs] Workspace root unavailable, keeping archive fallback: {}",
+                            path);
                 }
-                continue;
+                if (transferPath != null && transfer.supportsFileTransfer(transferPath)) {
+                    try {
+                        transfer.uploadFile(transferPath, content);
+                        results.add(FileUploadResponse.success(path));
+                    } catch (Exception e) {
+                        log.warn("[sandbox-fs] native upload failed for path: {}", path, e);
+                        results.add(FileUploadResponse.fail(path, e.getMessage()));
+                    }
+                    continue;
+                }
             }
 
             try {
@@ -141,6 +155,8 @@ public class SandboxBackedFilesystem extends BaseSandboxFilesystem implements Sa
         List<FileDownloadResponse> results = new ArrayList<>(paths.size());
 
         for (String path : paths) {
+            // Reads keep the raw-path probe, unlike uploads: no shared temp state to race on,
+            // and the exec fallback below stays a single round trip.
             if (active instanceof SandboxFileTransfer transfer
                     && transfer.supportsFileTransfer(path)) {
                 try {
@@ -219,10 +235,7 @@ public class SandboxBackedFilesystem extends BaseSandboxFilesystem implements Sa
     /** Constrains an upload path to the workspace and converts it to an archive path. */
     private String resolveArchivePath(Sandbox active, String path) throws IOException {
         AbstractFilesystem.validatePath(path);
-        String normalized = path.replace('\\', '/');
-        while (normalized.startsWith("./")) {
-            normalized = normalized.substring(2);
-        }
+        String normalized = normalizeUploadPath(path);
 
         if (normalized.startsWith("/")) {
             String workspaceRoot = resolveWorkspaceRoot(active);
@@ -235,6 +248,31 @@ public class SandboxBackedFilesystem extends BaseSandboxFilesystem implements Sa
 
         if (normalized.isBlank()) {
             throw new IOException("Upload path must identify a file: " + path);
+        }
+        return normalized;
+    }
+
+    /**
+     * Normalizes an upload path and resolves it to its sandbox-absolute form so
+     * workspace-relative paths can ride the native single-file transfer
+     * ({@link SandboxFileTransfer#uploadFile}) instead of the archive-hydrate fallback. Throws
+     * {@link IllegalArgumentException} for invalid paths — the caller fails just that file,
+     * matching the archive fallback's validation contract.
+     */
+    private String resolveTransferPath(Sandbox active, String path) throws IOException {
+        AbstractFilesystem.validatePath(path);
+        String normalized = normalizeUploadPath(path);
+        if (normalized.startsWith("/")) {
+            return normalized;
+        }
+        return resolveWorkspaceRoot(active) + "/" + normalized;
+    }
+
+    /** Normalizes separators and strips leading {@code ./} segments. */
+    private static String normalizeUploadPath(String path) {
+        String normalized = path.replace('\\', '/');
+        while (normalized.startsWith("./")) {
+            normalized = normalized.substring(2);
         }
         return normalized;
     }

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/filesystem/sandbox/SandboxBackedFilesystem.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/filesystem/sandbox/SandboxBackedFilesystem.java
@@ -106,6 +106,10 @@ public class SandboxBackedFilesystem extends BaseSandboxFilesystem implements Sa
         for (Map.Entry<String, byte[]> file : files) {
             String path = file.getKey();
             byte[] content = file.getValue();
+            if (content == null) {
+                results.add(FileUploadResponse.fail(path, "File content must not be null"));
+                continue;
+            }
 
             if (active instanceof SandboxFileTransfer transfer) {
                 String transferPath = null;

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/filesystem/sandbox/SandboxBackedFilesystemTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/filesystem/sandbox/SandboxBackedFilesystemTest.java
@@ -131,6 +131,22 @@ class SandboxBackedFilesystemTest {
     }
 
     @Test
+    void uploadFiles_rejectsNullContentOnNativeTransferPath() {
+        SandboxBackedFilesystem filesystem = new SandboxBackedFilesystem();
+        FakeTransferSandbox sandbox = new FakeTransferSandbox("/workspace");
+        filesystem.setSandbox(sandbox);
+
+        List<FileUploadResponse> responses =
+                filesystem.uploadFiles(
+                        RT, List.of(new AbstractMap.SimpleImmutableEntry<>("agents/a.txt", null)));
+
+        assertTrue(!responses.get(0).isSuccess());
+        assertEquals("File content must not be null", responses.get(0).error());
+        assertTrue(sandbox.uploaded.isEmpty());
+        assertEquals(0, sandbox.hydrateCalls);
+    }
+
+    @Test
     void uploadFiles_fallsBackToHydrationWhenRootUnavailable() throws Exception {
         SandboxBackedFilesystem filesystem = new SandboxBackedFilesystem();
         FakeTransferSandbox sandbox = new FakeTransferSandbox("/workspace");

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/filesystem/sandbox/SandboxBackedFilesystemTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/filesystem/sandbox/SandboxBackedFilesystemTest.java
@@ -109,9 +109,49 @@ class SandboxBackedFilesystemTest {
     }
 
     @Test
-    void uploadFiles_usesTarHydrationForUnsupportedNativePaths() throws Exception {
+    void uploadFiles_resolvesRelativePathForNativeTransfer() {
         SandboxBackedFilesystem filesystem = new SandboxBackedFilesystem();
         FakeTransferSandbox sandbox = new FakeTransferSandbox("/workspace");
+        filesystem.setSandbox(sandbox);
+
+        List<FileUploadResponse> responses =
+                filesystem.uploadFiles(
+                        RT,
+                        List.of(
+                                Map.entry(
+                                        "agents/通用智能助手/sessions/sessions.json",
+                                        new byte[] {3, 1, 4})));
+
+        assertTrue(responses.get(0).isSuccess());
+        assertArrayEquals(
+                new byte[] {3, 1, 4},
+                sandbox.uploaded.get("/workspace/agents/通用智能助手/sessions/sessions.json"));
+        assertNull(sandbox.lastCommand);
+        assertEquals(0, sandbox.hydrateCalls);
+    }
+
+    @Test
+    void uploadFiles_fallsBackToHydrationWhenRootUnavailable() throws Exception {
+        SandboxBackedFilesystem filesystem = new SandboxBackedFilesystem();
+        FakeTransferSandbox sandbox = new FakeTransferSandbox("/workspace");
+        sandbox.state.setWorkspaceSpec(null);
+        filesystem.setSandbox(sandbox);
+        byte[] content = new byte[] {5};
+
+        List<FileUploadResponse> responses =
+                filesystem.uploadFiles(RT, List.of(Map.entry("agents/a.jsonl", content)));
+
+        assertTrue(responses.get(0).isSuccess());
+        assertTrue(sandbox.uploaded.isEmpty());
+        assertEquals(1, sandbox.hydrateCalls);
+        assertArchive(sandbox.hydratedArchive, "agents/a.jsonl", content);
+    }
+
+    @Test
+    void uploadFiles_usesTarHydrationForUnsupportedNativePaths() throws Exception {
+        SandboxBackedFilesystem filesystem = new SandboxBackedFilesystem();
+        // File API rooted outside the workspace: resolved paths stay unsupported natively.
+        FakeTransferSandbox sandbox = new FakeTransferSandbox("/data");
         filesystem.setSandbox(sandbox);
         byte[] content = "session-data".getBytes(StandardCharsets.UTF_8);
 


### PR DESCRIPTION
## AgentScope-Java Version

main @ 2.0.3-SNAPSHOT

## Description

Fixes #2761.

Two commits:

1. `fix(sandbox-kubernetes)`: `hydrateViaFileApi` / `hydrateViaExec` / `persistViaFileApi` staged their temp tar at a name derived from the sandbox session id alone. Concurrent transfers on one sandbox shared that path, so one side's `rm -f` cleanup deleted the other side's archive between its upload and `tar -xf` (`Cannot open: No such file or directory`). The name now appends a UUID per transfer.

2. `fix(harness)`: `uploadFiles` probed `supportsFileTransfer` with the raw path. Workspace-relative paths (session index, transcript segments written via `WorkspaceManager`) never matched the absolute-path contract and always took the archive-hydrate fallback where that race lives. Relative paths are now resolved against the sandbox workspace root before probing and uploaded through `SandboxFileTransfer.uploadFile`. Absolute-path behavior and the hydrate fallback for sandboxes/paths without transfer support are unchanged.

**Tests**

- `KubernetesSandboxTest`: two hydrate calls on the same sandbox write distinct temp archive paths.
- `SandboxBackedFilesystemTest`: a workspace-relative path resolves against the workspace root and rides the native transfer (no hydrate); an unavailable workspace root falls back to hydration; paths outside the file-API root still hydrate.

## Checklist

Please check the following items before code is ready to be reviewed.

- [x]  Code has been formatted with `mvn spotless:apply`
- [x]  All tests are passing (`mvn test`)
- [x]  Javadoc comments are complete and follow project conventions
- [ ]  Related documentation has been updated (e.g. links, examples, etc.)
- [x]  Code is ready for review
