### PR TITLE
fix(agui): isolate HITL sessions by user

### DIFF
--- a/agentscope-examples/agentscope-copilotkit/frontend/package.json
+++ b/agentscope-examples/agentscope-copilotkit/frontend/package.json
@@ -10,9 +10,9 @@
   "type": "module",
   "dependencies": {
     "@ag-ui/client": "^0.0.57",
-    "@copilotkit/a2ui-renderer": "^1.65.0",
-    "@copilotkit/react-core": "^1.65.0",
-    "@copilotkit/react-ui": "^1.65.0",
+    "@copilotkit/a2ui-renderer": "^1.69.2",
+    "@copilotkit/react-core": "^1.69.2",
+    "@copilotkit/react-ui": "^1.69.2",
     "@radix-ui/react-scroll-area": "^1.2.18",
     "@radix-ui/react-separator": "^1.1.15",
     "@radix-ui/react-slot": "^1.3.3",

--- a/agentscope-examples/agentscope-copilotkit/frontend/src/main.tsx
+++ b/agentscope-examples/agentscope-copilotkit/frontend/src/main.tsx
@@ -15,7 +15,7 @@ ReactDOM.createRoot(document.getElementById("root")!).render(
       debug={true}
       useSingleEndpoint={false}
       agent={WORKBENCH_AGENT_ID}
-      enableInspector={false}
+      enableInspector={import.meta.env.DEV}
       headers={{}}
       // Passing a catalog is what activates the A2UI renderer against a self-hosted AG-UI
       // backend: CopilotKit normally learns about A2UI from a CopilotRuntime /info response,

--- a/agentscope-examples/agentscope-copilotkit/src/main/java/io/agentscope/examples/copilotkit/config/AgentConfiguration.java
+++ b/agentscope-examples/agentscope-copilotkit/src/main/java/io/agentscope/examples/copilotkit/config/AgentConfiguration.java
@@ -15,19 +15,20 @@
  */
 package io.agentscope.examples.copilotkit.config;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import io.agentscope.core.ReActAgent;
 import io.agentscope.core.agent.Agent;
 import io.agentscope.core.agent.RuntimeContext;
-import io.agentscope.core.agui.adapter.strategy.AgentEventConverter;
 import io.agentscope.core.agui.adapter.strategy.AguiEventEnricher;
-import io.agentscope.core.agui.adapter.strategy.AguiStreamContext;
 import io.agentscope.core.agui.event.AguiEvent;
 import io.agentscope.core.agui.event.AguiEvents;
+import io.agentscope.core.agui.runtime.AguiRuntimeContextResolver;
 import io.agentscope.core.event.AgentEvent;
 import io.agentscope.core.event.AgentStartEvent;
 import io.agentscope.core.event.CustomEvent;
-import io.agentscope.core.event.RequireExternalExecutionEvent;
-import io.agentscope.core.message.ToolUseBlock;
 import io.agentscope.core.middleware.AgentInput;
 import io.agentscope.core.middleware.MiddlewareBase;
 import io.agentscope.core.model.ToolSchema;
@@ -36,7 +37,10 @@ import io.agentscope.core.permission.PermissionContextState;
 import io.agentscope.core.permission.PermissionMode;
 import io.agentscope.core.permission.PermissionRule;
 import io.agentscope.core.tool.Toolkit;
+import io.agentscope.core.util.JacksonJsonCodec;
+import io.agentscope.core.util.JsonUtils;
 import io.agentscope.examples.copilotkit.a2ui.A2uiComposer;
+import io.agentscope.examples.copilotkit.service.DemoThreadStore;
 import io.agentscope.examples.copilotkit.service.InMemoryAgentEventStore;
 import io.agentscope.examples.copilotkit.service.PersistingAgentEventEnricher;
 import io.agentscope.examples.copilotkit.workbench.RefundOrderTool;
@@ -47,12 +51,13 @@ import io.agentscope.examples.copilotkit.workbench.WorkbenchTools;
 import io.agentscope.extensions.model.dashscope.DashScopeChatModel;
 import io.agentscope.extensions.model.dashscope.formatter.DashScopeChatFormatter;
 import io.agentscope.spring.boot.agui.common.AguiAgentRegistryCustomizer;
+import jakarta.annotation.PostConstruct;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.function.Function;
 import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.Ordered;
@@ -115,31 +120,6 @@ public class AgentConfiguration {
     }
 
     @Bean
-    public AgentEventConverter requireExternalExecutionEventConverter() {
-        return new AgentEventConverter() {
-            @Override
-            public Set<Class<? extends AgentEvent>> eventTypes() {
-                return Set.of(RequireExternalExecutionEvent.class);
-            }
-
-            @Override
-            public void convert(AgentEvent event, AguiStreamContext context) {
-                RequireExternalExecutionEvent customEvent = (RequireExternalExecutionEvent) event;
-                for (ToolUseBlock toolCall : customEvent.getToolCalls()) {
-                    context.emit(
-                            new AguiEvent.ToolCallChunk(
-                                    context.getThreadId(),
-                                    context.getRunId(),
-                                    toolCall.getId(),
-                                    toolCall.getName(),
-                                    null,
-                                    toolCall.getContent()));
-                }
-            }
-        };
-    }
-
-    @Bean
     public AguiEventEnricher exampleAguiEventEnricher() {
         return (source, events, context) -> {
             long timestamp = System.currentTimeMillis();
@@ -161,6 +141,20 @@ public class AgentConfiguration {
             InMemoryAgentEventStore eventStore,
             ObjectProvider<WorkbenchAguiEventConverter> workbenchConverterProvider) {
         return new PersistingAgentEventEnricher(eventStore, workbenchConverterProvider);
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    public AguiRuntimeContextResolver aguiRuntimeContextResolver() {
+        return request -> {
+            // Demo identity: treat X-Token as the user id when present.
+            String token = request.firstHeader("X-Token");
+            String userId = token == null || token.isBlank() ? DemoThreadStore.DEMO_USER_ID : token;
+            return RuntimeContext.builder()
+                    .sessionId(request.getInput().getThreadId())
+                    .userId(userId)
+                    .build();
+        };
     }
 
     /**
@@ -198,7 +192,7 @@ public class AgentConfiguration {
                 .model(
                         DashScopeChatModel.builder()
                                 .apiKey(getRequiredApiKey())
-                                .modelName("qwen3.5-plus")
+                                .modelName(getModelName())
                                 .stream(true)
                                 .enableThinking(true)
                                 .formatter(new DashScopeChatFormatter())
@@ -293,7 +287,7 @@ public class AgentConfiguration {
                 .model(
                         DashScopeChatModel.builder()
                                 .apiKey(apiKey)
-                                .modelName("qwen3.5-plus")
+                                .modelName(getModelName())
                                 .stream(true)
                                 .enableThinking(true)
                                 .formatter(new DashScopeChatFormatter())
@@ -339,8 +333,10 @@ public class AgentConfiguration {
                                 + "Engage in natural conversation and help users "
                                 + "with general questions and discussions.")
                 .model(
-                        DashScopeChatModel.builder().apiKey(apiKey).modelName("qwen-plus").stream(
-                                        true)
+                        DashScopeChatModel.builder()
+                                .apiKey(apiKey)
+                                .modelName(getModelName())
+                                .stream(true)
                                 .formatter(new DashScopeChatFormatter())
                                 .build())
                 .middleware(exampleCustomEventMiddleware())
@@ -365,8 +361,10 @@ public class AgentConfiguration {
                                 + "Use the calculate tool to perform mathematical operations. "
                                 + "Always show your work and explain the results.")
                 .model(
-                        DashScopeChatModel.builder().apiKey(apiKey).modelName("qwen-plus").stream(
-                                        true)
+                        DashScopeChatModel.builder()
+                                .apiKey(apiKey)
+                                .modelName(getModelName())
+                                .stream(true)
                                 .formatter(new DashScopeChatFormatter())
                                 .build())
                 .toolkit(toolkit)
@@ -427,5 +425,23 @@ public class AgentConfiguration {
                             + "Please set it before starting the application.");
         }
         return apiKey;
+    }
+
+    private String getModelName() {
+        String modelName = System.getenv("DASHSCOPE_MODEL");
+        if (modelName == null || modelName.isEmpty()) {
+            return "qwen3.5-flash";
+        }
+        return modelName;
+    }
+
+    @PostConstruct
+    public void init() {
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.registerModule(new JavaTimeModule());
+        objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+        // CopilotKit rejects JSON null fields on some AG-UI event payloads.
+        objectMapper.setDefaultPropertyInclusion(JsonInclude.Include.NON_NULL);
+        JsonUtils.setJsonCodec(new JacksonJsonCodec(objectMapper));
     }
 }

--- a/agentscope-examples/agentscope-copilotkit/src/main/java/io/agentscope/examples/copilotkit/config/CopilotKitRouteConfiguration.java
+++ b/agentscope-examples/agentscope-copilotkit/src/main/java/io/agentscope/examples/copilotkit/config/CopilotKitRouteConfiguration.java
@@ -114,20 +114,25 @@ public class CopilotKitRouteConfiguration {
 
     private Mono<ServerResponse> stopThread(
             ServerRequest request, ThreadSessionManager threadSessionManager) {
-        String agentId = request.pathVariable("agentId");
         String threadId = request.pathVariable("threadId");
+        String userId = resolveDemoUserId(request);
         threadSessionManager
-                .getSession(threadId)
+                .getSession(userId, threadId)
                 .ifPresent(
                         threadSession -> {
                             if (threadSession.getAgent() instanceof ReActAgent reActAgent) {
-                                reActAgent.interrupt(null, threadId);
+                                reActAgent.interrupt(userId, threadId);
                             } else {
                                 // todo Harness?
                                 threadSession.getAgent().interrupt();
                             }
                         });
         return Mono.empty();
+    }
+
+    private static String resolveDemoUserId(ServerRequest request) {
+        String token = request.headers().firstHeader("X-Token");
+        return token == null || token.isBlank() ? DemoThreadStore.DEMO_USER_ID : token;
     }
 
     private static Mono<ServerResponse> listThreads(

--- a/agentscope-examples/agentscope-copilotkit/src/main/java/io/agentscope/examples/copilotkit/config/CopilotKitRouteConfiguration.java
+++ b/agentscope-examples/agentscope-copilotkit/src/main/java/io/agentscope/examples/copilotkit/config/CopilotKitRouteConfiguration.java
@@ -16,6 +16,7 @@
 package io.agentscope.examples.copilotkit.config;
 
 import io.agentscope.core.ReActAgent;
+import io.agentscope.core.agui.AguiUtil;
 import io.agentscope.core.agui.model.RunAgentInput;
 import io.agentscope.examples.copilotkit.model.CopilotKitModels.ThreadInfo;
 import io.agentscope.examples.copilotkit.model.CopilotKitModels.ThreadMutationRequest;
@@ -112,6 +113,7 @@ public class CopilotKitRouteConfiguration {
                 .build();
     }
 
+    @SuppressWarnings("resource") // borrowed session agent; session owns lifecycle
     private Mono<ServerResponse> stopThread(
             ServerRequest request, ThreadSessionManager threadSessionManager) {
         String threadId = request.pathVariable("threadId");
@@ -120,10 +122,10 @@ public class CopilotKitRouteConfiguration {
                 .getSession(userId, threadId)
                 .ifPresent(
                         threadSession -> {
-                            if (threadSession.getAgent() instanceof ReActAgent reActAgent) {
-                                reActAgent.interrupt(userId, threadId);
+                            ReActAgent actAgent = AguiUtil.asReActAgent(threadSession.getAgent());
+                            if (actAgent != null) {
+                                actAgent.interrupt(userId, threadId);
                             } else {
-                                // todo Harness?
                                 threadSession.getAgent().interrupt();
                             }
                         });

--- a/agentscope-examples/agentscope-copilotkit/src/main/java/io/agentscope/examples/copilotkit/service/DemoThreadStore.java
+++ b/agentscope-examples/agentscope-copilotkit/src/main/java/io/agentscope/examples/copilotkit/service/DemoThreadStore.java
@@ -17,6 +17,7 @@ package io.agentscope.examples.copilotkit.service;
 
 import io.agentscope.core.ReActAgent;
 import io.agentscope.core.agent.Agent;
+import io.agentscope.core.agent.RuntimeContext;
 import io.agentscope.core.agui.registry.AguiAgentRegistry;
 import io.agentscope.core.message.Msg;
 import io.agentscope.examples.copilotkit.model.CopilotKitModels.ThreadInfo;
@@ -44,6 +45,9 @@ public final class DemoThreadStore {
 
     public static final String DEFAULT_AGENT_ID = "default";
 
+    /** Demo identity; matches {@code AgentConfiguration} when {@code X-Token} is absent. */
+    public static final String DEMO_USER_ID = "user-001";
+
     private final ThreadSessionManager sessionManager;
     private final AguiAgentRegistry agentRegistry;
     private final InMemoryAgentEventStore eventStore;
@@ -67,9 +71,13 @@ public final class DemoThreadStore {
 
         List<ThreadInfo> all =
                 sessionManager.getSessions().entrySet().stream()
+                        .filter(entry -> DEMO_USER_ID.equals(entry.getValue().getUserId()))
                         .filter(entry -> agentId.equals(entry.getValue().getAgentId()))
                         .filter(entry -> includeArchived || !entry.getValue().isArchived())
-                        .map(entry -> toThreadInfo(entry.getKey(), entry.getValue()))
+                        .map(
+                                entry ->
+                                        toThreadInfo(
+                                                entry.getValue().getThreadId(), entry.getValue()))
                         .sorted(Comparator.comparing(ThreadInfo::lastRunAt).reversed())
                         .toList();
 
@@ -84,7 +92,8 @@ public final class DemoThreadStore {
         String name = resolveName(request, "New Thread");
         String threadId = "thread-" + UUID.randomUUID();
         ThreadSession session =
-                sessionManager.ensureSession(threadId, agentId, name, () -> createAgent(agentId));
+                sessionManager.ensureSession(
+                        DEMO_USER_ID, threadId, agentId, name, () -> createAgent(agentId));
         return toThreadInfo(threadId, session);
     }
 
@@ -107,7 +116,7 @@ public final class DemoThreadStore {
     }
 
     public Map<String, Object> delete(String threadId) {
-        sessionManager.removeSession(threadId);
+        sessionManager.removeSession(DEMO_USER_ID, threadId);
         eventStore.clear(threadId);
         return Map.of("deleted", true, "threadId", threadId);
     }
@@ -124,11 +133,11 @@ public final class DemoThreadStore {
     public Map<String, Object> messages(String threadId) {
         List<Map<String, Object>> messages =
                 sessionManager
-                        .getSession(threadId)
+                        .getSession(DEMO_USER_ID, threadId)
                         .map(ThreadSession::getAgent)
                         .filter(ReActAgent.class::isInstance)
                         .map(ReActAgent.class::cast)
-                        .map(agent -> agent.getAgentState(null, threadId).getContext())
+                        .map(agent -> agent.getAgentState(DEMO_USER_ID, threadId).getContext())
                         .orElse(List.of())
                         .stream()
                         .map(this::toMessage)
@@ -139,11 +148,17 @@ public final class DemoThreadStore {
     public Map<String, Object> state(String threadId) {
         Map<String, Object> state = new LinkedHashMap<>();
         sessionManager
-                .getSession(threadId)
+                .getSession(DEMO_USER_ID, threadId)
                 .ifPresent(
                         session -> {
                             state.put("agentId", session.getAgentId());
-                            state.put("hasMemory", sessionManager.hasMemory(threadId));
+                            state.put(
+                                    "hasMemory",
+                                    sessionManager.hasMemory(
+                                            RuntimeContext.builder()
+                                                    .sessionId(threadId)
+                                                    .userId(DEMO_USER_ID)
+                                                    .build()));
                             state.put("archived", session.isArchived());
                             state.put("updatedAt", session.getLastAccess().toString());
                         });
@@ -153,7 +168,11 @@ public final class DemoThreadStore {
     private ThreadSession getOrCreateSession(String threadId, ThreadMutationRequest request) {
         String agentId = resolveAgentId(request);
         return sessionManager.ensureSession(
-                threadId, agentId, resolveName(request, null), () -> createAgent(agentId));
+                DEMO_USER_ID,
+                threadId,
+                agentId,
+                resolveName(request, null),
+                () -> createAgent(agentId));
     }
 
     private Agent createAgent(String agentId) {

--- a/agentscope-examples/agentscope-copilotkit/src/main/java/io/agentscope/examples/copilotkit/service/DemoThreadStore.java
+++ b/agentscope-examples/agentscope-copilotkit/src/main/java/io/agentscope/examples/copilotkit/service/DemoThreadStore.java
@@ -15,11 +15,14 @@
  */
 package io.agentscope.examples.copilotkit.service;
 
+import com.fasterxml.jackson.core.type.TypeReference;
 import io.agentscope.core.ReActAgent;
 import io.agentscope.core.agent.Agent;
 import io.agentscope.core.agent.RuntimeContext;
+import io.agentscope.core.agui.event.AguiEvent;
 import io.agentscope.core.agui.registry.AguiAgentRegistry;
 import io.agentscope.core.message.Msg;
+import io.agentscope.core.util.JsonUtils;
 import io.agentscope.examples.copilotkit.model.CopilotKitModels.ThreadInfo;
 import io.agentscope.examples.copilotkit.model.CopilotKitModels.ThreadMutationRequest;
 import io.agentscope.examples.copilotkit.model.CopilotKitModels.ThreadsResponse;
@@ -47,6 +50,9 @@ public final class DemoThreadStore {
 
     /** Demo identity; matches {@code AgentConfiguration} when {@code X-Token} is absent. */
     public static final String DEMO_USER_ID = "user-001";
+
+    private static final TypeReference<Map<String, Object>> AGUI_EVENT_JSON =
+            new TypeReference<>() {};
 
     private final ThreadSessionManager sessionManager;
     private final AguiAgentRegistry agentRegistry;
@@ -122,11 +128,12 @@ public final class DemoThreadStore {
     }
 
     public Map<String, Object> events(String threadId) {
+        List<Map<String, Object>> events =
+                eventReplayer.replay(threadId, null).stream()
+                        .map(DemoThreadStore::toEventPayload)
+                        .toList();
         Map<String, Object> payload = new LinkedHashMap<>();
-        // Source of truth: AgentScope AgentEvents.
-        payload.put("agentEvents", eventStore.snapshot(threadId));
-        // Protocol projection: same converter path as /connect.
-        payload.put("events", eventReplayer.replay(threadId, null));
+        payload.put("events", events);
         return payload;
     }
 
@@ -208,6 +215,21 @@ public final class DemoThreadStore {
             return name;
         }
         return threadId;
+    }
+
+    /**
+     * Encode one AG-UI event the same way {@code /connect} does, and keep {@code type} even when
+     * Jackson serializes the concrete record ( {@link AguiEvent#getType()} is {@code @JsonIgnore} ).
+     */
+    private static Map<String, Object> toEventPayload(AguiEvent event) {
+        Map<String, Object> encoded =
+                JsonUtils.getJsonCodec()
+                        .fromJson(JsonUtils.getJsonCodec().toJson(event), AGUI_EVENT_JSON);
+        Map<String, Object> payload = new LinkedHashMap<>();
+        payload.put("type", event.getType().name());
+        encoded.remove("type");
+        payload.putAll(encoded);
+        return payload;
     }
 
     private Map<String, Object> toMessage(Msg msg) {

--- a/agentscope-examples/agui/src/main/resources/static/index.html
+++ b/agentscope-examples/agui/src/main/resources/static/index.html
@@ -339,7 +339,7 @@
         </div>
 
         <div class="demo-actions">
-            <button id="approval-demo-btn">HITL interrupt（点击测试）</button>
+            <button id="approval-demo-btn">HITL 审批演示（点击测试）</button>
         </div>
 
         <div id="messages"></div>
@@ -372,11 +372,11 @@
         let messageHistory = [];
         let isRunning = false;
         let activeToolCalls = new Map();
-        let pendingApproval = null;
+        let pendingApprovalToolCall = null;
 
         const frontendTools = [{
             name: 'request_approval',
-            description: 'Ask the user to approve or reject an action before continuing. Always call this tool when the user asks for the approval interrupt demo.',
+            description: 'Ask the user to approve or reject an action before continuing. Always call this tool when the user asks for the approval demo.',
             parameters: {
                 type: 'object',
                 properties: {
@@ -477,19 +477,21 @@
             }
         }
 
-        function appendApprovalDialog(interrupt) {
-            const toolCall = activeToolCalls.get(interrupt.toolCallId) || {};
+        function isFrontendTool(name) {
+            return frontendTools.some(tool => tool.name === name);
+        }
+
+        function appendApprovalDialog(toolCall) {
             const args = parseToolArgs(toolCall.args);
             const div = document.createElement('div');
             div.className = 'message tool';
             div.innerHTML = `
                 <div class="message-role">approval required</div>
                 <div class="message-content">${escapeHtml([
-                    `toolCallId: ${interrupt.toolCallId}`,
-                    `tool: ${toolCall.name || interrupt.metadata?.toolName || 'request_approval'}`,
+                    `toolCallId: ${toolCall.toolCallId}`,
+                    `tool: ${toolCall.name || 'request_approval'}`,
                     `action: ${args.action || '(not provided)'}`,
-                    args.reason ? `reason: ${args.reason}` : null,
-                    interrupt.message ? `message: ${interrupt.message}` : null
+                    args.reason ? `reason: ${args.reason}` : null
                 ].filter(Boolean).join('\n'))}</div>
                 <div class="approval-actions">
                     <button class="approve" type="button">Approve</button>
@@ -503,21 +505,15 @@
         }
 
         async function resolveApproval(approved, dialog) {
-            if (!pendingApproval || isRunning) return;
+            if (!pendingApprovalToolCall || isRunning) return;
 
-            const interrupt = pendingApproval;
-            const toolCall = activeToolCalls.get(interrupt.toolCallId) || {};
+            const toolCall = pendingApprovalToolCall;
             const args = parseToolArgs(toolCall.args);
             const payload = {
                 approved,
                 action: args.action || null,
                 reason: approved ? 'Approved in the AG-UI example dialog.' : 'Rejected in the AG-UI example dialog.'
             };
-            const resume = [{
-                interruptId: interrupt.id,
-                status: 'resolved',
-                payload
-            }];
 
             dialog.querySelectorAll('button').forEach(button => button.disabled = true);
             const actions = dialog.querySelector('.approval-actions');
@@ -525,25 +521,47 @@
                 actions.remove();
             }
             appendMessage('tool', `${approved ? 'Approved' : 'Rejected'} request_approval\n${JSON.stringify(payload)}`);
-            pendingApproval = null;
 
-            await runAgent([], resume);
+            // Frontend tools no longer emit interrupts; the result is fed back as a
+            // tool-role message whose toolCallId matches the assistant's tool call.
+            const toolCallEntry = {
+                id: toolCall.toolCallId,
+                type: 'function',
+                function: { name: toolCall.name || 'request_approval', arguments: toolCall.args || '{}' }
+            };
+            const lastMsg = messageHistory[messageHistory.length - 1];
+            if (lastMsg && lastMsg.role === 'assistant') {
+                lastMsg.toolCalls = [...(lastMsg.toolCalls || []), toolCallEntry];
+            } else {
+                messageHistory.push({
+                    id: 'msg-assistant-tc-' + toolCall.toolCallId,
+                    role: 'assistant',
+                    toolCalls: [toolCallEntry]
+                });
+            }
+            messageHistory.push({
+                id: 'msg-toolresult-' + toolCall.toolCallId,
+                role: 'tool',
+                toolCallId: toolCall.toolCallId,
+                content: JSON.stringify(payload)
+            });
+
+            pendingApprovalToolCall = null;
+            activeToolCalls.delete(toolCall.toolCallId);
+
+            await runAgent(messageHistory);
         }
 
-        function handleRunFinished(event) {
-            const interrupts = event?.outcome?.type === 'interrupt' ? event.outcome.interrupts || [] : [];
-            const toolInterrupt = interrupts.find(item => item.reason === 'tool_call' && item.toolCallId);
-            if (!toolInterrupt) {
-                setStatus('ready', 'Ready');
+        function handleRunFinished() {
+            if (pendingApprovalToolCall) {
+                setStatus('waiting', 'Awaiting approval');
+                appendApprovalDialog(pendingApprovalToolCall);
                 return;
             }
-
-            pendingApproval = toolInterrupt;
-            setStatus('waiting', 'Awaiting approval');
-            appendApprovalDialog(toolInterrupt);
+            setStatus('ready', 'Ready');
         }
 
-        async function runAgent(messagesForServer, resumeEntries = []) {
+        async function runAgent(messagesForServer) {
             isRunning = true;
             sendBtn.style.display = 'none';
             stopBtn.style.display = 'inline-block';
@@ -562,9 +580,6 @@
                     messages: messagesForServer,
                     tools: frontendTools
                 };
-                if (resumeEntries.length > 0) {
-                    runInput.resume = resumeEntries;
-                }
 
                 await client.run(runInput, {
                     onRunStarted: () => {
@@ -636,6 +651,13 @@
                         if (toolCall?.args) {
                             appendMessage('tool', `Tool arguments for ${toolCall.name}\n${toolCall.args}`);
                         }
+                        if (toolCall && isFrontendTool(toolCall.name)) {
+                            pendingApprovalToolCall = {
+                                toolCallId: toolCallId,
+                                name: toolCall.name,
+                                args: toolCall.args || ''
+                            };
+                        }
                     },
                     onToolCallResult: (toolCallId, content) => {
                         hideTypingIndicator();
@@ -649,10 +671,10 @@
                         hideTypingIndicator();
                         appendMessage('custom', formatCustomEvent(event));
                     },
-                    onRunFinished: (threadId, runId, event) => {
+                    onRunFinished: () => {
                         console.log('Run finished');
                         hideTypingIndicator();
-                        handleRunFinished(event);
+                        handleRunFinished();
                     }
                 });
             } catch (error) {
@@ -698,141 +720,6 @@
             const userMessage = { id: 'msg-' + Date.now(), role: 'user', content: text };
             messageHistory.push(userMessage);
             await runAgent(messageHistory);
-            return;
-
-            isRunning = true;
-            sendBtn.style.display = 'none';
-            stopBtn.style.display = 'inline-block';
-            setStatus('running', 'Running...');
-
-            // Add user message
-            appendMessage('user', text);
-            messageHistory.push({ id: 'msg-' + Date.now(), role: 'user', content: text });
-
-            // Show typing indicator
-            showTypingIndicator();
-
-            let assistantContent = '';
-            let currentMessageId = null;
-            let reasoningContent = '';
-            let currentReasoningMessageId = null;
-            let currentReasoningDiv = null;
-
-            try {
-                await client.run({
-                    threadId: threadId,
-                    runId: 'run-' + Date.now(),
-                    messages: messageHistory
-                }, {
-                    onRunStarted: () => {
-                        console.log('Run started');
-                        currentAssistantDiv = null;
-                        currentReasoningDiv = null;
-                        reasoningContent = '';
-                    },
-                    onReasoningMessageStart: (messageId, role) => {
-                        console.log('Reasoning message start:', messageId, role);
-                        hideTypingIndicator();
-                        currentReasoningMessageId = messageId;
-                        reasoningContent = '';
-                        currentReasoningDiv = null;
-                    },
-                    onReasoningContent: (delta, messageId) => {
-                        console.log('Reasoning content delta:', delta);
-                        if (reasoningContent === '') {
-                            appendMessage('reasoning', delta);
-                        } else {
-                            appendMessage('reasoning', delta, true);
-                        }
-                        reasoningContent += delta;
-                    },
-                    onReasoningMessageEnd: (messageId) => {
-                        console.log('Reasoning message end:', messageId);
-                        currentReasoningDiv = null;
-                        reasoningContent = '';
-                    },
-                    onTextMessageStart: (messageId, role) => {
-                        console.log('Text message start:', messageId, role);
-                        hideTypingIndicator();
-                        currentMessageId = messageId;
-                        assistantContent = '';
-                        currentAssistantDiv = null;
-                    },
-                    onTextContent: (delta) => {
-                        console.log('Text content delta:', delta);
-                        if (assistantContent === '') {
-                            appendMessage('assistant', delta);
-                        } else {
-                            appendMessage('assistant', delta, true);
-                        }
-                        assistantContent += delta;
-                    },
-                    onTextMessageEnd: (messageId) => {
-                        console.log('Text message end:', messageId);
-                        if (assistantContent) {
-                            messageHistory.push({
-                                id: messageId,
-                                role: 'assistant',
-                                content: assistantContent
-                            });
-                        }
-                        currentAssistantDiv = null;
-                    },
-                    onToolCallStart: (toolCallId, toolName) => {
-                        hideTypingIndicator();
-                        currentAssistantDiv = null;
-                        appendMessage('tool', `🔧 Calling tool: ${toolName}`);
-                    },
-                    onToolCallEnd: (toolCallId) => {
-                        // Tool call completed
-                    },
-                    onError: (error) => {
-                        hideTypingIndicator();
-                        appendMessage('error', `Error: ${error}`);
-                    },
-                    onCustomEvent: (event) => {
-                        hideTypingIndicator();
-                        appendMessage('custom', formatCustomEvent(event));
-                    },
-                    onRunFinished: () => {
-                        console.log('Run finished');
-                        hideTypingIndicator();
-                        setStatus('ready', 'Ready');
-                    }
-                });
-            } catch (error) {
-                console.error('Error during agent run:', error);
-                hideTypingIndicator();
-
-                // Check if this was a user-initiated abort
-                if (error.name === 'AbortError') {
-                    console.log('Run was stopped by user');
-                    // Save whatever content we received before stopping
-                    if (assistantContent) {
-                        messageHistory.push({
-                            id: currentMessageId || 'msg-stopped-' + Date.now(),
-                            role: 'assistant',
-                            content: assistantContent + ' [stopped]'
-                        });
-                    }
-                    setStatus('ready', 'Stopped');
-                } else {
-                    appendMessage('error', `Error: ${error.message}`);
-                    setStatus('error', 'Error');
-                }
-            } finally {
-                console.log('Run complete, resetting state');
-                isRunning = false;
-                sendBtn.style.display = 'inline-block';
-                stopBtn.style.display = 'none';
-                hideTypingIndicator();
-                currentAssistantDiv = null;
-                currentReasoningDiv = null;
-                reasoningContent = '';
-                if (statusText.textContent === 'Running...') {
-                    setStatus('ready', 'Ready');
-                }
-            }
         }
 
         // Stop button handler
@@ -846,7 +733,7 @@
 
         function startApprovalDemo() {
             if (isRunning) return;
-            input.value = 'Run the approval interrupt demo. Call request_approval for deleting demo-file.txt, then continue after the user decision.';
+            input.value = 'Run the approval demo. Call request_approval for deleting demo-file.txt, then continue after the user decision.';
             sendMessage();
         }
 

--- a/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/main/java/io/agentscope/core/agui/AguiUtil.java
+++ b/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/main/java/io/agentscope/core/agui/AguiUtil.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.core.agui;
+
+import io.agentscope.core.ReActAgent;
+import io.agentscope.core.agent.Agent;
+import java.lang.reflect.Method;
+
+/**
+ * Helpers for inspecting AG-UI agent instances without taking a compile-time dependency on
+ * {@code agentscope-harness}.
+ *
+ * <p>{@link ReActAgent} is {@link AutoCloseable}. Values returned by {@link #asReActAgent(Agent)}
+ * are live session agents and must not be closed by the caller.
+ */
+public final class AguiUtil {
+
+    private static final String HARNESS_AGENT_CLASS_NAME =
+            "io.agentscope.harness.agent.HarnessAgent";
+
+    private AguiUtil() {}
+
+    /**
+     * Returns {@code true} when {@code agent} is a {@code HarnessAgent} (or a subclass).
+     *
+     * <p>Class-name matching is used so the AG-UI module can stream harness agents without
+     * depending on the harness artifact.
+     *
+     * @param agent the agent to inspect, may be {@code null}
+     * @return {@code true} if the runtime type is a harness agent
+     */
+    public static boolean isHarnessAgent(Agent agent) {
+        if (agent == null) {
+            return false;
+        }
+        Class<?> type = agent.getClass();
+        while (type != null) {
+            if (HARNESS_AGENT_CLASS_NAME.equals(type.getName())) {
+                return true;
+            }
+            type = type.getSuperclass();
+        }
+        return false;
+    }
+
+    /**
+     * Unwraps a {@link ReActAgent} from {@code agent} when possible.
+     *
+     * <p>Harness agents expose the inner ReAct delegate via a public {@code getDelegate()} method.
+     * The returned instance is the live agent used by the session; callers must not close it.
+     *
+     * @param agent the agent to unwrap, may be {@code null}
+     * @return the ReAct agent, or {@code null} when it cannot be resolved
+     */
+    public static ReActAgent asReActAgent(Agent agent) {
+        if (agent instanceof ReActAgent reactAgent) {
+            return reactAgent;
+        }
+        if (agent == null) {
+            return null;
+        }
+        try {
+            Method getDelegate = agent.getClass().getMethod("getDelegate");
+            Object delegate = getDelegate.invoke(agent);
+            if (delegate instanceof ReActAgent reactAgent) {
+                return reactAgent;
+            }
+        } catch (ReflectiveOperationException ignored) {
+            // Not a harness-style wrapper; fall through.
+        }
+        return null;
+    }
+}

--- a/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/main/java/io/agentscope/core/agui/adapter/AguiAgentAdapter.java
+++ b/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/main/java/io/agentscope/core/agui/adapter/AguiAgentAdapter.java
@@ -21,6 +21,7 @@ import io.agentscope.core.agent.Event;
 import io.agentscope.core.agent.EventType;
 import io.agentscope.core.agent.RuntimeContext;
 import io.agentscope.core.agent.StreamOptions;
+import io.agentscope.core.agui.AguiUtil;
 import io.agentscope.core.agui.adapter.strategy.AgentEventConverterRegistry;
 import io.agentscope.core.agui.adapter.strategy.AguiStreamContext;
 import io.agentscope.core.agui.converter.AguiMessageConverter;
@@ -207,7 +208,7 @@ public class AguiAgentAdapter {
             return new AgentStream(
                     convertAgentEvents(events, context), () -> finishPendingEvents(context));
         }
-        if (isHarnessAgent(agent)) {
+        if (AguiUtil.isHarnessAgent(agent)) {
             AguiStreamContext context = new AguiStreamContext(threadId, runId, config, input);
             Flux<AgentEvent> events =
                     Objects.requireNonNull(
@@ -272,17 +273,6 @@ public class AguiAgentAdapter {
             throw new IllegalStateException(
                     "HarnessAgent does not expose streamEvents(List, RuntimeContext)", e);
         }
-    }
-
-    private static boolean isHarnessAgent(Agent agent) {
-        Class<?> type = agent.getClass();
-        while (type != null) {
-            if ("io.agentscope.harness.agent.HarnessAgent".equals(type.getName())) {
-                return true;
-            }
-            type = type.getSuperclass();
-        }
-        return false;
     }
 
     /**

--- a/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/main/java/io/agentscope/core/agui/adapter/strategy/AgentLifecycleEventConverter.java
+++ b/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/main/java/io/agentscope/core/agui/adapter/strategy/AgentLifecycleEventConverter.java
@@ -22,6 +22,8 @@ import static io.agentscope.core.agui.AguiInterruptConstants.METADATA_TOOL_NAME;
 import static io.agentscope.core.agui.AguiInterruptConstants.TOOL_CALL_INTERRUPT_REASON;
 
 import io.agentscope.core.agui.event.AguiEvent;
+import io.agentscope.core.agui.model.AguiTool;
+import io.agentscope.core.agui.model.RunAgentInput;
 import io.agentscope.core.event.AgentEndEvent;
 import io.agentscope.core.event.AgentEvent;
 import io.agentscope.core.event.AgentResultEvent;
@@ -96,6 +98,7 @@ final class AgentLifecycleEventConverter implements AgentEventConverter {
         if (result == null || result.getGenerateReason() != GenerateReason.TOOL_SUSPENDED) {
             return;
         }
+        Set<String> frontTools = frontendToolNames(context);
 
         Map<String, ToolUseBlock> toolUses = new LinkedHashMap<>();
         for (ContentBlock block : result.getContent()) {
@@ -113,8 +116,11 @@ final class AgentLifecycleEventConverter implements AgentEventConverter {
                         "TOOL_SUSPENDED result contains a suspended tool result without a stable"
                                 + " id");
             }
-            context.addInterrupt(
-                    buildToolCallInterrupt(result, toolUses.get(toolResult.getId()), toolResult));
+            ToolUseBlock toolUse = toolUses.get(toolResult.getId());
+            if (toolUse == null || frontTools.contains(toolUse.getName())) {
+                continue;
+            }
+            context.addInterrupt(buildToolCallInterrupt(result, toolUse, toolResult));
         }
     }
 
@@ -162,6 +168,14 @@ final class AgentLifecycleEventConverter implements AgentEventConverter {
                         .filter(value -> value != null && !value.isEmpty())
                         .collect(Collectors.joining("\n"));
         return text.isEmpty() ? null : text;
+    }
+
+    private static Set<String> frontendToolNames(AguiStreamContext context) {
+        RunAgentInput runInput = context.getRunInput();
+        if (runInput == null || runInput.getTools() == null || runInput.getTools().isEmpty()) {
+            return Set.of();
+        }
+        return runInput.getTools().stream().map(AguiTool::getName).collect(Collectors.toSet());
     }
 
     private static boolean isBlank(String value) {

--- a/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/main/java/io/agentscope/core/agui/converter/AguiMessageConverter.java
+++ b/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/main/java/io/agentscope/core/agui/converter/AguiMessageConverter.java
@@ -103,6 +103,10 @@ public class AguiMessageConverter {
             for (InputContent input : blocksContent.parts()) {
                 blocks.add(toContentBlock(input));
             }
+        } else if (aguiMessage.isToolMessage() && aguiMessage.getToolCallId() != null) {
+            // Tool message with no content (e.g. frontend tool returning nothing): still
+            // emit a ToolResultBlock so the pending tool call is resolved downstream.
+            addTextBlock(blocks, "", aguiMessage);
         }
 
         // Add tool calls if present (for assistant messages)
@@ -255,18 +259,22 @@ public class AguiMessageConverter {
      * @param aguiMessage the source message (for role/tool-call-id context)
      */
     private void addTextBlock(List<ContentBlock> blocks, String text, AguiMessage aguiMessage) {
+        if (aguiMessage.isToolMessage() && aguiMessage.getToolCallId() != null) {
+            // Tool results must always carry a ToolResultBlock, even when the frontend
+            // returned empty content.
+            String resultText = text != null ? text : "";
+            blocks.add(
+                    ToolResultBlock.builder()
+                            .id(aguiMessage.getToolCallId())
+                            .output(TextBlock.builder().text(resultText).build())
+                            .state(ToolResultState.SUCCESS)
+                            .build());
+            return;
+        }
         if (text == null || text.isEmpty()) {
             return;
         }
-        if (aguiMessage.isToolMessage() && aguiMessage.getToolCallId() != null) {
-            blocks.add(
-                    ToolResultBlock.of(
-                            aguiMessage.getToolCallId(),
-                            null,
-                            TextBlock.builder().text(text).build()));
-        } else {
-            blocks.add(TextBlock.builder().text(text).build());
-        }
+        blocks.add(TextBlock.builder().text(text).build());
     }
 
     /**

--- a/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/main/java/io/agentscope/core/agui/processor/AgentResolver.java
+++ b/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/main/java/io/agentscope/core/agui/processor/AgentResolver.java
@@ -16,6 +16,7 @@
 package io.agentscope.core.agui.processor;
 
 import io.agentscope.core.agent.Agent;
+import io.agentscope.core.agent.RuntimeContext;
 import io.agentscope.core.agui.AguiException;
 
 /**
@@ -38,13 +39,29 @@ public interface AgentResolver {
     Agent resolveAgent(String agentId, String threadId);
 
     /**
+     * Resolve an agent by its ID, thread ID and user ID.
+     *
+     * <p>The default implementation ignores {@code userId}. Session-aware resolvers should override
+     * this so tenants with the same thread id do not share an agent instance.
+     *
+     * @param agentId The agent ID to resolve
+     * @param threadId The thread ID for session management
+     * @param userId The user ID, may be {@code null} for anonymous
+     * @return The resolved agent
+     * @throws AguiException.AgentNotFoundException if the agent is not found
+     */
+    default Agent resolveAgent(String agentId, String threadId, String userId) {
+        return resolveAgent(agentId, threadId);
+    }
+
+    /**
      * Check if a thread has existing memory/conversation history.
      *
      * <p>This is used to determine whether to use frontend-provided history
      * or rely on server-side memory.
      *
-     * @param threadId The thread ID to check
+     * @param runtimeContext The runtime context identifying the thread and user
      * @return true if the thread has existing memory
      */
-    boolean hasMemory(String threadId);
+    boolean hasMemory(RuntimeContext runtimeContext);
 }

--- a/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/main/java/io/agentscope/core/agui/processor/AguiRequestProcessor.java
+++ b/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/main/java/io/agentscope/core/agui/processor/AguiRequestProcessor.java
@@ -18,6 +18,7 @@ package io.agentscope.core.agui.processor;
 import io.agentscope.core.ReActAgent;
 import io.agentscope.core.agent.Agent;
 import io.agentscope.core.agent.RuntimeContext;
+import io.agentscope.core.agui.AguiUtil;
 import io.agentscope.core.agui.adapter.AguiAdapterConfig;
 import io.agentscope.core.agui.adapter.AguiAgentAdapter;
 import io.agentscope.core.agui.adapter.AguiAgentAdapterFactory;
@@ -107,7 +108,8 @@ public class AguiRequestProcessor {
          * @param threadId The AG-UI thread id for this request
          */
         public void interrupt(String threadId) {
-            if (agent instanceof ReActAgent reActAgent) {
+            ReActAgent reActAgent = AguiUtil.asReActAgent(agent);
+            if (reActAgent != null) {
                 RuntimeContext interruptContext =
                         RuntimeContext.builder(runtimeContext).sessionId(threadId).build();
                 reActAgent.interrupt(interruptContext);
@@ -134,7 +136,9 @@ public class AguiRequestProcessor {
         String headerAgentId = request.getHeaderAgentId();
         String pathAgentId = request.getPathAgentId();
         RuntimeContext runtimeContext =
-                runtimeContextResolver != null ? runtimeContextResolver.resolve(request) : null;
+                runtimeContextResolver != null
+                        ? runtimeContextResolver.resolve(request)
+                        : RuntimeContext.builder().sessionId(input.getThreadId()).build();
 
         String threadId = input.getThreadId();
         String runId = input.getRunId();
@@ -143,7 +147,7 @@ public class AguiRequestProcessor {
         String agentId = resolveAgentId(input, headerAgentId, pathAgentId);
 
         // Resolve agent
-        Agent agent = agentResolver.resolveAgent(agentId, threadId);
+        Agent agent = agentResolver.resolveAgent(agentId, threadId, runtimeContext.getUserId());
 
         Flux<AguiEvent> events =
                 Flux.defer(
@@ -161,11 +165,12 @@ public class AguiRequestProcessor {
                             try {
                                 // Determine effective input based on server-side memory
                                 RunAgentInput effectiveInput = input;
-                                if (agentResolver.hasMemory(threadId)) {
+                                if (agentResolver.hasMemory(runtimeContext)) {
                                     logger.debug(
-                                            "Using server-side memory for thread {}, extracting"
-                                                    + " latest user message",
-                                            threadId);
+                                            "Using server-side memory for thread {} user {},"
+                                                    + " extracting follow-up messages",
+                                            threadId,
+                                            runtimeContext.getUserId());
                                     effectiveInput = extractLatestUserMessage(input);
                                 }
 
@@ -285,13 +290,18 @@ public class AguiRequestProcessor {
     }
 
     /**
-     * Extract only the latest user message from the input.
+     * Extract messages that arrived after the last assistant turn.
      *
-     * <p>This is used when server-side memory is enabled and the agent already
-     * has conversation history. Only the latest user message needs to be passed.
+     * <p>When server-side memory is enabled the agent already holds prior turns. CopilotKit (and
+     * similar clients) still send the full transcript, including HITL tool results that follow the
+     * last assistant message. Only those trailing messages should be appended.
+     *
+     * <p>If the transcript has no assistant message yet, the original input is returned unchanged.
+     * If the last message is an assistant turn, metadata is preserved and the message list is
+     * cleared so history is not replayed into memory.
      *
      * @param input The original input
-     * @return A new input with only the latest user message
+     * @return A new input containing only the follow-up messages, or the original input
      */
     public RunAgentInput extractLatestUserMessage(RunAgentInput input) {
         List<AguiMessage> messages = input.getMessages();
@@ -299,25 +309,26 @@ public class AguiRequestProcessor {
             return input;
         }
 
-        // Find the last user message
-        AguiMessage lastUserMessage = null;
+        int lastAssistantIdx = -1;
         for (int i = messages.size() - 1; i >= 0; i--) {
-            AguiMessage msg = messages.get(i);
-            if ("user".equalsIgnoreCase(msg.getRole())) {
-                lastUserMessage = msg;
+            if ("assistant".equalsIgnoreCase(messages.get(i).getRole())) {
+                lastAssistantIdx = i;
                 break;
             }
         }
-
-        if (lastUserMessage == null) {
+        if (lastAssistantIdx < 0) {
             return input;
         }
 
-        // Create new input with only the last user message
+        List<AguiMessage> after =
+                lastAssistantIdx < messages.size() - 1
+                        ? List.copyOf(messages.subList(lastAssistantIdx + 1, messages.size()))
+                        : List.of();
+
         return RunAgentInput.builder()
                 .threadId(input.getThreadId())
                 .runId(input.getRunId())
-                .messages(List.of(lastUserMessage))
+                .messages(after)
                 .tools(input.getTools())
                 .context(input.getContext())
                 .state(input.getState())

--- a/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/main/java/io/agentscope/core/agui/processor/AguiRequestProcessor.java
+++ b/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/main/java/io/agentscope/core/agui/processor/AguiRequestProcessor.java
@@ -135,13 +135,13 @@ public class AguiRequestProcessor {
         RunAgentInput input = request.getInput();
         String headerAgentId = request.getHeaderAgentId();
         String pathAgentId = request.getPathAgentId();
-        RuntimeContext runtimeContext =
-                runtimeContextResolver != null
-                        ? runtimeContextResolver.resolve(request)
-                        : RuntimeContext.builder().sessionId(input.getThreadId()).build();
-
         String threadId = input.getThreadId();
         String runId = input.getRunId();
+
+        RuntimeContext resolved =
+                runtimeContextResolver != null ? runtimeContextResolver.resolve(request) : null;
+        RuntimeContext runtimeContext =
+                RuntimeContext.builder(resolved).sessionId(threadId).build();
 
         // Resolve agent ID
         String agentId = resolveAgentId(input, headerAgentId, pathAgentId);
@@ -297,8 +297,9 @@ public class AguiRequestProcessor {
      * last assistant message. Only those trailing messages should be appended.
      *
      * <p>If the transcript has no assistant message yet, the original input is returned unchanged.
-     * If the last message is an assistant turn, metadata is preserved and the message list is
-     * cleared so history is not replayed into memory.
+     * If the transcript ends with an assistant turn (regenerate/continue flows) and there
+     * are no trailing follow-up messages, the last user message before that turn is returned so
+     * the agent has a prompt to regenerate from instead of receiving an empty input.
      *
      * @param input The original input
      * @return A new input containing only the follow-up messages, or the original input
@@ -324,6 +325,15 @@ public class AguiRequestProcessor {
                 lastAssistantIdx < messages.size() - 1
                         ? List.copyOf(messages.subList(lastAssistantIdx + 1, messages.size()))
                         : List.of();
+
+        if (after.isEmpty()) {
+            for (int i = lastAssistantIdx - 1; i >= 0; i--) {
+                if ("user".equalsIgnoreCase(messages.get(i).getRole())) {
+                    after = List.of(messages.get(i));
+                    break;
+                }
+            }
+        }
 
         return RunAgentInput.builder()
                 .threadId(input.getThreadId())

--- a/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/test/java/io/agentscope/core/agui/AguiUtilTest.java
+++ b/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/test/java/io/agentscope/core/agui/AguiUtilTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.core.agui;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import io.agentscope.core.ReActAgent;
+import io.agentscope.core.agent.Agent;
+import io.agentscope.harness.agent.HarnessAgent;
+import org.junit.jupiter.api.Test;
+
+class AguiUtilTest {
+
+    @Test
+    void isHarnessAgentDetectsHarnessTypeAndIgnoresOthers() {
+        assertTrue(AguiUtil.isHarnessAgent(new HarnessAgent()));
+        assertFalse(AguiUtil.isHarnessAgent(mock(Agent.class)));
+        assertFalse(AguiUtil.isHarnessAgent(mock(ReActAgent.class)));
+        assertFalse(AguiUtil.isHarnessAgent(null));
+    }
+
+    @Test
+    void asReActAgentReturnsDirectInstanceWithoutClosing() {
+        ReActAgent agent = mock(ReActAgent.class);
+
+        assertSame(agent, AguiUtil.asReActAgent(agent));
+        verify(agent, never()).close();
+    }
+
+    @Test
+    void asReActAgentUnwrapsPublicDelegate() {
+        ReActAgent delegate = mock(ReActAgent.class);
+        Agent wrapper = new DelegatingAgent(delegate);
+
+        assertSame(delegate, AguiUtil.asReActAgent(wrapper));
+        verify(delegate, never()).close();
+    }
+
+    @Test
+    void asReActAgentReturnsNullWhenDelegateIsMissing() {
+        assertNull(AguiUtil.asReActAgent(mock(Agent.class)));
+        assertNull(AguiUtil.asReActAgent(null));
+        assertNull(AguiUtil.asReActAgent(new HarnessAgent()));
+    }
+
+    private static final class DelegatingAgent extends HarnessAgent {
+        private final ReActAgent delegate;
+
+        private DelegatingAgent(ReActAgent delegate) {
+            this.delegate = delegate;
+        }
+
+        public ReActAgent getDelegate() {
+            return delegate;
+        }
+    }
+}

--- a/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/test/java/io/agentscope/core/agui/AguiUtilTest.java
+++ b/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/test/java/io/agentscope/core/agui/AguiUtilTest.java
@@ -16,6 +16,7 @@
 package io.agentscope.core.agui;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -26,13 +27,22 @@ import static org.mockito.Mockito.verify;
 import io.agentscope.core.ReActAgent;
 import io.agentscope.core.agent.Agent;
 import io.agentscope.harness.agent.HarnessAgent;
+import java.lang.reflect.Constructor;
 import org.junit.jupiter.api.Test;
 
 class AguiUtilTest {
 
     @Test
+    void constructorIsPackagePrivateUtility() throws Exception {
+        Constructor<AguiUtil> constructor = AguiUtil.class.getDeclaredConstructor();
+        constructor.setAccessible(true);
+        assertNotNull(constructor.newInstance());
+    }
+
+    @Test
     void isHarnessAgentDetectsHarnessTypeAndIgnoresOthers() {
         assertTrue(AguiUtil.isHarnessAgent(new HarnessAgent()));
+        assertTrue(AguiUtil.isHarnessAgent(new DelegatingAgent(mock(ReActAgent.class))));
         assertFalse(AguiUtil.isHarnessAgent(mock(Agent.class)));
         assertFalse(AguiUtil.isHarnessAgent(mock(ReActAgent.class)));
         assertFalse(AguiUtil.isHarnessAgent(null));
@@ -60,6 +70,7 @@ class AguiUtilTest {
         assertNull(AguiUtil.asReActAgent(mock(Agent.class)));
         assertNull(AguiUtil.asReActAgent(null));
         assertNull(AguiUtil.asReActAgent(new HarnessAgent()));
+        assertNull(AguiUtil.asReActAgent(new NonReActDelegateAgent()));
     }
 
     private static final class DelegatingAgent extends HarnessAgent {
@@ -71,6 +82,12 @@ class AguiUtilTest {
 
         public ReActAgent getDelegate() {
             return delegate;
+        }
+    }
+
+    private static final class NonReActDelegateAgent extends HarnessAgent {
+        public Object getDelegate() {
+            return "not-a-react-agent";
         }
     }
 }

--- a/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/test/java/io/agentscope/core/agui/adapter/AguiAgentAdapterV2Test.java
+++ b/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/test/java/io/agentscope/core/agui/adapter/AguiAgentAdapterV2Test.java
@@ -768,6 +768,110 @@ class AguiAgentAdapterV2Test {
         }
 
         @Test
+        void testSuspendedFrontendToolDoesNotEmitInterrupt() {
+            ToolUseBlock toolUse =
+                    ToolUseBlock.builder()
+                            .id("tool-1")
+                            .name("lookup")
+                            .input(Map.of("city", "Paris"))
+                            .build();
+            Msg suspendedResult =
+                    suspendedToolResult(
+                            "reply-frontend",
+                            toolUse,
+                            ToolResultBlock.builder()
+                                    .id("tool-1")
+                                    .name("lookup")
+                                    .output(
+                                            TextBlock.builder()
+                                                    .text("Execute lookup on the client")
+                                                    .build())
+                                    .metadata(Map.of(ToolResultBlock.METADATA_SUSPENDED, true))
+                                    .build());
+
+            List<AguiEvent> events =
+                    runReActEvents(
+                            inputWithTools(frontendTool("lookup")),
+                            new AgentStartEvent("thread-v2", "reply-frontend", "react"),
+                            new AgentResultEvent(suspendedResult),
+                            new AgentEndEvent("reply-frontend"));
+
+            assertEquals(
+                    List.of(AguiEventType.RUN_STARTED, AguiEventType.RUN_FINISHED), types(events));
+            AguiEvent.RunFinished finished =
+                    assertInstanceOf(AguiEvent.RunFinished.class, events.get(1));
+            assertNull(finished.outcome());
+        }
+
+        @Test
+        void testSuspendedBackendToolStillInterruptsWhenFrontendToolsArePresent() {
+            ToolUseBlock frontendToolUse =
+                    ToolUseBlock.builder()
+                            .id("tool-1")
+                            .name("lookup")
+                            .input(Map.of("city", "Paris"))
+                            .build();
+            ToolUseBlock backendToolUse =
+                    ToolUseBlock.builder()
+                            .id("tool-2")
+                            .name("requestHumanApproval")
+                            .input(Map.of("summary", "refund"))
+                            .build();
+            Msg suspendedResult =
+                    AssistantMessage.builder()
+                            .id("reply-mixed")
+                            .content(
+                                    List.of(
+                                            frontendToolUse,
+                                            backendToolUse,
+                                            ToolResultBlock.builder()
+                                                    .id("tool-1")
+                                                    .name("lookup")
+                                                    .output(
+                                                            TextBlock.builder()
+                                                                    .text("client lookup")
+                                                                    .build())
+                                                    .metadata(
+                                                            Map.of(
+                                                                    ToolResultBlock
+                                                                            .METADATA_SUSPENDED,
+                                                                    true))
+                                                    .build(),
+                                            ToolResultBlock.builder()
+                                                    .id("tool-2")
+                                                    .name("requestHumanApproval")
+                                                    .output(
+                                                            TextBlock.builder()
+                                                                    .text("Approve refund?")
+                                                                    .build())
+                                                    .metadata(
+                                                            Map.of(
+                                                                    ToolResultBlock
+                                                                            .METADATA_SUSPENDED,
+                                                                    true))
+                                                    .build()))
+                            .generateReason(GenerateReason.TOOL_SUSPENDED)
+                            .build();
+
+            List<AguiEvent> events =
+                    runReActEvents(
+                            inputWithTools(frontendTool("lookup")),
+                            new AgentStartEvent("thread-v2", "reply-mixed", "react"),
+                            new AgentResultEvent(suspendedResult),
+                            new AgentEndEvent("reply-mixed"));
+
+            AguiEvent.RunFinished finished =
+                    assertInstanceOf(AguiEvent.RunFinished.class, events.get(1));
+            AguiEvent.RunFinishedInterruptOutcome outcome =
+                    assertInstanceOf(
+                            AguiEvent.RunFinishedInterruptOutcome.class, finished.outcome());
+            assertEquals(1, outcome.interrupts().size());
+            assertEquals("tool-2", outcome.interrupts().get(0).toolCallId());
+            assertEquals(
+                    "requestHumanApproval", outcome.interrupts().get(0).metadata().get("toolName"));
+        }
+
+        @Test
         void testSuspendedToolResultWithoutStableToolCallIdFailsRun() {
             ToolUseBlock toolUse =
                     ToolUseBlock.builder()
@@ -1834,15 +1938,24 @@ class AguiAgentAdapterV2Test {
     }
 
     private static List<AguiEvent> runReActEvents(AgentEvent... agentEvents) {
-        return runReActEvents(AguiAdapterConfig.defaultConfig(), agentEvents);
+        return runReActEvents(AguiAdapterConfig.defaultConfig(), input(), agentEvents);
     }
 
     private static List<AguiEvent> runReActEvents(
             AguiAdapterConfig config, AgentEvent... agentEvents) {
+        return runReActEvents(config, input(), agentEvents);
+    }
+
+    private static List<AguiEvent> runReActEvents(RunAgentInput input, AgentEvent... agentEvents) {
+        return runReActEvents(AguiAdapterConfig.defaultConfig(), input, agentEvents);
+    }
+
+    private static List<AguiEvent> runReActEvents(
+            AguiAdapterConfig config, RunAgentInput input, AgentEvent... agentEvents) {
         ReActAgent agent = mock(ReActAgent.class);
         when(agent.streamEvents(anyList(), any(RuntimeContext.class)))
                 .thenReturn(Flux.fromArray(agentEvents));
-        return new AguiAgentAdapter(agent, config).run(input()).collectList().block();
+        return new AguiAgentAdapter(agent, config).run(input).collectList().block();
     }
 
     private static List<AguiEvent> runReActFlux(Flux<AgentEvent> agentEvents) {

--- a/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/test/java/io/agentscope/core/agui/adapter/strategy/AgentLifecycleEventConverterTest.java
+++ b/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/test/java/io/agentscope/core/agui/adapter/strategy/AgentLifecycleEventConverterTest.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.core.agui.adapter.strategy;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.agentscope.core.agui.adapter.AguiAdapterConfig;
+import io.agentscope.core.agui.event.AguiEvent;
+import io.agentscope.core.agui.model.RunAgentInput;
+import io.agentscope.core.event.AgentEndEvent;
+import io.agentscope.core.event.AgentResultEvent;
+import io.agentscope.core.message.AssistantMessage;
+import io.agentscope.core.message.ContentBlock;
+import io.agentscope.core.message.GenerateReason;
+import io.agentscope.core.message.Msg;
+import io.agentscope.core.message.TextBlock;
+import io.agentscope.core.message.ToolResultBlock;
+import io.agentscope.core.message.ToolUseBlock;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+/** Unit tests for {@link AgentLifecycleEventConverter} edge branches. */
+class AgentLifecycleEventConverterTest {
+
+    @Test
+    void suspendedResultWithoutMatchingToolUseDoesNotEmitInterrupt() {
+        Msg result =
+                AssistantMessage.builder()
+                        .id("reply-orphan")
+                        .content(
+                                List.of(
+                                        ToolResultBlock.builder()
+                                                .id("orphan-tool")
+                                                .name("lookup")
+                                                .output(TextBlock.builder().text("orphan").build())
+                                                .metadata(
+                                                        Map.of(
+                                                                ToolResultBlock.METADATA_SUSPENDED,
+                                                                true))
+                                                .build()))
+                        .generateReason(GenerateReason.TOOL_SUSPENDED)
+                        .build();
+        AguiStreamContext context =
+                new AguiStreamContext("thread-1", "run-1", AguiAdapterConfig.defaultConfig());
+        AgentEventConverterRegistry registry = new AgentEventConverterRegistry();
+
+        registry.convert(new AgentResultEvent(result), context);
+        List<AguiEvent> events = registry.convert(new AgentEndEvent("reply-orphan"), context);
+
+        AguiEvent.RunFinished finished =
+                events.stream()
+                        .filter(AguiEvent.RunFinished.class::isInstance)
+                        .map(AguiEvent.RunFinished.class::cast)
+                        .findFirst()
+                        .orElseThrow();
+        assertNull(finished.outcome());
+    }
+
+    @Test
+    void nullRunInputStillInterruptsBackendTool() {
+        AguiStreamContext context =
+                new AguiStreamContext("thread-1", "run-1", AguiAdapterConfig.defaultConfig());
+        convertSuspendedLookup(context);
+        assertInterruptToolCallId(context, "tool-1");
+    }
+
+    @Test
+    void nullToolsOnRunInputStillInterruptsBackendTool() {
+        RunAgentInput input = mock(RunAgentInput.class);
+        when(input.getTools()).thenReturn(null);
+        AguiStreamContext context =
+                new AguiStreamContext(
+                        "thread-1", "run-1", AguiAdapterConfig.defaultConfig(), input);
+        convertSuspendedLookup(context);
+        assertInterruptToolCallId(context, "tool-1");
+    }
+
+    private static void convertSuspendedLookup(AguiStreamContext context) {
+        ToolUseBlock toolUse =
+                ToolUseBlock.builder()
+                        .id("tool-1")
+                        .name("lookup")
+                        .input(Map.of("city", "Paris"))
+                        .build();
+        Msg result =
+                AssistantMessage.builder()
+                        .id("reply-suspended")
+                        .content(
+                                List.<ContentBlock>of(
+                                        toolUse,
+                                        ToolResultBlock.builder()
+                                                .id("tool-1")
+                                                .name("lookup")
+                                                .output(
+                                                        TextBlock.builder()
+                                                                .text("lookup externally")
+                                                                .build())
+                                                .metadata(
+                                                        Map.of(
+                                                                ToolResultBlock.METADATA_SUSPENDED,
+                                                                true))
+                                                .build()))
+                        .generateReason(GenerateReason.TOOL_SUSPENDED)
+                        .build();
+        AgentEventConverterRegistry registry = new AgentEventConverterRegistry();
+        registry.convert(new AgentResultEvent(result), context);
+        registry.convert(new AgentEndEvent("reply-suspended"), context);
+    }
+
+    private static void assertInterruptToolCallId(AguiStreamContext context, String toolCallId) {
+        List<AguiEvent.Interrupt> interrupts = context.getPendingInterrupts();
+        assertEquals(1, interrupts.size());
+        assertEquals(toolCallId, interrupts.get(0).toolCallId());
+    }
+}

--- a/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/test/java/io/agentscope/core/agui/converter/AguiMessageConverterTest.java
+++ b/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/test/java/io/agentscope/core/agui/converter/AguiMessageConverterTest.java
@@ -205,7 +205,36 @@ class AguiMessageConverterTest {
 
         assertEquals("msg-t1", msg.getId());
         assertEquals(MsgRole.TOOL, msg.getRole());
-        assertTrue(msg.hasContentBlocks(ToolResultBlock.class));
+        ToolResultBlock result = msg.getFirstContentBlock(ToolResultBlock.class);
+        assertNotNull(result);
+        assertEquals("tc-1", result.getId());
+        assertEquals(ToolResultState.SUCCESS, result.getState());
+    }
+
+    @Test
+    void testConvertToolMessageWithEmptyContentStillProducesResultBlock() {
+        AguiMessage aguiMsg = AguiMessage.toolMessage("msg-t1", "tc-1", "");
+
+        Msg msg = converter.toMsg(aguiMsg);
+
+        assertEquals(MsgRole.TOOL, msg.getRole());
+        ToolResultBlock result = msg.getFirstContentBlock(ToolResultBlock.class);
+        assertNotNull(result);
+        assertEquals("tc-1", result.getId());
+        assertEquals(ToolResultState.SUCCESS, result.getState());
+    }
+
+    @Test
+    void testConvertToolMessageWithNullContentStillProducesResultBlock() {
+        AguiMessage aguiMsg = new AguiMessage("msg-t1", "tool", null, null, "tc-1");
+
+        Msg msg = converter.toMsg(aguiMsg);
+
+        assertEquals(MsgRole.TOOL, msg.getRole());
+        ToolResultBlock result = msg.getFirstContentBlock(ToolResultBlock.class);
+        assertNotNull(result);
+        assertEquals("tc-1", result.getId());
+        assertEquals(ToolResultState.SUCCESS, result.getState());
     }
 
     @Test

--- a/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/test/java/io/agentscope/core/agui/processor/AgentResolverTest.java
+++ b/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/test/java/io/agentscope/core/agui/processor/AgentResolverTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.core.agui.processor;
+
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+import io.agentscope.core.agent.Agent;
+import io.agentscope.core.agent.RuntimeContext;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+/** Unit tests for {@link AgentResolver} default methods. */
+class AgentResolverTest {
+
+    @Test
+    void resolveAgentWithUserIdDefaultsToTwoArgLookup() {
+        Agent agent = Mockito.mock(Agent.class);
+        AgentResolver resolver =
+                new AgentResolver() {
+                    @Override
+                    public Agent resolveAgent(String agentId, String threadId) {
+                        return agent;
+                    }
+
+                    @Override
+                    public boolean hasMemory(RuntimeContext runtimeContext) {
+                        return false;
+                    }
+                };
+
+        assertSame(agent, resolver.resolveAgent("agent-a", "thread-1", "user-1"));
+        assertSame(agent, resolver.resolveAgent("agent-a", "thread-1", null));
+    }
+}

--- a/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/test/java/io/agentscope/core/agui/processor/AguiRequestProcessorTest.java
+++ b/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/test/java/io/agentscope/core/agui/processor/AguiRequestProcessorTest.java
@@ -18,8 +18,12 @@ package io.agentscope.core.agui.processor;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -42,6 +46,7 @@ import io.agentscope.core.message.ToolResultBlock;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import reactor.core.Disposable;
@@ -84,12 +89,77 @@ class AguiRequestProcessorTest {
     }
 
     @Test
+    void extractLatestUserMessageKeepsFullInputWhenNoAssistantTurnExists() {
+        AguiRequestProcessor processor =
+                AguiRequestProcessor.builder().agentResolver(mock(AgentResolver.class)).build();
+        AguiMessage firstUser = AguiMessage.userMessage("msg-1", "first");
+        AguiMessage secondUser = AguiMessage.userMessage("msg-2", "second");
+        RunAgentInput input =
+                RunAgentInput.builder()
+                        .threadId("thread-1")
+                        .runId("run-1")
+                        .messages(List.of(firstUser, secondUser))
+                        .build();
+
+        assertSame(input, processor.extractLatestUserMessage(input));
+    }
+
+    @Test
+    void extractLatestUserMessageIncludesToolAndUserFollowUpsAfterAssistant() {
+        AguiRequestProcessor processor =
+                AguiRequestProcessor.builder().agentResolver(mock(AgentResolver.class)).build();
+        AguiMessage tool = AguiMessage.toolMessage("msg-3", "tool-1", "approved");
+        AguiMessage followUp = AguiMessage.userMessage("msg-4", "continue");
+        RunAgentInput input =
+                RunAgentInput.builder()
+                        .threadId("thread-1")
+                        .runId("run-1")
+                        .messages(
+                                List.of(
+                                        AguiMessage.userMessage("msg-1", "first"),
+                                        AguiMessage.assistantMessage("msg-2", "need approval"),
+                                        tool,
+                                        followUp))
+                        .state(Map.of("cursor", 8))
+                        .build();
+
+        RunAgentInput extracted = processor.extractLatestUserMessage(input);
+
+        assertEquals(List.of(tool, followUp), extracted.getMessages());
+        assertEquals(input.getState(), extracted.getState());
+    }
+
+    @Test
+    void extractLatestUserMessageClearsMessagesWhenAssistantIsLast() {
+        AguiRequestProcessor processor =
+                AguiRequestProcessor.builder().agentResolver(mock(AgentResolver.class)).build();
+        RunAgentInput input =
+                RunAgentInput.builder()
+                        .threadId("thread-1")
+                        .runId("run-1")
+                        .messages(
+                                List.of(
+                                        AguiMessage.userMessage("msg-1", "first"),
+                                        AguiMessage.assistantMessage("msg-2", "done")))
+                        .state(Map.of("cursor", 8))
+                        .forwardedProps(Map.of("agentId", "agent-a"))
+                        .build();
+
+        RunAgentInput extracted = processor.extractLatestUserMessage(input);
+
+        assertTrue(extracted.getMessages().isEmpty());
+        assertEquals(input.getState(), extracted.getState());
+        assertEquals(input.getForwardedProps(), extracted.getForwardedProps());
+    }
+
+    @Test
     void processPassesCustomRuntimeContextThroughAdapterWithoutLosingAguiMetadata() {
         AgentResolver resolver = mock(AgentResolver.class);
         ReActAgent agent = mock(ReActAgent.class);
         ArgumentCaptor<RuntimeContext> contextCaptor =
                 ArgumentCaptor.forClass(RuntimeContext.class);
-        when(resolver.resolveAgent("default", "thread-1")).thenReturn(agent);
+        when(resolver.resolveAgent(eq("default"), eq("thread-1"), nullable(String.class)))
+                .thenReturn(agent);
         when(agent.streamEvents(anyList(), contextCaptor.capture())).thenReturn(Flux.empty());
         RuntimeContext callerContext =
                 RuntimeContext.builder()
@@ -124,8 +194,9 @@ class AguiRequestProcessorTest {
     void processRecordsInterruptsAndResolvesOfficialResumeToToolCallId() {
         AgentResolver resolver = mock(AgentResolver.class);
         ReActAgent agent = mock(ReActAgent.class);
-        when(resolver.resolveAgent("default", "thread-1")).thenReturn(agent);
-        when(resolver.hasMemory("thread-1")).thenReturn(false);
+        when(resolver.resolveAgent(eq("default"), eq("thread-1"), nullable(String.class)))
+                .thenReturn(agent);
+        when(resolver.hasMemory(any(RuntimeContext.class))).thenReturn(false);
         ArgumentCaptor<List<Msg>> msgsCaptor = ArgumentCaptor.forClass(List.class);
         when(agent.streamEvents(msgsCaptor.capture(), any(RuntimeContext.class)))
                 .thenReturn(Flux.just(new AgentEndEvent("reply-2")));
@@ -165,7 +236,8 @@ class AguiRequestProcessorTest {
     void processRejectsNewInputWhenThreadHasOpenInterrupts() {
         AgentResolver resolver = mock(AgentResolver.class);
         ReActAgent agent = mock(ReActAgent.class);
-        when(resolver.resolveAgent("default", "thread-1")).thenReturn(agent);
+        when(resolver.resolveAgent(eq("default"), eq("thread-1"), nullable(String.class)))
+                .thenReturn(agent);
         AtomicInteger adapterCount = new AtomicInteger();
         AguiRequestProcessor processor =
                 AguiRequestProcessor.builder()
@@ -202,7 +274,8 @@ class AguiRequestProcessorTest {
     void processRejectsConcurrentRunOnSameThreadUntilActiveRunFinishes() {
         AgentResolver resolver = mock(AgentResolver.class);
         ReActAgent agent = mock(ReActAgent.class);
-        when(resolver.resolveAgent("default", "thread-1")).thenReturn(agent);
+        when(resolver.resolveAgent(eq("default"), eq("thread-1"), nullable(String.class)))
+                .thenReturn(agent);
         AtomicInteger adapterCount = new AtomicInteger();
         AguiRequestProcessor processor =
                 AguiRequestProcessor.builder()
@@ -237,7 +310,8 @@ class AguiRequestProcessorTest {
     void processDoesNotBeginRunUntilEventsAreSubscribed() {
         AgentResolver resolver = mock(AgentResolver.class);
         ReActAgent agent = mock(ReActAgent.class);
-        when(resolver.resolveAgent("default", "thread-1")).thenReturn(agent);
+        when(resolver.resolveAgent(eq("default"), eq("thread-1"), nullable(String.class)))
+                .thenReturn(agent);
         when(agent.streamEvents(anyList(), any(RuntimeContext.class))).thenReturn(Flux.empty());
         AguiRequestProcessor processor =
                 AguiRequestProcessor.builder().agentResolver(resolver).build();
@@ -252,7 +326,8 @@ class AguiRequestProcessorTest {
     void processCreatesIndependentRunStateForEachEventsSubscription() {
         AgentResolver resolver = mock(AgentResolver.class);
         ReActAgent agent = mock(ReActAgent.class);
-        when(resolver.resolveAgent("default", "thread-1")).thenReturn(agent);
+        when(resolver.resolveAgent(eq("default"), eq("thread-1"), nullable(String.class)))
+                .thenReturn(agent);
         when(agent.streamEvents(anyList(), any(RuntimeContext.class))).thenReturn(Flux.empty());
         AguiRequestProcessor.ProcessResult result =
                 AguiRequestProcessor.builder()
@@ -270,7 +345,8 @@ class AguiRequestProcessorTest {
     void processReleasesActiveRunWhenSynchronousSetupFailsAfterBeginRun() {
         AgentResolver resolver = mock(AgentResolver.class);
         ReActAgent agent = mock(ReActAgent.class);
-        when(resolver.resolveAgent("default", "thread-1")).thenReturn(agent);
+        when(resolver.resolveAgent(eq("default"), eq("thread-1"), nullable(String.class)))
+                .thenReturn(agent);
         when(agent.streamEvents(anyList(), any(RuntimeContext.class))).thenReturn(Flux.empty());
         AtomicInteger adapterCount = new AtomicInteger();
         AguiRequestProcessor processor =
@@ -300,7 +376,8 @@ class AguiRequestProcessorTest {
     void processRejectsPartialResumeWhenMultipleInterruptsAreOpen() {
         AgentResolver resolver = mock(AgentResolver.class);
         ReActAgent agent = mock(ReActAgent.class);
-        when(resolver.resolveAgent("default", "thread-1")).thenReturn(agent);
+        when(resolver.resolveAgent(eq("default"), eq("thread-1"), nullable(String.class)))
+                .thenReturn(agent);
         AguiRequestProcessor processor =
                 AguiRequestProcessor.builder()
                         .agentResolver(resolver)
@@ -340,7 +417,8 @@ class AguiRequestProcessorTest {
     void processRejectsUnsupportedResumeStatus() {
         AgentResolver resolver = mock(AgentResolver.class);
         ReActAgent agent = mock(ReActAgent.class);
-        when(resolver.resolveAgent("default", "thread-1")).thenReturn(agent);
+        when(resolver.resolveAgent(eq("default"), eq("thread-1"), nullable(String.class)))
+                .thenReturn(agent);
         AguiRequestProcessor processor =
                 AguiRequestProcessor.builder()
                         .agentResolver(resolver)
@@ -373,7 +451,8 @@ class AguiRequestProcessorTest {
     void processAllowsResumeOnlyWhenAllOpenInterruptsAreCovered() {
         AgentResolver resolver = mock(AgentResolver.class);
         ReActAgent agent = mock(ReActAgent.class);
-        when(resolver.resolveAgent("default", "thread-1")).thenReturn(agent);
+        when(resolver.resolveAgent(eq("default"), eq("thread-1"), nullable(String.class)))
+                .thenReturn(agent);
         ArgumentCaptor<List<Msg>> msgsCaptor = ArgumentCaptor.forClass(List.class);
         when(agent.streamEvents(msgsCaptor.capture(), any(RuntimeContext.class)))
                 .thenReturn(Flux.just(new AgentEndEvent("reply-2")));
@@ -430,7 +509,8 @@ class AguiRequestProcessorTest {
     void processRejectsResumeWhenNoInterruptsAreOpen() {
         AgentResolver resolver = mock(AgentResolver.class);
         ReActAgent agent = mock(ReActAgent.class);
-        when(resolver.resolveAgent("default", "thread-1")).thenReturn(agent);
+        when(resolver.resolveAgent(eq("default"), eq("thread-1"), nullable(String.class)))
+                .thenReturn(agent);
         AguiRequestProcessor processor =
                 AguiRequestProcessor.builder().agentResolver(resolver).build();
         RunAgentInput resumeInput =
@@ -457,7 +537,8 @@ class AguiRequestProcessorTest {
         ReActAgent agent = mock(ReActAgent.class);
         ArgumentCaptor<RuntimeContext> contextCaptor =
                 ArgumentCaptor.forClass(RuntimeContext.class);
-        when(resolver.resolveAgent("default", "thread-1")).thenReturn(agent);
+        when(resolver.resolveAgent(eq("default"), eq("thread-1"), nullable(String.class)))
+                .thenReturn(agent);
         when(agent.streamEvents(anyList(), contextCaptor.capture())).thenReturn(Flux.empty());
         RunAgentInput input =
                 RunAgentInput.builder()
@@ -477,6 +558,58 @@ class AguiRequestProcessorTest {
         assertEquals("custom-adapter", context.get("adapter"));
         assertEquals("thread-1", context.getSessionId());
         assertEquals("run-1", context.get(AguiAgentAdapter.RUNTIME_CONTEXT_RUN_ID_KEY));
+    }
+
+    @Test
+    void processExtractsFollowUpMessagesWhenServerHasMemory() {
+        AgentResolver resolver = mock(AgentResolver.class);
+        ReActAgent agent = mock(ReActAgent.class);
+        when(resolver.resolveAgent(eq("default"), eq("thread-1"), nullable(String.class)))
+                .thenReturn(agent);
+        when(resolver.hasMemory(any(RuntimeContext.class))).thenReturn(true);
+        AtomicReference<RunAgentInput> seenInput = new AtomicReference<>();
+        AguiMessage tool = AguiMessage.toolMessage("msg-3", "tool-1", "approved");
+        AguiMessage followUp = AguiMessage.userMessage("msg-4", "continue");
+        RunAgentInput input =
+                RunAgentInput.builder()
+                        .threadId("thread-1")
+                        .runId("run-1")
+                        .messages(
+                                List.of(
+                                        AguiMessage.userMessage("msg-1", "first"),
+                                        AguiMessage.assistantMessage("msg-2", "need approval"),
+                                        tool,
+                                        followUp))
+                        .build();
+        AguiRequestProcessor processor =
+                AguiRequestProcessor.builder()
+                        .agentResolver(resolver)
+                        .adapterFactory(
+                                (resolvedAgent, config) ->
+                                        new RecordingAdapter(resolvedAgent, config, seenInput))
+                        .build();
+
+        processor.process(request(input)).events().collectList().block();
+
+        verify(resolver).hasMemory(any(RuntimeContext.class));
+        assertEquals(List.of(tool, followUp), seenInput.get().getMessages());
+    }
+
+    private static final class RecordingAdapter extends AguiAgentAdapter {
+
+        private final AtomicReference<RunAgentInput> seenInput;
+
+        private RecordingAdapter(
+                Agent agent, AguiAdapterConfig config, AtomicReference<RunAgentInput> seenInput) {
+            super(agent, config);
+            this.seenInput = seenInput;
+        }
+
+        @Override
+        public Flux<AguiEvent> run(RunAgentInput input, RuntimeContext runtimeContext) {
+            seenInput.set(input);
+            return Flux.empty();
+        }
     }
 
     private static final class CustomAdapter extends AguiAgentAdapter {

--- a/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/test/java/io/agentscope/core/agui/processor/AguiRequestProcessorTest.java
+++ b/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/test/java/io/agentscope/core/agui/processor/AguiRequestProcessorTest.java
@@ -19,7 +19,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.eq;
@@ -131,26 +130,46 @@ class AguiRequestProcessorTest {
     }
 
     @Test
-    void extractLatestUserMessageClearsMessagesWhenAssistantIsLast() {
+    void extractLatestUserMessageFallsBackToLastUserWhenAssistantIsLast() {
         AguiRequestProcessor processor =
                 AguiRequestProcessor.builder().agentResolver(mock(AgentResolver.class)).build();
+        AguiMessage firstUser = AguiMessage.userMessage("msg-1", "first");
         RunAgentInput input =
                 RunAgentInput.builder()
                         .threadId("thread-1")
                         .runId("run-1")
-                        .messages(
-                                List.of(
-                                        AguiMessage.userMessage("msg-1", "first"),
-                                        AguiMessage.assistantMessage("msg-2", "done")))
+                        .messages(List.of(firstUser, AguiMessage.assistantMessage("msg-2", "done")))
                         .state(Map.of("cursor", 8))
                         .forwardedProps(Map.of("agentId", "agent-a"))
                         .build();
 
         RunAgentInput extracted = processor.extractLatestUserMessage(input);
 
-        assertTrue(extracted.getMessages().isEmpty());
+        assertEquals(List.of(firstUser), extracted.getMessages());
         assertEquals(input.getState(), extracted.getState());
         assertEquals(input.getForwardedProps(), extracted.getForwardedProps());
+    }
+
+    @Test
+    void processCoalescesNullResolverResultWithoutNpe() {
+        AgentResolver resolver = mock(AgentResolver.class);
+        ReActAgent agent = mock(ReActAgent.class);
+        when(resolver.resolveAgent(eq("default"), eq("thread-1"), nullable(String.class)))
+                .thenReturn(agent);
+        when(resolver.hasMemory(any(RuntimeContext.class))).thenReturn(false);
+        when(agent.streamEvents(anyList(), any(RuntimeContext.class)))
+                .thenReturn(Flux.just(new AgentEndEvent("ok")));
+
+        AguiRequestProcessor processor =
+                AguiRequestProcessor.builder()
+                        .agentResolver(resolver)
+                        .runtimeContextResolver(request -> null)
+                        .build();
+
+        List<AguiEvent> events =
+                processor.process(request(input("run-1"))).events().collectList().block();
+
+        assertNotNull(events);
     }
 
     @Test

--- a/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/test/java/io/agentscope/core/agui/processor/AguiRequestProcessorTest.java
+++ b/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/test/java/io/agentscope/core/agui/processor/AguiRequestProcessorTest.java
@@ -25,6 +25,7 @@ import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -593,6 +594,48 @@ class AguiRequestProcessorTest {
 
         verify(resolver).hasMemory(any(RuntimeContext.class));
         assertEquals(List.of(tool, followUp), seenInput.get().getMessages());
+    }
+
+    @Test
+    void processResultInterruptTargetsReActSessionWithoutClosingTheAgent() {
+        AgentResolver resolver = mock(AgentResolver.class);
+        ReActAgent agent = mock(ReActAgent.class);
+        when(resolver.resolveAgent(eq("default"), eq("thread-1"), nullable(String.class)))
+                .thenReturn(agent);
+        RuntimeContext callerContext =
+                RuntimeContext.builder().userId("user-1").sessionId("caller-session").build();
+        AguiRequestProcessor.ProcessResult result =
+                AguiRequestProcessor.builder()
+                        .agentResolver(resolver)
+                        .runtimeContextResolver(request -> callerContext)
+                        .build()
+                        .process(request(input("run-1")));
+
+        result.interrupt("thread-1");
+
+        ArgumentCaptor<RuntimeContext> contextCaptor =
+                ArgumentCaptor.forClass(RuntimeContext.class);
+        verify(agent).interrupt(contextCaptor.capture());
+        verify(agent, never()).interrupt();
+        assertEquals("thread-1", contextCaptor.getValue().getSessionId());
+        assertEquals("user-1", contextCaptor.getValue().getUserId());
+    }
+
+    @Test
+    void processResultInterruptFallsBackForNonReActAgent() {
+        AgentResolver resolver = mock(AgentResolver.class);
+        Agent agent = mock(Agent.class);
+        when(resolver.resolveAgent(eq("default"), eq("thread-1"), nullable(String.class)))
+                .thenReturn(agent);
+        AguiRequestProcessor.ProcessResult result =
+                AguiRequestProcessor.builder()
+                        .agentResolver(resolver)
+                        .build()
+                        .process(request(input("run-1")));
+
+        result.interrupt("thread-1");
+
+        verify(agent).interrupt();
     }
 
     private static final class RecordingAdapter extends AguiAgentAdapter {

--- a/agentscope-extensions/agentscope-spring-boot-starters/agentscope-agui-spring-boot-starter/src/main/java/io/agentscope/spring/boot/agui/common/DefaultAgentResolver.java
+++ b/agentscope-extensions/agentscope-spring-boot-starters/agentscope-agui-spring-boot-starter/src/main/java/io/agentscope/spring/boot/agui/common/DefaultAgentResolver.java
@@ -16,6 +16,7 @@
 package io.agentscope.spring.boot.agui.common;
 
 import io.agentscope.core.agent.Agent;
+import io.agentscope.core.agent.RuntimeContext;
 import io.agentscope.core.agui.AguiException;
 import io.agentscope.core.agui.processor.AgentResolver;
 import io.agentscope.core.agui.registry.AguiAgentRegistry;
@@ -63,9 +64,14 @@ public class DefaultAgentResolver implements AgentResolver {
 
     @Override
     public Agent resolveAgent(String agentId, String threadId) {
+        return resolveAgent(agentId, threadId, null);
+    }
+
+    @Override
+    public Agent resolveAgent(String agentId, String threadId, String userId) {
         if (serverSideMemory && sessionManager != null) {
-            // Server-side memory mode: use session manager
             return sessionManager.getOrCreateAgent(
+                    userId,
                     threadId,
                     agentId,
                     () ->
@@ -74,17 +80,15 @@ public class DefaultAgentResolver implements AgentResolver {
                                             () ->
                                                     new AguiException.AgentNotFoundException(
                                                             agentId)));
-        } else {
-            // Standard mode: create new agent for each request
-            return registry.getAgent(agentId)
-                    .orElseThrow(() -> new AguiException.AgentNotFoundException(agentId));
         }
+        return registry.getAgent(agentId)
+                .orElseThrow(() -> new AguiException.AgentNotFoundException(agentId));
     }
 
     @Override
-    public boolean hasMemory(String threadId) {
+    public boolean hasMemory(RuntimeContext runtimeContext) {
         if (serverSideMemory && sessionManager != null) {
-            return sessionManager.hasMemory(threadId);
+            return sessionManager.hasMemory(runtimeContext);
         }
         return false;
     }

--- a/agentscope-extensions/agentscope-spring-boot-starters/agentscope-agui-spring-boot-starter/src/main/java/io/agentscope/spring/boot/agui/common/ThreadSessionManager.java
+++ b/agentscope-extensions/agentscope-spring-boot-starters/agentscope-agui-spring-boot-starter/src/main/java/io/agentscope/spring/boot/agui/common/ThreadSessionManager.java
@@ -60,7 +60,12 @@ public class ThreadSessionManager {
 
     private static final Logger logger = LoggerFactory.getLogger(ThreadSessionManager.class);
 
-    /** Sentinel namespace for callers that pass {@code userId == null}. */
+    /**
+     * Sentinel namespace for callers that pass {@code userId == null}.
+     *
+     * <p>Must stay in sync with the anonymous sentinel used by {@code ReActAgent#slotKey}
+     * ({@value #ANON_USER}).
+     */
     static final String ANON_USER = "__anon__";
 
     private final Map<SessionKey, ThreadSession> sessions = new ConcurrentHashMap<>();

--- a/agentscope-extensions/agentscope-spring-boot-starters/agentscope-agui-spring-boot-starter/src/main/java/io/agentscope/spring/boot/agui/common/ThreadSessionManager.java
+++ b/agentscope-extensions/agentscope-spring-boot-starters/agentscope-agui-spring-boot-starter/src/main/java/io/agentscope/spring/boot/agui/common/ThreadSessionManager.java
@@ -17,6 +17,8 @@ package io.agentscope.spring.boot.agui.common;
 
 import io.agentscope.core.ReActAgent;
 import io.agentscope.core.agent.Agent;
+import io.agentscope.core.agent.RuntimeContext;
+import io.agentscope.core.agui.AguiUtil;
 import io.agentscope.core.state.AgentState;
 import java.time.Instant;
 import java.util.Collections;
@@ -29,24 +31,28 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Manages agent sessions by threadId for server-side memory management.
+ * Manages agent sessions by {@code (userId, threadId)} for server-side memory.
  *
- * <p>This manager maintains a pool of agent instances, each associated with a threadId. When
- * server-side memory is enabled, the same agent instance is reused for requests with the same
- * threadId, preserving conversation history across requests.
+ * <p>When server-side memory is enabled, the same agent instance is reused for requests with the
+ * same user and thread, preserving conversation history across requests. Sessions for different
+ * users never share a slot, even when they reuse a thread id.
  *
  * <p><b>Usage:</b>
  *
  * <pre>{@code
  * ThreadSessionManager manager = new ThreadSessionManager(1000, 30);
  *
- * // Get or create an agent for a thread
- * Agent agent = manager.getOrCreateAgent("thread-123", "default", () -> createAgent());
+ * Agent agent =
+ *         manager.getOrCreateAgent(
+ *                 "user-1", "thread-123", "default", () -> createAgent());
  *
- * // Check if agent has memory
- * boolean hasMemory = manager.hasMemory("thread-123");
+ * boolean hasMemory =
+ *         manager.hasMemory(
+ *                 RuntimeContext.builder()
+ *                         .userId("user-1")
+ *                         .sessionId("thread-123")
+ *                         .build());
  *
- * // Clean up expired sessions
  * manager.cleanupExpiredSessions();
  * }</pre>
  */
@@ -54,7 +60,10 @@ public class ThreadSessionManager {
 
     private static final Logger logger = LoggerFactory.getLogger(ThreadSessionManager.class);
 
-    private final Map<String, ThreadSession> sessions = new ConcurrentHashMap<>();
+    /** Sentinel namespace for callers that pass {@code userId == null}. */
+    static final String ANON_USER = "__anon__";
+
+    private final Map<SessionKey, ThreadSession> sessions = new ConcurrentHashMap<>();
     private final int maxSessions;
     private final int sessionTimeoutMinutes;
 
@@ -70,10 +79,7 @@ public class ThreadSessionManager {
     }
 
     /**
-     * Get or create an agent for the given threadId.
-     *
-     * <p>This method is thread-safe. It uses atomic operations to ensure that concurrent requests
-     * for the same threadId will share the same agent instance.
+     * Get or create an agent for the given threadId under the anonymous user slot.
      *
      * @param threadId The thread identifier
      * @param agentId The agent type identifier
@@ -81,41 +87,34 @@ public class ThreadSessionManager {
      * @return The agent for this thread
      */
     public Agent getOrCreateAgent(String threadId, String agentId, Supplier<Agent> agentFactory) {
-        ensureCapacity();
-
-        // Use compute() for atomic check-and-update to avoid race conditions
-        ThreadSession session =
-                sessions.compute(
-                        threadId,
-                        (k, existing) -> {
-                            if (existing == null) {
-                                // No existing session, create new one
-                                logger.debug("Creating new session for threadId: {}", threadId);
-                                return new ThreadSession(agentId, agentFactory.get());
-                            }
-                            if (!existing.getAgentId().equals(agentId)) {
-                                // Agent type changed, create new session
-                                logger.debug(
-                                        "Agent type changed for threadId {}: {} -> {}",
-                                        threadId,
-                                        existing.getAgentId(),
-                                        agentId);
-                                ThreadSession replacement =
-                                        new ThreadSession(agentId, agentFactory.get());
-                                replacement.setName(existing.getName());
-                                replacement.setArchived(existing.isArchived());
-                                return replacement;
-                            }
-                            // Same agent type, update access time and reuse
-                            existing.updateLastAccess();
-                            return existing;
-                        });
-
-        return session.getAgent();
+        return getOrCreateAgent(null, threadId, agentId, agentFactory);
     }
 
     /**
-     * Ensure a session exists for the given threadId, creating one if needed.
+     * Get or create an agent for the given user and thread.
+     *
+     * <p>This method is thread-safe. Concurrent requests for the same {@code (userId, threadId)}
+     * share the same agent instance.
+     *
+     * @param userId The user identifier, may be {@code null} for anonymous
+     * @param threadId The thread identifier
+     * @param agentId The agent type identifier
+     * @param agentFactory Factory to create new agents if needed
+     * @return The agent for this user and thread
+     */
+    public Agent getOrCreateAgent(
+            String userId, String threadId, String agentId, Supplier<Agent> agentFactory) {
+        ensureCapacity();
+        return sessions.compute(
+                        sessionKey(userId, threadId),
+                        (k, existing) ->
+                                upsertSession(
+                                        existing, userId, threadId, agentId, null, agentFactory))
+                .getAgent();
+    }
+
+    /**
+     * Ensure a session exists for the given threadId under the anonymous user slot.
      *
      * @param threadId The thread identifier
      * @param agentId The agent type identifier
@@ -125,81 +124,117 @@ public class ThreadSessionManager {
      */
     public ThreadSession ensureSession(
             String threadId, String agentId, String name, Supplier<Agent> agentFactory) {
-        ensureCapacity();
-
-        return sessions.compute(
-                threadId,
-                (k, existing) -> {
-                    if (existing == null) {
-                        ThreadSession created = new ThreadSession(agentId, agentFactory.get());
-                        if (name != null && !name.isBlank()) {
-                            created.setName(name);
-                        }
-                        return created;
-                    }
-                    if (!existing.getAgentId().equals(agentId)) {
-                        ThreadSession replacement = new ThreadSession(agentId, agentFactory.get());
-                        replacement.setName(
-                                name != null && !name.isBlank() ? name : existing.getName());
-                        replacement.setArchived(existing.isArchived());
-                        return replacement;
-                    }
-                    if (name != null && !name.isBlank()) {
-                        existing.setName(name);
-                    }
-                    existing.updateLastAccess();
-                    return existing;
-                });
+        return ensureSession(null, threadId, agentId, name, agentFactory);
     }
 
     /**
-     * Check if a session exists and has memory for the given threadId.
+     * Ensure a session exists for the given user and thread, creating one if needed.
      *
+     * @param userId The user identifier, may be {@code null} for anonymous
      * @param threadId The thread identifier
+     * @param agentId The agent type identifier
+     * @param name Display name for the thread (may be null)
+     * @param agentFactory Factory to create new agents if needed
+     * @return The session for this user and thread
+     */
+    public ThreadSession ensureSession(
+            String userId,
+            String threadId,
+            String agentId,
+            String name,
+            Supplier<Agent> agentFactory) {
+        ensureCapacity();
+        return sessions.compute(
+                sessionKey(userId, threadId),
+                (k, existing) ->
+                        upsertSession(existing, userId, threadId, agentId, name, agentFactory));
+    }
+
+    /**
+     * Check if a session exists and has memory for the given runtime context.
+     *
+     * <p>The session is keyed by {@link RuntimeContext#getUserId()} and {@link
+     * RuntimeContext#getSessionId()}. When the agent is a harness wrapper, the inner {@link
+     * ReActAgent} is inspected without closing it.
+     *
+     * @param runtimeContext The runtime context identifying the user and thread
      * @return true if the session exists and the agent has non-empty memory
      */
-    public boolean hasMemory(String threadId) {
-        ThreadSession session = sessions.get(threadId);
+    public boolean hasMemory(RuntimeContext runtimeContext) {
+        if (runtimeContext == null || runtimeContext.getSessionId() == null) {
+            return false;
+        }
+        ThreadSession session =
+                sessions.get(sessionKey(runtimeContext.getUserId(), runtimeContext.getSessionId()));
         if (session == null) {
             return false;
         }
 
-        Agent agent = session.getAgent();
-        if (agent instanceof ReActAgent reactAgent) {
-            AgentState state = reactAgent.getAgentState(null, threadId);
-            return state != null && !state.getContext().isEmpty();
+        ReActAgent reActAgent = AguiUtil.asReActAgent(session.getAgent());
+        if (reActAgent == null) {
+            return false;
         }
-
-        return false;
+        AgentState state = reActAgent.getAgentState(runtimeContext);
+        return state != null && !state.getContext().isEmpty();
     }
 
     /**
-     * Get the session for a threadId if it exists.
+     * Get the session for a threadId under the anonymous user slot if it exists.
      *
      * @param threadId The thread identifier
      * @return Optional containing the session, or empty if not found
      */
     public Optional<ThreadSession> getSession(String threadId) {
-        return Optional.ofNullable(sessions.get(threadId));
+        return getSession(null, threadId);
+    }
+
+    /**
+     * Get the session for a user and thread if it exists.
+     *
+     * @param userId The user identifier, may be {@code null} for anonymous
+     * @param threadId The thread identifier
+     * @return Optional containing the session, or empty if not found
+     */
+    public Optional<ThreadSession> getSession(String userId, String threadId) {
+        return Optional.ofNullable(sessions.get(sessionKey(userId, threadId)));
     }
 
     /**
      * Returns an unmodifiable snapshot of all sessions keyed by threadId.
      *
+     * <p>When two users share a thread id, the later entry in iteration order overwrites the
+     * snapshot. Use {@link ThreadSession#getUserId()} and {@link ThreadSession#getThreadId()} on
+     * each value for tenant-safe identity.
+     *
      * @return session snapshot
      */
     public Map<String, ThreadSession> getSessions() {
-        return Collections.unmodifiableMap(new LinkedHashMap<>(sessions));
+        Map<String, ThreadSession> snapshot = new LinkedHashMap<>();
+        for (ThreadSession session : sessions.values()) {
+            snapshot.put(session.getThreadId(), session);
+        }
+        return Collections.unmodifiableMap(snapshot);
     }
 
     /**
-     * Remove a session by threadId.
+     * Remove a session by threadId under the anonymous user slot.
      *
      * @param threadId The thread identifier
      * @return true if a session was removed
      */
     public boolean removeSession(String threadId) {
-        return sessions.remove(threadId) != null;
+        return removeSession(null, threadId);
+    }
+
+    /**
+     * Remove a session by user and thread.
+     *
+     * @param userId The user identifier, may be {@code null} for anonymous
+     * @param threadId The thread identifier
+     * @return true if a session was removed
+     */
+    public boolean removeSession(String userId, String threadId) {
+        return sessions.remove(sessionKey(userId, threadId)) != null;
     }
 
     /** Clean up sessions that have been inactive for longer than the timeout. */
@@ -225,6 +260,53 @@ public class ThreadSessionManager {
         }
     }
 
+    private ThreadSession upsertSession(
+            ThreadSession existing,
+            String userId,
+            String threadId,
+            String agentId,
+            String name,
+            Supplier<Agent> agentFactory) {
+        if (existing == null) {
+            logger.debug(
+                    "Creating new session for user {} threadId {}",
+                    normalizeUser(userId),
+                    threadId);
+            ThreadSession created =
+                    new ThreadSession(userId, threadId, agentId, agentFactory.get());
+            if (name != null && !name.isBlank()) {
+                created.setName(name);
+            }
+            return created;
+        }
+        if (!existing.getAgentId().equals(agentId)) {
+            logger.debug(
+                    "Agent type changed for user {} threadId {}: {} -> {}",
+                    normalizeUser(userId),
+                    threadId,
+                    existing.getAgentId(),
+                    agentId);
+            ThreadSession replacement =
+                    new ThreadSession(userId, threadId, agentId, agentFactory.get());
+            replacement.setName(name != null && !name.isBlank() ? name : existing.getName());
+            replacement.setArchived(existing.isArchived());
+            return replacement;
+        }
+        if (name != null && !name.isBlank()) {
+            existing.setName(name);
+        }
+        existing.updateLastAccess();
+        return existing;
+    }
+
+    private static SessionKey sessionKey(String userId, String threadId) {
+        return new SessionKey(normalizeUser(userId), threadId);
+    }
+
+    private static String normalizeUser(String userId) {
+        return userId == null || userId.isBlank() ? ANON_USER : userId;
+    }
+
     private void ensureCapacity() {
         if (sessions.size() >= maxSessions) {
             cleanupExpiredSessions();
@@ -236,7 +318,7 @@ public class ThreadSessionManager {
 
     /** Remove the oldest session to make room for new ones. */
     private void removeOldestSession() {
-        String oldestKey = null;
+        SessionKey oldestKey = null;
         Instant oldestTime = Instant.MAX;
 
         for (var entry : sessions.entrySet()) {
@@ -248,7 +330,10 @@ public class ThreadSessionManager {
 
         if (oldestKey != null) {
             sessions.remove(oldestKey);
-            logger.debug("Removed oldest session: {}", oldestKey);
+            logger.debug(
+                    "Removed oldest session: user {} thread {}",
+                    oldestKey.userId(),
+                    oldestKey.threadId());
         }
     }
 
@@ -266,9 +351,13 @@ public class ThreadSessionManager {
         sessions.clear();
     }
 
+    private record SessionKey(String userId, String threadId) {}
+
     /** Represents a thread session with its agent and metadata. */
     public static class ThreadSession {
 
+        private final String userId;
+        private final String threadId;
         private final String agentId;
         private final Agent agent;
         private final Instant createdAt;
@@ -276,12 +365,22 @@ public class ThreadSessionManager {
         private volatile String name;
         private volatile boolean archived;
 
-        ThreadSession(String agentId, Agent agent) {
+        ThreadSession(String userId, String threadId, String agentId, Agent agent) {
+            this.userId = normalizeUser(userId);
+            this.threadId = threadId;
             this.agentId = agentId;
             this.agent = agent;
             Instant now = Instant.now();
             this.createdAt = now;
             this.lastAccess = now;
+        }
+
+        public String getUserId() {
+            return userId;
+        }
+
+        public String getThreadId() {
+            return threadId;
         }
 
         public String getAgentId() {

--- a/agentscope-extensions/agentscope-spring-boot-starters/agentscope-agui-spring-boot-starter/src/test/java/io/agentscope/spring/boot/agui/common/DefaultAgentResolverTest.java
+++ b/agentscope-extensions/agentscope-spring-boot-starters/agentscope-agui-spring-boot-starter/src/test/java/io/agentscope/spring/boot/agui/common/DefaultAgentResolverTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.spring.boot.agui.common;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.agentscope.core.agent.Agent;
+import io.agentscope.core.agent.RuntimeContext;
+import io.agentscope.core.agui.AguiException;
+import io.agentscope.core.agui.registry.AguiAgentRegistry;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+/** Unit tests for {@link DefaultAgentResolver}. */
+@Tag("unit")
+@DisplayName("DefaultAgentResolver Unit Tests")
+class DefaultAgentResolverTest {
+
+    @Test
+    void resolveAgentLooksUpRegistryWhenServerSideMemoryIsDisabled() {
+        AguiAgentRegistry registry = new AguiAgentRegistry();
+        Agent registered = mock(Agent.class);
+        registry.register("agent-a", registered);
+        DefaultAgentResolver resolver = new DefaultAgentResolver(registry);
+
+        assertSame(registered, resolver.resolveAgent("agent-a", "thread-1"));
+        assertSame(registered, resolver.resolveAgent("agent-a", "thread-1", "user-1"));
+        assertFalse(
+                resolver.hasMemory(
+                        RuntimeContext.builder().userId("user-1").sessionId("thread-1").build()));
+        assertThrows(
+                AguiException.AgentNotFoundException.class,
+                () -> resolver.resolveAgent("missing", "thread-1", "user-1"));
+    }
+
+    @Test
+    void resolveAgentAndHasMemoryUseSessionManagerWhenServerSideMemoryIsEnabled() {
+        AguiAgentRegistry registry = new AguiAgentRegistry();
+        ThreadSessionManager sessionManager = mock(ThreadSessionManager.class);
+        Agent sessionAgent = mock(Agent.class);
+        RuntimeContext context =
+                RuntimeContext.builder().userId("user-1").sessionId("thread-1").build();
+        when(sessionManager.getOrCreateAgent(eq("user-1"), eq("thread-1"), eq("agent-a"), any()))
+                .thenReturn(sessionAgent);
+        when(sessionManager.getOrCreateAgent(isNull(), eq("thread-1"), eq("agent-a"), any()))
+                .thenReturn(sessionAgent);
+        when(sessionManager.hasMemory(context)).thenReturn(true);
+
+        DefaultAgentResolver resolver =
+                DefaultAgentResolver.builder()
+                        .registry(registry)
+                        .sessionManager(sessionManager)
+                        .serverSideMemory(true)
+                        .build();
+
+        assertSame(sessionAgent, resolver.resolveAgent("agent-a", "thread-1", "user-1"));
+        assertSame(sessionAgent, resolver.resolveAgent("agent-a", "thread-1"));
+        assertTrue(resolver.hasMemory(context));
+        verify(sessionManager).getOrCreateAgent(eq("user-1"), eq("thread-1"), eq("agent-a"), any());
+        verify(sessionManager).getOrCreateAgent(isNull(), eq("thread-1"), eq("agent-a"), any());
+        verify(sessionManager).hasMemory(context);
+    }
+
+    @Test
+    void serverSideMemoryWithoutSessionManagerFallsBackToRegistry() {
+        AguiAgentRegistry registry = new AguiAgentRegistry();
+        Agent registered = mock(Agent.class);
+        registry.register("agent-a", registered);
+        DefaultAgentResolver resolver =
+                DefaultAgentResolver.builder().registry(registry).serverSideMemory(true).build();
+
+        assertSame(registered, resolver.resolveAgent("agent-a", "thread-1", "user-1"));
+        assertFalse(resolver.hasMemory(RuntimeContext.builder().sessionId("thread-1").build()));
+    }
+}

--- a/agentscope-extensions/agentscope-spring-boot-starters/agentscope-agui-spring-boot-starter/src/test/java/io/agentscope/spring/boot/agui/common/ThreadSessionManagerTest.java
+++ b/agentscope-extensions/agentscope-spring-boot-starters/agentscope-agui-spring-boot-starter/src/test/java/io/agentscope/spring/boot/agui/common/ThreadSessionManagerTest.java
@@ -21,11 +21,15 @@ import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.agentscope.core.ReActAgent;
 import io.agentscope.core.agent.Agent;
+import io.agentscope.core.agent.RuntimeContext;
 import io.agentscope.core.message.Msg;
 import io.agentscope.core.state.AgentState;
 import io.agentscope.spring.boot.agui.common.ThreadSessionManager.ThreadSession;
@@ -35,6 +39,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 
 /** Unit tests for {@link ThreadSessionManager}. */
 @Tag("unit")
@@ -132,27 +137,69 @@ class ThreadSessionManagerTest {
     }
 
     @Test
-    void hasMemoryUsesThreadScopedAgentState() {
+    void hasMemoryUsesRuntimeContextScopedAgentStateWithoutClosingTheAgent() {
         ThreadSessionManager manager = new ThreadSessionManager(10, 30);
-        assertFalse(manager.hasMemory("missing"));
+        assertFalse(manager.hasMemory(ctx("missing")));
+        assertFalse(manager.hasMemory(null));
 
         Agent plain = mock(Agent.class);
         manager.getOrCreateAgent("thread-plain", "agent-a", () -> plain);
-        assertFalse(manager.hasMemory("thread-plain"));
+        assertFalse(manager.hasMemory(ctx("thread-plain")));
 
         ReActAgent emptyAgent = mock(ReActAgent.class);
         AgentState emptyState = mock(AgentState.class);
-        when(emptyAgent.getAgentState(null, "thread-empty")).thenReturn(emptyState);
+        when(emptyAgent.getAgentState(any(RuntimeContext.class))).thenReturn(emptyState);
         when(emptyState.getContext()).thenReturn(List.of());
         manager.getOrCreateAgent("thread-empty", "agent-a", () -> emptyAgent);
-        assertFalse(manager.hasMemory("thread-empty"));
+        assertFalse(manager.hasMemory(ctx("thread-empty")));
 
         ReActAgent filledAgent = mock(ReActAgent.class);
         AgentState filledState = mock(AgentState.class);
-        when(filledAgent.getAgentState(null, "thread-filled")).thenReturn(filledState);
+        ArgumentCaptor<RuntimeContext> contextCaptor =
+                ArgumentCaptor.forClass(RuntimeContext.class);
+        when(filledAgent.getAgentState(contextCaptor.capture())).thenReturn(filledState);
         when(filledState.getContext()).thenReturn(List.of(mock(Msg.class)));
-        manager.getOrCreateAgent("thread-filled", "agent-a", () -> filledAgent);
-        assertTrue(manager.hasMemory("thread-filled"));
+        manager.getOrCreateAgent("user-1", "thread-filled", "agent-a", () -> filledAgent);
+        assertTrue(
+                manager.hasMemory(
+                        RuntimeContext.builder()
+                                .sessionId("thread-filled")
+                                .userId("user-1")
+                                .build()));
+        assertFalse(manager.hasMemory(ctx("thread-filled")));
+        assertEquals("thread-filled", contextCaptor.getValue().getSessionId());
+        assertEquals("user-1", contextCaptor.getValue().getUserId());
+        verify(filledAgent, never()).close();
+    }
+
+    @Test
+    void sessionsAndHasMemoryAreIsolatedByUserId() {
+        ThreadSessionManager manager = new ThreadSessionManager(10, 30);
+        ReActAgent agentA = mock(ReActAgent.class);
+        ReActAgent agentB = mock(ReActAgent.class);
+        AgentState filledState = mock(AgentState.class);
+        AgentState emptyState = mock(AgentState.class);
+        when(filledState.getContext()).thenReturn(List.of(mock(Msg.class)));
+        when(emptyState.getContext()).thenReturn(List.of());
+        when(agentA.getAgentState(any(RuntimeContext.class))).thenReturn(filledState);
+        when(agentB.getAgentState(any(RuntimeContext.class))).thenReturn(emptyState);
+
+        Agent createdA = manager.getOrCreateAgent("user-a", "thread-1", "agent-a", () -> agentA);
+        Agent createdB = manager.getOrCreateAgent("user-b", "thread-1", "agent-a", () -> agentB);
+
+        assertSame(agentA, createdA);
+        assertSame(agentB, createdB);
+        assertEquals(2, manager.getSessionCount());
+        assertSame(agentA, manager.getSession("user-a", "thread-1").orElseThrow().getAgent());
+        assertSame(agentB, manager.getSession("user-b", "thread-1").orElseThrow().getAgent());
+        assertTrue(manager.getSession("thread-1").isEmpty());
+        assertTrue(
+                manager.hasMemory(
+                        RuntimeContext.builder().userId("user-a").sessionId("thread-1").build()));
+        assertFalse(
+                manager.hasMemory(
+                        RuntimeContext.builder().userId("user-b").sessionId("thread-1").build()));
+        assertFalse(manager.hasMemory(ctx("thread-1")));
     }
 
     @Test
@@ -204,5 +251,9 @@ class ThreadSessionManagerTest {
 
         manager.cleanupExpiredSessions();
         assertTrue(manager.getSession("thread-old").isEmpty());
+    }
+
+    private static RuntimeContext ctx(String threadId) {
+        return RuntimeContext.builder().sessionId(threadId).build();
     }
 }

--- a/agentscope-extensions/agentscope-spring-boot-starters/agentscope-agui-spring-boot-starter/src/test/java/io/agentscope/spring/boot/agui/common/ThreadSessionManagerTest.java
+++ b/agentscope-extensions/agentscope-spring-boot-starters/agentscope-agui-spring-boot-starter/src/test/java/io/agentscope/spring/boot/agui/common/ThreadSessionManagerTest.java
@@ -134,6 +134,12 @@ class ThreadSessionManagerTest {
         assertEquals("KeepMe", replaced.getName());
         assertTrue(replaced.isArchived());
         assertSame(second, replaced.getAgent());
+
+        ThreadSession renamed =
+                manager.ensureSession("thread-1", "agent-c", "NewName", () -> mock(Agent.class));
+        assertEquals("agent-c", renamed.getAgentId());
+        assertEquals("NewName", renamed.getName());
+        assertTrue(renamed.isArchived());
     }
 
     @Test
@@ -152,6 +158,12 @@ class ThreadSessionManagerTest {
         when(emptyState.getContext()).thenReturn(List.of());
         manager.getOrCreateAgent("thread-empty", "agent-a", () -> emptyAgent);
         assertFalse(manager.hasMemory(ctx("thread-empty")));
+
+        ReActAgent nullStateAgent = mock(ReActAgent.class);
+        when(nullStateAgent.getAgentState(any(RuntimeContext.class))).thenReturn(null);
+        manager.getOrCreateAgent("thread-null-state", "agent-a", () -> nullStateAgent);
+        assertFalse(manager.hasMemory(ctx("thread-null-state")));
+        assertFalse(manager.hasMemory(RuntimeContext.builder().userId("user-1").build()));
 
         ReActAgent filledAgent = mock(ReActAgent.class);
         AgentState filledState = mock(AgentState.class);
@@ -203,6 +215,32 @@ class ThreadSessionManagerTest {
     }
 
     @Test
+    void blankUserIdSharesAnonymousSessionAndEnsureSessionKeepsUserScope() {
+        ThreadSessionManager manager = new ThreadSessionManager(10, 30);
+        Agent first = mock(Agent.class);
+        Agent second = mock(Agent.class);
+
+        Agent created = manager.getOrCreateAgent("   ", "thread-1", "agent-a", () -> first);
+        Agent reused =
+                manager.getOrCreateAgent(null, "thread-1", "agent-a", () -> mock(Agent.class));
+        ThreadSession named =
+                manager.ensureSession("user-1", "thread-1", "agent-a", "Orders", () -> second);
+
+        assertSame(first, created);
+        assertSame(first, reused);
+        assertEquals(
+                ThreadSessionManager.ANON_USER,
+                manager.getSession("thread-1").orElseThrow().getUserId());
+        assertEquals("user-1", named.getUserId());
+        assertEquals("thread-1", named.getThreadId());
+        assertEquals("Orders", named.getName());
+        assertEquals(2, manager.getSessionCount());
+        assertTrue(manager.removeSession("user-1", "thread-1"));
+        assertTrue(manager.getSession("user-1", "thread-1").isEmpty());
+        assertEquals(1, manager.getSessionCount());
+    }
+
+    @Test
     void getSessionsReturnsUnmodifiableSnapshot() {
         ThreadSessionManager manager = new ThreadSessionManager(10, 30);
         Agent agent = mock(Agent.class);
@@ -213,6 +251,12 @@ class ThreadSessionManagerTest {
         assertThrows(
                 UnsupportedOperationException.class,
                 () -> snapshot.put("thread-2", mock(ThreadSession.class)));
+
+        manager.getOrCreateAgent("user-a", "thread-shared", "agent-a", () -> mock(Agent.class));
+        manager.getOrCreateAgent("user-b", "thread-shared", "agent-a", () -> mock(Agent.class));
+        Map<String, ThreadSession> overwritten = manager.getSessions();
+        assertEquals(2, overwritten.size());
+        assertEquals("thread-shared", overwritten.get("thread-shared").getThreadId());
     }
 
     @Test
@@ -250,6 +294,28 @@ class ThreadSessionManagerTest {
         field.set(session, java.time.Instant.now().minusSeconds(120));
 
         manager.cleanupExpiredSessions();
+        assertTrue(manager.getSession("thread-old").isEmpty());
+
+        manager.getOrCreateAgent("thread-fresh", "agent-a", () -> agent);
+        manager.cleanupExpiredSessions();
+        assertTrue(manager.getSession("thread-fresh").isPresent());
+    }
+
+    @Test
+    void ensureCapacityCleansExpiredSessionInsteadOfEvictingNewest() throws Exception {
+        ThreadSessionManager manager = new ThreadSessionManager(1, 1);
+        Agent first = mock(Agent.class);
+        Agent second = mock(Agent.class);
+        manager.getOrCreateAgent("thread-old", "agent-a", () -> first);
+
+        ThreadSession session = manager.getSession("thread-old").orElseThrow();
+        java.lang.reflect.Field field = ThreadSession.class.getDeclaredField("lastAccess");
+        field.setAccessible(true);
+        field.set(session, java.time.Instant.now().minusSeconds(120));
+
+        manager.getOrCreateAgent("thread-new", "agent-a", () -> second);
+        assertEquals(1, manager.getSessionCount());
+        assertTrue(manager.getSession("thread-new").isPresent());
         assertTrue(manager.getSession("thread-old").isEmpty());
     }
 


### PR DESCRIPTION
## Related issues
- Fixes #2855
- 
- ## Summary
- Key `ThreadSessionManager` / `AgentResolver` by `(userId, threadId)` so `hasMemory` and agent reuse no longer mix tenants.
- Inspect session memory without closing the live `ReActAgent`.
- Keep messages after the last assistant turn, including tool results, so HITL can resume.
- Do not emit interrupts for frontend tools.
- Unwrap harness/stop interrupts via `AguiUtil.asReActAgent` so demo `stopThread` and processor interrupt target the live session.
- Add unit coverage for user-scoped sessions, default `AgentResolver`, lifecycle interrupt filtering, and `ProcessResult.interrupt()`.

## Breaking Changes

This PR is source- and behavior-incompatible. Upgrading requires recompilation + minor migration.

### API (source-incompatible)
- `AgentResolver#hasMemory(String threadId)` -> `hasMemory(RuntimeContext)`. Custom `AgentResolver`
  implementations must update the signature; the single-arg form is removed.
- `ThreadSessionManager#hasMemory(String threadId)` -> `hasMemory(RuntimeContext)`. Callers must pass
  a `RuntimeContext` carrying `userId` + `sessionId`.

### Behavior (runtime-incompatible)
- Session keying changed `threadId` -> `(userId, threadId)`. Different users on the same thread id no
  longer share an agent instance. Anonymous callers (`userId == null`) stay on the shared `__anon__`
  slot, so single-tenant behavior is unchanged.
- `ThreadSessionManager#getSessions()` now returns a threadId-keyed snapshot that is lossy when
  multiple users share a thread id; use `getSession(userId, threadId)` for tenant-safe lookup.
- AG-UI event stream: frontend/external tools (`SchemaOnlyTool` / `@Tool(externalTool=true)`) no longer
  emit a `TOOL_SUSPENDED` interrupt. Results are delivered via message-based resume (a trailing
  `role:"tool"` message in the next run's transcript) instead of `RunAgentInput.resume`.
