### PR TITLE
fix(ragflow): type rerankId as String to match the RAGFlow API

### DIFF
--- a/agentscope-extensions/agentscope-extensions-rag/agentscope-extensions-rag-ragflow/src/main/java/io/agentscope/core/rag/integration/ragflow/RAGFlowConfig.java
+++ b/agentscope-extensions/agentscope-extensions-rag/agentscope-extensions-rag-ragflow/src/main/java/io/agentscope/core/rag/integration/ragflow/RAGFlowConfig.java
@@ -73,7 +73,7 @@ public class RAGFlowConfig {
 
     private final Boolean tocEnhance;
 
-    private final Integer rerankId;
+    private final String rerankId;
 
     private final Boolean keyword;
 
@@ -229,9 +229,12 @@ public class RAGFlowConfig {
     /**
      * Gets the rerank model ID.
      *
+     * <p>RAGFlow identifies rerank models by name, e.g. {@code "BAAI/bge-reranker-v2-m3@BAAI"}
+     * or a hex UUID, so this is a {@link String} rather than a numeric id.
+     *
      * @return the rerank model ID, or null if not set
      */
-    public Integer getRerankId() {
+    public String getRerankId() {
         return rerankId;
     }
 
@@ -320,7 +323,7 @@ public class RAGFlowConfig {
 
         private Boolean tocEnhance;
 
-        private Integer rerankId;
+        private String rerankId;
 
         private Boolean keyword;
 
@@ -536,11 +539,31 @@ public class RAGFlowConfig {
         /**
          * Sets the rerank model ID.
          *
+         * <p>RAGFlow's {@code /api/v1/retrieval} endpoint expects {@code rerank_id} to be the
+         * rerank model's name, e.g. {@code "BAAI/bge-reranker-v2-m3@BAAI"} or a hex UUID such as
+         * {@code "b2a62730759d11ef987d0242ac120004"}.
+         *
          * @param rerankId the rerank model ID
          * @return this builder
          */
-        public Builder rerankId(Integer rerankId) {
+        public Builder rerankId(String rerankId) {
             this.rerankId = rerankId;
+            return this;
+        }
+
+        /**
+         * Sets the rerank model ID from a numeric value.
+         *
+         * @param rerankId the rerank model ID
+         * @return this builder
+         * @deprecated RAGFlow identifies rerank models by name, not by a numeric id, so no
+         *     {@code Integer} maps to a real model and the retrieval request is rejected. Use
+         *     {@link #rerankId(String)} instead. This overload only keeps existing call sites
+         *     compiling and stringifies the value.
+         */
+        @Deprecated(forRemoval = true)
+        public Builder rerankId(Integer rerankId) {
+            this.rerankId = rerankId != null ? String.valueOf(rerankId) : null;
             return this;
         }
 

--- a/agentscope-extensions/agentscope-extensions-rag/agentscope-extensions-rag-ragflow/src/main/java/io/agentscope/core/rag/integration/ragflow/RAGFlowKnowledge.java
+++ b/agentscope-extensions/agentscope-extensions-rag/agentscope-extensions-rag-ragflow/src/main/java/io/agentscope/core/rag/integration/ragflow/RAGFlowKnowledge.java
@@ -115,7 +115,6 @@ public class RAGFlowKnowledge implements Knowledge {
      *
      * <ul>
      *   <li>❌ Conversation history for context-aware retrieval
-     *   <li>❌ Built-in reranking
      * </ul>
      *
      * @param query the query text (required)

--- a/agentscope-extensions/agentscope-extensions-rag/agentscope-extensions-rag-ragflow/src/test/java/io/agentscope/core/rag/integration/ragflow/RAGFlowClientRequestTest.java
+++ b/agentscope-extensions/agentscope-extensions-rag/agentscope-extensions-rag-ragflow/src/test/java/io/agentscope/core/rag/integration/ragflow/RAGFlowClientRequestTest.java
@@ -137,7 +137,7 @@ class RAGFlowClientRequestTest {
                         // === Advanced Features ===
                         .useKg(true) // Knowledge graph, default: false
                         .tocEnhance(true) // TOC enhancement, default: false
-                        .rerankId(1) // Rerank model ID
+                        .rerankId("BAAI/bge-reranker-v2-m3@BAAI") // Rerank model ID
                         .keyword(true) // Keyword matching, default: false
                         .highlight(true) // Highlight results, default: false
 
@@ -201,7 +201,7 @@ class RAGFlowClientRequestTest {
         // === Verify Advanced Features ===
         assertEquals(true, body.get("use_kg"));
         assertEquals(true, body.get("toc_enhance"));
-        assertEquals(1, body.get("rerank_id"));
+        assertEquals("BAAI/bge-reranker-v2-m3@BAAI", body.get("rerank_id"));
         assertEquals(true, body.get("keyword"));
         assertEquals(true, body.get("highlight"));
 

--- a/agentscope-extensions/agentscope-extensions-rag/agentscope-extensions-rag-ragflow/src/test/java/io/agentscope/core/rag/integration/ragflow/RAGFlowClientTest.java
+++ b/agentscope-extensions/agentscope-extensions-rag/agentscope-extensions-rag-ragflow/src/test/java/io/agentscope/core/rag/integration/ragflow/RAGFlowClientTest.java
@@ -539,7 +539,7 @@ class RAGFlowClientTest {
                         .apiKey("test-api-key")
                         .baseUrl(mockWebServer.url("").toString().replaceAll("/$", ""))
                         .addDatasetId("dataset-123")
-                        .rerankId(42)
+                        .rerankId("BAAI/bge-reranker-v2-m3@BAAI")
                         .maxRetries(0)
                         .build();
 
@@ -552,7 +552,7 @@ class RAGFlowClientTest {
                 JsonUtils.getJsonCodec()
                         .fromJson(body, new TypeReference<Map<String, Object>>() {});
 
-        assertEquals(42, parsed.get("rerank_id"));
+        assertEquals("BAAI/bge-reranker-v2-m3@BAAI", parsed.get("rerank_id"));
     }
 
     @Test
@@ -852,7 +852,7 @@ class RAGFlowClientTest {
                         .pageSize(50)
                         .useKg(true)
                         .tocEnhance(true)
-                        .rerankId(10)
+                        .rerankId("b2a62730759d11ef987d0242ac120004")
                         .keyword(true)
                         .highlight(true)
                         .addCrossLanguage("en")
@@ -890,7 +890,7 @@ class RAGFlowClientTest {
         assertEquals(50, parsed.get("page_size"));
         assertEquals(true, parsed.get("use_kg"));
         assertEquals(true, parsed.get("toc_enhance"));
-        assertEquals(10, parsed.get("rerank_id"));
+        assertEquals("b2a62730759d11ef987d0242ac120004", parsed.get("rerank_id"));
         assertEquals(true, parsed.get("keyword"));
         assertEquals(true, parsed.get("highlight"));
 

--- a/agentscope-extensions/agentscope-extensions-rag/agentscope-extensions-rag-ragflow/src/test/java/io/agentscope/core/rag/integration/ragflow/RAGFlowConfigTest.java
+++ b/agentscope-extensions/agentscope-extensions-rag/agentscope-extensions-rag-ragflow/src/test/java/io/agentscope/core/rag/integration/ragflow/RAGFlowConfigTest.java
@@ -296,16 +296,74 @@ class RAGFlowConfigTest {
                             .addDatasetId("dataset-123")
                             .useKg(true)
                             .tocEnhance(true)
-                            .rerankId(1)
+                            .rerankId("BAAI/bge-reranker-v2-m3@BAAI")
                             .keyword(true)
                             .highlight(true)
                             .build();
 
             assertTrue(config.getUseKg());
             assertTrue(config.getTocEnhance());
-            assertEquals(1, config.getRerankId());
+            assertEquals("BAAI/bge-reranker-v2-m3@BAAI", config.getRerankId());
             assertTrue(config.getKeyword());
             assertTrue(config.getHighlight());
+        }
+
+        @Test
+        void shouldAcceptRerankIdAsModelName() {
+            // RAGFlow identifies rerank models by name, including forms with '/' and '@'.
+            RAGFlowConfig named =
+                    RAGFlowConfig.builder()
+                            .apiKey("test-api-key")
+                            .baseUrl("http://localhost:9380")
+                            .addDatasetId("dataset-123")
+                            .rerankId("BAAI/bge-reranker-v2-m3@BAAI")
+                            .build();
+            assertEquals("BAAI/bge-reranker-v2-m3@BAAI", named.getRerankId());
+
+            // Hex UUID form returned by RAGFlow's model list.
+            RAGFlowConfig uuid =
+                    RAGFlowConfig.builder()
+                            .apiKey("test-api-key")
+                            .baseUrl("http://localhost:9380")
+                            .addDatasetId("dataset-123")
+                            .rerankId("b2a62730759d11ef987d0242ac120004")
+                            .build();
+            assertEquals("b2a62730759d11ef987d0242ac120004", uuid.getRerankId());
+        }
+
+        @Test
+        @SuppressWarnings("deprecation")
+        void deprecatedIntegerRerankIdIsStringified() {
+            RAGFlowConfig config =
+                    RAGFlowConfig.builder()
+                            .apiKey("test-api-key")
+                            .baseUrl("http://localhost:9380")
+                            .addDatasetId("dataset-123")
+                            .rerankId(Integer.valueOf(42))
+                            .build();
+            assertEquals("42", config.getRerankId());
+        }
+
+        @Test
+        @SuppressWarnings("deprecation")
+        void nullRerankIdStaysNullForBothOverloads() {
+            RAGFlowConfig viaString =
+                    RAGFlowConfig.builder()
+                            .apiKey("test-api-key")
+                            .baseUrl("http://localhost:9380")
+                            .addDatasetId("dataset-123")
+                            .rerankId((String) null)
+                            .build();
+            assertNull(viaString.getRerankId());
+
+            RAGFlowConfig viaInteger =
+                    RAGFlowConfig.builder()
+                            .apiKey("test-api-key")
+                            .baseUrl("http://localhost:9380")
+                            .addDatasetId("dataset-123")
+                            .rerankId((Integer) null)
+                            .build();
+            assertNull(viaInteger.getRerankId());
         }
 
         @Test
@@ -495,7 +553,7 @@ class RAGFlowConfigTest {
                         .pageSize(50)
                         .useKg(true)
                         .tocEnhance(true)
-                        .rerankId(1)
+                        .rerankId("BAAI/bge-reranker-v2-m3@BAAI")
                         .keyword(true)
                         .highlight(true)
                         .addCrossLanguage("en")
@@ -517,7 +575,7 @@ class RAGFlowConfigTest {
         assertEquals(50, config.getPageSize());
         assertTrue(config.getUseKg());
         assertTrue(config.getTocEnhance());
-        assertEquals(1, config.getRerankId());
+        assertEquals("BAAI/bge-reranker-v2-m3@BAAI", config.getRerankId());
         assertTrue(config.getKeyword());
         assertTrue(config.getHighlight());
         assertEquals(1, config.getCrossLanguages().size());

--- a/docs/v1/en/docs/task/rag.md
+++ b/docs/v1/en/docs/task/rag.md
@@ -441,7 +441,7 @@ RAGFlowConfig config = RAGFlowConfig.builder()
     // === Advanced Retrieval Features (Optional) ===
     .useKg(false)                               // Knowledge graph multi-hop query, default false
     .tocEnhance(false)                          // TOC-enhanced retrieval, default false
-    .rerankId(1)                                // Rerank model ID
+    .rerankId("BAAI/bge-reranker-v2-m3@BAAI")   // Rerank model ID (model name or hex UUID)
     .keyword(false)                             // Keyword matching, default false
     .highlight(false)                           // Highlight matched results, default false
     .addCrossLanguage("en")                     // Add target language

--- a/docs/v1/zh/docs/task/rag.md
+++ b/docs/v1/zh/docs/task/rag.md
@@ -441,7 +441,7 @@ RAGFlowConfig config = RAGFlowConfig.builder()
     // === 高级检索功能（可选）===
     .useKg(false)                               // 知识图谱多跳查询，默认 false
     .tocEnhance(false)                          // 目录增强检索，默认 false
-    .rerankId(1)                                // 重排序模型 ID
+    .rerankId("BAAI/bge-reranker-v2-m3@BAAI")   // 重排序模型 ID（模型名或 hex UUID）
     .keyword(false)                             // 关键词匹配，默认 false
     .highlight(false)                           // 高亮匹配结果，默认 false
     .addCrossLanguage("en")                     // 添加目标语言


### PR DESCRIPTION
## AgentScope-Java Version

2.0.3-SNAPSHOT (`main` at bf7b7dae)

## Description

### Background

`RAGFlowConfig` declares `rerankId` as `Integer`, but RAGFlow's `/api/v1/retrieval` endpoint identifies rerank models **by name**, e.g. `"BAAI/bge-reranker-v2-m3@BAAI"` or a hex UUID such as `"b2a62730759d11ef987d0242ac120004"`.

`RAGFlowClient` forwards the value verbatim:

```java
// RAGFlowClient.java:168
requestBody.put("rerank_id", config.getRerankId());
```

Since no `Integer` corresponds to a real rerank model, there is no way to enable reranking through the Java SDK — the feature is unreachable, as reported in #2740. The existing Javadoc already described the field as the "rerank **model** ID", so the declared type contradicted its own documented meaning.

### Changes

- `rerankId` field, builder field and `getRerankId()` are now `String`.
- New `Builder.rerankId(String)` is the supported entry point, documented with both accepted ID forms.
- `Builder.rerankId(Integer)` is retained as `@Deprecated(forRemoval = true)` so existing builder call sites keep compiling; it stringifies the value.
- Test call sites updated from integer literals to real RAGFlow model IDs, plus 3 new tests.
- `docs/v1/{en,zh}/docs/task/rag.md` updated: the RAGFlow config example showed `.rerankId(1)`, i.e. it was actively teaching the unusable form.

### On the null guard in the deprecated overload

```java
this.rerankId = rerankId != null ? String.valueOf(rerankId) : null;
```

The guard is not redundant. An `Integer` argument binds to `String.valueOf(Object)` (reference widening resolves in overload phase 1, before unboxing is considered), and that overload maps `null` to the **literal string** `"null"` rather than to `null`. Without the guard, `.rerankId((Integer) null)` would put `{"rerank_id": "null"}` on the wire — worse than omitting the field. Verified:

```
String.valueOf((Integer) null) = [null]   // 4-character String, not null
```

`nullRerankIdStaysNullForBothOverloads` locks this behaviour down for both overloads.

### Source compatibility — please read

This change is **not fully source-compatible**, and I want to be explicit rather than claim otherwise:

| Call shape | Status |
|---|---|
| `.rerankId(42)` (builder) | ✅ still compiles, via the deprecated overload |
| `Integer id = config.getRerankId()` | ❌ breaks — the getter now returns `String` |

Keeping an `Integer`-returning getter alongside a `String` field was considered and rejected: it would need duplicated state and could never return a usable value for a name-based ID, so it would preserve compilation while guaranteeing incorrect behaviour.

Practical exposure looks minimal: `RAGFlowClient` is the only reader of the getter in this repository, and because no valid `Integer` ever existed, callers are unlikely to be reading a meaningful value today. Still, this is the maintainers' call — happy to switch to a fully additive shape (leave `Integer` in place, add a separately named `String` accessor) if you prefer to avoid the break entirely.

### How to test

```bash
mvn -pl agentscope-extensions/agentscope-extensions-rag/agentscope-extensions-rag-ragflow -am test
# Tests run: 99, Failures: 0, Errors: 0, Skipped: 0
# BUILD SUCCESS
```

New tests in `RAGFlowConfigTest.AdvancedFeaturesTest`:

- `shouldAcceptRerankIdAsModelName` — both the `vendor/model@provider` and hex-UUID forms round-trip
- `deprecatedIntegerRerankIdIsStringified` — the deprecated overload yields `"42"`
- `nullRerankIdStaysNullForBothOverloads` — neither overload produces the string `"null"`

The tests were verified to actually exercise the fix: stubbing out `rerankId(String)` turns 6 tests red, including `shouldAcceptRerankIdAsModelName`.

### Relationship to open PRs

#2633 also touches this extension but only modifies `RAGFlowClient`, `RAGFlowKnowledge` and `RAGFlowKnowledgeTest` — it does not touch `RAGFlowConfig` or `rerankId` (diff checked), so there is no overlap.

## Checklist

Please check the following items before code is ready to be reviewed.

- [x]  Code has been formatted with `mvn spotless:apply` (`spotless:check` passes)
- [x]  All tests are passing (`mvn test`)
- [x]  Javadoc comments are complete and follow project conventions (both overloads document the accepted ID forms; the deprecated one explains why it cannot work and what to use instead)
- [x]  Related documentation has been updated (e.g. links, examples, etc.) — the RAGFlow example in `docs/v1/en/docs/task/rag.md` and its Chinese counterpart both showed `.rerankId(1)` and are updated to a real model name
- [x]  Code is ready for review

---
Closes #2740
