### PR TITLE
fix(harness): keep persisted snapshot id when resume falls back to fresh create

### DIFF
--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/sandbox/SandboxManager.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/sandbox/SandboxManager.java
@@ -16,6 +16,7 @@
 package io.agentscope.harness.agent.sandbox;
 
 import io.agentscope.core.agent.RuntimeContext;
+import io.agentscope.harness.agent.sandbox.snapshot.SandboxSnapshotSpec;
 import java.util.Objects;
 import java.util.Optional;
 import org.slf4j.Logger;
@@ -26,7 +27,9 @@ import org.slf4j.LoggerFactory;
  *
  * <p>Acquire priority: {@link SandboxContext#getExternalSandbox()} &gt; {@link
  * SandboxContext#getExternalSandboxState()} &gt; persisted {@link SandboxState} &gt; {@link
- * SandboxClient#create}.
+ * SandboxClient#create}. When a persisted state exists but the resume fails, the fresh-create
+ * fallback keeps the persisted snapshot id so the workspace restores from the previous archive
+ * instead of silently resetting.
  *
  * <p>When a {@link SandboxExecutionGuard} is configured, the manager acquires an execution
  * {@link SandboxLease} before sandbox resume/create for isolation keys that are present. The
@@ -95,6 +98,7 @@ public class SandboxManager {
         }
 
         try {
+            String persistedSnapshotId = null;
             if (scopeKey.isPresent()) {
                 try {
                     Optional<String> stateJson = stateStore.load(scopeKey.get());
@@ -108,6 +112,9 @@ public class SandboxManager {
                         // Overwrite stale WorkspaceSpec with current application config
                         if (sandboxContext.getWorkspaceSpec() != null) {
                             state.setWorkspaceSpec(sandboxContext.getWorkspaceSpec().copy());
+                        }
+                        if (state.getSnapshot() != null) {
+                            persistedSnapshotId = state.getSnapshot().getId();
                         }
                         Sandbox sandbox = client.resume(state);
                         return SandboxAcquireResult.selfManaged(sandbox, lease);
@@ -136,6 +143,8 @@ public class SandboxManager {
                             spec,
                             sandboxContext.getSnapshotSpec(),
                             sandboxContext.getClientOptions());
+            carryOverPersistedSnapshotId(
+                    sandbox, persistedSnapshotId, sandboxContext.getSnapshotSpec());
             return SandboxAcquireResult.selfManaged(sandbox, lease);
 
         } catch (Exception e) {
@@ -143,6 +152,33 @@ public class SandboxManager {
             lease.close();
             throw e;
         }
+    }
+
+    /**
+     * Keeps workspace continuity when a failed resume falls through to a fresh create: points
+     * the new sandbox at the snapshot id persisted for this scope, so {@link Sandbox#start()}
+     * restores the workspace from the previous archive instead of silently resetting it, and
+     * {@link Sandbox#stop()} overwrites that same archive instead of orphaning it. The snapshot
+     * is rebuilt from the current spec, so it carries a bound client regardless of how the
+     * persisted state deserialized.
+     */
+    private static void carryOverPersistedSnapshotId(
+            Sandbox sandbox, String persistedSnapshotId, SandboxSnapshotSpec snapshotSpec) {
+        SandboxState state = sandbox.getState();
+        if (persistedSnapshotId == null
+                || persistedSnapshotId.isBlank()
+                || snapshotSpec == null
+                || state == null
+                || state.getSnapshot() == null
+                || persistedSnapshotId.equals(state.getSnapshot().getId())) {
+            return;
+        }
+        log.info(
+                "[sandbox] Resume fell back to fresh create; carrying over snapshot id {} (fresh"
+                        + " id was {})",
+                persistedSnapshotId,
+                state.getSnapshot().getId());
+        state.setSnapshot(snapshotSpec.build(persistedSnapshotId));
     }
 
     public void release(SandboxAcquireResult result) {

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/sandbox/SandboxManagerIsolationTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/sandbox/SandboxManagerIsolationTest.java
@@ -26,6 +26,7 @@ import static org.mockito.Mockito.when;
 
 import io.agentscope.core.agent.RuntimeContext;
 import io.agentscope.harness.agent.IsolationScope;
+import io.agentscope.harness.agent.sandbox.snapshot.SandboxSnapshot;
 import io.agentscope.harness.agent.sandbox.snapshot.SandboxSnapshotSpec;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
@@ -173,6 +174,55 @@ class SandboxManagerIsolationTest {
 
         assertSame(resumedSandbox, result.getSandbox());
         verify(client).deserializeState(STATE_JSON, snapshotSpec);
+    }
+
+    // ---- Priority 3 resume failure → Priority 4 fresh create keeps persisted snapshot id ----
+
+    @Test
+    void priority3_resumeFails_freshCreateCarriesOverPersistedSnapshotId() throws Exception {
+        SandboxSnapshot persistedSnapshot = mock(SandboxSnapshot.class);
+        SandboxSnapshot freshSnapshot = mock(SandboxSnapshot.class);
+        SandboxSnapshot carriedOverSnapshot = mock(SandboxSnapshot.class);
+        SandboxState freshState = mock(SandboxState.class);
+        when(persistedSnapshot.getId()).thenReturn("persisted-id");
+        when(freshSnapshot.getId()).thenReturn("fresh-id");
+        when(resumedState.getSnapshot()).thenReturn(persistedSnapshot);
+        when(freshSandbox.getState()).thenReturn(freshState);
+        when(freshState.getSnapshot()).thenReturn(freshSnapshot);
+        when(snapshotSpec.build("persisted-id")).thenReturn(carriedOverSnapshot);
+
+        SandboxAcquireResult result = acquireAfterFailedResume();
+
+        assertSame(freshSandbox, result.getSandbox());
+        verify(freshState).setSnapshot(carriedOverSnapshot);
+    }
+
+    @Test
+    void priority3_resumeFails_noPersistedSnapshot_keepsFreshSnapshot() throws Exception {
+        SandboxState freshState = mock(SandboxState.class);
+        when(freshSandbox.getState()).thenReturn(freshState);
+
+        SandboxAcquireResult result = acquireAfterFailedResume();
+
+        assertSame(freshSandbox, result.getSandbox());
+        verify(freshState, never()).setSnapshot(any());
+        verify(snapshotSpec, never()).build(any());
+    }
+
+    /** Session-scope acquire where persisted state exists but resume fails (claim/pod gone). */
+    private SandboxAcquireResult acquireAfterFailedResume() throws Exception {
+        when(stateStore.load(any())).thenReturn(Optional.of(STATE_JSON));
+        when(client.deserializeState(STATE_JSON, snapshotSpec)).thenReturn(resumedState);
+        when(client.resume(resumedState)).thenThrow(new RuntimeException("claim gone"));
+        when(client.create(any(), any(), any())).thenReturn(freshSandbox);
+
+        RuntimeContext rtx = RuntimeContext.builder().sessionId("sess-1").build();
+        SandboxContext sCtx =
+                SandboxContext.builder()
+                        .isolationScope(IsolationScope.SESSION)
+                        .snapshotSpec(snapshotSpec)
+                        .build();
+        return manager.acquire(sCtx, rtx);
     }
 
     @Test


### PR DESCRIPTION
## AgentScope-Java Version

2.0.1 (fix developed against current `main`, `bf7b7dae`)

## Description

Fixes #2771.

**Background.** With a harness-managed sandbox (`filesystem(SandboxFilesystemSpec)`) backed by the stock `KubernetesSandboxClient`, the workspace silently resets on every call and each snapshot archive is orphaned:

1. `create()` sets `claimOwned=true`, so the per-call release (`stop()` → `shutdown()` → `terminate()`) deletes the claim/pod at the end of every call.
2. On the next call, Priority 3 resume throws (`getSandbox(claimName)` fails — the claim is gone) and `SandboxManager.acquire()` falls through to the Priority 4 fresh create.
3. The fresh create uses a new sessionId, so `snapshotSpec.build(newSessionId)` produces a **new** snapshot id: the previous archive is never referenced again, and `start()` runs the fresh-init branch — all files written in previous calls are gone, with only the P3 fallback warn as a trace.

The 4-branch workspace-start logic (Branch B/C restore) exists for exactly this situation but is unreachable on Kubernetes, because the resume never succeeds. Docker works because its `resume()` does not require a live container.

**Change.** In `SandboxManager.acquire()`, when a persisted state was loaded but the resume failed, the fresh-create fallback now carries the **persisted snapshot id** over to the new sandbox (rebuilding the snapshot from the current spec, so it carries a bound client regardless of deserialization). The next `start()` then restores the workspace from the previous archive (Branch C), and the next `stop()` overwrites that same archive instead of orphaning it.

The fix is client-agnostic: it applies to any `SandboxClient` whose resume can fail after its backing runtime is gone.

**How to test.** Two new unit tests in `SandboxManagerIsolationTest`:
- `priority3_resumeFails_freshCreateCarriesOverPersistedSnapshotId` — resume throws → fresh create re-seeds `state.snapshot` via `snapshotSpec.build(persistedId)`
- `priority3_resumeFails_noPersistedSnapshot_keepsFreshSnapshot` — no persisted snapshot → fresh snapshot untouched

Full harness module suite: `mvn -pl agentscope-harness test` — all passing.

## Checklist

Please check the following items before code is ready to be reviewed.

- [x]  Code has been formatted with `mvn spotless:apply`
- [x]  All tests are passing (`mvn test`)
- [x]  Javadoc comments are complete and follow project conventions
- [x]  Related documentation has been updated (e.g. links, examples, etc.)
- [x]  Code is ready for review
