### PR TITLE
fix(core): persist state on call cancellation

### DIFF
--- a/agentscope-core/src/main/java/io/agentscope/core/ReActAgent.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/ReActAgent.java
@@ -155,6 +155,7 @@ import reactor.core.Disposable;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.FluxSink;
 import reactor.core.publisher.Mono;
+import reactor.core.publisher.SignalType;
 import reactor.core.scheduler.Schedulers;
 import reactor.util.context.Context;
 
@@ -476,24 +477,52 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
         if (stateStore == null) {
             return Mono.empty();
         }
+        return Mono.<Void>fromRunnable(() -> persistState(scope))
+                .subscribeOn(Schedulers.boundedElastic());
+    }
+
+    private void persistState(CallExecution scope) {
         syncToolkitToState(scope.state);
         SlotRef ref = SlotRef.parse(scope.slotKey);
-        AgentState toSave = scope.state;
-        return Mono.<Void>fromRunnable(
-                        () -> {
-                            long newVersion =
-                                    persistAgentStateCas(
-                                            ref.userId,
-                                            ref.sessionId,
-                                            scope.slotKey,
-                                            toSave,
-                                            scope.loadedVersion,
-                                            scope.loadedContextSize);
-                            if (newVersion != AgentStateStore.UNVERSIONED) {
-                                scope.loadedVersion = newVersion;
-                            }
-                        })
-                .subscribeOn(Schedulers.boundedElastic());
+        long newVersion =
+                persistAgentStateCas(
+                        ref.userId,
+                        ref.sessionId,
+                        scope.slotKey,
+                        scope.state,
+                        scope.loadedVersion,
+                        scope.loadedContextSize);
+        if (newVersion != AgentStateStore.UNVERSIONED) {
+            scope.loadedVersion = newVersion;
+        }
+    }
+
+    private void prepareStateForAbnormalSave(CallExecution scope) {
+        try {
+            scope.dropUncommittedToolCallsFromCurrentCall();
+        } catch (RuntimeException repairError) {
+            log.warn("Failed to repair agent state before saving", repairError);
+        }
+    }
+
+    private void saveStateAfterCancellation(CallExecution scope) {
+        prepareStateForAbnormalSave(scope);
+        try {
+            if (stateStore != null) {
+                persistState(scope);
+            }
+        } catch (RuntimeException saveError) {
+            log.warn("Failed to save agent state after cancellation", saveError);
+        }
+    }
+
+    private <T> Mono<T> checkpointOnCancellation(CallExecution scope, Mono<T> execution) {
+        return execution.doFinally(
+                signal -> {
+                    if (signal == SignalType.CANCEL) {
+                        saveStateAfterCancellation(scope);
+                    }
+                });
     }
 
     /**
@@ -512,6 +541,7 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
         if (ExceptionUtils.containsInterruptedException(callFailure)) {
             return Mono.error(callFailure);
         }
+        prepareStateForAbnormalSave(scope);
         return saveStateToSession(scope)
                 .onErrorResume(
                         saveFailure -> {
@@ -1213,7 +1243,7 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
                         AgentEventEmitter.fromForwardingContext(cv)
                                 .ifPresent(ae -> scope.externalEventEmitter = ae);
                     }
-                    return scope.doCallInner(msgs)
+                    return checkpointOnCancellation(scope, scope.doCallInner(msgs))
                             .onErrorResume(error -> saveStateAfterCallFailure(scope, error))
                             .flatMap(result -> saveStateToSession(scope).thenReturn(result));
                 });
@@ -1305,7 +1335,7 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
 
                     int contextSizeBefore = scope.state.contextMutable().size();
 
-                    return scope.doCallInner(msgs)
+                    return checkpointOnCancellation(scope, scope.doCallInner(msgs))
                             .flatMap(
                                     result -> {
                                         Msg out = wrapNativeStructuredResult(result);
@@ -1348,7 +1378,7 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
 
                     scope.soTool = createStructuredOutputTool(jsonSchema);
 
-                    return scope.doCallInner(msgs)
+                    return checkpointOnCancellation(scope, scope.doCallInner(msgs))
                             .onErrorResume(error -> saveStateAfterCallFailure(scope, error))
                             .flatMap(
                                     result -> {
@@ -2111,6 +2141,42 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
                         "Synthesized interrupted-result for pending tool call: {} ({})",
                         toolCall.getName(),
                         toolCall.getId());
+            }
+        }
+
+        /** Remove current-call PENDING or ALLOWED tool calls that never produced results. */
+        private void dropUncommittedToolCallsFromCurrentCall() {
+            Set<String> pendingIds = getPendingToolUseIds();
+            if (pendingIds.isEmpty()) {
+                return;
+            }
+            List<Msg> context = state.contextMutable();
+            for (int i = context.size() - 1; i >= loadedContextSize; i--) {
+                Msg message = context.get(i);
+                if (message.getRole() != MsgRole.ASSISTANT
+                        || !message.hasContentBlocks(ToolUseBlock.class)) {
+                    continue;
+                }
+                List<ContentBlock> retained =
+                        message.getContent().stream()
+                                .filter(
+                                        block ->
+                                                !(block instanceof ToolUseBlock toolUse)
+                                                        || (toolUse.getState()
+                                                                        != ToolCallState.PENDING
+                                                                && toolUse.getState()
+                                                                        != ToolCallState.ALLOWED)
+                                                        || !pendingIds.contains(toolUse.getId()))
+                                .toList();
+                if (retained.size() == message.getContent().size()) {
+                    return;
+                }
+                if (retained.isEmpty()) {
+                    context.remove(i);
+                } else {
+                    context.set(i, message.withContent(retained));
+                }
+                return;
             }
         }
 

--- a/agentscope-core/src/main/java/io/agentscope/core/ReActAgent.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/ReActAgent.java
@@ -155,6 +155,7 @@ import reactor.core.Disposable;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.FluxSink;
 import reactor.core.publisher.Mono;
+import reactor.core.publisher.SignalType;
 import reactor.core.scheduler.Schedulers;
 import reactor.util.context.Context;
 
@@ -476,24 +477,52 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
         if (stateStore == null) {
             return Mono.empty();
         }
+        return Mono.<Void>fromRunnable(() -> persistState(scope))
+                .subscribeOn(Schedulers.boundedElastic());
+    }
+
+    private void persistState(CallExecution scope) {
         syncToolkitToState(scope.state);
         SlotRef ref = SlotRef.parse(scope.slotKey);
-        AgentState toSave = scope.state;
-        return Mono.<Void>fromRunnable(
-                        () -> {
-                            long newVersion =
-                                    persistAgentStateCas(
-                                            ref.userId,
-                                            ref.sessionId,
-                                            scope.slotKey,
-                                            toSave,
-                                            scope.loadedVersion,
-                                            scope.loadedContextSize);
-                            if (newVersion != AgentStateStore.UNVERSIONED) {
-                                scope.loadedVersion = newVersion;
-                            }
-                        })
-                .subscribeOn(Schedulers.boundedElastic());
+        long newVersion =
+                persistAgentStateCas(
+                        ref.userId,
+                        ref.sessionId,
+                        scope.slotKey,
+                        scope.state,
+                        scope.loadedVersion,
+                        scope.loadedContextSize);
+        if (newVersion != AgentStateStore.UNVERSIONED) {
+            scope.loadedVersion = newVersion;
+        }
+    }
+
+    private void prepareStateForAbnormalSave(CallExecution scope) {
+        try {
+            scope.dropUncommittedToolCallsFromCurrentCall();
+        } catch (RuntimeException repairError) {
+            log.warn("Failed to repair agent state before saving", repairError);
+        }
+    }
+
+    private void saveStateAfterCancellation(CallExecution scope) {
+        prepareStateForAbnormalSave(scope);
+        try {
+            if (stateStore != null) {
+                persistState(scope);
+            }
+        } catch (RuntimeException saveError) {
+            log.warn("Failed to save agent state after cancellation", saveError);
+        }
+    }
+
+    private <T> Mono<T> checkpointOnCancellation(CallExecution scope, Mono<T> execution) {
+        return execution.doFinally(
+                signal -> {
+                    if (signal == SignalType.CANCEL) {
+                        saveStateAfterCancellation(scope);
+                    }
+                });
     }
 
     /**
@@ -512,6 +541,7 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
         if (ExceptionUtils.containsInterruptedException(callFailure)) {
             return Mono.error(callFailure);
         }
+        prepareStateForAbnormalSave(scope);
         return saveStateToSession(scope)
                 .onErrorResume(
                         saveFailure -> {
@@ -1213,7 +1243,7 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
                         AgentEventEmitter.fromForwardingContext(cv)
                                 .ifPresent(ae -> scope.externalEventEmitter = ae);
                     }
-                    return scope.doCallInner(msgs)
+                    return checkpointOnCancellation(scope, scope.doCallInner(msgs))
                             .onErrorResume(error -> saveStateAfterCallFailure(scope, error))
                             .flatMap(result -> saveStateToSession(scope).thenReturn(result))
                             .switchIfEmpty(
@@ -1310,7 +1340,7 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
 
                     int contextSizeBefore = scope.state.contextMutable().size();
 
-                    return scope.doCallInner(msgs)
+                    return checkpointOnCancellation(scope, scope.doCallInner(msgs))
                             .flatMap(
                                     result -> {
                                         Msg out = wrapNativeStructuredResult(result);
@@ -1358,7 +1388,7 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
 
                     scope.soTool = createStructuredOutputTool(jsonSchema);
 
-                    return scope.doCallInner(msgs)
+                    return checkpointOnCancellation(scope, scope.doCallInner(msgs))
                             .onErrorResume(error -> saveStateAfterCallFailure(scope, error))
                             .flatMap(
                                     result -> {
@@ -2154,6 +2184,42 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
                         "Synthesized interrupted-result for pending tool call: {} ({})",
                         toolCall.getName(),
                         toolCall.getId());
+            }
+        }
+
+        /** Remove current-call PENDING or ALLOWED tool calls that never produced results. */
+        private void dropUncommittedToolCallsFromCurrentCall() {
+            Set<String> pendingIds = getPendingToolUseIds();
+            if (pendingIds.isEmpty()) {
+                return;
+            }
+            List<Msg> context = state.contextMutable();
+            for (int i = context.size() - 1; i >= loadedContextSize; i--) {
+                Msg message = context.get(i);
+                if (message.getRole() != MsgRole.ASSISTANT
+                        || !message.hasContentBlocks(ToolUseBlock.class)) {
+                    continue;
+                }
+                List<ContentBlock> retained =
+                        message.getContent().stream()
+                                .filter(
+                                        block ->
+                                                !(block instanceof ToolUseBlock toolUse)
+                                                        || (toolUse.getState()
+                                                                        != ToolCallState.PENDING
+                                                                && toolUse.getState()
+                                                                        != ToolCallState.ALLOWED)
+                                                        || !pendingIds.contains(toolUse.getId()))
+                                .toList();
+                if (retained.size() == message.getContent().size()) {
+                    return;
+                }
+                if (retained.isEmpty()) {
+                    context.remove(i);
+                } else {
+                    context.set(i, message.withContent(retained));
+                }
+                return;
             }
         }
 

--- a/agentscope-core/src/test/java/io/agentscope/core/agent/ReActAgentCallFailurePersistenceTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/agent/ReActAgentCallFailurePersistenceTest.java
@@ -22,27 +22,47 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.agentscope.core.ReActAgent;
+import io.agentscope.core.event.AgentEvent;
 import io.agentscope.core.message.ContentBlock;
 import io.agentscope.core.message.Msg;
 import io.agentscope.core.message.MsgRole;
 import io.agentscope.core.message.TextBlock;
+import io.agentscope.core.message.ToolCallState;
+import io.agentscope.core.message.ToolResultBlock;
 import io.agentscope.core.message.ToolUseBlock;
+import io.agentscope.core.middleware.ActingInput;
+import io.agentscope.core.middleware.MiddlewareBase;
 import io.agentscope.core.model.ChatModelBase;
 import io.agentscope.core.model.ChatResponse;
 import io.agentscope.core.model.GenerateOptions;
 import io.agentscope.core.model.ToolSchema;
+import io.agentscope.core.permission.PermissionContextState;
+import io.agentscope.core.permission.PermissionDecision;
 import io.agentscope.core.state.AgentState;
 import io.agentscope.core.state.InMemoryAgentStateStore;
 import io.agentscope.core.state.State;
+import io.agentscope.core.tool.ToolBase;
+import io.agentscope.core.tool.ToolCallParam;
+import io.agentscope.core.tool.Toolkit;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import reactor.core.Disposable;
 import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 
-/** Regression tests for durable conversation state when a model stream fails. */
-@DisplayName("ReActAgent failed-call persistence")
+/** Regression tests for durable conversation state after abnormal call termination. */
+@DisplayName("ReActAgent abnormal-call persistence")
 class ReActAgentCallFailurePersistenceTest {
 
     private static final RuntimeContext CONTEXT =
@@ -190,6 +210,213 @@ class ReActAgentCallFailurePersistenceTest {
         assertFalse(textContents(persisted.getContext()).contains("incomplete answer"));
     }
 
+    @ParameterizedTest(name = "structured={0}, native={1}")
+    @CsvSource({"false, false", "true, false", "true, true"})
+    @DisplayName("cancelled calls persist only safe conversation state")
+    void cancelledCallPersistsOnlySafeConversationState(
+            boolean structuredOutput, boolean nativeStructuredOutput) throws Exception {
+        InMemoryAgentStateStore store = new InMemoryAgentStateStore();
+        CountDownLatch responseEmitted = new CountDownLatch(1);
+        ReActAgent agent =
+                agent(new NeverCompletingModel(responseEmitted, nativeStructuredOutput), store);
+
+        Disposable subscription =
+                structuredOutput
+                        ? agent.call(
+                                        List.of(userMsg("original question")),
+                                        StructuredReply.class,
+                                        CONTEXT)
+                                .subscribe()
+                        : agent.call(List.of(userMsg("original question")), CONTEXT).subscribe();
+        try {
+            assertTrue(responseEmitted.await(5, TimeUnit.SECONDS));
+        } finally {
+            subscription.dispose();
+        }
+
+        AgentState persisted =
+                store.get("u1", "session-1", "agent_state", AgentState.class).orElseThrow();
+        assertEquals(List.of("original question"), textContents(persisted.getContext()));
+        assertFalse(hasToolUse(persisted));
+    }
+
+    @Test
+    @DisplayName("tool execution is cancelled before state is saved")
+    void cancellationStopsAllowedToolBeforeSavingState() throws Exception {
+        CountDownLatch toolStarted = new CountDownLatch(1);
+        CountDownLatch toolCancelled = new CountDownLatch(1);
+        AtomicBoolean savedBeforeToolCancellation = new AtomicBoolean();
+        AtomicInteger savesAfterToolStarted = new AtomicInteger();
+        InMemoryAgentStateStore store =
+                new InMemoryAgentStateStore() {
+                    @Override
+                    public long saveIfVersion(
+                            String userId,
+                            String sessionId,
+                            String key,
+                            State value,
+                            long expectedVersion) {
+                        if (toolStarted.getCount() == 0) {
+                            savesAfterToolStarted.incrementAndGet();
+                            if (toolCancelled.getCount() != 0) {
+                                savedBeforeToolCancellation.set(true);
+                            }
+                        }
+                        return super.saveIfVersion(userId, sessionId, key, value, expectedVersion);
+                    }
+                };
+        Toolkit toolkit = new Toolkit();
+        toolkit.registerAgentTool(
+                new TestTool(
+                        PermissionDecision.allow("allowed"),
+                        Mono.<ToolResultBlock>never()
+                                .doOnSubscribe(ignored -> toolStarted.countDown())
+                                .doOnCancel(toolCancelled::countDown)));
+        ReActAgent agent =
+                ReActAgent.builder()
+                        .name("asst")
+                        .sysPrompt("system prompt")
+                        .model(new FixedResponseModel(incompleteResponse()))
+                        .toolkit(toolkit)
+                        .stateStore(store)
+                        .build();
+
+        Disposable subscription =
+                agent.call(List.of(userMsg("original question")), CONTEXT).subscribe();
+        try {
+            assertTrue(toolStarted.await(5, TimeUnit.SECONDS));
+            assertEquals(
+                    ToolCallState.ALLOWED,
+                    onlyToolUse(agent.getAgentState("u1", "session-1")).getState());
+        } finally {
+            subscription.dispose();
+        }
+
+        assertTrue(toolCancelled.await(5, TimeUnit.SECONDS));
+        assertFalse(savedBeforeToolCancellation.get());
+        assertEquals(1, savesAfterToolStarted.get());
+        AgentState persisted =
+                store.get("u1", "session-1", "agent_state", AgentState.class).orElseThrow();
+        assertEquals(
+                List.of("original question", "incomplete answer"),
+                textContents(persisted.getContext()));
+        assertFalse(hasToolUse(persisted));
+    }
+
+    @Test
+    @DisplayName("cancelling an in-flight normal save does not start a second save")
+    void cancellationDuringNormalSaveDoesNotDoubleWrite() throws Exception {
+        AtomicBoolean responseProduced = new AtomicBoolean();
+        AtomicInteger savesAfterResponse = new AtomicInteger();
+        CountDownLatch saveStarted = new CountDownLatch(1);
+        CountDownLatch releaseSave = new CountDownLatch(1);
+        CountDownLatch saveFinished = new CountDownLatch(1);
+        InMemoryAgentStateStore store =
+                new InMemoryAgentStateStore() {
+                    @Override
+                    public long saveIfVersion(
+                            String userId,
+                            String sessionId,
+                            String key,
+                            State value,
+                            long expectedVersion) {
+                        int saveNumber =
+                                responseProduced.get() ? savesAfterResponse.incrementAndGet() : 0;
+                        if (saveNumber == 1) {
+                            saveStarted.countDown();
+                            awaitUninterruptibly(releaseSave);
+                        }
+                        try {
+                            return super.saveIfVersion(
+                                    userId, sessionId, key, value, expectedVersion);
+                        } finally {
+                            if (saveNumber == 1) {
+                                saveFinished.countDown();
+                            }
+                        }
+                    }
+                };
+        ReActAgent agent =
+                agent(
+                        new FixedResponseModel(
+                                textResponse("done"), () -> responseProduced.set(true)),
+                        store);
+
+        Disposable subscription =
+                agent.call(List.of(userMsg("original question")), CONTEXT).subscribe();
+        try {
+            assertTrue(saveStarted.await(5, TimeUnit.SECONDS));
+            subscription.dispose();
+            assertEquals(1, savesAfterResponse.get());
+        } finally {
+            subscription.dispose();
+            releaseSave.countDown();
+        }
+        assertTrue(saveFinished.await(5, TimeUnit.SECONDS));
+        assertEquals(1, savesAfterResponse.get());
+    }
+
+    @Test
+    @DisplayName("acting failures do not persist tool calls without results")
+    void actingFailureDropsUncommittedToolCall() {
+        InMemoryAgentStateStore store = new InMemoryAgentStateStore();
+        ReActAgent agent =
+                ReActAgent.builder()
+                        .name("asst")
+                        .sysPrompt("system prompt")
+                        .model(new FixedResponseModel(incompleteResponse()))
+                        .middleware(new FailingActingMiddleware())
+                        .stateStore(store)
+                        .build();
+
+        IllegalStateException thrown =
+                assertThrows(
+                        IllegalStateException.class,
+                        () -> agent.call(List.of(userMsg("original question")), CONTEXT).block());
+
+        assertEquals("acting failed", thrown.getMessage());
+        AgentState persisted =
+                store.get("u1", "session-1", "agent_state", AgentState.class).orElseThrow();
+        assertEquals(
+                List.of("original question", "incomplete answer"),
+                textContents(persisted.getContext()));
+        assertFalse(hasToolUse(persisted));
+    }
+
+    @ParameterizedTest(name = "permissionAsking={0}")
+    @ValueSource(booleans = {false, true})
+    @DisplayName("post-acting failures remove ALLOWED calls but preserve ASKING calls")
+    void postActingFailureKeepsOnlyResumableToolCalls(boolean permissionAsking) {
+        InMemoryAgentStateStore store = new InMemoryAgentStateStore();
+        Toolkit toolkit = new Toolkit();
+        PermissionDecision decision =
+                permissionAsking
+                        ? PermissionDecision.ask("confirmation required")
+                        : PermissionDecision.allow("allowed");
+        toolkit.registerAgentTool(new TestTool(decision, Mono.just(ToolResultBlock.text("done"))));
+        ReActAgent agent =
+                ReActAgent.builder()
+                        .name("asst")
+                        .sysPrompt("system prompt")
+                        .model(new FixedResponseModel(incompleteResponse()))
+                        .toolkit(toolkit)
+                        .middleware(new FailAfterActingMiddleware())
+                        .stateStore(store)
+                        .build();
+
+        assertThrows(
+                IllegalStateException.class,
+                () -> agent.call(List.of(userMsg("original question")), CONTEXT).block());
+
+        AgentState persisted =
+                store.get("u1", "session-1", "agent_state", AgentState.class).orElseThrow();
+        if (permissionAsking) {
+            assertEquals(ToolCallState.ASKING, onlyToolUse(persisted).getState());
+        } else {
+            assertFalse(hasToolUse(persisted));
+        }
+    }
+
     private static ReActAgent agent(ChatModelBase model, InMemoryAgentStateStore store) {
         return ReActAgent.builder()
                 .name("asst")
@@ -236,6 +463,36 @@ class ReActAgentCallFailurePersistenceTest {
             }
         }
         return result;
+    }
+
+    private static boolean hasToolUse(AgentState state) {
+        return state.getContext().stream()
+                .flatMap(message -> message.getContentBlocks(ToolUseBlock.class).stream())
+                .findAny()
+                .isPresent();
+    }
+
+    private static ToolUseBlock onlyToolUse(AgentState state) {
+        List<ToolUseBlock> toolUses =
+                state.getContext().stream()
+                        .flatMap(message -> message.getContentBlocks(ToolUseBlock.class).stream())
+                        .toList();
+        assertEquals(1, toolUses.size());
+        return toolUses.get(0);
+    }
+
+    private static void awaitUninterruptibly(CountDownLatch latch) {
+        boolean interrupted = false;
+        while (latch.getCount() != 0) {
+            try {
+                latch.await();
+            } catch (InterruptedException ignored) {
+                interrupted = true;
+            }
+        }
+        if (interrupted) {
+            Thread.currentThread().interrupt();
+        }
     }
 
     private static final class AlwaysFailingModel extends ChatModelBase {
@@ -299,6 +556,115 @@ class ReActAgentCallFailurePersistenceTest {
 
         private List<List<Msg>> calls() {
             return calls;
+        }
+    }
+
+    private static final class NeverCompletingModel extends ChatModelBase {
+        private final CountDownLatch responseEmitted;
+        private final boolean nativeStructuredOutput;
+
+        private NeverCompletingModel(
+                CountDownLatch responseEmitted, boolean nativeStructuredOutput) {
+            this.responseEmitted = responseEmitted;
+            this.nativeStructuredOutput = nativeStructuredOutput;
+        }
+
+        @Override
+        public String getModelName() {
+            return "never-completing";
+        }
+
+        @Override
+        protected Flux<ChatResponse> doStream(
+                List<Msg> messages, List<ToolSchema> tools, GenerateOptions options) {
+            return Flux.just(incompleteResponse())
+                    .doOnComplete(responseEmitted::countDown)
+                    .concatWith(Flux.never());
+        }
+
+        @Override
+        public boolean supportsNativeStructuredOutput() {
+            return nativeStructuredOutput;
+        }
+    }
+
+    private static final class FixedResponseModel extends ChatModelBase {
+        private final ChatResponse response;
+        private final Runnable beforeStream;
+
+        private FixedResponseModel(ChatResponse response) {
+            this(response, () -> {});
+        }
+
+        private FixedResponseModel(ChatResponse response, Runnable beforeStream) {
+            this.response = response;
+            this.beforeStream = beforeStream;
+        }
+
+        @Override
+        public String getModelName() {
+            return "fixed-response";
+        }
+
+        @Override
+        protected Flux<ChatResponse> doStream(
+                List<Msg> messages, List<ToolSchema> tools, GenerateOptions options) {
+            beforeStream.run();
+            return Flux.just(response);
+        }
+    }
+
+    private static final class FailingActingMiddleware implements MiddlewareBase {
+        @Override
+        public Flux<AgentEvent> onActing(
+                Agent agent,
+                RuntimeContext ctx,
+                ActingInput input,
+                Function<ActingInput, Flux<AgentEvent>> next) {
+            return Flux.error(new IllegalStateException("acting failed"));
+        }
+    }
+
+    private static final class FailAfterActingMiddleware implements MiddlewareBase {
+        @Override
+        public Flux<AgentEvent> onActing(
+                Agent agent,
+                RuntimeContext ctx,
+                ActingInput input,
+                Function<ActingInput, Flux<AgentEvent>> next) {
+            return next.apply(input)
+                    .concatWith(Flux.error(new IllegalStateException("post-acting failed")));
+        }
+    }
+
+    private static final class TestTool extends ToolBase {
+        private final PermissionDecision decision;
+        private final Mono<ToolResultBlock> result;
+
+        private TestTool(PermissionDecision decision, Mono<ToolResultBlock> result) {
+            super(
+                    "unfinished_tool",
+                    "test tool",
+                    Map.of("type", "object", "properties", Map.of()),
+                    true,
+                    true,
+                    false,
+                    null,
+                    false,
+                    false);
+            this.decision = decision;
+            this.result = result;
+        }
+
+        @Override
+        public Mono<PermissionDecision> checkPermissions(
+                Map<String, Object> input, PermissionContextState context) {
+            return Mono.just(decision);
+        }
+
+        @Override
+        public Mono<ToolResultBlock> callAsync(ToolCallParam param) {
+            return result;
         }
     }
 

--- a/agentscope-core/src/test/java/io/agentscope/core/agent/ReActAgentCallFailurePersistenceTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/agent/ReActAgentCallFailurePersistenceTest.java
@@ -23,27 +23,47 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.agentscope.core.ReActAgent;
+import io.agentscope.core.event.AgentEvent;
 import io.agentscope.core.message.ContentBlock;
 import io.agentscope.core.message.Msg;
 import io.agentscope.core.message.MsgRole;
 import io.agentscope.core.message.TextBlock;
+import io.agentscope.core.message.ToolCallState;
+import io.agentscope.core.message.ToolResultBlock;
 import io.agentscope.core.message.ToolUseBlock;
+import io.agentscope.core.middleware.ActingInput;
+import io.agentscope.core.middleware.MiddlewareBase;
 import io.agentscope.core.model.ChatModelBase;
 import io.agentscope.core.model.ChatResponse;
 import io.agentscope.core.model.GenerateOptions;
 import io.agentscope.core.model.ToolSchema;
+import io.agentscope.core.permission.PermissionContextState;
+import io.agentscope.core.permission.PermissionDecision;
 import io.agentscope.core.state.AgentState;
 import io.agentscope.core.state.InMemoryAgentStateStore;
 import io.agentscope.core.state.State;
+import io.agentscope.core.tool.ToolBase;
+import io.agentscope.core.tool.ToolCallParam;
+import io.agentscope.core.tool.Toolkit;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import reactor.core.Disposable;
 import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 
-/** Regression tests for durable conversation state when a model stream fails. */
-@DisplayName("ReActAgent failed-call persistence")
+/** Regression tests for durable conversation state after abnormal call termination. */
+@DisplayName("ReActAgent abnormal-call persistence")
 class ReActAgentCallFailurePersistenceTest {
 
     private static final RuntimeContext CONTEXT =
@@ -241,6 +261,213 @@ class ReActAgentCallFailurePersistenceTest {
         assertEquals(List.of("empty native request"), textContents(persisted.getContext()));
     }
 
+    @ParameterizedTest(name = "structured={0}, native={1}")
+    @CsvSource({"false, false", "true, false", "true, true"})
+    @DisplayName("cancelled calls persist only safe conversation state")
+    void cancelledCallPersistsOnlySafeConversationState(
+            boolean structuredOutput, boolean nativeStructuredOutput) throws Exception {
+        InMemoryAgentStateStore store = new InMemoryAgentStateStore();
+        CountDownLatch responseEmitted = new CountDownLatch(1);
+        ReActAgent agent =
+                agent(new NeverCompletingModel(responseEmitted, nativeStructuredOutput), store);
+
+        Disposable subscription =
+                structuredOutput
+                        ? agent.call(
+                                        List.of(userMsg("original question")),
+                                        StructuredReply.class,
+                                        CONTEXT)
+                                .subscribe()
+                        : agent.call(List.of(userMsg("original question")), CONTEXT).subscribe();
+        try {
+            assertTrue(responseEmitted.await(5, TimeUnit.SECONDS));
+        } finally {
+            subscription.dispose();
+        }
+
+        AgentState persisted =
+                store.get("u1", "session-1", "agent_state", AgentState.class).orElseThrow();
+        assertEquals(List.of("original question"), textContents(persisted.getContext()));
+        assertFalse(hasToolUse(persisted));
+    }
+
+    @Test
+    @DisplayName("tool execution is cancelled before state is saved")
+    void cancellationStopsAllowedToolBeforeSavingState() throws Exception {
+        CountDownLatch toolStarted = new CountDownLatch(1);
+        CountDownLatch toolCancelled = new CountDownLatch(1);
+        AtomicBoolean savedBeforeToolCancellation = new AtomicBoolean();
+        AtomicInteger savesAfterToolStarted = new AtomicInteger();
+        InMemoryAgentStateStore store =
+                new InMemoryAgentStateStore() {
+                    @Override
+                    public long saveIfVersion(
+                            String userId,
+                            String sessionId,
+                            String key,
+                            State value,
+                            long expectedVersion) {
+                        if (toolStarted.getCount() == 0) {
+                            savesAfterToolStarted.incrementAndGet();
+                            if (toolCancelled.getCount() != 0) {
+                                savedBeforeToolCancellation.set(true);
+                            }
+                        }
+                        return super.saveIfVersion(userId, sessionId, key, value, expectedVersion);
+                    }
+                };
+        Toolkit toolkit = new Toolkit();
+        toolkit.registerAgentTool(
+                new TestTool(
+                        PermissionDecision.allow("allowed"),
+                        Mono.<ToolResultBlock>never()
+                                .doOnSubscribe(ignored -> toolStarted.countDown())
+                                .doOnCancel(toolCancelled::countDown)));
+        ReActAgent agent =
+                ReActAgent.builder()
+                        .name("asst")
+                        .sysPrompt("system prompt")
+                        .model(new FixedResponseModel(incompleteResponse()))
+                        .toolkit(toolkit)
+                        .stateStore(store)
+                        .build();
+
+        Disposable subscription =
+                agent.call(List.of(userMsg("original question")), CONTEXT).subscribe();
+        try {
+            assertTrue(toolStarted.await(5, TimeUnit.SECONDS));
+            assertEquals(
+                    ToolCallState.ALLOWED,
+                    onlyToolUse(agent.getAgentState("u1", "session-1")).getState());
+        } finally {
+            subscription.dispose();
+        }
+
+        assertTrue(toolCancelled.await(5, TimeUnit.SECONDS));
+        assertFalse(savedBeforeToolCancellation.get());
+        assertEquals(1, savesAfterToolStarted.get());
+        AgentState persisted =
+                store.get("u1", "session-1", "agent_state", AgentState.class).orElseThrow();
+        assertEquals(
+                List.of("original question", "incomplete answer"),
+                textContents(persisted.getContext()));
+        assertFalse(hasToolUse(persisted));
+    }
+
+    @Test
+    @DisplayName("cancelling an in-flight normal save does not start a second save")
+    void cancellationDuringNormalSaveDoesNotDoubleWrite() throws Exception {
+        AtomicBoolean responseProduced = new AtomicBoolean();
+        AtomicInteger savesAfterResponse = new AtomicInteger();
+        CountDownLatch saveStarted = new CountDownLatch(1);
+        CountDownLatch releaseSave = new CountDownLatch(1);
+        CountDownLatch saveFinished = new CountDownLatch(1);
+        InMemoryAgentStateStore store =
+                new InMemoryAgentStateStore() {
+                    @Override
+                    public long saveIfVersion(
+                            String userId,
+                            String sessionId,
+                            String key,
+                            State value,
+                            long expectedVersion) {
+                        int saveNumber =
+                                responseProduced.get() ? savesAfterResponse.incrementAndGet() : 0;
+                        if (saveNumber == 1) {
+                            saveStarted.countDown();
+                            awaitUninterruptibly(releaseSave);
+                        }
+                        try {
+                            return super.saveIfVersion(
+                                    userId, sessionId, key, value, expectedVersion);
+                        } finally {
+                            if (saveNumber == 1) {
+                                saveFinished.countDown();
+                            }
+                        }
+                    }
+                };
+        ReActAgent agent =
+                agent(
+                        new FixedResponseModel(
+                                textResponse("done"), () -> responseProduced.set(true)),
+                        store);
+
+        Disposable subscription =
+                agent.call(List.of(userMsg("original question")), CONTEXT).subscribe();
+        try {
+            assertTrue(saveStarted.await(5, TimeUnit.SECONDS));
+            subscription.dispose();
+            assertEquals(1, savesAfterResponse.get());
+        } finally {
+            subscription.dispose();
+            releaseSave.countDown();
+        }
+        assertTrue(saveFinished.await(5, TimeUnit.SECONDS));
+        assertEquals(1, savesAfterResponse.get());
+    }
+
+    @Test
+    @DisplayName("acting failures do not persist tool calls without results")
+    void actingFailureDropsUncommittedToolCall() {
+        InMemoryAgentStateStore store = new InMemoryAgentStateStore();
+        ReActAgent agent =
+                ReActAgent.builder()
+                        .name("asst")
+                        .sysPrompt("system prompt")
+                        .model(new FixedResponseModel(incompleteResponse()))
+                        .middleware(new FailingActingMiddleware())
+                        .stateStore(store)
+                        .build();
+
+        IllegalStateException thrown =
+                assertThrows(
+                        IllegalStateException.class,
+                        () -> agent.call(List.of(userMsg("original question")), CONTEXT).block());
+
+        assertEquals("acting failed", thrown.getMessage());
+        AgentState persisted =
+                store.get("u1", "session-1", "agent_state", AgentState.class).orElseThrow();
+        assertEquals(
+                List.of("original question", "incomplete answer"),
+                textContents(persisted.getContext()));
+        assertFalse(hasToolUse(persisted));
+    }
+
+    @ParameterizedTest(name = "permissionAsking={0}")
+    @ValueSource(booleans = {false, true})
+    @DisplayName("post-acting failures remove ALLOWED calls but preserve ASKING calls")
+    void postActingFailureKeepsOnlyResumableToolCalls(boolean permissionAsking) {
+        InMemoryAgentStateStore store = new InMemoryAgentStateStore();
+        Toolkit toolkit = new Toolkit();
+        PermissionDecision decision =
+                permissionAsking
+                        ? PermissionDecision.ask("confirmation required")
+                        : PermissionDecision.allow("allowed");
+        toolkit.registerAgentTool(new TestTool(decision, Mono.just(ToolResultBlock.text("done"))));
+        ReActAgent agent =
+                ReActAgent.builder()
+                        .name("asst")
+                        .sysPrompt("system prompt")
+                        .model(new FixedResponseModel(incompleteResponse()))
+                        .toolkit(toolkit)
+                        .middleware(new FailAfterActingMiddleware())
+                        .stateStore(store)
+                        .build();
+
+        assertThrows(
+                IllegalStateException.class,
+                () -> agent.call(List.of(userMsg("original question")), CONTEXT).block());
+
+        AgentState persisted =
+                store.get("u1", "session-1", "agent_state", AgentState.class).orElseThrow();
+        if (permissionAsking) {
+            assertEquals(ToolCallState.ASKING, onlyToolUse(persisted).getState());
+        } else {
+            assertFalse(hasToolUse(persisted));
+        }
+    }
+
     private static ReActAgent agent(ChatModelBase model, InMemoryAgentStateStore store) {
         return ReActAgent.builder()
                 .name("asst")
@@ -287,6 +514,36 @@ class ReActAgentCallFailurePersistenceTest {
             }
         }
         return result;
+    }
+
+    private static boolean hasToolUse(AgentState state) {
+        return state.getContext().stream()
+                .flatMap(message -> message.getContentBlocks(ToolUseBlock.class).stream())
+                .findAny()
+                .isPresent();
+    }
+
+    private static ToolUseBlock onlyToolUse(AgentState state) {
+        List<ToolUseBlock> toolUses =
+                state.getContext().stream()
+                        .flatMap(message -> message.getContentBlocks(ToolUseBlock.class).stream())
+                        .toList();
+        assertEquals(1, toolUses.size());
+        return toolUses.get(0);
+    }
+
+    private static void awaitUninterruptibly(CountDownLatch latch) {
+        boolean interrupted = false;
+        while (latch.getCount() != 0) {
+            try {
+                latch.await();
+            } catch (InterruptedException ignored) {
+                interrupted = true;
+            }
+        }
+        if (interrupted) {
+            Thread.currentThread().interrupt();
+        }
     }
 
     private static final class AlwaysFailingModel extends ChatModelBase {
@@ -378,6 +635,115 @@ class ReActAgentCallFailurePersistenceTest {
         protected Flux<ChatResponse> doStream(
                 List<Msg> messages, List<ToolSchema> tools, GenerateOptions options) {
             return Flux.just(ChatResponse.builder().content(List.of()).build());
+        }
+    }
+
+    private static final class NeverCompletingModel extends ChatModelBase {
+        private final CountDownLatch responseEmitted;
+        private final boolean nativeStructuredOutput;
+
+        private NeverCompletingModel(
+                CountDownLatch responseEmitted, boolean nativeStructuredOutput) {
+            this.responseEmitted = responseEmitted;
+            this.nativeStructuredOutput = nativeStructuredOutput;
+        }
+
+        @Override
+        public String getModelName() {
+            return "never-completing";
+        }
+
+        @Override
+        protected Flux<ChatResponse> doStream(
+                List<Msg> messages, List<ToolSchema> tools, GenerateOptions options) {
+            return Flux.just(incompleteResponse())
+                    .doOnComplete(responseEmitted::countDown)
+                    .concatWith(Flux.never());
+        }
+
+        @Override
+        public boolean supportsNativeStructuredOutput() {
+            return nativeStructuredOutput;
+        }
+    }
+
+    private static final class FixedResponseModel extends ChatModelBase {
+        private final ChatResponse response;
+        private final Runnable beforeStream;
+
+        private FixedResponseModel(ChatResponse response) {
+            this(response, () -> {});
+        }
+
+        private FixedResponseModel(ChatResponse response, Runnable beforeStream) {
+            this.response = response;
+            this.beforeStream = beforeStream;
+        }
+
+        @Override
+        public String getModelName() {
+            return "fixed-response";
+        }
+
+        @Override
+        protected Flux<ChatResponse> doStream(
+                List<Msg> messages, List<ToolSchema> tools, GenerateOptions options) {
+            beforeStream.run();
+            return Flux.just(response);
+        }
+    }
+
+    private static final class FailingActingMiddleware implements MiddlewareBase {
+        @Override
+        public Flux<AgentEvent> onActing(
+                Agent agent,
+                RuntimeContext ctx,
+                ActingInput input,
+                Function<ActingInput, Flux<AgentEvent>> next) {
+            return Flux.error(new IllegalStateException("acting failed"));
+        }
+    }
+
+    private static final class FailAfterActingMiddleware implements MiddlewareBase {
+        @Override
+        public Flux<AgentEvent> onActing(
+                Agent agent,
+                RuntimeContext ctx,
+                ActingInput input,
+                Function<ActingInput, Flux<AgentEvent>> next) {
+            return next.apply(input)
+                    .concatWith(Flux.error(new IllegalStateException("post-acting failed")));
+        }
+    }
+
+    private static final class TestTool extends ToolBase {
+        private final PermissionDecision decision;
+        private final Mono<ToolResultBlock> result;
+
+        private TestTool(PermissionDecision decision, Mono<ToolResultBlock> result) {
+            super(
+                    "unfinished_tool",
+                    "test tool",
+                    Map.of("type", "object", "properties", Map.of()),
+                    true,
+                    true,
+                    false,
+                    null,
+                    false,
+                    false);
+            this.decision = decision;
+            this.result = result;
+        }
+
+        @Override
+        public Mono<PermissionDecision> checkPermissions(
+                Map<String, Object> input, PermissionContextState context) {
+            return Mono.just(decision);
+        }
+
+        @Override
+        public Mono<ToolResultBlock> callAsync(ToolCallParam param) {
+            return result;
         }
     }
 


### PR DESCRIPTION
## AgentScope-Java Version

2.0.3-SNAPSHOT

## Description

### 背景

#2799 已在模型调用报错时保存安全的对话状态，但 Reactor cancellation 不会进入异常处理，因此取消普通或 structured-output 调用时，本轮用户输入仍可能丢失。

另外，如果 reasoning 已经提交了 tool call，而 acting 或 middleware 在写入 tool result 前报错，直接保存会留下没有结果的 `PENDING` tool call。

本 PR 是 #2713 基于 #2799 的精简后续，只补充上述两个场景。

### 改动

- 普通、native structured-output 和 fallback structured-output 调用被取消时，先向上游传播 cancel，再尽力保存当前安全状态。
- 复用 #2799 的报错保存流程；异常保存前删除本轮没有结果的 `PENDING`/`ALLOWED` tool call，保留可恢复的 `ASKING`。
- 不保存未完成的 assistant 流式片段，不修改 public API 或 Session schema。

### 测试

- `mvn -pl agentscope-core -Dtest=ReActAgentCallFailurePersistenceTest test`
- `mvn -pl agentscope-core test`

2302 tests passed，8 skipped。

## Checklist

- [x] Code has been formatted with `mvn spotless:apply`
- [x] All tests are passing (`mvn test`)
- [x] Javadoc comments are complete and follow project conventions
- [x] Related documentation has been updated (no documentation change required)
- [x] Code is ready for review
