### PR TITLE
fix(agent): 模型调用失败时持久化当前轮次上下文

### DIFF
--- a/agentscope-core/src/main/java/io/agentscope/core/ReActAgent.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/ReActAgent.java
@@ -501,6 +501,27 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
     }
 
     /**
+     * Persist the safe conversation state accumulated before a failed call and rethrow the original
+     * failure. Incomplete model chunks are only held by the per-iteration accumulator, so they are
+     * deliberately not added to {@link AgentState} or persisted here.
+     */
+    private <T> Mono<T> saveStateAfterCallFailure(CallExecution scope, Throwable callFailure) {
+        return saveStateToSession(scope)
+                .onErrorResume(
+                        saveFailure -> {
+                            if (saveFailure != callFailure) {
+                                callFailure.addSuppressed(saveFailure);
+                            }
+                            log.warn(
+                                    "Failed to persist agent state after a call failure; preserving"
+                                            + " the original failure",
+                                    saveFailure);
+                            return Mono.empty();
+                        })
+                .then(Mono.error(callFailure));
+    }
+
+    /**
      * CAS-aware persist of {@code agent_state}. Applies {@link #conflictPolicy} on conflict.
      *
      * @return the new store version, or {@link AgentStateStore#UNVERSIONED} when the backend does
@@ -1187,6 +1208,7 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
                                 .ifPresent(ae -> scope.externalEventEmitter = ae);
                     }
                     return scope.doCallInner(msgs)
+                            .onErrorResume(error -> saveStateAfterCallFailure(scope, error))
                             .flatMap(result -> saveStateToSession(scope).thenReturn(result));
                 });
     }
@@ -1321,6 +1343,7 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
                     scope.soTool = createStructuredOutputTool(jsonSchema);
 
                     return scope.doCallInner(msgs)
+                            .onErrorResume(error -> saveStateAfterCallFailure(scope, error))
                             .flatMap(
                                     result -> {
                                         Msg out = result;

--- a/agentscope-core/src/main/java/io/agentscope/core/ReActAgent.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/ReActAgent.java
@@ -504,8 +504,18 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
      * Persist the safe conversation state accumulated before a failed call and rethrow the original
      * failure. Incomplete model chunks are only held by the per-iteration accumulator, so they are
      * deliberately not added to {@link AgentState} or persisted here.
+     *
+     * <p>{@link InterruptedException} is intentionally skipped: an interrupt is already handled end
+     * to end by {@link #handleInterrupt}, which first reconciles any dangling tool_use produced
+     * during reasoning (synthesizing error results for pending tool calls) and only then persists.
+     * Saving here would race ahead of that reconciliation and persist an inconsistent intermediate
+     * state (a tool_use with no matching tool result), so the interrupt is allowed to propagate
+     * untouched.
      */
     private <T> Mono<T> saveStateAfterCallFailure(CallExecution scope, Throwable callFailure) {
+        if (ExceptionUtils.containsInterruptedException(callFailure)) {
+            return Mono.error(callFailure);
+        }
         return saveStateToSession(scope)
                 .onErrorResume(
                         saveFailure -> {

--- a/agentscope-core/src/main/java/io/agentscope/core/util/ExceptionUtils.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/util/ExceptionUtils.java
@@ -15,6 +15,8 @@
  */
 package io.agentscope.core.util;
 
+import java.util.IdentityHashMap;
+
 /**
  * Utility methods for exception handling.
  */
@@ -56,5 +58,25 @@ public final class ExceptionUtils {
 
         // Fall back to the exception class name
         return throwable.getClass().getSimpleName();
+    }
+
+    /**
+     * Whether the given throwable (or any throwable in its cause chain) is an
+     * {@link InterruptedException}. The cause chain is walked with an identity set guard so
+     * circular causes cannot cause an infinite loop.
+     *
+     * @param error the throwable to inspect (may be {@code null})
+     * @return {@code true} if an {@link InterruptedException} is present in the cause chain
+     */
+    public static boolean containsInterruptedException(Throwable error) {
+        IdentityHashMap<Throwable, Boolean> visited = new IdentityHashMap<>();
+        Throwable current = error;
+        while (current != null && visited.put(current, Boolean.TRUE) == null) {
+            if (current instanceof InterruptedException) {
+                return true;
+            }
+            current = current.getCause();
+        }
+        return false;
     }
 }

--- a/agentscope-core/src/test/java/io/agentscope/core/agent/ReActAgentCallFailurePersistenceTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/agent/ReActAgentCallFailurePersistenceTest.java
@@ -1,0 +1,279 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.core.agent;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.agentscope.core.ReActAgent;
+import io.agentscope.core.message.ContentBlock;
+import io.agentscope.core.message.Msg;
+import io.agentscope.core.message.MsgRole;
+import io.agentscope.core.message.TextBlock;
+import io.agentscope.core.message.ToolUseBlock;
+import io.agentscope.core.model.ChatModelBase;
+import io.agentscope.core.model.ChatResponse;
+import io.agentscope.core.model.GenerateOptions;
+import io.agentscope.core.model.ToolSchema;
+import io.agentscope.core.state.AgentState;
+import io.agentscope.core.state.InMemoryAgentStateStore;
+import io.agentscope.core.state.State;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Flux;
+
+/** Regression tests for durable conversation state when a model stream fails. */
+@DisplayName("ReActAgent failed-call persistence")
+class ReActAgentCallFailurePersistenceTest {
+
+    private static final RuntimeContext CONTEXT =
+            RuntimeContext.builder().userId("u1").sessionId("session-1").build();
+
+    @Test
+    @DisplayName("failed model stream persists the user input but not incomplete model output")
+    void failedStreamPersistsOnlySafeConversationState() {
+        InMemoryAgentStateStore store = new InMemoryAgentStateStore();
+        RuntimeException modelFailure = new RuntimeException("model stream failed");
+        ReActAgent agent = agent(new AlwaysFailingModel(modelFailure), store);
+
+        RuntimeException thrown =
+                assertThrows(
+                        RuntimeException.class,
+                        () -> agent.call(List.of(userMsg("original question")), CONTEXT).block());
+
+        assertSame(modelFailure, thrown);
+        AgentState persisted =
+                store.get("u1", "session-1", "agent_state", AgentState.class).orElseThrow();
+        assertEquals(List.of("original question"), textContents(persisted.getContext()));
+        assertEquals(
+                List.of(MsgRole.USER), persisted.getContext().stream().map(Msg::getRole).toList());
+        assertFalse(
+                persisted.getContext().stream()
+                        .flatMap(msg -> msg.getContent().stream())
+                        .anyMatch(ToolUseBlock.class::isInstance),
+                "an incomplete tool call must not enter durable model history");
+    }
+
+    @Test
+    @DisplayName("same agent can continue with the user input from the failed turn")
+    void sameAgentCanContinueAfterFailure() {
+        InMemoryAgentStateStore store = new InMemoryAgentStateStore();
+        FailOnceThenCaptureModel model = new FailOnceThenCaptureModel();
+        ReActAgent agent = agent(model, store);
+
+        assertThrows(
+                RuntimeException.class,
+                () -> agent.call(List.of(userMsg("original question")), CONTEXT).block());
+        Msg response = agent.call(List.of(userMsg("continue")), CONTEXT).block();
+
+        assertEquals("recovered", response.getTextContent());
+        List<String> secondPrompt = textContents(model.calls().get(1));
+        assertTrue(secondPrompt.contains("original question"));
+        assertTrue(secondPrompt.contains("continue"));
+        assertFalse(secondPrompt.contains("incomplete answer"));
+    }
+
+    @Test
+    @DisplayName("a rebuilt agent can continue with the user input from the failed turn")
+    void rebuiltAgentCanContinueAfterFailure() {
+        InMemoryAgentStateStore store = new InMemoryAgentStateStore();
+        ReActAgent failingAgent =
+                agent(new AlwaysFailingModel(new RuntimeException("model stream failed")), store);
+
+        assertThrows(
+                RuntimeException.class,
+                () -> failingAgent.call(List.of(userMsg("original question")), CONTEXT).block());
+
+        CapturingModel recoveryModel = new CapturingModel();
+        ReActAgent rebuiltAgent = agent(recoveryModel, store);
+        rebuiltAgent.call(List.of(userMsg("continue")), CONTEXT).block();
+
+        List<String> recoveryPrompt = textContents(recoveryModel.calls().get(0));
+        assertTrue(recoveryPrompt.contains("original question"));
+        assertTrue(recoveryPrompt.contains("continue"));
+        assertFalse(recoveryPrompt.contains("incomplete answer"));
+    }
+
+    @Test
+    @DisplayName("state-store failure does not replace the original model failure")
+    void persistenceFailureDoesNotMaskModelFailure() {
+        RuntimeException modelFailure = new RuntimeException("model stream failed");
+        RuntimeException storeFailure = new RuntimeException("state store failed");
+        InMemoryAgentStateStore store =
+                new InMemoryAgentStateStore() {
+                    @Override
+                    public long saveIfVersion(
+                            String userId,
+                            String sessionId,
+                            String key,
+                            State value,
+                            long expectedVersion) {
+                        throw storeFailure;
+                    }
+                };
+        ReActAgent agent = agent(new AlwaysFailingModel(modelFailure), store);
+
+        RuntimeException thrown =
+                assertThrows(
+                        RuntimeException.class,
+                        () -> agent.call(List.of(userMsg("original question")), CONTEXT).block());
+
+        assertSame(modelFailure, thrown);
+        assertTrue(
+                List.of(thrown.getSuppressed()).contains(storeFailure),
+                "the persistence failure should remain available for diagnostics");
+    }
+
+    @Test
+    @DisplayName("failed structured-output fallback also persists the user input")
+    void failedStructuredOutputFallbackPersistsUserInput() {
+        InMemoryAgentStateStore store = new InMemoryAgentStateStore();
+        ReActAgent agent =
+                agent(new AlwaysFailingModel(new RuntimeException("model stream failed")), store);
+
+        assertThrows(
+                RuntimeException.class,
+                () ->
+                        agent.call(List.of(userMsg("structured question")), StructuredReply.class)
+                                .block());
+
+        AgentState persisted =
+                store.get(null, agent.getDefaultSessionId(), "agent_state", AgentState.class)
+                        .orElseThrow();
+        assertTrue(textContents(persisted.getContext()).contains("structured question"));
+        assertFalse(textContents(persisted.getContext()).contains("incomplete answer"));
+    }
+
+    private static ReActAgent agent(ChatModelBase model, InMemoryAgentStateStore store) {
+        return ReActAgent.builder()
+                .name("asst")
+                .sysPrompt("system prompt")
+                .model(model)
+                .stateStore(store)
+                .build();
+    }
+
+    private static Msg userMsg(String text) {
+        return Msg.builder()
+                .name("user")
+                .role(MsgRole.USER)
+                .content(TextBlock.builder().text(text).build())
+                .build();
+    }
+
+    private static ChatResponse incompleteResponse() {
+        return ChatResponse.builder()
+                .content(
+                        List.of(
+                                TextBlock.builder().text("incomplete answer").build(),
+                                ToolUseBlock.builder()
+                                        .id("incomplete-call")
+                                        .name("unfinished_tool")
+                                        .input(Map.of("value", "partial"))
+                                        .build()))
+                .build();
+    }
+
+    private static ChatResponse textResponse(String text) {
+        return ChatResponse.builder()
+                .content(List.of(TextBlock.builder().text(text).build()))
+                .build();
+    }
+
+    private static List<String> textContents(List<Msg> messages) {
+        List<String> result = new ArrayList<>();
+        for (Msg message : messages) {
+            for (ContentBlock block : message.getContent()) {
+                if (block instanceof TextBlock textBlock) {
+                    result.add(textBlock.getText());
+                }
+            }
+        }
+        return result;
+    }
+
+    private static final class AlwaysFailingModel extends ChatModelBase {
+        private final RuntimeException failure;
+
+        private AlwaysFailingModel(RuntimeException failure) {
+            this.failure = failure;
+        }
+
+        @Override
+        public String getModelName() {
+            return "always-failing";
+        }
+
+        @Override
+        protected Flux<ChatResponse> doStream(
+                List<Msg> messages, List<ToolSchema> tools, GenerateOptions options) {
+            return Flux.concat(Flux.just(incompleteResponse()), Flux.error(failure));
+        }
+    }
+
+    private static final class FailOnceThenCaptureModel extends ChatModelBase {
+        private final List<List<Msg>> calls = new ArrayList<>();
+
+        @Override
+        public String getModelName() {
+            return "fail-once-then-capture";
+        }
+
+        @Override
+        protected Flux<ChatResponse> doStream(
+                List<Msg> messages, List<ToolSchema> tools, GenerateOptions options) {
+            calls.add(List.copyOf(messages));
+            if (calls.size() == 1) {
+                return Flux.concat(
+                        Flux.just(incompleteResponse()),
+                        Flux.error(new RuntimeException("model stream failed")));
+            }
+            return Flux.just(textResponse("recovered"));
+        }
+
+        private List<List<Msg>> calls() {
+            return calls;
+        }
+    }
+
+    private static final class CapturingModel extends ChatModelBase {
+        private final List<List<Msg>> calls = new ArrayList<>();
+
+        @Override
+        public String getModelName() {
+            return "capturing";
+        }
+
+        @Override
+        protected Flux<ChatResponse> doStream(
+                List<Msg> messages, List<ToolSchema> tools, GenerateOptions options) {
+            calls.add(List.copyOf(messages));
+            return Flux.just(textResponse("recovered"));
+        }
+
+        private List<List<Msg>> calls() {
+            return calls;
+        }
+    }
+
+    private record StructuredReply(String answer) {}
+}

--- a/agentscope-core/src/test/java/io/agentscope/core/agent/ReActAgentCallFailurePersistenceTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/agent/ReActAgentCallFailurePersistenceTest.java
@@ -144,6 +144,33 @@ class ReActAgentCallFailurePersistenceTest {
     }
 
     @Test
+    @DisplayName("the same call and state-store failure is not self-suppressed")
+    void identicalPersistenceAndModelFailureIsNotSelfSuppressed() {
+        RuntimeException sharedFailure = new RuntimeException("shared failure");
+        InMemoryAgentStateStore store =
+                new InMemoryAgentStateStore() {
+                    @Override
+                    public long saveIfVersion(
+                            String userId,
+                            String sessionId,
+                            String key,
+                            State value,
+                            long expectedVersion) {
+                        throw sharedFailure;
+                    }
+                };
+        ReActAgent agent = agent(new AlwaysFailingModel(sharedFailure), store);
+
+        RuntimeException thrown =
+                assertThrows(
+                        RuntimeException.class,
+                        () -> agent.call(List.of(userMsg("original question")), CONTEXT).block());
+
+        assertSame(sharedFailure, thrown);
+        assertFalse(List.of(thrown.getSuppressed()).contains(sharedFailure));
+    }
+
+    @Test
     @DisplayName("failed structured-output fallback also persists the user input")
     void failedStructuredOutputFallbackPersistsUserInput() {
         InMemoryAgentStateStore store = new InMemoryAgentStateStore();

--- a/agentscope-core/src/test/java/io/agentscope/core/agent/ReActAgentInterruptToolCallTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/agent/ReActAgentInterruptToolCallTest.java
@@ -36,6 +36,9 @@ import io.agentscope.core.model.ChatModelBase;
 import io.agentscope.core.model.ChatResponse;
 import io.agentscope.core.model.GenerateOptions;
 import io.agentscope.core.model.ToolSchema;
+import io.agentscope.core.state.AgentState;
+import io.agentscope.core.state.InMemoryAgentStateStore;
+import io.agentscope.core.state.State;
 import io.agentscope.core.tool.Toolkit;
 import java.util.HashMap;
 import java.util.List;
@@ -212,5 +215,75 @@ class ReActAgentInterruptToolCallTest {
         Msg second = agent.call(List.of(userMsg("continue"))).block();
         assertNotNull(second);
         assertEquals("resumed-ok", second.getTextContent());
+    }
+
+    /**
+     * A user interrupt after the model emits a tool_use must be reconciled (error tool result
+     * synthesized) and persisted exactly once via {@link ReActAgent#handleInterrupt}. The
+     * call-failure persistence hook must NOT race ahead of that reconciliation and persist an
+     * unreconciled dangling tool_use. Regression test for the saveStateAfterCallFailure /
+     * InterruptedException interaction.
+     */
+    @Test
+    void interruptPersistsOnceWithReconciledToolResult() {
+        ChatModelBase model =
+                new ScriptedModel(
+                        List.of(
+                                () -> Flux.just(toolUseResponse("tc1", "search")),
+                                () -> Flux.just(textResponse("resumed"))));
+        CountingStateStore store = new CountingStateStore();
+        ReActAgent agent =
+                buildAgentWithStore(model, store, new InterruptAfterModelCallMiddleware());
+
+        Msg result = agent.call(List.of(userMsg("do something"))).block();
+        assertNotNull(result);
+        assertEquals(GenerateReason.INTERRUPTED, result.getGenerateReason());
+
+        assertEquals(
+                1,
+                store.saveIfVersionCalls.get(),
+                "interrupt must persist exactly once via handleInterrupt, not preemptively"
+                        + " before reconciliation");
+
+        AgentState persisted =
+                store.get(null, agent.getDefaultSessionId(), "agent_state", AgentState.class)
+                        .orElseThrow();
+        List<ToolUseBlock> toolUses =
+                persisted.getContext().stream()
+                        .flatMap(m -> m.getContentBlocks(ToolUseBlock.class).stream())
+                        .toList();
+        List<ToolResultBlock> toolResults =
+                persisted.getContext().stream()
+                        .flatMap(m -> m.getContentBlocks(ToolResultBlock.class).stream())
+                        .toList();
+        assertEquals(1, toolUses.size(), "the emitted tool_use must be persisted");
+        assertEquals(
+                1,
+                toolResults.size(),
+                "a matching error tool result must be reconciled for the pending tool_use");
+        assertEquals(toolUses.get(0).getId(), toolResults.get(0).getId());
+        assertEquals(ToolResultState.ERROR, toolResults.get(0).getState());
+    }
+
+    private static ReActAgent buildAgentWithStore(
+            ChatModelBase model, InMemoryAgentStateStore store, MiddlewareBase... middlewares) {
+        return ReActAgent.builder()
+                .name("asst")
+                .model(model)
+                .toolkit(new Toolkit())
+                .middlewares(List.of(middlewares))
+                .stateStore(store)
+                .build();
+    }
+
+    private static final class CountingStateStore extends InMemoryAgentStateStore {
+        final AtomicInteger saveIfVersionCalls = new AtomicInteger();
+
+        @Override
+        public long saveIfVersion(
+                String userId, String sessionId, String key, State value, long expectedVersion) {
+            saveIfVersionCalls.incrementAndGet();
+            return super.saveIfVersion(userId, sessionId, key, value, expectedVersion);
+        }
     }
 }

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/memory/compaction/ConversationCompactor.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/memory/compaction/ConversationCompactor.java
@@ -23,13 +23,13 @@ import io.agentscope.core.message.TextBlock;
 import io.agentscope.core.message.ToolResultBlock;
 import io.agentscope.core.message.ToolUseBlock;
 import io.agentscope.core.model.Model;
+import io.agentscope.core.util.ExceptionUtils;
 import io.agentscope.harness.agent.memory.MemoryFlushManager;
 import io.agentscope.harness.agent.memory.compaction.CompactionConfig.TruncateArgsConfig;
 import io.agentscope.harness.agent.middleware.CompactionMiddleware;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -139,7 +139,7 @@ public class ConversationCompactor {
                                 .doOnSuccess(v -> log.debug("Memory flush before compaction done"))
                                 .onErrorResume(
                                         e -> {
-                                            if (containsInterruptedException(e)) {
+                                            if (ExceptionUtils.containsInterruptedException(e)) {
                                                 return Mono.error(e);
                                             }
                                             log.warn(
@@ -170,7 +170,7 @@ public class ConversationCompactor {
                                                     path))
                             .onErrorResume(
                                     e -> {
-                                        if (containsInterruptedException(e)) {
+                                        if (ExceptionUtils.containsInterruptedException(e)) {
                                             return Mono.error(e);
                                         }
                                         log.warn(
@@ -375,24 +375,12 @@ public class ConversationCompactor {
                 .defaultIfEmpty("(Summary unavailable)")
                 .onErrorResume(
                         e -> {
-                            if (containsInterruptedException(e)) {
+                            if (ExceptionUtils.containsInterruptedException(e)) {
                                 return Mono.error(e);
                             }
                             log.warn("Summarization LLM call failed: {}", e.getMessage());
                             return Mono.just("(Summarization failed: " + e.getMessage() + ")");
                         });
-    }
-
-    private static boolean containsInterruptedException(Throwable error) {
-        IdentityHashMap<Throwable, Boolean> visited = new IdentityHashMap<>();
-        Throwable current = error;
-        while (current != null && visited.put(current, Boolean.TRUE) == null) {
-            if (current instanceof InterruptedException) {
-                return true;
-            }
-            current = current.getCause();
-        }
-        return false;
     }
 
     /**

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/middleware/CompactionMiddleware.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/middleware/CompactionMiddleware.java
@@ -24,12 +24,12 @@ import io.agentscope.core.message.MsgRole;
 import io.agentscope.core.middleware.ReasoningInput;
 import io.agentscope.core.model.Model;
 import io.agentscope.core.state.AgentState;
+import io.agentscope.core.util.ExceptionUtils;
 import io.agentscope.harness.agent.memory.MemoryFlushManager;
 import io.agentscope.harness.agent.memory.compaction.CompactionConfig;
 import io.agentscope.harness.agent.memory.compaction.ConversationCompactor;
 import io.agentscope.harness.agent.workspace.WorkspaceManager;
 import java.util.ArrayList;
-import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Function;
@@ -114,7 +114,7 @@ public class CompactionMiddleware implements HarnessRuntimeMiddleware {
                             .compactIfNeeded(rc, conversation, effectiveConfig, agentId, sessionId)
                             .onErrorResume(
                                     error -> {
-                                        if (containsInterruptedException(error)) {
+                                        if (ExceptionUtils.containsInterruptedException(error)) {
                                             return Mono.error(error);
                                         }
                                         log.warn(
@@ -147,18 +147,6 @@ public class CompactionMiddleware implements HarnessRuntimeMiddleware {
                                                         input.options()));
                                     });
                 });
-    }
-
-    private static boolean containsInterruptedException(Throwable error) {
-        IdentityHashMap<Throwable, Boolean> visited = new IdentityHashMap<>();
-        Throwable current = error;
-        while (current != null && visited.put(current, Boolean.TRUE) == null) {
-            if (current instanceof InterruptedException) {
-                return true;
-            }
-            current = current.getCause();
-        }
-        return false;
     }
 
     /**


### PR DESCRIPTION
## AgentScope-Java Version

2.0.3-SNAPSHOT（基于提交 `00367241`）

## 问题背景

在 `ReActAgent` 中，当前用户消息会先加入内存里的 `AgentState`，但原有流程只有在模型调用成功完成后才会保存 state。

因此，当模型在流式回答过程中发生异常时：

1. 本轮调用会向上返回异常；
2. 当前用户问题没有写入 Session；
3. 如果随后从同一个 Session 重建 Agent（包括 `HarnessAgent`），再输入“继续”或“刚才为什么报错”，模型看不到上一轮用户问题，也就无法知道应该继续什么。

本 PR 先做一个范围较小、风险可控的修复：无论模型是否成功产出完整回复，都不要丢失已经确定的用户输入和此前的安全上下文。

## 本次修改

- 普通模型调用失败时，保存异常发生前已进入 `AgentState` 的安全对话状态；
- structured output 第一次调用失败、进入 fallback 之前，同样保存当前状态；
- 状态保存完成后继续抛出原始模型异常；
- 如果保存状态自身也失败，将该异常作为 suppressed exception 附在原始异常上，避免掩盖真正的模型错误；
- 不保存尚未完成的 assistant 流式片段或未闭合的 tool call，避免污染下一次正常推理；
- 不修改现有 Session schema 和 public API，`HarnessAgent` 通过其委托的 `ReActAgent` 自动获得该行为。

修复后的语义是：用户再次说“继续”时，模型至少能看到刚才的原始问题；但不会假装知道未完整提交的模型输出。

## 测试

新增 `ReActAgentCallFailurePersistenceTest`，覆盖：

- 模型输出部分 chunk 后失败时，只持久化用户输入，不持久化不完整 assistant 输出；
- 同一个 Agent 实例可以基于失败轮次继续；
- 从同一个 Session 重建 Agent 后仍可继续；
- Session 保存失败不会掩盖原始模型异常；
- structured-output fallback 的失败路径也会保存用户输入。

已执行：

`mvn -pl agentscope-core -Dtest=ReActAgentCallFailurePersistenceTest test`

结果：5 tests passed，0 failures，0 errors。

另外做了一个未提交到仓库的真实模型临时 E2E 探针：第一次调用 Claude 得到实际模型输出后人为注入流异常，再使用同一个 `JsonFileSession` 和 session id 重建 `HarnessAgent`，输入“继续，并告诉我刚才的校验码”。第二次请求能够看到原始问题并正确回答 `ORANGE-7319`，且上下文中没有不完整 assistant 消息。

本地直接调用 DeepSeek / OpenAI endpoint 时凭证返回 HTTP 401，因此没有把这部分写成通过的供应商实测结论。

## 关于“异常前 partial output 能否继续复用”的后续讨论

本 PR 有意不持久化模型异常前的 partial output。直接把中间 chunk 当成正常 assistant message 写回上下文可能带来：

- JSON / structured output 尚未闭合；
- tool arguments 不完整；
- tool call 尚未执行，却在后续上下文中看起来像已经执行；
- 重试时产生重复工具副作用；
- provider-specific reasoning / hidden state 被错误地当作普通文本复用。

代价是：修复后 Agent 知道用户刚才问了什么，但不能精确地从已经输出到屏幕的最后一个 token 无缝续写。这个能力值得由维护者进一步评估，但更适合通过显式的 interrupted-turn 语义实现，而不是直接保存原始 chunk。

### DeepSeek Harness 调研

DeepSeek Harness 的公开设计更接近 append-only event log：

- assistant chunk 可以作为原始事件持久化，供 replay / UI 恢复；
- 用户显式取消时，可将已交付的可见前缀收束成带 `interrupted: true` 的 assistant/message；
- 未派发的 tool call 不进入可继续执行的上下文；
- transport / protocol error 不会被伪装成正常完成的 assistant turn，而是通过 agent/request-error 等事件暴露并决定是否 retry。

参考：

- [Session subsystem](https://github.com/deepseek-ai/deepseek-harness/blob/master/docs/subsystems/session.md)
- [LLM streaming subsystem](https://github.com/deepseek-ai/deepseek-harness/blob/master/docs/subsystems/llm-streaming.md)
- [Persistence subsystem](https://github.com/deepseek-ai/deepseek-harness/blob/master/docs/subsystems/persistence.md)

### Codex 调研

Codex 的公开实现把已完成的 response item、tool result 和 terminal event 写入 rollout；在 turn 被中止时，还会加入一个 model-visible、但对用户隐藏的 `<turn_aborted>` 标记，提醒后续模型上一轮被打断，需要先检查当前状态，避免盲目重复动作。

它解决的重点是“后续模型知道上一轮异常终止”，而不是承诺保存任意未完成 delta 并从精确 token 位置续写。

参考：

- [Codex PR #9043: Persist turn aborted marker to rollout](https://github.com/openai/codex/pull/9043)
- [rollout policy](https://github.com/openai/codex/blob/main/codex-rs/rollout/src/policy.rs)
- [app-server README](https://github.com/openai/codex/blob/main/codex-rs/app-server/README.md)

### 建议维护者后续考虑

如果 AgentScope-Java 后续希望进一步支持“尽量不浪费异常前输出”，建议显式区分：

1. raw stream chunk：仅用于审计和 UI replay；
2. 完整 assistant message：正常进入模型上下文；
3. interrupted assistant message：只保留安全的 visible text，并带明确中断标记；
4. incomplete tool call / structured output：只审计，不作为可执行历史；
5. 已完成 tool result：保留，并在继续前检查外部副作用；
6. explicit cancellation 与 transport/provider error 是否采用不同提交策略。

这会涉及消息模型、Session schema、不同 provider 的流式语义和工具幂等性，超出了本次贡献者 PR 的最小修复范围，希望维护者可以结合整体架构决定是否推进。

## Checklist

- [ ] Code has been formatted with `mvn spotless:apply`
- [ ] All tests are passing (`mvn test`)
- [x] 新增的定向测试已通过
- [x] Javadoc comments are complete and follow project conventions
- [ ] Related documentation has been updated（本次未修改 public API / schema）
- [x] Code is ready for review
