### PR TITLE
fix(e2b): reject incomplete process streams without exit code

### DIFF
--- a/agentscope-extensions/agentscope-extensions-sandbox/agentscope-extensions-sandbox-e2b/src/main/java/io/agentscope/extensions/sandbox/e2b/E2bEnvdProcessClient.java
+++ b/agentscope-extensions/agentscope-extensions-sandbox/agentscope-extensions-sandbox-e2b/src/main/java/io/agentscope/extensions/sandbox/e2b/E2bEnvdProcessClient.java
@@ -142,7 +142,7 @@ final class E2bEnvdProcessClient {
 
         ByteArrayOutputStream stdout = new ByteArrayOutputStream();
         ByteArrayOutputStream stderr = new ByteArrayOutputStream();
-        int exit = Integer.MIN_VALUE;
+        int exit;
         try (Response res = callClient.newCall(req).execute()) {
             if (!res.isSuccessful()) {
                 String err = res.body() != null ? res.body().string() : "";
@@ -165,7 +165,7 @@ final class E2bEnvdProcessClient {
     private int drainStartStream(
             InputStream in, ByteArrayOutputStream stdout, ByteArrayOutputStream stderr)
             throws IOException {
-        int exit = Integer.MIN_VALUE;
+        Integer exit = null;
         Descriptors.FieldDescriptor srEventF = startResponseDesc.findFieldByName("event");
         Descriptors.FieldDescriptor peDataF = processEventDesc.findFieldByName("data");
         Descriptors.FieldDescriptor peEndF = processEventDesc.findFieldByName("end");
@@ -211,6 +211,9 @@ final class E2bEnvdProcessClient {
             } catch (IOException e) {
                 continue;
             }
+        }
+        if (exit == null) {
+            throw new IOException("envd process stream ended before receiving a process exit code");
         }
         return exit;
     }

--- a/agentscope-extensions/agentscope-extensions-sandbox/agentscope-extensions-sandbox-e2b/src/test/java/io/agentscope/extensions/sandbox/e2b/E2bEnvdProcessClientTest.java
+++ b/agentscope-extensions/agentscope-extensions-sandbox/agentscope-extensions-sandbox-e2b/src/test/java/io/agentscope/extensions/sandbox/e2b/E2bEnvdProcessClientTest.java
@@ -17,6 +17,7 @@ package io.agentscope.extensions.sandbox.e2b;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.google.protobuf.ByteString;
@@ -24,7 +25,9 @@ import com.google.protobuf.Descriptors;
 import com.google.protobuf.DynamicMessage;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.io.InputStream;
+import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
@@ -116,22 +119,65 @@ class E2bEnvdProcessClientTest {
     }
 
     @Test
-    void jsonCodecReturnsSentinelWhenEndMissing() throws Exception {
+    void jsonCodecRejectsEofBeforeEnd() throws Exception {
         E2bEnvdProcessClient client = new E2bEnvdProcessClient(options(E2bCodec.JSON));
         ByteArrayOutputStream stdout = new ByteArrayOutputStream();
         ByteArrayOutputStream stderr = new ByteArrayOutputStream();
-        int exit =
-                drainStartStream(
-                        client,
-                        connectFrames(
-                                responseJson(base64("hello\n"), null, null),
-                                responseJson(null, base64("warn\n"), null)),
-                        stdout,
-                        stderr);
+        IOException exception =
+                assertThrows(
+                        IOException.class,
+                        () ->
+                                drainStartStream(
+                                        client,
+                                        connectFrames(
+                                                responseJson(base64("hello\n"), null, null),
+                                                responseJson(null, base64("warn\n"), null)),
+                                        stdout,
+                                        stderr));
 
-        assertEquals(Integer.MIN_VALUE, exit);
+        assertTrue(exception.getMessage().contains("before receiving a process exit code"));
         assertEquals("hello\n", stdout.toString(StandardCharsets.UTF_8));
         assertEquals("warn\n", stderr.toString(StandardCharsets.UTF_8));
+    }
+
+    @Test
+    void jsonCodecRejectsTruncatedFrameLengthBeforeEnd() throws Exception {
+        E2bEnvdProcessClient client = new E2bEnvdProcessClient(options(E2bCodec.JSON));
+        byte[] truncatedLength = new byte[] {0x00, 0x00, 0x00};
+
+        IOException exception =
+                assertThrows(
+                        IOException.class,
+                        () ->
+                                drainStartStream(
+                                        client,
+                                        truncatedLength,
+                                        new ByteArrayOutputStream(),
+                                        new ByteArrayOutputStream()));
+
+        assertTrue(exception.getMessage().contains("before receiving a process exit code"));
+    }
+
+    @Test
+    void jsonCodecRejectsTruncatedFramePayloadBeforeEnd() throws Exception {
+        E2bEnvdProcessClient client = new E2bEnvdProcessClient(options(E2bCodec.JSON));
+        ByteBuffer truncatedPayload = ByteBuffer.allocate(7).order(ByteOrder.BIG_ENDIAN);
+        truncatedPayload.put((byte) 0x00);
+        truncatedPayload.putInt(4);
+        truncatedPayload.put((byte) '{');
+        truncatedPayload.put((byte) '}');
+
+        IOException exception =
+                assertThrows(
+                        IOException.class,
+                        () ->
+                                drainStartStream(
+                                        client,
+                                        truncatedPayload.array(),
+                                        new ByteArrayOutputStream(),
+                                        new ByteArrayOutputStream()));
+
+        assertTrue(exception.getMessage().contains("before receiving a process exit code"));
     }
 
     @Test
@@ -195,7 +241,19 @@ class E2bEnvdProcessClientTest {
                         ByteArrayOutputStream.class,
                         ByteArrayOutputStream.class);
         method.setAccessible(true);
-        return (int) method.invoke(client, new ByteArrayInputStream(connectFrame), stdout, stderr);
+        try {
+            return (int)
+                    method.invoke(client, new ByteArrayInputStream(connectFrame), stdout, stderr);
+        } catch (InvocationTargetException e) {
+            Throwable cause = e.getCause();
+            if (cause instanceof Exception exception) {
+                throw exception;
+            }
+            if (cause instanceof Error error) {
+                throw error;
+            }
+            throw e;
+        }
     }
 
     private static byte[] connectFrame(String json) {

--- a/agentscope-extensions/agentscope-spring-boot-starters/agentscope-agui-spring-boot-starter/src/test/java/io/agentscope/spring/boot/agui/mvc/AguiMvcControllerTest.java
+++ b/agentscope-extensions/agentscope-spring-boot-starters/agentscope-agui-spring-boot-starter/src/test/java/io/agentscope/spring/boot/agui/mvc/AguiMvcControllerTest.java
@@ -83,6 +83,7 @@ class AguiMvcControllerTest {
             assertTrue(fixture.firstRunSubscribed.await(5, TimeUnit.SECONDS));
 
             invokeError(emitter);
+            assertTrue(fixture.firstRunTerminated.await(5, TimeUnit.SECONDS));
 
             fixture.processor.process(input("run-2"), null, null).events().collectList().block();
 
@@ -127,6 +128,7 @@ class AguiMvcControllerTest {
 
             Object timeoutCallback = ReflectionTestUtils.getField(emitter, "timeoutCallback");
             ReflectionTestUtils.invokeMethod(timeoutCallback, "run");
+            assertTrue(fixture.firstRunTerminated.await(5, TimeUnit.SECONDS));
 
             fixture.processor.process(input("run-2"), null, null).events().collectList().block();
 

--- a/agentscope-extensions/agentscope-spring-boot-starters/agentscope-agui-spring-boot-starter/src/test/java/io/agentscope/spring/boot/agui/mvc/AguiMvcControllerTest.java
+++ b/agentscope-extensions/agentscope-spring-boot-starters/agentscope-agui-spring-boot-starter/src/test/java/io/agentscope/spring/boot/agui/mvc/AguiMvcControllerTest.java
@@ -226,8 +226,9 @@ class AguiMvcControllerTest {
         @Override
         public Flux<AguiEvent> run(RunAgentInput input, RuntimeContext runtimeContext) {
             if (runCount.incrementAndGet() == 1) {
-                firstRunSubscribed.countDown();
-                return firstRunEvents.doFinally(signalType -> firstRunTerminated.countDown());
+                return firstRunEvents
+                        .doOnRequest(ignored -> firstRunSubscribed.countDown())
+                        .doFinally(signalType -> firstRunTerminated.countDown());
             }
             return Flux.empty();
         }


### PR DESCRIPTION


# PR 描述

## AgentScope-Java Version

2.0.3-SNAPSHOT

## Description

Fixes #2824.

`E2bEnvdProcessClient.drainStartStream()` previously returned `Integer.MIN_VALUE` when the envd response stream ended before a process exit event was received.

The sentinel was then interpreted as a real non-zero process exit code, causing an incomplete transport response to be misreported as a command failure.

This change:

- Removes the `Integer.MIN_VALUE` fallback.
- Throws an explicit `IOException` when the stream ends without a process exit code.
- Preserves valid zero and non-zero exit codes.
- Adds regression coverage for EOF, truncated frame length, and truncated frame payload scenarios.

The missing exit code is treated as an incomplete transport response rather than being assumed to mean success.

## Tests

Targeted tests:

```shell
mvn -pl agentscope-extensions/agentscope-extensions-sandbox/agentscope-extensions-sandbox-e2b \
  -am \
  -Dtest=E2bEnvdProcessClientTest \
  -Dsurefire.failIfNoSpecifiedTests=false \
  test
```

Result: 10 tests passed.

Full module tests:

```shell
mvn -pl agentscope-extensions/agentscope-extensions-sandbox/agentscope-extensions-sandbox-e2b \
  -am test
```

Results:

- `agentscope-core`: 2294 tests, 0 failures
- `agentscope-harness`: 834 tests, 0 failures
- `agentscope-extensions-sandbox-e2b`: 14 tests, 0 failures

## Checklist

- [x] Code is formatted with Spotless
- [x] Targeted and module tests pass
- [x] No public API changes
- [x] Ready for review