### PR TITLE
fix(sandbox-kubernetes): bump fabric8 to 7.8.0 to fix watch NPE with Jackson 2.19+

### DIFF
--- a/agentscope-dependencies-bom/pom.xml
+++ b/agentscope-dependencies-bom/pom.xml
@@ -114,7 +114,7 @@
         <kotlin.version>1.9.24</kotlin.version>
         <kotlin.coroutines.version>1.10.2</kotlin.coroutines.version>
         <jgit.version>7.6.0.202603022253-r</jgit.version>
-        <fabric8.kubernetes-client.version>6.13.4</fabric8.kubernetes-client.version>
+        <fabric8.kubernetes-client.version>7.8.0</fabric8.kubernetes-client.version>
         <protobuf.java.version>4.29.3</protobuf.java.version>
 
         <spotless.version>3.4.0</spotless.version>

--- a/agentscope-extensions/agentscope-extensions-sandbox/agentscope-extensions-sandbox-kubernetes/src/test/java/io/agentscope/extensions/sandbox/kubernetes/KubernetesSerializationCompatTest.java
+++ b/agentscope-extensions/agentscope-extensions-sandbox/agentscope-extensions-sandbox-kubernetes/src/test/java/io/agentscope/extensions/sandbox/kubernetes/KubernetesSerializationCompatTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.extensions.sandbox.kubernetes;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import io.agentscope.extensions.sandbox.kubernetes.client.crd.SandboxClaim;
+import io.fabric8.kubernetes.api.model.FieldsV1;
+import io.fabric8.kubernetes.api.model.GenericKubernetesResource;
+import io.fabric8.kubernetes.api.model.ManagedFieldsEntry;
+import io.fabric8.kubernetes.api.model.ObjectMeta;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.KubernetesClientBuilder;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Guards against fabric8/Jackson serialization regressions on the CRD watch
+ * path: {@code AbstractWatchManager.eventReceived} converts untyped watch
+ * event objects ({@code GenericKubernetesResource}) to the target custom
+ * resource via {@code KubernetesSerialization.convertValue}. With fabric8
+ * 6.13.x and Jackson >= 2.19 this crashed with a {@code keySerializer is
+ * null} NPE on {@code metadata.managedFields[].fieldsV1} (fabric8 issue
+ * #7036, fixed in fabric8 7.3.0).
+ */
+class KubernetesSerializationCompatTest {
+
+    @Test
+    void convertValueWithManagedFieldsFieldsV1ShouldNotThrow() {
+        try (KubernetesClient client = new KubernetesClientBuilder().build()) {
+            GenericKubernetesResource gkr = new GenericKubernetesResource();
+            ObjectMeta metadata = new ObjectMeta();
+            metadata.setName("sandboxclaim-test");
+
+            ManagedFieldsEntry managedFieldsEntry = new ManagedFieldsEntry();
+            FieldsV1 fieldsV1 = new FieldsV1();
+            Map<String, Object> additional = new LinkedHashMap<>();
+            additional.put("f:metadata", Map.of("f:name", Map.of()));
+            fieldsV1.setAdditionalProperties(additional);
+            managedFieldsEntry.setFieldsV1(fieldsV1);
+            metadata.setManagedFields(List.of(managedFieldsEntry));
+            gkr.setMetadata(metadata);
+
+            SandboxClaim claim =
+                    client.getKubernetesSerialization().convertValue(gkr, SandboxClaim.class);
+            assertEquals("sandboxclaim-test", claim.getMetadata().getName());
+        }
+    }
+}


### PR DESCRIPTION
## AgentScope-Java Version

2.0.3-SNAPSHOT (main @ bf7b7dae)

## Description

Fixes #2765.

**Background**: the dependencies BOM pins fabric8 6.13.4 while managing Jackson 2.21.1. fabric8 6.13.x is incompatible with Jackson >= 2.19 (fabric8io/kubernetes-client#7036, fixed in fabric8 7.3.0): serializing any object whose `metadata.managedFields[].fieldsV1` is populated crashes with `NullPointerException: keySerializer is null` in Jackson's `MapSerializer`. On the K8s sandbox backend this makes sandbox creation fail on **every** run - `K8sHelper.resolveSandboxName` watches the `SandboxClaim` CRD, and fabric8's `AbstractWatchManager.eventReceived` converts the untyped watch event object (`GenericKubernetesResource` carrying `managedFields`) via `KubernetesSerialization.convertValue(resource, SandboxClaim.class)`, which hits the NPE. No user misconfiguration is involved; the broken combination is what the BOM itself produces (and every Spring Boot 3.5+/4 app resolves Jackson >= 2.19).

**Changes**:
- Bump `fabric8.kubernetes-client.version` in `agentscope-dependencies-bom/pom.xml` from 6.13.4 to **7.8.0** (first fixed version is 7.3.0; latest is 7.8.0)
- Add `KubernetesSerializationCompatTest`: a no-cluster regression guard mirroring the watch path - `convertValue` of a `GenericKubernetesResource` with `managedFields[].fieldsV1` to `SandboxClaim`. Passes on 7.8.0; fails with the exact production NPE on 6.13.x + Jackson >= 2.19

**Notes**:
- No source changes needed: all 39 sources of `agentscope-extensions-sandbox-kubernetes` compile against 7.8.0 unchanged, and no other module uses fabric8 (`grep -r 'import io.fabric8'`), so the blast radius is this one version bump plus its test suite
- fabric8 7.x switches the default HTTP client to Vert.x (`kubernetes-httpclient-vertx` arrives as a runtime-scoped transitive dependency); the new test constructs a real `KubernetesClient`, confirming the engine loads and the serialization path works
- Downgrading Jackson to <= 2.18 instead is not viable long-term: the ecosystem (Spring Boot 3.5+/4) moves Jackson forward, and AgentScope's own BOM already manages 2.21.1

**How to test**:
- `mvn -pl agentscope-extensions/agentscope-extensions-sandbox/agentscope-extensions-sandbox-kubernetes -am install` then `mvn -pl agentscope-extensions/agentscope-extensions-sandbox/agentscope-extensions-sandbox-kubernetes test` - full suite passes (26/26, including the new test)
- Reverting only the BOM version makes `KubernetesSerializationCompatTest` fail with the NPE from #2765

## Checklist

Please check the following items before code is ready to be reviewed.

- [x]  Code has been formatted with `mvn spotless:apply`
- [x]  All tests are passing (`mvn test`)
- [x]  Javadoc comments are complete and follow project conventions
- [x]  Related documentation has been updated (e.g. links, examples, etc.)
- [x]  Code is ready for review
