### PR TITLE
fix(core): default model retry to RETRYABLE_ERRORS when retryOn is unset

### DIFF
--- a/agentscope-core/src/main/java/io/agentscope/core/model/ModelUtils.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/model/ModelUtils.java
@@ -55,7 +55,9 @@ public final class ModelUtils {
      * <ul>
      *   <li>If RetryConfig is provided, failed requests will be retried with exponential backoff
      *   <li>Retries respect the maxAttempts, initialBackoff, and maxBackoff settings
-     *   <li>Only errors matching the retryOn predicate will be retried
+     *   <li>Only errors matching the retryOn predicate will be retried; when no predicate is
+     *       configured, only retryable errors (HTTP 429/5xx, timeout, network/IO) are retried,
+     *       per {@link ExecutionConfig#RETRYABLE_ERRORS}
      *   <li>Each retry is logged with attempt number and failure reason
      * </ul>
      *
@@ -108,7 +110,10 @@ public final class ModelUtils {
                     maxBackoff = Duration.ofSeconds(10);
                 }
                 if (retryOn == null) {
-                    retryOn = error -> true; // retry all errors by default
+                    // Default to the documented retryable-error policy (429/5xx, timeout,
+                    // network/IO) instead of retrying every error, so that auth (401/403)
+                    // and other request-side failures fail fast
+                    retryOn = ExecutionConfig.RETRYABLE_ERRORS;
                 }
 
                 Retry retrySpec =

--- a/agentscope-core/src/test/java/io/agentscope/core/model/ModelUtilsRetryDefaultsTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/model/ModelUtilsRetryDefaultsTest.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.core.model;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import io.agentscope.core.message.TextBlock;
+import java.io.IOException;
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Flux;
+import reactor.test.StepVerifier;
+
+/**
+ * Tests for the default retry policy of {@link ModelUtils#applyTimeoutAndRetry} when no {@code
+ * retryOn} predicate is configured: the default must follow {@link ExecutionConfig#RETRYABLE_ERRORS}
+ * instead of retrying every error.
+ */
+@DisplayName("ModelUtils default retry policy when retryOn is unset")
+class ModelUtilsRetryDefaultsTest {
+
+    @Test
+    @DisplayName("Should not retry non-retryable (401) errors when retryOn is unset")
+    void shouldNotRetryAuthErrorsByDefault() {
+        AtomicInteger attempts = new AtomicInteger();
+        Flux<ChatResponse> flux =
+                Flux.defer(
+                        () -> {
+                            attempts.incrementAndGet();
+                            return Flux.error(new TestModelHttpException(401));
+                        });
+
+        StepVerifier.create(
+                        ModelUtils.applyTimeoutAndRetry(
+                                flux, optionsWithoutRetryOn(), null, "test-model", "test"))
+                .expectError(TestModelHttpException.class)
+                .verify();
+
+        assertEquals(1, attempts.get(), "auth errors must fail fast without retries");
+    }
+
+    @Test
+    @DisplayName("Should not retry unknown errors when retryOn is unset")
+    void shouldNotRetryUnknownErrorsByDefault() {
+        AtomicInteger attempts = new AtomicInteger();
+        Flux<ChatResponse> flux =
+                Flux.defer(
+                        () -> {
+                            attempts.incrementAndGet();
+                            return Flux.error(new IllegalArgumentException("bad request"));
+                        });
+
+        StepVerifier.create(
+                        ModelUtils.applyTimeoutAndRetry(
+                                flux, optionsWithoutRetryOn(), null, "test-model", "test"))
+                .expectError(IllegalArgumentException.class)
+                .verify();
+
+        assertEquals(1, attempts.get(), "unknown errors must fail fast without retries");
+    }
+
+    @Test
+    @DisplayName("Should retry retryable (network) errors when retryOn is unset")
+    void shouldRetryNetworkErrorsByDefault() {
+        AtomicInteger attempts = new AtomicInteger();
+        Flux<ChatResponse> flux =
+                Flux.defer(
+                        () -> {
+                            return attempts.incrementAndGet() == 1
+                                    ? Flux.error(new IOException("connection reset"))
+                                    : Flux.just(mockResponse());
+                        });
+
+        StepVerifier.create(
+                        ModelUtils.applyTimeoutAndRetry(
+                                flux, optionsWithoutRetryOn(), null, "test-model", "test"))
+                .expectNextCount(1)
+                .verifyComplete();
+
+        assertEquals(2, attempts.get(), "network errors must be retried by default");
+    }
+
+    private static GenerateOptions optionsWithoutRetryOn() {
+        ExecutionConfig config =
+                ExecutionConfig.builder()
+                        .maxAttempts(3)
+                        .initialBackoff(Duration.ofMillis(10))
+                        .maxBackoff(Duration.ofMillis(50))
+                        .build();
+        return GenerateOptions.builder().executionConfig(config).build();
+    }
+
+    private static ChatResponse mockResponse() {
+        return new ChatResponse(
+                "test-id",
+                List.of(TextBlock.builder().text("test response").build()),
+                null,
+                null,
+                null);
+    }
+
+    /** Minimal model exception carrying an HTTP status code for retry classification. */
+    private static final class TestModelHttpException extends RuntimeException
+            implements ModelHttpException {
+
+        private final int statusCode;
+
+        TestModelHttpException(int statusCode) {
+            super("HTTP " + statusCode);
+            this.statusCode = statusCode;
+        }
+
+        @Override
+        public Integer getStatusCode() {
+            return statusCode;
+        }
+    }
+}


### PR DESCRIPTION
## What

`ModelUtils.applyTimeoutAndRetry` fell back to `retryOn = error -> true` (retry **every** error) when no `retryOn` predicate was configured. This contradicts the documented default of `ExecutionConfig`, where only retryable errors — HTTP 429/5xx, timeout, network/IO — are retried, and non-retryable errors (400, 401/403, other 4xx) fail fast.

## Why it matters

Without this fix, a model call that retries with the default config (e.g. `maxAttempts=3` without an explicit `retryOn`) will:

- retry authentication failures (401/403) that can never succeed on retry, wasting backoff time (up to `maxBackoff` per attempt) before surfacing the real error;
- retry unknown programming errors, masking request-side bugs behind repeated failing calls.

`ExecutionConfig.MODEL_DEFAULTS` already sets `retryOn(RETRYABLE_ERRORS)`, so this only affects configs built without an explicit predicate (custom `ExecutionConfig` or merged configs where `retryOn` is null).

## Change

- `ModelUtils.applyTimeoutAndRetry`: when `retryOn` is null, default to `ExecutionConfig.RETRYABLE_ERRORS` instead of `error -> true`. One-line behavior change plus javadoc.
- New test `ModelUtilsRetryDefaultsTest` covering the default policy: 401 → 1 attempt (no retry), unknown error → 1 attempt, transient IOException → retried and succeeds.

## Behavior comparison (retryOn unset)

| error | before | after |
|---|---|---|
| HTTP 401/403, 4xx | retried until exhausted | fails fast (1 attempt) |
| unknown `RuntimeException` | retried | fails fast |
| HTTP 429/5xx, timeout, IOException | retried | retried (unchanged) |

Fixes #2861

---

*This patch was developed with AI assistance (Claude Code); the change, tests and PR description were reviewed by the author.*