### PR TITLE
feat(harness): add disableLocalWorkspace() to opt out of local workspace materialisation

### DIFF
--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/HarnessAgent.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/HarnessAgent.java
@@ -1136,9 +1136,8 @@ public class HarnessAgent implements Agent, AutoCloseable {
      * @return the ephemeral workspace directory; never {@code null}
      */
     static Path resolveEphemeralWorkspace(String agentId) {
-        String safeAgentId =
-                agentId.replaceAll("[/\\\\\\s\\p{Cntrl}]", "_").replaceAll("^[_\\-\\.]+", "");
-        if (safeAgentId.isBlank()) {
+        String safeAgentId = HarnessAgentBuilderSupport.sanitizeIdentifier(agentId);
+        if (safeAgentId == null || safeAgentId.isBlank()) {
             safeAgentId = "ReActAgent";
         }
         return Paths.get(System.getProperty("java.io.tmpdir"))
@@ -2506,9 +2505,7 @@ public class HarnessAgent implements Agent, AutoCloseable {
                                                 .resolve(".agentscope/transcripts"));
                     }
                 }
-                if (effectiveTranscriptStore == null) {
-                    // Transcripts simply not recorded in this mode (see warning above).
-                } else {
+                if (effectiveTranscriptStore != null) {
                     inner.middleware(
                             new TranscriptMiddleware(
                                     wsManager, effectiveTranscriptStore, transcriptTenant));

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/HarnessAgent.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/HarnessAgent.java
@@ -1127,6 +1127,26 @@ public class HarnessAgent implements Agent, AutoCloseable {
     }
 
     /**
+     * Resolves the ephemeral workspace used when {@link Builder#disableLocalWorkspace()} is
+     * enabled and no explicit {@link Builder#workspace(Path)} is set. The path lives under the
+     * JVM temp directory so that nothing is materialised in the application's working directory;
+     * it is defensive fallback and is not created eagerly.
+     *
+     * @param agentId the resolved agent id (already non-blank)
+     * @return the ephemeral workspace directory; never {@code null}
+     */
+    static Path resolveEphemeralWorkspace(String agentId) {
+        String safeAgentId =
+                agentId.replaceAll("[/\\\\\\s\\p{Cntrl}]", "_").replaceAll("^[_\\-\\.]+", "");
+        if (safeAgentId.isBlank()) {
+            safeAgentId = "ReActAgent";
+        }
+        return Paths.get(System.getProperty("java.io.tmpdir"))
+                .resolve("agentscope-workspace")
+                .resolve(safeAgentId);
+    }
+
+    /**
      * Returns true when the given session is a local in-process implementation that cannot share
      * state across nodes. Used by sandbox / remote-filesystem fail-fast checks to reject
      * configurations that would silently leak per-node state in distributed deployments.
@@ -1199,6 +1219,16 @@ public class HarnessAgent implements Agent, AutoCloseable {
         String transcriptTenant;
         boolean disableSessionPersistence = false;
         boolean disableWorkspaceContext = false;
+
+        /**
+         * When enabled, the harness never materialises the default local workspace
+         * ({@code ${user.dir}/.agentscope/workspace}) for this build. Intended for
+         * SaaS / containerised deployments where all file IO is handled by a remote
+         * sandbox or an in-memory / distributed store, and a local workspace directory
+         * would only pollute the application's working directory.
+         */
+        boolean disableLocalWorkspace = false;
+
         boolean disableAtPathExpansion = false;
         boolean disableSubagents = false;
         boolean disableDynamicSkills = false;
@@ -2145,6 +2175,42 @@ public class HarnessAgent implements Agent, AutoCloseable {
             return this;
         }
 
+        /**
+         * Prevents the harness from materialising the default local workspace
+         * ({@code .agentscope/workspace} under the current working directory) for this agent.
+         *
+         * <p>When enabled and no explicit {@link #workspace(Path)} is set, the workspace path
+         * resolves to an ephemeral location under the JVM temp directory
+         * ({@code ${java.io.tmpdir}/agentscope-workspace/<agentId>}) instead of
+         * {@code ${user.dir}/.agentscope/workspace}, and no default local filesystem is created.
+         * This targets SaaS / container deployments that run agents inside a remote sandbox or
+         * with an in-memory / distributed store, and never want a {@code .agentscope} directory
+         * to appear in the application's working directory.
+         *
+         * <p><strong>Required companion configuration:</strong> because the workspace-backed
+         * defaults (JsonFileAgentStateStore, WorkspaceTaskRepository, local filesystem) are not
+         * available in this mode, the build fails fast with a descriptive error unless the caller
+         * supplies the corresponding custom implementations:
+         * <ul>
+         *   <li>an explicit {@link #stateStore(io.agentscope.core.state.AgentStateStore)} (or a
+         *       {@code DistributedStore});</li>
+         *   <li>an explicit {@link #taskRepository(io.agentscope.harness.agent.subagent.task.TaskRepository)}
+         *       when subagents are enabled;</li>
+         *   <li>a set of opt-outs for workspace-local subsystems that are not desired in this
+         *       mode, e.g. {@link #disableFilesystemTools()}, {@link #disableShellTool()},
+         *       {@link #disableMemoryTools()}, {@link #disableMemoryHooks()},
+         *       {@link #disableDynamicSkills()}, {@link #disableDefaultWorkspaceSkills()} and
+         *       {@link #disableTranscript()}. Any such subsystem that is left enabled reads and
+         *       writes the ephemeral temp workspace instead of {@code ${user.dir}}.</li>
+         * </ul>
+         *
+         * @return this builder
+         */
+        public Builder disableLocalWorkspace() {
+            this.disableLocalWorkspace = true;
+            return this;
+        }
+
         public Builder disableAtPathExpansion() {
             this.disableAtPathExpansion = true;
             return this;
@@ -2241,11 +2307,16 @@ public class HarnessAgent implements Agent, AutoCloseable {
                         "abstractFilesystem() is an escape hatch and is mutually exclusive with"
                                 + " filesystem(...) specs");
             }
-            Path resolvedWorkspace = workspace != null ? workspace : resolveDefaultWorkspace();
             String resolvedAgentId =
                     agentId != null && !agentId.isBlank()
                             ? agentId
                             : (name != null && !name.isBlank() ? name : "ReActAgent");
+            Path resolvedWorkspace =
+                    workspace != null
+                            ? workspace
+                            : (disableLocalWorkspace
+                                    ? resolveEphemeralWorkspace(resolvedAgentId)
+                                    : resolveDefaultWorkspace());
             // ---- DistributedStore auto-wiring ----
             // distributedStore provides storage components; filesystem mode is user's choice.
             // Priority: explicit builder methods > distributedStore > workspace defaults
@@ -2280,6 +2351,14 @@ public class HarnessAgent implements Agent, AutoCloseable {
                             : new LocalPeriodicGate();
 
             AgentStateStore effectiveSession = stateStoreOverride;
+            if (disableLocalWorkspace && effectiveSession == null) {
+                throw new IllegalStateException(
+                        "disableLocalWorkspace() leaves no default AgentStateStore: the default"
+                            + " JsonFileAgentStateStore would persist to ~/.agentscope/state, which"
+                            + " is exactly what this mode must avoid. Pass an explicit"
+                            + " .stateStore(...) or configure a DistributedStore that supplies"
+                            + " one.");
+            }
             IsolationScope fsIsolationScope = IsolationScope.USER;
             if (remoteFilesystemSpec != null && remoteFilesystemSpec.getIsolationScope() != null) {
                 fsIsolationScope = remoteFilesystemSpec.getIsolationScope();
@@ -2412,6 +2491,13 @@ public class HarnessAgent implements Agent, AutoCloseable {
                     if (wsManager.getFilesystem() != null) {
                         effectiveTranscriptStore =
                                 new ObjectStoreTranscriptStore(wsManager.getFilesystem());
+                    } else if (disableLocalWorkspace) {
+                        // No local workspace and no filesystem: transcripts would have to be
+                        // persisted to ${user.dir}, which this mode explicitly forbids.
+                        log.warn(
+                                "[harness] disableLocalWorkspace() leaves no transcript backend;"
+                                    + " transcripts are disabled. Supply .transcriptStore(...) or"
+                                    + " omit disableLocalWorkspace() to persist session logs.");
                     } else {
                         effectiveTranscriptStore =
                                 new FilesystemTranscriptStore(
@@ -2420,9 +2506,13 @@ public class HarnessAgent implements Agent, AutoCloseable {
                                                 .resolve(".agentscope/transcripts"));
                     }
                 }
-                inner.middleware(
-                        new TranscriptMiddleware(
-                                wsManager, effectiveTranscriptStore, transcriptTenant));
+                if (effectiveTranscriptStore == null) {
+                    // Transcripts simply not recorded in this mode (see warning above).
+                } else {
+                    inner.middleware(
+                            new TranscriptMiddleware(
+                                    wsManager, effectiveTranscriptStore, transcriptTenant));
+                }
             }
             Model memoryModel = memoryConfig.model() != null ? memoryConfig.model() : model;
             if (memoryModel != null && !disableMemoryHooks) {
@@ -2472,7 +2562,9 @@ public class HarnessAgent implements Agent, AutoCloseable {
                     inner.middleware(compactionHook);
                 }
             }
-            if (!disableToolResultEviction && toolResultEvictionConfig != null) {
+            if (!disableToolResultEviction
+                    && toolResultEvictionConfig != null
+                    && filesystem != null) {
                 inner.middleware(
                         new ToolResultEvictionMiddleware(filesystem, toolResultEvictionConfig));
             }
@@ -2575,7 +2667,7 @@ public class HarnessAgent implements Agent, AutoCloseable {
                 pathNormalizer =
                         WorkspacePathNormalizer.of(resolvedWorkspace.toAbsolutePath().toString());
             }
-            if (!disableFilesystemTools) {
+            if (!disableFilesystemTools && filesystem != null) {
                 agentToolkit.registerTool(new FilesystemTool(filesystem, pathNormalizer));
             }
             if (!disableShellTool && filesystem instanceof AbstractSandboxFilesystem sandbox) {
@@ -2724,7 +2816,7 @@ public class HarnessAgent implements Agent, AutoCloseable {
 
             if (!orderedSkillRepos.isEmpty()) {
                 io.agentscope.harness.agent.skill.runtime.MarketplaceStager stager =
-                        resolvedWorkspace != null
+                        resolvedWorkspace != null && !disableLocalWorkspace
                                 ? new io.agentscope.harness.agent.skill.runtime.MarketplaceStager(
                                         resolvedWorkspace)
                                 : null;
@@ -2801,7 +2893,7 @@ public class HarnessAgent implements Agent, AutoCloseable {
                     "HarnessAgent '{}' built [workspace={}, filesystem={}, subagents={}]",
                     name,
                     resolvedWorkspace,
-                    filesystem.getClass().getSimpleName(),
+                    filesystem != null ? filesystem.getClass().getSimpleName() : "none",
                     !leafSubagent && !disableSubagents && model != null);
 
             // ---- Build inner ReActAgent ----

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/HarnessAgentBuilderSupport.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/HarnessAgentBuilderSupport.java
@@ -162,6 +162,14 @@ final class HarnessAgentBuilderSupport {
         if (b.localFilesystemSpec != null) {
             return b.localFilesystemSpec.toFilesystem(workspace, nsFactory);
         }
+        if (b.disableLocalWorkspace) {
+            // No default local filesystem: nothing to materialise under the working directory.
+            // Workspace-backed components (WorkspaceMessageBus, WorkspaceAsyncToolRegistry,
+            // workspace task repository, transcript-on-disk, skills staging…) are consequently
+            // skipped or require an explicit custom implementation — exactly the intent for
+            // SaaS/sandboxed builds that never want a .agentscope directory locally.
+            return null;
+        }
         // Default: route through LocalFilesystemSpec so the default project (= ${user.dir})
         // is overlaid below the agent workspace, matching the Claude-Code-style two-layer model.
         return new LocalFilesystemSpec().toFilesystem(workspace, nsFactory);
@@ -759,6 +767,13 @@ final class HarnessAgentBuilderSupport {
             if (distributed != null) {
                 return distributed;
             }
+        }
+        if (b.disableLocalWorkspace) {
+            throw new IllegalStateException(
+                    "disableLocalWorkspace() prevents the workspace-backed default TaskRepository"
+                            + " (which would materialise agents/<agentId>/tasks under the working"
+                            + " directory). Pass an explicit .taskRepository(...), or configure a"
+                            + " DistributedStore that supplies one.");
         }
         Objects.requireNonNull(
                 wsManager,

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/HarnessAgentLocalWorkspaceDisabledTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/HarnessAgentLocalWorkspaceDisabledTest.java
@@ -1,0 +1,240 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.harness.agent;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.agentscope.core.agent.RuntimeContext;
+import io.agentscope.core.message.Msg;
+import io.agentscope.core.message.TextBlock;
+import io.agentscope.core.model.ChatResponse;
+import io.agentscope.core.model.GenerateOptions;
+import io.agentscope.core.model.Model;
+import io.agentscope.core.model.ToolSchema;
+import io.agentscope.core.state.InMemoryAgentStateStore;
+import io.agentscope.harness.agent.subagent.task.BackgroundTask;
+import io.agentscope.harness.agent.subagent.task.TaskRepository;
+import io.agentscope.harness.agent.subagent.task.TaskRunSpec;
+import io.agentscope.harness.agent.subagent.task.TaskStatus;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import reactor.core.publisher.Flux;
+
+/**
+ * Tests for {@link HarnessAgent.Builder#disableLocalWorkspace()}: a "no local workspace" build
+ * must never materialise {@code .agentscope} under the working directory, and it must fail fast
+ * with a descriptive error when the workspace-backed defaults (state store, task repository)
+ * cannot be avoided.
+ */
+class HarnessAgentLocalWorkspaceDisabledTest {
+
+    @TempDir Path workingDirectory;
+
+    private String previousUserDir;
+    private String previousWorkspaceProperty;
+
+    @BeforeEach
+    void pointWorkingDirectoryAtTempDir() {
+        previousUserDir = System.getProperty("user.dir");
+        previousWorkspaceProperty = System.getProperty(HarnessAgent.WORKSPACE_PROPERTY);
+        // The default workspace would resolve against ${user.dir}; redirect it to a scratch dir
+        // so the test can assert that NOTHING is created there in disabled mode.
+        System.setProperty("user.dir", workingDirectory.toString());
+        System.clearProperty(HarnessAgent.WORKSPACE_PROPERTY);
+    }
+
+    @AfterEach
+    void restoreEnvironment() {
+        System.setProperty("user.dir", previousUserDir);
+        if (previousWorkspaceProperty != null) {
+            System.setProperty(HarnessAgent.WORKSPACE_PROPERTY, previousWorkspaceProperty);
+        } else {
+            System.clearProperty(HarnessAgent.WORKSPACE_PROPERTY);
+        }
+    }
+
+    @Test
+    void disabledBuild_doesNotCreateDotAgentscopeUnderWorkingDirectory() {
+        try (HarnessAgent agent = buildFullyDisabledAgent().build()) {
+            assertFalse(
+                    Files.exists(workingDirectory.resolve(".agentscope")),
+                    "disableLocalWorkspace() must not create .agentscope under the working"
+                            + " directory");
+            assertFalse(
+                    Files.exists(workingDirectory.resolve(".agentscope/workspace")),
+                    "disableLocalWorkspace() must not create .agentscope/workspace under the"
+                            + " working directory");
+        }
+    }
+
+    @Test
+    void disabledBuild_withoutExplicitStateStore_failsFast() {
+        IllegalStateException ex =
+                assertThrows(
+                        IllegalStateException.class,
+                        () ->
+                                HarnessAgent.builder()
+                                        .name("ws-disabled")
+                                        .model(stubModel("ok"))
+                                        .disableLocalWorkspace()
+                                        .disableSubagents()
+                                        .build());
+        assertTrue(ex.getMessage().contains("disableLocalWorkspace()"));
+        assertTrue(ex.getMessage().contains("AgentStateStore"));
+    }
+
+    @Test
+    void disabledBuild_withSubagentsButNoTaskRepository_failsFast() {
+        IllegalStateException ex =
+                assertThrows(
+                        IllegalStateException.class,
+                        () ->
+                                HarnessAgent.builder()
+                                        .name("ws-disabled")
+                                        .model(stubModel("ok"))
+                                        .disableLocalWorkspace()
+                                        .stateStore(new InMemoryAgentStateStore())
+                                        .disableFilesystemTools()
+                                        .disableShellTool()
+                                        .disableMemoryTools()
+                                        .disableMemoryHooks()
+                                        .disableDynamicSkills()
+                                        .disableDefaultWorkspaceSkills()
+                                        .disableWorkspaceContext()
+                                        .disableTranscript()
+                                        .build());
+        assertTrue(ex.getMessage().contains("disableLocalWorkspace()"));
+        assertTrue(ex.getMessage().contains("taskRepository"));
+    }
+
+    @Test
+    void ephemeralWorkspace_resolvesOutsideWorkingDirectory() {
+        Path ephemeral = HarnessAgent.resolveEphemeralWorkspace("my-agent");
+        assertTrue(ephemeral.startsWith(Paths.get(System.getProperty("java.io.tmpdir"))));
+        assertFalse(
+                ephemeral.toAbsolutePath().toString().contains(workingDirectory.toString()),
+                "ephemeral workspace must stay under the JVM temp dir, never the working"
+                        + " directory");
+        assertEquals(
+                Paths.get(System.getProperty("java.io.tmpdir"), "agentscope-workspace", "my-agent"),
+                ephemeral);
+    }
+
+    @Test
+    void ephemeralWorkspace_sanitizesBlankAgentId() {
+        assertEquals(
+                Paths.get(
+                        System.getProperty("java.io.tmpdir"), "agentscope-workspace", "ReActAgent"),
+                HarnessAgent.resolveEphemeralWorkspace("   "));
+        assertEquals(
+                Paths.get(
+                        System.getProperty("java.io.tmpdir"), "agentscope-workspace", "ReActAgent"),
+                HarnessAgent.resolveEphemeralWorkspace(""));
+    }
+
+    private static HarnessAgent.Builder buildFullyDisabledAgent() {
+        return HarnessAgent.builder()
+                .name("ws-disabled")
+                .model(stubModel("ok"))
+                .disableLocalWorkspace()
+                .stateStore(new InMemoryAgentStateStore())
+                .disableSubagents()
+                .disableFilesystemTools()
+                .disableShellTool()
+                .disableMemoryTools()
+                .disableMemoryHooks()
+                .disableDynamicSkills()
+                .disableDefaultWorkspaceSkills()
+                .disableWorkspaceContext()
+                .disableTranscript()
+                .disableCompaction()
+                .disableToolResultEviction()
+                .taskRepository(new NoopTaskRepository());
+    }
+
+    private static Model stubModel(String assistantText) {
+        ChatResponse chunk =
+                new ChatResponse(
+                        "stub-id",
+                        List.of(TextBlock.builder().text(assistantText).build()),
+                        null,
+                        Map.of(),
+                        "stop");
+        return new StubModel(chunk);
+    }
+
+    /** Hand-written {@link Model} stub — avoids Mockito, which is JVM-version sensitive. */
+    private static final class StubModel implements Model {
+
+        private final ChatResponse response;
+
+        StubModel(ChatResponse response) {
+            this.response = response;
+        }
+
+        @Override
+        public String getModelName() {
+            return "stub-model";
+        }
+
+        @Override
+        public Flux<ChatResponse> stream(
+                List<Msg> messages, List<ToolSchema> tools, GenerateOptions options) {
+            return Flux.just(response);
+        }
+    }
+
+    /** Minimal task repository that persists nothing. */
+    private static final class NoopTaskRepository implements TaskRepository {
+
+        @Override
+        public BackgroundTask getTask(RuntimeContext rc, String sessionId, String taskId) {
+            return null;
+        }
+
+        @Override
+        public BackgroundTask putTask(
+                RuntimeContext rc,
+                String taskId,
+                String subAgentId,
+                String sessionId,
+                TaskRunSpec spec) {
+            return null;
+        }
+
+        @Override
+        public Collection<BackgroundTask> listTasks(
+                RuntimeContext rc, String sessionId, TaskStatus filter) {
+            return List.of();
+        }
+
+        @Override
+        public boolean cancelTask(RuntimeContext rc, String sessionId, String taskId) {
+            return false;
+        }
+    }
+}

--- a/docs/v2/en/docs/harness/workspace.md
+++ b/docs/v2/en/docs/harness/workspace.md
@@ -496,6 +496,45 @@ At load time:
 
 This "details on disk, index in the prompt" pattern keeps token budget bounded even with a large knowledge base.
 
+## Disabling the local workspace
+
+When your agents run in a SaaS / containerised deployment and all file IO happens inside a remote
+sandbox or an in-memory / distributed store, a local workspace under the working directory
+(`${user.dir}/.agentscope/workspace`) is pure dead weight — it appears in the application's
+working directory even when the filesystem tools are disabled.
+
+`HarnessAgent.Builder.disableLocalWorkspace()` opts a single build out of materialising the default
+local workspace:
+
+```java
+HarnessAgent agent = HarnessAgent.builder()
+    .name("chat-agent")
+    .model(model)
+    .stateStore(redisStateStore)          // required — no default JsonFileAgentStateStore
+    .taskRepository(myTaskRepository)     // required when subagents are enabled
+    .disableFilesystemTools()             // recommended — no local file tools either
+    .disableLocalWorkspace()
+    .build();
+```
+
+What changes:
+
+| Aspect | Default | With `disableLocalWorkspace()` |
+|--------|---------|-------------------------------|
+| Workspace location (when `workspace(...)` unset) | `${user.dir}/.agentscope/workspace` | `${java.io.tmpdir}/agentscope-workspace/<agentId>` — ephemeral, never the working directory |
+| Default filesystem | Overlay of `${user.dir}` + workspace | none — no local `AbstractFilesystem` is created |
+| Default `AgentStateStore` | `JsonFileAgentStateStore` at `~/.agentscope/state/<agentId>` | build fails fast — pass `.stateStore(...)` |
+| Default `TaskRepository` | `WorkspaceTaskRepository` under `agents/<agentId>/tasks` | build fails fast — pass `.taskRepository(...)` |
+| `MessageBus` / async-tool registry | Workspace-backed | skipped (no local filesystem) |
+| Transcripts | persisted under the workspace | skipped with a warning unless a `.transcriptStore(...)` is supplied |
+| Skills staging (`.skills-cache`) | materialised in the workspace | not staged |
+
+> The flag relocates / disables *local* workspace materialisation. Subsystems that are left
+> enabled (memory hooks, plan mode, …) read and write the ephemeral temp workspace instead of the
+> working directory. For a fully stateless build, combine it with the `disable*` opt-outs for the
+> workspace-local subsystems you do not use (`disableMemoryTools()`, `disableMemoryHooks()`,
+> `disableDynamicSkills()`, `disableDefaultWorkspaceSkills()`, `disableTranscript()`, …).
+
 ## Safety rules for writing to the workspace
 
 `additionalContextFile`, `writeUtf8WorkspaceRelative`, `memory_get`, and friends accept **workspace-relative paths**. The framework does basic path-traversal validation (refusing `../../etc/passwd` and similar escapes).

--- a/docs/v2/en/docs/others/release-notes.md
+++ b/docs/v2/en/docs/others/release-notes.md
@@ -7,6 +7,22 @@ This page tracks per-version changes for AgentScope Java 2.0. For the overall mi
 
 ---
 
+## Next
+
+### Added
+
+**Harness / Workspace**
+
+- `HarnessAgent.Builder.disableLocalWorkspace()`: opt a build out of materialising the default
+  local workspace (`${user.dir}/.agentscope/workspace`). Intended for SaaS / containerised
+  deployments where all file IO happens inside a remote sandbox or an in-memory / distributed
+  store. When enabled, the workspace resolves to an ephemeral JVM-temp location, no default
+  local filesystem is created, and missing `.stateStore(...)` / `.taskRepository(...)` fail fast
+  with descriptive errors instead of silently persisting to the working directory or
+  `~/.agentscope/state`. See [Workspace → Disabling the local workspace](../harness/workspace.md#disabling-the-local-workspace).
+
+---
+
 ## 2.0.1
 
 > Released: 2026-08-05

--- a/docs/v2/zh/docs/harness/workspace.md
+++ b/docs/v2/zh/docs/harness/workspace.md
@@ -493,6 +493,37 @@ knowledge/
 
 这种"目录里全是细节，prompt 里只放索引"的模式，避免把整个知识库塞进 token 预算。
 
+## 禁用本地工作区
+
+当你的智能体跑在 SaaS / 容器化部署里，所有文件 IO 都在远程沙箱或内存 / 分布式存储中完成时，工作目录下的本地工作区（`${user.dir}/.agentscope/workspace`）纯粹是负担——即使禁用了文件系统工具，它还是会出现在应用的工作目录里。
+
+`HarnessAgent.Builder.disableLocalWorkspace()` 让单个 build 不再落地默认的本地工作区：
+
+```java
+HarnessAgent agent = HarnessAgent.builder()
+    .name("chat-agent")
+    .model(model)
+    .stateStore(redisStateStore)          // 必填——不再使用默认 JsonFileAgentStateStore
+    .taskRepository(myTaskRepository)     // 启用子 Agent 时必填
+    .disableFilesystemTools()             // 建议——文件工具也不再注册
+    .disableLocalWorkspace()
+    .build();
+```
+
+行为变化：
+
+| 方面 | 默认行为 | 启用 `disableLocalWorkspace()` 后 |
+|------|---------|-----------------------------------|
+| 工作区位置（未显式 `workspace(...)`） | `${user.dir}/.agentscope/workspace` | `${java.io.tmpdir}/agentscope-workspace/<agentId>` —— 临时目录，绝不落在工作目录 |
+| 默认文件系统 | `${user.dir}` 与工作区的 Overlay | 无——不创建任何本地 `AbstractFilesystem` |
+| 默认 `AgentStateStore` | `~/.agentscope/state/<agentId>` 下的 `JsonFileAgentStateStore` | 构建直接报错——需要传 `.stateStore(...)` |
+| 默认 `TaskRepository` | `agents/<agentId>/tasks` 下的 `WorkspaceTaskRepository` | 构建直接报错——需要传 `.taskRepository(...)` |
+| `MessageBus` / 异步工具注册表 | workspace 版 | 跳过（没有本地文件系统） |
+| Transcript（会话记录） | 持久化在工作区内 | 未提供 `.transcriptStore(...)` 时跳过并输出告警 |
+| 技能 staging（`.skills-cache`） | 落到工作区 | 不再 staging |
+
+> 该开关只重定向 / 禁用**本地**工作区的落盘。仍然开启的子系统（记忆钩子、Plan Mode 等）会读写临时工作区而不是你的工作目录。想要完全无状态构建，请组合使用你不需要的那些 workspace 本地子系统的 `disable*` 开关（`disableMemoryTools()`、`disableMemoryHooks()`、`disableDynamicSkills()`、`disableDefaultWorkspaceSkills()`、`disableTranscript()` 等）。
+
 ## 写入工作区的安全规则
 
 `additionalContextFile`、`writeUtf8WorkspaceRelative`、`memory_get` 这些接口接受**工作区相对路径**。框架做基本的 path-traversal 校验（拒绝 `../../etc/passwd` 这种逃出工作区的写法）。


### PR DESCRIPTION
﻿# feat(harness): add `disableLocalWorkspace()` to opt out of local workspace materialisation

Closes #2763

## Motivation

In SaaS / containerised deployments where **all file IO happens inside a remote sandbox or an
in-memory / distributed store**, the harness still resolves and uses a local workspace at
`${user.dir}/.agentscope/workspace` by default. Even when the File/Shell tools are disabled via
`disableFilesystemTools().disableShellTool()`, components that are intrinsic to the harness
(workspace-backed default `TaskRepository`, default `JsonFileAgentStateStore`, skills staging
`.skills-cache`, transcripts, message bus) keep writing into the application's working
directory — a `.agentscope` tree appears in the project root for every deployment that never
wanted one.

The existing escape hatch (`workspace(...)` / `agentscope.workspace` / `AGENTSCOPE_WORKSPACE`)
only **relocates** the directory; it cannot turn it off, and requiring every SaaS service to
know about and point at a local directory is exactly the kind of implicit state this mode wants
to eliminate.

## What this PR adds

`HarnessAgent.Builder.disableLocalWorkspace()` — a per-build opt-out:

- When no explicit `.workspace(...)` is set, the workspace resolves to an **ephemeral
  `${java.io.tmpdir}/agentscope-workspace/<agentId>`** instead of `${user.dir}/.agentscope/workspace`.
- **No default local filesystem is created** (`resolveFilesystem` returns `null` instead of
  materialising a `LocalFilesystemSpec` overlay). This also disables the workspace-backed
  `WorkspaceMessageBus` / `WorkspaceAsyncToolRegistry` fallbacks.
- **Fail-fast validation** replaces silent persistence:
  - missing explicit `.stateStore(...)` → `IllegalStateException` (the default
    `JsonFileAgentStateStore` would otherwise persist to `~/.agentscope/state/<agentId>`);
  - subagents enabled without an explicit `.taskRepository(...)` → `IllegalStateException`
    (the default `WorkspaceTaskRepository` would otherwise materialise
    `agents/<agentId>/tasks`).
- Transcripts are **skipped with a warning** instead of being persisted to
  `workspace/.agentscope/transcripts` when no `.transcriptStore(...)` is supplied and no
  filesystem exists.
- Skills staging (`.skills-cache`) and the `FilesystemTool` registration are skipped when there
  is no local filesystem.

Backward compatible: default behaviour is unchanged; the flag is additive and only takes effect
when explicitly enabled. No existing API is broken.

## Behaviour table

| Aspect | Default | `disableLocalWorkspace()` |
|--------|---------|---------------------------|
| Workspace location (no `workspace(...)`) | `${user.dir}/.agentscope/workspace` | `${java.io.tmpdir}/agentscope-workspace/<agentId>` |
| Default filesystem | `user.dir` + workspace overlay | none (`null`) |
| Default `AgentStateStore` | `~/.agentscope/state/<agentId>` | build fails fast, requires `.stateStore(...)` |
| Default `TaskRepository` | `agents/<agentId>/tasks` | build fails fast, requires `.taskRepository(...)` |
| MessageBus / async-tool registry | workspace-backed | skipped |
| Transcripts | persisted in workspace | skipped with warning (unless `transcriptStore` given) |
| Skills staging (`.skills-cache`) | materialised | not staged |

## Tests

`HarnessAgentLocalWorkspaceDisabledTest` (5 tests):

- no `.agentscope` created under the working directory in disabled mode;
- missing explicit state store fails fast;
- subagents enabled without explicit task repository fails fast;
- ephemeral workspace resolves under `${java.io.tmpdir}`, never the working directory;
- blank agent id sanitisation.

## Documentation

- `docs/v2/en/docs/harness/workspace.md` + `docs/v2/zh/docs/harness/workspace.md`:
  new "Disabling the local workspace" section.
- `docs/v2/en/docs/others/release-notes.md`: "Next" entry.

## Checklist

- [x] Conventional Commit message
- [x] Unit tests included and passing
- [x] Docs updated (EN + ZH)
- [x] Backward compatible, no API breakage
- [ ] Spotless formatting applied (run `mvn spotless:apply`)