### PR TITLE
docs: correct MySQL skill repository registration

### DIFF
--- a/docs/v2/en/integration/skill/mysql-repository.md
+++ b/docs/v2/en/integration/skill/mysql-repository.md
@@ -22,6 +22,7 @@
 
 ```java
 import com.zaxxer.hikari.HikariDataSource;
+import io.agentscope.core.ReActAgent;
 import io.agentscope.core.skill.repository.mysql.MysqlSkillRepository;
 
 HikariDataSource ds = new HikariDataSource();
@@ -32,8 +33,11 @@ ds.setPassword("***");
 // Second arg createIfNotExist=true: auto-create database and tables
 MysqlSkillRepository repo = new MysqlSkillRepository(ds, true);
 
-Toolkit toolkit = new Toolkit();
-repo.getAllSkills().forEach(toolkit::registerSkill);
+ReActAgent agent = ReActAgent.builder()
+    .name("assistant")
+    .model(model)
+    .skillRepository(repo)
+    .build();
 ```
 
 ## Schema

--- a/docs/v2/zh/integration/skill/mysql-repository.md
+++ b/docs/v2/zh/integration/skill/mysql-repository.md
@@ -22,6 +22,7 @@
 
 ```java
 import com.zaxxer.hikari.HikariDataSource;
+import io.agentscope.core.ReActAgent;
 import io.agentscope.core.skill.repository.mysql.MysqlSkillRepository;
 
 HikariDataSource ds = new HikariDataSource();
@@ -32,8 +33,11 @@ ds.setPassword("***");
 // 第二参数 createIfNotExist=true：自动建库建表
 MysqlSkillRepository repo = new MysqlSkillRepository(ds, true);
 
-Toolkit toolkit = new Toolkit();
-repo.getAllSkills().forEach(toolkit::registerSkill);
+ReActAgent agent = ReActAgent.builder()
+    .name("assistant")
+    .model(model)
+    .skillRepository(repo)
+    .build();
 ```
 
 ## 表结构


### PR DESCRIPTION
## AgentScope-Java Version

Documentation-only change against the `docs/v2` tree; it corrects a code
sample and is not tied to one dependency version. The corrected snippet uses
`ReActAgent.Builder.skillRepository(...)`, which is the current v2 API.

## Description

Replace the invalid `Toolkit` registration block in both localized quickstarts with the established `ReActAgent.builder()` flow, passing the existing `MysqlSkillRepository` instance to `skillRepository(...)`. Add the imports and minimal agent builder context needed for each snippet to communicate where the repository belongs, following the examples in the building-block documentation. Keep repository construction, database setup, schema, and CRUD guidance unchanged because those sections describe valid APIs and are outside the reported defect.

The Chinese MySQL skill repository quickstart instructs users to pass loaded skills to `Toolkit.registerSkill`, but `Toolkit` has no such method. The English counterpart contains the same invalid call, so users following either version receive a compile-time error. In the current API, repositories are attached to an agent through `ReActAgent.Builder.skillRepository(...)`, which installs the dynamic skill middleware during agent construction. The defect is confined to the paired documentation examples; the repository and agent APIs already support the intended integration.

Fixes #2657

## Checklist

Please check the following items before code is ready to be reviewed.

- [ ] Code has been formatted with `mvn spotless:apply`
  Not run: no test command resolved in this workspace, so nothing was executed to pass.
- [ ] All tests are passing (`mvn test`)
  Not run: no test command resolved in this workspace, so nothing was executed to pass.
- [ ] Javadoc comments are complete and follow project conventions
  N/A: this PR changes Markdown documentation only, no Java sources.
- [x] Related documentation has been updated (e.g. links, examples, etc.)
  This PR *is* the documentation update: both the English and Chinese
  MySQL skill-repository quickstarts.
- [x] Code is ready for review
