### PR TITLE
fix(model): move cache control to content blocks

### DIFF
--- a/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-dashscope/src/main/java/io/agentscope/extensions/model/dashscope/dto/DashScopeContentPart.java
+++ b/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-dashscope/src/main/java/io/agentscope/extensions/model/dashscope/dto/DashScopeContentPart.java
@@ -18,6 +18,7 @@ package io.agentscope.extensions.model.dashscope.dto;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.List;
+import java.util.Map;
 
 /**
  * DashScope content part DTO for multimodal messages.
@@ -78,6 +79,11 @@ public class DashScopeContentPart {
     /** Used to limit the total pixels of all frames extracted from the video (single image pixels × total frames). */
     @JsonProperty("total_pixels")
     private Integer totalPixels;
+
+    /** Cache control configuration for this content part. */
+    @JsonProperty("cache_control")
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    private Map<String, String> cacheControl;
 
     public DashScopeContentPart() {}
 
@@ -151,6 +157,24 @@ public class DashScopeContentPart {
 
     public void setTotalPixels(Integer totalPixels) {
         this.totalPixels = totalPixels;
+    }
+
+    /**
+     * Get the cache control configuration.
+     *
+     * @return the cache control configuration, or null when not configured
+     */
+    public Map<String, String> getCacheControl() {
+        return cacheControl;
+    }
+
+    /**
+     * Set the cache control configuration.
+     *
+     * @param cacheControl the cache control configuration
+     */
+    public void setCacheControl(Map<String, String> cacheControl) {
+        this.cacheControl = cacheControl;
     }
 
     /**
@@ -287,6 +311,17 @@ public class DashScopeContentPart {
 
         public Builder totalPixels(Integer totalPixels) {
             part.setTotalPixels(totalPixels);
+            return this;
+        }
+
+        /**
+         * Set the cache control configuration.
+         *
+         * @param cacheControl the cache control configuration
+         * @return this builder
+         */
+        public Builder cacheControl(Map<String, String> cacheControl) {
+            part.setCacheControl(cacheControl);
             return this;
         }
 

--- a/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-dashscope/src/main/java/io/agentscope/extensions/model/dashscope/dto/DashScopeMessage.java
+++ b/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-dashscope/src/main/java/io/agentscope/extensions/model/dashscope/dto/DashScopeMessage.java
@@ -84,13 +84,11 @@ public class DashScopeMessage {
     private String reasoningContent;
 
     /**
-     * Cache control configuration for prompt caching.
+     * Legacy message-level cache control state.
      *
-     * <p>Tri-state: {@code null} means "not specified" (the automatic cache-control strategy may
-     * add {@code {"type": "ephemeral"}}); a non-empty map is an explicit {@code cache_control}
-     * value; an empty map is the explicit "no cache" sentinel — combined with
-     * {@link JsonInclude.Include#NON_EMPTY} it is serialized away, so the API receives no
-     * {@code cache_control} field and therefore performs no caching.
+     * <p>Non-empty legacy values are migrated to a content part by the formatter. {@code null}
+     * means "not specified"; an empty map is the explicit "no marker" sentinel and is serialized
+     * away by {@link JsonInclude.Include#NON_EMPTY} while still blocking the automatic strategy.
      */
     @JsonProperty("cache_control")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)

--- a/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-dashscope/src/main/java/io/agentscope/extensions/model/dashscope/formatter/DashScopeChatFormatter.java
+++ b/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-dashscope/src/main/java/io/agentscope/extensions/model/dashscope/formatter/DashScopeChatFormatter.java
@@ -21,6 +21,7 @@ import io.agentscope.core.model.ChatResponse;
 import io.agentscope.core.model.GenerateOptions;
 import io.agentscope.core.model.ToolChoice;
 import io.agentscope.core.model.ToolSchema;
+import io.agentscope.extensions.model.dashscope.dto.DashScopeContentPart;
 import io.agentscope.extensions.model.dashscope.dto.DashScopeInput;
 import io.agentscope.extensions.model.dashscope.dto.DashScopeMessage;
 import io.agentscope.extensions.model.dashscope.dto.DashScopeParameters;
@@ -46,9 +47,9 @@ public class DashScopeChatFormatter
     private static final Map<String, String> EPHEMERAL_CACHE_CONTROL = Map.of("type", "ephemeral");
 
     /**
-     * Sentinel for an explicit "no cache" intent. An empty map is serialized away (via
+     * Sentinel for an explicit "no marker" intent. An empty map is serialized away (via
      * {@code @JsonInclude(NON_EMPTY)} on {@link DashScopeMessage#cacheControl}), so the upstream
-     * API receives no {@code cache_control} field and therefore performs no caching.
+     * API receives no explicit {@code cache_control} marker.
      */
     private static final Map<String, String> NO_CACHE_CONTROL = Collections.emptyMap();
 
@@ -183,25 +184,69 @@ public class DashScopeChatFormatter
     /**
      * Apply cache control to DashScope messages.
      *
-     * <p>Adds <code>cache_control: {"type": "ephemeral"}</code> to all system messages and the last
-     * message in the list. Messages that already carry a cache_control value (including the empty
-     * "no cache" sentinel) are left untouched.
+     * <p>Adds <code>cache_control: {"type": "ephemeral"}</code> to the last content part of all
+     * system messages and the last message in the list. Legacy message-level values are migrated to
+     * the last content part. Messages explicitly excluded from caching are left untouched.
      *
      * @param messages the list of formatted DashScope messages
      */
     public void applyCacheControl(List<DashScopeMessage> messages) {
+        applyCacheControlToMessages(messages);
+    }
+
+    static void applyCacheControlToMessages(List<DashScopeMessage> messages) {
         if (messages == null || messages.isEmpty()) {
             return;
         }
         for (DashScopeMessage msg : messages) {
+            migrateLegacyCacheControl(msg);
+        }
+        for (DashScopeMessage msg : messages) {
             if ("system".equals(msg.getRole()) && shouldAutoCache(msg)) {
-                msg.setCacheControl(EPHEMERAL_CACHE_CONTROL);
+                setCacheControlOnContent(msg, EPHEMERAL_CACHE_CONTROL);
             }
         }
         DashScopeMessage lastMsg = messages.get(messages.size() - 1);
         if (shouldAutoCache(lastMsg)) {
-            lastMsg.setCacheControl(EPHEMERAL_CACHE_CONTROL);
+            setCacheControlOnContent(lastMsg, EPHEMERAL_CACHE_CONTROL);
         }
+    }
+
+    static void setCacheControlOnContent(
+            DashScopeMessage message, Map<String, String> cacheControl) {
+        DashScopeContentPart lastPart = getOrCreateLastContentPart(message);
+        if (lastPart != null && lastPart.getCacheControl() == null) {
+            lastPart.setCacheControl(cacheControl);
+        }
+        message.setCacheControl(null);
+    }
+
+    private static void migrateLegacyCacheControl(DashScopeMessage message) {
+        Map<String, String> legacyCacheControl = message.getCacheControl();
+        if (legacyCacheControl != null && !legacyCacheControl.isEmpty()) {
+            setCacheControlOnContent(message, legacyCacheControl);
+        }
+    }
+
+    private static DashScopeContentPart getOrCreateLastContentPart(DashScopeMessage message) {
+        Object content = message.getContent();
+        if (content instanceof String text) {
+            DashScopeContentPart textPart = DashScopeContentPart.text(text);
+            message.setContent(List.of(textPart));
+            return textPart;
+        }
+        return findLastContentPart(content);
+    }
+
+    private static DashScopeContentPart findLastContentPart(Object content) {
+        if (content instanceof List<?> parts) {
+            for (int i = parts.size() - 1; i >= 0; i--) {
+                if (parts.get(i) instanceof DashScopeContentPart part) {
+                    return part;
+                }
+            }
+        }
+        return null;
     }
 
     /**
@@ -214,9 +259,9 @@ public class DashScopeChatFormatter
     }
 
     /**
-     * Get the "no cache" sentinel constant.
+     * Get the "no marker" sentinel constant.
      *
-     * @return unmodifiable empty map representing an explicit "no cache" intent
+     * @return unmodifiable empty map representing an explicit "no marker" intent
      */
     static Map<String, String> getNoCacheControl() {
         return NO_CACHE_CONTROL;
@@ -225,14 +270,18 @@ public class DashScopeChatFormatter
     /**
      * Whether the automatic cache-control strategy should mark a message as ephemeral.
      *
-     * <p>Returns {@code true} only when the message has no cache_control value at all. Any non-null
-     * value — an explicit {@code {"type": "ephemeral"}}, a custom value, or the empty "no cache"
-     * sentinel — is left unchanged.
+     * <p>Returns {@code true} only when neither the legacy message-level state nor the last content
+     * part carries a cache-control value. The empty message-level "no marker" sentinel is therefore
+     * preserved across repeated automatic-strategy passes.
      *
      * @param message the message to inspect
      * @return {@code true} if the message should be auto-cached, {@code false} otherwise
      */
     static boolean shouldAutoCache(DashScopeMessage message) {
-        return message.getCacheControl() == null;
+        if (message.getCacheControl() != null) {
+            return false;
+        }
+        DashScopeContentPart lastPart = findLastContentPart(message.getContent());
+        return lastPart == null || lastPart.getCacheControl() == null;
     }
 }

--- a/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-dashscope/src/main/java/io/agentscope/extensions/model/dashscope/formatter/DashScopeMessageConverter.java
+++ b/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-dashscope/src/main/java/io/agentscope/extensions/model/dashscope/formatter/DashScopeMessageConverter.java
@@ -273,7 +273,7 @@ public class DashScopeMessageConverter {
      * @param msg the source message with metadata
      * @param result the converted DashScope message
      */
-    private void applyCacheControlFromMetadata(Msg msg, DashScopeMessage result) {
+    void applyCacheControlFromMetadata(Msg msg, DashScopeMessage result) {
         if (msg.getMetadata() == null) {
             return;
         }

--- a/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-dashscope/src/main/java/io/agentscope/extensions/model/dashscope/formatter/DashScopeMessageConverter.java
+++ b/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-dashscope/src/main/java/io/agentscope/extensions/model/dashscope/formatter/DashScopeMessageConverter.java
@@ -280,7 +280,8 @@ public class DashScopeMessageConverter {
         Object cacheFlag = msg.getMetadata().get(MessageMetadataKeys.CACHE_CONTROL);
         if (Boolean.TRUE.equals(cacheFlag)) {
             if (result.getCacheControl() == null || result.getCacheControl().isEmpty()) {
-                result.setCacheControl(DashScopeChatFormatter.getEphemeralCacheControl());
+                DashScopeChatFormatter.setCacheControlOnContent(
+                        result, DashScopeChatFormatter.getEphemeralCacheControl());
             }
         } else if (Boolean.FALSE.equals(cacheFlag)) {
             result.setCacheControl(DashScopeChatFormatter.getNoCacheControl());

--- a/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-dashscope/src/main/java/io/agentscope/extensions/model/dashscope/formatter/DashScopeMultiAgentFormatter.java
+++ b/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-dashscope/src/main/java/io/agentscope/extensions/model/dashscope/formatter/DashScopeMultiAgentFormatter.java
@@ -33,7 +33,6 @@ import io.agentscope.extensions.model.dashscope.dto.DashScopeResponse;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 
 /**
  * DashScope formatter for multi-agent conversations.
@@ -366,25 +365,13 @@ public class DashScopeMultiAgentFormatter
     /**
      * Apply cache control to DashScope messages.
      *
-     * <p>Adds <code>cache_control: {"type": "ephemeral"}</code> to all system messages and the last
-     * message in the list. Messages that are explicitly excluded from caching or that already carry
-     * a cache_control value are left untouched.
+     * <p>Adds <code>cache_control: {"type": "ephemeral"}</code> to the last content part of all
+     * system messages and the last message in the list. Legacy message-level values are migrated to
+     * the last content part. Messages explicitly excluded from caching are left untouched.
      *
      * @param messages the list of formatted DashScope messages
      */
     public void applyCacheControl(List<DashScopeMessage> messages) {
-        if (messages == null || messages.isEmpty()) {
-            return;
-        }
-        Map<String, String> ephemeral = DashScopeChatFormatter.getEphemeralCacheControl();
-        for (DashScopeMessage msg : messages) {
-            if ("system".equals(msg.getRole()) && DashScopeChatFormatter.shouldAutoCache(msg)) {
-                msg.setCacheControl(ephemeral);
-            }
-        }
-        DashScopeMessage lastMsg = messages.get(messages.size() - 1);
-        if (DashScopeChatFormatter.shouldAutoCache(lastMsg)) {
-            lastMsg.setCacheControl(ephemeral);
-        }
+        DashScopeChatFormatter.applyCacheControlToMessages(messages);
     }
 }

--- a/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-dashscope/src/main/java/io/agentscope/extensions/model/dashscope/formatter/DashScopeMultiAgentFormatter.java
+++ b/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-dashscope/src/main/java/io/agentscope/extensions/model/dashscope/formatter/DashScopeMultiAgentFormatter.java
@@ -16,6 +16,7 @@
 package io.agentscope.extensions.model.dashscope.formatter;
 
 import io.agentscope.core.formatter.AbstractBaseFormatter;
+import io.agentscope.core.message.MessageMetadataKeys;
 import io.agentscope.core.message.Msg;
 import io.agentscope.core.message.MsgRole;
 import io.agentscope.core.message.ToolResultBlock;
@@ -83,11 +84,14 @@ public class DashScopeMultiAgentFormatter
 
         // Process system message first (if any) - output separately
         if (!msgs.isEmpty() && msgs.get(0).getRole() == MsgRole.SYSTEM) {
-            result.add(
+            Msg systemMsg = msgs.get(0);
+            DashScopeMessage formattedSystemMessage =
                     DashScopeMessage.builder()
                             .role("system")
-                            .content(extractTextContent(msgs.get(0)))
-                            .build());
+                            .content(extractTextContent(systemMsg))
+                            .build();
+            messageConverter.applyCacheControlFromMetadata(systemMsg, formattedSystemMessage);
+            result.add(formattedSystemMessage);
             startIndex = 1;
         }
 
@@ -100,12 +104,14 @@ public class DashScopeMultiAgentFormatter
             if (group.type == GroupType.AGENT_MESSAGE) {
                 // Format agent messages with conversation history
                 String historyPrompt = isFirstAgentMessage ? conversationHistoryPrompt : "";
-                result.add(
+                DashScopeMessage mergedMessage =
                         conversationMerger.mergeToMessage(
                                 group.messages,
                                 msg -> msg.getName() != null ? msg.getName() : "Unknown",
                                 this::convertToolResultToString,
-                                historyPrompt));
+                                historyPrompt);
+                applyMergedCacheControlMetadata(group.messages, mergedMessage);
+                result.add(mergedMessage);
                 isFirstAgentMessage = false;
             } else if (group.type == GroupType.TOOL_SEQUENCE) {
                 // Format tool sequence directly
@@ -170,14 +176,17 @@ public class DashScopeMultiAgentFormatter
 
         // Process system message first (if any)
         if (!msgs.isEmpty() && msgs.get(0).getRole() == MsgRole.SYSTEM) {
-            result.add(
+            Msg systemMsg = msgs.get(0);
+            DashScopeMessage formattedSystemMessage =
                     DashScopeMessage.builder()
                             .role("system")
                             .content(
                                     List.of(
                                             DashScopeContentPart.text(
-                                                    extractTextContent(msgs.get(0)))))
-                            .build());
+                                                    extractTextContent(systemMsg))))
+                            .build();
+            messageConverter.applyCacheControlFromMetadata(systemMsg, formattedSystemMessage);
+            result.add(formattedSystemMessage);
             startIndex = 1;
         }
 
@@ -189,12 +198,14 @@ public class DashScopeMultiAgentFormatter
         for (MessageGroup group : groups) {
             if (group.type == GroupType.AGENT_MESSAGE) {
                 // Format agent messages with conversation history
-                result.add(
+                DashScopeMessage mergedMessage =
                         conversationMerger.mergeToMultiModalMessage(
                                 group.messages,
                                 msg -> msg.getName() != null ? msg.getName() : "Unknown",
                                 this::convertToolResultToString,
-                                isFirstAgentMessage));
+                                isFirstAgentMessage);
+                applyMergedCacheControlMetadata(group.messages, mergedMessage);
+                result.add(mergedMessage);
                 isFirstAgentMessage = false;
             } else if (group.type == GroupType.TOOL_SEQUENCE) {
                 // Format tool sequence directly
@@ -306,7 +317,9 @@ public class DashScopeMultiAgentFormatter
             builder.content(extractTextContent(msg));
         }
 
-        return builder.build();
+        DashScopeMessage result = builder.build();
+        messageConverter.applyCacheControlFromMetadata(msg, result);
+        return result;
     }
 
     /**
@@ -314,19 +327,38 @@ public class DashScopeMultiAgentFormatter
      */
     private DashScopeMessage formatToolResult(Msg msg) {
         ToolResultBlock result = msg.getFirstContentBlock(ToolResultBlock.class);
+        DashScopeMessage message;
         if (result != null) {
-            return DashScopeMessage.builder()
-                    .role("tool")
-                    .toolCallId(result.getId())
-                    .name(result.getName())
-                    .content(convertToolResultToString(result.getOutput()))
-                    .build();
+            message =
+                    DashScopeMessage.builder()
+                            .role("tool")
+                            .toolCallId(result.getId())
+                            .name(result.getName())
+                            .content(convertToolResultToString(result.getOutput()))
+                            .build();
         } else {
-            return DashScopeMessage.builder()
-                    .role("tool")
-                    .toolCallId("tool_call_" + System.currentTimeMillis())
-                    .content(extractTextContent(msg))
-                    .build();
+            message =
+                    DashScopeMessage.builder()
+                            .role("tool")
+                            .toolCallId("tool_call_" + System.currentTimeMillis())
+                            .content(extractTextContent(msg))
+                            .build();
+        }
+        messageConverter.applyCacheControlFromMetadata(msg, message);
+        return message;
+    }
+
+    private void applyMergedCacheControlMetadata(
+            List<Msg> messages, DashScopeMessage mergedMessage) {
+        // A merged output has one content boundary, so the last explicit directive wins.
+        for (int i = messages.size() - 1; i >= 0; i--) {
+            Msg message = messages.get(i);
+            if (message.getMetadata() != null
+                    && message.getMetadata().get(MessageMetadataKeys.CACHE_CONTROL)
+                            instanceof Boolean) {
+                messageConverter.applyCacheControlFromMetadata(message, mergedMessage);
+                return;
+            }
         }
     }
 

--- a/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-dashscope/src/test/java/io/agentscope/extensions/model/dashscope/formatter/DashScopeCacheControlTest.java
+++ b/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-dashscope/src/test/java/io/agentscope/extensions/model/dashscope/formatter/DashScopeCacheControlTest.java
@@ -17,12 +17,17 @@ package io.agentscope.extensions.model.dashscope.formatter;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.fasterxml.jackson.core.type.TypeReference;
 import io.agentscope.core.message.MessageMetadataKeys;
 import io.agentscope.core.message.Msg;
 import io.agentscope.core.message.MsgRole;
 import io.agentscope.core.util.JsonUtils;
+import io.agentscope.extensions.model.dashscope.dto.DashScopeContentPart;
 import io.agentscope.extensions.model.dashscope.dto.DashScopeMessage;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -64,10 +69,12 @@ class DashScopeCacheControlTest {
 
             formatter.applyCacheControl(messages);
 
-            assertEquals(EPHEMERAL, messages.get(0).getCacheControl());
-            assertNull(messages.get(1).getCacheControl());
-            assertNull(messages.get(2).getCacheControl());
-            assertEquals(EPHEMERAL, messages.get(3).getCacheControl());
+            assertCacheControlOnLastContentPart(messages.get(0), EPHEMERAL);
+            assertNoSerializedCacheControl(messages.get(1));
+            assertNoSerializedCacheControl(messages.get(2));
+            assertCacheControlOnLastContentPart(messages.get(3), EPHEMERAL);
+            assertEquals("You are helpful.", messages.get(0).getContentAsList().get(0).getText());
+            assertEquals("Question", messages.get(3).getContentAsList().get(0).getText());
         }
 
         @Test
@@ -79,8 +86,8 @@ class DashScopeCacheControlTest {
 
             formatter.applyCacheControl(messages);
 
-            assertNull(messages.get(0).getCacheControl());
-            assertEquals(EPHEMERAL, messages.get(1).getCacheControl());
+            assertNoSerializedCacheControl(messages.get(0));
+            assertCacheControlOnLastContentPart(messages.get(1), EPHEMERAL);
         }
 
         @Test
@@ -107,12 +114,12 @@ class DashScopeCacheControlTest {
 
             formatter.applyCacheControl(messages);
 
-            assertEquals(EPHEMERAL, messages.get(0).getCacheControl());
+            assertCacheControlOnLastContentPart(messages.get(0), EPHEMERAL);
         }
 
         @Test
-        @DisplayName("should not overwrite manually marked cache_control")
-        void manuallyMarkedNotOverridden() {
+        @DisplayName("should migrate a legacy system cache_control to its last content block")
+        void legacySystemMarkerMigrated() {
             Map<String, String> customCacheControl = Map.of("type", "custom");
 
             List<DashScopeMessage> messages = new ArrayList<>();
@@ -126,15 +133,13 @@ class DashScopeCacheControlTest {
 
             formatter.applyCacheControl(messages);
 
-            // System message keeps its custom cache_control
-            assertEquals(customCacheControl, messages.get(0).getCacheControl());
-            // Last message gets ephemeral
-            assertEquals(EPHEMERAL, messages.get(1).getCacheControl());
+            assertCacheControlOnLastContentPart(messages.get(0), customCacheControl);
+            assertCacheControlOnLastContentPart(messages.get(1), EPHEMERAL);
         }
 
         @Test
-        @DisplayName("should not overwrite last message with existing cache_control")
-        void lastMessageManuallyMarkedNotOverridden() {
+        @DisplayName("should migrate a legacy last-message cache_control without overwriting it")
+        void legacyLastMessageMarkerMigrated() {
             Map<String, String> customCacheControl = Map.of("type", "custom");
 
             List<DashScopeMessage> messages = new ArrayList<>();
@@ -148,10 +153,8 @@ class DashScopeCacheControlTest {
 
             formatter.applyCacheControl(messages);
 
-            // System message gets ephemeral
-            assertEquals(EPHEMERAL, messages.get(0).getCacheControl());
-            // Last message keeps its custom cache_control
-            assertEquals(customCacheControl, messages.get(1).getCacheControl());
+            assertCacheControlOnLastContentPart(messages.get(0), EPHEMERAL);
+            assertCacheControlOnLastContentPart(messages.get(1), customCacheControl);
         }
 
         @Test
@@ -164,9 +167,34 @@ class DashScopeCacheControlTest {
 
             formatter.applyCacheControl(messages);
 
-            assertEquals(EPHEMERAL, messages.get(0).getCacheControl());
-            assertEquals(EPHEMERAL, messages.get(1).getCacheControl());
-            assertEquals(EPHEMERAL, messages.get(2).getCacheControl());
+            assertCacheControlOnLastContentPart(messages.get(0), EPHEMERAL);
+            assertCacheControlOnLastContentPart(messages.get(1), EPHEMERAL);
+            assertCacheControlOnLastContentPart(messages.get(2), EPHEMERAL);
+        }
+
+        @Test
+        @DisplayName("should mark only the last existing multimodal content part")
+        void existingMultimodalContent() {
+            DashScopeContentPart text = DashScopeContentPart.text("Look at this image");
+            DashScopeContentPart image =
+                    DashScopeContentPart.builder()
+                            .image("https://example.com/image.png")
+                            .minPixels(256)
+                            .build();
+            List<DashScopeContentPart> content = new ArrayList<>(List.of(text, image));
+            DashScopeMessage message =
+                    DashScopeMessage.builder().role("user").content(content).build();
+
+            formatter.applyCacheControl(List.of(message));
+
+            assertSame(content, message.getContent());
+            assertEquals("Look at this image", content.get(0).getText());
+            assertEquals("https://example.com/image.png", content.get(1).getImage());
+            assertEquals(256, content.get(1).getMinPixels());
+            assertCacheControlOnLastContentPart(message, EPHEMERAL);
+            Map<String, Object> payload = serialize(message);
+            List<?> parts = (List<?>) payload.get("content");
+            assertFalse(((Map<?, ?>) parts.get(0)).containsKey("cache_control"));
         }
     }
 
@@ -189,7 +217,8 @@ class DashScopeCacheControlTest {
             List<DashScopeMessage> result = formatter.format(List.of(msg));
 
             assertEquals(1, result.size());
-            assertEquals(EPHEMERAL, result.get(0).getCacheControl());
+            assertCacheControlOnLastContentPart(result.get(0), EPHEMERAL);
+            assertEquals("Important context", result.get(0).getContentAsList().get(0).getText());
         }
 
         @Test
@@ -201,6 +230,7 @@ class DashScopeCacheControlTest {
 
             assertEquals(1, result.size());
             assertNull(result.get(0).getCacheControl());
+            assertNoSerializedCacheControl(result.get(0));
         }
 
         @Test
@@ -219,6 +249,7 @@ class DashScopeCacheControlTest {
 
             assertEquals(1, result.size());
             assertEquals(NO_CACHE, result.get(0).getCacheControl());
+            assertNoSerializedCacheControl(result.get(0));
         }
 
         @Test
@@ -236,9 +267,11 @@ class DashScopeCacheControlTest {
 
             List<DashScopeMessage> result = formatter.format(List.of(systemMsg, userMsg));
             formatter.applyCacheControl(result);
+            formatter.applyCacheControl(result);
 
             assertEquals(NO_CACHE, result.get(0).getCacheControl());
-            assertEquals(EPHEMERAL, result.get(1).getCacheControl());
+            assertNoSerializedCacheControl(result.get(0));
+            assertCacheControlOnLastContentPart(result.get(1), EPHEMERAL);
         }
 
         @Test
@@ -277,8 +310,8 @@ class DashScopeCacheControlTest {
             List<DashScopeMessage> result = formatter.format(List.of(systemMsg, userMsg));
 
             assertEquals(2, result.size());
-            assertEquals(EPHEMERAL, result.get(0).getCacheControl());
-            assertNull(result.get(1).getCacheControl());
+            assertCacheControlOnLastContentPart(result.get(0), EPHEMERAL);
+            assertNoSerializedCacheControl(result.get(1));
         }
     }
 
@@ -298,8 +331,42 @@ class DashScopeCacheControlTest {
 
             multiFormatter.applyCacheControl(messages);
 
-            assertEquals(EPHEMERAL, messages.get(0).getCacheControl());
-            assertEquals(EPHEMERAL, messages.get(1).getCacheControl());
+            assertCacheControlOnLastContentPart(messages.get(0), EPHEMERAL);
+            assertCacheControlOnLastContentPart(messages.get(1), EPHEMERAL);
+        }
+    }
+
+    private static Map<String, Object> serialize(DashScopeMessage message) {
+        return JsonUtils.getJsonCodec()
+                .fromJson(
+                        JsonUtils.getJsonCodec().toJson(message),
+                        new TypeReference<Map<String, Object>>() {});
+    }
+
+    private static void assertCacheControlOnLastContentPart(
+            DashScopeMessage message, Map<String, String> expected) {
+        assertNull(message.getCacheControl());
+        Map<String, Object> payload = serialize(message);
+        assertFalse(payload.containsKey("cache_control"));
+        assertTrue(payload.get("content") instanceof List<?>);
+        List<?> content = (List<?>) payload.get("content");
+        assertFalse(content.isEmpty());
+        assertTrue(content.get(content.size() - 1) instanceof Map<?, ?>);
+        Map<?, ?> lastPart = (Map<?, ?>) content.get(content.size() - 1);
+        assertEquals(expected, lastPart.get("cache_control"));
+    }
+
+    private static void assertNoSerializedCacheControl(DashScopeMessage message) {
+        Map<String, Object> payload = serialize(message);
+        assertFalse(payload.containsKey("cache_control"));
+        Object content = payload.get("content");
+        if (content instanceof List<?> parts) {
+            for (Object part : parts) {
+                assertNotNull(part);
+                if (part instanceof Map<?, ?> partMap) {
+                    assertFalse(partMap.containsKey("cache_control"));
+                }
+            }
         }
     }
 }

--- a/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-dashscope/src/test/java/io/agentscope/extensions/model/dashscope/formatter/DashScopeCacheControlTest.java
+++ b/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-dashscope/src/test/java/io/agentscope/extensions/model/dashscope/formatter/DashScopeCacheControlTest.java
@@ -334,6 +334,61 @@ class DashScopeCacheControlTest {
             assertCacheControlOnLastContentPart(messages.get(0), EPHEMERAL);
             assertCacheControlOnLastContentPart(messages.get(1), EPHEMERAL);
         }
+
+        @Test
+        @DisplayName("should preserve false metadata on a multi-agent system message")
+        void systemMetadataFalseBlocksAutomaticMarker() {
+            DashScopeMultiAgentFormatter multiFormatter = new DashScopeMultiAgentFormatter();
+            Msg systemMsg =
+                    Msg.builder()
+                            .role(MsgRole.SYSTEM)
+                            .textContent("Do not mark this prompt")
+                            .metadata(Map.of(MessageMetadataKeys.CACHE_CONTROL, false))
+                            .build();
+            Msg userMsg = Msg.builder().role(MsgRole.USER).textContent("Hello").build();
+
+            List<DashScopeMessage> messages = multiFormatter.format(List.of(systemMsg, userMsg));
+            multiFormatter.applyCacheControl(messages);
+
+            assertEquals(NO_CACHE, messages.get(0).getCacheControl());
+            assertNoSerializedCacheControl(messages.get(0));
+            assertCacheControlOnLastContentPart(messages.get(1), EPHEMERAL);
+        }
+
+        @Test
+        @DisplayName("should preserve true metadata on a merged multi-agent message")
+        void mergedMessageMetadataTrueMarksContentBlock() {
+            DashScopeMultiAgentFormatter multiFormatter = new DashScopeMultiAgentFormatter();
+            Msg msg =
+                    Msg.builder()
+                            .role(MsgRole.USER)
+                            .textContent("Remember this")
+                            .metadata(Map.of(MessageMetadataKeys.CACHE_CONTROL, true))
+                            .build();
+
+            List<DashScopeMessage> messages = multiFormatter.format(List.of(msg));
+
+            assertCacheControlOnLastContentPart(messages.get(0), EPHEMERAL);
+        }
+
+        @Test
+        @DisplayName("should preserve false metadata on a merged multi-agent message")
+        void mergedMessageMetadataFalseBlocksRepeatedAutomaticMarker() {
+            DashScopeMultiAgentFormatter multiFormatter = new DashScopeMultiAgentFormatter();
+            Msg msg =
+                    Msg.builder()
+                            .role(MsgRole.USER)
+                            .textContent("Do not mark this message")
+                            .metadata(Map.of(MessageMetadataKeys.CACHE_CONTROL, false))
+                            .build();
+
+            List<DashScopeMessage> messages = multiFormatter.format(List.of(msg));
+            multiFormatter.applyCacheControl(messages);
+            multiFormatter.applyCacheControl(messages);
+
+            assertEquals(NO_CACHE, messages.get(0).getCacheControl());
+            assertNoSerializedCacheControl(messages.get(0));
+        }
     }
 
     private static Map<String, Object> serialize(DashScopeMessage message) {

--- a/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-openai/src/main/java/io/agentscope/extensions/model/openai/dto/OpenAIContentPart.java
+++ b/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-openai/src/main/java/io/agentscope/extensions/model/openai/dto/OpenAIContentPart.java
@@ -17,6 +17,7 @@ package io.agentscope.extensions.model.openai.dto;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Map;
 
 /**
  * OpenAI content part DTO for multimodal messages.
@@ -65,6 +66,11 @@ public class OpenAIContentPart {
     @JsonProperty("video_url")
     private OpenAIVideoUrl videoUrl;
 
+    /** Cache control configuration for this content part. */
+    @JsonProperty("cache_control")
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    private Map<String, String> cacheControl;
+
     public OpenAIContentPart() {}
 
     public String getType() {
@@ -105,6 +111,24 @@ public class OpenAIContentPart {
 
     public void setVideoUrl(OpenAIVideoUrl videoUrl) {
         this.videoUrl = videoUrl;
+    }
+
+    /**
+     * Get the cache control configuration.
+     *
+     * @return the cache control configuration, or null when not configured
+     */
+    public Map<String, String> getCacheControl() {
+        return cacheControl;
+    }
+
+    /**
+     * Set the cache control configuration.
+     *
+     * @param cacheControl the cache control configuration
+     */
+    public void setCacheControl(Map<String, String> cacheControl) {
+        this.cacheControl = cacheControl;
     }
 
     /**
@@ -203,6 +227,17 @@ public class OpenAIContentPart {
 
         public Builder videoUrl(OpenAIVideoUrl videoUrl) {
             part.setVideoUrl(videoUrl);
+            return this;
+        }
+
+        /**
+         * Set the cache control configuration.
+         *
+         * @param cacheControl the cache control configuration
+         * @return this builder
+         */
+        public Builder cacheControl(Map<String, String> cacheControl) {
+            part.setCacheControl(cacheControl);
             return this;
         }
 

--- a/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-openai/src/main/java/io/agentscope/extensions/model/openai/dto/OpenAIMessage.java
+++ b/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-openai/src/main/java/io/agentscope/extensions/model/openai/dto/OpenAIMessage.java
@@ -98,13 +98,11 @@ public class OpenAIMessage {
     private String refusal;
 
     /**
-     * Cache control configuration for prompt caching.
+     * Legacy message-level cache control state.
      *
-     * <p>Tri-state: {@code null} means "not specified" (the automatic cache-control strategy may
-     * add {@code {"type": "ephemeral"}}); a non-empty map is an explicit {@code cache_control}
-     * value; an empty map is the explicit "no cache" sentinel — combined with
-     * {@link JsonInclude.Include#NON_EMPTY} it is serialized away, so the API receives no
-     * {@code cache_control} field and therefore performs no caching.
+     * <p>Non-empty legacy values are migrated to a content part by the formatter. {@code null}
+     * means "not specified"; an empty map is the explicit "no marker" sentinel and is serialized
+     * away by {@link JsonInclude.Include#NON_EMPTY} while still blocking the automatic strategy.
      */
     @JsonProperty("cache_control")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)

--- a/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-openai/src/main/java/io/agentscope/extensions/model/openai/formatter/OpenAIBaseFormatter.java
+++ b/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-openai/src/main/java/io/agentscope/extensions/model/openai/formatter/OpenAIBaseFormatter.java
@@ -20,6 +20,7 @@ import io.agentscope.core.model.ChatResponse;
 import io.agentscope.core.model.GenerateOptions;
 import io.agentscope.core.model.ToolChoice;
 import io.agentscope.core.model.ToolSchema;
+import io.agentscope.extensions.model.openai.dto.OpenAIContentPart;
 import io.agentscope.extensions.model.openai.dto.OpenAIMessage;
 import io.agentscope.extensions.model.openai.dto.OpenAIRequest;
 import io.agentscope.extensions.model.openai.dto.OpenAIResponse;
@@ -46,9 +47,9 @@ public abstract class OpenAIBaseFormatter
     private static final Map<String, String> EPHEMERAL_CACHE_CONTROL = Map.of("type", "ephemeral");
 
     /**
-     * Sentinel for an explicit "no cache" intent. An empty map is serialized away (via
+     * Sentinel for an explicit "no marker" intent. An empty map is serialized away (via
      * {@code @JsonInclude(NON_EMPTY)} on {@link OpenAIMessage#cacheControl}), so the upstream API
-     * receives no {@code cache_control} field and therefore performs no caching.
+     * receives no explicit {@code cache_control} marker.
      */
     private static final Map<String, String> NO_CACHE_CONTROL = Collections.emptyMap();
 
@@ -180,9 +181,9 @@ public abstract class OpenAIBaseFormatter
     /**
      * Apply cache control to OpenAI messages.
      *
-     * <p>Adds <code>cache_control: {"type": "ephemeral"}</code> to all system messages and the last
-     * message in the list. Messages that already carry a cache_control value (including the empty
-     * "no cache" sentinel) are left untouched.
+     * <p>Adds <code>cache_control: {"type": "ephemeral"}</code> to the last content part of all
+     * system messages and the last message in the list. Legacy message-level values are migrated to
+     * the last content part. Messages explicitly excluded from caching are left untouched.
      *
      * @param messages the list of formatted OpenAI messages
      */
@@ -191,14 +192,53 @@ public abstract class OpenAIBaseFormatter
             return;
         }
         for (OpenAIMessage msg : messages) {
+            migrateLegacyCacheControl(msg);
+        }
+        for (OpenAIMessage msg : messages) {
             if ("system".equals(msg.getRole()) && shouldAutoCache(msg)) {
-                msg.setCacheControl(EPHEMERAL_CACHE_CONTROL);
+                setCacheControlOnContent(msg, EPHEMERAL_CACHE_CONTROL);
             }
         }
         OpenAIMessage lastMsg = messages.get(messages.size() - 1);
         if (shouldAutoCache(lastMsg)) {
-            lastMsg.setCacheControl(EPHEMERAL_CACHE_CONTROL);
+            setCacheControlOnContent(lastMsg, EPHEMERAL_CACHE_CONTROL);
         }
+    }
+
+    static void setCacheControlOnContent(OpenAIMessage message, Map<String, String> cacheControl) {
+        OpenAIContentPart lastPart = getOrCreateLastContentPart(message);
+        if (lastPart != null && lastPart.getCacheControl() == null) {
+            lastPart.setCacheControl(cacheControl);
+        }
+        message.setCacheControl(null);
+    }
+
+    private static void migrateLegacyCacheControl(OpenAIMessage message) {
+        Map<String, String> legacyCacheControl = message.getCacheControl();
+        if (legacyCacheControl != null && !legacyCacheControl.isEmpty()) {
+            setCacheControlOnContent(message, legacyCacheControl);
+        }
+    }
+
+    private static OpenAIContentPart getOrCreateLastContentPart(OpenAIMessage message) {
+        Object content = message.getContent();
+        if (content instanceof String text) {
+            OpenAIContentPart textPart = OpenAIContentPart.text(text);
+            message.setContent(List.of(textPart));
+            return textPart;
+        }
+        return findLastContentPart(content);
+    }
+
+    private static OpenAIContentPart findLastContentPart(Object content) {
+        if (content instanceof List<?> parts) {
+            for (int i = parts.size() - 1; i >= 0; i--) {
+                if (parts.get(i) instanceof OpenAIContentPart part) {
+                    return part;
+                }
+            }
+        }
+        return null;
     }
 
     /**
@@ -211,9 +251,9 @@ public abstract class OpenAIBaseFormatter
     }
 
     /**
-     * Get the "no cache" sentinel constant.
+     * Get the "no marker" sentinel constant.
      *
-     * @return unmodifiable empty map representing an explicit "no cache" intent
+     * @return unmodifiable empty map representing an explicit "no marker" intent
      */
     static Map<String, String> getNoCacheControl() {
         return NO_CACHE_CONTROL;
@@ -222,14 +262,18 @@ public abstract class OpenAIBaseFormatter
     /**
      * Whether the automatic cache-control strategy should mark a message as ephemeral.
      *
-     * <p>Returns {@code true} only when the message has no cache_control value at all. Any non-null
-     * value — an explicit {@code {"type": "ephemeral"}}, a custom value, or the empty "no cache"
-     * sentinel — is left unchanged.
+     * <p>Returns {@code true} only when neither the legacy message-level state nor the last content
+     * part carries a cache-control value. The empty message-level "no marker" sentinel is therefore
+     * preserved across repeated automatic-strategy passes.
      *
      * @param message the message to inspect
      * @return {@code true} if the message should be auto-cached, {@code false} otherwise
      */
     private static boolean shouldAutoCache(OpenAIMessage message) {
-        return message.getCacheControl() == null;
+        if (message.getCacheControl() != null) {
+            return false;
+        }
+        OpenAIContentPart lastPart = findLastContentPart(message.getContent());
+        return lastPart == null || lastPart.getCacheControl() == null;
     }
 }

--- a/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-openai/src/main/java/io/agentscope/extensions/model/openai/formatter/OpenAIMessageConverter.java
+++ b/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-openai/src/main/java/io/agentscope/extensions/model/openai/formatter/OpenAIMessageConverter.java
@@ -534,7 +534,7 @@ public class OpenAIMessageConverter {
      * @param msg the source message with metadata
      * @param result the converted OpenAI message
      */
-    private void applyCacheControlFromMetadata(Msg msg, OpenAIMessage result) {
+    void applyCacheControlFromMetadata(Msg msg, OpenAIMessage result) {
         if (msg.getMetadata() == null) {
             return;
         }

--- a/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-openai/src/main/java/io/agentscope/extensions/model/openai/formatter/OpenAIMessageConverter.java
+++ b/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-openai/src/main/java/io/agentscope/extensions/model/openai/formatter/OpenAIMessageConverter.java
@@ -541,7 +541,8 @@ public class OpenAIMessageConverter {
         Object cacheFlag = msg.getMetadata().get(MessageMetadataKeys.CACHE_CONTROL);
         if (Boolean.TRUE.equals(cacheFlag)) {
             if (result.getCacheControl() == null || result.getCacheControl().isEmpty()) {
-                result.setCacheControl(OpenAIBaseFormatter.getEphemeralCacheControl());
+                OpenAIBaseFormatter.setCacheControlOnContent(
+                        result, OpenAIBaseFormatter.getEphemeralCacheControl());
             }
         } else if (Boolean.FALSE.equals(cacheFlag)) {
             result.setCacheControl(OpenAIBaseFormatter.getNoCacheControl());

--- a/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-openai/src/main/java/io/agentscope/extensions/model/openai/formatter/OpenAIMultiAgentFormatter.java
+++ b/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-openai/src/main/java/io/agentscope/extensions/model/openai/formatter/OpenAIMultiAgentFormatter.java
@@ -15,6 +15,7 @@
  */
 package io.agentscope.extensions.model.openai.formatter;
 
+import io.agentscope.core.message.MessageMetadataKeys;
 import io.agentscope.core.message.Msg;
 import io.agentscope.core.message.MsgRole;
 import io.agentscope.core.message.ToolUseBlock;
@@ -77,11 +78,13 @@ public class OpenAIMultiAgentFormatter extends OpenAIChatFormatter {
                 }
                 case TOOL_SEQUENCE -> result.addAll(formatToolSequence(group.messages));
                 case AGENT_CONVERSATION -> {
-                    result.add(
+                    OpenAIMessage mergedMessage =
                             conversationMerger.mergeToUserMessage(
                                     group.messages,
                                     msg -> formatRoleLabel(msg.getRole()),
-                                    this::convertToolResultToString));
+                                    this::convertToolResultToString);
+                    applyMergedCacheControlMetadata(group.messages, mergedMessage);
+                    result.add(mergedMessage);
                 }
                 case BYPASS -> {
                     Msg bypassMsg = group.messages.get(0);
@@ -91,6 +94,19 @@ public class OpenAIMultiAgentFormatter extends OpenAIChatFormatter {
         }
 
         return result;
+    }
+
+    private void applyMergedCacheControlMetadata(List<Msg> messages, OpenAIMessage mergedMessage) {
+        // A merged output has one content boundary, so the last explicit directive wins.
+        for (int i = messages.size() - 1; i >= 0; i--) {
+            Msg message = messages.get(i);
+            if (message.getMetadata() != null
+                    && message.getMetadata().get(MessageMetadataKeys.CACHE_CONTROL)
+                            instanceof Boolean) {
+                messageConverter.applyCacheControlFromMetadata(message, mergedMessage);
+                return;
+            }
+        }
     }
 
     // ========== Private Helper Methods ==========

--- a/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-openai/src/test/java/io/agentscope/extensions/model/openai/formatter/OpenAICacheControlTest.java
+++ b/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-openai/src/test/java/io/agentscope/extensions/model/openai/formatter/OpenAICacheControlTest.java
@@ -17,12 +17,17 @@ package io.agentscope.extensions.model.openai.formatter;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.fasterxml.jackson.core.type.TypeReference;
 import io.agentscope.core.message.MessageMetadataKeys;
 import io.agentscope.core.message.Msg;
 import io.agentscope.core.message.MsgRole;
 import io.agentscope.core.util.JsonUtils;
+import io.agentscope.extensions.model.openai.dto.OpenAIContentPart;
 import io.agentscope.extensions.model.openai.dto.OpenAIMessage;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -64,10 +69,12 @@ class OpenAICacheControlTest {
 
             formatter.applyCacheControl(messages);
 
-            assertEquals(EPHEMERAL, messages.get(0).getCacheControl());
-            assertNull(messages.get(1).getCacheControl());
-            assertNull(messages.get(2).getCacheControl());
-            assertEquals(EPHEMERAL, messages.get(3).getCacheControl());
+            assertCacheControlOnLastContentPart(messages.get(0), EPHEMERAL);
+            assertNoSerializedCacheControl(messages.get(1));
+            assertNoSerializedCacheControl(messages.get(2));
+            assertCacheControlOnLastContentPart(messages.get(3), EPHEMERAL);
+            assertEquals("You are helpful.", messages.get(0).getContentAsList().get(0).getText());
+            assertEquals("Question", messages.get(3).getContentAsList().get(0).getText());
         }
 
         @Test
@@ -79,8 +86,8 @@ class OpenAICacheControlTest {
 
             formatter.applyCacheControl(messages);
 
-            assertNull(messages.get(0).getCacheControl());
-            assertEquals(EPHEMERAL, messages.get(1).getCacheControl());
+            assertNoSerializedCacheControl(messages.get(0));
+            assertCacheControlOnLastContentPart(messages.get(1), EPHEMERAL);
         }
 
         @Test
@@ -107,12 +114,12 @@ class OpenAICacheControlTest {
 
             formatter.applyCacheControl(messages);
 
-            assertEquals(EPHEMERAL, messages.get(0).getCacheControl());
+            assertCacheControlOnLastContentPart(messages.get(0), EPHEMERAL);
         }
 
         @Test
-        @DisplayName("should not overwrite manually marked cache_control")
-        void manuallyMarkedNotOverridden() {
+        @DisplayName("should migrate a legacy system cache_control to its last content block")
+        void legacySystemMarkerMigrated() {
             Map<String, String> customCacheControl = Map.of("type", "custom");
 
             List<OpenAIMessage> messages = new ArrayList<>();
@@ -126,15 +133,13 @@ class OpenAICacheControlTest {
 
             formatter.applyCacheControl(messages);
 
-            // System message keeps its custom cache_control
-            assertEquals(customCacheControl, messages.get(0).getCacheControl());
-            // Last message gets ephemeral
-            assertEquals(EPHEMERAL, messages.get(1).getCacheControl());
+            assertCacheControlOnLastContentPart(messages.get(0), customCacheControl);
+            assertCacheControlOnLastContentPart(messages.get(1), EPHEMERAL);
         }
 
         @Test
-        @DisplayName("should not overwrite last message with existing cache_control")
-        void lastMessageManuallyMarkedNotOverridden() {
+        @DisplayName("should migrate a legacy last-message cache_control without overwriting it")
+        void legacyLastMessageMarkerMigrated() {
             Map<String, String> customCacheControl = Map.of("type", "custom");
 
             List<OpenAIMessage> messages = new ArrayList<>();
@@ -148,10 +153,8 @@ class OpenAICacheControlTest {
 
             formatter.applyCacheControl(messages);
 
-            // System message gets ephemeral
-            assertEquals(EPHEMERAL, messages.get(0).getCacheControl());
-            // Last message keeps its custom cache_control
-            assertEquals(customCacheControl, messages.get(1).getCacheControl());
+            assertCacheControlOnLastContentPart(messages.get(0), EPHEMERAL);
+            assertCacheControlOnLastContentPart(messages.get(1), customCacheControl);
         }
 
         @Test
@@ -164,9 +167,30 @@ class OpenAICacheControlTest {
 
             formatter.applyCacheControl(messages);
 
-            assertEquals(EPHEMERAL, messages.get(0).getCacheControl());
-            assertEquals(EPHEMERAL, messages.get(1).getCacheControl());
-            assertEquals(EPHEMERAL, messages.get(2).getCacheControl());
+            assertCacheControlOnLastContentPart(messages.get(0), EPHEMERAL);
+            assertCacheControlOnLastContentPart(messages.get(1), EPHEMERAL);
+            assertCacheControlOnLastContentPart(messages.get(2), EPHEMERAL);
+        }
+
+        @Test
+        @DisplayName("should mark only the last existing multimodal content part")
+        void existingMultimodalContent() {
+            OpenAIContentPart text = OpenAIContentPart.text("Look at this image");
+            OpenAIContentPart image =
+                    OpenAIContentPart.imageUrl("https://example.com/image.png", "high");
+            List<OpenAIContentPart> content = new ArrayList<>(List.of(text, image));
+            OpenAIMessage message = OpenAIMessage.builder().role("user").content(content).build();
+
+            formatter.applyCacheControl(List.of(message));
+
+            assertSame(content, message.getContent());
+            assertEquals("Look at this image", content.get(0).getText());
+            assertEquals("https://example.com/image.png", content.get(1).getImageUrl().getUrl());
+            assertEquals("high", content.get(1).getImageUrl().getDetail());
+            assertCacheControlOnLastContentPart(message, EPHEMERAL);
+            Map<String, Object> payload = serialize(message);
+            List<?> parts = (List<?>) payload.get("content");
+            assertFalse(((Map<?, ?>) parts.get(0)).containsKey("cache_control"));
         }
     }
 
@@ -189,7 +213,8 @@ class OpenAICacheControlTest {
             List<OpenAIMessage> result = formatter.format(List.of(msg));
 
             assertEquals(1, result.size());
-            assertEquals(EPHEMERAL, result.get(0).getCacheControl());
+            assertCacheControlOnLastContentPart(result.get(0), EPHEMERAL);
+            assertEquals("Important context", result.get(0).getContentAsList().get(0).getText());
         }
 
         @Test
@@ -201,6 +226,7 @@ class OpenAICacheControlTest {
 
             assertEquals(1, result.size());
             assertNull(result.get(0).getCacheControl());
+            assertNoSerializedCacheControl(result.get(0));
         }
 
         @Test
@@ -219,6 +245,7 @@ class OpenAICacheControlTest {
 
             assertEquals(1, result.size());
             assertEquals(NO_CACHE, result.get(0).getCacheControl());
+            assertNoSerializedCacheControl(result.get(0));
         }
 
         @Test
@@ -236,9 +263,11 @@ class OpenAICacheControlTest {
 
             List<OpenAIMessage> result = formatter.format(List.of(systemMsg, userMsg));
             formatter.applyCacheControl(result);
+            formatter.applyCacheControl(result);
 
             assertEquals(NO_CACHE, result.get(0).getCacheControl());
-            assertEquals(EPHEMERAL, result.get(1).getCacheControl());
+            assertNoSerializedCacheControl(result.get(0));
+            assertCacheControlOnLastContentPart(result.get(1), EPHEMERAL);
         }
 
         @Test
@@ -277,8 +306,42 @@ class OpenAICacheControlTest {
             List<OpenAIMessage> result = formatter.format(List.of(systemMsg, userMsg));
 
             assertEquals(2, result.size());
-            assertEquals(EPHEMERAL, result.get(0).getCacheControl());
-            assertNull(result.get(1).getCacheControl());
+            assertCacheControlOnLastContentPart(result.get(0), EPHEMERAL);
+            assertNoSerializedCacheControl(result.get(1));
+        }
+    }
+
+    private static Map<String, Object> serialize(OpenAIMessage message) {
+        return JsonUtils.getJsonCodec()
+                .fromJson(
+                        JsonUtils.getJsonCodec().toJson(message),
+                        new TypeReference<Map<String, Object>>() {});
+    }
+
+    private static void assertCacheControlOnLastContentPart(
+            OpenAIMessage message, Map<String, String> expected) {
+        assertNull(message.getCacheControl());
+        Map<String, Object> payload = serialize(message);
+        assertFalse(payload.containsKey("cache_control"));
+        assertTrue(payload.get("content") instanceof List<?>);
+        List<?> content = (List<?>) payload.get("content");
+        assertFalse(content.isEmpty());
+        assertTrue(content.get(content.size() - 1) instanceof Map<?, ?>);
+        Map<?, ?> lastPart = (Map<?, ?>) content.get(content.size() - 1);
+        assertEquals(expected, lastPart.get("cache_control"));
+    }
+
+    private static void assertNoSerializedCacheControl(OpenAIMessage message) {
+        Map<String, Object> payload = serialize(message);
+        assertFalse(payload.containsKey("cache_control"));
+        Object content = payload.get("content");
+        if (content instanceof List<?> parts) {
+            for (Object part : parts) {
+                assertNotNull(part);
+                if (part instanceof Map<?, ?> partMap) {
+                    assertFalse(partMap.containsKey("cache_control"));
+                }
+            }
         }
     }
 }

--- a/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-openai/src/test/java/io/agentscope/extensions/model/openai/formatter/OpenAICacheControlTest.java
+++ b/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-openai/src/test/java/io/agentscope/extensions/model/openai/formatter/OpenAICacheControlTest.java
@@ -311,6 +311,46 @@ class OpenAICacheControlTest {
         }
     }
 
+    @Nested
+    @DisplayName("OpenAIMultiAgentFormatter cache_control")
+    class MultiAgentFormatterTest {
+
+        @Test
+        @DisplayName("should preserve true metadata on a merged multi-agent message")
+        void mergedMessageMetadataTrueMarksContentBlock() {
+            OpenAIMultiAgentFormatter multiFormatter = new OpenAIMultiAgentFormatter();
+            Msg msg =
+                    Msg.builder()
+                            .role(MsgRole.USER)
+                            .textContent("Remember this")
+                            .metadata(Map.of(MessageMetadataKeys.CACHE_CONTROL, true))
+                            .build();
+
+            List<OpenAIMessage> messages = multiFormatter.format(List.of(msg));
+
+            assertCacheControlOnLastContentPart(messages.get(0), EPHEMERAL);
+        }
+
+        @Test
+        @DisplayName("should preserve false metadata on a merged multi-agent message")
+        void mergedMessageMetadataFalseBlocksRepeatedAutomaticMarker() {
+            OpenAIMultiAgentFormatter multiFormatter = new OpenAIMultiAgentFormatter();
+            Msg msg =
+                    Msg.builder()
+                            .role(MsgRole.USER)
+                            .textContent("Do not mark this message")
+                            .metadata(Map.of(MessageMetadataKeys.CACHE_CONTROL, false))
+                            .build();
+
+            List<OpenAIMessage> messages = multiFormatter.format(List.of(msg));
+            multiFormatter.applyCacheControl(messages);
+            multiFormatter.applyCacheControl(messages);
+
+            assertEquals(NO_CACHE, messages.get(0).getCacheControl());
+            assertNoSerializedCacheControl(messages.get(0));
+        }
+    }
+
     private static Map<String, Object> serialize(OpenAIMessage message) {
         return JsonUtils.getJsonCodec()
                 .fromJson(


### PR DESCRIPTION
## AgentScope-Java Version

2.0.3-SNAPSHOT

## Description

Fixes #1363

Supersedes #1377

DashScope native and OpenAI-compatible requests currently serialize explicit
`cache_control` markers at message level. The provider wire format expects the
marker on a content block instead.

This change:

- places automatic and metadata-driven markers on the final suitable content
  block of each selected message;
- converts marked string content to a text content-part array;
- preserves existing multimodal content and changes only its final suitable
  block;
- migrates legacy message-level markers and clears the invalid placement;
- preserves the empty-map `CACHE_CONTROL=false` sentinel so no marker is
  serialized and repeated automatic passes cannot add one; and
- carries explicit cache metadata through the multi-agent merge paths. When
  multiple source messages become one output block, the last explicit Boolean
  directive applies to that merged boundary.

The existing automatic selection remains unchanged: all system messages plus
the final message. Dynamic Hook caching policy and the provider's four-marker
limit are intentionally out of scope.

Thanks to @flystar32 for the original implementation and investigation in
#1377. This PR refreshes the fix for the current provider-module layout and
also handles legacy-marker migration and the false sentinel.

### Testing

- TDD regression cycle for `DashScopeCacheControlTest` and
  `OpenAICacheControlTest` (expected failures recorded before implementation)
- `mvn -B -T1 -pl agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-dashscope,agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-openai -am clean verify`

The verification covers local formatting, compilation, Javadocs, unit tests,
and final JSON serialization. No live provider E2E call was performed.

## Checklist

- [x] Code has been formatted with `mvn spotless:apply`
- [x] Relevant module and dependency tests pass with scoped `clean verify`
- [x] Javadoc comments are complete and follow project conventions
- [x] Documentation impact was assessed; no user-facing documentation change is required
- [ ] Code is ready for review (kept unchecked while this PR is a draft)
