### PR TITLE
docs: replace deprecated ToolExecutionContext with PermissionContextState (#2879)

### DIFF
--- a/docs/v2/en/docs/building-blocks/tool.md
+++ b/docs/v2/en/docs/building-blocks/tool.md
@@ -125,10 +125,10 @@ When you need a custom permission policy, external execution, or a more complex 
 import io.agentscope.core.message.TextBlock;
 import io.agentscope.core.message.ToolResultBlock;
 import io.agentscope.core.permission.PermissionBehavior;
+import io.agentscope.core.permission.PermissionContextState;
 import io.agentscope.core.permission.PermissionDecision;
 import io.agentscope.core.tool.ToolBase;
 import io.agentscope.core.tool.ToolCallParam;
-import io.agentscope.core.tool.ToolExecutionContext;
 import java.util.List;
 import java.util.Map;
 import reactor.core.publisher.Mono;
@@ -153,7 +153,7 @@ public class WebSearchTool extends ToolBase {
 
     @Override
     public Mono<PermissionDecision> checkPermissions(
-            Map<String, Object> toolInput, ToolExecutionContext context) {
+            Map<String, Object> toolInput, PermissionContextState context) {
         return Mono.just(PermissionDecision.allow("Web search is read-only."));
     }
 
@@ -180,9 +180,9 @@ This pattern is the foundation of [human-in-the-loop](./agent.md#human-in-the-lo
 To create an external tool, set `externalTool` to `true` and skip implementing `callAsync`:
 
 ```java
+import io.agentscope.core.permission.PermissionContextState;
 import io.agentscope.core.permission.PermissionDecision;
 import io.agentscope.core.tool.ToolBase;
-import io.agentscope.core.tool.ToolExecutionContext;
 import java.util.List;
 import java.util.Map;
 import reactor.core.publisher.Mono;
@@ -207,7 +207,7 @@ public class HumanApprovalTool extends ToolBase {
 
     @Override
     public Mono<PermissionDecision> checkPermissions(
-            Map<String, Object> toolInput, ToolExecutionContext context) {
+            Map<String, Object> toolInput, PermissionContextState context) {
         return Mono.just(PermissionDecision.allow("External tool dispatch is always allowed."));
     }
 }

--- a/docs/v2/zh/docs/building-blocks/tool.md
+++ b/docs/v2/zh/docs/building-blocks/tool.md
@@ -125,10 +125,10 @@ toolkit.registerTool(new SimpleTools());
 import io.agentscope.core.message.TextBlock;
 import io.agentscope.core.message.ToolResultBlock;
 import io.agentscope.core.permission.PermissionBehavior;
+import io.agentscope.core.permission.PermissionContextState;
 import io.agentscope.core.permission.PermissionDecision;
 import io.agentscope.core.tool.ToolBase;
 import io.agentscope.core.tool.ToolCallParam;
-import io.agentscope.core.tool.ToolExecutionContext;
 import java.util.List;
 import java.util.Map;
 import reactor.core.publisher.Mono;
@@ -153,7 +153,7 @@ public class WebSearchTool extends ToolBase {
 
     @Override
     public Mono<PermissionDecision> checkPermissions(
-            Map<String, Object> toolInput, ToolExecutionContext context) {
+            Map<String, Object> toolInput, PermissionContextState context) {
         return Mono.just(PermissionDecision.allow("Web search is read-only."));
     }
 
@@ -180,9 +180,9 @@ public class WebSearchTool extends ToolBase {
 创建外部执行 tool 只需把 `externalTool` 设为 `true`，不必实现 `callAsync`：
 
 ```java
+import io.agentscope.core.permission.PermissionContextState;
 import io.agentscope.core.permission.PermissionDecision;
 import io.agentscope.core.tool.ToolBase;
-import io.agentscope.core.tool.ToolExecutionContext;
 import java.util.List;
 import java.util.Map;
 import reactor.core.publisher.Mono;
@@ -207,7 +207,7 @@ public class HumanApprovalTool extends ToolBase {
 
     @Override
     public Mono<PermissionDecision> checkPermissions(
-            Map<String, Object> toolInput, ToolExecutionContext context) {
+            Map<String, Object> toolInput, PermissionContextState context) {
         return Mono.just(PermissionDecision.allow("External tool dispatch is always allowed."));
     }
 }


### PR DESCRIPTION
## 描述

修复文档中使用已弃用的 `ToolExecutionContext` 参数类型的问题。

## 变更内容

- 将 `WebSearchTool` 示例中的 `checkPermissions()` 方法参数从 `ToolExecutionContext` 更新为 `PermissionContextState`
- 将 `HumanApprovalTool` 示例中的 `checkPermissions()` 方法参数从 `ToolExecutionContext` 更新为 `PermissionContextState`
- 同时更新了中英文文档
- 更新了相应的 import 语句

## 关联 Issue

Closes #2879

## 测试

- [x] 检查了代码库中 `ToolExecutionContext` 已被标记为 `@Deprecated`
- [x] 确认 `PermissionContextState` 是正确的替代类型
- [x] 更新了中英文两个版本的文档

## 影响范围

- 仅文档更新，不涉及代码逻辑修改
- 影响文件：
  - `docs/v2/zh/docs/building-blocks/tool.md`
  - `docs/v2/en/docs/building-blocks/tool.md`