### PR TITLE
fix(accumulator): warn on malformed streamed tool arguments

### DIFF
--- a/agentscope-core/src/main/java/io/agentscope/core/ReActAgent.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/ReActAgent.java
@@ -3336,7 +3336,8 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
                                                         toolCall,
                                                         ToolResultBlock.error(
                                                                 toolCall.getId(),
-                                                                "Tool execution rejected: malformed tool arguments")))
+                                                                "Tool execution rejected: malformed"
+                                                                        + " tool arguments")))
                                 .toList());
             }
             return dispatchToolCalls(toolCalls)

--- a/agentscope-core/src/main/java/io/agentscope/core/ReActAgent.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/ReActAgent.java
@@ -3338,6 +3338,18 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
          */
         private Mono<List<Map.Entry<ToolUseBlock, ToolResultBlock>>> executeToolCalls(
                 List<ToolUseBlock> toolCalls) {
+            if (toolCalls.stream().anyMatch(t -> t.getState() == ToolCallState.PARSE_FAILED)) {
+                return Mono.just(
+                        toolCalls.stream()
+                                .map(
+                                        toolCall ->
+                                                Map.entry(
+                                                        toolCall,
+                                                        ToolResultBlock.error(
+                                                                toolCall.getId(),
+                                                                "Tool execution rejected: malformed tool arguments")))
+                                .toList());
+            }
             return dispatchToolCalls(toolCalls)
                     .map(
                             results ->

--- a/agentscope-core/src/main/java/io/agentscope/core/agent/accumulator/ToolCallsAccumulator.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/agent/accumulator/ToolCallsAccumulator.java
@@ -23,6 +23,8 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Tool calls accumulator for accumulating streaming tool call chunks.
@@ -38,6 +40,8 @@ import java.util.stream.Collectors;
  * @hidden
  */
 public class ToolCallsAccumulator implements ContentAccumulator<ToolUseBlock> {
+
+    private static final Logger log = LoggerFactory.getLogger(ToolCallsAccumulator.class);
 
     // Map to support multiple parallel tool calls
     // Key: tool identifier (ID, name, or index)
@@ -113,8 +117,13 @@ public class ToolCallsAccumulator implements ContentAccumulator<ToolUseBlock> {
                             }
                         }
                     }
-                } catch (Exception ignored) {
-                    // Parsing failed, keep previously merged args
+                } catch (Exception e) {
+                    // Keep previously merged args, but retain enough context to diagnose the
+                    // malformed arguments emitted by the model.
+                    log.warn(
+                            "Failed to parse accumulated tool call arguments: {}",
+                            rawContentStr,
+                            e);
                 }
             }
 

--- a/agentscope-core/src/main/java/io/agentscope/core/agent/accumulator/ToolCallsAccumulator.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/agent/accumulator/ToolCallsAccumulator.java
@@ -124,8 +124,10 @@ public class ToolCallsAccumulator implements ContentAccumulator<ToolUseBlock> {
                     }
                 } catch (Exception e) {
                     state = ToolCallState.PARSE_FAILED;
-                    // Keep previously merged args, but retain enough context to diagnose the
-                    // malformed arguments emitted by the model.
+                    // Do not leave stale or partial arguments executable after final parsing
+                    // fails. The PARSE_FAILED state prevents dispatch through ReActAgent, and
+                    // clearing the map keeps the block fail-closed for other consumers too.
+                    finalArgs.clear();
                     log.warn(
                             "Failed to parse accumulated tool call arguments: "
                                     + "toolId={}, toolName={}, byteLength={}, sha256={}, "

--- a/agentscope-core/src/main/java/io/agentscope/core/agent/accumulator/ToolCallsAccumulator.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/agent/accumulator/ToolCallsAccumulator.java
@@ -18,6 +18,9 @@ package io.agentscope.core.agent.accumulator;
 import io.agentscope.core.message.ContentBlock;
 import io.agentscope.core.message.ToolUseBlock;
 import io.agentscope.core.util.JsonUtils;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -121,9 +124,15 @@ public class ToolCallsAccumulator implements ContentAccumulator<ToolUseBlock> {
                     // Keep previously merged args, but retain enough context to diagnose the
                     // malformed arguments emitted by the model.
                     log.warn(
-                            "Failed to parse accumulated tool call arguments: {}",
-                            rawContentStr,
-                            e);
+                            "Failed to parse accumulated tool call arguments: "
+                                    + "toolId={}, toolName={}, byteLength={}, sha256={}, "
+                                    + "exceptionType={}, message={}",
+                            toolId,
+                            name,
+                            rawContentStr.getBytes(StandardCharsets.UTF_8).length,
+                            sha256(rawContentStr),
+                            e.getClass().getName(),
+                            e.getMessage());
                 }
             }
 
@@ -153,6 +162,21 @@ public class ToolCallsAccumulator implements ContentAccumulator<ToolUseBlock> {
             return "__fragment__".equals(name)
                     || "__pending__".equals(name)
                     || (name != null && name.startsWith("__"));
+        }
+
+        private String sha256(String value) {
+            try {
+                byte[] digest =
+                        MessageDigest.getInstance("SHA-256")
+                                .digest(value.getBytes(StandardCharsets.UTF_8));
+                StringBuilder hex = new StringBuilder(digest.length * 2);
+                for (byte b : digest) {
+                    hex.append(String.format("%02x", b));
+                }
+                return hex.toString();
+            } catch (NoSuchAlgorithmException e) {
+                throw new IllegalStateException("SHA-256 is not available", e);
+            }
         }
 
         private String generateId() {

--- a/agentscope-core/src/main/java/io/agentscope/core/agent/accumulator/ToolCallsAccumulator.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/agent/accumulator/ToolCallsAccumulator.java
@@ -16,6 +16,7 @@
 package io.agentscope.core.agent.accumulator;
 
 import io.agentscope.core.message.ContentBlock;
+import io.agentscope.core.message.ToolCallState;
 import io.agentscope.core.message.ToolUseBlock;
 import io.agentscope.core.util.JsonUtils;
 import java.nio.charset.StandardCharsets;
@@ -99,6 +100,7 @@ public class ToolCallsAccumulator implements ContentAccumulator<ToolUseBlock> {
 
         ToolUseBlock build() {
             Map<String, Object> finalArgs = new HashMap<>(args);
+            ToolCallState state = ToolCallState.PENDING;
             String rawContentStr = this.rawContent.toString();
 
             // Always attempt to parse the fully accumulated raw JSON. Early stream chunks may
@@ -121,6 +123,7 @@ public class ToolCallsAccumulator implements ContentAccumulator<ToolUseBlock> {
                         }
                     }
                 } catch (Exception e) {
+                    state = ToolCallState.PARSE_FAILED;
                     // Keep previously merged args, but retain enough context to diagnose the
                     // malformed arguments emitted by the model.
                     log.warn(
@@ -153,6 +156,7 @@ public class ToolCallsAccumulator implements ContentAccumulator<ToolUseBlock> {
                     .name(name)
                     .input(finalArgs)
                     .content(contentStr)
+                    .state(state)
                     .metadata(metadata.isEmpty() ? null : metadata)
                     .build();
         }

--- a/agentscope-core/src/main/java/io/agentscope/core/message/ToolCallState.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/message/ToolCallState.java
@@ -26,7 +26,10 @@ public enum ToolCallState {
 
     SUBMITTED("submitted"),
 
-    FINISHED("finished");
+    FINISHED("finished"),
+
+    /** The streamed tool arguments failed final JSON parsing and must not execute. */
+    PARSE_FAILED("parse_failed");
 
     private final String value;
 

--- a/agentscope-core/src/test/java/io/agentscope/core/agent/accumulator/ToolCallsAccumulatorTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/agent/accumulator/ToolCallsAccumulatorTest.java
@@ -21,6 +21,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import io.agentscope.core.message.ToolCallState;
 import io.agentscope.core.message.ToolUseBlock;
 import java.util.HashMap;
 import java.util.List;
@@ -116,8 +117,26 @@ class ToolCallsAccumulatorTest {
 
         ToolUseBlock toolCall = accumulator.buildAllToolCalls().get(0);
 
-        assertEquals("output.txt", toolCall.getInput().get("path"));
+        assertTrue(toolCall.getInput().isEmpty());
         assertEquals("{}", toolCall.getContent());
+        assertEquals(ToolCallState.PARSE_FAILED, toolCall.getState());
+    }
+
+    @Test
+    @DisplayName("Should allow an explicitly valid empty object")
+    void testValidEmptyObjectRemainsExecutable() {
+        accumulator.add(
+                ToolUseBlock.builder()
+                        .id("call_empty")
+                        .name("noop")
+                        .input(Map.of())
+                        .content("{}")
+                        .build());
+
+        ToolUseBlock toolCall = accumulator.buildAllToolCalls().get(0);
+
+        assertTrue(toolCall.getInput().isEmpty());
+        assertEquals(ToolCallState.PENDING, toolCall.getState());
     }
 
     @Test

--- a/agentscope-core/src/test/java/io/agentscope/core/agent/accumulator/ToolCallsAccumulatorTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/agent/accumulator/ToolCallsAccumulatorTest.java
@@ -105,8 +105,8 @@ class ToolCallsAccumulatorTest {
     }
 
     @Test
-    @DisplayName("Should preserve merged arguments and fallback content for malformed JSON")
-    void testMalformedJsonFallsBackWithoutDroppingMergedArguments() {
+    @DisplayName("Should fail closed and fallback content for malformed JSON")
+    void testMalformedJsonFailsClosedWithFallbackContent() {
         accumulator.add(
                 ToolUseBlock.builder()
                         .id("call_malformed")
@@ -117,6 +117,7 @@ class ToolCallsAccumulatorTest {
 
         ToolUseBlock toolCall = accumulator.buildAllToolCalls().get(0);
 
+        // Partial arguments must not remain executable after final JSON parsing fails.
         assertTrue(toolCall.getInput().isEmpty());
         assertEquals("{}", toolCall.getContent());
         assertEquals(ToolCallState.PARSE_FAILED, toolCall.getState());

--- a/agentscope-core/src/test/java/io/agentscope/core/agent/accumulator/ToolCallsAccumulatorTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/agent/accumulator/ToolCallsAccumulatorTest.java
@@ -104,6 +104,23 @@ class ToolCallsAccumulatorTest {
     }
 
     @Test
+    @DisplayName("Should preserve merged arguments and fallback content for malformed JSON")
+    void testMalformedJsonFallsBackWithoutDroppingMergedArguments() {
+        accumulator.add(
+                ToolUseBlock.builder()
+                        .id("call_malformed")
+                        .name("write_text_file")
+                        .input(Map.of("path", "output.txt"))
+                        .content("{\"projectName\": \"改造\"文化礼堂\"及配套设施\"}")
+                        .build());
+
+        ToolUseBlock toolCall = accumulator.buildAllToolCalls().get(0);
+
+        assertEquals("output.txt", toolCall.getInput().get("path"));
+        assertEquals("{}", toolCall.getContent());
+    }
+
+    @Test
     @DisplayName("Should handle parallel tool calls with different metadata")
     void testParallelToolCallsWithMetadata() {
         // First tool call with metadata


### PR DESCRIPTION
## Summary

- warn when accumulated streamed tool-call arguments cannot be parsed as JSON
- preserve the existing `{}` content fallback and merged-argument behavior
- add regression coverage for malformed arguments emitted by a model

## Testing

- `mvn -pl agentscope-core -Dtest=ToolCallsAccumulatorTest test`
- `mvn -pl agentscope-core test`
- `mvn -pl agentscope-core spotless:check`
- `git diff --check`

Closes #2841
