### PR TITLE
feat: offload base64 image payloads from agent state

### DIFF
--- a/agentscope-core/src/main/java/io/agentscope/core/ReActAgent.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/ReActAgent.java
@@ -70,6 +70,8 @@ import io.agentscope.core.memory.StaticLongTermMemoryHook;
 import io.agentscope.core.message.AssistantMessage;
 import io.agentscope.core.message.ContentBlock;
 import io.agentscope.core.message.GenerateReason;
+import io.agentscope.core.message.ImagePayloadState;
+import io.agentscope.core.message.ImagePayloadTransformer;
 import io.agentscope.core.message.MessageMetadataKeys;
 import io.agentscope.core.message.Msg;
 import io.agentscope.core.message.MsgRole;
@@ -114,6 +116,7 @@ import io.agentscope.core.skill.SkillBox;
 import io.agentscope.core.skill.SkillFilter;
 import io.agentscope.core.skill.repository.AgentSkillRepository;
 import io.agentscope.core.state.AgentState;
+import io.agentscope.core.state.AgentStateLoadMode;
 import io.agentscope.core.state.AgentStateStore;
 import io.agentscope.core.state.ConcurrentSessionModificationException;
 import io.agentscope.core.state.ConflictPolicy;
@@ -259,6 +262,13 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
     private final AgentStateStore stateStore;
 
     /**
+     * Whether new saves replace inline base64 images with separately stored payload references.
+     * Disabled by default so mixed-version rolling deployments keep writing the legacy format
+     * until every node understands image references.
+     */
+    private final boolean imagePayloadOffloadingEnabled;
+
+    /**
      * Policy applied when an optimistic-concurrency save of {@code agent_state} conflicts.
      * Defaults to {@link ConflictPolicy#OVERWRITE} (legacy last-writer-wins).
      */
@@ -291,6 +301,10 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
      * AgentStateStore#UNVERSIONED}.
      */
     private final ConcurrentHashMap<String, Long> slotVersions = new ConcurrentHashMap<>();
+
+    /** Context size observed with each cached slot version, used by manual APPEND_MERGE saves. */
+    private final ConcurrentHashMap<String, Integer> slotLoadedContextSizes =
+            new ConcurrentHashMap<>();
 
     /** Count of CAS conflicts observed during agent_state saves (metric / diagnostics). */
     private final AtomicLong stateConflictCount = new AtomicLong();
@@ -344,6 +358,7 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
         this.middlewares = List.copyOf(mws);
 
         this.stateStore = builder.stateStore;
+        this.imagePayloadOffloadingEnabled = builder.imagePayloadOffloadingEnabled;
         this.conflictPolicy =
                 builder.conflictPolicy != null ? builder.conflictPolicy : ConflictPolicy.OVERWRITE;
         this.defaultSessionId =
@@ -370,9 +385,7 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
                         String slot = slotKey(uid, sid);
                         long expected =
                                 slotVersions.getOrDefault(slot, AgentStateStore.UNVERSIONED);
-                        long newVersion =
-                                stateStore.saveIfVersion(
-                                        uid, sid, "agent_state", agentState, expected);
+                        long newVersion = writeAgentStateIfVersion(uid, sid, agentState, expected);
                         if (newVersion == AgentStateStore.UNVERSIONED
                                 && stateStore.supportsVersioning()
                                 && expected != AgentStateStore.UNVERSIONED) {
@@ -385,6 +398,13 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
                                     expected);
                         } else if (newVersion != AgentStateStore.UNVERSIONED) {
                             slotVersions.put(slot, newVersion);
+                        }
+                        if (newVersion != AgentStateStore.UNVERSIONED
+                                || !stateStore.supportsVersioning()
+                                || expected == AgentStateStore.UNVERSIONED) {
+                            AgentState lightweight = lightweightState(agentState);
+                            stateCache.put(slot, lightweight);
+                            slotLoadedContextSizes.put(slot, lightweight.getContext().size());
                         }
                     });
         }
@@ -431,7 +451,7 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
         }
         try {
             VersionedState<AgentState> versioned =
-                    stateStore.getVersioned(userId, sessionId, "agent_state", AgentState.class);
+                    stateStore.getAgentStateVersioned(userId, sessionId, AgentStateLoadMode.LEAN);
             if (versioned.isPresent()) {
                 return versioned;
             }
@@ -503,8 +523,28 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
                             if (newVersion != AgentStateStore.UNVERSIONED) {
                                 scope.loadedVersion = newVersion;
                             }
+                            AgentState persisted = stateCache.getOrDefault(scope.slotKey, toSave);
+                            AgentState lightweight = lightweightState(persisted);
+                            scope.state = lightweight;
+                            scope.loadedContextSize = lightweight.getContext().size();
+                            stateCache.put(scope.slotKey, lightweight);
+                            slotLoadedContextSizes.put(
+                                    scope.slotKey, lightweight.getContext().size());
+                            if (scope.rc != null) {
+                                scope.rc.setAgentState(lightweight);
+                            }
                         })
                 .subscribeOn(Schedulers.boundedElastic());
+    }
+
+    private AgentState lightweightState(AgentState state) {
+        if (!imagePayloadOffloadingEnabled) {
+            return state;
+        }
+        List<Msg> lightweight = ImagePayloadTransformer.offload(state.getContext()).messages();
+        state.contextMutable().clear();
+        state.contextMutable().addAll(lightweight);
+        return state;
     }
 
     /**
@@ -552,10 +592,11 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
             long expectedVersion,
             int loadedContextSize) {
         if (!stateStore.supportsVersioning() || expectedVersion == AgentStateStore.UNVERSIONED) {
-            stateStore.save(userId, sessionId, "agent_state", toSave);
+            writeAgentState(userId, sessionId, toSave);
             if (stateStore.supportsVersioning()) {
                 VersionedState<AgentState> after =
-                        stateStore.getVersioned(userId, sessionId, "agent_state", AgentState.class);
+                        stateStore.getAgentStateVersioned(
+                                userId, sessionId, AgentStateLoadMode.LEAN);
                 if (after.version() != AgentStateStore.UNVERSIONED) {
                     slotVersions.put(slot, after.version());
                     return after.version();
@@ -564,8 +605,7 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
             return AgentStateStore.UNVERSIONED;
         }
 
-        long newVersion =
-                stateStore.saveIfVersion(userId, sessionId, "agent_state", toSave, expectedVersion);
+        long newVersion = writeAgentStateIfVersion(userId, sessionId, toSave, expectedVersion);
         if (newVersion != AgentStateStore.UNVERSIONED) {
             slotVersions.put(slot, newVersion);
             return newVersion;
@@ -575,12 +615,8 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
         switch (conflictPolicy) {
             case OVERWRITE -> {
                 long overwritten =
-                        stateStore.saveIfVersion(
-                                userId,
-                                sessionId,
-                                "agent_state",
-                                toSave,
-                                AgentStateStore.UNVERSIONED);
+                        writeAgentStateIfVersion(
+                                userId, sessionId, toSave, AgentStateStore.UNVERSIONED);
                 if (overwritten != AgentStateStore.UNVERSIONED) {
                     slotVersions.put(slot, overwritten);
                     log.warn(
@@ -591,7 +627,7 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
                             expectedVersion);
                     return overwritten;
                 }
-                stateStore.save(userId, sessionId, "agent_state", toSave);
+                writeAgentState(userId, sessionId, toSave);
                 log.warn(
                         "agent_state CAS conflict — OVERWRITE applied"
                                 + " (userId={}, sessionId={}, expectedVersion={})",
@@ -602,10 +638,11 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
             }
             case FAIL ->
                     throw new ConcurrentSessionModificationException(
-                            userId, sessionId, "agent_state", expectedVersion);
+                            userId, sessionId, AgentStateStore.AGENT_STATE_KEY, expectedVersion);
             case APPEND_MERGE -> {
                 VersionedState<AgentState> latest =
-                        stateStore.getVersioned(userId, sessionId, "agent_state", AgentState.class);
+                        stateStore.getAgentStateVersioned(
+                                userId, sessionId, AgentStateLoadMode.LEAN);
                 AgentState baseline =
                         latest.isPresent()
                                 ? latest.value()
@@ -622,11 +659,10 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
                 }
                 baseline.setPermissionContext(toSave.getPermissionContext());
                 long merged =
-                        stateStore.saveIfVersion(
-                                userId, sessionId, "agent_state", baseline, latest.version());
+                        writeAgentStateIfVersion(userId, sessionId, baseline, latest.version());
                 if (merged == AgentStateStore.UNVERSIONED) {
                     throw new ConcurrentSessionModificationException(
-                            userId, sessionId, "agent_state", latest.version());
+                            userId, sessionId, AgentStateStore.AGENT_STATE_KEY, latest.version());
                 }
                 slotVersions.put(slot, merged);
                 stateCache.put(slot, baseline);
@@ -640,6 +676,22 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
             default ->
                     throw new IllegalStateException("Unknown conflict policy: " + conflictPolicy);
         }
+    }
+
+    private void writeAgentState(String userId, String sessionId, AgentState state) {
+        if (imagePayloadOffloadingEnabled) {
+            stateStore.saveAgentState(userId, sessionId, state);
+        } else {
+            stateStore.save(userId, sessionId, AgentStateStore.AGENT_STATE_KEY, state);
+        }
+    }
+
+    private long writeAgentStateIfVersion(
+            String userId, String sessionId, AgentState state, long expectedVersion) {
+        return imagePayloadOffloadingEnabled
+                ? stateStore.saveAgentStateIfVersion(userId, sessionId, state, expectedVersion)
+                : stateStore.saveIfVersion(
+                        userId, sessionId, AgentStateStore.AGENT_STATE_KEY, state, expectedVersion);
     }
 
     /**
@@ -679,6 +731,7 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
             loadedVersion = versioned.version();
             stateCache.put(slot, loaded);
             slotVersions.put(slot, loadedVersion);
+            slotLoadedContextSizes.put(slot, loaded.getContext().size());
         } else {
             loaded =
                     stateCache.computeIfAbsent(
@@ -1658,6 +1711,9 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
         /** Context size at load time; used by {@link ConflictPolicy#APPEND_MERGE}. */
         int loadedContextSize;
 
+        /** Image payloads restored during this call, keyed by content identifier. */
+        final Map<String, ImagePayloadState> hydratedImagePayloads = new HashMap<>();
+
         /**
          * Per-call system message, propagated across PreCallEvent → PreReasoningEvent /
          * PreSummaryEvent. Owned by a single logical execution: seeded to {@code null} at call
@@ -2269,6 +2325,43 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
             }
         }
 
+        /**
+         * Build a detached model-bound message list with persisted image references restored.
+         * The call-scoped {@link AgentState} remains lightweight so history inspection and
+         * subsequent saves do not retain duplicate base64 payloads in memory.
+         */
+        private List<Msg> hydrateModelMessages(List<Msg> messages, Set<String> payloadIds) {
+            if (stateStore == null || messages == null || messages.isEmpty()) {
+                return messages != null ? messages : List.of();
+            }
+            SlotRef ref = SlotRef.parse(slotKey);
+            Set<String> missing = new LinkedHashSet<>(payloadIds);
+            missing.removeAll(hydratedImagePayloads.keySet());
+            if (!missing.isEmpty()) {
+                hydratedImagePayloads.putAll(
+                        stateStore.getImagePayloads(ref.userId, ref.sessionId, missing));
+            }
+            return ImagePayloadTransformer.hydrate(messages, hydratedImagePayloads);
+        }
+
+        private Mono<List<Msg>> hydrateModelMessagesAsync(List<Msg> messages) {
+            List<Msg> safeMessages = messages != null ? messages : List.of();
+            if (stateStore == null || safeMessages.isEmpty()) {
+                return Mono.just(safeMessages);
+            }
+            return Mono.defer(
+                    () -> {
+                        Set<String> payloadIds =
+                                ImagePayloadTransformer.referencedPayloadIds(safeMessages);
+                        if (payloadIds.isEmpty()) {
+                            return Mono.just(List.copyOf(safeMessages));
+                        }
+                        return Mono.fromCallable(
+                                        () -> hydrateModelMessages(safeMessages, payloadIds))
+                                .subscribeOn(Schedulers.boundedElastic());
+                    });
+        }
+
         // ==================== Core ReAct Loop ====================
 
         /**
@@ -2510,17 +2603,38 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
                 GenerateOptions options) {
 
             Function<ModelCallInput, Flux<AgentEvent>> modelCallCore =
-                    mci -> modelCallStream(context, mci, true);
+                    mci ->
+                            hydrateModelMessagesAsync(mci.messages())
+                                    .flatMapMany(
+                                            hydrated ->
+                                                    modelCallStream(
+                                                            context,
+                                                            new ModelCallInput(
+                                                                    hydrated,
+                                                                    mci.tools(),
+                                                                    mci.options(),
+                                                                    mci.model()),
+                                                            true));
 
             StringBuilder transformedText = new StringBuilder();
             AtomicBoolean sawTransformedTextDelta = new AtomicBoolean(false);
-            return MiddlewareChain.build(
-                            middlewares,
-                            ReActAgent.this,
-                            rc,
-                            MiddlewareBase::onModelCall,
-                            modelCallCore)
-                    .apply(new ModelCallInput(messages, tools, options, modelForCall()))
+            Flux<AgentEvent> modelCall =
+                    hydrateModelMessagesAsync(messages)
+                            .flatMapMany(
+                                    hydrated ->
+                                            MiddlewareChain.build(
+                                                            middlewares,
+                                                            ReActAgent.this,
+                                                            rc,
+                                                            MiddlewareBase::onModelCall,
+                                                            modelCallCore)
+                                                    .apply(
+                                                            new ModelCallInput(
+                                                                    hydrated,
+                                                                    tools,
+                                                                    options,
+                                                                    modelForCall())));
+            return modelCall
                     .doOnNext(
                             event -> {
                                 if (event instanceof TextBlockDeltaEvent textDelta) {
@@ -3609,15 +3723,31 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
                 Model model) {
 
             Function<ModelCallInput, Flux<AgentEvent>> summaryModelCallCore =
-                    mci -> summaryModelCallStream(context, mci, options);
+                    mci ->
+                            hydrateModelMessagesAsync(mci.messages())
+                                    .flatMapMany(
+                                            hydrated ->
+                                                    summaryModelCallStream(
+                                                            context,
+                                                            new ModelCallInput(
+                                                                    hydrated,
+                                                                    mci.tools(),
+                                                                    mci.options(),
+                                                                    mci.model()),
+                                                            options));
 
-            return MiddlewareChain.build(
-                            middlewares,
-                            ReActAgent.this,
-                            rc,
-                            MiddlewareBase::onModelCall,
-                            summaryModelCallCore)
-                    .apply(new ModelCallInput(messages, List.of(), options, model))
+            return hydrateModelMessagesAsync(messages)
+                    .flatMapMany(
+                            hydrated ->
+                                    MiddlewareChain.build(
+                                                    middlewares,
+                                                    ReActAgent.this,
+                                                    rc,
+                                                    MiddlewareBase::onModelCall,
+                                                    summaryModelCallCore)
+                                            .apply(
+                                                    new ModelCallInput(
+                                                            hydrated, List.of(), options, model)))
                     .doOnNext(this::publishEvent);
         }
 
@@ -4058,8 +4188,10 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
                     if (source == InterruptSource.SYSTEM) {
                         String requestId =
                                 (String) cv.getOrDefault(AgentBase.SHUTDOWN_REQUEST_ID_KEY, null);
-                        shutdownManager.saveOnInterruptObserved(requestId);
-                        return Mono.error(new AgentShuttingDownException());
+                        return Mono.fromRunnable(
+                                        () -> shutdownManager.saveOnInterruptObserved(requestId))
+                                .subscribeOn(Schedulers.boundedElastic())
+                                .then(Mono.error(new AgentShuttingDownException()));
                     }
                     // Reconcile any pending tool calls before appending the recovery message.
                     // The tool_use written during reasoning would otherwise be persisted with no
@@ -4176,6 +4308,7 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
                                     getAgentId(),
                                     initialActiveToolGroups);
                     slotVersions.put(slot, versioned.version());
+                    slotLoadedContextSizes.put(slot, versioned.value().getContext().size());
                     return versioned.value();
                 });
     }
@@ -4194,6 +4327,8 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
     public void clearStateCache() {
         stateCache.clear();
         permissionEngineCache.clear();
+        slotVersions.clear();
+        slotLoadedContextSizes.clear();
     }
 
     /**
@@ -4224,6 +4359,8 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
         String slot = slotKey(userId, sid);
         stateCache.remove(slot);
         permissionEngineCache.remove(slot);
+        slotVersions.remove(slot);
+        slotLoadedContextSizes.remove(slot);
     }
 
     /**
@@ -4285,6 +4422,7 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
                 state = versioned.value();
                 stateCache.put(slot, state);
                 slotVersions.put(slot, versioned.version());
+                slotLoadedContextSizes.put(slot, state.getContext().size());
             } else {
                 state = stateCache.get(slot);
                 if (state == null) {
@@ -4412,7 +4550,13 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
         AgentState s = stateCache.get(slot);
         if (s != null) {
             long expected = slotVersions.getOrDefault(slot, AgentStateStore.UNVERSIONED);
-            persistAgentStateCas(userId, sessionId, slot, s, expected, s.getContext().size());
+            int loadedContextSize =
+                    slotLoadedContextSizes.getOrDefault(slot, s.getContext().size());
+            persistAgentStateCas(userId, sessionId, slot, s, expected, loadedContextSize);
+            AgentState persisted = stateCache.getOrDefault(slot, s);
+            AgentState lightweight = lightweightState(persisted);
+            stateCache.put(slot, lightweight);
+            slotLoadedContextSizes.put(slot, lightweight.getContext().size());
         }
     }
 
@@ -4429,6 +4573,11 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
     /** Returns the {@link AgentStateStore} configured for state persistence, or {@code null}. */
     public AgentStateStore getStateStore() {
         return stateStore;
+    }
+
+    /** Returns whether new AgentState saves offload inline base64 image payloads. */
+    public boolean isImagePayloadOffloadingEnabled() {
+        return imagePayloadOffloadingEnabled;
     }
 
     /**
@@ -4544,6 +4693,7 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
         private Model flatFallbackModel;
         private Boolean flatStopOnReject;
         private AgentStateStore stateStore;
+        private boolean imagePayloadOffloadingEnabled;
         private ConflictPolicy conflictPolicy;
         private String defaultSessionId;
 
@@ -4883,6 +5033,18 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
          */
         public Builder stateStore(AgentStateStore stateStore) {
             this.stateStore = stateStore;
+            return this;
+        }
+
+        /**
+         * Enables offloading inline base64 images from persisted AgentState messages.
+         *
+         * <p>Defaults to {@code false} for rolling-upgrade safety. Deploy the new version to all
+         * nodes before enabling this option; older nodes do not understand the lightweight image
+         * reference format. New code can always read legacy inline states.
+         */
+        public Builder imagePayloadOffloadingEnabled(boolean enabled) {
+            this.imagePayloadOffloadingEnabled = enabled;
             return this;
         }
 

--- a/agentscope-core/src/main/java/io/agentscope/core/message/ImagePayloadState.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/message/ImagePayloadState.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.core.message;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.agentscope.core.state.State;
+import java.util.Objects;
+
+/** Persistable payload extracted from an image {@link Base64Source}. */
+public record ImagePayloadState(
+        @JsonProperty("media_type") String mediaType, @JsonProperty("data") String data)
+        implements State {
+
+    @JsonCreator
+    public ImagePayloadState {
+        Objects.requireNonNull(mediaType, "mediaType must not be null");
+        Objects.requireNonNull(data, "data must not be null");
+    }
+}

--- a/agentscope-core/src/main/java/io/agentscope/core/message/ImagePayloadTransformer.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/message/ImagePayloadTransformer.java
@@ -1,0 +1,314 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.core.message;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Pure transformations between inline base64 image messages and lightweight payload references.
+ *
+ * <p>The transformer does not read or write storage. Callers persist the returned payload map and
+ * lightweight messages in the order required by their storage consistency model.
+ */
+public final class ImagePayloadTransformer {
+
+    private static final String REFERENCE_NAMESPACE = "__agentscope_image_ref__:";
+
+    /** Versioned prefix reserved for AgentScope image payload references. */
+    public static final String REFERENCE_PREFIX = REFERENCE_NAMESPACE + "v1:";
+
+    private static final byte[] HASH_DOMAIN =
+            "agentscope-image-payload-v1".getBytes(StandardCharsets.UTF_8);
+
+    private static final Pattern REFERENCE_PATTERN =
+            Pattern.compile(Pattern.quote(REFERENCE_PREFIX) + "([0-9a-f]{64})");
+
+    private ImagePayloadTransformer() {}
+
+    /**
+     * Replaces inline base64 images with content-addressed references.
+     *
+     * <p>Legacy {@link ImageBlock} values and image MIME {@link DataBlock} values are transformed,
+     * including values nested in {@link ToolResultBlock#getOutput()}. URL sources and non-image
+     * media remain unchanged.
+     */
+    public static OffloadResult offload(List<Msg> messages) {
+        Objects.requireNonNull(messages, "messages must not be null");
+        Map<String, ImagePayloadState> payloads = new LinkedHashMap<>();
+        List<Msg> transformed = transformMessages(messages, payloads, null, false);
+        return new OffloadResult(transformed, payloads);
+    }
+
+    /**
+     * Restores referenced image payloads into a detached message list.
+     *
+     * @throws IllegalArgumentException if a reserved reference is malformed
+     * @throws IllegalStateException if a referenced payload is absent or fails integrity checks
+     */
+    public static List<Msg> hydrate(List<Msg> messages, Map<String, ImagePayloadState> payloads) {
+        Objects.requireNonNull(messages, "messages must not be null");
+        Objects.requireNonNull(payloads, "payloads must not be null");
+        return transformMessages(messages, null, payloads, true);
+    }
+
+    /**
+     * Returns the payload identifiers referenced by the supported image blocks, in encounter order.
+     *
+     * <p>Inline base64 values are ignored. Malformed values in the reserved reference namespace are
+     * rejected using the same rules as {@link #offload(List)} and {@link #hydrate(List, Map)}.
+     */
+    public static Set<String> referencedPayloadIds(List<Msg> messages) {
+        Objects.requireNonNull(messages, "messages must not be null");
+        Set<String> result = new LinkedHashSet<>();
+        for (Msg message : messages) {
+            Objects.requireNonNull(message, "messages must not contain null elements");
+            collectReferencedPayloadIds(message.getContent(), result);
+        }
+        return Collections.unmodifiableSet(result);
+    }
+
+    private static void collectReferencedPayloadIds(
+            List<ContentBlock> blocks, Set<String> referencedPayloadIds) {
+        for (ContentBlock block : blocks) {
+            if (block instanceof ImageBlock image) {
+                collectReferencedPayloadId(image.getSource(), referencedPayloadIds);
+            } else if (block instanceof DataBlock data && isImageSource(data.getSource())) {
+                collectReferencedPayloadId(data.getSource(), referencedPayloadIds);
+            } else if (block instanceof ToolResultBlock toolResult) {
+                collectReferencedPayloadIds(toolResult.getOutput(), referencedPayloadIds);
+            }
+        }
+    }
+
+    private static void collectReferencedPayloadId(
+            Source source, Set<String> referencedPayloadIds) {
+        if (source instanceof Base64Source base64) {
+            String payloadId = parseReference(base64.getData());
+            if (payloadId != null) {
+                referencedPayloadIds.add(payloadId);
+            }
+        }
+    }
+
+    private static List<Msg> transformMessages(
+            List<Msg> messages,
+            Map<String, ImagePayloadState> collectedPayloads,
+            Map<String, ImagePayloadState> availablePayloads,
+            boolean hydrate) {
+        List<Msg> result = new ArrayList<>(messages.size());
+        for (Msg message : messages) {
+            Objects.requireNonNull(message, "messages must not contain null elements");
+            List<ContentBlock> content =
+                    transformBlocks(
+                            message.getContent(), collectedPayloads, availablePayloads, hydrate);
+            result.add(content == message.getContent() ? message : copyMessage(message, content));
+        }
+        return List.copyOf(result);
+    }
+
+    private static List<ContentBlock> transformBlocks(
+            List<ContentBlock> blocks,
+            Map<String, ImagePayloadState> collectedPayloads,
+            Map<String, ImagePayloadState> availablePayloads,
+            boolean hydrate) {
+        List<ContentBlock> result = null;
+        for (int i = 0; i < blocks.size(); i++) {
+            ContentBlock original = blocks.get(i);
+            ContentBlock transformed =
+                    transformBlock(original, collectedPayloads, availablePayloads, hydrate);
+            if (result != null) {
+                result.add(transformed);
+            } else if (transformed != original) {
+                result = new ArrayList<>(blocks.size());
+                result.addAll(blocks.subList(0, i));
+                result.add(transformed);
+            }
+        }
+        return result == null ? blocks : List.copyOf(result);
+    }
+
+    private static ContentBlock transformBlock(
+            ContentBlock block,
+            Map<String, ImagePayloadState> collectedPayloads,
+            Map<String, ImagePayloadState> availablePayloads,
+            boolean hydrate) {
+        if (block instanceof ImageBlock image) {
+            Source source =
+                    transformSource(
+                            image.getSource(), collectedPayloads, availablePayloads, hydrate);
+            if (source == image.getSource()) {
+                return image;
+            }
+            return ImageBlock.builder()
+                    .source(source)
+                    .minPixels(image.getMinPixels())
+                    .maxPixels(image.getMaxPixels())
+                    .build();
+        }
+        if (block instanceof DataBlock data && isImageSource(data.getSource())) {
+            Source source =
+                    transformSource(
+                            data.getSource(), collectedPayloads, availablePayloads, hydrate);
+            if (source == data.getSource()) {
+                return data;
+            }
+            return DataBlock.builder().source(source).id(data.getId()).name(data.getName()).build();
+        }
+        if (block instanceof ToolResultBlock toolResult) {
+            List<ContentBlock> output =
+                    transformBlocks(
+                            toolResult.getOutput(), collectedPayloads, availablePayloads, hydrate);
+            if (output == toolResult.getOutput()) {
+                return toolResult;
+            }
+            return new ToolResultBlock(
+                    toolResult.getId(),
+                    toolResult.getName(),
+                    output,
+                    toolResult.getMetadata(),
+                    toolResult.getState());
+        }
+        return block;
+    }
+
+    private static Source transformSource(
+            Source source,
+            Map<String, ImagePayloadState> collectedPayloads,
+            Map<String, ImagePayloadState> availablePayloads,
+            boolean hydrate) {
+        if (!(source instanceof Base64Source base64)) {
+            return source;
+        }
+        if (hydrate) {
+            return hydrateSource(base64, availablePayloads);
+        }
+        return offloadSource(base64, collectedPayloads);
+    }
+
+    private static Source offloadSource(
+            Base64Source source, Map<String, ImagePayloadState> payloads) {
+        String existingReference = parseReference(source.getData());
+        if (existingReference != null) {
+            return source;
+        }
+        ImagePayloadState payload = new ImagePayloadState(source.getMediaType(), source.getData());
+        String payloadId = payloadId(payload);
+        ImagePayloadState previous = payloads.putIfAbsent(payloadId, payload);
+        if (previous != null && !previous.equals(payload)) {
+            throw new IllegalStateException("SHA-256 collision for image payload: " + payloadId);
+        }
+        return new Base64Source(source.getMediaType(), REFERENCE_PREFIX + payloadId);
+    }
+
+    private static Source hydrateSource(
+            Base64Source source, Map<String, ImagePayloadState> payloads) {
+        String payloadId = parseReference(source.getData());
+        if (payloadId == null) {
+            return source;
+        }
+        ImagePayloadState payload = payloads.get(payloadId);
+        if (payload == null) {
+            throw new IllegalStateException("Missing image payload: " + payloadId);
+        }
+        if (!source.getMediaType().equals(payload.mediaType())) {
+            throw new IllegalStateException("Image payload media type mismatch: " + payloadId);
+        }
+        if (!payloadId.equals(payloadId(payload))) {
+            throw new IllegalStateException("Image payload hash mismatch: " + payloadId);
+        }
+        return new Base64Source(payload.mediaType(), payload.data());
+    }
+
+    private static boolean isImageSource(Source source) {
+        return source instanceof Base64Source base64
+                && base64.getMediaType().regionMatches(true, 0, "image/", 0, "image/".length());
+    }
+
+    private static String parseReference(String data) {
+        if (!data.startsWith(REFERENCE_NAMESPACE)) {
+            return null;
+        }
+        Matcher matcher = REFERENCE_PATTERN.matcher(data);
+        if (!matcher.matches()) {
+            throw new IllegalArgumentException("Malformed image payload reference: " + data);
+        }
+        return matcher.group(1);
+    }
+
+    private static String payloadId(ImagePayloadState payload) {
+        MessageDigest digest;
+        try {
+            digest = MessageDigest.getInstance("SHA-256");
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-256 is unavailable", e);
+        }
+        updateLengthPrefixed(digest, HASH_DOMAIN);
+        updateLengthPrefixed(digest, payload.mediaType().getBytes(StandardCharsets.UTF_8));
+        updateLengthPrefixed(digest, payload.data().getBytes(StandardCharsets.UTF_8));
+        byte[] hash = digest.digest();
+        return java.util.HexFormat.of().formatHex(hash);
+    }
+
+    private static void updateLengthPrefixed(MessageDigest digest, byte[] value) {
+        digest.update(ByteBuffer.allocate(Integer.BYTES).putInt(value.length).array());
+        digest.update(value);
+    }
+
+    private static Msg copyMessage(Msg message, List<ContentBlock> content) {
+        Msg.Builder builder;
+        if (message.getClass() == Msg.class) {
+            builder = Msg.builder().role(message.getRole());
+        } else if (message.getClass() == UserMessage.class
+                || message.getClass() == AssistantMessage.class
+                || message.getClass() == SystemMessage.class
+                || message.getClass() == ToolResultMessage.class) {
+            builder = Msg.builderForRole(message.getRole());
+        } else {
+            return message.copyWithContent(content);
+        }
+        builder.id = message.getId();
+        builder.name = message.getName();
+        builder.content = content;
+        builder.metadata = message.getMetadata();
+        builder.timestamp = message.getTimestamp();
+        builder.usage = message.getUsage();
+        return builder.build();
+    }
+
+    /** Result of an offload transformation; payloads are keyed by lowercase SHA-256. */
+    public record OffloadResult(List<Msg> messages, Map<String, ImagePayloadState> payloads) {
+
+        public OffloadResult {
+            Objects.requireNonNull(messages, "messages must not be null");
+            Objects.requireNonNull(payloads, "payloads must not be null");
+            messages = List.copyOf(messages);
+            payloads = Collections.unmodifiableMap(new LinkedHashMap<>(payloads));
+        }
+    }
+}

--- a/agentscope-core/src/main/java/io/agentscope/core/message/Msg.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/message/Msg.java
@@ -250,6 +250,21 @@ public class Msg implements State {
     }
 
     /**
+     * Creates a copy of this message with replacement content.
+     *
+     * <p>Framework transformations use this hook when they need to rewrite content blocks while
+     * preserving a public {@code Msg} subtype. Custom message subclasses may override it to retain
+     * subtype-specific fields; the default implementation preserves all standard {@link Msg}
+     * fields and returns a base message.
+     *
+     * @param newContent replacement content blocks
+     * @return a detached message carrying {@code newContent}
+     */
+    protected Msg copyWithContent(List<ContentBlock> newContent) {
+        return new Msg(id, name, role, newContent, metadata, timestamp, usage);
+    }
+
+    /**
      * Generates a random UUID string for use as a message ID.
      * Exposed to subclasses so their convenience constructors can mirror the
      * behaviour of {@link Builder} without re-implementing UUID logic.

--- a/agentscope-core/src/main/java/io/agentscope/core/state/AgentState.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/state/AgentState.java
@@ -270,6 +270,23 @@ public final class AgentState implements State {
         return new Builder();
     }
 
+    /** Returns a new state instance whose conversation context is replaced by {@code newContext}. */
+    public AgentState copyWithContext(List<Msg> newContext) {
+        return builder()
+                .sessionId(sessionId)
+                .userId(userId)
+                .summary(summary)
+                .context(newContext)
+                .replyId(replyId)
+                .curIter(curIter)
+                .shutdownInterrupted(shutdownInterrupted)
+                .permissionContext(permissionContext)
+                .toolContext(toolContext)
+                .tasksContext(tasksContext)
+                .planModeContext(planModeContext)
+                .build();
+    }
+
     /**
      * Serialize this state to a pretty-printed JSON string.
      *

--- a/agentscope-core/src/main/java/io/agentscope/core/state/AgentStateLoadMode.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/state/AgentStateLoadMode.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.core.state;
+
+/** Controls whether an {@link AgentState} load resolves offloaded image payloads. */
+public enum AgentStateLoadMode {
+    /** Return lightweight messages without querying separately stored image payloads. */
+    LEAN,
+
+    /** Resolve all image references back to their original inline base64 values. */
+    FULL
+}

--- a/agentscope-core/src/main/java/io/agentscope/core/state/AgentStateStore.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/state/AgentStateStore.java
@@ -15,7 +15,13 @@
  */
 package io.agentscope.core.state;
 
+import io.agentscope.core.message.ImagePayloadState;
+import io.agentscope.core.message.ImagePayloadTransformer;
+import io.agentscope.core.message.Msg;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 
@@ -45,20 +51,26 @@ import java.util.Set;
  * AgentStateStore store = new JsonFileAgentStateStore(Path.of("state"));
  *
  * // Save state for an anonymous session
- * store.save(null, "session-1", "agent_state", state);
+ * store.saveAgentState(null, "session-1", state);
  *
  * // Save state scoped to a user
- * store.save("alice", "session-1", "agent_state", state);
+ * store.saveAgentState("alice", "session-1", state);
  *
  * // Load state
- * Optional<AgentState> loaded =
- *         store.get("alice", "session-1", "agent_state", AgentState.class);
+ * Optional<AgentState> loaded = store.getAgentState(
+ *         "alice", "session-1", AgentStateLoadMode.LEAN);
  *
  * // List all sessions owned by a user (null lists anonymous sessions)
  * Set<String> mySessions = store.listSessionIds("alice");
  * }</pre>
  */
 public interface AgentStateStore {
+
+    /** Canonical key used for the per-session {@link AgentState}. */
+    String AGENT_STATE_KEY = "agent_state";
+
+    /** Prefix for content-addressed image payload entries stored outside {@link #AGENT_STATE_KEY}. */
+    String IMAGE_PAYLOAD_KEY_PREFIX = "agent_state_image_payload_";
 
     /**
      * Sentinel version for backends that do not support optimistic concurrency. Also returned by
@@ -132,6 +144,164 @@ public interface AgentStateStore {
             String userId, String sessionId, String key, State value, long expectedVersion) {
         save(userId, sessionId, key, value);
         return UNVERSIONED;
+    }
+
+    /**
+     * Save an agent state after replacing inline base64 images with lightweight references.
+     *
+     * <p>Content-addressed image entries are persisted before the lightweight agent state. A
+     * failure therefore cannot publish a state that references a payload this call failed to
+     * persist; a later failure may leave harmless unreferenced payloads.
+     *
+     * <p>The default implementation is an ordered write, not a transaction spanning multiple
+     * keys. Backends that permit {@link #delete(String, String)} to race with writes and require
+     * strict atomicity should override this method with a backend-native transaction.
+     */
+    default void saveAgentState(String userId, String sessionId, AgentState value) {
+        saveAgentStateIfVersion(userId, sessionId, value, UNVERSIONED);
+    }
+
+    /**
+     * Compare-and-swap variant of {@link #saveAgentState(String, String, AgentState)}.
+     *
+     * <p>The returned version and conflict behavior apply to {@link #AGENT_STATE_KEY}. Image
+     * payloads are immutable content-addressed entries and may be safely shared by retries.
+     * Backends overriding the non-versioned variant for transactional behavior should override
+     * this method as well.
+     */
+    default long saveAgentStateIfVersion(
+            String userId, String sessionId, AgentState value, long expectedVersion) {
+        Objects.requireNonNull(value, "value must not be null");
+        ImagePayloadTransformer.OffloadResult offloaded =
+                ImagePayloadTransformer.offload(value.getContext());
+
+        for (Map.Entry<String, ImagePayloadState> entry : offloaded.payloads().entrySet()) {
+            saveImagePayload(userId, sessionId, entry.getKey(), entry.getValue());
+        }
+
+        AgentState lightweight = value.copyWithContext(offloaded.messages());
+        return saveIfVersion(userId, sessionId, AGENT_STATE_KEY, lightweight, expectedVersion);
+    }
+
+    /** Load an agent state, resolving image payloads only when {@code mode == FULL}. */
+    default Optional<AgentState> getAgentState(
+            String userId, String sessionId, AgentStateLoadMode mode) {
+        return Optional.ofNullable(getAgentStateVersioned(userId, sessionId, mode).value());
+    }
+
+    /** Load a full, image-hydrated agent state. */
+    default Optional<AgentState> getAgentState(String userId, String sessionId) {
+        return getAgentState(userId, sessionId, AgentStateLoadMode.FULL);
+    }
+
+    /**
+     * Load an agent state and its optimistic-concurrency version.
+     *
+     * <p>{@link AgentStateLoadMode#LEAN} performs only the {@link #AGENT_STATE_KEY} read. {@link
+     * AgentStateLoadMode#FULL} additionally loads every referenced image payload and fails if one is
+     * missing or fails the Phase 1 integrity checks.
+     */
+    default VersionedState<AgentState> getAgentStateVersioned(
+            String userId, String sessionId, AgentStateLoadMode mode) {
+        Objects.requireNonNull(mode, "mode must not be null");
+        VersionedState<AgentState> stored =
+                getVersioned(userId, sessionId, AGENT_STATE_KEY, AgentState.class);
+        if (!stored.isPresent() || mode == AgentStateLoadMode.LEAN) {
+            return stored;
+        }
+
+        AgentState hydrated =
+                stored.value()
+                        .copyWithContext(
+                                hydrateImagePayloads(
+                                        userId, sessionId, stored.value().getContext()));
+        return new VersionedState<>(hydrated, stored.version());
+    }
+
+    /**
+     * Restore image payload references in a detached message list.
+     *
+     * <p>This is the model-boundary counterpart to {@link #saveAgentState}. It reads only payloads
+     * referenced by {@code messages}, leaves inline base64 and URL images unchanged, and never
+     * mutates the supplied list or the cached {@link AgentState}. Callers that only inspect history
+     * should keep the lightweight messages and avoid this method.
+     */
+    default List<Msg> hydrateImagePayloads(String userId, String sessionId, List<Msg> messages) {
+        Objects.requireNonNull(messages, "messages must not be null");
+        Set<String> payloadIds = ImagePayloadTransformer.referencedPayloadIds(messages);
+        if (payloadIds.isEmpty()) {
+            return List.copyOf(messages);
+        }
+        return ImagePayloadTransformer.hydrate(
+                messages, getImagePayloads(userId, sessionId, payloadIds));
+    }
+
+    /**
+     * Load image payloads by content identifier.
+     *
+     * <p>The default implementation performs one generic state read per distinct identifier.
+     * Remote backends may override this method with a native batch operation. The returned map
+     * must contain every requested identifier; a missing payload is treated as corrupted state.
+     */
+    default Map<String, ImagePayloadState> getImagePayloads(
+            String userId, String sessionId, Set<String> payloadIds) {
+        Objects.requireNonNull(payloadIds, "payloadIds must not be null");
+        if (payloadIds.isEmpty()) {
+            return Map.of();
+        }
+        Map<String, ImagePayloadState> payloads = new LinkedHashMap<>();
+        for (String payloadId : payloadIds) {
+            Objects.requireNonNull(payloadId, "payloadIds must not contain null elements");
+            ImagePayloadState payload =
+                    get(userId, sessionId, imagePayloadKey(payloadId), ImagePayloadState.class)
+                            .orElseThrow(
+                                    () ->
+                                            new IllegalStateException(
+                                                    "Missing image payload: " + payloadId));
+            payloads.put(payloadId, payload);
+        }
+        return Map.copyOf(payloads);
+    }
+
+    /** Load a full, image-hydrated agent state together with its store version. */
+    default VersionedState<AgentState> getAgentStateVersioned(String userId, String sessionId) {
+        return getAgentStateVersioned(userId, sessionId, AgentStateLoadMode.FULL);
+    }
+
+    private void saveImagePayload(
+            String userId, String sessionId, String payloadId, ImagePayloadState payload) {
+        String key = imagePayloadKey(payloadId);
+        if (!supportsVersioning()) {
+            Optional<ImagePayloadState> existing =
+                    get(userId, sessionId, key, ImagePayloadState.class);
+            if (existing.isPresent()) {
+                if (!existing.get().equals(payload)) {
+                    throw new IllegalStateException("Image payload collision: " + payloadId);
+                }
+                return;
+            }
+            save(userId, sessionId, key, payload);
+            return;
+        }
+        long version = saveIfVersion(userId, sessionId, key, payload, 0L);
+        if (version != UNVERSIONED) {
+            return;
+        }
+        ImagePayloadState concurrent =
+                get(userId, sessionId, key, ImagePayloadState.class)
+                        .orElseThrow(
+                                () ->
+                                        new IllegalStateException(
+                                                "Image payload write conflicted but no value"
+                                                        + " exists: "
+                                                        + payloadId));
+        if (!concurrent.equals(payload)) {
+            throw new IllegalStateException("Image payload collision: " + payloadId);
+        }
+    }
+
+    private static String imagePayloadKey(String payloadId) {
+        return IMAGE_PAYLOAD_KEY_PREFIX + payloadId;
     }
 
     /**

--- a/agentscope-core/src/main/java/io/agentscope/core/tool/subagent/SubAgentConfig.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/tool/subagent/SubAgentConfig.java
@@ -65,6 +65,7 @@ public class SubAgentConfig {
     private final boolean forwardEvents;
     private final StreamOptions streamOptions;
     private final AgentStateStore stateStore;
+    private final boolean imagePayloadOffloadingEnabled;
 
     private SubAgentConfig(Builder builder) {
         this.toolName = builder.toolName;
@@ -73,6 +74,7 @@ public class SubAgentConfig {
         this.streamOptions = builder.streamOptions;
         this.stateStore =
                 builder.stateStore != null ? builder.stateStore : new InMemoryAgentStateStore();
+        this.imagePayloadOffloadingEnabled = builder.imagePayloadOffloadingEnabled;
     }
 
     /**
@@ -149,6 +151,11 @@ public class SubAgentConfig {
         return stateStore;
     }
 
+    /** Returns whether sub-agent saves offload inline base64 image payloads. */
+    public boolean isImagePayloadOffloadingEnabled() {
+        return imagePayloadOffloadingEnabled;
+    }
+
     /** Builder for SubAgentConfig. */
     public static class Builder {
         private String toolName;
@@ -156,6 +163,7 @@ public class SubAgentConfig {
         private boolean forwardEvents = true;
         private StreamOptions streamOptions;
         private AgentStateStore stateStore;
+        private boolean imagePayloadOffloadingEnabled;
 
         private Builder() {}
 
@@ -227,6 +235,17 @@ public class SubAgentConfig {
          */
         public Builder stateStore(AgentStateStore stateStore) {
             this.stateStore = stateStore;
+            return this;
+        }
+
+        /**
+         * Enables offloading inline base64 images from persisted sub-agent state.
+         *
+         * <p>Defaults to {@code false}. Enable only after every process sharing the state store has
+         * been upgraded to a version that understands image payload references.
+         */
+        public Builder imagePayloadOffloadingEnabled(boolean enabled) {
+            this.imagePayloadOffloadingEnabled = enabled;
             return this;
         }
 

--- a/agentscope-core/src/main/java/io/agentscope/core/tool/subagent/SubAgentTool.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/tool/subagent/SubAgentTool.java
@@ -41,6 +41,7 @@ import org.slf4j.LoggerFactory;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.core.publisher.SignalType;
+import reactor.core.scheduler.Schedulers;
 
 /**
  * AgentTool implementation that wraps a sub-agent for multi-turn conversation.
@@ -149,68 +150,76 @@ public class SubAgentTool implements AgentTool {
                         // Create agent for this session
                         final String finalSessionId = sessionId;
                         Agent agent = agentProvider.provide();
+                        RuntimeContext subAgentRuntimeContext =
+                                createSubAgentRuntimeContext(
+                                        param.getRuntimeContext(), finalSessionId, agent);
 
-                        // Load existing state if continuing session
-                        if (!isNewSession) {
-                            loadAgentState(finalSessionId, agent);
-                        }
+                        Mono<Void> stateLoaded =
+                                isNewSession
+                                        ? Mono.empty()
+                                        : Mono.fromRunnable(
+                                                        () -> loadAgentState(finalSessionId, agent))
+                                                .subscribeOn(Schedulers.boundedElastic())
+                                                .then();
 
-                        // Build user message
-                        Msg userMsg =
-                                Msg.builder()
-                                        .role(MsgRole.USER)
-                                        .content(TextBlock.builder().text(message).build())
-                                        .build();
-                        RuntimeContext runtimeContext = param.getRuntimeContext();
+                        return stateLoaded.then(
+                                Mono.defer(
+                                        () -> {
+                                            Msg userMsg =
+                                                    Msg.builder()
+                                                            .role(MsgRole.USER)
+                                                            .content(
+                                                                    TextBlock.builder()
+                                                                            .text(message)
+                                                                            .build())
+                                                            .build();
 
-                        logger.debug(
-                                "AgentStateStore {} with agent '{}': {}",
-                                isNewSession ? "started" : "continued",
-                                agent.getName(),
-                                message.substring(0, Math.min(50, message.length())));
+                                            logger.debug(
+                                                    "AgentStateStore {} with agent '{}': {}",
+                                                    isNewSession ? "started" : "continued",
+                                                    agent.getName(),
+                                                    message.substring(
+                                                            0, Math.min(50, message.length())));
 
-                        // Get emitter for event forwarding
-                        ToolEmitter emitter = param.getEmitter();
+                                            ToolEmitter emitter = param.getEmitter();
+                                            Mono<ToolResultBlock> result =
+                                                    config.isForwardEvents()
+                                                            ? executeWithStreaming(
+                                                                    agent,
+                                                                    userMsg,
+                                                                    finalSessionId,
+                                                                    emitter,
+                                                                    subAgentRuntimeContext)
+                                                            : executeWithoutStreaming(
+                                                                    agent,
+                                                                    userMsg,
+                                                                    finalSessionId,
+                                                                    subAgentRuntimeContext);
 
-                        // Execute and save state after completion
-                        Mono<ToolResultBlock> result;
-                        if (config.isForwardEvents()) {
-                            result =
-                                    executeWithStreaming(
-                                            agent,
-                                            userMsg,
-                                            finalSessionId,
-                                            emitter,
-                                            runtimeContext);
-                        } else {
-                            result =
-                                    executeWithoutStreaming(
-                                            agent, userMsg, finalSessionId, runtimeContext);
-                        }
+                                            // Interrupt the sub-agent when the subscription is
+                                            // cancelled (e.g. a timeout-triggered retry).
+                                            result =
+                                                    result.doFinally(
+                                                            signal -> {
+                                                                if (signal == SignalType.CANCEL) {
+                                                                    interruptAgent(
+                                                                            agent,
+                                                                            subAgentRuntimeContext);
+                                                                }
+                                                            });
 
-                        // Interrupt the sub-agent when the subscription is cancelled
-                        // (e.g. ToolExecutor timeout triggers a retry on a new subscription).
-                        // Without this, the orphan agent keeps consuming LLM tokens, SSH
-                        // connections, and thread pool resources until it finishes naturally.
-                        //
-                        // Uses doFinally(CANCEL) rather than doOnCancel because doOnCancel
-                        // also fires on normal error propagation cleanup, which would
-                        // attempt to interrupt an already-failed agent.
-                        //
-                        // Uses interrupt(RuntimeContext) instead of the deprecated
-                        // interrupt(InterruptSource) because the latter only looks up
-                        // `defaultSessionId` which may differ from the session the call
-                        // actually runs in.
-                        result =
-                                result.doFinally(
-                                        signal -> {
-                                            if (signal == SignalType.CANCEL) {
-                                                interruptAgent(agent, runtimeContext);
-                                            }
-                                        });
-
-                        // Save state after execution
-                        return result.doOnSuccess(r -> saveAgentState(finalSessionId, agent));
+                                            return result.flatMap(
+                                                    toolResult ->
+                                                            Mono.fromRunnable(
+                                                                            () ->
+                                                                                    saveAgentState(
+                                                                                            finalSessionId,
+                                                                                            agent))
+                                                                    .subscribeOn(
+                                                                            Schedulers
+                                                                                    .boundedElastic())
+                                                                    .thenReturn(toolResult));
+                                        }));
                     } catch (Exception e) {
                         logger.error("Error in session setup: {}", e.getMessage(), e);
                         return Mono.just(
@@ -249,9 +258,14 @@ public class SubAgentTool implements AgentTool {
             return;
         }
         try {
-            subSession
-                    .get(null, sessionId, "agent_state", AgentState.class)
-                    .ifPresent(loaded -> applyLoadedState(ra, loaded));
+            (config.isImagePayloadOffloadingEnabled()
+                            ? subSession.getAgentState(null, sessionId)
+                            : subSession.get(
+                                    null,
+                                    sessionId,
+                                    AgentStateStore.AGENT_STATE_KEY,
+                                    AgentState.class))
+                    .ifPresent(loaded -> applyLoadedState(ra, sessionId, loaded));
             logger.debug("Loaded sub-agent state for session: {}", sessionId);
         } catch (Exception e) {
             logger.warn(
@@ -272,7 +286,12 @@ public class SubAgentTool implements AgentTool {
             return;
         }
         try {
-            subSession.save(null, sessionId, "agent_state", ra.getAgentState());
+            AgentState state = ra.getAgentState(null, sessionId);
+            if (config.isImagePayloadOffloadingEnabled()) {
+                subSession.saveAgentState(null, sessionId, state);
+            } else {
+                subSession.save(null, sessionId, AgentStateStore.AGENT_STATE_KEY, state);
+            }
             logger.debug("Saved sub-agent state for session: {}", sessionId);
         } catch (Exception e) {
             logger.warn(
@@ -280,8 +299,8 @@ public class SubAgentTool implements AgentTool {
         }
     }
 
-    private static void applyLoadedState(ReActAgent agent, AgentState loaded) {
-        AgentState live = agent.getAgentState();
+    private static void applyLoadedState(ReActAgent agent, String sessionId, AgentState loaded) {
+        AgentState live = agent.getAgentState(null, sessionId);
         if (live == null) {
             return;
         }
@@ -292,6 +311,22 @@ public class SubAgentTool implements AgentTool {
         live.setCurIter(loaded.getCurIter());
         live.setShutdownInterrupted(loaded.isShutdownInterrupted());
         live.getToolContext().setActivatedGroups(loaded.getToolContext().getActivatedGroups());
+    }
+
+    /**
+     * Isolate the child conversation from the parent's user/session slot while retaining the
+     * parent's call-scoped attributes and tool execution context.
+     */
+    private static RuntimeContext createSubAgentRuntimeContext(
+            RuntimeContext parent, String sessionId, Agent agent) {
+        if (!(agent instanceof ReActAgent)) {
+            return parent;
+        }
+        return RuntimeContext.builder(parent)
+                .userId(null)
+                .sessionId(sessionId)
+                .agentState(null)
+                .build();
     }
 
     /**

--- a/agentscope-core/src/test/java/io/agentscope/core/agent/ReActAgentImagePayloadPersistenceTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/agent/ReActAgentImagePayloadPersistenceTest.java
@@ -1,0 +1,380 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.core.agent;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.agentscope.core.ReActAgent;
+import io.agentscope.core.message.Base64Source;
+import io.agentscope.core.message.ContentBlock;
+import io.agentscope.core.message.ImageBlock;
+import io.agentscope.core.message.ImagePayloadTransformer;
+import io.agentscope.core.message.Msg;
+import io.agentscope.core.message.MsgRole;
+import io.agentscope.core.message.TextBlock;
+import io.agentscope.core.message.ToolUseBlock;
+import io.agentscope.core.model.ChatModelBase;
+import io.agentscope.core.model.ChatResponse;
+import io.agentscope.core.model.GenerateOptions;
+import io.agentscope.core.model.ToolSchema;
+import io.agentscope.core.state.AgentState;
+import io.agentscope.core.state.AgentStateStore;
+import io.agentscope.core.state.ConcurrentSessionModificationException;
+import io.agentscope.core.state.ConflictPolicy;
+import io.agentscope.core.state.InMemoryAgentStateStore;
+import io.agentscope.core.state.State;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Flux;
+
+@DisplayName("ReActAgent image payload persistence")
+class ReActAgentImagePayloadPersistenceTest {
+
+    private static final String IMAGE_DATA = "aW1hZ2UtcGF5bG9hZA==";
+    private static final String OTHER_IMAGE_DATA = "b3RoZXItaW1hZ2U=";
+    private static final RuntimeContext CONTEXT =
+            RuntimeContext.builder().userId("u1").sessionId("session-1").build();
+
+    @Test
+    @DisplayName("offloading is opt-in so rolling upgrades keep the legacy state format")
+    void offloadingIsDisabledByDefault() {
+        CountingStore store = new CountingStore();
+        ReActAgent agent =
+                ReActAgent.builder()
+                        .name("asst")
+                        .sysPrompt("system prompt")
+                        .model(new CapturingModel())
+                        .stateStore(store)
+                        .build();
+
+        agent.call(List.of(imageMessage()), CONTEXT).block();
+
+        assertFalse(agent.isImagePayloadOffloadingEnabled());
+        assertTrue(storedState(store).toJson().contains(IMAGE_DATA));
+        assertEquals(0, store.payloadReads());
+    }
+
+    @Test
+    @DisplayName("history stays lean while the model receives restored image payloads")
+    void historyStaysLeanAndModelReceivesHydratedImage() {
+        CountingStore store = new CountingStore();
+        CapturingModel firstModel = new CapturingModel();
+        ReActAgent firstAgent = agent(firstModel, store);
+
+        firstAgent.call(List.of(imageMessage()), CONTEXT).block();
+
+        AgentState persisted = storedState(store);
+        assertFalse(persisted.toJson().contains(IMAGE_DATA));
+        assertEquals(IMAGE_DATA, firstImageData(firstModel.calls().get(0)));
+        assertTrue(
+                firstImageData(firstAgent.getAgentState("u1", "session-1").getContext())
+                        .startsWith("__agentscope_image_ref__:"));
+
+        store.resetPayloadReads();
+        CapturingModel resumedModel = new CapturingModel();
+        ReActAgent resumedAgent = agent(resumedModel, store);
+
+        AgentState leanHistory = resumedAgent.getAgentState("u1", "session-1");
+        assertTrue(
+                firstImageData(leanHistory.getContext()).startsWith("__agentscope_image_ref__:"));
+        assertEquals(0, store.payloadReads());
+
+        resumedAgent.call(List.of(textMessage("continue")), CONTEXT).block();
+
+        assertEquals(IMAGE_DATA, firstImageData(resumedModel.calls().get(0)));
+        assertTrue(store.payloadReads() >= 1);
+        assertTrue(
+                firstImageData(resumedAgent.getAgentState("u1", "session-1").getContext())
+                        .startsWith("__agentscope_image_ref__:"));
+        assertFalse(storedState(store).toJson().contains(IMAGE_DATA));
+    }
+
+    @Test
+    @DisplayName("missing payload is deferred until model-bound hydration")
+    void missingPayloadFailsOnlyWhenModelInputIsBuilt() {
+        CountingStore store = new CountingStore();
+        ReActAgent writer = agent(new CapturingModel(), store);
+        writer.call(List.of(imageMessage()), CONTEXT).block();
+
+        AgentState lean = storedState(store);
+        String payloadId =
+                ImagePayloadTransformer.referencedPayloadIds(lean.getContext()).iterator().next();
+        store.delete("u1", "session-1", AgentStateStore.IMAGE_PAYLOAD_KEY_PREFIX + payloadId);
+        store.resetPayloadReads();
+
+        ReActAgent resumed = agent(new CapturingModel(), store);
+        assertTrue(
+                firstImageData(resumed.getAgentState("u1", "session-1").getContext())
+                        .startsWith("__agentscope_image_ref__:"));
+        assertEquals(0, store.payloadReads());
+
+        IllegalStateException failure =
+                assertThrows(
+                        IllegalStateException.class,
+                        () -> resumed.call(List.of(textMessage("continue")), CONTEXT).block());
+
+        assertTrue(failure.getMessage().contains("Missing image payload"));
+        assertTrue(store.payloadReads() >= 1);
+    }
+
+    @Test
+    @DisplayName("summary model receives restored image payloads")
+    void summaryModelReceivesHydratedImage() {
+        CountingStore store = new CountingStore();
+        store.saveAgentState(
+                "u1",
+                "session-1",
+                AgentState.builder()
+                        .userId("u1")
+                        .sessionId("session-1")
+                        .context(List.of(imageMessage()))
+                        .build());
+        store.resetPayloadReads();
+        CapturingModel summaryModel = new CapturingModel(true);
+        ReActAgent agent = agent(summaryModel, store, 1);
+
+        agent.call(List.of(textMessage("summarize")), CONTEXT).block();
+
+        assertEquals(IMAGE_DATA, firstImageData(summaryModel.calls().get(1)));
+        assertFalse(storedState(store).toJson().contains(IMAGE_DATA));
+        assertTrue(
+                firstImageData(agent.getAgentState("u1", "session-1").getContext())
+                        .startsWith("__agentscope_image_ref__:"));
+        assertEquals(
+                1,
+                store.payloadReads(),
+                "reasoning and summary should share one call-scoped payload read");
+    }
+
+    @Test
+    @DisplayName("legacy inline state migrates on the next agent save")
+    void legacyInlineStateMigratesOnNextSave() {
+        CountingStore store = new CountingStore();
+        store.save(
+                "u1",
+                "session-1",
+                AgentStateStore.AGENT_STATE_KEY,
+                AgentState.builder()
+                        .userId("u1")
+                        .sessionId("session-1")
+                        .context(List.of(imageMessage()))
+                        .build());
+        CapturingModel model = new CapturingModel();
+        ReActAgent agent = agent(model, store);
+
+        agent.call(List.of(textMessage("continue")), CONTEXT).block();
+
+        assertEquals(IMAGE_DATA, firstImageData(model.calls().get(0)));
+        assertFalse(storedState(store).toJson().contains(IMAGE_DATA));
+    }
+
+    @Test
+    @DisplayName("overwrite conflict path still persists lightweight state")
+    void overwriteConflictKeepsStateLightweight() {
+        CountingStore store = new CountingStore();
+        ReActAgent first = agent(new CapturingModel(), store, 10, ConflictPolicy.OVERWRITE);
+        ReActAgent stale = agent(new CapturingModel(), store, 10, ConflictPolicy.OVERWRITE);
+        AgentState firstState = first.getAgentState("u1", "session-1");
+        AgentState staleState = stale.getAgentState("u1", "session-1");
+        firstState.contextMutable().add(imageMessage(IMAGE_DATA));
+        staleState.contextMutable().add(imageMessage(OTHER_IMAGE_DATA));
+
+        first.saveAgentState("u1", "session-1");
+        stale.saveAgentState("u1", "session-1");
+
+        assertFalse(storedState(store).toJson().contains(OTHER_IMAGE_DATA));
+        assertEquals(
+                List.of(OTHER_IMAGE_DATA),
+                imageData(store.getAgentState("u1", "session-1").orElseThrow().getContext()));
+    }
+
+    @Test
+    @DisplayName("fail conflict path leaves the winning lightweight state untouched")
+    void failConflictKeepsWinningStateLightweight() {
+        CountingStore store = new CountingStore();
+        ReActAgent first = agent(new CapturingModel(), store, 10, ConflictPolicy.FAIL);
+        ReActAgent stale = agent(new CapturingModel(), store, 10, ConflictPolicy.FAIL);
+        first.getAgentState("u1", "session-1").contextMutable().add(imageMessage(IMAGE_DATA));
+        stale.getAgentState("u1", "session-1").contextMutable().add(imageMessage(OTHER_IMAGE_DATA));
+
+        first.saveAgentState("u1", "session-1");
+
+        assertThrows(
+                ConcurrentSessionModificationException.class,
+                () -> stale.saveAgentState("u1", "session-1"));
+        assertFalse(storedState(store).toJson().contains(IMAGE_DATA));
+        assertEquals(
+                List.of(IMAGE_DATA),
+                imageData(store.getAgentState("u1", "session-1").orElseThrow().getContext()));
+    }
+
+    @Test
+    @DisplayName("append-merge conflict preserves both image turns as references")
+    void appendMergeConflictPreservesBothImageTurns() {
+        CountingStore store = new CountingStore();
+        ReActAgent first = agent(new CapturingModel(), store, 10, ConflictPolicy.APPEND_MERGE);
+        ReActAgent stale = agent(new CapturingModel(), store, 10, ConflictPolicy.APPEND_MERGE);
+        first.getAgentState("u1", "session-1").contextMutable().add(imageMessage(IMAGE_DATA));
+        stale.getAgentState("u1", "session-1").contextMutable().add(imageMessage(OTHER_IMAGE_DATA));
+
+        first.saveAgentState("u1", "session-1");
+        stale.saveAgentState("u1", "session-1");
+
+        AgentState raw = storedState(store);
+        assertFalse(raw.toJson().contains(IMAGE_DATA));
+        assertFalse(raw.toJson().contains(OTHER_IMAGE_DATA));
+        assertEquals(
+                List.of(IMAGE_DATA, OTHER_IMAGE_DATA),
+                imageData(store.getAgentState("u1", "session-1").orElseThrow().getContext()));
+    }
+
+    private static ReActAgent agent(ChatModelBase model, AgentStateStore store) {
+        return agent(model, store, 10);
+    }
+
+    private static ReActAgent agent(ChatModelBase model, AgentStateStore store, int maxIters) {
+        return agent(model, store, maxIters, ConflictPolicy.OVERWRITE);
+    }
+
+    private static ReActAgent agent(
+            ChatModelBase model,
+            AgentStateStore store,
+            int maxIters,
+            ConflictPolicy conflictPolicy) {
+        return ReActAgent.builder()
+                .name("asst")
+                .sysPrompt("system prompt")
+                .model(model)
+                .stateStore(store)
+                .imagePayloadOffloadingEnabled(true)
+                .maxIters(maxIters)
+                .conflictPolicy(conflictPolicy)
+                .build();
+    }
+
+    private static Msg imageMessage() {
+        return imageMessage(IMAGE_DATA);
+    }
+
+    private static Msg imageMessage(String data) {
+        return Msg.builder()
+                .name("user")
+                .role(MsgRole.USER)
+                .content(ImageBlock.builder().source(new Base64Source("image/png", data)).build())
+                .build();
+    }
+
+    private static Msg textMessage(String text) {
+        return Msg.builder()
+                .name("user")
+                .role(MsgRole.USER)
+                .content(TextBlock.builder().text(text).build())
+                .build();
+    }
+
+    private static AgentState storedState(AgentStateStore store) {
+        return store.get("u1", "session-1", AgentStateStore.AGENT_STATE_KEY, AgentState.class)
+                .orElseThrow();
+    }
+
+    private static String firstImageData(List<Msg> messages) {
+        return imageData(messages).stream().findFirst().orElseThrow();
+    }
+
+    private static List<String> imageData(List<Msg> messages) {
+        return messages.stream()
+                .flatMap(message -> message.getContent().stream())
+                .filter(ImageBlock.class::isInstance)
+                .map(ImageBlock.class::cast)
+                .map(ImageBlock::getSource)
+                .filter(Base64Source.class::isInstance)
+                .map(Base64Source.class::cast)
+                .map(Base64Source::getData)
+                .toList();
+    }
+
+    private static final class CapturingModel extends ChatModelBase {
+        private final List<List<Msg>> calls = new ArrayList<>();
+        private final boolean forceSummary;
+
+        private CapturingModel() {
+            this(false);
+        }
+
+        private CapturingModel(boolean forceSummary) {
+            this.forceSummary = forceSummary;
+        }
+
+        @Override
+        public String getModelName() {
+            return "capturing-model";
+        }
+
+        @Override
+        protected Flux<ChatResponse> doStream(
+                List<Msg> messages, List<ToolSchema> tools, GenerateOptions options) {
+            calls.add(List.copyOf(messages));
+            if (forceSummary && calls.size() == 1) {
+                return Flux.just(
+                        ChatResponse.builder()
+                                .content(
+                                        List.<ContentBlock>of(
+                                                ToolUseBlock.builder()
+                                                        .id("missing-call")
+                                                        .name("missing-tool")
+                                                        .input(Map.of())
+                                                        .build()))
+                                .build());
+            }
+            return Flux.just(
+                    ChatResponse.builder()
+                            .content(List.<ContentBlock>of(TextBlock.builder().text("ok").build()))
+                            .build());
+        }
+
+        private List<List<Msg>> calls() {
+            return calls;
+        }
+    }
+
+    private static final class CountingStore extends InMemoryAgentStateStore {
+        private int payloadReads;
+
+        @Override
+        public <T extends State> Optional<T> get(
+                String userId, String sessionId, String key, Class<T> type) {
+            if (key.startsWith(AgentStateStore.IMAGE_PAYLOAD_KEY_PREFIX)) {
+                payloadReads++;
+            }
+            return super.get(userId, sessionId, key, type);
+        }
+
+        private int payloadReads() {
+            return payloadReads;
+        }
+
+        private void resetPayloadReads() {
+            payloadReads = 0;
+        }
+    }
+}

--- a/agentscope-core/src/test/java/io/agentscope/core/agent/ReActAgentPerSessionStateTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/agent/ReActAgentPerSessionStateTest.java
@@ -251,10 +251,11 @@ class ReActAgentPerSessionStateTest {
 
         agent.clearContext("u1", "sessA");
 
-        assertEquals("sessA", target.getSessionId());
-        assertTrue(target.getContext().isEmpty());
-        assertEquals("", target.getSummary());
-        assertTrue(target.getPlanModeContext().isPlanActive(), "non-context state is preserved");
+        AgentState cleared = agent.getAgentState("u1", "sessA");
+        assertEquals("sessA", cleared.getSessionId());
+        assertTrue(cleared.getContext().isEmpty());
+        assertEquals("", cleared.getSummary());
+        assertTrue(cleared.getPlanModeContext().isPlanActive(), "non-context state is preserved");
         assertEquals(List.of("keep this"), allText(other));
         assertEquals("other summary", other.getSummary());
 

--- a/agentscope-core/src/test/java/io/agentscope/core/message/ImagePayloadTransformerTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/message/ImagePayloadTransformerTest.java
@@ -1,0 +1,327 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.core.message;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.agentscope.core.model.ChatUsage;
+import io.agentscope.core.util.JsonUtils;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class ImagePayloadTransformerTest {
+
+    private static final String PNG_DATA = "aW1hZ2UtcGF5bG9hZA==";
+
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    @Test
+    void offloadAndHydratePreserveMessagesWithoutMutatingInput() throws Exception {
+        ChatUsage usage = new ChatUsage(11, 7, 3, 0.25);
+        ImageBlock image = image("image/png", PNG_DATA, 128, 2048);
+        DataBlock data =
+                DataBlock.builder()
+                        .source(new Base64Source("image/png", PNG_DATA))
+                        .id("data-1")
+                        .name("diagram.png")
+                        .build();
+        UserMessage user =
+                UserMessage.builder()
+                        .id("user-1")
+                        .name("alice")
+                        .content(List.of(image, data))
+                        .metadata(Map.of("trace", "t-1"))
+                        .timestamp("2026-08-27 10:00:00.000")
+                        .usage(usage)
+                        .build();
+        Msg base =
+                new Msg(
+                        "base-1",
+                        "legacy",
+                        MsgRole.USER,
+                        List.of(image),
+                        Map.of("legacy", true),
+                        null,
+                        usage);
+
+        ImagePayloadTransformer.OffloadResult result =
+                ImagePayloadTransformer.offload(List.of(user, base));
+
+        assertEquals(1, result.payloads().size(), "identical images should be deduplicated");
+        assertEquals(PNG_DATA, ((Base64Source) image.getSource()).getData());
+
+        Msg strippedUser = result.messages().get(0);
+        Msg strippedBase = result.messages().get(1);
+        assertInstanceOf(UserMessage.class, strippedUser);
+        assertEquals(Msg.class, strippedBase.getClass());
+        assertNotSame(user, strippedUser);
+        assertNotSame(base, strippedBase);
+        assertMessageFields(user, strippedUser);
+        assertMessageFields(base, strippedBase);
+        assertNull(strippedBase.getTimestamp());
+
+        ImageBlock strippedImage = (ImageBlock) strippedUser.getContent().get(0);
+        DataBlock strippedData = (DataBlock) strippedUser.getContent().get(1);
+        String imageReference = ((Base64Source) strippedImage.getSource()).getData();
+        String dataReference = ((Base64Source) strippedData.getSource()).getData();
+        assertEquals(imageReference, dataReference);
+        assertEquals(1, ImagePayloadTransformer.referencedPayloadIds(result.messages()).size());
+        assertTrue(
+                imageReference.matches("^__agentscope_image_ref__:v1:[0-9a-f]{64}$"),
+                imageReference);
+        assertEquals(128, strippedImage.getMinPixels());
+        assertEquals(2048, strippedImage.getMaxPixels());
+        assertEquals("data-1", strippedData.getId());
+        assertEquals("diagram.png", strippedData.getName());
+        assertFalse(
+                JsonUtils.getJsonCodec().toJson(result.messages()).contains(PNG_DATA),
+                "lightweight messages must not contain inline image data");
+
+        List<Msg> hydrated = ImagePayloadTransformer.hydrate(result.messages(), result.payloads());
+        assertEquals(
+                mapper.readTree(mapper.writeValueAsString(List.of(user, base))),
+                mapper.readTree(mapper.writeValueAsString(hydrated)));
+        assertInstanceOf(UserMessage.class, hydrated.get(0));
+        assertEquals(Msg.class, hydrated.get(1).getClass());
+    }
+
+    @Test
+    void recursivelyTransformsNestedToolResultsAndPreservesFields() throws Exception {
+        ImageBlock nestedImage = image("image/jpeg", "bmVzdGVkLWltYWdl", 32, 4096);
+        ToolResultBlock inner =
+                new ToolResultBlock(
+                        "inner-id",
+                        "inner-tool",
+                        List.of(nestedImage),
+                        Map.of("inner", 1),
+                        ToolResultState.SUCCESS);
+        ToolResultBlock outer =
+                new ToolResultBlock(
+                        "outer-id",
+                        "outer-tool",
+                        List.of(TextBlock.builder().text("before").build(), inner),
+                        Map.of("outer", 2),
+                        ToolResultState.ERROR);
+        ToolResultMessage message =
+                ToolResultMessage.builder()
+                        .id("tool-message")
+                        .name("runner")
+                        .content(outer)
+                        .metadata(Map.of("message", "metadata"))
+                        .timestamp("2026-08-27 11:00:00.000")
+                        .build();
+
+        ImagePayloadTransformer.OffloadResult result =
+                ImagePayloadTransformer.offload(List.of(message));
+
+        assertEquals(1, result.payloads().size());
+        ToolResultMessage stripped =
+                assertInstanceOf(ToolResultMessage.class, result.messages().get(0));
+        ToolResultBlock strippedOuter =
+                assertInstanceOf(ToolResultBlock.class, stripped.getContent().get(0));
+        ToolResultBlock strippedInner =
+                assertInstanceOf(ToolResultBlock.class, strippedOuter.getOutput().get(1));
+        assertToolResultFields(outer, strippedOuter);
+        assertToolResultFields(inner, strippedInner);
+        assertTrue(
+                ((Base64Source) ((ImageBlock) strippedInner.getOutput().get(0)).getSource())
+                        .getData()
+                        .startsWith(ImagePayloadTransformer.REFERENCE_PREFIX));
+
+        List<Msg> hydrated = ImagePayloadTransformer.hydrate(result.messages(), result.payloads());
+        assertEquals(
+                mapper.readTree(mapper.writeValueAsString(List.of(message))),
+                mapper.readTree(mapper.writeValueAsString(hydrated)));
+    }
+
+    @Test
+    void leavesUrlsAndNonImageDataUntouchedAndMatchesImageMimeCaseInsensitively() {
+        ImageBlock urlImage =
+                ImageBlock.builder().source(new URLSource("https://example.com/image.png")).build();
+        DataBlock audio =
+                DataBlock.builder()
+                        .source(new Base64Source("audio/wav", "YXVkaW8="))
+                        .id("audio-1")
+                        .build();
+        DataBlock nonCanonicalMime =
+                DataBlock.builder()
+                        .source(new Base64Source("Image/PNG", PNG_DATA))
+                        .id("data-2")
+                        .build();
+        UserMessage message =
+                UserMessage.builder().content(List.of(urlImage, audio, nonCanonicalMime)).build();
+
+        ImagePayloadTransformer.OffloadResult result =
+                ImagePayloadTransformer.offload(List.of(message));
+
+        assertEquals(1, result.payloads().size());
+        Msg lightweight = result.messages().get(0);
+        assertSame(urlImage, lightweight.getContent().get(0));
+        assertSame(audio, lightweight.getContent().get(1));
+        assertTrue(
+                ((Base64Source) ((DataBlock) lightweight.getContent().get(2)).getSource())
+                        .getData()
+                        .startsWith(ImagePayloadTransformer.REFERENCE_PREFIX));
+        List<Msg> hydrated = ImagePayloadTransformer.hydrate(result.messages(), result.payloads());
+        assertEquals(
+                PNG_DATA,
+                ((Base64Source) ((DataBlock) hydrated.get(0).getContent().get(2)).getSource())
+                        .getData());
+    }
+
+    @Test
+    void hashesMimeTypeAndPayloadAndMakesRepeatedOffloadIdempotent() {
+        UserMessage message =
+                UserMessage.builder()
+                        .content(
+                                List.of(
+                                        image("image/png", PNG_DATA, null, null),
+                                        image("image/jpeg", PNG_DATA, null, null)))
+                        .build();
+
+        ImagePayloadTransformer.OffloadResult first =
+                ImagePayloadTransformer.offload(List.of(message));
+        assertEquals(2, first.payloads().size());
+        String firstReference =
+                ((Base64Source)
+                                ((ImageBlock) first.messages().get(0).getContent().get(0))
+                                        .getSource())
+                        .getData();
+        String secondReference =
+                ((Base64Source)
+                                ((ImageBlock) first.messages().get(0).getContent().get(1))
+                                        .getSource())
+                        .getData();
+        assertNotEquals(firstReference, secondReference);
+
+        ImagePayloadTransformer.OffloadResult second =
+                ImagePayloadTransformer.offload(first.messages());
+        assertTrue(second.payloads().isEmpty());
+        assertSame(first.messages().get(0), second.messages().get(0));
+    }
+
+    @Test
+    void rejectsMalformedMissingAndTamperedPayloads() {
+        UserMessage inline =
+                UserMessage.builder().content(image("image/png", PNG_DATA, null, null)).build();
+        ImagePayloadTransformer.OffloadResult result =
+                ImagePayloadTransformer.offload(List.of(inline));
+        String payloadId = result.payloads().keySet().iterator().next();
+
+        assertThrows(
+                IllegalStateException.class,
+                () -> ImagePayloadTransformer.hydrate(result.messages(), Map.of()));
+        assertThrows(
+                IllegalStateException.class,
+                () ->
+                        ImagePayloadTransformer.hydrate(
+                                result.messages(),
+                                Map.of(
+                                        payloadId,
+                                        new ImagePayloadState("image/png", "dGFtcGVyZWQ="))));
+        assertThrows(
+                IllegalStateException.class,
+                () ->
+                        ImagePayloadTransformer.hydrate(
+                                result.messages(),
+                                Map.of(payloadId, new ImagePayloadState("image/jpeg", PNG_DATA))));
+
+        UserMessage malformed =
+                UserMessage.builder()
+                        .content(
+                                image(
+                                        "image/png",
+                                        "__agentscope_image_ref__:v2:" + "a".repeat(64),
+                                        null,
+                                        null))
+                        .build();
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> ImagePayloadTransformer.offload(List.of(malformed)));
+    }
+
+    @Test
+    void imagePayloadStateRoundTripsThroughJson() throws Exception {
+        ImagePayloadState payload = new ImagePayloadState("image/png", PNG_DATA);
+
+        String json = mapper.writeValueAsString(payload);
+        ImagePayloadState restored = mapper.readValue(json, ImagePayloadState.class);
+
+        assertEquals(payload, restored);
+        assertTrue(json.contains("\"media_type\":\"image/png\""), json);
+    }
+
+    @Test
+    void customMsgSubtypeCanPreserveItsTypeWhenContentNeedsTransformation() {
+        Msg custom =
+                new CustomMessage("custom-id", List.of(image("image/png", PNG_DATA, null, null)));
+
+        ImagePayloadTransformer.OffloadResult offloaded =
+                ImagePayloadTransformer.offload(List.of(custom));
+
+        assertInstanceOf(CustomMessage.class, offloaded.messages().get(0));
+        assertInstanceOf(
+                CustomMessage.class,
+                ImagePayloadTransformer.hydrate(offloaded.messages(), offloaded.payloads()).get(0));
+    }
+
+    private static ImageBlock image(
+            String mediaType, String data, Integer minPixels, Integer maxPixels) {
+        return ImageBlock.builder()
+                .source(new Base64Source(mediaType, data))
+                .minPixels(minPixels)
+                .maxPixels(maxPixels)
+                .build();
+    }
+
+    private static void assertMessageFields(Msg expected, Msg actual) {
+        assertEquals(expected.getId(), actual.getId());
+        assertEquals(expected.getName(), actual.getName());
+        assertEquals(expected.getRole(), actual.getRole());
+        assertEquals(expected.getMetadata(), actual.getMetadata());
+        assertEquals(expected.getTimestamp(), actual.getTimestamp());
+        assertSame(expected.getUsage(), actual.getUsage());
+    }
+
+    private static void assertToolResultFields(ToolResultBlock expected, ToolResultBlock actual) {
+        assertEquals(expected.getId(), actual.getId());
+        assertEquals(expected.getName(), actual.getName());
+        assertEquals(expected.getMetadata(), actual.getMetadata());
+        assertEquals(expected.getState(), actual.getState());
+    }
+
+    private static final class CustomMessage extends Msg {
+
+        private CustomMessage(String id, List<ContentBlock> content) {
+            super(id, "custom", MsgRole.USER, content, Map.of(), null, null);
+        }
+
+        @Override
+        protected Msg copyWithContent(List<ContentBlock> newContent) {
+            return new CustomMessage(getId(), newContent);
+        }
+    }
+}

--- a/agentscope-core/src/test/java/io/agentscope/core/state/AgentStateStoreImagePayloadTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/state/AgentStateStoreImagePayloadTest.java
@@ -1,0 +1,321 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.core.state;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.agentscope.core.message.Base64Source;
+import io.agentscope.core.message.ContentBlock;
+import io.agentscope.core.message.ImageBlock;
+import io.agentscope.core.message.ImagePayloadState;
+import io.agentscope.core.message.ImagePayloadTransformer;
+import io.agentscope.core.message.UserMessage;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class AgentStateStoreImagePayloadTest {
+
+    private static final String PNG_DATA = "aW1hZ2UtcGF5bG9hZA==";
+
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    @Test
+    void savesLightweightStateAndLoadsLeanOrFullWithoutMutatingInput() throws Exception {
+        InMemoryAgentStateStore store = new InMemoryAgentStateStore();
+        AgentState original = stateWithImage("session-1", PNG_DATA);
+
+        store.saveAgentState("alice", "session-1", original);
+
+        AgentState stored =
+                store.get("alice", "session-1", AgentStateStore.AGENT_STATE_KEY, AgentState.class)
+                        .orElseThrow();
+        AgentState lean =
+                store.getAgentState("alice", "session-1", AgentStateLoadMode.LEAN).orElseThrow();
+        AgentState full = store.getAgentState("alice", "session-1").orElseThrow();
+
+        assertFalse(json(stored).contains(PNG_DATA));
+        assertEquals(json(stored), json(lean));
+        assertEquals(json(original), json(full));
+        assertTrue(json(original).contains(PNG_DATA), "the caller's state must remain unchanged");
+    }
+
+    @Test
+    void leanLoadDoesNotReadImagePayloads() {
+        CountingStore store = new CountingStore();
+        store.saveAgentState(null, "session-1", stateWithImage("session-1", PNG_DATA));
+        store.resetPayloadReads();
+
+        store.getAgentState(null, "session-1", AgentStateLoadMode.LEAN).orElseThrow();
+        assertEquals(0, store.payloadReads());
+
+        store.getAgentState(null, "session-1", AgentStateLoadMode.FULL).orElseThrow();
+        assertEquals(1, store.payloadReads());
+    }
+
+    @Test
+    void savingAnUnchangedLeanStateDoesNotReadHistoricalPayloads() {
+        CountingStore store = new CountingStore();
+        store.saveAgentState(null, "session-1", stateWithImage("session-1", PNG_DATA));
+        AgentState lean =
+                store.getAgentState(null, "session-1", AgentStateLoadMode.LEAN).orElseThrow();
+        store.resetPayloadReads();
+
+        store.saveAgentState(null, "session-1", lean);
+
+        assertEquals(0, store.payloadReads());
+        assertEquals(
+                PNG_DATA,
+                ((Base64Source)
+                                ((ImageBlock)
+                                                store.getAgentState(null, "session-1")
+                                                        .orElseThrow()
+                                                        .getContext()
+                                                        .get(0)
+                                                        .getContent()
+                                                        .get(0))
+                                        .getSource())
+                        .getData());
+    }
+
+    @Test
+    void jsonFileStoreKeepsBase64OutOfAgentStateFile(@TempDir Path tempDir) throws Exception {
+        JsonFileAgentStateStore store = new JsonFileAgentStateStore(tempDir);
+        AgentState original = stateWithImage("session-1", PNG_DATA);
+
+        store.saveAgentState(null, "session-1", original);
+
+        Path sessionDir = store.getSessionDir(null, "session-1");
+        String stateJson =
+                Files.readString(
+                        sessionDir.resolve(AgentStateStore.AGENT_STATE_KEY + ".json"),
+                        StandardCharsets.UTF_8);
+        assertFalse(stateJson.contains(PNG_DATA));
+        try (Stream<Path> files = Files.list(sessionDir)) {
+            assertTrue(
+                    files.anyMatch(
+                            path ->
+                                    path.getFileName()
+                                            .toString()
+                                            .startsWith(AgentStateStore.IMAGE_PAYLOAD_KEY_PREFIX)));
+        }
+        assertEquals(json(original), json(store.getAgentState(null, "session-1").orElseThrow()));
+    }
+
+    @Test
+    void imageAwareSavePreservesAgentStateCasVersioning() throws Exception {
+        InMemoryAgentStateStore store = new InMemoryAgentStateStore();
+        AgentState first = stateWithImage("session-1", PNG_DATA);
+        AgentState stale = stateWithImage("session-1", "c3RhbGUtaW1hZ2U=");
+
+        long version = store.saveAgentStateIfVersion(null, "session-1", first, 0L);
+        long conflict = store.saveAgentStateIfVersion(null, "session-1", stale, 0L);
+
+        assertEquals(1L, version);
+        assertEquals(AgentStateStore.UNVERSIONED, conflict);
+        VersionedState<AgentState> loaded =
+                store.getAgentStateVersioned(null, "session-1", AgentStateLoadMode.FULL);
+        assertEquals(1L, loaded.version());
+        assertEquals(json(first), json(loaded.value()));
+    }
+
+    @Test
+    void fullLoadFailsForMissingPayloadWhileLeanLoadStillWorks() {
+        InMemoryAgentStateStore store = new InMemoryAgentStateStore();
+        store.saveAgentState(null, "session-1", stateWithImage("session-1", PNG_DATA));
+        AgentState lean =
+                store.getAgentState(null, "session-1", AgentStateLoadMode.LEAN).orElseThrow();
+        String payloadId =
+                ImagePayloadTransformer.referencedPayloadIds(lean.getContext()).iterator().next();
+
+        store.delete(null, "session-1", AgentStateStore.IMAGE_PAYLOAD_KEY_PREFIX + payloadId);
+
+        assertTrue(store.getAgentState(null, "session-1", AgentStateLoadMode.LEAN).isPresent());
+        assertThrows(
+                IllegalStateException.class,
+                () -> store.getAgentState(null, "session-1", AgentStateLoadMode.FULL));
+    }
+
+    @Test
+    void laterPayloadFailureDoesNotPublishLightweightAgentState() {
+        FailingPayloadStore store = new FailingPayloadStore(2);
+        AgentState state = stateWithImages("session-1", PNG_DATA, "c2Vjb25kLWltYWdl");
+
+        assertThrows(
+                IllegalStateException.class, () -> store.saveAgentState(null, "session-1", state));
+        assertTrue(
+                store.get(null, "session-1", AgentStateStore.AGENT_STATE_KEY, AgentState.class)
+                        .isEmpty());
+    }
+
+    @Test
+    void mainStateFailureLeavesNoPublishedLightweightState() {
+        FailingAgentStateStore store = new FailingAgentStateStore();
+
+        assertThrows(
+                IllegalStateException.class,
+                () ->
+                        store.saveAgentState(
+                                null, "session-1", stateWithImage("session-1", PNG_DATA)));
+        assertTrue(
+                store.get(null, "session-1", AgentStateStore.AGENT_STATE_KEY, AgentState.class)
+                        .isEmpty());
+    }
+
+    @Test
+    void rejectsConflictingPayloadAlreadyStoredUnderContentAddress() {
+        InMemoryAgentStateStore store = new InMemoryAgentStateStore();
+        AgentState state = stateWithImage("session-1", PNG_DATA);
+        ImagePayloadTransformer.OffloadResult offloaded =
+                ImagePayloadTransformer.offload(state.getContext());
+        String payloadId = offloaded.payloads().keySet().iterator().next();
+        store.save(
+                null,
+                "session-1",
+                AgentStateStore.IMAGE_PAYLOAD_KEY_PREFIX + payloadId,
+                new ImagePayloadState("image/png", "dGFtcGVyZWQ="));
+
+        assertThrows(
+                IllegalStateException.class, () -> store.saveAgentState(null, "session-1", state));
+        assertTrue(
+                store.get(null, "session-1", AgentStateStore.AGENT_STATE_KEY, AgentState.class)
+                        .isEmpty());
+    }
+
+    @Test
+    void deletingSessionRemovesStateAndImagePayloads() {
+        InMemoryAgentStateStore store = new InMemoryAgentStateStore();
+        store.saveAgentState(null, "session-1", stateWithImage("session-1", PNG_DATA));
+
+        store.delete(null, "session-1");
+
+        assertFalse(store.exists(null, "session-1"));
+        assertTrue(store.getAgentState(null, "session-1").isEmpty());
+    }
+
+    @Test
+    void fullLoadKeepsLegacyInlineAgentStateCompatible() throws Exception {
+        CountingStore store = new CountingStore();
+        AgentState legacy = stateWithImage("session-1", PNG_DATA);
+        store.save(null, "session-1", AgentStateStore.AGENT_STATE_KEY, legacy);
+        store.resetPayloadReads();
+
+        AgentState loaded = store.getAgentState(null, "session-1").orElseThrow();
+
+        assertEquals(json(legacy), json(loaded));
+        assertEquals(0, store.payloadReads());
+    }
+
+    private AgentState stateWithImage(String sessionId, String data) {
+        return stateWithImages(sessionId, data);
+    }
+
+    private AgentState stateWithImages(String sessionId, String... data) {
+        UserMessage message =
+                UserMessage.builder()
+                        .id("message-1")
+                        .name("alice")
+                        .content(
+                                java.util.Arrays.stream(data)
+                                        .map(AgentStateStoreImagePayloadTest::image)
+                                        .map(block -> (ContentBlock) block)
+                                        .toList())
+                        .timestamp("2026-08-27 16:00:00.000")
+                        .build();
+        return AgentState.builder()
+                .sessionId(sessionId)
+                .userId("alice")
+                .summary("summary")
+                .context(List.of(message))
+                .replyId("reply-1")
+                .curIter(3)
+                .shutdownInterrupted(true)
+                .build();
+    }
+
+    private static ImageBlock image(String data) {
+        return ImageBlock.builder()
+                .source(new Base64Source("image/png", data))
+                .minPixels(64)
+                .maxPixels(4096)
+                .build();
+    }
+
+    private String json(AgentState state) throws IOException {
+        return mapper.readTree(mapper.writeValueAsString(state)).toString();
+    }
+
+    private static class CountingStore extends InMemoryAgentStateStore {
+        private int payloadReads;
+
+        @Override
+        public <T extends State> Optional<T> get(
+                String userId, String sessionId, String key, Class<T> type) {
+            if (key.startsWith(AgentStateStore.IMAGE_PAYLOAD_KEY_PREFIX)) {
+                payloadReads++;
+            }
+            return super.get(userId, sessionId, key, type);
+        }
+
+        int payloadReads() {
+            return payloadReads;
+        }
+
+        void resetPayloadReads() {
+            payloadReads = 0;
+        }
+    }
+
+    private static final class FailingPayloadStore extends InMemoryAgentStateStore {
+        private final int failAtWrite;
+        private int payloadWrites;
+
+        private FailingPayloadStore(int failAtWrite) {
+            this.failAtWrite = failAtWrite;
+        }
+
+        @Override
+        public long saveIfVersion(
+                String userId, String sessionId, String key, State value, long expectedVersion) {
+            if (key.startsWith(AgentStateStore.IMAGE_PAYLOAD_KEY_PREFIX)
+                    && ++payloadWrites == failAtWrite) {
+                throw new IllegalStateException("payload store unavailable");
+            }
+            return super.saveIfVersion(userId, sessionId, key, value, expectedVersion);
+        }
+    }
+
+    private static final class FailingAgentStateStore extends InMemoryAgentStateStore {
+        @Override
+        public long saveIfVersion(
+                String userId, String sessionId, String key, State value, long expectedVersion) {
+            if (AgentStateStore.AGENT_STATE_KEY.equals(key)) {
+                throw new IllegalStateException("agent state store unavailable");
+            }
+            return super.saveIfVersion(userId, sessionId, key, value, expectedVersion);
+        }
+    }
+}

--- a/agentscope-core/src/test/java/io/agentscope/core/tool/subagent/SubAgentConfigTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/tool/subagent/SubAgentConfigTest.java
@@ -16,6 +16,7 @@
 package io.agentscope.core.tool.subagent;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -49,6 +50,7 @@ class SubAgentConfigTest {
             assertNull(config.getStreamOptions());
             assertNotNull(config.getStateStore());
             assertInstanceOf(InMemoryAgentStateStore.class, config.getStateStore());
+            assertFalse(config.isImagePayloadOffloadingEnabled());
         }
 
         @Test
@@ -134,6 +136,7 @@ class SubAgentConfigTest {
                             .forwardEvents(true)
                             .streamOptions(streamOptions)
                             .stateStore(customSession)
+                            .imagePayloadOffloadingEnabled(true)
                             .build();
 
             assertEquals("expert_agent", config.getToolName());
@@ -141,6 +144,7 @@ class SubAgentConfigTest {
             assertTrue(config.isForwardEvents());
             assertEquals(streamOptions, config.getStreamOptions());
             assertEquals(customSession, config.getStateStore());
+            assertTrue(config.isImagePayloadOffloadingEnabled());
         }
 
         @Test
@@ -168,6 +172,7 @@ class SubAgentConfigTest {
                             .forwardEvents(true)
                             .streamOptions(null)
                             .stateStore(new InMemoryAgentStateStore())
+                            .imagePayloadOffloadingEnabled(true)
                             .build();
 
             assertNotNull(config);

--- a/agentscope-core/src/test/java/io/agentscope/core/tool/subagent/SubAgentToolImagePayloadTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/tool/subagent/SubAgentToolImagePayloadTest.java
@@ -1,0 +1,224 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.core.tool.subagent;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.agentscope.core.ReActAgent;
+import io.agentscope.core.agent.RuntimeContext;
+import io.agentscope.core.message.Base64Source;
+import io.agentscope.core.message.ContentBlock;
+import io.agentscope.core.message.ImageBlock;
+import io.agentscope.core.message.Msg;
+import io.agentscope.core.message.MsgRole;
+import io.agentscope.core.message.TextBlock;
+import io.agentscope.core.message.ToolResultBlock;
+import io.agentscope.core.message.ToolUseBlock;
+import io.agentscope.core.model.ChatModelBase;
+import io.agentscope.core.model.ChatResponse;
+import io.agentscope.core.model.GenerateOptions;
+import io.agentscope.core.model.ToolSchema;
+import io.agentscope.core.state.AgentState;
+import io.agentscope.core.state.AgentStateStore;
+import io.agentscope.core.state.InMemoryAgentStateStore;
+import io.agentscope.core.state.State;
+import io.agentscope.core.tool.ToolCallParam;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.CopyOnWriteArrayList;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Flux;
+import reactor.core.scheduler.Scheduler;
+import reactor.core.scheduler.Schedulers;
+
+@DisplayName("SubAgentTool image payload persistence")
+class SubAgentToolImagePayloadTest {
+
+    private static final String IMAGE_DATA = "c3ViYWdlbnQtaW1hZ2U=";
+
+    @Test
+    @DisplayName("continued child session hydrates its own history instead of the parent slot")
+    void continuedChildSessionHydratesItsOwnHistory() {
+        String childSession = "child-session";
+        RecordingStore childStore = new RecordingStore();
+        childStore.saveAgentState(
+                null,
+                childSession,
+                AgentState.builder()
+                        .sessionId(childSession)
+                        .context(List.of(imageMessage()))
+                        .build());
+        childStore.resetIoThreads();
+
+        CapturingModel model = new CapturingModel();
+        List<ReActAgent> createdAgents = new ArrayList<>();
+        SubAgentProvider<ReActAgent> provider =
+                () -> {
+                    ReActAgent agent =
+                            ReActAgent.builder()
+                                    .name("child")
+                                    .sysPrompt("child system")
+                                    .model(model)
+                                    .build();
+                    createdAgents.add(agent);
+                    return agent;
+                };
+        SubAgentTool tool =
+                new SubAgentTool(
+                        provider,
+                        SubAgentConfig.builder()
+                                .stateStore(childStore)
+                                .imagePayloadOffloadingEnabled(true)
+                                .forwardEvents(false)
+                                .build());
+        RuntimeContext parentContext =
+                RuntimeContext.builder()
+                        .userId("parent-user")
+                        .sessionId("parent-session")
+                        .put("trace", "preserved")
+                        .build();
+        ToolCallParam param =
+                ToolCallParam.builder()
+                        .toolUseBlock(
+                                ToolUseBlock.builder()
+                                        .id("call-1")
+                                        .name(tool.getName())
+                                        .input(
+                                                Map.of(
+                                                        "session_id",
+                                                        childSession,
+                                                        "message",
+                                                        "continue"))
+                                        .build())
+                        .input(Map.of("session_id", childSession, "message", "continue"))
+                        .runtimeContext(parentContext)
+                        .build();
+
+        ToolResultBlock result;
+        Scheduler caller = Schedulers.newSingle("subagent-caller");
+        try {
+            result = tool.callAsync(param).subscribeOn(caller).block();
+        } finally {
+            caller.dispose();
+        }
+
+        assertNotNull(result);
+        assertFalse(childStore.ioThreads().isEmpty());
+        assertTrue(
+                childStore.ioThreads().stream()
+                        .allMatch(name -> name.startsWith("boundedElastic-")),
+                childStore.ioThreads().toString());
+        assertEquals(IMAGE_DATA, firstImageData(model.calls().get(0)));
+        ReActAgent executedAgent = createdAgents.get(1);
+        assertEquals(
+                List.of("continue", "done"),
+                textContents(executedAgent.getAgentState(null, childSession).getContext()));
+        AgentState raw =
+                childStore
+                        .get(null, childSession, AgentStateStore.AGENT_STATE_KEY, AgentState.class)
+                        .orElseThrow();
+        assertFalse(raw.toJson().contains(IMAGE_DATA));
+    }
+
+    private static Msg imageMessage() {
+        return Msg.builder()
+                .name("user")
+                .role(MsgRole.USER)
+                .content(
+                        ImageBlock.builder()
+                                .source(new Base64Source("image/png", IMAGE_DATA))
+                                .build())
+                .build();
+    }
+
+    private static String firstImageData(List<Msg> messages) {
+        return messages.stream()
+                .flatMap(message -> message.getContent().stream())
+                .filter(ImageBlock.class::isInstance)
+                .map(ImageBlock.class::cast)
+                .map(ImageBlock::getSource)
+                .filter(Base64Source.class::isInstance)
+                .map(Base64Source.class::cast)
+                .map(Base64Source::getData)
+                .findFirst()
+                .orElseThrow();
+    }
+
+    private static List<String> textContents(List<Msg> messages) {
+        return messages.stream()
+                .flatMap(message -> message.getContent().stream())
+                .filter(TextBlock.class::isInstance)
+                .map(TextBlock.class::cast)
+                .map(TextBlock::getText)
+                .toList();
+    }
+
+    private static final class CapturingModel extends ChatModelBase {
+        private final List<List<Msg>> calls = new ArrayList<>();
+
+        @Override
+        public String getModelName() {
+            return "subagent-capturing-model";
+        }
+
+        @Override
+        protected Flux<ChatResponse> doStream(
+                List<Msg> messages, List<ToolSchema> tools, GenerateOptions options) {
+            calls.add(List.copyOf(messages));
+            return Flux.just(
+                    ChatResponse.builder()
+                            .content(
+                                    List.<ContentBlock>of(TextBlock.builder().text("done").build()))
+                            .build());
+        }
+
+        private List<List<Msg>> calls() {
+            return calls;
+        }
+    }
+
+    private static final class RecordingStore extends InMemoryAgentStateStore {
+        private final List<String> ioThreads = new CopyOnWriteArrayList<>();
+
+        @Override
+        public <T extends State> Optional<T> get(
+                String userId, String sessionId, String key, Class<T> type) {
+            ioThreads.add(Thread.currentThread().getName());
+            return super.get(userId, sessionId, key, type);
+        }
+
+        @Override
+        public long saveIfVersion(
+                String userId, String sessionId, String key, State value, long expectedVersion) {
+            ioThreads.add(Thread.currentThread().getName());
+            return super.saveIfVersion(userId, sessionId, key, value, expectedVersion);
+        }
+
+        private List<String> ioThreads() {
+            return List.copyOf(ioThreads);
+        }
+
+        private void resetIoThreads() {
+            ioThreads.clear();
+        }
+    }
+}

--- a/agentscope-examples/documentation/src/main/java/io/agentscope/examples/documentation2/harness/context/ContextStatePersistenceExample.java
+++ b/agentscope-examples/documentation/src/main/java/io/agentscope/examples/documentation2/harness/context/ContextStatePersistenceExample.java
@@ -19,6 +19,7 @@ import io.agentscope.core.agent.RuntimeContext;
 import io.agentscope.core.message.Msg;
 import io.agentscope.core.message.UserMessage;
 import io.agentscope.core.state.AgentState;
+import io.agentscope.core.state.AgentStateLoadMode;
 import io.agentscope.core.state.AgentStateStore;
 import io.agentscope.core.state.JsonFileAgentStateStore;
 import io.agentscope.harness.agent.HarnessAgent;
@@ -69,6 +70,7 @@ public class ContextStatePersistenceExample {
                         .sysPrompt("You are a helpful assistant. Keep answers under two sentences.")
                         .model("dashscope:qwen-plus")
                         .stateStore(stateStore)
+                        .imagePayloadOffloadingEnabled(true)
                         .build();
 
         RuntimeContext aliceCtx =
@@ -95,9 +97,9 @@ public class ContextStatePersistenceExample {
         System.out.println("\n── Step 2: Inspect persisted AgentState ──\n");
 
         Optional<AgentState> aliceState =
-                stateStore.get("alice", "alice-session-1", "agent_state", AgentState.class);
+                stateStore.getAgentState("alice", "alice-session-1", AgentStateLoadMode.LEAN);
         Optional<AgentState> bobState =
-                stateStore.get("bob", "bob-session-1", "agent_state", AgentState.class);
+                stateStore.getAgentState("bob", "bob-session-1", AgentStateLoadMode.LEAN);
 
         System.out.println(
                 "Alice context size: "
@@ -120,6 +122,7 @@ public class ContextStatePersistenceExample {
                         .sysPrompt("You are a helpful assistant. Keep answers under two sentences.")
                         .model("dashscope:qwen-plus")
                         .stateStore(stateStore)
+                        .imagePayloadOffloadingEnabled(true)
                         .build();
 
         Msg resumed = agent2.call(new UserMessage("What is my name?"), aliceCtx).block();
@@ -127,7 +130,7 @@ public class ContextStatePersistenceExample {
                 "Resumed reply: " + (resumed != null ? resumed.getTextContent() : "(null)"));
 
         Optional<AgentState> resumedState =
-                stateStore.get("alice", "alice-session-1", "agent_state", AgentState.class);
+                stateStore.getAgentState("alice", "alice-session-1", AgentStateLoadMode.LEAN);
         System.out.println(
                 "Alice context after resume: "
                         + resumedState.map(s -> s.getContext().size()).orElse(0)

--- a/agentscope-examples/documentation/src/main/java/io/agentscope/examples/documentation2/state/StateAutoSaveExample.java
+++ b/agentscope-examples/documentation/src/main/java/io/agentscope/examples/documentation2/state/StateAutoSaveExample.java
@@ -33,11 +33,11 @@ import java.nio.file.Paths;
  * <p><b>How auto-save/restore works:</b>
  * <ol>
  *   <li><b>Load:</b> When the agent is constructed with a {@code session} and {@code sessionKey},
- *       it calls {@code stateStore.get(userId, sessionId, "agent_state", AgentState.class)} to restore any
- *       previously persisted conversation history and toolkit state.</li>
+ *       it calls {@code stateStore.getAgentStateVersioned(userId, sessionId, LEAN)} to restore
+ *       lightweight conversation history and toolkit state.</li>
  *   <li><b>Save after each call:</b> After every {@code call()} or {@code stream()} the agent
- *       automatically calls {@code stateStore.save(userId, sessionId, "agent_state", agentState)} to persist
- *       the updated state. No manual save is needed.</li>
+ *       automatically calls {@code stateStore.saveAgentState(userId, sessionId, agentState)} to
+ *       persist the updated state. No manual save is needed.</li>
  *   <li><b>Shutdown save:</b> The {@link io.agentscope.core.shutdown.GracefulShutdownManager}
  *       registers a state saver at construction time, so state is also flushed on JVM shutdown.</li>
  * </ol>
@@ -150,6 +150,9 @@ public class StateAutoSaveExample {
                 // stateStore() + defaultSessionId() wires automatic load-on-start and
                 // save-after-call
                 .stateStore(stateStore)
+                // Enable only after all nodes sharing this store run a version that understands
+                // image payload references.
+                .imagePayloadOffloadingEnabled(true)
                 .defaultSessionId(SESSION_ID + "-" + userId)
                 .build();
     }

--- a/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agent-protocol/src/test/java/io/agentscope/extensions/agentprotocol/AgentProtocolTaskStoreHitlTest.java
+++ b/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agent-protocol/src/test/java/io/agentscope/extensions/agentprotocol/AgentProtocolTaskStoreHitlTest.java
@@ -111,7 +111,11 @@ class AgentProtocolTaskStoreHitlTest {
 
         store.resume("hitl-1", List.of(new RemoteConfirmDecision("tc-ask", false)));
 
-        awaitCondition(() -> "success".equals(store.snapshot("hitl-1").get("status")), 5_000);
+        awaitCondition(
+                () ->
+                        "success".equals(store.snapshot("hitl-1").get("status"))
+                                && !store.hasSubmitContext("hitl-1"),
+                5_000);
 
         Map<String, Object> done = store.snapshot("hitl-1");
         assertEquals("success", done.get("status"));
@@ -130,7 +134,11 @@ class AgentProtocolTaskStoreHitlTest {
                                 new AgentEndEvent(null)));
 
         store.submit("ok-1", "worker", "hello", Map.of("user_id", "u1", "detail", "status"));
-        awaitCondition(() -> "success".equals(store.snapshot("ok-1").get("status")), 5_000);
+        awaitCondition(
+                () ->
+                        "success".equals(store.snapshot("ok-1").get("status"))
+                                && !store.hasSubmitContext("ok-1"),
+                5_000);
         assertFalse(store.hasSubmitContext("ok-1"));
     }
 

--- a/agentscope-extensions/agentscope-spring-boot-starters/agentscope-admin-spring-boot-starter/src/main/java/io/agentscope/spring/boot/admin/service/SessionOperations.java
+++ b/agentscope-extensions/agentscope-spring-boot-starters/agentscope-admin-spring-boot-starter/src/main/java/io/agentscope/spring/boot/admin/service/SessionOperations.java
@@ -433,17 +433,11 @@ public final class SessionOperations {
     }
 
     private Mono<Void> persist(ReActAgent react, AgentState state) {
-        AgentStateStore stateStore = react.getStateStore();
-        if (stateStore == null) {
+        if (react.getStateStore() == null) {
             return Mono.empty();
         }
         return Mono.fromRunnable(
-                        () ->
-                                stateStore.save(
-                                        state.getUserId(),
-                                        react.getDefaultSessionId(),
-                                        "agent_state",
-                                        state))
+                        () -> react.saveAgentState(state.getUserId(), state.getSessionId()))
                 .subscribeOn(Schedulers.boundedElastic())
                 .then();
     }

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/HarnessAgent.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/HarnessAgent.java
@@ -1381,6 +1381,7 @@ public class HarnessAgent implements Agent, AutoCloseable {
             if (srcSession != null) {
                 b.stateStore(srcSession);
             }
+            b.imagePayloadOffloadingEnabled(agent.isImagePayloadOffloadingEnabled());
             String srcDefaultSessionId = agent.getDefaultSessionId();
             if (srcDefaultSessionId != null) {
                 b.defaultSessionId(srcDefaultSessionId);
@@ -1568,6 +1569,17 @@ public class HarnessAgent implements Agent, AutoCloseable {
         public Builder stateStore(AgentStateStore stateStore) {
             this.stateStoreOverride = stateStore;
             inner.stateStore(stateStore);
+            return this;
+        }
+
+        /**
+         * Enables separately persisted base64 image payloads for conversation state.
+         *
+         * <p>Defaults to {@code false} for mixed-version rolling-upgrade safety. Upgrade all nodes
+         * sharing the state store before enabling it.
+         */
+        public Builder imagePayloadOffloadingEnabled(boolean enabled) {
+            inner.imagePayloadOffloadingEnabled(enabled);
             return this;
         }
 

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/HarnessAgentDynamicHookBuilderTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/HarnessAgentDynamicHookBuilderTest.java
@@ -49,6 +49,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.mockito.ArgumentCaptor;
@@ -75,11 +76,19 @@ import reactor.core.publisher.Flux;
 class HarnessAgentDynamicHookBuilderTest {
 
     @TempDir Path workspace;
+    private HarnessAgent agent;
+
+    @AfterEach
+    void closeAgent() {
+        if (agent != null) {
+            agent.close();
+        }
+    }
 
     @Test
     void defaultBuild_registersDynamicSkillAndSubagentMiddlewares() throws Exception {
         Files.createDirectories(workspace);
-        HarnessAgent agent =
+        agent =
                 HarnessAgent.builder()
                         .name("t")
                         .model(stubModel("ok"))
@@ -107,7 +116,7 @@ class HarnessAgentDynamicHookBuilderTest {
         Files.createDirectories(workspace);
         AgentSkillRepository emptyRepo = new EmptySkillRepository();
 
-        HarnessAgent agent =
+        agent =
                 HarnessAgent.builder()
                         .name("t")
                         .model(stubModel("ok"))
@@ -125,7 +134,7 @@ class HarnessAgentDynamicHookBuilderTest {
     @Test
     void disableDynamicSkills_skipsDynamicSkillMiddleware() throws Exception {
         Files.createDirectories(workspace);
-        HarnessAgent agent =
+        agent =
                 HarnessAgent.builder()
                         .name("t")
                         .model(stubModel("ok"))
@@ -153,7 +162,7 @@ class HarnessAgentDynamicHookBuilderTest {
                                         "# Frozen skill",
                                         null)));
 
-        HarnessAgent agent =
+        agent =
                 HarnessAgent.builder()
                         .name("t")
                         .model(model)
@@ -222,7 +231,7 @@ class HarnessAgentDynamicHookBuilderTest {
                                 skill("beta", "beta description"),
                                 skill("gamma", "gamma description")));
 
-        HarnessAgent agent =
+        agent =
                 HarnessAgent.builder()
                         .name("t")
                         .model(model)
@@ -265,7 +274,7 @@ class HarnessAgentDynamicHookBuilderTest {
         CountingSkillRepository repository =
                 new CountingSkillRepository(List.of(skill("disabled", "must stay hidden")));
 
-        HarnessAgent agent =
+        agent =
                 HarnessAgent.builder()
                         .name("t")
                         .model(model)
@@ -293,7 +302,7 @@ class HarnessAgentDynamicHookBuilderTest {
                 "---\nname: lazy-resource\ndescription: Loads a lazy reference\n---\n# Body\n");
         Files.writeString(skillDir.resolve("references/guide.md"), "lazy reference body");
 
-        HarnessAgent agent =
+        agent =
                 HarnessAgent.builder()
                         .name("t")
                         .model(stubModel("ok"))
@@ -331,7 +340,7 @@ class HarnessAgentDynamicHookBuilderTest {
         Files.createDirectories(workspace);
         AgentSkillRepository custom = new EmptySkillRepository();
 
-        HarnessAgent agent =
+        agent =
                 HarnessAgent.builder()
                         .name("t")
                         .model(stubModel("ok"))
@@ -356,7 +365,7 @@ class HarnessAgentDynamicHookBuilderTest {
     @Test
     void getSkillRepositories_isEmptyWhenNothingComposed() throws Exception {
         Files.createDirectories(workspace);
-        HarnessAgent agent =
+        agent =
                 HarnessAgent.builder()
                         .name("t")
                         .model(stubModel("ok"))
@@ -371,7 +380,7 @@ class HarnessAgentDynamicHookBuilderTest {
     @Test
     void getSkillRepositories_returnsImmutableList() throws Exception {
         Files.createDirectories(workspace);
-        HarnessAgent agent =
+        agent =
                 HarnessAgent.builder()
                         .name("t")
                         .model(stubModel("ok"))
@@ -394,7 +403,7 @@ class HarnessAgentDynamicHookBuilderTest {
     @Test
     void disableDynamicSubagents_fallsBackToStaticSubagentsMiddleware() throws Exception {
         Files.createDirectories(workspace);
-        HarnessAgent agent =
+        agent =
                 HarnessAgent.builder()
                         .name("t")
                         .model(stubModel("ok"))


### PR DESCRIPTION
## AgentScope-Java Version

2.0.3-SNAPSHOT

## Description

Closes #2852

Large inline base64 image payloads were stored directly in agent state, so ordinary session and history retrieval had to load and deserialize the full image data even when the caller did not need it.

This PR introduces opt-in image payload offloading for agent state:

- Extract inline base64 image data into content-addressed payload records and persist lightweight versioned references in messages.
- Add `LEAN` and `FULL` agent-state load modes so ordinary state reads can skip image payload hydration.
- Hydrate detached model input only when assembling model history, with per-call payload caching to avoid duplicate reads.
- Support image payloads in `ImageBlock`, image `DataBlock`, and nested `ToolResultBlock` content while preserving custom `Msg` subtypes.
- Route state and payload persistence through bounded-elastic execution for ReAct agents, sub-agents, harness agents, admin operations, and shutdown saves.
- Add an explicit `imagePayloadOffloadingEnabled(true)` opt-in to keep mixed-version deployments safe; the default remains disabled.
- Update examples and add migration, compatibility, missing-payload, deduplication, concurrency, and sub-agent coverage.

### Compatibility

Existing inline base64 states remain readable. When offloading is enabled, a subsequent save migrates inline payloads to referenced payload records. Keeping the feature disabled by default prevents older nodes in rolling deployments from receiving states that contain references they cannot hydrate.

### Validation

- `mvn spotless:apply`
- Full `agentscope-core` test suite: 2,329 tests, 0 failures, 0 errors, 9 skipped
- Focused image payload persistence, transformer, state-store, ReActAgent, and SubAgentTool tests
- Cross-backend verification for Redis, MySQL, PostgreSQL, COS, OSS, and Admin modules
- Package verification for affected modules and documentation examples
- `git diff --check`

## Checklist

Please check the following items before code is ready to be reviewed.

- [x] Code has been formatted with `mvn spotless:apply`
- [x] All tests are passing (`mvn test`)
- [x] Javadoc comments are complete and follow project conventions
- [x] Related documentation has been updated (e.g. links, examples, etc.)
- [x] Code is ready for review