### PR TITLE
fix(agui): cancel MVC subscription on disconnect

### DIFF
--- a/agentscope-extensions/agentscope-spring-boot-starters/agentscope-agui-spring-boot-starter/src/main/java/io/agentscope/spring/boot/agui/mvc/AguiMvcController.java
+++ b/agentscope-extensions/agentscope-spring-boot-starters/agentscope-agui-spring-boot-starter/src/main/java/io/agentscope/spring/boot/agui/mvc/AguiMvcController.java
@@ -41,6 +41,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.http.MediaType;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 import reactor.core.Disposable;
+import reactor.core.publisher.BaseSubscriber;
 
 /**
  * MVC controller for AG-UI protocol requests.
@@ -169,7 +170,6 @@ public class AguiMvcController {
 
         executorService.submit(
                 () -> {
-                    Disposable subscription = null;
                     try {
                         // Process request - returns both agent and event stream
                         RuntimeContext runtimeContext =
@@ -177,6 +177,31 @@ public class AguiMvcController {
                         AguiRequestProcessor.ProcessResult result =
                                 processor.process(
                                         input, headerAgentId, pathAgentId, runtimeContext);
+                        BaseSubscriber<AguiEvent> subscription =
+                                new BaseSubscriber<>() {
+                                    @Override
+                                    protected void hookOnNext(AguiEvent event) {
+                                        sendEvent(emitter, event);
+                                    }
+
+                                    @Override
+                                    protected void hookOnError(Throwable error) {
+                                        logger.error(
+                                                "Error during AG-UI run: {}", error.getMessage());
+                                        sendErrorAndComplete(
+                                                emitter, threadId, runId, error.getMessage());
+                                    }
+
+                                    @Override
+                                    protected void hookOnComplete() {
+                                        try {
+                                            emitter.complete();
+                                        } catch (Exception e) {
+                                            logger.debug(
+                                                    "Error completing emitter: {}", e.getMessage());
+                                        }
+                                    }
+                                };
 
                         // Set up callbacks for client disconnect handling
                         // using the same agent instance from the result
@@ -189,7 +214,8 @@ public class AguiMvcController {
                                                 "SSE connection timed out for run {}, interrupting"
                                                         + " agent",
                                                 runId);
-                                        result.interrupt(threadId, runtimeContext);
+                                        interruptAndCancel(
+                                                result, threadId, runtimeContext, subscription);
                                     } else {
                                         logger.info(
                                                 "SSE connection timed out for run {}, agent"
@@ -205,7 +231,8 @@ public class AguiMvcController {
                                                         + " agent",
                                                 runId,
                                                 ex.getMessage());
-                                        result.interrupt(threadId, runtimeContext);
+                                        interruptAndCancel(
+                                                result, threadId, runtimeContext, subscription);
                                     } else {
                                         logger.info(
                                                 "SSE connection error for run {}: {}, agent"
@@ -216,29 +243,9 @@ public class AguiMvcController {
                                 });
 
                         // Subscribe to event stream from the same result
-                        subscription =
-                                result.events()
-                                        .subscribe(
-                                                event -> sendEvent(emitter, event),
-                                                error -> {
-                                                    logger.error(
-                                                            "Error during AG-UI run: {}",
-                                                            error.getMessage());
-                                                    sendErrorAndComplete(
-                                                            emitter,
-                                                            threadId,
-                                                            runId,
-                                                            error.getMessage());
-                                                },
-                                                () -> {
-                                                    try {
-                                                        emitter.complete();
-                                                    } catch (Exception e) {
-                                                        logger.debug(
-                                                                "Error completing emitter: {}",
-                                                                e.getMessage());
-                                                    }
-                                                });
+                        // The subscriber is created before disconnect callbacks are registered so
+                        // cancellation is safe even if the client disconnects before subscribe().
+                        result.events().subscribe(subscription);
 
                     } catch (AguiException.AgentNotFoundException e) {
                         logger.error("Agent not found: {}", e.getMessage());
@@ -250,6 +257,18 @@ public class AguiMvcController {
                 });
 
         return emitter;
+    }
+
+    private static void interruptAndCancel(
+            AguiRequestProcessor.ProcessResult result,
+            String threadId,
+            RuntimeContext runtimeContext,
+            Disposable subscription) {
+        try {
+            result.interrupt(threadId, runtimeContext);
+        } finally {
+            subscription.dispose();
+        }
     }
 
     private RuntimeContext resolveRuntimeContext(

--- a/agentscope-extensions/agentscope-spring-boot-starters/agentscope-agui-spring-boot-starter/src/test/java/io/agentscope/spring/boot/agui/mvc/AguiMvcControllerTest.java
+++ b/agentscope-extensions/agentscope-spring-boot-starters/agentscope-agui-spring-boot-starter/src/test/java/io/agentscope/spring/boot/agui/mvc/AguiMvcControllerTest.java
@@ -1,0 +1,182 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.spring.boot.agui.mvc;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import io.agentscope.core.ReActAgent;
+import io.agentscope.core.agent.Agent;
+import io.agentscope.core.agent.RuntimeContext;
+import io.agentscope.core.agui.adapter.AguiAdapterConfig;
+import io.agentscope.core.agui.adapter.AguiAgentAdapter;
+import io.agentscope.core.agui.event.AguiEvent;
+import io.agentscope.core.agui.event.AguiEventType;
+import io.agentscope.core.agui.model.AguiMessage;
+import io.agentscope.core.agui.model.RunAgentInput;
+import io.agentscope.core.agui.processor.AguiRequestProcessor;
+import io.agentscope.core.agui.registry.AguiAgentRegistry;
+import java.io.IOException;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+import reactor.core.publisher.Flux;
+
+class AguiMvcControllerTest {
+
+    @Test
+    void sseErrorCancelsSubscriptionAndReleasesThread() throws Exception {
+        ControllerFixture fixture = fixture(true);
+        try {
+            SseEmitter emitter = fixture.controller.handle(input("run-1"), null);
+            assertTrue(fixture.firstRunSubscribed.await(5, TimeUnit.SECONDS));
+
+            invokeError(emitter);
+
+            fixture.processor.process(input("run-2"), null, null).events().collectList().block();
+
+            assertEquals(2, fixture.runCount.get());
+            verify(fixture.agent).interrupt(any(RuntimeContext.class));
+        } finally {
+            fixture.executor.shutdownNow();
+        }
+    }
+
+    @Test
+    void sseErrorKeepsRunActiveWhenInterruptOnDisconnectIsDisabled() throws Exception {
+        ControllerFixture fixture = fixture(false);
+        try {
+            SseEmitter emitter = fixture.controller.handle(input("run-1"), null);
+            assertTrue(fixture.firstRunSubscribed.await(5, TimeUnit.SECONDS));
+
+            invokeError(emitter);
+
+            List<AguiEvent> events =
+                    fixture.processor
+                            .process(input("run-2"), null, null)
+                            .events()
+                            .collectList()
+                            .block();
+
+            assertEquals(1, fixture.runCount.get());
+            assertEquals(
+                    List.of(AguiEventType.RUN_STARTED, AguiEventType.RUN_ERROR),
+                    events.stream().map(AguiEvent::getType).toList());
+        } finally {
+            fixture.executor.shutdownNow();
+        }
+    }
+
+    @Test
+    void sseTimeoutCancelsSubscriptionAndReleasesThread() throws Exception {
+        ControllerFixture fixture = fixture(true);
+        try {
+            SseEmitter emitter = fixture.controller.handle(input("run-1"), null);
+            assertTrue(fixture.firstRunSubscribed.await(5, TimeUnit.SECONDS));
+
+            Object timeoutCallback = ReflectionTestUtils.getField(emitter, "timeoutCallback");
+            ReflectionTestUtils.invokeMethod(timeoutCallback, "run");
+
+            fixture.processor.process(input("run-2"), null, null).events().collectList().block();
+
+            assertEquals(2, fixture.runCount.get());
+            verify(fixture.agent).interrupt(any(RuntimeContext.class));
+        } finally {
+            fixture.executor.shutdownNow();
+        }
+    }
+
+    private static ControllerFixture fixture(boolean interruptOnDisconnect) {
+        ReActAgent agent = mock(ReActAgent.class);
+        AguiAgentRegistry registry = new AguiAgentRegistry();
+        registry.register("default", agent);
+        CountDownLatch firstRunSubscribed = new CountDownLatch(1);
+        AtomicInteger runCount = new AtomicInteger();
+        AguiMvcController controller =
+                AguiMvcController.builder()
+                        .agentRegistry(registry)
+                        .interruptOnDisconnect(interruptOnDisconnect)
+                        .adapterFactory(
+                                (resolvedAgent, config) ->
+                                        new TestAdapter(
+                                                resolvedAgent,
+                                                config,
+                                                firstRunSubscribed,
+                                                runCount))
+                        .build();
+        AguiRequestProcessor processor =
+                (AguiRequestProcessor) ReflectionTestUtils.getField(controller, "processor");
+        ExecutorService executor =
+                (ExecutorService) ReflectionTestUtils.getField(controller, "executorService");
+        return new ControllerFixture(
+                controller, processor, executor, agent, firstRunSubscribed, runCount);
+    }
+
+    private static void invokeError(SseEmitter emitter) {
+        Object errorCallback = ReflectionTestUtils.getField(emitter, "errorCallback");
+        ReflectionTestUtils.invokeMethod(
+                errorCallback, "accept", new IOException("client disconnected"));
+    }
+
+    private static RunAgentInput input(String runId) {
+        return RunAgentInput.builder()
+                .threadId("thread-1")
+                .runId(runId)
+                .messages(List.of(AguiMessage.userMessage("message-1", "hello")))
+                .build();
+    }
+
+    private record ControllerFixture(
+            AguiMvcController controller,
+            AguiRequestProcessor processor,
+            ExecutorService executor,
+            ReActAgent agent,
+            CountDownLatch firstRunSubscribed,
+            AtomicInteger runCount) {}
+
+    private static final class TestAdapter extends AguiAgentAdapter {
+
+        private final CountDownLatch firstRunSubscribed;
+        private final AtomicInteger runCount;
+
+        private TestAdapter(
+                Agent agent,
+                AguiAdapterConfig config,
+                CountDownLatch firstRunSubscribed,
+                AtomicInteger runCount) {
+            super(agent, config);
+            this.firstRunSubscribed = firstRunSubscribed;
+            this.runCount = runCount;
+        }
+
+        @Override
+        public Flux<AguiEvent> run(RunAgentInput input, RuntimeContext runtimeContext) {
+            if (runCount.incrementAndGet() == 1) {
+                firstRunSubscribed.countDown();
+                return Flux.never();
+            }
+            return Flux.empty();
+        }
+    }
+}

--- a/agentscope-extensions/agentscope-spring-boot-starters/agentscope-agui-spring-boot-starter/src/test/java/io/agentscope/spring/boot/agui/mvc/AguiMvcControllerTest.java
+++ b/agentscope-extensions/agentscope-spring-boot-starters/agentscope-agui-spring-boot-starter/src/test/java/io/agentscope/spring/boot/agui/mvc/AguiMvcControllerTest.java
@@ -46,6 +46,36 @@ import reactor.core.publisher.Flux;
 class AguiMvcControllerTest {
 
     @Test
+    void eventStreamSignalsAreForwardedAndEmitterCompletes() throws Exception {
+        ControllerFixture fixture =
+                fixture(true, Flux.just(new AguiEvent.RunFinished("thread-1", "run-1")));
+        try {
+            SseEmitter emitter = fixture.controller.handle(input("run-1"), null);
+
+            assertTrue(fixture.firstRunTerminated.await(5, TimeUnit.SECONDS));
+            assertTrue((Boolean) ReflectionTestUtils.getField(emitter, "complete"));
+            assertEquals(1, fixture.runCount.get());
+        } finally {
+            fixture.executor.shutdownNow();
+        }
+    }
+
+    @Test
+    void eventStreamErrorCompletesEmitter() throws Exception {
+        ControllerFixture fixture =
+                fixture(true, Flux.error(new IllegalStateException("run failed")));
+        try {
+            SseEmitter emitter = fixture.controller.handle(input("run-1"), null);
+
+            assertTrue(fixture.firstRunTerminated.await(5, TimeUnit.SECONDS));
+            assertTrue((Boolean) ReflectionTestUtils.getField(emitter, "complete"));
+            assertEquals(1, fixture.runCount.get());
+        } finally {
+            fixture.executor.shutdownNow();
+        }
+    }
+
+    @Test
     void sseErrorCancelsSubscriptionAndReleasesThread() throws Exception {
         ControllerFixture fixture = fixture(true);
         try {
@@ -108,10 +138,16 @@ class AguiMvcControllerTest {
     }
 
     private static ControllerFixture fixture(boolean interruptOnDisconnect) {
+        return fixture(interruptOnDisconnect, Flux.never());
+    }
+
+    private static ControllerFixture fixture(
+            boolean interruptOnDisconnect, Flux<AguiEvent> firstRunEvents) {
         ReActAgent agent = mock(ReActAgent.class);
         AguiAgentRegistry registry = new AguiAgentRegistry();
         registry.register("default", agent);
         CountDownLatch firstRunSubscribed = new CountDownLatch(1);
+        CountDownLatch firstRunTerminated = new CountDownLatch(1);
         AtomicInteger runCount = new AtomicInteger();
         AguiMvcController controller =
                 AguiMvcController.builder()
@@ -123,6 +159,8 @@ class AguiMvcControllerTest {
                                                 resolvedAgent,
                                                 config,
                                                 firstRunSubscribed,
+                                                firstRunTerminated,
+                                                firstRunEvents,
                                                 runCount))
                         .build();
         AguiRequestProcessor processor =
@@ -130,7 +168,13 @@ class AguiMvcControllerTest {
         ExecutorService executor =
                 (ExecutorService) ReflectionTestUtils.getField(controller, "executorService");
         return new ControllerFixture(
-                controller, processor, executor, agent, firstRunSubscribed, runCount);
+                controller,
+                processor,
+                executor,
+                agent,
+                firstRunSubscribed,
+                firstRunTerminated,
+                runCount);
     }
 
     private static void invokeError(SseEmitter emitter) {
@@ -153,20 +197,27 @@ class AguiMvcControllerTest {
             ExecutorService executor,
             ReActAgent agent,
             CountDownLatch firstRunSubscribed,
+            CountDownLatch firstRunTerminated,
             AtomicInteger runCount) {}
 
     private static final class TestAdapter extends AguiAgentAdapter {
 
         private final CountDownLatch firstRunSubscribed;
+        private final CountDownLatch firstRunTerminated;
+        private final Flux<AguiEvent> firstRunEvents;
         private final AtomicInteger runCount;
 
         private TestAdapter(
                 Agent agent,
                 AguiAdapterConfig config,
                 CountDownLatch firstRunSubscribed,
+                CountDownLatch firstRunTerminated,
+                Flux<AguiEvent> firstRunEvents,
                 AtomicInteger runCount) {
             super(agent, config);
             this.firstRunSubscribed = firstRunSubscribed;
+            this.firstRunTerminated = firstRunTerminated;
+            this.firstRunEvents = firstRunEvents;
             this.runCount = runCount;
         }
 
@@ -174,7 +225,7 @@ class AguiMvcControllerTest {
         public Flux<AguiEvent> run(RunAgentInput input, RuntimeContext runtimeContext) {
             if (runCount.incrementAndGet() == 1) {
                 firstRunSubscribed.countDown();
-                return Flux.never();
+                return firstRunEvents.doFinally(signalType -> firstRunTerminated.countDown());
             }
             return Flux.empty();
         }


### PR DESCRIPTION
## Summary

- cancel the MVC event subscription on SSE error or timeout when `interruptOnDisconnect` is enabled
- create the subscriber before disconnect callbacks are registered, so cancellation is safe before the event stream is subscribed
- preserve the existing behavior when automatic interruption is disabled
- add regression tests for SSE error, timeout, and the disabled configuration

## Why this is still needed

The behavior reported on 2.0.1 had more than one lifecycle problem. #2646 fixed one part by preventing the conflicting `RUN_ERROR` followed by `RUN_FINISHED` sequence.

However, that change did not cancel the MVC Reactor subscription when the SSE connection fails or times out. On the latest `main` (`bf7b7dae`), the controller only interrupts the agent. The active-run entry is still released by the event stream's `doFinally`, so an immediate request on the same thread can still be rejected while upstream termination is delayed.

Disposing the subscription after requesting interruption triggers the cancellation lifecycle immediately and lets `doFinally` release the thread.

## Tests

- SSE error cancels the active subscription and allows an immediate second run
- SSE timeout cancels the active subscription and allows an immediate second run
- disabling `interruptOnDisconnect` keeps the first run active

Fixes #2782
