### PR TITLE
fix(dataplane): make the self-hosted environment worker path usable

### DIFF
--- a/agentscope-service/service-dataplane/src/main/java/io/agentscope/builder/control/ControlPlaneClient.java
+++ b/agentscope-service/service-dataplane/src/main/java/io/agentscope/builder/control/ControlPlaneClient.java
@@ -22,6 +22,8 @@ import io.agentscope.builder.web.managed.EnvironmentDto;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.function.Consumer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -45,6 +47,19 @@ import org.springframework.web.server.ResponseStatusException;
  */
 @Service
 public class ControlPlaneClient {
+
+    /**
+     * Dedicated pool for {@link #verifyEnvironmentKey}: it is invoked from the reactive security
+     * filter chain, so the blocking verification HTTP call must not run on a NonBlocking thread.
+     */
+    private final ExecutorService envKeyVerifyPool =
+            Executors.newFixedThreadPool(
+                    4,
+                    r -> {
+                        Thread t = new Thread(r, "env-key-verify");
+                        t.setDaemon(true);
+                        return t;
+                    });
 
     private static final Logger log = LoggerFactory.getLogger(ControlPlaneClient.class);
 
@@ -329,6 +344,17 @@ public class ControlPlaneClient {
      * so the auth filter can fall through without 5xx.
      */
     public boolean verifyEnvironmentKey(String environmentId, String plaintextKey) {
+        try {
+            return envKeyVerifyPool
+                    .submit(() -> doVerifyEnvironmentKey(environmentId, plaintextKey))
+                    .get();
+        } catch (Exception ex) {
+            log.debug("verifyEnvironmentKey failed for {}: {}", environmentId, ex.getMessage());
+            return false;
+        }
+    }
+
+    private boolean doVerifyEnvironmentKey(String environmentId, String plaintextKey) {
         try {
             Map<String, Object> body = Map.of("key", plaintextKey);
             Map<?, ?> resp =

--- a/agentscope-service/service-dataplane/src/main/java/io/agentscope/builder/control/ControlPlaneClient.java
+++ b/agentscope-service/service-dataplane/src/main/java/io/agentscope/builder/control/ControlPlaneClient.java
@@ -22,8 +22,6 @@ import io.agentscope.builder.web.managed.EnvironmentDto;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.function.Consumer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -47,19 +45,6 @@ import org.springframework.web.server.ResponseStatusException;
  */
 @Service
 public class ControlPlaneClient {
-
-    /**
-     * Dedicated pool for {@link #verifyEnvironmentKey}: it is invoked from the reactive security
-     * filter chain, so the blocking verification HTTP call must not run on a NonBlocking thread.
-     */
-    private final ExecutorService envKeyVerifyPool =
-            Executors.newFixedThreadPool(
-                    4,
-                    r -> {
-                        Thread t = new Thread(r, "env-key-verify");
-                        t.setDaemon(true);
-                        return t;
-                    });
 
     private static final Logger log = LoggerFactory.getLogger(ControlPlaneClient.class);
 
@@ -344,17 +329,6 @@ public class ControlPlaneClient {
      * so the auth filter can fall through without 5xx.
      */
     public boolean verifyEnvironmentKey(String environmentId, String plaintextKey) {
-        try {
-            return envKeyVerifyPool
-                    .submit(() -> doVerifyEnvironmentKey(environmentId, plaintextKey))
-                    .get();
-        } catch (Exception ex) {
-            log.debug("verifyEnvironmentKey failed for {}: {}", environmentId, ex.getMessage());
-            return false;
-        }
-    }
-
-    private boolean doVerifyEnvironmentKey(String environmentId, String plaintextKey) {
         try {
             Map<String, Object> body = Map.of("key", plaintextKey);
             Map<?, ?> resp =

--- a/agentscope-service/service-dataplane/src/main/java/io/agentscope/builder/web/api/SelfHostedWorkerController.java
+++ b/agentscope-service/service-dataplane/src/main/java/io/agentscope/builder/web/api/SelfHostedWorkerController.java
@@ -39,6 +39,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.server.ResponseStatusException;
 import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
 
 /**
  * Outbound-worker data plane for {@code self_hosted}: pending tool_use listing, tool_result
@@ -74,10 +75,11 @@ public class SelfHostedWorkerController {
             @PathVariable("sessionId") String sessionId,
             Authentication auth) {
         return Mono.fromCallable(
-                () -> {
-                    requireEnvironmentWorker(auth, environmentId, sessionId);
-                    return pendingHandsToolService.listPending(sessionId);
-                });
+                        () -> {
+                            requireEnvironmentWorker(auth, environmentId, sessionId);
+                            return pendingHandsToolService.listPending(sessionId);
+                        })
+                .subscribeOn(Schedulers.boundedElastic());
     }
 
     /** Posts one or more tool results and resumes the suspended turn. */
@@ -88,27 +90,33 @@ public class SelfHostedWorkerController {
             @RequestBody ToolResultsRequest body,
             Authentication auth) {
         return Mono.fromCallable(
-                () -> {
-                    ManagedSessionDto session =
-                            requireEnvironmentWorker(auth, environmentId, sessionId);
-                    if (body == null || body.results() == null || body.results().isEmpty()) {
-                        throw ApiException.invalidRequest(
-                                "missing_results", "results is required", "results");
-                    }
-                    List<ToolResultBlock> blocks = new ArrayList<>();
-                    List<SessionEventDto> recorded = new ArrayList<>();
-                    for (Map<String, Object> payload : body.results()) {
-                        ToolResultBlock block = SessionTurnRunner.toolResultFromPayload(payload);
-                        blocks.add(block);
-                        Map<String, Object> stored = new LinkedHashMap<>(payload);
-                        stored.putIfAbsent("tool_use_id", block.getId());
-                        recorded.add(
-                                eventLog.append(
-                                        sessionId, SessionEventTypes.USER_TOOL_RESULT, stored));
-                    }
-                    turnRunner.resumeWithToolResults(session, blocks);
-                    return recorded;
-                });
+                        () -> {
+                            ManagedSessionDto session =
+                                    requireEnvironmentWorker(auth, environmentId, sessionId);
+                            if (body == null
+                                    || body.results() == null
+                                    || body.results().isEmpty()) {
+                                throw ApiException.invalidRequest(
+                                        "missing_results", "results is required", "results");
+                            }
+                            List<ToolResultBlock> blocks = new ArrayList<>();
+                            List<SessionEventDto> recorded = new ArrayList<>();
+                            for (Map<String, Object> payload : body.results()) {
+                                ToolResultBlock block =
+                                        SessionTurnRunner.toolResultFromPayload(payload);
+                                blocks.add(block);
+                                Map<String, Object> stored = new LinkedHashMap<>(payload);
+                                stored.putIfAbsent("tool_use_id", block.getId());
+                                recorded.add(
+                                        eventLog.append(
+                                                sessionId,
+                                                SessionEventTypes.USER_TOOL_RESULT,
+                                                stored));
+                            }
+                            turnRunner.resumeWithToolResults(session, blocks);
+                            return recorded;
+                        })
+                .subscribeOn(Schedulers.boundedElastic());
     }
 
     /** Downloads the session agent's skills bundle for local staging on the worker. */
@@ -118,10 +126,11 @@ public class SelfHostedWorkerController {
             @PathVariable("sessionId") String sessionId,
             Authentication auth) {
         return Mono.fromCallable(
-                () -> {
-                    requireEnvironmentWorker(auth, environmentId, sessionId);
-                    return skillsBundleService.bundleForSession(sessionId);
-                });
+                        () -> {
+                            requireEnvironmentWorker(auth, environmentId, sessionId);
+                            return skillsBundleService.bundleForSession(sessionId);
+                        })
+                .subscribeOn(Schedulers.boundedElastic());
     }
 
     private ManagedSessionDto requireEnvironmentWorker(

--- a/agentscope-service/service-dataplane/src/main/java/io/agentscope/builder/web/api/WorkerEnvironmentController.java
+++ b/agentscope-service/service-dataplane/src/main/java/io/agentscope/builder/web/api/WorkerEnvironmentController.java
@@ -37,6 +37,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.server.ResponseStatusException;
 import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
 
 /**
  * REST surface for out-of-process Environment Workers on {@code self_hosted} environments.
@@ -76,19 +77,20 @@ public class WorkerEnvironmentController {
             @RequestParam("workerId") String workerId,
             @RequestParam(name = "timeoutMs", defaultValue = "25000") long timeoutMs) {
         return Mono.fromCallable(
-                () -> {
-                    try {
-                        Optional<EnvironmentWorkQueue.WorkItem> item =
-                                workQueue.poll(environmentId, workerId, timeoutMs);
-                        return item.map(this::withSessionMetadata)
-                                .map(ResponseEntity::ok)
-                                .orElseGet(() -> ResponseEntity.noContent().build());
-                    } catch (InterruptedException e) {
-                        Thread.currentThread().interrupt();
-                        throw new ResponseStatusException(
-                                HttpStatus.SERVICE_UNAVAILABLE, "Poll interrupted");
-                    }
-                });
+                        () -> {
+                            try {
+                                Optional<EnvironmentWorkQueue.WorkItem> item =
+                                        workQueue.poll(environmentId, workerId, timeoutMs);
+                                return item.map(this::withSessionMetadata)
+                                        .map(ResponseEntity::ok)
+                                        .orElseGet(() -> ResponseEntity.noContent().build());
+                            } catch (InterruptedException e) {
+                                Thread.currentThread().interrupt();
+                                throw new ResponseStatusException(
+                                        HttpStatus.SERVICE_UNAVAILABLE, "Poll interrupted");
+                            }
+                        })
+                .subscribeOn(Schedulers.boundedElastic());
     }
 
     private EnvironmentWorkQueue.WorkItem withSessionMetadata(EnvironmentWorkQueue.WorkItem item) {
@@ -109,7 +111,8 @@ public class WorkerEnvironmentController {
             @RequestParam(value = "state", required = false) String state,
             Authentication auth) {
         requireUserAuth(auth);
-        return Mono.fromCallable(() -> workQueue.list(environmentId, state));
+        return Mono.fromCallable(() -> workQueue.list(environmentId, state))
+                .subscribeOn(Schedulers.boundedElastic());
     }
 
     /** Returns per-status counts and oldest queued age for the environment. */
@@ -117,7 +120,8 @@ public class WorkerEnvironmentController {
     public Mono<CoordinationStore.WorkStats> workStats(
             @PathVariable("id") String environmentId, Authentication auth) {
         requireUserAuth(auth);
-        return Mono.fromCallable(() -> workQueue.stats(environmentId));
+        return Mono.fromCallable(() -> workQueue.stats(environmentId))
+                .subscribeOn(Schedulers.boundedElastic());
     }
 
     /** Returns a single work item by id. */
@@ -128,14 +132,15 @@ public class WorkerEnvironmentController {
             Authentication auth) {
         requireUserAuth(auth);
         return Mono.fromCallable(
-                () ->
-                        workQueue
-                                .get(workId)
-                                .orElseThrow(
-                                        () ->
-                                                new ResponseStatusException(
-                                                        HttpStatus.NOT_FOUND,
-                                                        "Unknown work item: " + workId)));
+                        () ->
+                                workQueue
+                                        .get(workId)
+                                        .orElseThrow(
+                                                () ->
+                                                        new ResponseStatusException(
+                                                                HttpStatus.NOT_FOUND,
+                                                                "Unknown work item: " + workId)))
+                .subscribeOn(Schedulers.boundedElastic());
     }
 
     /**


### PR DESCRIPTION
## Problem

The self-hosted environment (type `self_hosted`) hands execution to an external `HandsWorkerMain` worker, but on current `main` the whole worker path is broken — every worker API call fails before doing any work:

1. **401 on every worker request.** `EnvironmentKeyAuthFilter` calls `ControlPlaneClient.verifyEnvironmentKey` from the reactive security filter chain (a `reactor-http-epoll` thread). The WebClient call inside ends with `.block()`, which Reactor rejects on `NonBlocking` threads:

```
verifyEnvironmentKey failed for env_xxx: block()/blockFirst()/blockLast()
are blocking, which is not supported in thread reactor-http-epoll-4
```

Verification therefore always returns `false` and the filter never sets the `env:<id>` authentication, so `pending-tools` / `tool-results` / `work/poll` all answer 401.

2. **502 / intermittent failures on the worker controllers.** `SelfHostedWorkerController` and `WorkerEnvironmentController` wrap blocking work (session resolve through `ControlPlaneClient`, work-queue ops) in `Mono.fromCallable` **without** `subscribeOn`, so the callable runs on the subscribing `parallel-*` thread:

```
resolveSession failed for sess_xxx: block()/blockFirst()/blockLast()
are blocking, which is not supported in thread parallel-1
```

`GET /api/environments/{id}/sessions/{sid}/pending-tools` returns 502 and `work/poll` fails intermittently.

## Fix

- `ControlPlaneClient`: run the blocking key verification on a small dedicated daemon thread pool instead of the event-loop thread.
- Both worker controllers: add `.subscribeOn(Schedulers.boundedElastic())`, matching what the other data-plane controllers (`DataSessionApiController`) already do — the class javadoc of `ControlPlaneClient` explicitly requires callers to schedule off the event loop.

## Verification

Deployed the data plane with these patches and verified the full flow end to end with a real `HandsWorkerMain` worker:

- `pending-tools` / `tool-results` / `work/poll` return 200 with valid environment keys (`X-Builder-Environment-Key`);
- a session on a `self_hosted` environment suspends with `session.requires_action (tool_suspended)` as designed;
- the external worker polls the work queue, executes `execute` + `write_file` locally, posts results, and the suspended turn resumes and produces the final `agent.message`.

`mvn spotless:check` and `mvn -pl agentscope-service/service-dataplane package` pass.