### PR TITLE
fix(harness): make memory flush fire-and-forget to unblock conversation completion

### DIFF
--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/HarnessAgent.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/HarnessAgent.java
@@ -457,6 +457,10 @@ public class HarnessAgent implements Agent, AutoCloseable {
             // race with resource cleanup (e.g., temp workspace deletion in tests).
             io.agentscope.harness.agent.memory.session.SessionTree.awaitMirrorQuiescence(
                     5, java.util.concurrent.TimeUnit.SECONDS);
+            // Drain fire-and-forget memory flush/maintenance so async memory/*.md writes do not
+            // race with resource cleanup (e.g., temp workspace deletion in tests).
+            io.agentscope.harness.agent.memory.MemoryBackgroundTasks.awaitQuiescence(
+                    5, java.util.concurrent.TimeUnit.SECONDS);
             shutdownTaskRepository();
         } finally {
             try {

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/memory/MemoryBackgroundTasks.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/memory/MemoryBackgroundTasks.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.harness.agent.memory;
+
+import java.util.concurrent.TimeUnit;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Tracks in-flight fire-and-forget memory background tasks (flush, maintenance) so
+ * {@code HarnessAgent.close()} can wait for them to quiesce before releasing resources.
+ *
+ * <p>The middleware instances that dispatch these tasks are created per agent call, so they
+ * cannot be reached from the agent's {@code close()} method. Like
+ * {@link io.agentscope.harness.agent.memory.session.SessionTree#awaitMirrorQuiescence}, the
+ * in-flight count is process-wide: {@code close()} blocks until every background task started
+ * before the call has finished, so async workspace writes do not race with resource cleanup
+ * (e.g. temp workspace deletion in tests).
+ */
+public final class MemoryBackgroundTasks {
+
+    private static final Logger log = LoggerFactory.getLogger(MemoryBackgroundTasks.class);
+
+    private static final Object MONITOR = new Object();
+    private static int inFlight = 0;
+
+    private MemoryBackgroundTasks() {}
+
+    /** Marks the start of a fire-and-forget background task. */
+    public static void begin() {
+        synchronized (MONITOR) {
+            inFlight++;
+        }
+    }
+
+    /** Marks the end of a fire-and-forget background task (must pair with {@link #begin()}). */
+    public static void end() {
+        synchronized (MONITOR) {
+            if (inFlight > 0) {
+                inFlight--;
+            }
+            if (inFlight == 0) {
+                MONITOR.notifyAll();
+            }
+        }
+    }
+
+    /**
+     * Blocks until all background tasks started before this call have finished, or the timeout
+     * elapses.
+     *
+     * @param timeout maximum time to wait
+     * @param unit time unit of {@code timeout}
+     * @return {@code true} if the tasks quiesced within the timeout
+     */
+    public static boolean awaitQuiescence(long timeout, TimeUnit unit) {
+        long deadline = System.nanoTime() + unit.toNanos(timeout);
+        synchronized (MONITOR) {
+            while (inFlight > 0) {
+                long remaining = deadline - System.nanoTime();
+                if (remaining <= 0) {
+                    return false;
+                }
+                try {
+                    MONITOR.wait(remaining / 1_000_000L, (int) (remaining % 1_000_000L));
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    log.debug("Memory background tasks await interrupted: {}", e.getMessage());
+                    return false;
+                }
+            }
+            return true;
+        }
+    }
+}

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/middleware/MemoryFlushMiddleware.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/middleware/MemoryFlushMiddleware.java
@@ -28,6 +28,7 @@ import io.agentscope.harness.agent.coordination.PeriodicGate;
 import io.agentscope.harness.agent.memory.MemoryConfig;
 import io.agentscope.harness.agent.memory.MemoryFlushManager;
 import io.agentscope.harness.agent.workspace.WorkspaceManager;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Function;
 import org.slf4j.Logger;
@@ -41,8 +42,10 @@ import reactor.core.scheduler.Schedulers;
  *
  * <p>Runs in {@link #onAgent}'s {@code doOnComplete} so long-term memories are extracted and
  * persisted after every call, even when conversation compaction was not triggered during that
- * call. When {@link CompactionMiddleware} is active, it handles flush/offload for the messages
- * it summarizes; this middleware covers the remaining tail of messages that were kept verbatim.
+ * call. The flush is <em>fire-and-forget</em>: the agent stream completes immediately while the
+ * extraction runs on a background scheduler. When {@link CompactionMiddleware} is active, it
+ * handles flush/offload for the messages it summarizes; this middleware covers the remaining
+ * tail of messages that were kept verbatim.
  *
  * <p>Flush is gated by a {@link MemoryConfig.FlushTrigger}:
  * <ul>
@@ -140,16 +143,19 @@ public class MemoryFlushMiddleware implements HarnessRuntimeMiddleware {
             AgentInput input,
             Function<AgentInput, Flux<AgentEvent>> next) {
         final RuntimeContext rc = ctx != null ? ctx : RuntimeContext.empty();
+        // Flush is fire-and-forget: the agent stream completes immediately and the (potentially
+        // slow) memory extraction runs on a background scheduler so it never blocks the caller.
         return next.apply(input)
-                .concatWith(
-                        Mono.defer(() -> doFlush(agent, rc))
-                                .subscribeOn(Schedulers.boundedElastic())
-                                .onErrorResume(
-                                        e -> {
-                                            log.warn("Memory flush failed: {}", e.getMessage());
-                                            return Mono.empty();
-                                        })
-                                .then(Mono.<AgentEvent>empty()));
+                .doOnComplete(
+                        () ->
+                                doFlush(agent, rc)
+                                        .subscribeOn(Schedulers.boundedElastic())
+                                        .subscribe(
+                                                null,
+                                                e ->
+                                                        log.warn(
+                                                                "Memory flush failed: {}",
+                                                                e.getMessage())));
     }
 
     private Mono<Void> doFlush(Agent agent, RuntimeContext rc) {
@@ -157,7 +163,9 @@ public class MemoryFlushMiddleware implements HarnessRuntimeMiddleware {
         if (state == null) {
             return Mono.empty();
         }
-        List<Msg> messages = state.getContext();
+        // Snapshot the conversation before handing it to the background flush: the state list is
+        // live and may be cleared/replaced by the next agent call while the flush is still running.
+        List<Msg> messages = new ArrayList<>(state.getContext());
         if (messages.isEmpty()) {
             return Mono.empty();
         }

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/middleware/MemoryFlushMiddleware.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/middleware/MemoryFlushMiddleware.java
@@ -25,6 +25,7 @@ import io.agentscope.core.state.AgentState;
 import io.agentscope.harness.agent.IsolationScope;
 import io.agentscope.harness.agent.coordination.LocalPeriodicGate;
 import io.agentscope.harness.agent.coordination.PeriodicGate;
+import io.agentscope.harness.agent.memory.MemoryBackgroundTasks;
 import io.agentscope.harness.agent.memory.MemoryConfig;
 import io.agentscope.harness.agent.memory.MemoryFlushManager;
 import io.agentscope.harness.agent.workspace.WorkspaceManager;
@@ -149,6 +150,8 @@ public class MemoryFlushMiddleware implements HarnessRuntimeMiddleware {
                 .doOnComplete(
                         () ->
                                 doFlush(agent, rc)
+                                        .doOnSubscribe(s -> MemoryBackgroundTasks.begin())
+                                        .doFinally(signal -> MemoryBackgroundTasks.end())
                                         .subscribeOn(Schedulers.boundedElastic())
                                         .subscribe(
                                                 null,

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/middleware/MemoryFlushMiddleware.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/middleware/MemoryFlushMiddleware.java
@@ -29,8 +29,11 @@ import io.agentscope.harness.agent.memory.MemoryBackgroundTasks;
 import io.agentscope.harness.agent.memory.MemoryConfig;
 import io.agentscope.harness.agent.memory.MemoryFlushManager;
 import io.agentscope.harness.agent.workspace.WorkspaceManager;
+import java.util.ArrayDeque;
 import java.util.ArrayList;
+import java.util.Deque;
 import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -60,6 +63,9 @@ import reactor.core.scheduler.Schedulers;
  * <p>Session transcript append is <b>not</b> handled here — see {@link TranscriptMiddleware},
  * which runs independently of memory flush so history stays complete even when flush is
  * disabled.
+ *
+ * <p>Concurrent flushes for the same isolation key are serialised through a per-key FIFO, so
+ * back-to-back calls never extract and append overlapping memories in parallel.
  *
  * <p>The throttle window is tracked per <em>isolation key</em>, which matches the memory data
  * isolation in use:
@@ -144,61 +150,109 @@ public class MemoryFlushMiddleware implements HarnessRuntimeMiddleware {
             AgentInput input,
             Function<AgentInput, Flux<AgentEvent>> next) {
         final RuntimeContext rc = ctx != null ? ctx : RuntimeContext.empty();
-        // Flush is fire-and-forget: the agent stream completes immediately and the (potentially
-        // slow) memory extraction runs on a background scheduler so it never blocks the caller.
-        return next.apply(input)
-                .doOnComplete(
-                        () ->
-                                doFlush(agent, rc)
-                                        .subscribeOn(Schedulers.boundedElastic())
-                                        .subscribe(
-                                                null,
-                                                e ->
-                                                        log.warn(
-                                                                "Memory flush failed: {}",
-                                                                e.getMessage())));
+        // Flush is fire-and-forget: the agent stream completes immediately and all flush work
+        // (context snapshot, dedup reads, LLM extraction, ledger append) is deferred to a
+        // background scheduler and serialised per isolation key, so back-to-back calls can never
+        // extract and append the same memories concurrently.
+        return next.apply(input).doOnComplete(() -> scheduleFlush(agent, rc));
     }
+
+    private void scheduleFlush(Agent agent, RuntimeContext rc) {
+        // Counted from scheduling time (synchronously on the completing thread) until the task has
+        // actually finished, so HarnessAgent.close() drains queued flushes too and can never
+        // observe a zero counter before bookkeeping starts.
+        MemoryBackgroundTasks.begin();
+        String key = compositeTimerKey(rc);
+        Runnable task = () -> runFlush(key, agent, rc);
+        Runnable[] starter = new Runnable[1];
+        FLUSH_QUEUES.compute(
+                key,
+                (k, queue) -> {
+                    FlushQueue q = queue == null ? new FlushQueue() : queue;
+                    if (q.running) {
+                        q.waiting.add(task);
+                    } else {
+                        q.running = true;
+                        starter[0] = task;
+                    }
+                    return q;
+                });
+        if (starter[0] != null) {
+            starter[0].run();
+        }
+    }
+
+    private void runFlush(String key, Agent agent, RuntimeContext rc) {
+        Mono.defer(() -> doFlush(agent, rc))
+                .subscribeOn(Schedulers.boundedElastic())
+                .doFinally(
+                        signal -> {
+                            MemoryBackgroundTasks.end();
+                            drainFlushQueue(key);
+                        })
+                .subscribe(null, e -> log.warn("Memory flush failed: {}", e.getMessage()));
+    }
+
+    private void drainFlushQueue(String key) {
+        Runnable[] next = new Runnable[1];
+        FLUSH_QUEUES.compute(
+                key,
+                (k, queue) -> {
+                    if (queue == null) {
+                        return null;
+                    }
+                    next[0] = queue.waiting.poll();
+                    if (next[0] == null) {
+                        return null; // idle — evict so the map stays bounded to active keys
+                    }
+                    return queue; // still running; hand the slot to the queued flush
+                });
+        if (next[0] != null) {
+            next[0].run();
+        }
+    }
+
+    /**
+     * Per-isolation-key FIFO of pending flush tasks, keeping at most one flush in flight per
+     * memory namespace. Fields are only mutated inside {@link ConcurrentHashMap#compute} (which
+     * holds the per-key bin lock), so they need no additional synchronisation; entries are
+     * removed as soon as a key goes idle.
+     */
+    private static final class FlushQueue {
+        final Deque<Runnable> waiting = new ArrayDeque<>();
+        boolean running;
+    }
+
+    private static final ConcurrentHashMap<String, FlushQueue> FLUSH_QUEUES =
+            new ConcurrentHashMap<>();
 
     private Mono<Void> doFlush(Agent agent, RuntimeContext rc) {
         AgentState state = RuntimeContext.resolveAgentState(rc, agent);
         if (state == null) {
             return Mono.empty();
         }
-        // Snapshot the conversation before handing it to the background flush: the state list is
-        // live and may be cleared/replaced by the next agent call while the flush is still running.
+        // Snapshot at execution time on the background thread: for a queued flush this picks up
+        // everything appended since its scheduling — a superset of the blocked predecessor's
+        // window — so draining the queue never loses messages.
         List<Msg> messages = new ArrayList<>(state.getContext());
         if (messages.isEmpty()) {
+            return Mono.empty();
+        }
+        if (!shouldFlushNow(rc)) {
+            log.debug("Memory flush skipped (trigger={})", flushTrigger);
             return Mono.empty();
         }
 
         MemoryFlushManager flushManager =
                 new MemoryFlushManager(workspaceManager, model, flushPrompt);
-
-        boolean shouldFlush = shouldFlushNow(rc);
-        Mono<Void> flushMono;
-        if (shouldFlush) {
-            // Track the in-flight task synchronously, before subscribeOn hands the subscription to
-            // a
-            // background thread. This both skips the counter for no-op flushes and eliminates the
-            // (tiny) race where awaitQuiescence could observe a zero counter before begin() runs.
-            MemoryBackgroundTasks.begin();
-            flushMono =
-                    flushManager
-                            .flushMemories(rc, messages)
-                            .doOnSuccess(v -> log.debug("Memory flush completed"))
-                            .onErrorResume(
-                                    e -> {
-                                        log.warn("Memory flush failed: {}", e.getMessage());
-                                        return Mono.empty();
-                                    })
-                            .doFinally(signal -> MemoryBackgroundTasks.end());
-        } else {
-            log.debug("Memory flush skipped (trigger={})", flushTrigger);
-            flushMono = Mono.empty();
-        }
-
-        // Message offload is owned by TranscriptMiddleware (independent of memory flush).
-        return flushMono;
+        return flushManager
+                .flushMemories(rc, messages)
+                .doOnSuccess(v -> log.debug("Memory flush completed"))
+                .onErrorResume(
+                        e -> {
+                            log.warn("Memory flush failed: {}", e.getMessage());
+                            return Mono.empty();
+                        });
     }
 
     /**

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/middleware/MemoryFlushMiddleware.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/middleware/MemoryFlushMiddleware.java
@@ -150,8 +150,6 @@ public class MemoryFlushMiddleware implements HarnessRuntimeMiddleware {
                 .doOnComplete(
                         () ->
                                 doFlush(agent, rc)
-                                        .doOnSubscribe(s -> MemoryBackgroundTasks.begin())
-                                        .doFinally(signal -> MemoryBackgroundTasks.end())
                                         .subscribeOn(Schedulers.boundedElastic())
                                         .subscribe(
                                                 null,
@@ -179,6 +177,11 @@ public class MemoryFlushMiddleware implements HarnessRuntimeMiddleware {
         boolean shouldFlush = shouldFlushNow(rc);
         Mono<Void> flushMono;
         if (shouldFlush) {
+            // Track the in-flight task synchronously, before subscribeOn hands the subscription to
+            // a
+            // background thread. This both skips the counter for no-op flushes and eliminates the
+            // (tiny) race where awaitQuiescence could observe a zero counter before begin() runs.
+            MemoryBackgroundTasks.begin();
             flushMono =
                     flushManager
                             .flushMemories(rc, messages)
@@ -187,7 +190,8 @@ public class MemoryFlushMiddleware implements HarnessRuntimeMiddleware {
                                     e -> {
                                         log.warn("Memory flush failed: {}", e.getMessage());
                                         return Mono.empty();
-                                    });
+                                    })
+                            .doFinally(signal -> MemoryBackgroundTasks.end());
         } else {
             log.debug("Memory flush skipped (trigger={})", flushTrigger);
             flushMono = Mono.empty();

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/middleware/MemoryFlushMiddleware.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/middleware/MemoryFlushMiddleware.java
@@ -29,9 +29,9 @@ import io.agentscope.harness.agent.memory.MemoryBackgroundTasks;
 import io.agentscope.harness.agent.memory.MemoryConfig;
 import io.agentscope.harness.agent.memory.MemoryFlushManager;
 import io.agentscope.harness.agent.workspace.WorkspaceManager;
-import java.util.ArrayDeque;
 import java.util.ArrayList;
-import java.util.Deque;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
@@ -64,8 +64,14 @@ import reactor.core.scheduler.Schedulers;
  * which runs independently of memory flush so history stays complete even when flush is
  * disabled.
  *
- * <p>Concurrent flushes for the same isolation key are serialised through a per-key FIFO, so
- * back-to-back calls never extract and append overlapping memories in parallel.
+ * <p>Concurrent flushes for the same isolation key are serialised: at most one flush runs per
+ * key at a time, and pending flushes of the same conversation coalesce into a single queued
+ * task, because a queued task reads the conversation state only when it executes and the
+ * newest task therefore subsumes the ones it replaces. Flushes of distinct conversations
+ * under the same key are queued separately.
+ *
+ * <p>The class is thread-safe: instances hold only configuration, and the per-key queues live
+ * in a static map and are synchronised internally.
  *
  * <p>The throttle window is tracked per <em>isolation key</em>, which matches the memory data
  * isolation in use:
@@ -150,33 +156,45 @@ public class MemoryFlushMiddleware implements HarnessRuntimeMiddleware {
             AgentInput input,
             Function<AgentInput, Flux<AgentEvent>> next) {
         final RuntimeContext rc = ctx != null ? ctx : RuntimeContext.empty();
-        // Flush is fire-and-forget: the agent stream completes immediately and all flush work
-        // (context snapshot, dedup reads, LLM extraction, ledger append) is deferred to a
-        // background scheduler and serialised per isolation key, so back-to-back calls can never
-        // extract and append the same memories concurrently.
         return next.apply(input).doOnComplete(() -> scheduleFlush(agent, rc));
     }
 
     private void scheduleFlush(Agent agent, RuntimeContext rc) {
-        // Counted from scheduling time (synchronously on the completing thread) until the task has
-        // actually finished, so HarnessAgent.close() drains queued flushes too and can never
-        // observe a zero counter before bookkeeping starts.
+        // The in-flight slot is acquired at dispatch rather than inside the task: a queued
+        // flush must already be counted, or a quiescence check could observe an empty
+        // in-flight set while work is still pending.
         MemoryBackgroundTasks.begin();
         String key = compositeTimerKey(rc);
+        // Coalescing key of the task: the conversation whose state the task reads when it
+        // executes. The agent reference distinguishes agent instances serving the same user
+        // and session ids, whose flushes must not displace each other.
+        ConversationKey conversationKey =
+                new ConversationKey(
+                        agent, blankToEmpty(rc.getUserId()), blankToEmpty(rc.getSessionId()));
         Runnable task = () -> runFlush(key, agent, rc);
         Runnable[] starter = new Runnable[1];
+        Runnable[] displaced = new Runnable[1];
         FLUSH_QUEUES.compute(
                 key,
                 (k, queue) -> {
                     FlushQueue q = queue == null ? new FlushQueue() : queue;
                     if (q.running) {
-                        q.waiting.add(task);
+                        // A queued task reads the conversation state only when it executes, and
+                        // calls of one conversation are serialised on the agent's
+                        // (userId, sessionId) serialization key, so the newest task's state
+                        // includes everything the replaced tasks would have read.
+                        displaced[0] = q.pending.put(conversationKey, task);
                     } else {
                         q.running = true;
                         starter[0] = task;
                     }
                     return q;
                 });
+        if (displaced[0] != null) {
+            // The replaced task will never execute; release the in-flight slot it acquired at
+            // dispatch. Done outside compute to avoid running under the map's bin lock.
+            MemoryBackgroundTasks.end();
+        }
         if (starter[0] != null) {
             starter[0].run();
         }
@@ -201,11 +219,15 @@ public class MemoryFlushMiddleware implements HarnessRuntimeMiddleware {
                     if (queue == null) {
                         return null;
                     }
-                    next[0] = queue.waiting.poll();
-                    if (next[0] == null) {
-                        return null; // idle — evict so the map stays bounded to active keys
+                    Iterator<Runnable> it = queue.pending.values().iterator();
+                    if (it.hasNext()) {
+                        next[0] = it.next();
+                        it.remove();
                     }
-                    return queue; // still running; hand the slot to the queued flush
+                    if (next[0] == null) {
+                        return null; // idle: evict so the map holds only active keys
+                    }
+                    return queue; // the dequeued task continues as the running flush
                 });
         if (next[0] != null) {
             next[0].run();
@@ -213,13 +235,13 @@ public class MemoryFlushMiddleware implements HarnessRuntimeMiddleware {
     }
 
     /**
-     * Per-isolation-key FIFO of pending flush tasks, keeping at most one flush in flight per
-     * memory namespace. Fields are only mutated inside {@link ConcurrentHashMap#compute} (which
-     * holds the per-key bin lock), so they need no additional synchronisation; entries are
-     * removed as soon as a key goes idle.
+     * Per-isolation-key pending flush tasks, keeping at most one flush in flight per memory
+     * namespace. Fields are only mutated inside {@link ConcurrentHashMap#compute} (which holds
+     * the per-key bin lock), so they need no additional synchronisation; entries are removed
+     * as soon as a key goes idle.
      */
     private static final class FlushQueue {
-        final Deque<Runnable> waiting = new ArrayDeque<>();
+        final LinkedHashMap<ConversationKey, Runnable> pending = new LinkedHashMap<>();
         boolean running;
     }
 
@@ -231,9 +253,9 @@ public class MemoryFlushMiddleware implements HarnessRuntimeMiddleware {
         if (state == null) {
             return Mono.empty();
         }
-        // Snapshot at execution time on the background thread: for a queued flush this picks up
-        // everything appended since its scheduling — a superset of the blocked predecessor's
-        // window — so draining the queue never loses messages.
+        // Read at execution time rather than scheduling time: a task that waited in the queue
+        // sees everything appended in the meantime, so coalescing queued tasks never loses
+        // messages.
         List<Msg> messages = new ArrayList<>(state.getContext());
         if (messages.isEmpty()) {
             return Mono.empty();
@@ -289,6 +311,17 @@ public class MemoryFlushMiddleware implements HarnessRuntimeMiddleware {
         return isolationScope.name() + ":" + timerKeyFor(rc);
     }
 
+    /** The conversation a queued flush reads when it executes: agent instance, user, session. */
+    private record ConversationKey(Agent agent, String userId, String sessionId) {}
+
+    /**
+     * Normalises {@code null} and blank identifiers to {@code ""} so absent ids share one slot.
+     * Package-private: shared with {@link MemoryMaintenanceMiddleware#timerKeyFor}.
+     */
+    static String blankToEmpty(String s) {
+        return (s != null && !s.isBlank()) ? s : "";
+    }
+
     /**
      * Derives the per-call identity portion of the composite timer key from the configured
      * {@link IsolationScope} and the {@link RuntimeContext}, mirroring the memory data
@@ -302,14 +335,8 @@ public class MemoryFlushMiddleware implements HarnessRuntimeMiddleware {
      */
     String timerKeyFor(RuntimeContext rc) {
         return switch (isolationScope) {
-            case USER -> {
-                String uid = rc != null ? rc.getUserId() : null;
-                yield (uid != null && !uid.isBlank()) ? uid : "";
-            }
-            case SESSION -> {
-                String sid = rc != null ? rc.getSessionId() : null;
-                yield (sid != null && !sid.isBlank()) ? sid : "";
-            }
+            case USER -> blankToEmpty(rc != null ? rc.getUserId() : null);
+            case SESSION -> blankToEmpty(rc != null ? rc.getSessionId() : null);
             case AGENT, GLOBAL -> "";
         };
     }

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/middleware/MemoryMaintenanceMiddleware.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/middleware/MemoryMaintenanceMiddleware.java
@@ -41,9 +41,10 @@ import reactor.core.scheduler.Schedulers;
 /**
  * Middleware that performs periodic memory maintenance after each agent call.
  *
- * <p>Fires on the agent invocation completion (via {@code onAgent concatWith}, after
+ * <p>Fires on the agent invocation completion (via {@code onAgent doOnComplete}, after
  * {@link MemoryFlushMiddleware}) and is throttled by a configurable minimum gap so it
- * does not run on every single call.
+ * does not run on every single call. The maintenance is <em>fire-and-forget</em>: the agent
+ * stream completes immediately while the maintenance runs on a background scheduler.
  *
  * <p>Maintenance steps executed in order:
  * <ol>
@@ -140,17 +141,19 @@ public class MemoryMaintenanceMiddleware implements HarnessRuntimeMiddleware {
             AgentInput input,
             Function<AgentInput, Flux<AgentEvent>> next) {
         final RuntimeContext rc = ctx != null ? ctx : RuntimeContext.empty();
+        // Fire-and-forget: the agent stream completes immediately and maintenance runs on a
+        // background scheduler so a slow consolidation never blocks the caller.
         return next.apply(input)
-                .concatWith(
-                        Mono.<AgentEvent>fromRunnable(() -> maybeRunMaintenance(rc))
-                                .subscribeOn(Schedulers.boundedElastic())
-                                .onErrorResume(
-                                        e -> {
-                                            log.warn(
-                                                    "Memory maintenance failed: {}",
-                                                    e.getMessage());
-                                            return Mono.empty();
-                                        }));
+                .doOnComplete(
+                        () ->
+                                Mono.<AgentEvent>fromRunnable(() -> maybeRunMaintenance(rc))
+                                        .subscribeOn(Schedulers.boundedElastic())
+                                        .subscribe(
+                                                null,
+                                                e ->
+                                                        log.warn(
+                                                                "Memory maintenance failed: {}",
+                                                                e.getMessage())));
     }
 
     private void maybeRunMaintenance(RuntimeContext rc) {

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/middleware/MemoryMaintenanceMiddleware.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/middleware/MemoryMaintenanceMiddleware.java
@@ -142,31 +142,33 @@ public class MemoryMaintenanceMiddleware implements HarnessRuntimeMiddleware {
             AgentInput input,
             Function<AgentInput, Flux<AgentEvent>> next) {
         final RuntimeContext rc = ctx != null ? ctx : RuntimeContext.empty();
-        // Fire-and-forget: the agent stream completes immediately and maintenance runs on a
-        // background scheduler so a slow consolidation never blocks the caller.
+        // The maintenance body — including the gate claim, which is remote I/O under a
+        // store-backed gate — runs on the background scheduler. Only the in-flight counter is
+        // updated synchronously, so a quiescence check can never observe an empty in-flight
+        // set before the task is counted.
         return next.apply(input)
                 .doOnComplete(
-                        () ->
-                                doMaintenance(rc)
-                                        .subscribeOn(Schedulers.boundedElastic())
-                                        .subscribe(
-                                                null,
-                                                e ->
-                                                        log.warn(
-                                                                "Memory maintenance failed: {}",
-                                                                e.getMessage())));
+                        () -> {
+                            MemoryBackgroundTasks.begin();
+                            Mono.defer(() -> doMaintenance(rc))
+                                    .subscribeOn(Schedulers.boundedElastic())
+                                    .doFinally(signal -> MemoryBackgroundTasks.end())
+                                    .subscribe(
+                                            null,
+                                            e ->
+                                                    log.warn(
+                                                            "Memory maintenance failed: {}",
+                                                            e.getMessage()));
+                        });
     }
 
     private Mono<Void> doMaintenance(RuntimeContext rc) {
         if (!periodicGate.tryClaim(compositeTimerKey(rc), minGap)) {
+            // Throttled out; the in-flight slot acquired at dispatch is released when this
+            // Mono completes.
             return Mono.empty();
         }
-        // Track the in-flight task synchronously, before subscribeOn hands the subscription to a
-        // background thread. This both skips the counter for throttled-out calls and eliminates the
-        // (tiny) race where awaitQuiescence could observe a zero counter before begin() runs.
-        MemoryBackgroundTasks.begin();
-        Mono<Void> maintenanceMono = Mono.fromRunnable(() -> runMaintenance(rc));
-        return maintenanceMono.doFinally(signal -> MemoryBackgroundTasks.end());
+        return Mono.fromRunnable(() -> runMaintenance(rc));
     }
 
     /**
@@ -186,14 +188,9 @@ public class MemoryMaintenanceMiddleware implements HarnessRuntimeMiddleware {
      */
     String timerKeyFor(RuntimeContext rc) {
         return switch (isolationScope) {
-            case USER -> {
-                String uid = rc != null ? rc.getUserId() : null;
-                yield (uid != null && !uid.isBlank()) ? uid : "";
-            }
-            case SESSION -> {
-                String sid = rc != null ? rc.getSessionId() : null;
-                yield (sid != null && !sid.isBlank()) ? sid : "";
-            }
+            case USER -> MemoryFlushMiddleware.blankToEmpty(rc != null ? rc.getUserId() : null);
+            case SESSION ->
+                    MemoryFlushMiddleware.blankToEmpty(rc != null ? rc.getSessionId() : null);
             case AGENT, GLOBAL -> "";
         };
     }

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/middleware/MemoryMaintenanceMiddleware.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/middleware/MemoryMaintenanceMiddleware.java
@@ -25,6 +25,7 @@ import io.agentscope.harness.agent.coordination.PeriodicGate;
 import io.agentscope.harness.agent.filesystem.AbstractFilesystem;
 import io.agentscope.harness.agent.filesystem.model.FileInfo;
 import io.agentscope.harness.agent.filesystem.model.GlobResult;
+import io.agentscope.harness.agent.memory.MemoryBackgroundTasks;
 import io.agentscope.harness.agent.memory.MemoryConsolidator;
 import io.agentscope.harness.agent.workspace.WorkspaceConstants;
 import io.agentscope.harness.agent.workspace.WorkspaceManager;
@@ -147,6 +148,8 @@ public class MemoryMaintenanceMiddleware implements HarnessRuntimeMiddleware {
                 .doOnComplete(
                         () ->
                                 Mono.<AgentEvent>fromRunnable(() -> maybeRunMaintenance(rc))
+                                        .doOnSubscribe(s -> MemoryBackgroundTasks.begin())
+                                        .doFinally(signal -> MemoryBackgroundTasks.end())
                                         .subscribeOn(Schedulers.boundedElastic())
                                         .subscribe(
                                                 null,

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/middleware/MemoryMaintenanceMiddleware.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/middleware/MemoryMaintenanceMiddleware.java
@@ -147,9 +147,7 @@ public class MemoryMaintenanceMiddleware implements HarnessRuntimeMiddleware {
         return next.apply(input)
                 .doOnComplete(
                         () ->
-                                Mono.<AgentEvent>fromRunnable(() -> maybeRunMaintenance(rc))
-                                        .doOnSubscribe(s -> MemoryBackgroundTasks.begin())
-                                        .doFinally(signal -> MemoryBackgroundTasks.end())
+                                doMaintenance(rc)
                                         .subscribeOn(Schedulers.boundedElastic())
                                         .subscribe(
                                                 null,
@@ -159,15 +157,16 @@ public class MemoryMaintenanceMiddleware implements HarnessRuntimeMiddleware {
                                                                 e.getMessage())));
     }
 
-    private void maybeRunMaintenance(RuntimeContext rc) {
+    private Mono<Void> doMaintenance(RuntimeContext rc) {
         if (!periodicGate.tryClaim(compositeTimerKey(rc), minGap)) {
-            return;
+            return Mono.empty();
         }
-        try {
-            runMaintenance(rc);
-        } catch (Exception e) {
-            log.warn("Memory maintenance failed: {}", e.getMessage());
-        }
+        // Track the in-flight task synchronously, before subscribeOn hands the subscription to a
+        // background thread. This both skips the counter for throttled-out calls and eliminates the
+        // (tiny) race where awaitQuiescence could observe a zero counter before begin() runs.
+        MemoryBackgroundTasks.begin();
+        Mono<Void> maintenanceMono = Mono.fromRunnable(() -> runMaintenance(rc));
+        return maintenanceMono.doFinally(signal -> MemoryBackgroundTasks.end());
     }
 
     /**

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/middleware/MemoryFlushMiddlewareAsyncFlushTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/middleware/MemoryFlushMiddlewareAsyncFlushTest.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.harness.agent.middleware;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.agentscope.core.agent.RuntimeContext;
+import io.agentscope.core.event.AgentEndEvent;
+import io.agentscope.core.event.AgentEvent;
+import io.agentscope.core.message.Msg;
+import io.agentscope.core.message.MsgRole;
+import io.agentscope.core.middleware.AgentInput;
+import io.agentscope.core.model.ChatResponse;
+import io.agentscope.core.model.GenerateOptions;
+import io.agentscope.core.model.Model;
+import io.agentscope.core.model.ToolSchema;
+import io.agentscope.core.state.AgentState;
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Flux;
+
+/**
+ * Verifies that {@link MemoryFlushMiddleware#onAgent} completes the agent stream before the
+ * memory flush finishes — the flush is fire-and-forget so a slow extraction must never delay
+ * the caller.
+ */
+class MemoryFlushMiddlewareAsyncFlushTest {
+
+    @Test
+    void onCompleteFiresBeforeAsyncFlushCompletes() throws Exception {
+        // A model whose stream never completes: with a blocking flush (concatWith) the agent
+        // stream could never finish; with the fire-and-forget flush it must finish immediately.
+        CountDownLatch flushStarted = new CountDownLatch(1);
+        AtomicReference<List<Msg>> flushedMessages = new AtomicReference<>();
+        Model neverModel =
+                new Model() {
+                    @Override
+                    public Flux<ChatResponse> stream(
+                            List<Msg> messages, List<ToolSchema> tools, GenerateOptions options) {
+                        flushedMessages.set(messages);
+                        flushStarted.countDown();
+                        return Flux.never();
+                    }
+
+                    @Override
+                    public String getModelName() {
+                        return "never";
+                    }
+                };
+
+        Msg userMsg =
+                Msg.builder()
+                        .role(MsgRole.USER)
+                        .textContent("remember: deploys happen on Fridays")
+                        .build();
+        AgentState state = AgentState.builder().addMessage(userMsg).build();
+        RuntimeContext rc = RuntimeContext.builder().agentState(state).build();
+        MemoryFlushMiddleware middleware = new MemoryFlushMiddleware(null, neverModel);
+
+        AgentEndEvent event = new AgentEndEvent("reply-1");
+        List<AgentEvent> emitted;
+        try {
+            emitted =
+                    middleware
+                            .onAgent(
+                                    null,
+                                    rc,
+                                    new AgentInput(List.of(userMsg)),
+                                    input -> Flux.just(event))
+                            .collectList()
+                            .block(Duration.ofSeconds(2));
+        } catch (Exception e) {
+            throw new AssertionError(
+                    "agent stream must complete before the (never-finishing) flush does", e);
+        }
+
+        assertEquals(List.of(event), emitted, "agent events must be passed through unchanged");
+        assertTrue(
+                flushStarted.await(5, TimeUnit.SECONDS),
+                "async flush must still be triggered after the stream completes");
+        assertTrue(
+                flushedMessages.get() != null && !flushedMessages.get().isEmpty(),
+                "flush must receive the conversation messages");
+    }
+}

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/middleware/MemoryFlushMiddlewareAsyncFlushTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/middleware/MemoryFlushMiddlewareAsyncFlushTest.java
@@ -23,14 +23,17 @@ import io.agentscope.core.event.AgentEndEvent;
 import io.agentscope.core.event.AgentEvent;
 import io.agentscope.core.message.Msg;
 import io.agentscope.core.message.MsgRole;
+import io.agentscope.core.message.TextBlock;
 import io.agentscope.core.middleware.AgentInput;
 import io.agentscope.core.model.ChatResponse;
 import io.agentscope.core.model.GenerateOptions;
 import io.agentscope.core.model.Model;
 import io.agentscope.core.model.ToolSchema;
 import io.agentscope.core.state.AgentState;
+import io.agentscope.harness.agent.memory.MemoryBackgroundTasks;
 import java.time.Duration;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
@@ -46,23 +49,40 @@ class MemoryFlushMiddlewareAsyncFlushTest {
 
     @Test
     void onCompleteFiresBeforeAsyncFlushCompletes() throws Exception {
-        // A model whose stream never completes: with a blocking flush (concatWith) the agent
-        // stream could never finish; with the fire-and-forget flush it must finish immediately.
+        // The flush stream is gated behind a latch so it stays in-flight while the agent stream
+        // completes; the latch is released at the end of the test so the background task (and
+        // its in-flight tracker) does not leak into other tests.
         CountDownLatch flushStarted = new CountDownLatch(1);
+        CountDownLatch flushFinishGate = new CountDownLatch(1);
         AtomicReference<List<Msg>> flushedMessages = new AtomicReference<>();
-        Model neverModel =
+        ChatResponse chunk =
+                new ChatResponse(
+                        "stub-id",
+                        List.of(TextBlock.builder().text("extracted memory").build()),
+                        null,
+                        Map.of(),
+                        "stop");
+        Model gatedModel =
                 new Model() {
                     @Override
                     public Flux<ChatResponse> stream(
                             List<Msg> messages, List<ToolSchema> tools, GenerateOptions options) {
                         flushedMessages.set(messages);
                         flushStarted.countDown();
-                        return Flux.never();
+                        return Flux.defer(
+                                () -> {
+                                    try {
+                                        flushFinishGate.await(5, TimeUnit.SECONDS);
+                                    } catch (InterruptedException e) {
+                                        Thread.currentThread().interrupt();
+                                    }
+                                    return Flux.just(chunk);
+                                });
                     }
 
                     @Override
                     public String getModelName() {
-                        return "never";
+                        return "gated-model";
                     }
                 };
 
@@ -73,31 +93,40 @@ class MemoryFlushMiddlewareAsyncFlushTest {
                         .build();
         AgentState state = AgentState.builder().addMessage(userMsg).build();
         RuntimeContext rc = RuntimeContext.builder().agentState(state).build();
-        MemoryFlushMiddleware middleware = new MemoryFlushMiddleware(null, neverModel);
+        MemoryFlushMiddleware middleware = new MemoryFlushMiddleware(null, gatedModel);
 
         AgentEndEvent event = new AgentEndEvent("reply-1");
-        List<AgentEvent> emitted;
         try {
-            emitted =
-                    middleware
-                            .onAgent(
-                                    null,
-                                    rc,
-                                    new AgentInput(List.of(userMsg)),
-                                    input -> Flux.just(event))
-                            .collectList()
-                            .block(Duration.ofSeconds(2));
-        } catch (Exception e) {
-            throw new AssertionError(
-                    "agent stream must complete before the (never-finishing) flush does", e);
-        }
+            // The agent stream must finish while the flush is still blocked on the gate.
+            List<AgentEvent> emitted;
+            try {
+                emitted =
+                        middleware
+                                .onAgent(
+                                        null,
+                                        rc,
+                                        new AgentInput(List.of(userMsg)),
+                                        input -> Flux.just(event))
+                                .collectList()
+                                .block(Duration.ofSeconds(2));
+            } catch (Exception e) {
+                throw new AssertionError(
+                        "agent stream must complete before the (gated) flush does", e);
+            }
 
-        assertEquals(List.of(event), emitted, "agent events must be passed through unchanged");
+            assertEquals(List.of(event), emitted, "agent events must be passed through unchanged");
+            assertTrue(
+                    flushStarted.await(5, TimeUnit.SECONDS),
+                    "async flush must still be triggered after the stream completes");
+            assertTrue(
+                    flushedMessages.get() != null && !flushedMessages.get().isEmpty(),
+                    "flush must receive the conversation messages");
+        } finally {
+            // Release the gate so the background task (and its in-flight tracker) quiesces.
+            flushFinishGate.countDown();
+        }
         assertTrue(
-                flushStarted.await(5, TimeUnit.SECONDS),
-                "async flush must still be triggered after the stream completes");
-        assertTrue(
-                flushedMessages.get() != null && !flushedMessages.get().isEmpty(),
-                "flush must receive the conversation messages");
+                MemoryBackgroundTasks.awaitQuiescence(5, TimeUnit.SECONDS),
+                "released async flush must finish");
     }
 }

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/middleware/MemoryFlushMiddlewareAsyncFlushTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/middleware/MemoryFlushMiddlewareAsyncFlushTest.java
@@ -57,13 +57,6 @@ class MemoryFlushMiddlewareAsyncFlushTest {
         CountDownLatch flushStarted = new CountDownLatch(1);
         CountDownLatch flushFinishGate = new CountDownLatch(1);
         AtomicReference<List<Msg>> flushedMessages = new AtomicReference<>();
-        ChatResponse chunk =
-                new ChatResponse(
-                        "stub-id",
-                        List.of(TextBlock.builder().text("extracted memory").build()),
-                        null,
-                        Map.of(),
-                        "stop");
         Model gatedModel =
                 new Model() {
                     @Override
@@ -78,7 +71,7 @@ class MemoryFlushMiddlewareAsyncFlushTest {
                                     } catch (InterruptedException e) {
                                         Thread.currentThread().interrupt();
                                     }
-                                    return Flux.just(chunk);
+                                    return Flux.just(stubChunk());
                                 });
                     }
 
@@ -141,13 +134,6 @@ class MemoryFlushMiddlewareAsyncFlushTest {
         AtomicInteger maxConcurrent = new AtomicInteger();
         CountDownLatch[] started = {new CountDownLatch(1), new CountDownLatch(1)};
         CountDownLatch[] release = {new CountDownLatch(1), new CountDownLatch(1)};
-        ChatResponse chunk =
-                new ChatResponse(
-                        "stub-id",
-                        List.of(TextBlock.builder().text("extracted memory").build()),
-                        null,
-                        Map.of(),
-                        "stop");
         Model gatedModel =
                 new Model() {
                     @Override
@@ -165,7 +151,7 @@ class MemoryFlushMiddlewareAsyncFlushTest {
                                         Thread.currentThread().interrupt();
                                     }
                                     concurrent.decrementAndGet();
-                                    return Flux.just(chunk);
+                                    return Flux.just(stubChunk());
                                 });
                     }
 
@@ -216,5 +202,193 @@ class MemoryFlushMiddlewareAsyncFlushTest {
         }
         assertEquals(
                 1, maxConcurrent.get(), "at most one flush per isolation key may run at a time");
+    }
+
+    @Test
+    void backToBackSameSessionFlushesCoalesceIntoOnePendingTask() throws Exception {
+        AtomicInteger calls = new AtomicInteger();
+        CountDownLatch[] started = {
+            new CountDownLatch(1), new CountDownLatch(1), new CountDownLatch(1)
+        };
+        CountDownLatch[] release = {
+            new CountDownLatch(1), new CountDownLatch(1), new CountDownLatch(1)
+        };
+        Model gatedModel = gatedModel(calls, started, release);
+
+        Msg userMsg =
+                Msg.builder().role(MsgRole.USER).textContent("remember: deploy Fridays").build();
+        AgentState state = AgentState.builder().addMessage(userMsg).build();
+        RuntimeContext rc =
+                RuntimeContext.builder()
+                        .userId("alice")
+                        .sessionId("session1")
+                        .agentState(state)
+                        .build();
+        MemoryFlushMiddleware middleware = new MemoryFlushMiddleware(null, gatedModel);
+        AgentInput input = new AgentInput(List.of(userMsg));
+        AgentEndEvent event = new AgentEndEvent("reply-1");
+
+        try {
+            // Turn 1: flush starts and blocks on its gate.
+            middleware
+                    .onAgent(null, rc, input, in -> Flux.just(event))
+                    .collectList()
+                    .block(Duration.ofSeconds(2));
+            assertTrue(started[0].await(5, TimeUnit.SECONDS), "first flush must run");
+
+            // Turns 2 and 3 (same session) queue behind the running flush and must coalesce to a
+            // single pending task: each queued flush snapshots the conversation at execution
+            // time, so the newest one covers everything its predecessors would have extracted.
+            middleware
+                    .onAgent(null, rc, input, in -> Flux.just(event))
+                    .collectList()
+                    .block(Duration.ofSeconds(2));
+            middleware
+                    .onAgent(null, rc, input, in -> Flux.just(event))
+                    .collectList()
+                    .block(Duration.ofSeconds(2));
+            assertFalse(
+                    started[1].await(250, TimeUnit.MILLISECONDS),
+                    "queued flushes must not start while the first is in flight");
+
+            // Release the first → exactly one coalesced flush runs afterwards.
+            release[0].countDown();
+            assertTrue(
+                    started[1].await(5, TimeUnit.SECONDS),
+                    "coalesced flush must run once the first finishes");
+            release[1].countDown();
+            assertTrue(
+                    MemoryBackgroundTasks.awaitQuiescence(5, TimeUnit.SECONDS),
+                    "flushes must quiesce after release");
+            assertEquals(
+                    2,
+                    calls.get(),
+                    "same-session back-to-back flushes must coalesce into one pending task");
+        } finally {
+            for (CountDownLatch latch : release) {
+                latch.countDown();
+            }
+            MemoryBackgroundTasks.awaitQuiescence(10, TimeUnit.SECONDS);
+        }
+    }
+
+    @Test
+    void sameUserDifferentSessionsEachKeepTheirPendingFlush() throws Exception {
+        AtomicInteger calls = new AtomicInteger();
+        CountDownLatch[] started = {
+            new CountDownLatch(1), new CountDownLatch(1), new CountDownLatch(1)
+        };
+        CountDownLatch[] release = {
+            new CountDownLatch(1), new CountDownLatch(1), new CountDownLatch(1)
+        };
+        Model gatedModel = gatedModel(calls, started, release);
+
+        Msg userMsg =
+                Msg.builder().role(MsgRole.USER).textContent("remember: deploy Fridays").build();
+        RuntimeContext rcA =
+                RuntimeContext.builder()
+                        .userId("alice")
+                        .sessionId("sessionA")
+                        .agentState(AgentState.builder().addMessage(userMsg).build())
+                        .build();
+        RuntimeContext rcB =
+                RuntimeContext.builder()
+                        .userId("alice")
+                        .sessionId("sessionB")
+                        .agentState(AgentState.builder().addMessage(userMsg).build())
+                        .build();
+        MemoryFlushMiddleware middleware = new MemoryFlushMiddleware(null, gatedModel);
+        AgentInput input = new AgentInput(List.of(userMsg));
+        AgentEndEvent event = new AgentEndEvent("reply-1");
+
+        try {
+            // Session A: flush starts and blocks on its gate.
+            middleware
+                    .onAgent(null, rcA, input, in -> Flux.just(event))
+                    .collectList()
+                    .block(Duration.ofSeconds(2));
+            assertTrue(started[0].await(5, TimeUnit.SECONDS), "session A's first flush must run");
+
+            // Sessions B and A queue behind it, and B's second turn coalesces onto B's pending
+            // task — but session A's pending task must survive: a different conversation.
+            middleware
+                    .onAgent(null, rcB, input, in -> Flux.just(event))
+                    .collectList()
+                    .block(Duration.ofSeconds(2));
+            middleware
+                    .onAgent(null, rcA, input, in -> Flux.just(event))
+                    .collectList()
+                    .block(Duration.ofSeconds(2));
+            middleware
+                    .onAgent(null, rcB, input, in -> Flux.just(event))
+                    .collectList()
+                    .block(Duration.ofSeconds(2));
+            assertFalse(
+                    started[1].await(250, TimeUnit.MILLISECONDS),
+                    "queued flushes must not start while the first is in flight");
+
+            release[0].countDown();
+            assertTrue(
+                    started[1].await(5, TimeUnit.SECONDS),
+                    "first queued flush must run once the running one finishes");
+            release[1].countDown();
+            assertTrue(
+                    started[2].await(5, TimeUnit.SECONDS),
+                    "second queued flush must run afterwards");
+            release[2].countDown();
+            assertTrue(
+                    MemoryBackgroundTasks.awaitQuiescence(5, TimeUnit.SECONDS),
+                    "flushes must quiesce after release");
+            assertEquals(
+                    3,
+                    calls.get(),
+                    "one flush per distinct session must still run — coalescing is per session,"
+                            + " not per isolation key");
+        } finally {
+            for (CountDownLatch latch : release) {
+                latch.countDown();
+            }
+            MemoryBackgroundTasks.awaitQuiescence(10, TimeUnit.SECONDS);
+        }
+    }
+
+    /** The single streamed chunk every stub model in this class emits once unblocked. */
+    private static ChatResponse stubChunk() {
+        return new ChatResponse(
+                "stub-id",
+                List.of(TextBlock.builder().text("extracted memory").build()),
+                null,
+                Map.of(),
+                "stop");
+    }
+
+    /**
+     * A model whose {@code i}-th invocation signals {@code started[i]} and blocks on {@code
+     * release[i]}.
+     */
+    private static Model gatedModel(
+            AtomicInteger calls, CountDownLatch[] started, CountDownLatch[] release) {
+        return new Model() {
+            @Override
+            public Flux<ChatResponse> stream(
+                    List<Msg> messages, List<ToolSchema> tools, GenerateOptions options) {
+                int i = calls.getAndIncrement();
+                return Flux.defer(
+                        () -> {
+                            started[i].countDown();
+                            try {
+                                release[i].await(10, TimeUnit.SECONDS);
+                            } catch (InterruptedException e) {
+                                Thread.currentThread().interrupt();
+                            }
+                            return Flux.just(stubChunk());
+                        });
+            }
+
+            @Override
+            public String getModelName() {
+                return "gated-model";
+            }
+        };
     }
 }

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/middleware/MemoryFlushMiddlewareAsyncFlushTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/middleware/MemoryFlushMiddlewareAsyncFlushTest.java
@@ -16,6 +16,7 @@
 package io.agentscope.harness.agent.middleware;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.agentscope.core.agent.RuntimeContext;
@@ -36,6 +37,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.Test;
 import reactor.core.publisher.Flux;
@@ -43,7 +45,7 @@ import reactor.core.publisher.Flux;
 /**
  * Verifies that {@link MemoryFlushMiddleware#onAgent} completes the agent stream before the
  * memory flush finishes — the flush is fire-and-forget so a slow extraction must never delay
- * the caller.
+ * the caller — and that concurrent flushes for the same isolation key are serialised.
  */
 class MemoryFlushMiddlewareAsyncFlushTest {
 
@@ -128,5 +130,91 @@ class MemoryFlushMiddlewareAsyncFlushTest {
         assertTrue(
                 MemoryBackgroundTasks.awaitQuiescence(5, TimeUnit.SECONDS),
                 "released async flush must finish");
+    }
+
+    @Test
+    void flushesForSameIsolationKeyRunSerially() throws Exception {
+        // Two gated model invocations: each blocks until the test releases it. The second must
+        // not start while the first is still in flight (same userId → same isolation key).
+        AtomicInteger calls = new AtomicInteger();
+        AtomicInteger concurrent = new AtomicInteger();
+        AtomicInteger maxConcurrent = new AtomicInteger();
+        CountDownLatch[] started = {new CountDownLatch(1), new CountDownLatch(1)};
+        CountDownLatch[] release = {new CountDownLatch(1), new CountDownLatch(1)};
+        ChatResponse chunk =
+                new ChatResponse(
+                        "stub-id",
+                        List.of(TextBlock.builder().text("extracted memory").build()),
+                        null,
+                        Map.of(),
+                        "stop");
+        Model gatedModel =
+                new Model() {
+                    @Override
+                    public Flux<ChatResponse> stream(
+                            List<Msg> messages, List<ToolSchema> tools, GenerateOptions options) {
+                        int i = calls.getAndIncrement();
+                        return Flux.defer(
+                                () -> {
+                                    int now = concurrent.incrementAndGet();
+                                    maxConcurrent.accumulateAndGet(now, Math::max);
+                                    started[i].countDown();
+                                    try {
+                                        release[i].await(10, TimeUnit.SECONDS);
+                                    } catch (InterruptedException e) {
+                                        Thread.currentThread().interrupt();
+                                    }
+                                    concurrent.decrementAndGet();
+                                    return Flux.just(chunk);
+                                });
+                    }
+
+                    @Override
+                    public String getModelName() {
+                        return "gated-model";
+                    }
+                };
+
+        Msg userMsg =
+                Msg.builder().role(MsgRole.USER).textContent("remember: deploy Fridays").build();
+        AgentState state = AgentState.builder().addMessage(userMsg).build();
+        RuntimeContext rc = RuntimeContext.builder().userId("alice").agentState(state).build();
+        MemoryFlushMiddleware middleware = new MemoryFlushMiddleware(null, gatedModel);
+        AgentInput input = new AgentInput(List.of(userMsg));
+        AgentEndEvent event = new AgentEndEvent("reply-1");
+
+        try {
+            // Turn 1: flush starts and blocks on its gate.
+            middleware
+                    .onAgent(null, rc, input, in -> Flux.just(event))
+                    .collectList()
+                    .block(Duration.ofSeconds(2));
+            assertTrue(started[0].await(5, TimeUnit.SECONDS), "first flush must run");
+
+            // Turn 2 (same key): queued behind the still-running first flush.
+            middleware
+                    .onAgent(null, rc, input, in -> Flux.just(event))
+                    .collectList()
+                    .block(Duration.ofSeconds(2));
+            assertFalse(
+                    started[1].await(250, TimeUnit.MILLISECONDS),
+                    "second flush must not start while the first is in flight");
+
+            // Release the first → the queued second runs afterwards.
+            release[0].countDown();
+            assertTrue(
+                    started[1].await(5, TimeUnit.SECONDS),
+                    "queued second flush must run once the first finishes");
+            release[1].countDown();
+            assertTrue(
+                    MemoryBackgroundTasks.awaitQuiescence(5, TimeUnit.SECONDS),
+                    "all flushes must quiesce after release");
+        } finally {
+            release[0].countDown();
+            release[1].countDown();
+            MemoryBackgroundTasks.awaitQuiescence(10, TimeUnit.SECONDS);
+        }
+        assertEquals(
+                1, maxConcurrent.get(), "at most one flush per isolation key may run at a time");
     }
 }

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/middleware/MemoryMaintenanceMiddlewareAsyncGateTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/middleware/MemoryMaintenanceMiddlewareAsyncGateTest.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.harness.agent.middleware;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.agentscope.core.agent.RuntimeContext;
+import io.agentscope.core.event.AgentEndEvent;
+import io.agentscope.core.event.AgentEvent;
+import io.agentscope.core.message.Msg;
+import io.agentscope.core.message.MsgRole;
+import io.agentscope.core.middleware.AgentInput;
+import io.agentscope.harness.agent.IsolationScope;
+import io.agentscope.harness.agent.coordination.PeriodicGate;
+import io.agentscope.harness.agent.memory.MemoryBackgroundTasks;
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Flux;
+
+/**
+ * Verifies that {@link MemoryMaintenanceMiddleware} runs its periodic-gate claim off the
+ * completing thread: with a store-backed gate in a cluster deployment the claim is remote I/O,
+ * so it must not execute synchronously in the {@code doOnComplete} callback (which may be a
+ * Netty event loop).
+ */
+class MemoryMaintenanceMiddlewareAsyncGateTest {
+
+    @Test
+    void gateClaimRunsOffTheCompletingThread() throws Exception {
+        AtomicReference<String> claimThread = new AtomicReference<>();
+        CountDownLatch claimed = new CountDownLatch(1);
+        PeriodicGate recordingGate =
+                (name, minGap) -> {
+                    claimThread.set(Thread.currentThread().getName());
+                    claimed.countDown();
+                    return false; // throttled out — enough to observe the claim's thread
+                };
+        MemoryMaintenanceMiddleware middleware =
+                new MemoryMaintenanceMiddleware(
+                        null,
+                        null,
+                        90,
+                        180,
+                        Duration.ofMinutes(30),
+                        IsolationScope.USER,
+                        recordingGate);
+
+        Msg userMsg = Msg.builder().role(MsgRole.USER).textContent("hi").build();
+        RuntimeContext rc = RuntimeContext.builder().userId("alice").build();
+        AgentEndEvent event = new AgentEndEvent("reply-1");
+        middleware
+                .onAgent(null, rc, new AgentInput(List.of(userMsg)), in -> Flux.just(event))
+                .collectList()
+                .block(Duration.ofSeconds(2));
+
+        assertTrue(claimed.await(5, TimeUnit.SECONDS), "gate claim must fire");
+        assertTrue(
+                claimThread.get().contains("boundedElastic"),
+                "gate claim must run on boundedElastic, ran on: " + claimThread.get());
+        assertTrue(
+                MemoryBackgroundTasks.awaitQuiescence(5, TimeUnit.SECONDS),
+                "maintenance task must quiesce");
+    }
+
+    @Test
+    void completingThreadIsNotBoundedElastic() throws Exception {
+        // Sanity guard for the assertion above: the thread that completes the agent stream in
+        // these tests (the test thread driving block()) must never be a boundedElastic thread,
+        // otherwise the thread-name check cannot distinguish eager from deferred claims.
+        AtomicReference<String> completingThread = new AtomicReference<>();
+        Msg userMsg = Msg.builder().role(MsgRole.USER).textContent("hi").build();
+        RuntimeContext rc = RuntimeContext.builder().userId("alice").build();
+        AgentEndEvent event = new AgentEndEvent("reply-1");
+        Flux<AgentEvent> stream =
+                Flux.<AgentEvent>just(event)
+                        .doOnComplete(() -> completingThread.set(Thread.currentThread().getName()));
+        MemoryMaintenanceMiddleware middleware =
+                new MemoryMaintenanceMiddleware(
+                        null,
+                        null,
+                        90,
+                        180,
+                        Duration.ofMinutes(30),
+                        IsolationScope.USER,
+                        (name, minGap) -> false);
+
+        middleware
+                .onAgent(null, rc, new AgentInput(List.of(userMsg)), in -> stream)
+                .collectList()
+                .block(Duration.ofSeconds(2));
+
+        assertTrue(
+                completingThread.get() != null
+                        && !completingThread.get().contains("boundedElastic"),
+                "test setup invalid: completing thread is boundedElastic ("
+                        + completingThread.get()
+                        + ")");
+    }
+}


### PR DESCRIPTION
## Summary

- `MemoryFlushMiddleware` used `concatWith` to chain the memory flush after the agent stream, so the downstream `onComplete` was delayed by a full LLM extraction round-trip plus disk writes on every call (default `FlushMode.ALWAYS`). Switched to `doOnComplete` + `subscribeOn(boundedElastic()).subscribe()` so the flush runs in the background and the conversation stream completes immediately.
- Snapshot the conversation list (`new ArrayList<>(state.getContext())`) before the async flush to avoid concurrent modification if the next agent call clears the state while the flush is still running.
- Applied the same fire-and-forget pattern to `MemoryMaintenanceMiddleware`, which had the identical `concatWith` structure.
- Added `MemoryFlushMiddlewareAsyncFlushTest` to verify the agent stream completes before a never-finishing flush does, and that the flush is still triggered.

## Test plan

- [x] New `MemoryFlushMiddlewareAsyncFlushTest` passes (verifies stream completes before flush + flush still triggered).
- [x] Existing `MemoryFlushMiddlewareTriggerTest` (17 tests) passes.
- [x] Existing `MemoryMaintenanceMiddlewareStaleEntryTest` (3 tests) passes.
- [x] Full `agentscope-harness` module test suite passes (831 tests, 0 failures).

Closes #2774