### PR TITLE
fix(core): make JsonSchemaUtils schema generation thread-safe

### DIFF
--- a/agentscope-core/src/main/java/io/agentscope/core/util/JsonSchemaUtils.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/util/JsonSchemaUtils.java
@@ -53,6 +53,10 @@ import java.util.Map;
  *   <li>{@code @JsonClassDescription(...)} - add class description</li>
  * </ul>
  *
+ * <p>All public methods are thread-safe. Schema generation through the shared victools
+ * {@code SchemaGenerator} is serialized by an internal lock, because the generator itself
+ * is not designed for concurrent use.</p>
+ *
  * @hidden
  */
 public class JsonSchemaUtils {
@@ -60,6 +64,13 @@ public class JsonSchemaUtils {
     private static final boolean PROPERTY_REQUIRED_BY_DEFAULT = false;
 
     private static final SchemaGenerator schemaGenerator;
+
+    /**
+     * Guards the shared victools {@link SchemaGenerator}, which is not thread-safe: its
+     * JacksonModule keeps an unsynchronized introspection cache, so concurrent schema
+     * generation must be serialized.
+     */
+    private static final Object SCHEMA_LOCK = new Object();
 
     static {
         // JacksonModule to support @JsonProperty, @JsonPropertyDescription annotations
@@ -95,7 +106,10 @@ public class JsonSchemaUtils {
      */
     public static Map<String, Object> generateSchemaFromClass(Class<?> clazz) {
         try {
-            JsonNode schemaNode = schemaGenerator.generateSchema(clazz);
+            JsonNode schemaNode;
+            synchronized (SCHEMA_LOCK) {
+                schemaNode = schemaGenerator.generateSchema(clazz);
+            }
             return JsonUtils.getJsonCodec()
                     .convertValue(schemaNode, new TypeReference<Map<String, Object>>() {});
         } catch (Exception e) {
@@ -130,7 +144,10 @@ public class JsonSchemaUtils {
      */
     public static Map<String, Object> generateSchemaFromType(Type type) {
         try {
-            JsonNode schemaNode = schemaGenerator.generateSchema(type);
+            JsonNode schemaNode;
+            synchronized (SCHEMA_LOCK) {
+                schemaNode = schemaGenerator.generateSchema(type);
+            }
             return JsonUtils.getJsonCodec()
                     .convertValue(schemaNode, new TypeReference<Map<String, Object>>() {});
         } catch (Exception e) {

--- a/agentscope-core/src/test/java/io/agentscope/core/util/JsonSchemaUtilsTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/util/JsonSchemaUtilsTest.java
@@ -23,11 +23,22 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import java.lang.reflect.Type;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.function.IntFunction;
 import org.junit.jupiter.api.Test;
 
 class JsonSchemaUtilsTest {
+
+    private static final int CONCURRENT_THREAD_COUNT = 12;
+
+    private static final int CONCURRENT_CALL_COUNT = 240;
 
     static class SimpleModel {
         public String name;
@@ -155,5 +166,93 @@ class JsonSchemaUtilsTest {
         Map<String, Object> mapSchema = JsonSchemaUtils.generateSchemaFromType(mapType);
         assertNotNull(mapSchema);
         assertEquals("object", mapSchema.get("type"));
+    }
+
+    static class ConcurrentClassA {
+        public String name;
+        public int age;
+    }
+
+    static class ConcurrentClassB {
+        public String title;
+        public List<String> tags;
+    }
+
+    static class ConcurrentClassC {
+        public String id;
+        public boolean active;
+    }
+
+    static class ConcurrentClassD {
+        public double score;
+    }
+
+    @Test
+    void testGenerateSchemaFromClassConcurrently() throws Exception {
+        List<Class<?>> targetClasses = List.of(ConcurrentClassA.class, ConcurrentClassB.class);
+
+        List<Map<String, Object>> schemas =
+                generateConcurrently(
+                        index ->
+                                JsonSchemaUtils.generateSchemaFromClass(
+                                        targetClasses.get(index % targetClasses.size())));
+
+        assertEquals(CONCURRENT_CALL_COUNT, schemas.size());
+        for (Map<String, Object> schema : schemas) {
+            assertNotNull(schema);
+            assertEquals("object", schema.get("type"));
+            assertNotNull(schema.get("properties"));
+        }
+    }
+
+    @Test
+    void testGenerateSchemaFromTypeConcurrently() throws Exception {
+        List<Type> targetTypes =
+                List.of(
+                        new TypeReference<ConcurrentClassC>() {}.getType(),
+                        new TypeReference<List<ConcurrentClassD>>() {}.getType());
+
+        List<Map<String, Object>> schemas =
+                generateConcurrently(
+                        index ->
+                                JsonSchemaUtils.generateSchemaFromType(
+                                        targetTypes.get(index % targetTypes.size())));
+
+        assertEquals(CONCURRENT_CALL_COUNT, schemas.size());
+        for (Map<String, Object> schema : schemas) {
+            assertNotNull(schema);
+            assertNotNull(schema.get("type"));
+        }
+    }
+
+    /**
+     * Runs the given generator on a fixed thread pool, with all tasks released at the same
+     * time to maximize the chance of overlapping schema generation. Any exception thrown
+     * inside a task propagates through {@code Future#get} and fails the test.
+     */
+    private static List<Map<String, Object>> generateConcurrently(
+            IntFunction<Map<String, Object>> generator) throws Exception {
+        ExecutorService executor = Executors.newFixedThreadPool(CONCURRENT_THREAD_COUNT);
+        CountDownLatch start = new CountDownLatch(1);
+        try {
+            List<Future<Map<String, Object>>> futures = new ArrayList<>();
+            for (int i = 0; i < CONCURRENT_CALL_COUNT; i++) {
+                final int index = i;
+                futures.add(
+                        executor.submit(
+                                () -> {
+                                    start.await();
+                                    return generator.apply(index);
+                                }));
+            }
+            start.countDown();
+            List<Map<String, Object>> results = new ArrayList<>();
+            for (Future<Map<String, Object>> future : futures) {
+                results.add(future.get(30, TimeUnit.SECONDS));
+            }
+            return results;
+        } finally {
+            executor.shutdownNow();
+        }
     }
 }


### PR DESCRIPTION
## AgentScope-Java Version

2.0.3-SNAPSHOT (latest `main`, commit `0de9ed43`)

## Description

Fixes #2795

`JsonSchemaUtils` shares a single static victools `SchemaGenerator` across the
JVM without synchronization. victools' `SchemaGenerator` is not thread-safe
(its `JacksonModule` keeps an unsynchronized `Map<Class, BeanDescription>`
introspection cache), so concurrent structured calls — e.g. multiple agents
running in parallel with the same target class — race on the shared generator
and can fail with a `ConcurrentModificationException`. The linked issue has the
full root-cause analysis, including the identical bug fixed in Spring AI
(spring-ai#6207, resolved with the same synchronized-guard approach).

Changes:

- Added a private `SCHEMA_LOCK` and guarded the two
  `schemaGenerator.generateSchema(...)` call sites
  (`generateSchemaFromClass` / `generateSchemaFromType`). Public API is
  unchanged.
- Class Javadoc now documents the thread-safety guarantee.
- Added concurrent regression tests for both guarded methods: 12 threads ×
  240 tasks released simultaneously via `CountDownLatch`, alternating between
  multiple POJOs so the victools introspection cache starts cold. Any exception
  propagates through `Future#get` and fails the test; all results are
  validated.

Note: the pre-fix race window is narrow and cannot be reproduced
deterministically, so the tests are regression protection rather than a
reproducer.

`mvn -pl agentscope-core test`: 2277 tests, 0 failures.

## Checklist

Please check the following items before code is ready to be reviewed.

- [x]  Code has been formatted with `mvn spotless:apply`
- [x]  All tests are passing (`mvn test`)
- [x]  Javadoc comments are complete and follow project conventions
- [x]  Related documentation has been updated (e.g. links, examples, etc.)
- [x]  Code is ready for review