### PR TITLE
fix(core): synchronize shared JSON schema generation

### DIFF
--- a/agentscope-core/src/main/java/io/agentscope/core/util/JsonSchemaUtils.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/util/JsonSchemaUtils.java
@@ -61,6 +61,8 @@ public class JsonSchemaUtils {
 
     private static final SchemaGenerator schemaGenerator;
 
+    private static final Object schemaGenerationLock = new Object();
+
     static {
         // JacksonModule to support @JsonProperty, @JsonPropertyDescription annotations
         JacksonModule jacksonModule =
@@ -95,7 +97,10 @@ public class JsonSchemaUtils {
      */
     public static Map<String, Object> generateSchemaFromClass(Class<?> clazz) {
         try {
-            JsonNode schemaNode = schemaGenerator.generateSchema(clazz);
+            JsonNode schemaNode;
+            synchronized (schemaGenerationLock) {
+                schemaNode = schemaGenerator.generateSchema(clazz);
+            }
             return JsonUtils.getJsonCodec()
                     .convertValue(schemaNode, new TypeReference<Map<String, Object>>() {});
         } catch (Exception e) {
@@ -130,7 +135,10 @@ public class JsonSchemaUtils {
      */
     public static Map<String, Object> generateSchemaFromType(Type type) {
         try {
-            JsonNode schemaNode = schemaGenerator.generateSchema(type);
+            JsonNode schemaNode;
+            synchronized (schemaGenerationLock) {
+                schemaNode = schemaGenerator.generateSchema(type);
+            }
             return JsonUtils.getJsonCodec()
                     .convertValue(schemaNode, new TypeReference<Map<String, Object>>() {});
         } catch (Exception e) {

--- a/agentscope-core/src/test/java/io/agentscope/core/util/JsonSchemaUtilsTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/util/JsonSchemaUtilsTest.java
@@ -23,8 +23,14 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import java.lang.reflect.Type;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.Test;
 
 class JsonSchemaUtilsTest {
@@ -155,5 +161,39 @@ class JsonSchemaUtilsTest {
         Map<String, Object> mapSchema = JsonSchemaUtils.generateSchemaFromType(mapType);
         assertNotNull(mapSchema);
         assertEquals("object", mapSchema.get("type"));
+    }
+
+    @Test
+    void testConcurrentSchemaGeneration() throws Exception {
+        int workers = 8;
+        ExecutorService executor = Executors.newFixedThreadPool(workers);
+        CountDownLatch ready = new CountDownLatch(workers);
+        CountDownLatch start = new CountDownLatch(1);
+        try {
+            List<Future<Void>> futures = new ArrayList<>();
+            for (int i = 0; i < workers; i++) {
+                futures.add(
+                        executor.submit(
+                                () -> {
+                                    ready.countDown();
+                                    start.await();
+                                    for (int attempt = 0; attempt < 25; attempt++) {
+                                        Map<String, Object> schema =
+                                                JsonSchemaUtils.generateSchemaFromClass(
+                                                        NestedModel.class);
+                                        assertEquals("object", schema.get("type"));
+                                    }
+                                    return null;
+                                }));
+            }
+            assertTrue(ready.await(5, TimeUnit.SECONDS));
+            start.countDown();
+            for (Future<Void> future : futures) {
+                future.get(10, TimeUnit.SECONDS);
+            }
+        } finally {
+            executor.shutdown();
+            assertTrue(executor.awaitTermination(10, TimeUnit.SECONDS));
+        }
     }
 }


### PR DESCRIPTION
## Summary

`JsonSchemaUtils` shares one victools `SchemaGenerator` instance across all structured-output calls. The generator and Jackson introspection caches are not thread-safe, so overlapping calls can fail with `ConcurrentModificationException`.

This change serializes schema generation for both class and generic type entry points with a dedicated lock. The public API and schema conversion behavior remain unchanged.

## Testing

- `mvn -pl agentscope-core -Dtest=JsonSchemaUtilsTest test` (8 tests passed)
- `mvn -pl agentscope-core spotless:apply`
- `git diff --check`

Closes #2795.
