### PR TITLE
fix(core): preserve permission context when loading legacy v1 session state

### DIFF
--- a/agentscope-core/src/main/java/io/agentscope/core/ReActAgent.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/ReActAgent.java
@@ -430,7 +430,7 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
             }
             LegacyStateLoader.LegacyLoadResult legacy =
                     LegacyStateLoader.loadFromLegacySessionWithPresence(
-                            stateStore, userId, sessionId);
+                            stateStore, userId, sessionId, permCtx);
             if (legacy.found()) {
                 // Legacy keys have no version; treat as create-if-absent baseline.
                 long version = stateStore.supportsVersioning() ? 0L : AgentStateStore.UNVERSIONED;

--- a/agentscope-core/src/main/java/io/agentscope/core/state/LegacyStateLoader.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/state/LegacyStateLoader.java
@@ -16,6 +16,7 @@
 package io.agentscope.core.state;
 
 import io.agentscope.core.message.Msg;
+import io.agentscope.core.permission.PermissionContextState;
 import io.agentscope.core.state.legacy.ToolkitState;
 import java.util.List;
 import java.util.Optional;
@@ -27,6 +28,11 @@ import java.util.Optional;
  * {@code toolkit_activeGroups}) and constructs an equivalent {@link AgentState} object. The
  * original session data is not modified or migrated in place; subsequent saves will use the new
  * format automatically.
+ *
+ * <p>Legacy keys carry no 2.0-era {@link PermissionContextState}, so callers that need a specific
+ * permission context (for example {@code BYPASS} for a pre-seeded privileged session) must pass it
+ * in explicitly — otherwise the reconstructed state silently falls back to the default
+ * permission mode.
  */
 public final class LegacyStateLoader {
 
@@ -48,7 +54,29 @@ public final class LegacyStateLoader {
      */
     public static AgentState loadFromLegacySession(
             AgentStateStore stateStore, String userId, String sessionId) {
-        return loadFromLegacySessionWithPresence(stateStore, userId, sessionId).state();
+        return loadFromLegacySessionWithPresence(stateStore, userId, sessionId, null).state();
+    }
+
+    /**
+     * Load an {@link AgentState} from a v1 session, applying the supplied permission context.
+     *
+     * <p>See {@link #loadFromLegacySession(AgentStateStore, String, String)} for the read keys.
+     * Legacy keys carry no permission context; passing {@code permCtx} is the only way to
+     * preserve a non-default permission mode (for example {@code BYPASS}) when reconstructing
+     * state from a v1 session.
+     *
+     * @param stateStore the state store to read from
+     * @param userId nullable user identifier
+     * @param sessionId the session identifier (required)
+     * @param permCtx the permission context to attach, or {@code null} to keep the default
+     * @return a new AgentState populated with the legacy data
+     */
+    public static AgentState loadFromLegacySession(
+            AgentStateStore stateStore,
+            String userId,
+            String sessionId,
+            PermissionContextState permCtx) {
+        return loadFromLegacySessionWithPresence(stateStore, userId, sessionId, permCtx).state();
     }
 
     /**
@@ -57,14 +85,44 @@ public final class LegacyStateLoader {
      * <p>The presence bit is required because an explicitly persisted {@code
      * toolkit_activeGroups=[]} has different semantics from a missing key even though both produce
      * an empty {@link ToolContextState}.
+     *
+     * <p>The overload with a {@link PermissionContextState} applies the supplied permission
+     * context to the reconstructed state; legacy keys themselves never carry one. Callers that
+     * do not need a specific permission mode may use the {@code (stateStore, userId, sessionId)}
+     * variant.
      */
     public static LegacyLoadResult loadFromLegacySessionWithPresence(
             AgentStateStore stateStore, String userId, String sessionId) {
+        return loadFromLegacySessionWithPresence(stateStore, userId, sessionId, null);
+    }
+
+    /**
+     * Loads legacy state without discarding the presence of the singleton tool-group key, and
+     * applies the supplied permission context to the reconstructed state.
+     *
+     * <p>See {@link #loadFromLegacySessionWithPresence(AgentStateStore, String, String)} for the
+     * presence semantics. When {@code permCtx} is non-null it is attached to the reconstructed
+     * {@link AgentState}; otherwise the state keeps the default permission context.
+     *
+     * @param stateStore the state store to read from
+     * @param userId nullable user identifier
+     * @param sessionId the session identifier (required)
+     * @param permCtx the permission context to attach, or {@code null} to keep the default
+     * @return the reconstructed legacy state and whether the legacy keys were present
+     */
+    public static LegacyLoadResult loadFromLegacySessionWithPresence(
+            AgentStateStore stateStore,
+            String userId,
+            String sessionId,
+            PermissionContextState permCtx) {
         List<Msg> msgs = stateStore.getList(userId, sessionId, "memory_messages", Msg.class);
         Optional<ToolkitState> toolkitState =
                 stateStore.get(userId, sessionId, "toolkit_activeGroups", ToolkitState.class);
 
         AgentState.Builder builder = AgentState.builder().context(msgs);
+        if (permCtx != null) {
+            builder.permissionContext(permCtx);
+        }
 
         toolkitState.ifPresent(
                 value -> {

--- a/agentscope-core/src/test/java/io/agentscope/core/state/LegacyStateLoaderTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/state/LegacyStateLoaderTest.java
@@ -46,8 +46,7 @@ class LegacyStateLoaderTest {
                 PermissionContextState.builder().mode(PermissionMode.BYPASS).build();
 
         LegacyStateLoader.LegacyLoadResult result =
-                LegacyStateLoader.loadFromLegacySessionWithPresence(
-                        stateStore, USER, SESSION, ctx);
+                LegacyStateLoader.loadFromLegacySessionWithPresence(stateStore, USER, SESSION, ctx);
 
         assertTrue(result.found());
         assertEquals(PermissionMode.BYPASS, result.state().getPermissionContext().getMode());
@@ -59,8 +58,7 @@ class LegacyStateLoaderTest {
         PermissionContextState ctx =
                 PermissionContextState.builder().mode(PermissionMode.EXPLORE).build();
 
-        AgentState state =
-                LegacyStateLoader.loadFromLegacySession(stateStore, USER, SESSION, ctx);
+        AgentState state = LegacyStateLoader.loadFromLegacySession(stateStore, USER, SESSION, ctx);
 
         assertEquals(PermissionMode.EXPLORE, state.getPermissionContext().getMode());
     }
@@ -79,19 +77,14 @@ class LegacyStateLoaderTest {
 
     @Test
     void legacyContent_isPreservedAlongsidePermissionContext() {
-        Msg legacyMsg =
-                Msg.builder()
-                        .role(MsgRole.USER)
-                        .textContent("hello from v1")
-                        .build();
+        Msg legacyMsg = Msg.builder().role(MsgRole.USER).textContent("hello from v1").build();
         stateStore.save(USER, SESSION, "memory_messages", List.of(legacyMsg));
         stateStore.save(
                 USER, SESSION, "toolkit_activeGroups", new ToolkitState(List.of("team-alpha")));
         PermissionContextState ctx =
                 PermissionContextState.builder().mode(PermissionMode.BYPASS).build();
 
-        AgentState state =
-                LegacyStateLoader.loadFromLegacySession(stateStore, USER, SESSION, ctx);
+        AgentState state = LegacyStateLoader.loadFromLegacySession(stateStore, USER, SESSION, ctx);
 
         assertEquals(1, state.getContext().size());
         assertEquals(legacyMsg, state.getContext().get(0));

--- a/agentscope-core/src/test/java/io/agentscope/core/state/LegacyStateLoaderTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/state/LegacyStateLoaderTest.java
@@ -76,6 +76,17 @@ class LegacyStateLoaderTest {
     }
 
     @Test
+    void withPresence_noPermissionContext_keepsDefault() {
+        seedLegacyKeys();
+
+        LegacyStateLoader.LegacyLoadResult result =
+                LegacyStateLoader.loadFromLegacySessionWithPresence(stateStore, USER, SESSION);
+
+        assertTrue(result.found());
+        assertEquals(PermissionMode.DEFAULT, result.state().getPermissionContext().getMode());
+    }
+
+    @Test
     void legacyContent_isPreservedAlongsidePermissionContext() {
         Msg legacyMsg = Msg.builder().role(MsgRole.USER).textContent("hello from v1").build();
         stateStore.save(USER, SESSION, "memory_messages", List.of(legacyMsg));

--- a/agentscope-core/src/test/java/io/agentscope/core/state/LegacyStateLoaderTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/state/LegacyStateLoaderTest.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.core.state;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.agentscope.core.message.Msg;
+import io.agentscope.core.message.MsgRole;
+import io.agentscope.core.permission.PermissionContextState;
+import io.agentscope.core.permission.PermissionMode;
+import io.agentscope.core.state.legacy.ToolkitState;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link LegacyStateLoader}: the v1-session reconstruction path must always preserve
+ * the caller-supplied {@link PermissionContextState} — legacy keys themselves never carry one,
+ * so a missing permission context must not silently downgrade the reconstructed state.
+ */
+class LegacyStateLoaderTest {
+
+    private static final String USER = "uid-1";
+    private static final String SESSION = "session-1";
+
+    private final InMemoryAgentStateStore stateStore = new InMemoryAgentStateStore();
+
+    @Test
+    void withPresence_appliesSuppliedPermissionContext() {
+        seedLegacyKeys();
+        PermissionContextState ctx =
+                PermissionContextState.builder().mode(PermissionMode.BYPASS).build();
+
+        LegacyStateLoader.LegacyLoadResult result =
+                LegacyStateLoader.loadFromLegacySessionWithPresence(
+                        stateStore, USER, SESSION, ctx);
+
+        assertTrue(result.found());
+        assertEquals(PermissionMode.BYPASS, result.state().getPermissionContext().getMode());
+    }
+
+    @Test
+    void withoutPresence_appliesSuppliedPermissionContext() {
+        seedLegacyKeys();
+        PermissionContextState ctx =
+                PermissionContextState.builder().mode(PermissionMode.EXPLORE).build();
+
+        AgentState state =
+                LegacyStateLoader.loadFromLegacySession(stateStore, USER, SESSION, ctx);
+
+        assertEquals(PermissionMode.EXPLORE, state.getPermissionContext().getMode());
+    }
+
+    @Test
+    void noPermissionContext_keepsDefault() {
+        seedLegacyKeys();
+
+        AgentState state = LegacyStateLoader.loadFromLegacySession(stateStore, USER, SESSION);
+
+        assertEquals(
+                PermissionMode.DEFAULT,
+                state.getPermissionContext().getMode(),
+                "the overload without a permission context must keep the default mode");
+    }
+
+    @Test
+    void legacyContent_isPreservedAlongsidePermissionContext() {
+        Msg legacyMsg =
+                Msg.builder()
+                        .role(MsgRole.USER)
+                        .textContent("hello from v1")
+                        .build();
+        stateStore.save(USER, SESSION, "memory_messages", List.of(legacyMsg));
+        stateStore.save(
+                USER, SESSION, "toolkit_activeGroups", new ToolkitState(List.of("team-alpha")));
+        PermissionContextState ctx =
+                PermissionContextState.builder().mode(PermissionMode.BYPASS).build();
+
+        AgentState state =
+                LegacyStateLoader.loadFromLegacySession(stateStore, USER, SESSION, ctx);
+
+        assertEquals(1, state.getContext().size());
+        assertEquals(legacyMsg, state.getContext().get(0));
+        assertEquals(PermissionMode.BYPASS, state.getPermissionContext().getMode());
+        assertEquals(
+                List.of("team-alpha"),
+                state.getToolContext().getActivatedGroups(),
+                "legacy tool activation groups must survive reconstruction");
+    }
+
+    @Test
+    void noLegacyKeys_returnsNotFound() {
+        LegacyStateLoader.LegacyLoadResult result =
+                LegacyStateLoader.loadFromLegacySessionWithPresence(
+                        stateStore,
+                        USER,
+                        SESSION,
+                        PermissionContextState.builder().mode(PermissionMode.BYPASS).build());
+
+        assertFalse(result.found());
+    }
+
+    private void seedLegacyKeys() {
+        stateStore.save(
+                USER, SESSION, "toolkit_activeGroups", new ToolkitState(List.of("team-alpha")));
+    }
+}


### PR DESCRIPTION
# fix(core): preserve permission context when loading legacy v1 session state

Closes #2768

## Problem

`ReActAgent.loadOrCreateAgentStateForSlot(...)` loads a session's state in this order:

1. a new-format `agent_state` entry from the `AgentStateStore`,
2. else v1 **legacy** session keys (`memory_messages` / `toolkit_activeGroups`) via
   `LegacyStateLoader`,
3. else a fresh state built from the caller's parameters (`freshState(permCtx, ...)`).

Step 2 is leaky: `LegacyStateLoader` reconstructs the `AgentState` with only the legacy
conversation context (+ tool activation groups) and **never sets `permissionContext`**. Legacy
keys cannot carry one — the concept did not exist in v1 — so the reconstructed state silently
falls back to the default `DEFAULT` permission mode. This happens even though the caller
explicitly supplied a non-default permission context (for example `BYPASS`) that step 3 would
have preserved, and even though `permCtx` is already in scope at the call site.

Affected sessions: any session that still has v1-era keys but no new-format `agent_state` yet —
typically the first turn after a 1.x → 2.0 migration. The caller-configured permission mode is
silently downgraded, weakening permission semantics.

## Change

- `LegacyStateLoader.loadFromLegacySession(...)` / `loadFromLegacySessionWithPresence(...)`:
  new overloads accepting a `PermissionContextState`; when non-null it is attached to the
  reconstructed `AgentState`. The existing overloads are kept and delegate with `null`, so
  behaviour for callers without a specific permission context is unchanged.
- `ReActAgent.loadOrCreateAgentStateForSlot(...)`: pass the in-scope `permCtx` into the legacy
  load, exactly like `freshState` already does.

## Tests

`LegacyStateLoaderTest` (5 tests):

- supplied permission context is preserved (presence + non-presence variants);
- no permission context keeps the default mode (old overload behaviour);
- legacy messages and tool activation groups survive reconstruction alongside the permission
  context;
- no legacy keys reports `found=false`.

## Checklist

- [x] Conventional Commit message
- [x] Unit tests included
- [x] Backward compatible, no API breakage (old overloads kept)
- [ ] Full build verified locally (blocked by sandbox; CI runs `mvn clean verify` on Linux + Windows)