### PR TITLE
fix(harness): recover lost async task completions in legacy wait

### DIFF
--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/tool/WaitAsyncResultsTool.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/tool/WaitAsyncResultsTool.java
@@ -32,14 +32,14 @@ import org.slf4j.LoggerFactory;
 
 /**
  * Tool that blocks until async results arrive, either for a specific task barrier or (legacy)
- * until any message appears in the session inbox.
+ * until any inbox message arrives or any task running at wait start reaches terminal state.
  *
  * <p>Prefer barrier mode ({@code task_ids} or {@code wait_all=true}): when the wait set reaches
  * terminal state, this tool embeds each task's status and result in the tool return so the model
  * can continue reasoning immediately without waiting for push-back delivery.
  *
- * <p>Without {@code task_ids} / {@code wait_all}, this keeps the legacy inbox-any behavior: the
- * tool returns as soon as <em>any</em> inbox message is present — it is not a wait-all barrier.
+ * <p>Without {@code task_ids} / {@code wait_all}, this keeps the legacy ANY-result behavior: the
+ * tool returns for <em>any</em> inbox message or tracked task completion, not a wait-all barrier.
  *
  * <p>Guardrails prevent unbounded blocking:
  * <ul>
@@ -103,9 +103,10 @@ public class WaitAsyncResultsTool {
                             + "wait_all=true waits for the snapshot of currently running tasks "
                             + "(tasks created while waiting are not added) and also returns their "
                             + "results. "
-                            + "Without task_ids and without wait_all, this is legacy inbox-any "
-                            + "mode: returns when ANY inbox message arrives — not wait-all. For "
-                            + "must-collect-all groups use task_ids or wait_all=true. "
+                            + "Without task_ids and without wait_all, this is legacy ANY-result "
+                            + "mode: returns when ANY inbox message arrives or any task running at "
+                            + "wait start becomes terminal — not wait-all. For must-collect-all "
+                            + "groups use task_ids or wait_all=true. "
                             + "Also covers AgentTeams teammate work via the external-work probe. "
                             + "Max timeout is 120 seconds. "
                             + "If you have already waited without results, use task_list or "
@@ -179,9 +180,10 @@ public class WaitAsyncResultsTool {
                     + "blocking.";
         }
 
+        List<String> legacyWaitSet = List.of();
         if (taskRepository != null) {
-            boolean hasNonTerminal =
-                    hasNonTerminalTasks(runtimeContext, sessionId) || hasExternalWork();
+            legacyWaitSet = snapshotNonTerminalTaskIds(runtimeContext, sessionId);
+            boolean hasNonTerminal = !legacyWaitSet.isEmpty() || hasExternalWork();
             if (!hasNonTerminal) {
                 Boolean hasMessages = messageBus.inboxHasMessages(sessionId).block();
                 if (!Boolean.TRUE.equals(hasMessages)) {
@@ -199,18 +201,14 @@ public class WaitAsyncResultsTool {
         int timeout = normalizeTimeout(timeoutSeconds, sessionId);
 
         log.info(
-                "wait_async_results: waiting up to {}s for any inbox message (legacy inbox-any),"
-                        + " session={}",
+                "wait_async_results: waiting up to {}s for any inbox message or tracked task"
+                        + " completion (legacy ANY-result), session={}",
                 timeout,
                 sessionId);
 
         long deadlineMs = System.currentTimeMillis() + (timeout * 1000L);
 
         while (true) {
-            long remainingMs = deadlineMs - System.currentTimeMillis();
-            if (remainingMs <= 0) {
-                break;
-            }
             Boolean hasMessages = messageBus.inboxHasMessages(sessionId).block();
             if (Boolean.TRUE.equals(hasMessages)) {
                 log.info("wait_async_results: inbox has messages, session={}", sessionId);
@@ -220,8 +218,22 @@ public class WaitAsyncResultsTool {
                         + "automatically. Prefer wait_async_results(task_ids=...) or "
                         + "wait_all=true when you need every task in a group.";
             }
+            BackgroundTask terminalTask =
+                    findFirstTerminalTrackedTask(runtimeContext, sessionId, legacyWaitSet);
+            if (terminalTask != null) {
+                log.info(
+                        "wait_async_results: tracked task {} is terminal, session={}",
+                        terminalTask.getTaskId(),
+                        sessionId);
+                emptyWaits.set(0);
+                return formatLegacyResult(runtimeContext, sessionId, terminalTask);
+            }
+            long remainingMs = deadlineMs - System.currentTimeMillis();
+            if (remainingMs <= 0) {
+                break;
+            }
             // Cap sleep to the remaining budget so the tool never overshoots the caller's timeout.
-            Thread.sleep(Math.min(POLL_INTERVAL_MS, remainingMs));
+            sleepForPollInterval(remainingMs);
         }
 
         int emptyCount = emptyWaits.incrementAndGet();
@@ -364,15 +376,52 @@ public class WaitAsyncResultsTool {
         return formatBarrierResults(runtimeContext, sessionId, terminalTasks);
     }
 
+    private BackgroundTask findFirstTerminalTrackedTask(
+            RuntimeContext runtimeContext, String sessionId, List<String> waitSet) {
+        if (waitSet.isEmpty()) {
+            return null;
+        }
+        Collection<BackgroundTask> currentTasks =
+                taskRepository.listTasks(runtimeContext, sessionId, null);
+        for (String taskId : waitSet) {
+            for (BackgroundTask task : currentTasks) {
+                if (taskId.equals(task.getTaskId()) && task.getTaskStatus().isTerminal()) {
+                    return task;
+                }
+            }
+        }
+        return null;
+    }
+
+    private String formatLegacyResult(
+            RuntimeContext runtimeContext, String sessionId, BackgroundTask task) {
+        return formatTerminalResults(
+                runtimeContext,
+                sessionId,
+                List.of(task),
+                "A tracked background task is terminal. Its result is included below.");
+    }
+
     /**
      * Embeds each terminal task's status/result in the tool return so the parent can continue
      * without waiting for inbox push-back. Marks tasks delivered to avoid duplicate reminders.
      */
     private String formatBarrierResults(
             RuntimeContext runtimeContext, String sessionId, List<BackgroundTask> tasks) {
+        return formatTerminalResults(
+                runtimeContext,
+                sessionId,
+                tasks,
+                "All requested background tasks are terminal. Results are included below.");
+    }
+
+    private String formatTerminalResults(
+            RuntimeContext runtimeContext,
+            String sessionId,
+            List<BackgroundTask> tasks,
+            String heading) {
         StringBuilder sb = new StringBuilder();
-        sb.append("All requested background tasks are terminal. Results are included below.")
-                .append('\n');
+        sb.append(heading).append('\n');
         for (BackgroundTask task : tasks) {
             task.updateLastCheckedAt();
             if (task.isCompleted() && task.getTaskStatus().isTerminal()) {
@@ -471,10 +520,5 @@ public class WaitAsyncResultsTool {
                 .filter(t -> !t.getTaskStatus().isTerminal())
                 .map(BackgroundTask::getTaskId)
                 .toList();
-    }
-
-    private boolean hasNonTerminalTasks(RuntimeContext rc, String sessionId) {
-        Collection<BackgroundTask> tasks = taskRepository.listTasks(rc, sessionId, null);
-        return tasks.stream().anyMatch(t -> !t.getTaskStatus().isTerminal());
     }
 }

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/tool/WaitAsyncResultsToolTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/tool/WaitAsyncResultsToolTest.java
@@ -204,8 +204,8 @@ class WaitAsyncResultsToolTest {
     }
 
     @Test
-    @DisplayName("some tasks still running → proceeds to wait normally")
-    void nonTerminalTasksProcedsToWait() throws Exception {
+    @DisplayName("legacy mode times out while all tracked tasks remain non-terminal")
+    void legacyTimesOutWhenTrackedTasksRemainNonTerminal() throws Exception {
         CompletableFuture<String> running = new CompletableFuture<>();
         BackgroundTask runningTask = new BackgroundTask("t1", "agent-1", running);
 
@@ -214,6 +214,131 @@ class WaitAsyncResultsToolTest {
 
         String result = tool.waitForResults(1, ctx());
         assertTrue(result.contains("Timeout"), "should proceed to wait and timeout");
+    }
+
+    @Test
+    @DisplayName("legacy mode detects completion when the inbox notification is lost")
+    void legacyDetectsCompletionFromTaskRepositoryWhenNotificationIsLost() throws Exception {
+        CompletableFuture<String> future = new CompletableFuture<>();
+        BackgroundTask task = new BackgroundTask("t1", "agent-1", future);
+        TrackingTaskRepository repo = new TrackingTaskRepository(List.of(task));
+        MessageBus bus = new StubMessageBus(false, () -> future.complete("repository-result"));
+        WaitAsyncResultsTool tool = new WaitAsyncResultsTool(bus, repo);
+
+        String result = tool.waitForResults(1, ctx());
+
+        assertFalse(
+                result.contains("Timeout"), "should detect repository completion, got: " + result);
+        assertTrue(
+                result.contains("task_id: t1"), "should identify completed task, got: " + result);
+        assertTrue(
+                result.contains("repository-result"),
+                "should return actual result, got: " + result);
+        assertTrue(repo.delivered.contains("t1"), "should mark fallback result as delivered");
+    }
+
+    @Test
+    @DisplayName("legacy repository fallback keeps ANY-result semantics")
+    void legacyRepositoryFallbackReturnsAfterAnyTrackedTaskCompletes() throws Exception {
+        CompletableFuture<String> first = new CompletableFuture<>();
+        CompletableFuture<String> second = new CompletableFuture<>();
+        TaskRepository repo =
+                new StubTaskRepository(
+                        List.of(
+                                new BackgroundTask("t1", "agent-1", first),
+                                new BackgroundTask("t2", "agent-2", second)));
+        MessageBus bus = new StubMessageBus(false, () -> first.complete("first-result"));
+        WaitAsyncResultsTool tool = new WaitAsyncResultsTool(bus, repo);
+
+        String result = tool.waitForResults(1, ctx());
+
+        assertTrue(
+                result.contains("task_id: t1"), "should return first completion, got: " + result);
+        assertTrue(result.contains("first-result"), "should embed first result, got: " + result);
+        assertFalse(
+                result.contains("task_id: t2"), "must not wait for or return t2, got: " + result);
+        assertFalse(second.isDone(), "second task should still be running when wait returns");
+    }
+
+    @Test
+    @DisplayName("legacy repository fallback ignores tasks terminal before wait start")
+    void legacyRepositoryFallbackDoesNotConsumeHistoricalCompletion() throws Exception {
+        BackgroundTask historical =
+                new BackgroundTask(
+                        "old", "agent-old", CompletableFuture.completedFuture("historical-result"));
+        BackgroundTask running =
+                new BackgroundTask("current", "agent-current", new CompletableFuture<>());
+        TaskRepository repo = new StubTaskRepository(List.of(historical, running));
+        WaitAsyncResultsTool tool = new WaitAsyncResultsTool(emptyBus(), repo);
+
+        String result = tool.waitForResults(1, ctx());
+
+        assertTrue(
+                result.contains("Timeout"), "should keep waiting for current task, got: " + result);
+        assertFalse(
+                result.contains("historical-result"),
+                "must not return a completion from before wait start, got: " + result);
+    }
+
+    @Test
+    @DisplayName("legacy inbox notification remains the fast path")
+    void legacyInboxNotificationTakesPriorityOverRepositoryFallback() throws Exception {
+        CompletableFuture<String> future = new CompletableFuture<>();
+        TaskRepository repo =
+                new StubTaskRepository(List.of(new BackgroundTask("t1", "agent-1", future)));
+        MessageBus bus = new StubMessageBus(true, () -> future.complete("repository-result"));
+        WaitAsyncResultsTool tool = new WaitAsyncResultsTool(bus, repo);
+
+        long start = System.currentTimeMillis();
+        String result = tool.waitForResults(1, ctx());
+        long elapsed = System.currentTimeMillis() - start;
+
+        assertTrue(result.contains("inbox-any"), "should use existing inbox path, got: " + result);
+        assertFalse(
+                result.contains("repository-result"),
+                "inbox fast path should return before repository fallback, got: " + result);
+        assertTrue(elapsed < 1_000, "available inbox notification should return immediately");
+    }
+
+    @Test
+    @DisplayName("legacy repository fallback returns failed task error")
+    void legacyRepositoryFallbackReturnsFailedTaskError() throws Exception {
+        CompletableFuture<String> future = new CompletableFuture<>();
+        BackgroundTask task = new BackgroundTask("failed", "agent-1", future);
+        TrackingTaskRepository repo = new TrackingTaskRepository(List.of(task));
+        MessageBus bus =
+                new StubMessageBus(
+                        false,
+                        () -> future.completeExceptionally(new IllegalStateException("broken")));
+        WaitAsyncResultsTool tool = new WaitAsyncResultsTool(bus, repo);
+
+        String result = tool.waitForResults(1, ctx());
+
+        assertTrue(
+                result.contains("task_id: failed"), "should identify failed task, got: " + result);
+        assertTrue(result.contains("broken"), "should return task error, got: " + result);
+        assertTrue(repo.delivered.contains("failed"), "should mark failed fallback as delivered");
+    }
+
+    @Test
+    @DisplayName("legacy repository fallback returns cancelled task status")
+    void legacyRepositoryFallbackReturnsCancelledTaskStatus() throws Exception {
+        CompletableFuture<String> future = new CompletableFuture<>();
+        BackgroundTask task = new BackgroundTask("cancelled", "agent-1", future);
+        TrackingTaskRepository repo = new TrackingTaskRepository(List.of(task));
+        MessageBus bus = new StubMessageBus(false, () -> future.cancel(false));
+        WaitAsyncResultsTool tool = new WaitAsyncResultsTool(bus, repo);
+
+        String result = tool.waitForResults(1, ctx());
+
+        assertTrue(
+                result.contains("task_id: cancelled"),
+                "should identify cancelled task, got: " + result);
+        assertTrue(
+                result.contains("status: Cancelled"), "should return cancelled status: " + result);
+        assertTrue(
+                repo.delivered.contains("cancelled"),
+                "should mark cancelled fallback as delivered");
     }
 
     @Test
@@ -381,13 +506,23 @@ class WaitAsyncResultsToolTest {
     private static class StubMessageBus implements MessageBus {
 
         private final AtomicBoolean hasMessages;
+        private final Runnable onPeek;
 
         StubMessageBus(boolean hasMessages) {
-            this.hasMessages = new AtomicBoolean(hasMessages);
+            this(new AtomicBoolean(hasMessages), null);
         }
 
         StubMessageBus(AtomicBoolean hasMessages) {
+            this(hasMessages, null);
+        }
+
+        StubMessageBus(boolean hasMessages, Runnable onPeek) {
+            this(new AtomicBoolean(hasMessages), onPeek);
+        }
+
+        StubMessageBus(AtomicBoolean hasMessages, Runnable onPeek) {
             this.hasMessages = hasMessages;
+            this.onPeek = onPeek;
         }
 
         @Override
@@ -407,6 +542,9 @@ class WaitAsyncResultsToolTest {
 
         @Override
         public Mono<Boolean> queuePeek(String key) {
+            if (onPeek != null) {
+                onPeek.run();
+            }
             return Mono.just(hasMessages.get());
         }
 


### PR DESCRIPTION
## Summary

- snapshot non-terminal async tasks when legacy `wait_async_results` starts
- keep inbox notifications as the first fast path
- fall back to authoritative `TaskRepository` state when a tracked task becomes terminal
- return the completed task's actual result/error and mark it delivered

## Compatibility

- preserves legacy ANY-result semantics: one tracked completion returns immediately
- excludes tasks already terminal before wait start
- leaves `task_ids` and `wait_all=true` barrier semantics unchanged
- preserves inbox fast-path and timeout behavior

## Tests

- reproduced the bug before the production change: the core regression timed out and failed
- `WaitAsyncResultsToolTest`: 23 tests passed
- `WaitAsyncResultsToolTest`, `WorkspaceTaskRepositoryTest`, and `WorkspaceTaskRepositoryDeliveryTest`: 54 tests passed
- Spotless check passed

Fixes #2791