### PR TITLE
fix(harness): bound filesystem search tool output

### DIFF
--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/memory/compaction/ToolResultEvictionConfig.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/memory/compaction/ToolResultEvictionConfig.java
@@ -57,7 +57,7 @@ public class ToolResultEvictionConfig {
      * <ul>
      *   <li>{@code read_file} — evicting would cause re-read loops; pagination handles size</li>
      *   <li>{@code write_file}, {@code edit_file} — return tiny success messages</li>
-     *   <li>{@code grep_files}, {@code glob_files}, {@code list_files} — self-limiting outputs</li>
+     *   <li>{@code list_files} — normally returns a small directory listing</li>
      *   <li>{@code memory_search}, {@code memory_get}, {@code session_search} — small/paginated results</li>
      * </ul>
      *
@@ -68,8 +68,6 @@ public class ToolResultEvictionConfig {
                     "read_file",
                     "write_file",
                     "edit_file",
-                    "grep_files",
-                    "glob_files",
                     "list_files",
                     "memory_search",
                     "memory_get",

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/tool/FilesystemTool.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/tool/FilesystemTool.java
@@ -140,7 +140,9 @@ public class FilesystemTool {
                     String glob,
             @ToolParam(
                             name = "limit",
-                            description = "Maximum matches to return (default: 100, maximum: 1000)",
+                            description =
+                                    "Maximum matches to return (default/recommended: 100; hard"
+                                            + " maximum: 1000)",
                             required = false)
                     Integer limit) {
         int effectiveLimit = effectiveLimit(limit, DEFAULT_GREP_LIMIT);
@@ -160,7 +162,7 @@ public class FilesystemTool {
                         .limit(effectiveLimit)
                         .map(m -> m.path() + ":" + m.line() + ":" + m.text())
                         .collect(Collectors.joining("\n"));
-        return appendTruncationNotice(output, matches.size(), effectiveLimit);
+        return appendTruncationNotice(output, matches.size(), effectiveLimit, "matches");
     }
 
     /** Backward-compatible overload for direct Java callers. */
@@ -173,7 +175,7 @@ public class FilesystemTool {
             name = "glob_files",
             readOnly = true,
             description =
-                    "Find files matching a glob pattern. Returns at most 200 matches by default to"
+                    "Find files matching a glob pattern. Returns at most 200 files by default to"
                             + " keep tool output bounded.")
     public String globFiles(
             RuntimeContext runtimeContext,
@@ -186,7 +188,9 @@ public class FilesystemTool {
                     String path,
             @ToolParam(
                             name = "limit",
-                            description = "Maximum matches to return (default: 200, maximum: 1000)",
+                            description =
+                                    "Maximum files to return (default/recommended: 200; hard"
+                                            + " maximum: 1000)",
                             required = false)
                     Integer limit) {
         int effectiveLimit = effectiveLimit(limit, DEFAULT_GLOB_LIMIT);
@@ -206,7 +210,7 @@ public class FilesystemTool {
                         .limit(effectiveLimit)
                         .map(f -> f.path() + (f.isDirectory() ? "/" : " (" + f.size() + " bytes)"))
                         .collect(Collectors.joining("\n"));
-        return appendTruncationNotice(output, files.size(), effectiveLimit);
+        return appendTruncationNotice(output, files.size(), effectiveLimit, "files");
     }
 
     /** Backward-compatible overload for direct Java callers. */
@@ -221,18 +225,30 @@ public class FilesystemTool {
         return Math.min(requestedLimit, MAX_SEARCH_LIMIT);
     }
 
-    private static String appendTruncationNotice(String output, int total, int limit) {
+    private static String appendTruncationNotice(
+            String output, int total, int limit, String resultLabel) {
         if (total <= limit) {
             return output;
         }
+        String guidance =
+                limit < MAX_SEARCH_LIMIT
+                        ? "Narrow the path/pattern or increase limit (hard maximum: "
+                                + MAX_SEARCH_LIMIT
+                                + ")."
+                        : "Hard maximum of "
+                                + MAX_SEARCH_LIMIT
+                                + " reached; narrow the path/pattern to retrieve more targeted"
+                                + " results.";
         return output
                 + "\n[Results truncated: showing "
                 + limit
                 + " of "
                 + total
-                + " matches. Narrow the path/pattern or increase limit (maximum: "
-                + MAX_SEARCH_LIMIT
-                + ").]";
+                + " "
+                + resultLabel
+                + ". "
+                + guidance
+                + "]";
     }
 
     @Tool(

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/tool/FilesystemTool.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/tool/FilesystemTool.java
@@ -37,6 +37,10 @@ import java.util.stream.Collectors;
  */
 public class FilesystemTool {
 
+    static final int DEFAULT_GREP_LIMIT = 100;
+    static final int DEFAULT_GLOB_LIMIT = 200;
+    static final int MAX_SEARCH_LIMIT = 1_000;
+
     private final AbstractFilesystem abstractFilesystem;
     private final WorkspacePathNormalizer pathNormalizer;
 
@@ -120,7 +124,9 @@ public class FilesystemTool {
     @Tool(
             name = "grep_files",
             readOnly = true,
-            description = "Search file contents for a literal text pattern.")
+            description =
+                    "Search file contents for a literal text pattern. Returns at most 100 matches"
+                            + " by default to keep tool output bounded.")
     public String grepFiles(
             RuntimeContext runtimeContext,
             @ToolParam(name = "pattern", description = "Literal text pattern to search for")
@@ -131,7 +137,16 @@ public class FilesystemTool {
                             name = "glob",
                             description = "Optional file glob filter (e.g., *.java)",
                             required = false)
-                    String glob) {
+                    String glob,
+            @ToolParam(
+                            name = "limit",
+                            description = "Maximum matches to return (default: 100, maximum: 1000)",
+                            required = false)
+                    Integer limit) {
+        int effectiveLimit = effectiveLimit(limit, DEFAULT_GREP_LIMIT);
+        if (effectiveLimit < 1) {
+            return "Error: limit must be greater than 0";
+        }
         GrepResult r = abstractFilesystem.grep(runtimeContext, pattern, norm(path), glob);
         if (!r.isSuccess()) {
             return "Error: " + r.error();
@@ -140,12 +155,26 @@ public class FilesystemTool {
         if (matches == null || matches.isEmpty()) {
             return "No matches found";
         }
-        return matches.stream()
-                .map(m -> m.path() + ":" + m.line() + ":" + m.text())
-                .collect(Collectors.joining("\n"));
+        String output =
+                matches.stream()
+                        .limit(effectiveLimit)
+                        .map(m -> m.path() + ":" + m.line() + ":" + m.text())
+                        .collect(Collectors.joining("\n"));
+        return appendTruncationNotice(output, matches.size(), effectiveLimit);
     }
 
-    @Tool(name = "glob_files", readOnly = true, description = "Find files matching a glob pattern.")
+    /** Backward-compatible overload for direct Java callers. */
+    public String grepFiles(
+            RuntimeContext runtimeContext, String pattern, String path, String glob) {
+        return grepFiles(runtimeContext, pattern, path, glob, null);
+    }
+
+    @Tool(
+            name = "glob_files",
+            readOnly = true,
+            description =
+                    "Find files matching a glob pattern. Returns at most 200 matches by default to"
+                            + " keep tool output bounded.")
     public String globFiles(
             RuntimeContext runtimeContext,
             @ToolParam(name = "pattern", description = "Glob pattern (e.g., **/*.java)")
@@ -154,7 +183,16 @@ public class FilesystemTool {
                             name = "path",
                             description = "Base directory to search from",
                             required = false)
-                    String path) {
+                    String path,
+            @ToolParam(
+                            name = "limit",
+                            description = "Maximum matches to return (default: 200, maximum: 1000)",
+                            required = false)
+                    Integer limit) {
+        int effectiveLimit = effectiveLimit(limit, DEFAULT_GLOB_LIMIT);
+        if (effectiveLimit < 1) {
+            return "Error: limit must be greater than 0";
+        }
         GlobResult r = abstractFilesystem.glob(runtimeContext, pattern, norm(path));
         if (!r.isSuccess()) {
             return "Error: " + r.error();
@@ -163,9 +201,38 @@ public class FilesystemTool {
         if (files == null || files.isEmpty()) {
             return "No matching files found";
         }
-        return files.stream()
-                .map(f -> f.path() + (f.isDirectory() ? "/" : " (" + f.size() + " bytes)"))
-                .collect(Collectors.joining("\n"));
+        String output =
+                files.stream()
+                        .limit(effectiveLimit)
+                        .map(f -> f.path() + (f.isDirectory() ? "/" : " (" + f.size() + " bytes)"))
+                        .collect(Collectors.joining("\n"));
+        return appendTruncationNotice(output, files.size(), effectiveLimit);
+    }
+
+    /** Backward-compatible overload for direct Java callers. */
+    public String globFiles(RuntimeContext runtimeContext, String pattern, String path) {
+        return globFiles(runtimeContext, pattern, path, null);
+    }
+
+    private static int effectiveLimit(Integer requestedLimit, int defaultLimit) {
+        if (requestedLimit == null) {
+            return defaultLimit;
+        }
+        return Math.min(requestedLimit, MAX_SEARCH_LIMIT);
+    }
+
+    private static String appendTruncationNotice(String output, int total, int limit) {
+        if (total <= limit) {
+            return output;
+        }
+        return output
+                + "\n[Results truncated: showing "
+                + limit
+                + " of "
+                + total
+                + " matches. Narrow the path/pattern or increase limit (maximum: "
+                + MAX_SEARCH_LIMIT
+                + ").]";
     }
 
     @Tool(

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/middleware/ToolResultEvictionMiddlewareTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/middleware/ToolResultEvictionMiddlewareTest.java
@@ -61,6 +61,8 @@ class ToolResultEvictionMiddlewareTest {
         ToolResultEvictionConfig config =
                 ToolResultEvictionConfig.builder().maxResultChars(20).previewChars(4).build();
         assertEquals("large_tool_results", config.getEvictionPath());
+        assertFalse(config.getExcludedToolNames().contains("grep_files"));
+        assertFalse(config.getExcludedToolNames().contains("glob_files"));
 
         LocalFilesystem filesystem =
                 new LocalFilesystem(tempDir, LocalFsMode.ROOTED, PathPolicy.empty(), 10, null);

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/tool/FilesystemToolTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/tool/FilesystemToolTest.java
@@ -153,6 +153,8 @@ class FilesystemToolTest {
 
         assertFalse(result.contains("file-1000.txt:1001:match-1000"));
         assertTrue(result.contains("showing 1000 of 1001 matches"));
+        assertTrue(result.contains("Hard maximum of 1000 reached"));
+        assertFalse(result.contains("increase limit"));
     }
 
     @Test
@@ -172,7 +174,7 @@ class FilesystemToolTest {
 
         assertTrue(result.contains("file-199.txt (199 bytes)"));
         assertFalse(result.contains("file-200.txt (200 bytes)"));
-        assertTrue(result.contains("showing 200 of 201 matches"));
+        assertTrue(result.contains("showing 200 of 201 files"));
     }
 
     @Test

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/tool/FilesystemToolTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/tool/FilesystemToolTest.java
@@ -16,21 +16,30 @@
 package io.agentscope.harness.agent.tool;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import io.agentscope.core.agent.RuntimeContext;
+import io.agentscope.core.tool.AgentTool;
+import io.agentscope.core.tool.Toolkit;
 import io.agentscope.harness.agent.filesystem.AbstractFilesystem;
 import io.agentscope.harness.agent.filesystem.model.EditResult;
 import io.agentscope.harness.agent.filesystem.model.FileData;
 import io.agentscope.harness.agent.filesystem.model.FileInfo;
+import io.agentscope.harness.agent.filesystem.model.GlobResult;
+import io.agentscope.harness.agent.filesystem.model.GrepMatch;
+import io.agentscope.harness.agent.filesystem.model.GrepResult;
 import io.agentscope.harness.agent.filesystem.model.LsResult;
 import io.agentscope.harness.agent.filesystem.model.ReadResult;
 import io.agentscope.harness.agent.workspace.WorkspacePathNormalizer;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.IntStream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -109,5 +118,99 @@ class FilesystemToolTest {
 
         assertEquals("world", result);
         verify(filesystem).read(RT, "f.txt", 2, 5);
+    }
+
+    @Test
+    void grepFiles_omittedLimit_appliesServerDefaultAndReportsTruncation() {
+        when(filesystem.grep(RT, "needle", ".", null))
+                .thenReturn(GrepResult.success(grepMatches(FilesystemTool.DEFAULT_GREP_LIMIT + 1)));
+
+        String result = tool.grepFiles(RT, "needle", ".", null, null);
+
+        assertTrue(result.contains("file-99.txt:100:match-99"));
+        assertFalse(result.contains("file-100.txt:101:match-100"));
+        assertTrue(result.contains("showing 100 of 101 matches"));
+    }
+
+    @Test
+    void grepFiles_explicitLimit_isApplied() {
+        when(filesystem.grep(RT, "needle", ".", null))
+                .thenReturn(GrepResult.success(grepMatches(3)));
+
+        String result = tool.grepFiles(RT, "needle", ".", null, 2);
+
+        assertTrue(result.contains("file-1.txt:2:match-1"));
+        assertFalse(result.contains("file-2.txt:3:match-2"));
+        assertTrue(result.contains("showing 2 of 3 matches"));
+    }
+
+    @Test
+    void grepFiles_limitAboveMaximum_isCapped() {
+        when(filesystem.grep(RT, "needle", ".", null))
+                .thenReturn(GrepResult.success(grepMatches(FilesystemTool.MAX_SEARCH_LIMIT + 1)));
+
+        String result = tool.grepFiles(RT, "needle", ".", null, Integer.MAX_VALUE);
+
+        assertFalse(result.contains("file-1000.txt:1001:match-1000"));
+        assertTrue(result.contains("showing 1000 of 1001 matches"));
+    }
+
+    @Test
+    void grepFiles_nonPositiveLimit_isRejectedBeforeSearch() {
+        String result = tool.grepFiles(RT, "needle", ".", null, 0);
+
+        assertEquals("Error: limit must be greater than 0", result);
+        verifyNoInteractions(filesystem);
+    }
+
+    @Test
+    void globFiles_omittedLimit_appliesServerDefaultAndReportsTruncation() {
+        when(filesystem.glob(RT, "**/*.txt", "."))
+                .thenReturn(GlobResult.success(files(FilesystemTool.DEFAULT_GLOB_LIMIT + 1)));
+
+        String result = tool.globFiles(RT, "**/*.txt", ".", null);
+
+        assertTrue(result.contains("file-199.txt (199 bytes)"));
+        assertFalse(result.contains("file-200.txt (200 bytes)"));
+        assertTrue(result.contains("showing 200 of 201 matches"));
+    }
+
+    @Test
+    void searchOverloads_remainBackwardCompatibleForDirectCallers() {
+        when(filesystem.grep(RT, "needle", ".", null))
+                .thenReturn(GrepResult.success(grepMatches(1)));
+        when(filesystem.glob(RT, "*.txt", ".")).thenReturn(GlobResult.success(files(1)));
+
+        assertEquals("file-0.txt:1:match-0", tool.grepFiles(RT, "needle", ".", null));
+        assertEquals("file-0.txt (0 bytes)", tool.globFiles(RT, "*.txt", "."));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void searchToolSchemas_exposeLimitAsOptional() {
+        Toolkit toolkit = new Toolkit();
+        toolkit.registerTool(tool);
+
+        for (String toolName : List.of("grep_files", "glob_files")) {
+            AgentTool registered = toolkit.getTool(toolName);
+            Map<String, Object> schema = registered.getParameters();
+            Map<String, Object> properties = (Map<String, Object>) schema.get("properties");
+            List<String> required = (List<String>) schema.get("required");
+
+            assertTrue(properties.containsKey("limit"));
+            assertFalse(required.contains("limit"));
+        }
+    }
+
+    private static List<GrepMatch> grepMatches(int count) {
+        return IntStream.range(0, count)
+                .mapToObj(i -> new GrepMatch("file-" + i + ".txt", i + 1, "match-" + i))
+                .toList();
+    }
+
+    private static List<FileInfo> files(int count) {
+        return IntStream.range(0, count)
+                .mapToObj(i -> FileInfo.ofFile("file-" + i + ".txt", i, ""))
+                .toList();
     }
 }

--- a/docs/v1/en/docs/harness/tool.md
+++ b/docs/v1/en/docs/harness/tool.md
@@ -29,8 +29,8 @@ Wraps `AbstractFilesystem`; paths are the backend's local paths.
 | `read_file` | Read file content | `path`, `offset` (0-indexed), `limit` (0 = read all) |
 | `write_file` | Create new file | `path`, `content` (errors if file already exists) |
 | `edit_file` | Exact string replacement | `path`, `old_string` (unique by default), `new_string`, `replace_all` (default false) |
-| `grep_files` | Search string in specified path (not regex) | `pattern`, `path`, `glob` (e.g. `*.java`) |
-| `glob_files` | Find files by glob pattern | `pattern` (e.g. `**/*.md`), `path` |
+| `grep_files` | Search string in specified path (not regex) | `pattern`, `path`, `glob` (e.g. `*.java`), `limit` (default 100, max 1000) |
+| `glob_files` | Find files by glob pattern | `pattern` (e.g. `**/*.md`), `path`, `limit` (default 200, max 1000) |
 | `list_files` | List directory | `path` |
 
 ## Memory — `MemorySearchTool` / `MemoryGetTool`

--- a/docs/v1/zh/docs/harness/tool.md
+++ b/docs/v1/zh/docs/harness/tool.md
@@ -29,8 +29,8 @@ graph LR
 | `read_file` | 读文件内容 | `path`, `offset`（0-indexed）, `limit`（0 = 读全） |
 | `write_file` | 创建新文件 | `path`, `content`（已存在会报错） |
 | `edit_file` | 精确字符串替换 | `path`, `old_string`（默认唯一）, `new_string`, `replace_all`（默认 false） |
-| `grep_files` | 指定路径中搜字符串（非正则）| `pattern`, `path`, `glob`（如 `*.java`） |
-| `glob_files` | 按 glob 查文件 | `pattern`（如 `**/*.md`）, `path` |
+| `grep_files` | 指定路径中搜字符串（非正则）| `pattern`, `path`, `glob`（如 `*.java`）, `limit`（默认 100，最大 1000） |
+| `glob_files` | 按 glob 查文件 | `pattern`（如 `**/*.md`）, `path`, `limit`（默认 200，最大 1000） |
 | `list_files` | 列目录 | `path` |
 
 ## 记忆·`MemorySearchTool` / `MemoryGetTool`

--- a/docs/v2/en/docs/harness/compaction.md
+++ b/docs/v2/en/docs/harness/compaction.md
@@ -47,7 +47,7 @@ HarnessAgent.builder()
     .build();
 ```
 
-`read_file` / `write_file` / `edit_file` / `grep_files` / `glob_files` / `list_files` / `memory_*` / `session_search` are excluded by default — they either self-paginate or return tiny payloads. **Shell `execute` is deliberately NOT excluded** because command output can be arbitrarily large.
+`read_file` / `write_file` / `edit_file` / `list_files` / `memory_*` / `session_search` are excluded by default — they either self-paginate or return tiny payloads. `grep_files` and `glob_files` enforce result-count limits, but remain eligible for eviction as a second safety net when individual matches are unusually large. **Shell `execute` is deliberately NOT excluded** because command output can be arbitrarily large.
 
 Details in [Memory — Large tool-result offloading](./memory.md#large-tool-result-offloading).
 

--- a/docs/v2/zh/docs/harness/compaction.md
+++ b/docs/v2/zh/docs/harness/compaction.md
@@ -47,7 +47,7 @@ HarnessAgent.builder()
     .build();
 ```
 
-默认排除 `read_file` / `write_file` / `edit_file` / `grep_files` / `glob_files` / `list_files` / `memory_*` / `session_search`——这些工具要么自带分页、要么返回值很小。**Shell `execute` 默认不排除**,因为命令输出可能非常大。
+默认排除 `read_file` / `write_file` / `edit_file` / `list_files` / `memory_*` / `session_search`——这些工具要么自带分页、要么返回值很小。`grep_files` 和 `glob_files` 会强制限制结果条数，但仍可触发大结果卸载，作为单条结果异常大时的第二道保护。**Shell `execute` 默认不排除**,因为命令输出可能非常大。
 
 详情见[记忆 - 大工具结果卸载](./memory.md#大工具结果卸载)。
 


### PR DESCRIPTION
## 背景与必要性

目前 `grep_files` 和 `glob_files` 会将文件系统后端返回的全部匹配项拼接成一条工具结果。当工作区文件较多、搜索条件较宽（例如 `**/*`）时，单次工具调用可能向上下文写入 MB 级内容，进而导致上下文压缩或下一次模型调用失败。

### 为什么现有压缩机制不能稳定兜底

这里的问题并不是单纯“历史消息太多”，而是超大搜索结果通常产生在当前推理轮次的最新位置，正好落在现有压缩机制的保护区域中：

1. `TokenCounterUtil` 会统计 `ToolResultBlock` 的输出，因此 `grep_files` / `glob_files` 的大结果会被计入总 token，并可能触发 compaction；
2. 但 `ConversationCompactor.pruneToolResults` 会从后向前扫描，并默认保护最近约 40,000 token 的工具输出。刚刚产生的超大搜索结果通常位于这段保护窗口内，不会被 prune；
3. 后续 compaction 又会按 `keepMessages` / `keepTokens` 保留最近一段消息原文。默认消息模式会保留最近 20 条消息，因此这条最新的超大工具结果通常仍位于 preserved tail，不会进入摘要；
4. 与此同时，`ToolResultEvictionConfig.DEFAULT_EXCLUDED_TOOLS` 当前默认排除了 `grep_files` 和 `glob_files`，因为配置假设它们的输出已经是自限制的，但现有实现实际上没有结果数量限制。

因此可能出现这样的链路：

```text
无上限搜索结果
  -> 默认 eviction 跳过
  -> token 统计触发 compaction
  -> 结果因处于最近保护窗口 / preserved tail 而原样保留
  -> 压缩后上下文仍然过大，下一次模型调用失败
```

也就是说，仅依赖事后 compaction 不能稳定解决这个问题，更合适的第一道防线是在工具输出进入上下文之前就实施确定性的数量限制。

相关问题：#2831

## 当前实现草案

这个 PR 先提供了一版偏保守的保护方案：

- 为 `grep_files` 和 `glob_files` 增加可选的 `limit` 参数；
- 即使模型没有传入 `limit`，也由 `FilesystemTool` 强制应用默认值：
  - `grep_files`：100 条；
  - `glob_files`：200 条；
- 调用方可以调整 `limit`，但服务端硬上限为 1000；
- 存在更多匹配项时，在结果末尾明确提示已截断；
- 将 `grep_files` / `glob_files` 从 tool-result eviction 的默认排除列表中移除，作为单条匹配内容异常大时的第二道保护；
- 保留原有 Java 方法重载，避免影响直接调用 `FilesystemTool` 的现有代码；
- 同步更新中英文文档及测试。

这里的关键点是：**安全上限由 Harness 兜底，不依赖模型是否记得传可选参数。**

## 当前范围与已知限制

本 PR 当前限制的是 `FilesystemTool` 最终返回给模型的结果条数，即首先解决 #2831 中的上下文膨胀问题。`AbstractFilesystem.grep/glob` 的接口目前没有 `limit` 参数，各 filesystem backend 仍会完成全量搜索并将匹配项物化后，再由工具层截断输出。

因此，这一版能够限制工具消息大小，但尚未限制病态搜索场景下的后端扫描时间和内存占用。把 limit 下推到 `AbstractFilesystem` 和各后端、支持扫描阶段提前终止，是更完整但影响范围更大的后续优化；还需要同时确定 Composite/Overlay 合并排序、去重以及 `hasMore` / `truncated` 的语义。
## 想请维护者确认的取舍

这版数值和落点并非一定要固定，希望听取维护者意见：

1. 默认值采用 `grep=100`、`glob=200`，硬上限为 `1000`，是否符合项目的常见工作区规模？是否更倾向两个工具使用同一默认值？
2. 当前限制放在 `FilesystemTool` 输出边界，能以较小改动解决上下文膨胀，并兼容所有 filesystem backend；后续是否希望继续把 limit 下推到 `AbstractFilesystem` 及各后端，以便在扫描阶段提前停止、进一步降低 I/O 和内存开销？
3. `grep_files` / `glob_files` 是否应该恢复参与默认 eviction？当前实现认为“条数限制 + 字符数 eviction”是两层互补保护；如果维护者希望维持原有排除策略，我也可以只保留条数限制。
4. 截断提示目前使用纯文本，是否需要在后续演进为带 `truncated` / `next_offset` 等字段的结构化结果或分页接口？
5. 从压缩策略角度，是否也希望单独调整 recent tool-result protection，使单条超大结果即使位于保护窗口内也能被裁剪？这可以作为与工具侧限流互补的后续改进。

如果项目对默认值、API 形态或分层位置有既定方向，我可以按维护者建议调整本 PR。

## 兼容性

- 原有 Java 调用签名继续保留，并委托到带 `limit` 的新方法；
- 小于默认上限的搜索结果格式保持不变；
- `limit` 在工具 schema 中是可选参数。

## 验证

- `mvn -pl agentscope-harness -am '-Dtest=FilesystemToolTest,ToolResultEvictionMiddlewareTest' '-Dsurefire.failIfNoSpecifiedTests=false' test`
- `mvn -pl agentscope-harness -am -DskipTests package`

Fixes #2831