### PR TITLE
fix(protocol): clear task submit context before publishing terminal status to close await race

### DIFF
--- a/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agent-protocol/src/main/java/io/agentscope/extensions/agentprotocol/AgentProtocolTaskStore.java
+++ b/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agent-protocol/src/main/java/io/agentscope/extensions/agentprotocol/AgentProtocolTaskStore.java
@@ -279,14 +279,15 @@ public final class AgentProtocolTaskStore {
             }
 
             String text = reply != null ? reply.getTextContent() : "";
+            clearSubmitContext(taskId);
             update(taskId, TaskStatus.COMPLETED, text, null, agentId, false, null);
             publishStatus(taskId, agentId, "success", null);
             eventBus.complete(taskId);
-            clearSubmitContext(taskId);
             return text;
         } catch (Exception e) {
             String err = e.getMessage() != null ? e.getMessage() : e.getClass().getSimpleName();
             log.warn("Protocol task {} failed", taskId, e);
+            clearSubmitContext(taskId);
             update(taskId, TaskStatus.FAILED, null, err, agentId, false, null);
             RemoteAgentEvent error = new RemoteAgentEvent();
             error.setType(RemoteEventType.RUN_ERROR);
@@ -295,7 +296,6 @@ public final class AgentProtocolTaskStore {
             error.setStatus("error");
             eventBus.publish(taskId, error);
             eventBus.complete(taskId);
-            clearSubmitContext(taskId);
             throw new RuntimeException(e);
         }
     }


### PR DESCRIPTION
## 背景

CI（https://github.com/agentscope-ai/agentscope-java/actions/runs/32563230291）出现偶发失败：

AgentProtocolTaskStoreHitlTest.submitContextClearedOnDirectSuccess:134
expected: <false> but was: <true>

该测试断言任务成功后 `hasSubmitContext(taskId)` 为 `false`。
其 `awaitCondition` 轮询 `snapshot(taskId).get("status")` 等到 `"success"` 后立即检查 `hasSubmitContext`，
本地难以复现，属典型的时序竞态。

## 根因

在 `AgentProtocolTaskStore.runAgent` 的成功路径中，状态翻转与 submit context 清理是先后两步：

    update(taskId, TaskStatus.COMPLETED, ...);   // 持久化 record 置为 COMPLETED，snapshot 立即返回 "success"
    publishStatus(taskId, agentId, "success", null);
    eventBus.complete(taskId);
    clearSubmitContext(taskId);                  // submit context 在此后才清理

`snapshot` 直接读取持久化的 `TaskRecord` 判定状态，因此「状态可见为 success」与
`submitContexts`（内存）被移除之间不存在 happens-before 约束。
await 键在状态上，会在 `clearSubmitContext` 执行之前提前返回，
导致此时 `hasSubmitContext` 仍为 `true`，断言失败。失败路径（catch 分支）存在同样的顺序问题。

## 修复

将 `clearSubmitContext(taskId)` 提前到 `update(...COMPLETED/FAILED...)` 之前执行，
保证终端状态对外可见时 submit context 已被移除，竞态窗口消除：

    clearSubmitContext(taskId);
    update(taskId, TaskStatus.COMPLETED, text, null, agentId, false, null);
    publishStatus(taskId, agentId, "success", null);
    eventBus.complete(taskId);

`resume` 仅在 `awaiting_confirm` 期间复用 submit context，终态时不再使用，
因此提前清理安全无副作用。成功与失败两条路径均做此调整。
