### PR TITLE
fix(agui): emit frontend tool args from fragment deltas

### DIFF
--- a/agentscope-examples/agentscope-copilotkit/frontend/package-lock.json
+++ b/agentscope-examples/agentscope-copilotkit/frontend/package-lock.json
@@ -9,9 +9,9 @@
       "version": "0.1.0",
       "dependencies": {
         "@ag-ui/client": "^0.0.57",
-        "@copilotkit/a2ui-renderer": "^1.65.0",
-        "@copilotkit/react-core": "^1.65.0",
-        "@copilotkit/react-ui": "^1.65.0",
+        "@copilotkit/a2ui-renderer": "^1.69.2",
+        "@copilotkit/react-core": "^1.69.2",
+        "@copilotkit/react-ui": "^1.69.2",
         "@radix-ui/react-scroll-area": "^1.2.18",
         "@radix-ui/react-separator": "^1.1.15",
         "@radix-ui/react-slot": "^1.3.3",
@@ -38,12 +38,12 @@
       }
     },
     "node_modules/@0no-co/graphql.web": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmmirror.com/@0no-co/graphql.web/-/graphql.web-1.3.3.tgz",
-      "integrity": "sha512-4gFGBdyaFmQ6n9euhp5JtIGS4ZeivwDr1tCPENUxTvy5wyv532yOtFCr9zzYAJh1s6uibgC+TRXUcay+mxzCoQ==",
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/@0no-co/graphql.web/-/graphql.web-1.3.4.tgz",
+      "integrity": "sha512-imSwulOeDQodRy/olQmVEo2PiY6ntjkZ9eiGdw6lMYylh/tay9b7MusyJBmEnkL8GiKRKr6ltr+D42mY5bd8Bg==",
       "license": "MIT",
       "peerDependencies": {
-        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0"
+        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
       },
       "peerDependenciesMeta": {
         "graphql": {
@@ -175,9 +175,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@copilotkit/a2ui-renderer": {
-      "version": "1.66.2",
-      "resolved": "https://registry.npmmirror.com/@copilotkit/a2ui-renderer/-/a2ui-renderer-1.66.2.tgz",
-      "integrity": "sha512-XKalmTPIbOs4Y25+wUdqGtPFoWBMaFW9IPUcKOg/VJnde8k5t68GUqtubsS3v7D/Wx6bPyrm7d3iX2u6OnUbsw==",
+      "version": "1.69.3",
+      "resolved": "https://registry.npmjs.org/@copilotkit/a2ui-renderer/-/a2ui-renderer-1.69.3.tgz",
+      "integrity": "sha512-lsyA3CFQCpuQP0G91cv+AT7KefsCYL1wmC2lslJ/SEBckrD6ctK6e8rgCKLj1Y92+z9APgWZyWfrUmdnIIOj6Q==",
       "license": "MIT",
       "dependencies": {
         "@a2ui/web_core": "0.10.4",
@@ -209,12 +209,12 @@
       }
     },
     "node_modules/@copilotkit/core": {
-      "version": "1.66.2",
-      "resolved": "https://registry.npmmirror.com/@copilotkit/core/-/core-1.66.2.tgz",
-      "integrity": "sha512-XWxbs72EkmhdCUgK80rRNjt+k3yTmbe0qP82iiU2cV5IWNbKbSvC9jO9ZAsa3Wbilhf2XTD1PSWa4dwN3xulHg==",
+      "version": "1.69.3",
+      "resolved": "https://registry.npmjs.org/@copilotkit/core/-/core-1.69.3.tgz",
+      "integrity": "sha512-h8RQcqTAwXNulFh4DSQwZ3Vkf6Jzy9+6uML8hu5iLXt5AICY5QOBzB/ztADKFHSNsBjSZITrAxI2EcNeP/QXzQ==",
       "dependencies": {
         "@ag-ui/client": "0.0.57",
-        "@copilotkit/shared": "1.66.2",
+        "@copilotkit/shared": "1.69.3",
         "@tanstack/pacer": "^0.20.1",
         "phoenix": "^1.8.4",
         "rxjs": "7.8.1",
@@ -226,26 +226,25 @@
     },
     "node_modules/@copilotkit/license-verifier": {
       "version": "0.5.0",
-      "resolved": "https://registry.npmmirror.com/@copilotkit/license-verifier/-/license-verifier-0.5.0.tgz",
+      "resolved": "https://registry.npmjs.org/@copilotkit/license-verifier/-/license-verifier-0.5.0.tgz",
       "integrity": "sha512-vrwKtIpYwF0FT9ZoYASH8owa2cGV0dhDvJGaCRaRMStwDxpc6DRdydKkhx8cWZXyBRxEYcq/Vygv4JvevhQQdQ==",
       "license": "MIT"
     },
     "node_modules/@copilotkit/react-core": {
-      "version": "1.66.2",
-      "resolved": "https://registry.npmmirror.com/@copilotkit/react-core/-/react-core-1.66.2.tgz",
-      "integrity": "sha512-tq0QvzYQUj5b80/qexXsFg6aVRafdReAmb1rRWhQLUEDvB5bZCLjQcJlEAi8rwtAp6RjtKpIbeFJnJqmr3lREg==",
+      "version": "1.69.3",
+      "resolved": "https://registry.npmjs.org/@copilotkit/react-core/-/react-core-1.69.3.tgz",
+      "integrity": "sha512-GDHr2omEYmmfBo/QJFn7MOJSd9MQ1gtfbriOZIzws1cYn4N7VBwYH/Vhacal7Q5VErUkbXHUPLX6WtU/fVKd/g==",
       "license": "MIT",
       "dependencies": {
         "@ag-ui/client": "0.0.57",
         "@ag-ui/core": "0.0.57",
-        "@copilotkit/a2ui-renderer": "1.66.2",
-        "@copilotkit/core": "1.66.2",
-        "@copilotkit/runtime-client-gql": "1.66.2",
-        "@copilotkit/shared": "1.66.2",
-        "@copilotkit/web-components": "1.66.2",
-        "@copilotkit/web-inspector": "1.66.2",
+        "@copilotkit/a2ui-renderer": "1.69.3",
+        "@copilotkit/core": "1.69.3",
+        "@copilotkit/runtime-client-gql": "1.69.3",
+        "@copilotkit/shared": "1.69.3",
+        "@copilotkit/web-components": "1.69.3",
+        "@copilotkit/web-inspector": "1.69.3",
         "@jetbrains/websandbox": "^1.1.3",
-        "@lit-labs/react": "^2.0.2",
         "@radix-ui/react-dropdown-menu": "^2.1.15",
         "@radix-ui/react-slot": "^1.2.3",
         "@radix-ui/react-tooltip": "^1.2.7",
@@ -281,14 +280,14 @@
       }
     },
     "node_modules/@copilotkit/react-ui": {
-      "version": "1.66.2",
-      "resolved": "https://registry.npmmirror.com/@copilotkit/react-ui/-/react-ui-1.66.2.tgz",
-      "integrity": "sha512-lEbqjJ/2y+/c3XPcze+1mbxSNHhnOIedh/gz65zklcEKXqcBu+x6RXjhwcOPTybXQSxDT7GZrQ5B1VDhoKkWZQ==",
+      "version": "1.69.3",
+      "resolved": "https://registry.npmjs.org/@copilotkit/react-ui/-/react-ui-1.69.3.tgz",
+      "integrity": "sha512-dVqNwrlM8pJbzxNDk/Oep+BILUMyXtChQpnCgpTkLYDM5k7m6DdV3sTCIVIuJy+qemjQxdYfD08Xb9/OMEIg7Q==",
       "license": "MIT",
       "dependencies": {
-        "@copilotkit/react-core": "1.66.2",
-        "@copilotkit/runtime-client-gql": "1.66.2",
-        "@copilotkit/shared": "1.66.2",
+        "@copilotkit/react-core": "1.69.3",
+        "@copilotkit/runtime-client-gql": "1.69.3",
+        "@copilotkit/shared": "1.69.3",
         "@headlessui/react": "^2.2.9",
         "react-markdown": "^10.1.0",
         "react-syntax-highlighter": "^16.1.1",
@@ -425,12 +424,12 @@
       }
     },
     "node_modules/@copilotkit/runtime-client-gql": {
-      "version": "1.66.2",
-      "resolved": "https://registry.npmmirror.com/@copilotkit/runtime-client-gql/-/runtime-client-gql-1.66.2.tgz",
-      "integrity": "sha512-Cz2KYXpsGfZT/7cNPrr19LxnbgSoX31rWJ6gYmF4iGPJ3MOXy839TNBknoOsGR9wX9Y7twBvm9enb8WXUj7H8A==",
+      "version": "1.69.3",
+      "resolved": "https://registry.npmjs.org/@copilotkit/runtime-client-gql/-/runtime-client-gql-1.69.3.tgz",
+      "integrity": "sha512-jSmrOBA1EfXkJI2jOne5Sh33pTADTvRQl3SzgvWgZEomFeWGaHaTkng5dfVlrba1IKzaPoT++P/3sVJyS/CKZQ==",
       "license": "MIT",
       "dependencies": {
-        "@copilotkit/shared": "1.66.2",
+        "@copilotkit/shared": "1.69.3",
         "@urql/core": "^5.0.3",
         "untruncate-json": "^0.0.1",
         "urql": "^4.1.0"
@@ -440,9 +439,9 @@
       }
     },
     "node_modules/@copilotkit/shared": {
-      "version": "1.66.2",
-      "resolved": "https://registry.npmmirror.com/@copilotkit/shared/-/shared-1.66.2.tgz",
-      "integrity": "sha512-FmLAVm1jvSflxiVulozRbdft5dFPqP5EHyTq7Fl9CVwrxQR2Z2/CO9plifwKBJRkZpxIBsgp05i8NR3u6xUqgA==",
+      "version": "1.69.3",
+      "resolved": "https://registry.npmjs.org/@copilotkit/shared/-/shared-1.69.3.tgz",
+      "integrity": "sha512-6/B8oj6l+FQLRI2SJtebzQ8zf6f4uNeAy/+jhN1qpFWT4ppHU3XcHeMyLfrHWb595yRd8TTMM0NPT2KY2I6PnA==",
       "license": "MIT",
       "dependencies": {
         "@ag-ui/client": "0.0.57",
@@ -462,7 +461,7 @@
     },
     "node_modules/@copilotkit/shared/node_modules/zod": {
       "version": "3.25.76",
-      "resolved": "https://registry.npmmirror.com/zod/-/zod-3.25.76.tgz",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
       "funding": {
@@ -470,9 +469,9 @@
       }
     },
     "node_modules/@copilotkit/web-components": {
-      "version": "1.66.2",
-      "resolved": "https://registry.npmmirror.com/@copilotkit/web-components/-/web-components-1.66.2.tgz",
-      "integrity": "sha512-PnmGVJqnpe+FKUcw3b062vorBRUXPEZONM0+N6a8uufvz456PBYVQQeTHlU+sVCW9Jsx7iSDsAUSrDNiso19Gw==",
+      "version": "1.69.3",
+      "resolved": "https://registry.npmjs.org/@copilotkit/web-components/-/web-components-1.69.3.tgz",
+      "integrity": "sha512-huj89wHytUJ2jxAZzV/WS1f7TWq0GH6wHc+9xk+wkBAn/0c6ggPMsoSZ0sy4mfhp3mdWPgyzlEkzFIFMVr6Txw==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -482,12 +481,13 @@
       }
     },
     "node_modules/@copilotkit/web-inspector": {
-      "version": "1.66.2",
-      "resolved": "https://registry.npmmirror.com/@copilotkit/web-inspector/-/web-inspector-1.66.2.tgz",
-      "integrity": "sha512-kXYRfdfkE76gx68Jhqap6aivj6xq8pR5nDn4KPkyX7XCueJ+zZUhrCemSf16xYonOsyng5iq7VYyy+CUge9cJQ==",
+      "version": "1.69.3",
+      "resolved": "https://registry.npmjs.org/@copilotkit/web-inspector/-/web-inspector-1.69.3.tgz",
+      "integrity": "sha512-WgCRjRUY/eu5KWdXF4BRE0C7/GHEr3QHh+xresueIudeW/898o2wovLFfcFt7GyNJaR8A6iJa3r3/+Ehnx9OPA==",
       "dependencies": {
         "@ag-ui/client": "0.0.57",
-        "@copilotkit/core": "1.66.2",
+        "@copilotkit/core": "1.69.3",
+        "@copilotkit/shared": "1.69.3",
         "lit": "^3.2.0",
         "lucide": "^0.525.0",
         "marked": "^12.0.2"
@@ -669,29 +669,11 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
-    "node_modules/@lit-labs/react": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmmirror.com/@lit-labs/react/-/react-2.1.3.tgz",
-      "integrity": "sha512-OD9h2JynerBQUMNzb563jiVpxfvPF0HjQkKY2mx0lpVYvD7F+rtJpOGz6ek+6ufMidV3i+MPT9SX62OKWHFrQg==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@lit/react": "^1.0.3"
-      }
-    },
     "node_modules/@lit-labs/ssr-dom-shim": {
       "version": "1.6.0",
       "resolved": "https://registry.npmmirror.com/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.6.0.tgz",
       "integrity": "sha512-VHb0ALPMTlgKjM6yIxxoQNnpKyUKLD04VzeQdsiXkMqkvYlAHxq9glGLmgbb889/1GsohSOAjvQYoiBppXFqrQ==",
       "license": "BSD-3-Clause"
-    },
-    "node_modules/@lit/react": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmmirror.com/@lit/react/-/react-1.0.8.tgz",
-      "integrity": "sha512-p2+YcF+JE67SRX3mMlJ1TKCSTsgyOVdAwd/nxp3NuV1+Cb6MWALbN6nT7Ld4tpmYofcE5kcaSY1YBB9erY+6fw==",
-      "license": "BSD-3-Clause",
-      "peerDependencies": {
-        "@types/react": "17 || 18 || 19"
-      }
     },
     "node_modules/@lit/reactive-element": {
       "version": "2.1.2",
@@ -704,7 +686,7 @@
     },
     "node_modules/@lukeed/csprng": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmmirror.com/@lukeed/csprng/-/csprng-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/@lukeed/csprng/-/csprng-1.1.0.tgz",
       "integrity": "sha512-Z7C/xXCiGWsg0KuKsHTKJxbWhpI3Vs5GwLfOean7MGyVFGqdRgBbAjOCh6u4bbjPc/8MJ2pZmK/0DLdCbivLDA==",
       "license": "MIT",
       "engines": {
@@ -713,7 +695,7 @@
     },
     "node_modules/@lukeed/uuid": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmmirror.com/@lukeed/uuid/-/uuid-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/@lukeed/uuid/-/uuid-2.0.1.tgz",
       "integrity": "sha512-qC72D4+CDdjGqJvkFMMEAtancHUQ7/d/tAiHf64z8MopFDmcrtbcJuerDtFceuAfQJ2pDSfCKCtbqoGBNnwg0w==",
       "license": "MIT",
       "dependencies": {
@@ -1733,7 +1715,7 @@
     },
     "node_modules/@segment/analytics-core": {
       "version": "1.8.2",
-      "resolved": "https://registry.npmmirror.com/@segment/analytics-core/-/analytics-core-1.8.2.tgz",
+      "resolved": "https://registry.npmjs.org/@segment/analytics-core/-/analytics-core-1.8.2.tgz",
       "integrity": "sha512-5FDy6l8chpzUfJcNlIcyqYQq4+JTUynlVoCeCUuVz+l+6W0PXg+ljKp34R4yLVCcY5VVZohuW+HH0VLWdwYVAg==",
       "license": "MIT",
       "dependencies": {
@@ -1745,7 +1727,7 @@
     },
     "node_modules/@segment/analytics-generic-utils": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmmirror.com/@segment/analytics-generic-utils/-/analytics-generic-utils-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/@segment/analytics-generic-utils/-/analytics-generic-utils-1.2.0.tgz",
       "integrity": "sha512-DfnW6mW3YQOLlDQQdR89k4EqfHb0g/3XvBXkovH1FstUN93eL1kfW9CsDcVQyH3bAC5ZsFyjA/o/1Q2j0QeoWw==",
       "license": "MIT",
       "dependencies": {
@@ -1754,7 +1736,7 @@
     },
     "node_modules/@segment/analytics-node": {
       "version": "2.3.0",
-      "resolved": "https://registry.npmmirror.com/@segment/analytics-node/-/analytics-node-2.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/@segment/analytics-node/-/analytics-node-2.3.0.tgz",
       "integrity": "sha512-fOXLL8uY0uAWw/sTLmezze80hj8YGgXXlAfvSS6TUmivk4D/SP0C0sxnbpFdkUzWg2zT64qWIZj26afEtSnxUA==",
       "license": "MIT",
       "dependencies": {
@@ -1857,7 +1839,7 @@
     },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmmirror.com/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
       "license": "MIT"
     },
@@ -2144,7 +2126,7 @@
     },
     "node_modules/@tanstack/devtools-event-client": {
       "version": "0.4.4",
-      "resolved": "https://registry.npmmirror.com/@tanstack/devtools-event-client/-/devtools-event-client-0.4.4.tgz",
+      "resolved": "https://registry.npmjs.org/@tanstack/devtools-event-client/-/devtools-event-client-0.4.4.tgz",
       "integrity": "sha512-6T5Yop/793YI+H+5J8Hsyj4kCih9sl4t3ElLgKioW5hk3ocn+ZdSJ94tT7vL7uabxSugWYBZlOTMPzEw2puvQw==",
       "license": "MIT",
       "bin": {
@@ -2160,7 +2142,7 @@
     },
     "node_modules/@tanstack/pacer": {
       "version": "0.20.1",
-      "resolved": "https://registry.npmmirror.com/@tanstack/pacer/-/pacer-0.20.1.tgz",
+      "resolved": "https://registry.npmjs.org/@tanstack/pacer/-/pacer-0.20.1.tgz",
       "integrity": "sha512-ZNQ1bIL6eUXVKdic0tiImvBVkWrg/IoSK6VIacTrO3d3HAGnd70qFJNJagR/YOJIOw4EKGWnodwpYZkN1pWuVQ==",
       "license": "MIT",
       "dependencies": {
@@ -2194,7 +2176,7 @@
     },
     "node_modules/@tanstack/store": {
       "version": "0.9.3",
-      "resolved": "https://registry.npmmirror.com/@tanstack/store/-/store-0.9.3.tgz",
+      "resolved": "https://registry.npmjs.org/@tanstack/store/-/store-0.9.3.tgz",
       "integrity": "sha512-8reSzl/qGWGGVKhBoxXPMWzATSbZLZFWhwBAFO9NAyp0TxzfBP0mIrGb8CP8KrQTmvzXlR/vFPPUrHTLBGyFyw==",
       "license": "MIT",
       "funding": {
@@ -2942,7 +2924,7 @@
     },
     "node_modules/@urql/core": {
       "version": "5.2.0",
-      "resolved": "https://registry.npmmirror.com/@urql/core/-/core-5.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/@urql/core/-/core-5.2.0.tgz",
       "integrity": "sha512-/n0ieD0mvvDnVAXEQgX/7qJiVcvYvNkOHeBvkwtylfjydar123caCXcl58PXFY11oU1oquJocVXHxLAbtv4x1A==",
       "license": "MIT",
       "dependencies": {
@@ -2978,7 +2960,7 @@
     },
     "node_modules/ansi-styles": {
       "version": "4.3.0",
-      "resolved": "https://registry.npmmirror.com/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
       "license": "MIT",
       "dependencies": {
@@ -3015,7 +2997,7 @@
     },
     "node_modules/base64-js": {
       "version": "1.5.1",
-      "resolved": "https://registry.npmmirror.com/base64-js/-/base64-js-1.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
       "funding": [
         {
@@ -3035,7 +3017,7 @@
     },
     "node_modules/buffer": {
       "version": "6.0.3",
-      "resolved": "https://registry.npmmirror.com/buffer/-/buffer-6.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
       "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
       "funding": [
         {
@@ -3069,7 +3051,7 @@
     },
     "node_modules/chalk": {
       "version": "4.1.2",
-      "resolved": "https://registry.npmmirror.com/chalk/-/chalk-4.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "license": "MIT",
       "dependencies": {
@@ -3146,7 +3128,7 @@
     },
     "node_modules/color-convert": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmmirror.com/color-convert/-/color-convert-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
       "license": "MIT",
       "dependencies": {
@@ -3158,7 +3140,7 @@
     },
     "node_modules/color-name": {
       "version": "1.1.4",
-      "resolved": "https://registry.npmmirror.com/color-name/-/color-name-1.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "license": "MIT"
     },
@@ -3823,7 +3805,7 @@
     },
     "node_modules/dset": {
       "version": "3.1.4",
-      "resolved": "https://registry.npmmirror.com/dset/-/dset-3.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/dset/-/dset-3.1.4.tgz",
       "integrity": "sha512-2QF/g9/zTaPDc3BjNcVTGoBbXBgYfMTTceLaYcFJ/W9kggFUkhxD/hMEeuLKbugyef9SqAx8cpgwlIP/jinUTA==",
       "license": "MIT",
       "engines": {
@@ -3985,7 +3967,7 @@
     },
     "node_modules/graphql": {
       "version": "16.14.2",
-      "resolved": "https://registry.npmmirror.com/graphql/-/graphql-16.14.2.tgz",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.14.2.tgz",
       "integrity": "sha512-Chq1s4CY7jmh8gO2qvLIJyfCDIN+EHLFW/9iShnp1z8FjBQMoodWP1kDC36VAMXXIvAjj4ARa7ntfAV2BrjsbA==",
       "license": "MIT",
       "engines": {
@@ -4000,7 +3982,7 @@
     },
     "node_modules/has-flag": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmmirror.com/has-flag/-/has-flag-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "license": "MIT",
       "engines": {
@@ -4596,7 +4578,7 @@
     },
     "node_modules/ieee754": {
       "version": "1.2.1",
-      "resolved": "https://registry.npmmirror.com/ieee754/-/ieee754-1.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
       "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
       "funding": [
         {
@@ -4730,7 +4712,7 @@
     },
     "node_modules/jose": {
       "version": "5.10.0",
-      "resolved": "https://registry.npmmirror.com/jose/-/jose-5.10.0.tgz",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-5.10.0.tgz",
       "integrity": "sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==",
       "license": "MIT",
       "funding": {
@@ -5115,7 +5097,7 @@
     },
     "node_modules/lucide": {
       "version": "0.525.0",
-      "resolved": "https://registry.npmmirror.com/lucide/-/lucide-0.525.0.tgz",
+      "resolved": "https://registry.npmjs.org/lucide/-/lucide-0.525.0.tgz",
       "integrity": "sha512-sfehWlaE/7NVkcEQ4T9JD3eID8RNMIGJBBUq9wF3UFiJIrcMKRbU3g1KGfDk4svcW7yw8BtDLXaXo02scDtUYQ==",
       "license": "ISC"
     },
@@ -5150,7 +5132,7 @@
     },
     "node_modules/marked": {
       "version": "12.0.2",
-      "resolved": "https://registry.npmmirror.com/marked/-/marked-12.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-12.0.2.tgz",
       "integrity": "sha512-qXUm7e/YKFoqFPYPa3Ukg9xlI5cyAtGmyEIzMfW//m6kXwCy2Ps9DYf5ioijFKQ8qyuscrHoY04iJGctu2Kg0Q==",
       "license": "MIT",
       "bin": {
@@ -6316,7 +6298,7 @@
     },
     "node_modules/node-fetch": {
       "version": "2.7.0",
-      "resolved": "https://registry.npmmirror.com/node-fetch/-/node-fetch-2.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
       "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
       "license": "MIT",
       "dependencies": {
@@ -6399,7 +6381,7 @@
     },
     "node_modules/partial-json": {
       "version": "0.1.7",
-      "resolved": "https://registry.npmmirror.com/partial-json/-/partial-json-0.1.7.tgz",
+      "resolved": "https://registry.npmjs.org/partial-json/-/partial-json-0.1.7.tgz",
       "integrity": "sha512-Njv/59hHaokb/hRUjce3Hdv12wd60MtM9Z5Olmn+nehe0QDAsRtRbJPvJ0Z91TusF0SuZRIvnM+S4l6EIP8leA==",
       "license": "MIT"
     },
@@ -6410,9 +6392,9 @@
       "license": "MIT"
     },
     "node_modules/phoenix": {
-      "version": "1.8.9",
-      "resolved": "https://registry.npmmirror.com/phoenix/-/phoenix-1.8.9.tgz",
-      "integrity": "sha512-/2qzAZB3P2s08fFAYaG65lqaNFmVXUSlXdY4/JDdDKIC81y2cFWkPwI8gycy4VLpv197JwZ5PpBf3VhoG32yGA==",
+      "version": "1.8.13",
+      "resolved": "https://registry.npmjs.org/phoenix/-/phoenix-1.8.13.tgz",
+      "integrity": "sha512-5UByH7ejdsPLd6eihwzV3L3i6YX4mHUtFjLaE8S1YuA+3aBj37rzH6KDjxBuPlB04o9ZHVz+PKRiUg3aYYvzmQ==",
       "license": "MIT"
     },
     "node_modules/picocolors": {
@@ -8129,7 +8111,7 @@
     },
     "node_modules/supports-color": {
       "version": "7.2.0",
-      "resolved": "https://registry.npmmirror.com/supports-color/-/supports-color-7.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
       "license": "MIT",
       "dependencies": {
@@ -8204,7 +8186,7 @@
     },
     "node_modules/tr46": {
       "version": "0.0.3",
-      "resolved": "https://registry.npmmirror.com/tr46/-/tr46-0.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
       "license": "MIT"
     },
@@ -8505,7 +8487,7 @@
     },
     "node_modules/urql": {
       "version": "4.2.2",
-      "resolved": "https://registry.npmmirror.com/urql/-/urql-4.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/urql/-/urql-4.2.2.tgz",
       "integrity": "sha512-3GgqNa6iF7bC4hY/ImJKN4REQILcSU9VKcKL8gfELZM8mM5BnLH1BsCc8kBdnVGD1LIFOs4W3O2idNHhON1r0w==",
       "license": "MIT",
       "dependencies": {
@@ -9063,13 +9045,13 @@
     },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmmirror.com/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
       "license": "BSD-2-Clause"
     },
     "node_modules/whatwg-url": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmmirror.com/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
       "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
       "license": "MIT",
       "dependencies": {
@@ -9079,7 +9061,7 @@
     },
     "node_modules/wonka": {
       "version": "6.3.6",
-      "resolved": "https://registry.npmmirror.com/wonka/-/wonka-6.3.6.tgz",
+      "resolved": "https://registry.npmjs.org/wonka/-/wonka-6.3.6.tgz",
       "integrity": "sha512-MXH+6mDHAZ2GuMpgKS055FR6v0xVP3XwquxIMYXgiW+FejHQlMGlvVRZT4qMCxR+bEo/FCtIdKxwej9WV3YQag==",
       "license": "MIT"
     },

--- a/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/main/java/io/agentscope/core/agui/adapter/AguiAdapterConfig.java
+++ b/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/main/java/io/agentscope/core/agui/adapter/AguiAdapterConfig.java
@@ -34,6 +34,7 @@ public class AguiAdapterConfig {
 
     private final ToolMergeMode toolMergeMode;
     private final boolean emitStateEvents;
+    // frontend/external tools always emit args
     private final boolean emitToolCallArgs;
     private final boolean emitTokenUsage;
     private final boolean enableReasoning;

--- a/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/main/java/io/agentscope/core/agui/adapter/AguiAgentAdapter.java
+++ b/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/main/java/io/agentscope/core/agui/adapter/AguiAgentAdapter.java
@@ -51,6 +51,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Predicate;
 import java.util.function.Supplier;
 import reactor.core.publisher.Flux;
 
@@ -201,7 +202,8 @@ public class AguiAgentAdapter {
         String runId = input.getRunId();
 
         if (agent instanceof ReActAgent reAct) {
-            AguiStreamContext context = new AguiStreamContext(threadId, runId, config, input);
+            AguiStreamContext context =
+                    new AguiStreamContext(threadId, runId, config, input, externalToolDetector());
             Flux<AgentEvent> events =
                     Objects.requireNonNull(
                             reAct.streamEvents(msgs, runtimeContext), "agent stream is null");
@@ -209,7 +211,8 @@ public class AguiAgentAdapter {
                     convertAgentEvents(events, context), () -> finishPendingEvents(context));
         }
         if (AguiUtil.isHarnessAgent(agent)) {
-            AguiStreamContext context = new AguiStreamContext(threadId, runId, config, input);
+            AguiStreamContext context =
+                    new AguiStreamContext(threadId, runId, config, input, externalToolDetector());
             Flux<AgentEvent> events =
                     Objects.requireNonNull(
                             invokeHarnessStreamEvents(agent, msgs, runtimeContext),
@@ -318,6 +321,20 @@ public class AguiAgentAdapter {
             }
         }
         return Map.copyOf(interrupts);
+    }
+
+    /**
+     * External-tool detector backed by the live toolkit.
+     *
+     * <p>Used to decide whether {@code TOOL_CALL_ARGS} must still be emitted when
+     * {@code emitToolCallArgs} is disabled: external tools (frontend-provided or schema-only)
+     * execute outside the framework, so the client needs their arguments. Returns {@code null}
+     * when the agent exposes no toolkit, in which case the stream context falls back to
+     * matching names from {@link RunAgentInput#getTools()}.
+     */
+    private Predicate<String> externalToolDetector() {
+        Toolkit toolkit = agent.getToolkit();
+        return toolkit == null ? null : toolkit::isExternalTool;
     }
 
     private ToolInjection injectFrontendTools(RunAgentInput input) {

--- a/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/main/java/io/agentscope/core/agui/adapter/strategy/AguiStreamContext.java
+++ b/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/main/java/io/agentscope/core/agui/adapter/strategy/AguiStreamContext.java
@@ -31,6 +31,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -62,20 +63,41 @@ public class AguiStreamContext {
     private final Map<String, AguiEvent.Interrupt> pendingInterrupts = new LinkedHashMap<>();
     private final Set<String> warnedMissingToolCallIdOperations = new LinkedHashSet<>();
     private final TokenUsageAccumulator tokenUsageAccumulator = new TokenUsageAccumulator();
-    private final Set<String> frontTools;
+    private final Predicate<String> isExternalTool;
     private final Map<String, String> startedToolCallNames = new LinkedHashMap<>();
 
     public AguiStreamContext(String threadId, String runId, AguiAdapterConfig config) {
-        this(threadId, runId, config, null);
+        this(threadId, runId, config, null, null);
     }
 
     public AguiStreamContext(
             String threadId, String runId, AguiAdapterConfig config, RunAgentInput runInput) {
+        this(threadId, runId, config, runInput, null);
+    }
+
+    /**
+     * Stream conversion context.
+     *
+     * <p>The {@code isExternalTool} predicate tells whether a tool call resolves to an external
+     * tool (executed outside the framework, e.g. a frontend-provided or schema-only tool). When
+     * {@code emitToolCallArgs} is disabled, external tools still need {@code TOOL_CALL_ARGS} so
+     * the client can invoke them. Pass {@code null} to fall back to matching tool names from
+     * {@link RunAgentInput#getTools()} (used when no live toolkit is available, e.g. replay).
+     *
+     * @param isExternalTool predicate for external-tool resolution by tool name
+     */
+    public AguiStreamContext(
+            String threadId,
+            String runId,
+            AguiAdapterConfig config,
+            RunAgentInput runInput,
+            Predicate<String> isExternalTool) {
         this.threadId = Objects.requireNonNull(threadId, "threadId cannot be null");
         this.runId = Objects.requireNonNull(runId, "runId cannot be null");
         this.config = Objects.requireNonNull(config, "config cannot be null");
         this.runInput = runInput;
-        this.frontTools = frontendToolNames(runInput);
+        this.isExternalTool =
+                isExternalTool != null ? isExternalTool : defaultExternalToolDetector(runInput);
     }
 
     public String getThreadId() {
@@ -346,17 +368,29 @@ public class AguiStreamContext {
     }
 
     /**
-     * Whether the started tool call is a frontend tool.
+     * Whether the started tool call resolves to an external tool.
      *
-     * <p>Streaming argument chunks often use a placeholder name such as {@code __fragment__}.
-     * Frontend-tool matching must therefore use the real name recorded on {@code ToolCallStart}.
+     * <p>External tools execute outside the framework (e.g. frontend-provided or schema-only
+     * tools) and need {@code TOOL_CALL_ARGS} delivered to the client even when
+     * {@code emitToolCallArgs} is disabled. Streaming argument chunks often use a placeholder
+     * name such as {@code __fragment__}, so the real name recorded on {@code ToolCallStart} is
+     * resolved by {@code toolCallId} rather than read from the delta.
      */
-    public boolean isFrontendToolCall(String toolCallId) {
+    public boolean isExternalToolCall(String toolCallId) {
         String toolCallName = startedToolCallNames.get(toolCallId);
-        return toolCallName != null && frontTools.contains(toolCallName);
+        return toolCallName != null && isExternalTool.test(toolCallName);
     }
 
-    private Set<String> frontendToolNames(RunAgentInput runInput) {
+    /**
+     * Fallback external-tool detector used when no live toolkit is available (e.g. event
+     * replay). Matches tool names registered in {@link RunAgentInput#getTools()}.
+     */
+    private static Predicate<String> defaultExternalToolDetector(RunAgentInput runInput) {
+        Set<String> names = frontendToolNames(runInput);
+        return names.isEmpty() ? name -> false : names::contains;
+    }
+
+    private static Set<String> frontendToolNames(RunAgentInput runInput) {
         if (runInput == null || runInput.getTools() == null || runInput.getTools().isEmpty()) {
             return Set.of();
         }

--- a/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/main/java/io/agentscope/core/agui/adapter/strategy/AguiStreamContext.java
+++ b/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/main/java/io/agentscope/core/agui/adapter/strategy/AguiStreamContext.java
@@ -17,6 +17,7 @@ package io.agentscope.core.agui.adapter.strategy;
 
 import io.agentscope.core.agui.adapter.AguiAdapterConfig;
 import io.agentscope.core.agui.event.AguiEvent;
+import io.agentscope.core.agui.model.AguiTool;
 import io.agentscope.core.agui.model.RunAgentInput;
 import io.agentscope.core.message.ContentBlock;
 import io.agentscope.core.message.TextBlock;
@@ -30,6 +31,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -60,6 +62,8 @@ public class AguiStreamContext {
     private final Map<String, AguiEvent.Interrupt> pendingInterrupts = new LinkedHashMap<>();
     private final Set<String> warnedMissingToolCallIdOperations = new LinkedHashSet<>();
     private final TokenUsageAccumulator tokenUsageAccumulator = new TokenUsageAccumulator();
+    private final Set<String> frontTools;
+    private final Map<String, String> startedToolCallNames = new LinkedHashMap<>();
 
     public AguiStreamContext(String threadId, String runId, AguiAdapterConfig config) {
         this(threadId, runId, config, null);
@@ -71,6 +75,7 @@ public class AguiStreamContext {
         this.runId = Objects.requireNonNull(runId, "runId cannot be null");
         this.config = Objects.requireNonNull(config, "config cannot be null");
         this.runInput = runInput;
+        this.frontTools = frontendToolNames(runInput);
     }
 
     public String getThreadId() {
@@ -187,6 +192,9 @@ public class AguiStreamContext {
             return;
         }
         if (startedToolCalls.add(toolCallId)) {
+            if (toolCallName != null && !toolCallName.isBlank()) {
+                startedToolCallNames.put(toolCallId, toolCallName);
+            }
             emit(
                     new AguiEvent.ToolCallStart(
                             threadId, runId, toolCallId, normalizeToolCallName(toolCallName)));
@@ -334,6 +342,24 @@ public class AguiStreamContext {
                 "Ignoring {}: null/blank toolCallId. Upstream must supply a stable toolCallId per"
                         + " AG-UI protocol.",
                 eventName);
+    }
+
+    /**
+     * Whether the started tool call is a frontend tool.
+     *
+     * <p>Streaming argument chunks often use a placeholder name such as {@code __fragment__}.
+     * Frontend-tool matching must therefore use the real name recorded on {@code ToolCallStart}.
+     */
+    public boolean isFrontendToolCall(String toolCallId) {
+        String toolCallName = startedToolCallNames.get(toolCallId);
+        return toolCallName != null && frontTools.contains(toolCallName);
+    }
+
+    private Set<String> frontendToolNames(RunAgentInput runInput) {
+        if (runInput == null || runInput.getTools() == null || runInput.getTools().isEmpty()) {
+            return Set.of();
+        }
+        return runInput.getTools().stream().map(AguiTool::getName).collect(Collectors.toSet());
     }
 
     static final class TokenUsageAccumulator {

--- a/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/main/java/io/agentscope/core/agui/adapter/strategy/AguiStreamContext.java
+++ b/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/main/java/io/agentscope/core/agui/adapter/strategy/AguiStreamContext.java
@@ -216,6 +216,7 @@ public class AguiStreamContext {
         }
         if (endedToolCalls.add(toolCallId)) {
             emit(new AguiEvent.ToolCallEnd(threadId, runId, toolCallId));
+            startedToolCallNames.remove(toolCallId);
         }
     }
 

--- a/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/main/java/io/agentscope/core/agui/adapter/strategy/ToolCallEventConverter.java
+++ b/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/main/java/io/agentscope/core/agui/adapter/strategy/ToolCallEventConverter.java
@@ -31,7 +31,9 @@ final class ToolCallEventConverter implements AgentEventConverter {
     @Override
     public void convert(AgentEvent event, AguiStreamContext context) {
         if (event instanceof ToolCallDeltaEvent delta) {
-            if (context.getConfig().isEmitToolCallArgs()) {
+            // Frontend tools always need args; streaming deltas often use a placeholder name.
+            if (context.getConfig().isEmitToolCallArgs()
+                    || context.isFrontendToolCall(delta.getToolCallId())) {
                 context.appendToolCallArgs(delta.getToolCallId(), delta.getDelta());
             }
         } else if (event instanceof ToolCallStartEvent start) {

--- a/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/main/java/io/agentscope/core/agui/adapter/strategy/ToolCallEventConverter.java
+++ b/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/main/java/io/agentscope/core/agui/adapter/strategy/ToolCallEventConverter.java
@@ -31,9 +31,10 @@ final class ToolCallEventConverter implements AgentEventConverter {
     @Override
     public void convert(AgentEvent event, AguiStreamContext context) {
         if (event instanceof ToolCallDeltaEvent delta) {
-            // Frontend tools always need args; streaming deltas often use a placeholder name.
+            // External tools always need args so the client can invoke them; streaming deltas
+            // often use a placeholder name, so resolution happens by toolCallId in the context.
             if (context.getConfig().isEmitToolCallArgs()
-                    || context.isFrontendToolCall(delta.getToolCallId())) {
+                    || context.isExternalToolCall(delta.getToolCallId())) {
                 context.appendToolCallArgs(delta.getToolCallId(), delta.getDelta());
             }
         } else if (event instanceof ToolCallStartEvent start) {

--- a/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/test/java/io/agentscope/core/agui/adapter/AguiAgentAdapterV2Test.java
+++ b/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/test/java/io/agentscope/core/agui/adapter/AguiAgentAdapterV2Test.java
@@ -522,6 +522,50 @@ class AguiAgentAdapterV2Test {
         }
 
         @Test
+        void testFrontendToolFragmentDeltaEmitsArgsWhenEmitToolCallArgsDisabled() {
+            List<AguiEvent> events =
+                    runReActEvents(
+                            AguiAdapterConfig.builder().emitToolCallArgs(false).build(),
+                            inputWithTools(frontendTool("lookup")),
+                            new ToolCallStartEvent("reply-tool", "tool-1", "lookup"),
+                            new ToolCallDeltaEvent(
+                                    "reply-tool", "tool-1", "__fragment__", "{\"q\""),
+                            new ToolCallDeltaEvent(
+                                    "reply-tool", "tool-1", "__fragment__", ":\"agent\"}"),
+                            new ToolCallEndEvent("reply-tool", "tool-1", "lookup"));
+
+            assertEquals(
+                    List.of(
+                            AguiEventType.TOOL_CALL_START,
+                            AguiEventType.TOOL_CALL_ARGS,
+                            AguiEventType.TOOL_CALL_ARGS,
+                            AguiEventType.TOOL_CALL_END),
+                    types(events));
+            AguiEvent.ToolCallArgs firstArgs =
+                    assertInstanceOf(AguiEvent.ToolCallArgs.class, events.get(1));
+            AguiEvent.ToolCallArgs secondArgs =
+                    assertInstanceOf(AguiEvent.ToolCallArgs.class, events.get(2));
+            assertEquals("{\"q\"", firstArgs.delta());
+            assertEquals(":\"agent\"}", secondArgs.delta());
+        }
+
+        @Test
+        void testBackendToolFragmentDeltaDoesNotEmitArgsWhenEmitToolCallArgsDisabled() {
+            List<AguiEvent> events =
+                    runReActEvents(
+                            AguiAdapterConfig.builder().emitToolCallArgs(false).build(),
+                            inputWithTools(frontendTool("lookup")),
+                            new ToolCallStartEvent("reply-tool", "tool-1", "search"),
+                            new ToolCallDeltaEvent(
+                                    "reply-tool", "tool-1", "__fragment__", "{\"q\""),
+                            new ToolCallEndEvent("reply-tool", "tool-1", "search"));
+
+            assertEquals(
+                    List.of(AguiEventType.TOOL_CALL_START, AguiEventType.TOOL_CALL_END),
+                    types(events));
+        }
+
+        @Test
         void testToolResultDeltasAreAggregatedIntoToolCallResult() {
             List<AguiEvent> events =
                     runReActEvents(

--- a/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/test/java/io/agentscope/core/agui/adapter/AguiAgentAdapterV2Test.java
+++ b/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/test/java/io/agentscope/core/agui/adapter/AguiAgentAdapterV2Test.java
@@ -566,6 +566,60 @@ class AguiAgentAdapterV2Test {
         }
 
         @Test
+        void testAgentExternalToolEmitsArgsWhenEmitToolCallArgsDisabled() {
+            // Agent-level schema-only tool registered in the toolkit (not in RunAgentInput.tools).
+            // External tools execute outside the framework, so args must reach the client even
+            // when emitToolCallArgs is disabled. The name-set heuristic would miss this.
+            Toolkit toolkit = new Toolkit();
+            toolkit.registerAgentTool(schemaOnlyTool("agent_external"));
+
+            List<AguiEvent> events =
+                    runReActEvents(
+                            toolkit,
+                            AguiAdapterConfig.builder().emitToolCallArgs(false).build(),
+                            input(),
+                            new ToolCallStartEvent("reply-tool", "tool-1", "agent_external"),
+                            new ToolCallDeltaEvent(
+                                    "reply-tool", "tool-1", "__fragment__", "{\"q\""),
+                            new ToolCallEndEvent("reply-tool", "tool-1", "agent_external"));
+
+            assertEquals(
+                    List.of(
+                            AguiEventType.TOOL_CALL_START,
+                            AguiEventType.TOOL_CALL_ARGS,
+                            AguiEventType.TOOL_CALL_END),
+                    types(events));
+            AguiEvent.ToolCallArgs args =
+                    assertInstanceOf(AguiEvent.ToolCallArgs.class, events.get(1));
+            assertEquals("{\"q\"", args.delta());
+        }
+
+        @Test
+        void testAgentOnlyModeHidesArgsForFrontendRegisteredName() {
+            // "lookup" is registered in RunAgentInput.tools, but AGENT_ONLY skips injection, so
+            // the live toolkit never sees it. The authoritative toolkit predicate must return
+            // false and suppress args; the name-set heuristic would wrongly emit them.
+            Toolkit toolkit = new Toolkit();
+
+            List<AguiEvent> events =
+                    runReActEvents(
+                            toolkit,
+                            AguiAdapterConfig.builder()
+                                    .emitToolCallArgs(false)
+                                    .toolMergeMode(ToolMergeMode.AGENT_ONLY)
+                                    .build(),
+                            inputWithTools(frontendTool("lookup")),
+                            new ToolCallStartEvent("reply-tool", "tool-1", "lookup"),
+                            new ToolCallDeltaEvent(
+                                    "reply-tool", "tool-1", "__fragment__", "{\"q\""),
+                            new ToolCallEndEvent("reply-tool", "tool-1", "lookup"));
+
+            assertEquals(
+                    List.of(AguiEventType.TOOL_CALL_START, AguiEventType.TOOL_CALL_END),
+                    types(events));
+        }
+
+        @Test
         void testToolResultDeltasAreAggregatedIntoToolCallResult() {
             List<AguiEvent> events =
                     runReActEvents(
@@ -1997,6 +2051,18 @@ class AguiAgentAdapterV2Test {
     private static List<AguiEvent> runReActEvents(
             AguiAdapterConfig config, RunAgentInput input, AgentEvent... agentEvents) {
         ReActAgent agent = mock(ReActAgent.class);
+        when(agent.streamEvents(anyList(), any(RuntimeContext.class)))
+                .thenReturn(Flux.fromArray(agentEvents));
+        return new AguiAgentAdapter(agent, config).run(input).collectList().block();
+    }
+
+    private static List<AguiEvent> runReActEvents(
+            Toolkit toolkit,
+            AguiAdapterConfig config,
+            RunAgentInput input,
+            AgentEvent... agentEvents) {
+        ReActAgent agent = mock(ReActAgent.class);
+        when(agent.getToolkit()).thenReturn(toolkit);
         when(agent.streamEvents(anyList(), any(RuntimeContext.class)))
                 .thenReturn(Flux.fromArray(agentEvents));
         return new AguiAgentAdapter(agent, config).run(input).collectList().block();


### PR DESCRIPTION
## Related issues
- Fixes #2873

## Summary
- Record the real tool name on `ToolCallStart` and match frontend tools by `toolCallId`.
- Emit `TOOL_CALL_ARGS` for frontend tools even when streamed deltas use `__fragment__`.
- Keep backend tool args hidden when `emitToolCallArgs` is false.
- Add unit coverage for frontend and backend fragment deltas.

## Breaking Changes
None.
