### PR TITLE
refactor(agui): 下沉 AguiRuntimeContextRequest / AguiRuntimeContextResolver / AguiRequestBodyParser 到 extensions-agui 协议层

### DIFF
--- a/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/main/java/io/agentscope/core/agui/processor/AguiRequestProcessor.java
+++ b/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/main/java/io/agentscope/core/agui/processor/AguiRequestProcessor.java
@@ -24,6 +24,8 @@ import io.agentscope.core.agui.adapter.AguiAgentAdapterFactory;
 import io.agentscope.core.agui.event.AguiEvent;
 import io.agentscope.core.agui.model.AguiMessage;
 import io.agentscope.core.agui.model.RunAgentInput;
+import io.agentscope.core.agui.runtime.AguiRuntimeContextRequest;
+import io.agentscope.core.agui.runtime.AguiRuntimeContextResolver;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -53,9 +55,11 @@ import reactor.core.publisher.Flux;
  *     .config(AguiAdapterConfig.defaultConfig())
  *     .build();
  *
- * ProcessResult result = processor.process(input, headerAgentId, pathAgentId);
+ * AguiRuntimeContextRequest<?> request = AguiRuntimeContextRequest.builder()
+ *         .input(input)
+ *         .build();
+ * ProcessResult result = processor.process(request);
  * Flux<AguiEvent> events = result.events();
- * Agent agent = result.agent(); // For interrupt handling
  * }</pre>
  */
 public class AguiRequestProcessor {
@@ -66,6 +70,7 @@ public class AguiRequestProcessor {
     private final AguiAdapterConfig config;
     private final AguiAgentAdapterFactory adapterFactory;
     private final AguiResumeCoordinator resumeCoordinator;
+    private final AguiRuntimeContextResolver runtimeContextResolver;
 
     private AguiRequestProcessor(Builder builder) {
         this.agentResolver =
@@ -76,6 +81,7 @@ public class AguiRequestProcessor {
                         ? builder.adapterFactory
                         : AguiAgentAdapterFactory.defaultFactory();
         this.resumeCoordinator = new AguiResumeCoordinator();
+        this.runtimeContextResolver = builder.runtimeContextResolver;
     }
 
     /**
@@ -85,8 +91,10 @@ public class AguiRequestProcessor {
      *
      * @param agent The resolved agent instance
      * @param events The event stream
+     * @param runtimeContext The resolved caller-provided runtime context, may be null
      */
-    public record ProcessResult(Agent agent, Flux<AguiEvent> events) {
+    public record ProcessResult(
+            Agent agent, Flux<AguiEvent> events, RuntimeContext runtimeContext) {
 
         /**
          * Interrupt this request's active session.
@@ -97,9 +105,8 @@ public class AguiRequestProcessor {
          * session.
          *
          * @param threadId The AG-UI thread id for this request
-         * @param runtimeContext The caller-provided runtime context, may be null
          */
-        public void interrupt(String threadId, RuntimeContext runtimeContext) {
+        public void interrupt(String threadId) {
             if (agent instanceof ReActAgent reActAgent) {
                 RuntimeContext interruptContext =
                         RuntimeContext.builder(runtimeContext).sessionId(threadId).build();
@@ -113,32 +120,22 @@ public class AguiRequestProcessor {
     /**
      * Process an AG-UI request and return the result containing agent and event stream.
      *
-     * @param input The run agent input
-     * @param headerAgentId The agent ID from HTTP header (may be null)
-     * @param pathAgentId The agent ID from URL path variable (may be null)
+     * <p>The {@link AguiRuntimeContextResolver} (if configured on this processor) is invoked with
+     * the given request to obtain a caller-provided {@link RuntimeContext}. That context is copied
+     * and enriched by {@link AguiAgentAdapter}, so callers can provide custom attributes without
+     * replacing the standard AG-UI metadata.
+     *
+     * @param request The AG-UI request context carrying input, agent IDs, transport details and the
+     *     native request
      * @return A ProcessResult containing the agent and event stream
      */
-    public ProcessResult process(RunAgentInput input, String headerAgentId, String pathAgentId) {
-        return process(input, headerAgentId, pathAgentId, null);
-    }
+    public ProcessResult process(AguiRuntimeContextRequest<?> request) {
+        RunAgentInput input = request.getInput();
+        String headerAgentId = request.getHeaderAgentId();
+        String pathAgentId = request.getPathAgentId();
+        RuntimeContext runtimeContext =
+                runtimeContextResolver != null ? runtimeContextResolver.resolve(request) : null;
 
-    /**
-     * Process an AG-UI request with caller-provided runtime context and return the result.
-     *
-     * <p>The runtime context is copied and enriched by {@link AguiAgentAdapter}; callers can
-     * provide custom attributes without replacing the standard AG-UI metadata.
-     *
-     * @param input The run agent input
-     * @param headerAgentId The agent ID from HTTP header (may be null)
-     * @param pathAgentId The agent ID from URL path variable (may be null)
-     * @param runtimeContext Optional caller-provided runtime context
-     * @return A ProcessResult containing the agent and event stream
-     */
-    public ProcessResult process(
-            RunAgentInput input,
-            String headerAgentId,
-            String pathAgentId,
-            RuntimeContext runtimeContext) {
         String threadId = input.getThreadId();
         String runId = input.getRunId();
 
@@ -203,7 +200,7 @@ public class AguiRequestProcessor {
                                 return processorErrorEvents(input, error);
                             }
                         });
-        return new ProcessResult(agent, events);
+        return new ProcessResult(agent, events, runtimeContext);
     }
 
     private Flux<AguiEvent> processorErrorEvents(RunAgentInput input, Throwable error) {
@@ -344,6 +341,7 @@ public class AguiRequestProcessor {
         private AgentResolver agentResolver;
         private AguiAdapterConfig config;
         private AguiAgentAdapterFactory adapterFactory;
+        private AguiRuntimeContextResolver runtimeContextResolver;
 
         /**
          * Set the agent resolver.
@@ -375,6 +373,18 @@ public class AguiRequestProcessor {
          */
         public Builder adapterFactory(AguiAgentAdapterFactory adapterFactory) {
             this.adapterFactory = adapterFactory;
+            return this;
+        }
+
+        /**
+         * Set the runtime context resolver invoked for each request to produce a caller-provided
+         * {@link RuntimeContext}. Optional; when null, no caller context is attached.
+         *
+         * @param runtimeContextResolver The resolver used for each request
+         * @return This builder
+         */
+        public Builder runtimeContextResolver(AguiRuntimeContextResolver runtimeContextResolver) {
+            this.runtimeContextResolver = runtimeContextResolver;
             return this;
         }
 

--- a/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/main/java/io/agentscope/core/agui/runtime/AguiRequestBodyParser.java
+++ b/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/main/java/io/agentscope/core/agui/runtime/AguiRequestBodyParser.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.agentscope.spring.boot.agui.common;
+package io.agentscope.core.agui.runtime;
 
 import io.agentscope.core.agui.model.RunAgentInput;
 import io.agentscope.core.util.JsonUtils;
@@ -25,10 +25,12 @@ import java.util.Objects;
  * <p>The default AgentScope codec is Jackson 2. Keeping this conversion at the AG-UI boundary
  * avoids selecting Spring Boot 4's Jackson 3 codec for AG-UI's Jackson 2-annotated models, while
  * leaving the application's other HTTP converters unchanged.
+ *
+ * <p>The Spring Boot starter exposes this type as a bean and provides a default instance via
+ * {@code @ConditionalOnMissingBean}. Applications can register their own {@code
+ * AguiRequestBodyParser} bean to customize request body conversion.
  */
-public final class AguiRequestBodyParser {
-
-    private AguiRequestBodyParser() {}
+public class AguiRequestBodyParser {
 
     /**
      * Parses a JSON request body into {@link RunAgentInput}.
@@ -36,7 +38,7 @@ public final class AguiRequestBodyParser {
      * @param body the raw JSON request body
      * @return the parsed AG-UI input
      */
-    public static RunAgentInput parse(String body) {
+    public RunAgentInput parse(String body) {
         Objects.requireNonNull(body, "body cannot be null");
         return JsonUtils.getJsonCodec().fromJson(body, RunAgentInput.class);
     }

--- a/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/main/java/io/agentscope/core/agui/runtime/AguiRuntimeContextRequest.java
+++ b/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/main/java/io/agentscope/core/agui/runtime/AguiRuntimeContextRequest.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.agentscope.spring.boot.agui.common;
+package io.agentscope.core.agui.runtime;
 
 import io.agentscope.core.agui.model.RunAgentInput;
 import java.util.ArrayList;
@@ -26,8 +26,12 @@ import java.util.Objects;
 /**
  * Request-scoped data available when resolving an AG-UI {@link
  * io.agentscope.core.agent.RuntimeContext}.
+ *
+ * @param <T> the native request type (e.g. {@code HttpServletRequest} under Spring MVC,
+ *            {@code ServerRequest} under WebFlux, or {@code Object} when there is no
+ *            transport-specific native request)
  */
-public final class AguiRuntimeContextRequest {
+public final class AguiRuntimeContextRequest<T> {
 
     /** Transport that received the AG-UI request. */
     public enum Transport {
@@ -44,9 +48,9 @@ public final class AguiRuntimeContextRequest {
     private final String path;
     private final Map<String, List<String>> headers;
     private final Map<String, List<String>> queryParams;
-    private final Object nativeRequest;
+    private final T nativeRequest;
 
-    private AguiRuntimeContextRequest(Builder builder) {
+    private AguiRuntimeContextRequest(Builder<T> builder) {
         this.input = Objects.requireNonNull(builder.input, "input cannot be null");
         this.headerAgentId = builder.headerAgentId;
         this.pathAgentId = builder.pathAgentId;
@@ -98,19 +102,12 @@ public final class AguiRuntimeContextRequest {
         return firstValue(queryParams, name, false);
     }
 
-    public Object getNativeRequest() {
+    public T getNativeRequest() {
         return nativeRequest;
     }
 
-    public <T> T getNativeRequest(Class<T> type) {
-        if (type == null || !type.isInstance(nativeRequest)) {
-            return null;
-        }
-        return type.cast(nativeRequest);
-    }
-
-    public static Builder builder() {
-        return new Builder();
+    public static <T> Builder<T> builder() {
+        return new Builder<>();
     }
 
     private static String firstValue(
@@ -146,7 +143,7 @@ public final class AguiRuntimeContextRequest {
     }
 
     /** Builder for {@link AguiRuntimeContextRequest}. */
-    public static final class Builder {
+    public static final class Builder<T> {
 
         private RunAgentInput input;
         private String headerAgentId;
@@ -156,55 +153,55 @@ public final class AguiRuntimeContextRequest {
         private String path;
         private Map<String, List<String>> headers;
         private Map<String, List<String>> queryParams;
-        private Object nativeRequest;
+        private T nativeRequest;
 
-        public Builder input(RunAgentInput input) {
+        public Builder<T> input(RunAgentInput input) {
             this.input = input;
             return this;
         }
 
-        public Builder headerAgentId(String headerAgentId) {
+        public Builder<T> headerAgentId(String headerAgentId) {
             this.headerAgentId = headerAgentId;
             return this;
         }
 
-        public Builder pathAgentId(String pathAgentId) {
+        public Builder<T> pathAgentId(String pathAgentId) {
             this.pathAgentId = pathAgentId;
             return this;
         }
 
-        public Builder transport(Transport transport) {
+        public Builder<T> transport(Transport transport) {
             this.transport = transport;
             return this;
         }
 
-        public Builder method(String method) {
+        public Builder<T> method(String method) {
             this.method = method;
             return this;
         }
 
-        public Builder path(String path) {
+        public Builder<T> path(String path) {
             this.path = path;
             return this;
         }
 
-        public Builder headers(Map<String, List<String>> headers) {
+        public Builder<T> headers(Map<String, List<String>> headers) {
             this.headers = headers;
             return this;
         }
 
-        public Builder queryParams(Map<String, List<String>> queryParams) {
+        public Builder<T> queryParams(Map<String, List<String>> queryParams) {
             this.queryParams = queryParams;
             return this;
         }
 
-        public Builder nativeRequest(Object nativeRequest) {
+        public Builder<T> nativeRequest(T nativeRequest) {
             this.nativeRequest = nativeRequest;
             return this;
         }
 
-        public AguiRuntimeContextRequest build() {
-            return new AguiRuntimeContextRequest(this);
+        public AguiRuntimeContextRequest<T> build() {
+            return new AguiRuntimeContextRequest<>(this);
         }
     }
 }

--- a/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/main/java/io/agentscope/core/agui/runtime/AguiRuntimeContextResolver.java
+++ b/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/main/java/io/agentscope/core/agui/runtime/AguiRuntimeContextResolver.java
@@ -13,16 +13,22 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.agentscope.spring.boot.agui.common;
+package io.agentscope.core.agui.runtime;
 
 import io.agentscope.core.agent.RuntimeContext;
 
 /**
  * Resolves a caller-provided {@link RuntimeContext} for an AG-UI request.
  *
- * <p>Spring applications can expose this as a bean to attach request-scoped values such as tenant
- * information, tracing data, or tool dependencies. The AG-UI runtime metadata is still supplied by
- * the protocol adapter and takes precedence over conflicting values.
+ * <p>Applications can expose this as a bean (or pass it programmatically to
+ * {@link io.agentscope.core.agui.processor.AguiRequestProcessor}) to attach request-scoped values
+ * such as tenant information, tracing data, or tool dependencies. The AG-UI runtime metadata is
+ * still supplied by the protocol adapter and takes precedence over conflicting values.
+ *
+ * <p>The native request type is transport-specific, so the request parameter uses a wildcard
+ * ({@code <?>}). Implementations that need the native request can obtain it via
+ * {@code request.getNativeRequest()} (returned as the captured type) and narrow it with
+ * {@code instanceof}.
  */
 @FunctionalInterface
 public interface AguiRuntimeContextResolver {
@@ -33,5 +39,5 @@ public interface AguiRuntimeContextResolver {
      * @param request The AG-UI request context
      * @return A runtime context to merge into the AG-UI run, or null
      */
-    RuntimeContext resolve(AguiRuntimeContextRequest request);
+    RuntimeContext resolve(AguiRuntimeContextRequest<?> request);
 }

--- a/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/test/java/io/agentscope/core/agui/processor/AguiRequestProcessorTest.java
+++ b/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/test/java/io/agentscope/core/agui/processor/AguiRequestProcessorTest.java
@@ -35,6 +35,7 @@ import io.agentscope.core.agui.event.AguiEventType;
 import io.agentscope.core.agui.model.AguiMessage;
 import io.agentscope.core.agui.model.AguiResume;
 import io.agentscope.core.agui.model.RunAgentInput;
+import io.agentscope.core.agui.runtime.AguiRuntimeContextRequest;
 import io.agentscope.core.event.AgentEndEvent;
 import io.agentscope.core.message.Msg;
 import io.agentscope.core.message.ToolResultBlock;
@@ -103,9 +104,12 @@ class AguiRequestProcessorTest {
                         .messages(List.of(AguiMessage.userMessage("msg-1", "hello")))
                         .build();
         AguiRequestProcessor processor =
-                AguiRequestProcessor.builder().agentResolver(resolver).build();
+                AguiRequestProcessor.builder()
+                        .agentResolver(resolver)
+                        .runtimeContextResolver(request -> callerContext)
+                        .build();
 
-        processor.process(input, null, null, callerContext).events().collectList().block();
+        processor.process(request(input)).events().collectList().block();
 
         RuntimeContext context = contextCaptor.getValue();
         assertEquals("thread-1", context.getSessionId());
@@ -136,7 +140,7 @@ class AguiRequestProcessorTest {
                                                 : new AguiAgentAdapter(resolvedAgent, config))
                         .build();
 
-        processor.process(input("run-1"), null, null).events().collectList().block();
+        processor.process(request(input("run-1"))).events().collectList().block();
         RunAgentInput resumeInput =
                 RunAgentInput.builder()
                         .threadId("thread-1")
@@ -149,7 +153,7 @@ class AguiRequestProcessorTest {
                                                 Map.of("approved", true))))
                         .build();
 
-        processor.process(resumeInput, null, null).events().collectList().block();
+        processor.process(request(resumeInput)).events().collectList().block();
 
         ToolResultBlock result =
                 msgsCaptor.getValue().get(0).getFirstContentBlock(ToolResultBlock.class);
@@ -173,20 +177,19 @@ class AguiRequestProcessorTest {
                                 })
                         .build();
 
-        processor.process(input("run-1"), null, null).events().collectList().block();
+        processor.process(request(input("run-1"))).events().collectList().block();
         List<AguiEvent> events =
                 processor
                         .process(
-                                RunAgentInput.builder()
-                                        .threadId("thread-1")
-                                        .runId("run-2")
-                                        .messages(
-                                                List.of(
-                                                        AguiMessage.userMessage(
-                                                                "msg-2", "new input")))
-                                        .build(),
-                                null,
-                                null)
+                                request(
+                                        RunAgentInput.builder()
+                                                .threadId("thread-1")
+                                                .runId("run-2")
+                                                .messages(
+                                                        List.of(
+                                                                AguiMessage.userMessage(
+                                                                        "msg-2", "new input")))
+                                                .build()))
                         .events()
                         .collectList()
                         .block();
@@ -211,10 +214,10 @@ class AguiRequestProcessorTest {
                                 })
                         .build();
 
-        Disposable activeRun = processor.process(input("run-1"), null, null).events().subscribe();
+        Disposable activeRun = processor.process(request(input("run-1"))).events().subscribe();
         try {
             List<AguiEvent> rejectedEvents =
-                    processor.process(input("run-2"), null, null).events().collectList().block();
+                    processor.process(request(input("run-2"))).events().collectList().block();
 
             assertEquals(1, adapterCount.get());
             assertResumeContractErrorLifecycle(rejectedEvents);
@@ -222,7 +225,7 @@ class AguiRequestProcessorTest {
             activeRun.dispose();
         }
 
-        Disposable nextRun = processor.process(input("run-3"), null, null).events().subscribe();
+        Disposable nextRun = processor.process(request(input("run-3"))).events().subscribe();
         try {
             assertEquals(2, adapterCount.get());
         } finally {
@@ -239,8 +242,8 @@ class AguiRequestProcessorTest {
         AguiRequestProcessor processor =
                 AguiRequestProcessor.builder().agentResolver(resolver).build();
 
-        processor.process(input("run-1"), null, null);
-        processor.process(input("run-2"), null, null).events().collectList().block();
+        processor.process(request(input("run-1")));
+        processor.process(request(input("run-2"))).events().collectList().block();
 
         verify(agent, times(1)).streamEvents(anyList(), any(RuntimeContext.class));
     }
@@ -255,7 +258,7 @@ class AguiRequestProcessorTest {
                 AguiRequestProcessor.builder()
                         .agentResolver(resolver)
                         .build()
-                        .process(input("run-1"), null, null);
+                        .process(request(input("run-1")));
 
         result.events().collectList().block();
         result.events().collectList().block();
@@ -283,9 +286,9 @@ class AguiRequestProcessorTest {
                         .build();
 
         List<AguiEvent> setupErrorEvents =
-                processor.process(input("run-1"), null, null).events().collectList().block();
+                processor.process(request(input("run-1"))).events().collectList().block();
         List<AguiEvent> nextRunEvents =
-                processor.process(input("run-2"), null, null).events().collectList().block();
+                processor.process(request(input("run-2"))).events().collectList().block();
 
         assertProcessorErrorLifecycle(
                 setupErrorEvents, "adapter setup failed", "INVALID_INPUT_ERROR");
@@ -311,22 +314,21 @@ class AguiRequestProcessorTest {
                                                         interrupt("interrupt-2", "tool-call-2"))))
                         .build();
 
-        processor.process(input("run-1"), null, null).events().collectList().block();
+        processor.process(request(input("run-1"))).events().collectList().block();
         List<AguiEvent> events =
                 processor
                         .process(
-                                RunAgentInput.builder()
-                                        .threadId("thread-1")
-                                        .runId("run-2")
-                                        .resume(
-                                                List.of(
-                                                        new AguiResume(
-                                                                "interrupt-1",
-                                                                AguiResume.STATUS_RESOLVED,
-                                                                Map.of("approved", true))))
-                                        .build(),
-                                null,
-                                null)
+                                request(
+                                        RunAgentInput.builder()
+                                                .threadId("thread-1")
+                                                .runId("run-2")
+                                                .resume(
+                                                        List.of(
+                                                                new AguiResume(
+                                                                        "interrupt-1",
+                                                                        AguiResume.STATUS_RESOLVED,
+                                                                        Map.of("approved", true))))
+                                                .build()))
                         .events()
                         .collectList()
                         .block();
@@ -345,22 +347,21 @@ class AguiRequestProcessorTest {
                         .adapterFactory(InterruptingAdapter::new)
                         .build();
 
-        processor.process(input("run-1"), null, null).events().collectList().block();
+        processor.process(request(input("run-1"))).events().collectList().block();
         List<AguiEvent> events =
                 processor
                         .process(
-                                RunAgentInput.builder()
-                                        .threadId("thread-1")
-                                        .runId("run-2")
-                                        .resume(
-                                                List.of(
-                                                        new AguiResume(
-                                                                "interrupt-from-server",
-                                                                "accepted",
-                                                                Map.of("approved", true))))
-                                        .build(),
-                                null,
-                                null)
+                                request(
+                                        RunAgentInput.builder()
+                                                .threadId("thread-1")
+                                                .runId("run-2")
+                                                .resume(
+                                                        List.of(
+                                                                new AguiResume(
+                                                                        "interrupt-from-server",
+                                                                        "accepted",
+                                                                        Map.of("approved", true))))
+                                                .build()))
                         .events()
                         .collectList()
                         .block();
@@ -396,25 +397,24 @@ class AguiRequestProcessorTest {
                                                 : new AguiAgentAdapter(resolvedAgent, config))
                         .build();
 
-        processor.process(input("run-1"), null, null).events().collectList().block();
+        processor.process(request(input("run-1"))).events().collectList().block();
         processor
                 .process(
-                        RunAgentInput.builder()
-                                .threadId("thread-1")
-                                .runId("run-2")
-                                .resume(
-                                        List.of(
-                                                new AguiResume(
-                                                        "interrupt-1",
-                                                        AguiResume.STATUS_RESOLVED,
-                                                        Map.of("approved", true)),
-                                                new AguiResume(
-                                                        "interrupt-2",
-                                                        AguiResume.STATUS_CANCELLED,
-                                                        null)))
-                                .build(),
-                        null,
-                        null)
+                        request(
+                                RunAgentInput.builder()
+                                        .threadId("thread-1")
+                                        .runId("run-2")
+                                        .resume(
+                                                List.of(
+                                                        new AguiResume(
+                                                                "interrupt-1",
+                                                                AguiResume.STATUS_RESOLVED,
+                                                                Map.of("approved", true)),
+                                                        new AguiResume(
+                                                                "interrupt-2",
+                                                                AguiResume.STATUS_CANCELLED,
+                                                                null)))
+                                        .build()))
                 .events()
                 .collectList()
                 .block();
@@ -446,7 +446,7 @@ class AguiRequestProcessorTest {
                         .build();
 
         List<AguiEvent> events =
-                processor.process(resumeInput, null, null).events().collectList().block();
+                processor.process(request(resumeInput)).events().collectList().block();
 
         assertResumeContractErrorLifecycle(events);
     }
@@ -471,7 +471,7 @@ class AguiRequestProcessorTest {
                         .adapterFactory(CustomAdapter::new)
                         .build();
 
-        processor.process(input, null, null).events().collectList().block();
+        processor.process(request(input)).events().collectList().block();
 
         RuntimeContext context = contextCaptor.getValue();
         assertEquals("custom-adapter", context.get("adapter"));
@@ -565,5 +565,9 @@ class AguiRequestProcessorTest {
                 .runId(runId)
                 .messages(List.of(AguiMessage.userMessage("msg-1", "hello")))
                 .build();
+    }
+
+    private static AguiRuntimeContextRequest<?> request(RunAgentInput runInput) {
+        return AguiRuntimeContextRequest.builder().input(runInput).build();
     }
 }

--- a/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/test/java/io/agentscope/core/agui/runtime/AguiRequestBodyParserTest.java
+++ b/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/test/java/io/agentscope/core/agui/runtime/AguiRequestBodyParserTest.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.agentscope.spring.boot.agui.common;
+package io.agentscope.core.agui.runtime;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
@@ -25,6 +25,8 @@ import io.agentscope.core.agui.model.RunAgentInput;
 import org.junit.jupiter.api.Test;
 
 class AguiRequestBodyParserTest {
+
+    private final AguiRequestBodyParser parser = new AguiRequestBodyParser();
 
     @Test
     void shouldParseTextContentWithAgentScopeCodec() {
@@ -39,7 +41,7 @@ class AguiRequestBodyParserTest {
                 }
                 """;
 
-        RunAgentInput input = AguiRequestBodyParser.parse(body);
+        RunAgentInput input = parser.parse(body);
 
         assertEquals("Hello!", input.getMessages().get(0).getTextContent());
     }
@@ -70,7 +72,7 @@ class AguiRequestBodyParserTest {
                 }
                 """;
 
-        RunAgentInput input = AguiRequestBodyParser.parse(body);
+        RunAgentInput input = parser.parse(body);
         MessageContent.Blocks content =
                 assertInstanceOf(
                         MessageContent.Blocks.class, input.getMessages().get(0).getContent());
@@ -81,6 +83,6 @@ class AguiRequestBodyParserTest {
 
     @Test
     void shouldRejectNullBody() {
-        assertThrows(NullPointerException.class, () -> AguiRequestBodyParser.parse(null));
+        assertThrows(NullPointerException.class, () -> parser.parse(null));
     }
 }

--- a/agentscope-extensions/agentscope-spring-boot-starters/agentscope-agui-spring-boot-starter/src/main/java/io/agentscope/spring/boot/agui/mvc/AgentscopeAguiMvcAutoConfiguration.java
+++ b/agentscope-extensions/agentscope-spring-boot-starters/agentscope-agui-spring-boot-starter/src/main/java/io/agentscope/spring/boot/agui/mvc/AgentscopeAguiMvcAutoConfiguration.java
@@ -21,8 +21,9 @@ import io.agentscope.core.agui.adapter.AguiAgentAdapterFactory;
 import io.agentscope.core.agui.adapter.strategy.AgentEventConverter;
 import io.agentscope.core.agui.adapter.strategy.AguiEventEnricher;
 import io.agentscope.core.agui.registry.AguiAgentRegistry;
+import io.agentscope.core.agui.runtime.AguiRequestBodyParser;
+import io.agentscope.core.agui.runtime.AguiRuntimeContextResolver;
 import io.agentscope.spring.boot.agui.common.AguiProperties;
-import io.agentscope.spring.boot.agui.common.AguiRuntimeContextResolver;
 import io.agentscope.spring.boot.agui.common.ThreadSessionManager;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
@@ -65,6 +66,21 @@ public class AgentscopeAguiMvcAutoConfiguration {
     public ThreadSessionManager threadSessionManager(AguiProperties props) {
         return new ThreadSessionManager(
                 props.getMaxThreadSessions(), props.getSessionTimeoutMinutes());
+    }
+
+    /**
+     * Creates the default AG-UI request body parser bean.
+     *
+     * <p>The parser decodes request bodies with AgentScope's Jackson 2 codec so that Spring Boot
+     * 4's Jackson 3 converters do not touch AG-UI's Jackson 2-annotated models. Applications can
+     * override this bean to customize request body parsing.
+     *
+     * @return A new AguiRequestBodyParser
+     */
+    @Bean
+    @ConditionalOnMissingBean
+    public AguiRequestBodyParser aguiRequestBodyParser() {
+        return new AguiRequestBodyParser();
     }
 
     /**
@@ -122,8 +138,13 @@ public class AgentscopeAguiMvcAutoConfiguration {
     @Bean
     @ConditionalOnMissingBean
     public AguiRestController aguiRestController(
-            AguiMvcController aguiMvcController, AguiProperties props) {
+            AguiMvcController aguiMvcController,
+            AguiProperties props,
+            AguiRequestBodyParser requestBodyParser) {
         return new AguiRestController(
-                aguiMvcController, props.getPathPrefix(), props.isEnablePathRouting());
+                aguiMvcController,
+                props.getPathPrefix(),
+                props.isEnablePathRouting(),
+                requestBodyParser);
     }
 }

--- a/agentscope-extensions/agentscope-spring-boot-starters/agentscope-agui-spring-boot-starter/src/main/java/io/agentscope/spring/boot/agui/mvc/AguiMvcController.java
+++ b/agentscope-extensions/agentscope-spring-boot-starters/agentscope-agui-spring-boot-starter/src/main/java/io/agentscope/spring/boot/agui/mvc/AguiMvcController.java
@@ -15,7 +15,6 @@
  */
 package io.agentscope.spring.boot.agui.mvc;
 
-import io.agentscope.core.agent.RuntimeContext;
 import io.agentscope.core.agui.AguiException;
 import io.agentscope.core.agui.adapter.AguiAdapterConfig;
 import io.agentscope.core.agui.adapter.AguiAgentAdapterFactory;
@@ -24,8 +23,8 @@ import io.agentscope.core.agui.event.AguiEvent;
 import io.agentscope.core.agui.model.RunAgentInput;
 import io.agentscope.core.agui.processor.AguiRequestProcessor;
 import io.agentscope.core.agui.registry.AguiAgentRegistry;
-import io.agentscope.spring.boot.agui.common.AguiRuntimeContextRequest;
-import io.agentscope.spring.boot.agui.common.AguiRuntimeContextResolver;
+import io.agentscope.core.agui.runtime.AguiRuntimeContextRequest;
+import io.agentscope.core.agui.runtime.AguiRuntimeContextResolver;
 import io.agentscope.spring.boot.agui.common.DefaultAgentResolver;
 import io.agentscope.spring.boot.agui.common.ThreadSessionManager;
 import jakarta.servlet.http.HttpServletRequest;
@@ -79,7 +78,6 @@ public class AguiMvcController {
     private final long sseTimeout;
     private final boolean interruptOnDisconnect;
     private final ExecutorService executorService;
-    private final AguiRuntimeContextResolver runtimeContextResolver;
 
     private AguiMvcController(Builder builder) {
         this.processor =
@@ -95,6 +93,7 @@ public class AguiMvcController {
                                         ? builder.config
                                         : AguiAdapterConfig.defaultConfig())
                         .adapterFactory(builder.adapterFactory)
+                        .runtimeContextResolver(builder.runtimeContextResolver)
                         .build();
         this.encoder = new AguiEventEncoder();
         this.agentIdHeader =
@@ -102,7 +101,6 @@ public class AguiMvcController {
         this.sseTimeout = builder.sseTimeout > 0 ? builder.sseTimeout : 600000L;
         this.interruptOnDisconnect = builder.interruptOnDisconnect;
         this.executorService = Executors.newCachedThreadPool();
-        this.runtimeContextResolver = builder.runtimeContextResolver;
     }
 
     /**
@@ -172,11 +170,10 @@ public class AguiMvcController {
                 () -> {
                     try {
                         // Process request - returns both agent and event stream
-                        RuntimeContext runtimeContext =
-                                resolveRuntimeContext(input, headerAgentId, pathAgentId, request);
                         AguiRequestProcessor.ProcessResult result =
                                 processor.process(
-                                        input, headerAgentId, pathAgentId, runtimeContext);
+                                        runtimeContextRequest(
+                                                input, headerAgentId, pathAgentId, request));
                         BaseSubscriber<AguiEvent> subscription =
                                 new BaseSubscriber<>() {
                                     @Override
@@ -214,8 +211,7 @@ public class AguiMvcController {
                                                 "SSE connection timed out for run {}, interrupting"
                                                         + " agent",
                                                 runId);
-                                        interruptAndCancel(
-                                                result, threadId, runtimeContext, subscription);
+                                        interruptAndCancel(result, threadId, subscription);
                                     } else {
                                         logger.info(
                                                 "SSE connection timed out for run {}, agent"
@@ -231,8 +227,7 @@ public class AguiMvcController {
                                                         + " agent",
                                                 runId,
                                                 ex.getMessage());
-                                        interruptAndCancel(
-                                                result, threadId, runtimeContext, subscription);
+                                        interruptAndCancel(result, threadId, subscription);
                                     } else {
                                         logger.info(
                                                 "SSE connection error for run {}: {}, agent"
@@ -260,34 +255,20 @@ public class AguiMvcController {
     }
 
     private static void interruptAndCancel(
-            AguiRequestProcessor.ProcessResult result,
-            String threadId,
-            RuntimeContext runtimeContext,
-            Disposable subscription) {
+            AguiRequestProcessor.ProcessResult result, String threadId, Disposable subscription) {
         try {
-            result.interrupt(threadId, runtimeContext);
+            result.interrupt(threadId);
         } finally {
             subscription.dispose();
         }
     }
 
-    private RuntimeContext resolveRuntimeContext(
+    private AguiRuntimeContextRequest<HttpServletRequest> runtimeContextRequest(
             RunAgentInput input,
             String headerAgentId,
             String pathAgentId,
             HttpServletRequest request) {
-        return runtimeContextResolver != null
-                ? runtimeContextResolver.resolve(
-                        runtimeContextRequest(input, headerAgentId, pathAgentId, request))
-                : null;
-    }
-
-    private AguiRuntimeContextRequest runtimeContextRequest(
-            RunAgentInput input,
-            String headerAgentId,
-            String pathAgentId,
-            HttpServletRequest request) {
-        return AguiRuntimeContextRequest.builder()
+        return AguiRuntimeContextRequest.<HttpServletRequest>builder()
                 .input(input)
                 .headerAgentId(headerAgentId)
                 .pathAgentId(pathAgentId)

--- a/agentscope-extensions/agentscope-spring-boot-starters/agentscope-agui-spring-boot-starter/src/main/java/io/agentscope/spring/boot/agui/mvc/AguiRestController.java
+++ b/agentscope-extensions/agentscope-spring-boot-starters/agentscope-agui-spring-boot-starter/src/main/java/io/agentscope/spring/boot/agui/mvc/AguiRestController.java
@@ -18,8 +18,8 @@ package io.agentscope.spring.boot.agui.mvc;
 import io.agentscope.core.agui.encoder.AguiEventEncoder;
 import io.agentscope.core.agui.event.AguiEvent;
 import io.agentscope.core.agui.model.RunAgentInput;
+import io.agentscope.core.agui.runtime.AguiRequestBodyParser;
 import io.agentscope.core.util.JsonException;
-import io.agentscope.spring.boot.agui.common.AguiRequestBodyParser;
 import jakarta.servlet.http.HttpServletRequest;
 import java.util.Map;
 import org.springframework.http.MediaType;
@@ -43,6 +43,7 @@ public class AguiRestController {
 
     private final AguiMvcController aguiMvcController;
     private final AguiEventEncoder encoder = new AguiEventEncoder();
+    private final AguiRequestBodyParser requestBodyParser;
     private final String pathPrefix;
     private final boolean enablePathRouting;
 
@@ -52,12 +53,17 @@ public class AguiRestController {
      * @param aguiMvcController The AG-UI MVC controller
      * @param pathPrefix The path prefix for endpoints
      * @param enablePathRouting Whether to enable path variable routing
+     * @param requestBodyParser The parser used to decode request bodies
      */
     public AguiRestController(
-            AguiMvcController aguiMvcController, String pathPrefix, boolean enablePathRouting) {
+            AguiMvcController aguiMvcController,
+            String pathPrefix,
+            boolean enablePathRouting,
+            AguiRequestBodyParser requestBodyParser) {
         this.aguiMvcController = aguiMvcController;
         this.pathPrefix = pathPrefix;
         this.enablePathRouting = enablePathRouting;
+        this.requestBodyParser = requestBodyParser;
     }
 
     /**
@@ -86,7 +92,7 @@ public class AguiRestController {
                             required = false)
                     String agentIdHeader,
             HttpServletRequest request) {
-        RunAgentInput input = AguiRequestBodyParser.parse(body);
+        RunAgentInput input = requestBodyParser.parse(body);
         return aguiMvcController.handle(input, agentIdHeader, request);
     }
 
@@ -112,7 +118,7 @@ public class AguiRestController {
                             required = false)
                     String agentIdHeader,
             HttpServletRequest request) {
-        RunAgentInput input = AguiRequestBodyParser.parse(body);
+        RunAgentInput input = requestBodyParser.parse(body);
         return aguiMvcController.handleWithAgentId(input, agentIdHeader, agentId, request);
     }
 

--- a/agentscope-extensions/agentscope-spring-boot-starters/agentscope-agui-spring-boot-starter/src/main/java/io/agentscope/spring/boot/agui/webflux/AgentscopeAguiWebFluxAutoConfiguration.java
+++ b/agentscope-extensions/agentscope-spring-boot-starters/agentscope-agui-spring-boot-starter/src/main/java/io/agentscope/spring/boot/agui/webflux/AgentscopeAguiWebFluxAutoConfiguration.java
@@ -21,8 +21,9 @@ import io.agentscope.core.agui.adapter.AguiAgentAdapterFactory;
 import io.agentscope.core.agui.adapter.strategy.AgentEventConverter;
 import io.agentscope.core.agui.adapter.strategy.AguiEventEnricher;
 import io.agentscope.core.agui.registry.AguiAgentRegistry;
+import io.agentscope.core.agui.runtime.AguiRequestBodyParser;
+import io.agentscope.core.agui.runtime.AguiRuntimeContextResolver;
 import io.agentscope.spring.boot.agui.common.AguiProperties;
-import io.agentscope.spring.boot.agui.common.AguiRuntimeContextResolver;
 import io.agentscope.spring.boot.agui.common.ThreadSessionManager;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
@@ -71,6 +72,21 @@ public class AgentscopeAguiWebFluxAutoConfiguration {
     }
 
     /**
+     * Creates the default AG-UI request body parser bean.
+     *
+     * <p>The parser decodes request bodies with AgentScope's Jackson 2 codec so that Spring Boot
+     * 4's Jackson 3 converters do not touch AG-UI's Jackson 2-annotated models. Applications can
+     * override this bean to customize request body parsing.
+     *
+     * @return A new AguiRequestBodyParser
+     */
+    @Bean
+    @ConditionalOnMissingBean
+    public AguiRequestBodyParser aguiRequestBodyParser() {
+        return new AguiRequestBodyParser();
+    }
+
+    /**
      * Creates the AG-UI WebFlux handler bean.
      *
      * @param registry The agent registry
@@ -87,7 +103,8 @@ public class AgentscopeAguiWebFluxAutoConfiguration {
             ObjectProvider<AgentEventConverter> eventConvertersProvider,
             ObjectProvider<AguiEventEnricher> eventEnrichersProvider,
             ObjectProvider<AguiRuntimeContextResolver> runtimeContextResolverProvider,
-            ObjectProvider<AguiAgentAdapterFactory> adapterFactoryProvider) {
+            ObjectProvider<AguiAgentAdapterFactory> adapterFactoryProvider,
+            AguiRequestBodyParser requestBodyParser) {
         AguiAdapterConfig config =
                 AguiAdapterConfig.builder()
                         .toolMergeMode(props.getDefaultToolMergeMode())
@@ -110,6 +127,7 @@ public class AgentscopeAguiWebFluxAutoConfiguration {
                 .interruptOnDisconnect(props.isInterruptOnDisconnect())
                 .runtimeContextResolver(runtimeContextResolverProvider.getIfAvailable())
                 .adapterFactory(adapterFactoryProvider.getIfAvailable())
+                .requestBodyParser(requestBodyParser)
                 .config(config)
                 .build();
     }

--- a/agentscope-extensions/agentscope-spring-boot-starters/agentscope-agui-spring-boot-starter/src/main/java/io/agentscope/spring/boot/agui/webflux/AguiWebFluxHandler.java
+++ b/agentscope-extensions/agentscope-spring-boot-starters/agentscope-agui-spring-boot-starter/src/main/java/io/agentscope/spring/boot/agui/webflux/AguiWebFluxHandler.java
@@ -15,7 +15,6 @@
  */
 package io.agentscope.spring.boot.agui.webflux;
 
-import io.agentscope.core.agent.RuntimeContext;
 import io.agentscope.core.agui.AguiException;
 import io.agentscope.core.agui.adapter.AguiAdapterConfig;
 import io.agentscope.core.agui.adapter.AguiAgentAdapterFactory;
@@ -24,9 +23,9 @@ import io.agentscope.core.agui.event.AguiEvent;
 import io.agentscope.core.agui.model.RunAgentInput;
 import io.agentscope.core.agui.processor.AguiRequestProcessor;
 import io.agentscope.core.agui.registry.AguiAgentRegistry;
-import io.agentscope.spring.boot.agui.common.AguiRequestBodyParser;
-import io.agentscope.spring.boot.agui.common.AguiRuntimeContextRequest;
-import io.agentscope.spring.boot.agui.common.AguiRuntimeContextResolver;
+import io.agentscope.core.agui.runtime.AguiRequestBodyParser;
+import io.agentscope.core.agui.runtime.AguiRuntimeContextRequest;
+import io.agentscope.core.agui.runtime.AguiRuntimeContextResolver;
 import io.agentscope.spring.boot.agui.common.DefaultAgentResolver;
 import io.agentscope.spring.boot.agui.common.ThreadSessionManager;
 import java.util.LinkedHashMap;
@@ -79,9 +78,9 @@ public class AguiWebFluxHandler {
 
     private final AguiRequestProcessor processor;
     private final AguiEventEncoder encoder;
+    private final AguiRequestBodyParser requestBodyParser;
     private final String agentIdHeader;
     private final boolean interruptOnDisconnect;
-    private final AguiRuntimeContextResolver runtimeContextResolver;
 
     private AguiWebFluxHandler(Builder builder) {
         this.processor =
@@ -97,12 +96,16 @@ public class AguiWebFluxHandler {
                                         ? builder.config
                                         : AguiAdapterConfig.defaultConfig())
                         .adapterFactory(builder.adapterFactory)
+                        .runtimeContextResolver(builder.runtimeContextResolver)
                         .build();
         this.encoder = new AguiEventEncoder();
+        this.requestBodyParser =
+                builder.requestBodyParser != null
+                        ? builder.requestBodyParser
+                        : new AguiRequestBodyParser();
         this.agentIdHeader =
                 builder.agentIdHeader != null ? builder.agentIdHeader : DEFAULT_AGENT_ID_HEADER;
         this.interruptOnDisconnect = builder.interruptOnDisconnect;
-        this.runtimeContextResolver = builder.runtimeContextResolver;
     }
 
     /**
@@ -116,7 +119,7 @@ public class AguiWebFluxHandler {
      */
     public Mono<ServerResponse> handle(ServerRequest request) {
         return request.bodyToMono(String.class)
-                .map(AguiRequestBodyParser::parse)
+                .map(requestBodyParser::parse)
                 .flatMap(input -> processInput(input, request, null))
                 .onErrorResume(this::handleParseError);
     }
@@ -133,7 +136,7 @@ public class AguiWebFluxHandler {
     public Mono<ServerResponse> handleWithAgentId(ServerRequest request) {
         String pathAgentId = request.pathVariable(AGENT_ID_PATH_VARIABLE);
         return request.bodyToMono(String.class)
-                .map(AguiRequestBodyParser::parse)
+                .map(requestBodyParser::parse)
                 .flatMap(input -> processInput(input, request, pathAgentId))
                 .onErrorResume(this::handleParseError);
     }
@@ -146,12 +149,11 @@ public class AguiWebFluxHandler {
         try {
             // Get header agent ID
             String headerAgentId = request.headers().firstHeader(agentIdHeader);
-            RuntimeContext runtimeContext =
-                    resolveRuntimeContext(input, headerAgentId, pathAgentId, request);
 
             // Process request - returns both agent and event stream
             AguiRequestProcessor.ProcessResult result =
-                    processor.process(input, headerAgentId, pathAgentId, runtimeContext);
+                    processor.process(
+                            runtimeContextRequest(input, headerAgentId, pathAgentId, request));
 
             // Create SSE stream using ServerSentEvent for proper streaming behavior
             Flux<AguiEvent> events =
@@ -172,7 +174,7 @@ public class AguiWebFluxHandler {
                                                     "SSE stream cancelled for run {}, interrupting"
                                                             + " agent",
                                                     runId);
-                                            result.interrupt(threadId, runtimeContext);
+                                            result.interrupt(threadId);
                                         } else {
                                             logger.info(
                                                     "SSE stream cancelled for run {}, agent"
@@ -194,17 +196,9 @@ public class AguiWebFluxHandler {
         }
     }
 
-    private RuntimeContext resolveRuntimeContext(
+    private AguiRuntimeContextRequest<ServerRequest> runtimeContextRequest(
             RunAgentInput input, String headerAgentId, String pathAgentId, ServerRequest request) {
-        return runtimeContextResolver != null
-                ? runtimeContextResolver.resolve(
-                        runtimeContextRequest(input, headerAgentId, pathAgentId, request))
-                : null;
-    }
-
-    private AguiRuntimeContextRequest runtimeContextRequest(
-            RunAgentInput input, String headerAgentId, String pathAgentId, ServerRequest request) {
-        return AguiRuntimeContextRequest.builder()
+        return AguiRuntimeContextRequest.<ServerRequest>builder()
                 .input(input)
                 .headerAgentId(headerAgentId)
                 .pathAgentId(pathAgentId)
@@ -297,6 +291,7 @@ public class AguiWebFluxHandler {
         private boolean interruptOnDisconnect = true;
         private AguiRuntimeContextResolver runtimeContextResolver;
         private AguiAgentAdapterFactory adapterFactory;
+        private AguiRequestBodyParser requestBodyParser;
 
         /**
          * Set the agent registry.
@@ -383,6 +378,17 @@ public class AguiWebFluxHandler {
          */
         public Builder adapterFactory(AguiAgentAdapterFactory adapterFactory) {
             this.adapterFactory = adapterFactory;
+            return this;
+        }
+
+        /**
+         * Set the request body parser.
+         *
+         * @param requestBodyParser The parser used to decode request bodies
+         * @return This builder
+         */
+        public Builder requestBodyParser(AguiRequestBodyParser requestBodyParser) {
+            this.requestBodyParser = requestBodyParser;
             return this;
         }
 

--- a/agentscope-extensions/agentscope-spring-boot-starters/agentscope-agui-spring-boot-starter/src/test/java/io/agentscope/spring/boot/agui/common/AguiAdapterConfigAutoConfigurationTest.java
+++ b/agentscope-extensions/agentscope-spring-boot-starters/agentscope-agui-spring-boot-starter/src/test/java/io/agentscope/spring/boot/agui/common/AguiAdapterConfigAutoConfigurationTest.java
@@ -30,6 +30,8 @@ import io.agentscope.core.agui.adapter.strategy.AguiStreamContext;
 import io.agentscope.core.agui.model.AguiMessage;
 import io.agentscope.core.agui.model.RunAgentInput;
 import io.agentscope.core.agui.registry.AguiAgentRegistry;
+import io.agentscope.core.agui.runtime.AguiRuntimeContextRequest;
+import io.agentscope.core.agui.runtime.AguiRuntimeContextResolver;
 import io.agentscope.core.event.AgentEndEvent;
 import io.agentscope.core.event.AgentEvent;
 import io.agentscope.core.event.AgentStartEvent;
@@ -271,7 +273,7 @@ class AguiAdapterConfigAutoConfigurationTest {
     @Test
     @DisplayName("Should expose servlet request context to MVC runtime context resolver")
     void testMvcRuntimeContextResolverReceivesServletRequestContext() {
-        AtomicReference<AguiRuntimeContextRequest> seenRequest = new AtomicReference<>();
+        AtomicReference<AguiRuntimeContextRequest<?>> seenRequest = new AtomicReference<>();
         AguiRuntimeContextResolver resolver =
                 request -> {
                     seenRequest.set(request);
@@ -290,16 +292,17 @@ class AguiAdapterConfigAutoConfigurationTest {
         request.addParameter("debug", "true");
         RunAgentInput input = input();
 
-        RuntimeContext context =
+        AguiRuntimeContextRequest<?> contextRequest =
                 ReflectionTestUtils.invokeMethod(
                         controller,
-                        "resolveRuntimeContext",
+                        "runtimeContextRequest",
                         input,
                         "header-agent",
                         "path-agent",
                         request);
+        RuntimeContext context = resolver.resolve(contextRequest);
 
-        AguiRuntimeContextRequest seen = seenRequest.get();
+        AguiRuntimeContextRequest<?> seen = seenRequest.get();
         assertEquals("tenant-a", context.get("tenant"));
         assertEquals("true", context.get("debug"));
         assertSame(input, seen.getInput());
@@ -310,13 +313,13 @@ class AguiAdapterConfigAutoConfigurationTest {
         assertEquals("/agui/run/path-agent", seen.getPath());
         assertEquals("tenant-a", seen.firstHeader("x-tenant"));
         assertEquals("true", seen.firstQueryParam("debug"));
-        assertSame(request, seen.getNativeRequest(MockHttpServletRequest.class));
+        assertSame(request, seen.getNativeRequest());
     }
 
     @Test
     @DisplayName("Should expose server request context to WebFlux runtime context resolver")
     void testWebFluxRuntimeContextResolverReceivesServerRequestContext() {
-        AtomicReference<AguiRuntimeContextRequest> seenRequest = new AtomicReference<>();
+        AtomicReference<AguiRuntimeContextRequest<?>> seenRequest = new AtomicReference<>();
         AguiRuntimeContextResolver resolver =
                 request -> {
                     seenRequest.set(request);
@@ -339,16 +342,17 @@ class AguiAdapterConfigAutoConfigurationTest {
                         .build();
         RunAgentInput input = input();
 
-        RuntimeContext context =
+        AguiRuntimeContextRequest<?> contextRequest =
                 ReflectionTestUtils.invokeMethod(
                         handler,
-                        "resolveRuntimeContext",
+                        "runtimeContextRequest",
                         input,
                         "header-agent",
                         "path-agent",
                         request);
+        RuntimeContext context = resolver.resolve(contextRequest);
 
-        AguiRuntimeContextRequest seen = seenRequest.get();
+        AguiRuntimeContextRequest<?> seen = seenRequest.get();
         assertEquals("tenant-a", context.get("tenant"));
         assertEquals("true", context.get("debug"));
         assertSame(input, seen.getInput());
@@ -359,13 +363,13 @@ class AguiAdapterConfigAutoConfigurationTest {
         assertEquals("/agui/run/path-agent", seen.getPath());
         assertEquals("tenant-a", seen.firstHeader("x-tenant"));
         assertEquals("true", seen.firstQueryParam("debug"));
-        assertSame(request, seen.getNativeRequest(MockServerRequest.class));
+        assertSame(request, seen.getNativeRequest());
     }
 
     @Test
     @DisplayName("Should expose immutable request headers and query params")
     void testRuntimeContextRequestHelpers() {
-        AguiRuntimeContextRequest request =
+        AguiRuntimeContextRequest<?> request =
                 AguiRuntimeContextRequest.builder()
                         .input(input())
                         .headers(Map.of("X-Tenant", List.of("tenant-a")))
@@ -391,14 +395,16 @@ class AguiAdapterConfigAutoConfigurationTest {
 
     private static AguiRuntimeContextResolver mvcRuntimeContextResolver(
             AguiMvcController controller) {
+        Object processor = ReflectionTestUtils.getField(controller, "processor");
         return (AguiRuntimeContextResolver)
-                ReflectionTestUtils.getField(controller, "runtimeContextResolver");
+                ReflectionTestUtils.getField(processor, "runtimeContextResolver");
     }
 
     private static AguiRuntimeContextResolver webFluxRuntimeContextResolver(
             AguiWebFluxHandler handler) {
+        Object processor = ReflectionTestUtils.getField(handler, "processor");
         return (AguiRuntimeContextResolver)
-                ReflectionTestUtils.getField(handler, "runtimeContextResolver");
+                ReflectionTestUtils.getField(processor, "runtimeContextResolver");
     }
 
     private static boolean interruptOnDisconnect(Object handler) {

--- a/agentscope-extensions/agentscope-spring-boot-starters/agentscope-agui-spring-boot-starter/src/test/java/io/agentscope/spring/boot/agui/mvc/AguiMvcControllerTest.java
+++ b/agentscope-extensions/agentscope-spring-boot-starters/agentscope-agui-spring-boot-starter/src/test/java/io/agentscope/spring/boot/agui/mvc/AguiMvcControllerTest.java
@@ -39,6 +39,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.locks.LockSupport;
 import org.junit.jupiter.api.Test;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
@@ -85,13 +86,7 @@ class AguiMvcControllerTest {
 
             invokeError(emitter);
 
-            assertTrue(fixture.firstRunTerminated.await(5, TimeUnit.SECONDS));
-
-            fixture.processor
-                    .process(AguiRuntimeContextRequest.builder().input(input("run-2")).build())
-                    .events()
-                    .collectList()
-                    .block();
+            awaitSecondRunAccepted(fixture);
 
             assertEquals(2, fixture.runCount.get());
             verify(fixture.agent).interrupt(any(RuntimeContext.class));
@@ -138,13 +133,7 @@ class AguiMvcControllerTest {
             Object timeoutCallback = ReflectionTestUtils.getField(emitter, "timeoutCallback");
             ReflectionTestUtils.invokeMethod(timeoutCallback, "run");
 
-            assertTrue(fixture.firstRunTerminated.await(5, TimeUnit.SECONDS));
-
-            fixture.processor
-                    .process(AguiRuntimeContextRequest.builder().input(input("run-2")).build())
-                    .events()
-                    .collectList()
-                    .block();
+            awaitSecondRunAccepted(fixture);
 
             assertEquals(2, fixture.runCount.get());
             verify(fixture.agent).interrupt(any(RuntimeContext.class));
@@ -197,6 +186,27 @@ class AguiMvcControllerTest {
         Object errorCallback = ReflectionTestUtils.getField(emitter, "errorCallback");
         ReflectionTestUtils.invokeMethod(
                 errorCallback, "accept", new IOException("client disconnected"));
+    }
+
+    /**
+     * Submits run-2 until it is accepted by the processor.
+     *
+     * <p>On disconnect the controller cancels run-1's subscription. Reactor's {@code doFinally}
+     * fires inner callbacks before outer ones on cancel, so the adapter's own teardown (which
+     * counts down {@code firstRunTerminated}) completes <em>before</em> {@code
+     * AguiResumeCoordinator.finishRun} releases the thread. Retrying run-2 therefore waits
+     * deterministically for the thread to actually become free instead of racing it.
+     */
+    private static void awaitSecondRunAccepted(ControllerFixture fixture) {
+        long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(5);
+        while (fixture.runCount.get() < 2 && System.nanoTime() < deadline) {
+            fixture.processor
+                    .process(AguiRuntimeContextRequest.builder().input(input("run-2")).build())
+                    .events()
+                    .collectList()
+                    .block();
+            LockSupport.parkNanos(TimeUnit.MILLISECONDS.toNanos(5));
+        }
     }
 
     private static RunAgentInput input(String runId) {

--- a/agentscope-extensions/agentscope-spring-boot-starters/agentscope-agui-spring-boot-starter/src/test/java/io/agentscope/spring/boot/agui/mvc/AguiMvcControllerTest.java
+++ b/agentscope-extensions/agentscope-spring-boot-starters/agentscope-agui-spring-boot-starter/src/test/java/io/agentscope/spring/boot/agui/mvc/AguiMvcControllerTest.java
@@ -85,6 +85,8 @@ class AguiMvcControllerTest {
 
             invokeError(emitter);
 
+            assertTrue(fixture.firstRunTerminated.await(5, TimeUnit.SECONDS));
+
             fixture.processor
                     .process(AguiRuntimeContextRequest.builder().input(input("run-2")).build())
                     .events()
@@ -135,6 +137,8 @@ class AguiMvcControllerTest {
 
             Object timeoutCallback = ReflectionTestUtils.getField(emitter, "timeoutCallback");
             ReflectionTestUtils.invokeMethod(timeoutCallback, "run");
+
+            assertTrue(fixture.firstRunTerminated.await(5, TimeUnit.SECONDS));
 
             fixture.processor
                     .process(AguiRuntimeContextRequest.builder().input(input("run-2")).build())

--- a/agentscope-extensions/agentscope-spring-boot-starters/agentscope-agui-spring-boot-starter/src/test/java/io/agentscope/spring/boot/agui/mvc/AguiMvcControllerTest.java
+++ b/agentscope-extensions/agentscope-spring-boot-starters/agentscope-agui-spring-boot-starter/src/test/java/io/agentscope/spring/boot/agui/mvc/AguiMvcControllerTest.java
@@ -32,6 +32,7 @@ import io.agentscope.core.agui.model.AguiMessage;
 import io.agentscope.core.agui.model.RunAgentInput;
 import io.agentscope.core.agui.processor.AguiRequestProcessor;
 import io.agentscope.core.agui.registry.AguiAgentRegistry;
+import io.agentscope.core.agui.runtime.AguiRuntimeContextRequest;
 import java.io.IOException;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
@@ -84,7 +85,11 @@ class AguiMvcControllerTest {
 
             invokeError(emitter);
 
-            fixture.processor.process(input("run-2"), null, null).events().collectList().block();
+            fixture.processor
+                    .process(AguiRuntimeContextRequest.builder().input(input("run-2")).build())
+                    .events()
+                    .collectList()
+                    .block();
 
             assertEquals(2, fixture.runCount.get());
             verify(fixture.agent).interrupt(any(RuntimeContext.class));
@@ -104,7 +109,10 @@ class AguiMvcControllerTest {
 
             List<AguiEvent> events =
                     fixture.processor
-                            .process(input("run-2"), null, null)
+                            .process(
+                                    AguiRuntimeContextRequest.builder()
+                                            .input(input("run-2"))
+                                            .build())
                             .events()
                             .collectList()
                             .block();
@@ -128,7 +136,11 @@ class AguiMvcControllerTest {
             Object timeoutCallback = ReflectionTestUtils.getField(emitter, "timeoutCallback");
             ReflectionTestUtils.invokeMethod(timeoutCallback, "run");
 
-            fixture.processor.process(input("run-2"), null, null).events().collectList().block();
+            fixture.processor
+                    .process(AguiRuntimeContextRequest.builder().input(input("run-2")).build())
+                    .events()
+                    .collectList()
+                    .block();
 
             assertEquals(2, fixture.runCount.get());
             verify(fixture.agent).interrupt(any(RuntimeContext.class));

--- a/agentscope-extensions/agentscope-spring-boot-starters/agentscope-agui-spring-boot-starter/src/test/java/io/agentscope/spring/boot/agui/mvc/AguiRestControllerTest.java
+++ b/agentscope-extensions/agentscope-spring-boot-starters/agentscope-agui-spring-boot-starter/src/test/java/io/agentscope/spring/boot/agui/mvc/AguiRestControllerTest.java
@@ -19,6 +19,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import io.agentscope.core.agui.runtime.AguiRequestBodyParser;
 import io.agentscope.core.util.JsonException;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
@@ -29,7 +30,8 @@ class AguiRestControllerTest {
 
     @Test
     void shouldReturnBadRequestSseForParseErrors() {
-        AguiRestController controller = new AguiRestController(null, "/agui", true);
+        AguiRestController controller =
+                new AguiRestController(null, "/agui", true, new AguiRequestBodyParser());
 
         ResponseEntity<String> response =
                 controller.handleParseError(new JsonException("bad json"));


### PR DESCRIPTION
## 背景

`AguiRuntimeContextRequest`、`AguiRuntimeContextResolver`（PR #2306 引入）与 `AguiRequestBodyParser`（PR #2638 引入）目前被放在 Spring starter 的 `common` 包内。但它们三处均不含任何 Spring 依赖（仅依赖 `RuntimeContext` 与 `RunAgentInput`），本质上与 `AgentEventConverter`、`AguiEventEnricher`、`AguiAgentAdapterFactory` 属于同一类协议层 SPI。

锁在 starter 里形态上似乎违背了 starter 作为“Spring 装配层”的职责边界，让非 Spring 接入方（纯 WebFlux/RSocket 等）无法复用这三类协议层能力。本 PR 将其下沉到 `agentscope-extensions-agui` 协议模块。

## 改动内容

1. **归位**：将 `AguiRuntimeContextRequest`、`AguiRuntimeContextResolver`、`AguiRequestBodyParser` 下沉到 `agentscope-extensions-agui` 的 `io.agentscope.core.agui.runtime` 包，与同类扩展点同模块。

2. **类型安全**：`AguiRuntimeContextRequest` 泛型化为 `AguiRuntimeContextRequest<T>`，用编译期泛型刻画 transport-specific 的 `nativeRequest`，替代原先 `Object + 运行期 Class<T>` 的转型方式。

3. **职责收口**：以 `AguiRequestProcessor#process(AguiRuntimeContextRequest<?>)` 作为统一入口，将 runtimeContextResolver 内置到 processor。MVC/WebFlux handler 不再各自持有 resolver、各自调用 `resolve()`，只负责把原生请求（`HttpServletRequest` / `ServerRequest`）映射为 `AguiRuntimeContextRequest<T>` 后交给 processor 统一解析。

4. **Parser Bean 化**：`AguiRequestBodyParser` 改为可通过 Spring Bean 覆盖的组件（`@ConditionalOnMissingBean`），并注入 MVC/WebFlux 控制器，允许应用自定义请求体解析。

## Breaking Changes

本次为 clean break（无 @Deprecated 桥接），升级需改代码。

### 包名 / 模块迁移

| 旧 (agentscope-agui-spring-boot-starter)                        | 新 (agentscope-extensions-agui)                       |
|-----------------------------------------------------------------|-------------------------------------------------------|
| io.agentscope.spring.boot.agui.common.AguiRuntimeContextRequest | io.agentscope.core.agui.runtime.AguiRuntimeContextRequest |
| io.agentscope.spring.boot.agui.common.AguiRuntimeContextResolver| io.agentscope.core.agui.runtime.AguiRuntimeContextResolver|
| io.agentscope.spring.boot.agui.common.AguiRequestBodyParser    | io.agentscope.core.agui.runtime.AguiRequestBodyParser   |

- 非 Spring 接入方：只需依赖 `agentscope-extensions-agui` 即可直接复用这三类能力。
- Spring 用户：仍用 `agentscope-agui-spring-boot-starter`（已传递依赖），仅更新 import。

### 公共 API 变更

1. `AguiRuntimeContextRequest` 泛型化为 `AguiRuntimeContextRequest<T>`
   - `builder()` → `Builder<T>`：`AguiRuntimeContextRequest.<HttpServletRequest>builder()...nativeRequest(req)`
   - `getNativeRequest()` 返回 `T`；删除 `getNativeRequest(Class<T>)`，改用 `getNativeRequest()` + `instanceof` 收窄。

2. `AguiRequestBodyParser`：`final` + 私有构造 + `static parse(String)` → 可实例化 + 实例 `parse(String)`
   - `AguiRequestBodyParser.parse(body)` → `new AguiRequestBodyParser().parse(body)`，或注入 bean（`@ConditionalOnMissingBean`，可被自定义 bean 覆盖）。

3. `AguiRequestProcessor.process`
   - 删除 `process(RunAgentInput, String, String)` 与 `process(RunAgentInput, String, String, RuntimeContext)`
   - 新签名：`ProcessResult process(AguiRuntimeContextRequest<?> request)`
   - 迁移：`AguiRuntimeContextRequest.builder().input(input).headerAgentId(h).pathAgentId(p).build()` 后 `processor.process(request)`。

4. `ProcessResult` record 新增第三组件 `runtimeContext`：`ProcessResult(Agent agent, Flux<AguiEvent> events, RuntimeContext runtimeContext)`，新增 `runtimeContext()`。
   - `interrupt(String threadId, RuntimeContext)` → `interrupt(String threadId)`（使用 result 内捕获的 `runtimeContext`）。
