### PR TITLE
fix(sandbox): retain active fallback across concurrent calls

### DIFF
--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/filesystem/sandbox/SandboxBackedFilesystem.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/filesystem/sandbox/SandboxBackedFilesystem.java
@@ -53,15 +53,18 @@ import org.slf4j.LoggerFactory;
  * {@code volatile sandbox} field is retained only as a best-effort fallback for context-free
  * internal callers that resolve the filesystem with a shared empty {@link RuntimeContext} (e.g.
  * {@link io.agentscope.harness.agent.bus.WorkspaceMessageBus}, which carries no per-call binding).
- * The middleware still maintains that field via {@link #setSandbox} on acquire and {@link
- * #clearSandboxIfCurrent} on release, so it remains last-writer-wins under concurrency and must not
- * be relied on for isolation.
+ * The middleware maintains that fallback via {@link #setSandbox} on acquire and {@link
+ * #clearSandboxIfCurrent} on release. Active bindings are retained in acquisition order so a
+ * release restores another still-active binding instead of transiently leaving context-free
+ * callers without a sandbox (issue #2849). The fallback still must not be relied on for session
+ * isolation; per-call bindings remain authoritative.
  */
 public class SandboxBackedFilesystem extends BaseSandboxFilesystem implements SandboxAware {
 
     private static final Logger log = LoggerFactory.getLogger(SandboxBackedFilesystem.class);
 
     private final String fsId;
+    private final List<Sandbox> fallbackBindings = new ArrayList<>();
     private volatile Sandbox sandbox;
 
     public SandboxBackedFilesystem() {
@@ -70,6 +73,12 @@ public class SandboxBackedFilesystem extends BaseSandboxFilesystem implements Sa
 
     @Override
     public synchronized void setSandbox(Sandbox sandbox) {
+        if (sandbox == null) {
+            fallbackBindings.clear();
+            this.sandbox = null;
+            return;
+        }
+        fallbackBindings.add(sandbox);
         this.sandbox = sandbox;
     }
 
@@ -79,16 +88,25 @@ public class SandboxBackedFilesystem extends BaseSandboxFilesystem implements Sa
     }
 
     /**
-     * Clears the fallback {@code sandbox} field only if it still points at {@code expected}. Used by
-     * {@link io.agentscope.harness.agent.middleware.SandboxLifecycleMiddleware} on release so a
-     * finishing call never nulls a concurrent sibling call's fallback binding (issue #2490).
+     * Removes one fallback binding for {@code expected} and restores the most recently acquired
+     * binding that remains active. Used by {@link
+     * io.agentscope.harness.agent.middleware.SandboxLifecycleMiddleware} on release so a finishing
+     * call neither clears nor later restores a concurrent sibling call's binding (issues #2490 and
+     * #2849).
      *
      * @param expected the sandbox this call bound at acquire time
      */
     public synchronized void clearSandboxIfCurrent(Sandbox expected) {
-        if (this.sandbox == expected) {
-            this.sandbox = null;
+        for (int i = fallbackBindings.size() - 1; i >= 0; i--) {
+            if (fallbackBindings.get(i) == expected) {
+                fallbackBindings.remove(i);
+                break;
+            }
         }
+        this.sandbox =
+                fallbackBindings.isEmpty()
+                        ? null
+                        : fallbackBindings.get(fallbackBindings.size() - 1);
     }
 
     @Override

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/filesystem/sandbox/SandboxBackedFilesystem.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/filesystem/sandbox/SandboxBackedFilesystem.java
@@ -36,6 +36,7 @@ import java.util.ArrayList;
 import java.util.Base64;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.UUID;
 import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
 import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream;
@@ -71,13 +72,15 @@ public class SandboxBackedFilesystem extends BaseSandboxFilesystem implements Sa
         this.fsId = "sandbox-" + UUID.randomUUID().toString().substring(0, 8);
     }
 
+    /**
+     * Registers an active fallback binding.
+     *
+     * @param sandbox the active sandbox; must not be {@code null}
+     * @throws NullPointerException if {@code sandbox} is {@code null}
+     */
     @Override
     public synchronized void setSandbox(Sandbox sandbox) {
-        if (sandbox == null) {
-            fallbackBindings.clear();
-            this.sandbox = null;
-            return;
-        }
+        Objects.requireNonNull(sandbox, "sandbox");
         fallbackBindings.add(sandbox);
         this.sandbox = sandbox;
     }

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/middleware/SandboxLifecycleMiddleware.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/middleware/SandboxLifecycleMiddleware.java
@@ -159,8 +159,8 @@ public class SandboxLifecycleMiddleware implements HarnessRuntimeMiddleware {
             return;
         }
         ctx.put(SandboxAcquireResult.class, null);
-        // Compare-and-clear the fallback field so a releasing call never nulls a concurrent
-        // sibling's binding (issue #2490); it only clears the field when it still points here.
+        // Remove this call's fallback binding. The proxy restores the most recently acquired
+        // binding that is still active, so a sibling call is neither cleared nor resurrected.
         filesystemProxy.clearSandboxIfCurrent(result.getSandbox());
         SandboxContext sandboxContext = ctx.get(SandboxContext.class);
         try {

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/middleware/SandboxLifecycleMiddleware.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/middleware/SandboxLifecycleMiddleware.java
@@ -109,6 +109,7 @@ public class SandboxLifecycleMiddleware implements HarnessRuntimeMiddleware {
             }
             SandboxAcquireResult result = sandboxManager.acquire(sandboxContext, ctx);
             Sandbox sandbox = result.getSandbox();
+            boolean fallbackBound = false;
             try {
                 sandbox.start();
                 // Bind the acquired sandbox per-call on this invocation's RuntimeContext rather
@@ -119,12 +120,15 @@ public class SandboxLifecycleMiddleware implements HarnessRuntimeMiddleware {
                 // context-free callers (e.g. WorkspaceMessageBus) that do not thread a per-call.
                 ctx.put(SandboxAcquireResult.class, result);
                 filesystemProxy.setSandbox(sandbox);
+                fallbackBound = true;
                 log.debug(
                         "[sandbox-mw] Acquired sandbox {}",
                         sandbox.getState() != null ? sandbox.getState().getSessionId() : "?");
             } catch (Exception e) {
                 ctx.put(SandboxAcquireResult.class, null);
-                filesystemProxy.clearSandboxIfCurrent(sandbox);
+                if (fallbackBound) {
+                    filesystemProxy.clearSandboxIfCurrent(sandbox);
+                }
                 try {
                     sandboxManager.release(result);
                 } catch (Exception releaseErr) {

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/filesystem/sandbox/SandboxBackedFilesystemTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/filesystem/sandbox/SandboxBackedFilesystemTest.java
@@ -18,6 +18,7 @@ package io.agentscope.harness.agent.filesystem.sandbox;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.agentscope.core.agent.RuntimeContext;
@@ -25,6 +26,7 @@ import io.agentscope.harness.agent.filesystem.model.FileDownloadResponse;
 import io.agentscope.harness.agent.filesystem.model.FileUploadResponse;
 import io.agentscope.harness.agent.sandbox.ExecResult;
 import io.agentscope.harness.agent.sandbox.Sandbox;
+import io.agentscope.harness.agent.sandbox.SandboxException;
 import io.agentscope.harness.agent.sandbox.SandboxFileTransfer;
 import io.agentscope.harness.agent.sandbox.SandboxState;
 import io.agentscope.harness.agent.sandbox.WorkspaceSpec;
@@ -43,6 +45,52 @@ import org.junit.jupiter.api.Test;
 class SandboxBackedFilesystemTest {
 
     private static final RuntimeContext RT = RuntimeContext.empty();
+
+    @Test
+    void contextFreeCallUsesRemainingSandboxWhenLatestCallReleases() {
+        SandboxBackedFilesystem filesystem = new SandboxBackedFilesystem();
+        FakeSandbox first = new FakeSandbox(new ExecResult(0, "first", "", false));
+        FakeSandbox second = new FakeSandbox(new ExecResult(0, "second", "", false));
+        filesystem.setSandbox(first);
+        filesystem.setSandbox(second);
+
+        filesystem.clearSandboxIfCurrent(second);
+
+        assertEquals("first", filesystem.execute(RT, "whoami", null).output());
+    }
+
+    @Test
+    void releasingNonCurrentSandboxDoesNotRestoreItLater() {
+        SandboxBackedFilesystem filesystem = new SandboxBackedFilesystem();
+        FakeSandbox first = new FakeSandbox(new ExecResult(0, "first", "", false));
+        FakeSandbox second = new FakeSandbox(new ExecResult(0, "second", "", false));
+        filesystem.setSandbox(first);
+        filesystem.setSandbox(second);
+
+        filesystem.clearSandboxIfCurrent(first);
+        assertEquals("second", filesystem.execute(RT, "whoami", null).output());
+
+        filesystem.clearSandboxIfCurrent(second);
+        assertThrows(
+                SandboxException.SandboxConfigurationException.class,
+                () -> filesystem.execute(RT, "whoami", null));
+    }
+
+    @Test
+    void sharedSandboxRemainsBoundUntilEveryCallReleases() {
+        SandboxBackedFilesystem filesystem = new SandboxBackedFilesystem();
+        FakeSandbox shared = new FakeSandbox(new ExecResult(0, "shared", "", false));
+        filesystem.setSandbox(shared);
+        filesystem.setSandbox(shared);
+
+        filesystem.clearSandboxIfCurrent(shared);
+        assertEquals("shared", filesystem.execute(RT, "whoami", null).output());
+
+        filesystem.clearSandboxIfCurrent(shared);
+        assertThrows(
+                SandboxException.SandboxConfigurationException.class,
+                () -> filesystem.execute(RT, "whoami", null));
+    }
 
     @Test
     void downloadFiles_decodesWrappedBase64Output() {

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/filesystem/sandbox/SandboxBackedFilesystemTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/filesystem/sandbox/SandboxBackedFilesystemTest.java
@@ -93,6 +93,21 @@ class SandboxBackedFilesystemTest {
     }
 
     @Test
+    void nullSandboxIsRejectedWithoutClearingActiveFallback() {
+        SandboxBackedFilesystem filesystem = new SandboxBackedFilesystem();
+        FakeSandbox first = new FakeSandbox(new ExecResult(0, "first", "", false));
+        FakeSandbox second = new FakeSandbox(new ExecResult(0, "second", "", false));
+        filesystem.setSandbox(first);
+        filesystem.setSandbox(second);
+
+        assertThrows(NullPointerException.class, () -> filesystem.setSandbox(null));
+        assertEquals("second", filesystem.execute(RT, "whoami", null).output());
+
+        filesystem.clearSandboxIfCurrent(second);
+        assertEquals("first", filesystem.execute(RT, "whoami", null).output());
+    }
+
+    @Test
     void downloadFiles_decodesWrappedBase64Output() {
         byte[] expected = new byte[] {1, 2, 3, 4, 5, 6};
         SandboxBackedFilesystem filesystem = new SandboxBackedFilesystem();

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/middleware/SandboxLifecycleConcurrencyReproTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/middleware/SandboxLifecycleConcurrencyReproTest.java
@@ -17,6 +17,7 @@ package io.agentscope.harness.agent.middleware;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 
@@ -27,6 +28,7 @@ import io.agentscope.harness.agent.sandbox.Sandbox;
 import io.agentscope.harness.agent.sandbox.SandboxAcquireResult;
 import io.agentscope.harness.agent.sandbox.SandboxClient;
 import io.agentscope.harness.agent.sandbox.SandboxContext;
+import io.agentscope.harness.agent.sandbox.SandboxException;
 import io.agentscope.harness.agent.sandbox.SandboxLease;
 import io.agentscope.harness.agent.sandbox.SandboxManager;
 import io.agentscope.harness.agent.sandbox.SandboxState;
@@ -114,6 +116,46 @@ class SandboxLifecycleConcurrencyReproTest {
                 "call B must still run against its own sandbox after A released");
     }
 
+    @Test
+    void failedSharedSandboxStartDoesNotRemoveActiveFallback() {
+        SandboxBackedFilesystem proxy = new SandboxBackedFilesystem();
+        RecordingSandbox shared = new RecordingSandbox("shared");
+        shared.failStartOnCall(2);
+
+        SandboxManager manager = sharedUserManagedManager(shared);
+        SandboxLifecycleMiddleware mw = new SandboxLifecycleMiddleware(manager, proxy);
+        RuntimeContext ctxA = callContext("s1");
+        RuntimeContext ctxB = callContext("s2");
+
+        mw.acquireForCall(ctxA);
+        assertThrows(RuntimeException.class, () -> mw.acquireForCall(ctxB));
+
+        assertEquals(
+                "shared",
+                proxy.execute(RuntimeContext.empty(), "whoami", null).output(),
+                "a failed start must not remove another call's active fallback binding");
+
+        mw.releaseForCall(ctxA);
+        assertThrows(
+                SandboxException.SandboxConfigurationException.class,
+                () -> proxy.execute(RuntimeContext.empty(), "whoami", null));
+    }
+
+    @Test
+    void failureAfterFallbackRegistrationClearsOwnBinding() {
+        SandboxBackedFilesystem proxy = new SandboxBackedFilesystem();
+        RecordingSandbox sandbox = new RecordingSandbox("failing");
+        sandbox.failStateLookup();
+
+        SandboxManager manager = sharedUserManagedManager(sandbox);
+        SandboxLifecycleMiddleware mw = new SandboxLifecycleMiddleware(manager, proxy);
+
+        assertThrows(RuntimeException.class, () -> mw.acquireForCall(callContext("s1")));
+        assertThrows(
+                SandboxException.SandboxConfigurationException.class,
+                () -> proxy.execute(RuntimeContext.empty(), "whoami", null));
+    }
+
     private static RuntimeContext callContext(String sessionId) {
         SandboxContext sandboxContext = SandboxContext.builder().build();
         return RuntimeContext.builder()
@@ -158,10 +200,25 @@ class SandboxLifecycleConcurrencyReproTest {
         };
     }
 
+    private static SandboxManager sharedUserManagedManager(RecordingSandbox shared) {
+        SandboxClient<?> client = mock(SandboxClient.class);
+        SessionSandboxStateStore stateStore = mock(SessionSandboxStateStore.class);
+        return new SandboxManager(client, stateStore, "repro-agent") {
+            @Override
+            public SandboxAcquireResult acquire(
+                    SandboxContext sandboxContext, RuntimeContext runtimeContext) {
+                return SandboxAcquireResult.userManaged(shared);
+            }
+        };
+    }
+
     /** Minimal {@link Sandbox} that records teardown and echoes its session id from exec. */
     private static final class RecordingSandbox implements Sandbox {
 
         private final String sessionId;
+        private int failStartOnCall = -1;
+        private boolean failStateLookup;
+        private int startCalls;
         volatile boolean stopped;
 
         RecordingSandbox(String sessionId) {
@@ -169,7 +226,20 @@ class SandboxLifecycleConcurrencyReproTest {
         }
 
         @Override
-        public void start() {}
+        public void start() {
+            startCalls++;
+            if (startCalls == failStartOnCall) {
+                throw new IllegalStateException("start failed");
+            }
+        }
+
+        void failStartOnCall(int call) {
+            this.failStartOnCall = call;
+        }
+
+        void failStateLookup() {
+            this.failStateLookup = true;
+        }
 
         @Override
         public void stop() {
@@ -188,6 +258,9 @@ class SandboxLifecycleConcurrencyReproTest {
 
         @Override
         public SandboxState getState() {
+            if (failStateLookup) {
+                throw new IllegalStateException("state lookup failed");
+            }
             return null;
         }
 


### PR DESCRIPTION
## AgentScope-Java Version

2.0.3-SNAPSHOT

## Description

Fixes #2849.

When concurrent calls shared one agent, the context-free filesystem fallback remembered only the
latest sandbox. If that call released while an earlier call was still active, it cleared the
fallback and caused the remaining call's internal filesystem work to fail.

This change retains every active fallback binding in acquisition order. Releasing a call removes
one matching binding and restores the most recently acquired binding that is still active. It also
removes non-current bindings so they cannot be restored after release, and preserves repeated
bindings to the same sandbox until every matching call has released. Per-call context binding
remains authoritative and unchanged. Startup cleanup also records whether the current call
actually registered a fallback, so a failed startup cannot remove an identical sandbox binding
that belongs to another active call.

This follow-up is intentionally limited to the reported empty-fallback window. Context-free
callers still use the most recently acquired active fallback and do not gain session routing;
per-call context remains the isolation mechanism.

The failed-start regression was run against both versions: it reaches the reported missing-sandbox
failure before this follow-up and passes afterward. The existing release-order regressions and
focused lifecycle checks also pass locally.

The null-binding regression confirms that a rejected null update leaves both the current and previous active bindings intact.

Local `clean verify` passes for the Harness module and its dependencies, including formatting and the full relevant test suites. GitHub CI runs the complete cross-platform build and remaining repository checks.

## Checklist

Please check the following items before code is ready to be reviewed.

- [x]  Code has been formatted with `mvn spotless:apply`
- [x]  All tests are passing (`mvn test`)
- [x]  Javadoc comments are complete and follow project conventions
- [x]  Related documentation has been updated (not applicable; behavior is internal)
- [x]  Code is ready for review
