### PR TITLE
feat(tool): expose API to add registered tool to group

### DIFF
--- a/agentscope-core/src/main/java/io/agentscope/core/tool/Toolkit.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/tool/Toolkit.java
@@ -632,6 +632,24 @@ public class Toolkit {
     }
 
     /**
+     * Add an already-registered tool to an existing tool group.
+     *
+     * <p>A tool may belong to multiple groups. Adding the same tool to the same group more than
+     * once has no additional effect.
+     *
+     * @param groupName Name of the existing tool group
+     * @param toolName Name of the registered tool
+     * @throws IllegalArgumentException if the group or tool doesn't exist
+     */
+    public void addToolToGroup(String groupName, String toolName) {
+        groupManager.validateGroupExists(groupName);
+        if (toolRegistry.getTool(toolName) == null) {
+            throw new IllegalArgumentException("Tool not found: " + toolName);
+        }
+        groupManager.addToolToGroup(groupName, toolName);
+    }
+
+    /**
      * Update the activation status of tool groups.
      *
      * <p>When {@code allowToolDeletion} is disabled and {@code active} is false, the deactivation

--- a/agentscope-core/src/test/java/io/agentscope/core/tool/ToolkitTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/tool/ToolkitTest.java
@@ -518,7 +518,13 @@ class ToolkitTest {
         toolkit.createToolGroup("groupB", "Group B", false);
 
         toolkit.registration().tool(sampleTools).group("groupA").apply();
-        toolkit.registration().tool(sampleTools).group("groupB").apply();
+        AgentTool registeredTool = toolkit.getTool("add");
+        toolkit.addToolToGroup("groupB", "add");
+        toolkit.addToolToGroup("groupB", "add");
+
+        assertNotNull(registeredTool);
+        assertSame(registeredTool, toolkit.getTool("add"));
+        assertEquals(Set.of("add"), toolkit.getToolGroup("groupB").getTools());
 
         Map<String, Object> addInput = Map.of("a", 5, "b", 7);
         ToolUseBlock toolCall =
@@ -563,6 +569,26 @@ class ToolkitTest {
         assertTrue(
                 isErrorResult(resultWithNone),
                 "Should fail when no groups are active: " + getResultText(resultWithNone));
+    }
+
+    @Test
+    @DisplayName("Should reject adding an unknown group or tool")
+    void testAddToolToGroupValidation() {
+        toolkit.createToolGroup("existingGroup", "Existing group", false);
+        toolkit.registerAgentTool(namedAgentTool("registeredTool"));
+
+        IllegalArgumentException missingGroup =
+                assertThrows(
+                        IllegalArgumentException.class,
+                        () -> toolkit.addToolToGroup("missingGroup", "registeredTool"));
+        assertEquals("Tool group 'missingGroup' does not exist", missingGroup.getMessage());
+
+        IllegalArgumentException missingTool =
+                assertThrows(
+                        IllegalArgumentException.class,
+                        () -> toolkit.addToolToGroup("existingGroup", "missingTool"));
+        assertEquals("Tool not found: missingTool", missingTool.getMessage());
+        assertTrue(toolkit.getToolGroup("existingGroup").getTools().isEmpty());
     }
 
     @Test


### PR DESCRIPTION
## AgentScope-Java Version

2.0.3-SNAPSHOT

## Description

Closes #2835.

`ToolGroupManager` already supports an n:m relationship between tools and tool groups, but `Toolkit` did not expose a public API for assigning an already-registered tool to an additional group.

This PR:

- Adds `Toolkit#addToolToGroup(String groupName, String toolName)`.
- Validates that both the target group and tool exist.
- Preserves the existing registered tool instance and metadata.
- Keeps repeated assignments idempotent.
- Replaces the duplicate-registration workaround in the multi-group regression test.
- Adds validation coverage for unknown groups and unregistered tools.

## Testing

- `mvn -pl agentscope-core -Dtest=ToolkitTest test`
  - 37 tests passed
- `mvn -pl agentscope-core test`
  - 2295 tests passed
  - 0 failures
  - 0 errors
  - 9 skipped
- `git diff --check`
- Spotless check passed

## Checklist

- [x] Code formatting has been verified with Spotless
- [x] All affected module tests are passing
- [x] Javadoc comments are complete and follow project conventions
- [x] Public API behavior is covered by regression tests
- [x] Code is ready for review