### PR TITLE
feat(models): add OrcaRouter as a named OpenAI-compatible provider

### DIFF
--- a/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-openai/src/main/java/io/agentscope/extensions/model/openai/compat/orcarouter/OrcaRouterModelProvider.java
+++ b/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-openai/src/main/java/io/agentscope/extensions/model/openai/compat/orcarouter/OrcaRouterModelProvider.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.extensions.model.openai.compat.orcarouter;
+
+import static io.agentscope.core.model.ModelProviderSupport.firstNonBlank;
+import static io.agentscope.core.model.ModelProviderSupport.trimToNull;
+import static io.agentscope.extensions.model.openai.OpenAIModelProviderSupport.applyAdvancedOptions;
+
+import io.agentscope.core.formatter.Formatter;
+import io.agentscope.core.model.GenerateOptions;
+import io.agentscope.core.model.Model;
+import io.agentscope.core.model.ModelCreationContext;
+import io.agentscope.core.model.spi.ModelProvider;
+import io.agentscope.extensions.model.openai.OpenAIChatModel;
+import io.agentscope.extensions.model.openai.formatter.OpenAIChatFormatter;
+import java.util.regex.Pattern;
+
+/**
+ * OrcaRouter provider registered through {@link java.util.ServiceLoader}.
+ *
+ * <p>OrcaRouter is an OpenAI-compatible AI gateway that exposes a provider/model namespace
+ * across many models — the same Chat Completions shape as OpenRouter — so this provider creates
+ * {@link OpenAIChatModel} instances preconfigured for OrcaRouter:
+ * <ul>
+ *   <li>Base URL defaults to {@code https://api.orcarouter.ai/v1}</li>
+ *   <li>Formatter defaults to {@link OpenAIChatFormatter}; a custom {@link Formatter} component
+ *       in the {@link ModelCreationContext} takes precedence</li>
+ *   <li>Native structured output defaults to disabled, because OrcaRouter routes to a mix of
+ *       upstream providers whose {@code response_format} support varies; the agent falls back to
+ *       the {@code generate_response} tool instead</li>
+ * </ul>
+ *
+ * <p>The API key is taken from {@link ModelCreationContext#getApiKey()}, then from the
+ * {@code ORCAROUTER_API_KEY} environment variable.
+ *
+ * <p>Usage:
+ * <pre>{@code
+ * ReActAgent agent = ReActAgent.builder()
+ *     .name("assistant")
+ *     .model("orcarouter:openai/gpt-5.5") // resolved by ModelRegistry through this provider
+ *     .build();
+ * }</pre>
+ */
+public final class OrcaRouterModelProvider implements ModelProvider {
+
+    private static final String PREFIX = "orcarouter:";
+    private static final Pattern MODEL_ID = Pattern.compile("orcarouter:.+");
+    private static final String DEFAULT_BASE_URL = "https://api.orcarouter.ai/v1";
+
+    @Override
+    public String providerId() {
+        return "orcarouter";
+    }
+
+    @Override
+    public boolean supports(String modelId) {
+        return modelId != null && MODEL_ID.matcher(modelId).matches();
+    }
+
+    @Override
+    public Model create(String modelId) {
+        return create(modelId, ModelCreationContext.empty());
+    }
+
+    @Override
+    public Model create(String modelId, ModelCreationContext context) {
+        if (!supports(modelId)) {
+            throw new IllegalArgumentException("Unsupported OrcaRouter model id: " + modelId);
+        }
+
+        String apiKey = firstNonBlank(context.getApiKey(), System.getenv("ORCAROUTER_API_KEY"));
+        if (apiKey == null) {
+            throw new IllegalStateException(
+                    "Environment variable ORCAROUTER_API_KEY is required to auto-create model: "
+                            + modelId);
+        }
+        String modelName = trimToNull(modelId.substring(PREFIX.length()));
+        String baseUrl = firstNonBlank(context.getBaseUrl(), DEFAULT_BASE_URL);
+        String endpointPath = trimToNull(context.getEndpointPath());
+        boolean stream = context.getStream() != null ? context.getStream() : true;
+
+        OpenAIChatModel.Builder builder =
+                OpenAIChatModel.builder().apiKey(apiKey).modelName(modelName).stream(stream)
+                        .baseUrl(baseUrl)
+                        .endpointPath(endpointPath)
+                        .formatter(new OpenAIChatFormatter())
+                        .nativeStructuredOutput(false);
+
+        GenerateOptions userOptions = context.component(GenerateOptions.class);
+        applyAdvancedOptions(builder, context, userOptions);
+        return builder.build();
+    }
+}

--- a/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-openai/src/main/resources/META-INF/services/io.agentscope.core.model.spi.ModelProvider
+++ b/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-openai/src/main/resources/META-INF/services/io.agentscope.core.model.spi.ModelProvider
@@ -3,3 +3,4 @@ io.agentscope.extensions.model.openai.compat.kimi.KimiModelProvider
 io.agentscope.extensions.model.openai.compat.minimax.MiniMaxModelProvider
 io.agentscope.extensions.model.openai.compat.glm.GLMModelProvider
 io.agentscope.extensions.model.openai.compat.deepseek.DeepSeekModelProvider
+io.agentscope.extensions.model.openai.compat.orcarouter.OrcaRouterModelProvider

--- a/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-openai/src/test/java/io/agentscope/extensions/model/openai/compat/orcarouter/OrcaRouterModelProviderE2ETest.java
+++ b/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-openai/src/test/java/io/agentscope/extensions/model/openai/compat/orcarouter/OrcaRouterModelProviderE2ETest.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.extensions.model.openai.compat.orcarouter;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import io.agentscope.core.message.ContentBlock;
+import io.agentscope.core.message.Msg;
+import io.agentscope.core.message.MsgRole;
+import io.agentscope.core.message.TextBlock;
+import io.agentscope.core.message.ThinkingBlock;
+import io.agentscope.core.model.ChatResponse;
+import io.agentscope.core.model.GenerateOptions;
+import io.agentscope.core.model.Model;
+import io.agentscope.core.model.ModelCreationContext;
+import io.agentscope.core.model.ModelRegistry;
+import java.time.Duration;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+import reactor.test.StepVerifier;
+
+/**
+ * End-to-end smoke test for OrcaRouter through the AgentScope model registry.
+ *
+ * <p>This test makes a real OrcaRouter API call and may incur costs. It is skipped unless
+ * {@code ORCAROUTER_API_KEY} is set.
+ */
+@Tag("e2e")
+@Tag("orcarouter")
+@DisplayName("OrcaRouter ModelProvider E2E Tests (Real OrcaRouter API)")
+@EnabledIfEnvironmentVariable(
+        named = "ORCAROUTER_API_KEY",
+        matches = ".+",
+        disabledReason = "Requires ORCAROUTER_API_KEY environment variable")
+class OrcaRouterModelProviderE2ETest {
+
+    private static final String DEFAULT_MODEL = "openai/gpt-5.5";
+    private static final Duration TEST_TIMEOUT = Duration.ofSeconds(60);
+
+    @AfterEach
+    void tearDown() {
+        ModelRegistry.reset();
+    }
+
+    @Test
+    @DisplayName("Should resolve OrcaRouter model through SPI and complete a chat request")
+    void shouldResolveOrcaRouterModelThroughSpiAndCompleteChatRequest() {
+        String modelName = firstNonBlank(System.getenv("ORCAROUTER_MODEL"), DEFAULT_MODEL);
+        Model model =
+                ModelRegistry.resolve(
+                        "orcarouter:" + modelName,
+                        ModelCreationContext.builder().stream(false).build());
+
+        List<Msg> messages =
+                List.of(
+                        Msg.builder()
+                                .role(MsgRole.USER)
+                                .content(
+                                        List.of(
+                                                TextBlock.builder()
+                                                        .text(
+                                                                "Reply with one short sentence"
+                                                                        + " about Java.")
+                                                        .build()))
+                                .build());
+        GenerateOptions options =
+                GenerateOptions.builder().temperature(0.1).maxCompletionTokens(512).build();
+
+        StepVerifier.create(model.stream(messages, null, options))
+                .assertNext(this::assertHasNonBlankText)
+                .expectComplete()
+                .verify(TEST_TIMEOUT);
+    }
+
+    private void assertHasNonBlankText(ChatResponse response) {
+        assertNotNull(response);
+        assertNotNull(response.getContent());
+        if (response.getContent().stream().noneMatch(this::isNonBlankTextBlock)) {
+            fail(
+                    "Expected OrcaRouter response to contain a non-blank TextBlock, but got: "
+                            + summarize(response));
+        }
+    }
+
+    private boolean isNonBlankTextBlock(ContentBlock block) {
+        return block instanceof TextBlock textBlock
+                && textBlock.getText() != null
+                && !textBlock.getText().isBlank();
+    }
+
+    private String summarize(ChatResponse response) {
+        return "finishReason="
+                + response.getFinishReason()
+                + ", content="
+                + response.getContent().stream().map(this::summarizeBlock).toList();
+    }
+
+    private String summarizeBlock(ContentBlock block) {
+        if (block instanceof TextBlock textBlock) {
+            return "TextBlock(length=" + textBlock.getText().length() + ")";
+        }
+        if (block instanceof ThinkingBlock thinkingBlock) {
+            return "ThinkingBlock(length=" + thinkingBlock.getThinking().length() + ")";
+        }
+        return block.getClass().getSimpleName();
+    }
+
+    private static String firstNonBlank(String... values) {
+        for (String value : values) {
+            if (value != null && !value.isBlank()) {
+                return value;
+            }
+        }
+        throw new IllegalArgumentException("At least one non-blank value is required");
+    }
+}

--- a/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-openai/src/test/java/io/agentscope/extensions/model/openai/compat/orcarouter/OrcaRouterModelProviderTest.java
+++ b/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-openai/src/test/java/io/agentscope/extensions/model/openai/compat/orcarouter/OrcaRouterModelProviderTest.java
@@ -1,0 +1,301 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.extensions.model.openai.compat.orcarouter;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.agentscope.core.formatter.Formatter;
+import io.agentscope.core.message.Msg;
+import io.agentscope.core.message.MsgRole;
+import io.agentscope.core.message.TextBlock;
+import io.agentscope.core.model.Model;
+import io.agentscope.core.model.ModelCreationContext;
+import io.agentscope.core.model.ModelRegistry;
+import io.agentscope.core.model.transport.HttpRequest;
+import io.agentscope.core.model.transport.HttpResponse;
+import io.agentscope.core.model.transport.HttpTransport;
+import io.agentscope.core.model.transport.ProxyConfig;
+import io.agentscope.extensions.model.openai.OpenAIChatModel;
+import io.agentscope.extensions.model.openai.dto.OpenAIMessage;
+import io.agentscope.extensions.model.openai.dto.OpenAIRequest;
+import io.agentscope.extensions.model.openai.dto.OpenAIResponse;
+import io.agentscope.extensions.model.openai.formatter.OpenAIChatFormatter;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Flux;
+
+@DisplayName("OrcaRouterModelProvider Unit Tests")
+class OrcaRouterModelProviderTest {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    @AfterEach
+    void tearDown() {
+        ModelRegistry.reset();
+    }
+
+    @Test
+    @DisplayName("Returns provider id")
+    void returnsProviderId() {
+        assertEquals("orcarouter", new OrcaRouterModelProvider().providerId());
+    }
+
+    @Test
+    @DisplayName("Supports OrcaRouter model ids")
+    void supportsOrcaRouterModelIds() {
+        OrcaRouterModelProvider provider = new OrcaRouterModelProvider();
+
+        assertTrue(provider.supports("orcarouter:openai/gpt-5.5"));
+        assertTrue(provider.supports("orcarouter:orcarouter/auto"));
+        assertFalse(provider.supports("orcarouter:"));
+        assertFalse(provider.supports("openai:gpt-4o-mini"));
+        assertFalse(provider.supports(null));
+    }
+
+    @Test
+    @DisplayName("Rejects unsupported model ids before reading environment")
+    void createRejectsUnsupportedModelIdsBeforeReadingEnvironment() {
+        OrcaRouterModelProvider provider = new OrcaRouterModelProvider();
+
+        assertThrows(IllegalArgumentException.class, () -> provider.create("orcarouter:"));
+        assertThrows(IllegalArgumentException.class, () -> provider.create("openai:gpt-4o-mini"));
+        assertThrows(IllegalArgumentException.class, () -> provider.create(null));
+    }
+
+    @Test
+    @DisplayName("Fails clearly when ORCAROUTER_API_KEY is missing")
+    void createFailsClearlyWhenApiKeyMissing() {
+        assumeTrue(System.getenv("ORCAROUTER_API_KEY") == null);
+        OrcaRouterModelProvider provider = new OrcaRouterModelProvider();
+
+        IllegalStateException error =
+                assertThrows(
+                        IllegalStateException.class,
+                        () -> provider.create("orcarouter:openai/gpt-5.5"));
+
+        assertTrue(error.getMessage().contains("ORCAROUTER_API_KEY"));
+    }
+
+    @Test
+    @DisplayName("Uses OrcaRouter defaults for structured output")
+    void createUsesOrcaRouterStructuredOutputDefaults() {
+        ModelCreationContext context =
+                ModelCreationContext.builder().apiKey("test-orcarouter-key").build();
+
+        Model model = new OrcaRouterModelProvider().create("orcarouter:openai/gpt-5.5", context);
+
+        assertFalse(model.supportsNativeStructuredOutput());
+        assertFalse(model.supportsNativeStructuredOutputWithTools());
+    }
+
+    @Test
+    @DisplayName("Creates model from context and applies default request settings")
+    void createUsesModelCreationContextAndDefaultOrcaRouterRequestSettings() throws Exception {
+        CapturingTransport transport = new CapturingTransport();
+        ModelCreationContext context =
+                ModelCreationContext.builder()
+                        .apiKey("test-orcarouter-key")
+                        .baseUrl("   ")
+                        .endpointPath("   ")
+                        .stream(false)
+                        .component(HttpTransport.class, transport)
+                        .component(ProxyConfig.class, ProxyConfig.http("proxy.example.com", 8080))
+                        .option("contextWindowSize", 128000)
+                        .option("nativeStructuredOutput", true)
+                        .build();
+
+        Model model = new OrcaRouterModelProvider().create("orcarouter:openai/gpt-5.5", context);
+
+        assertInstanceOf(OpenAIChatModel.class, model);
+        assertEquals("openai/gpt-5.5", model.getModelName());
+        assertEquals(128000, model.getContextWindowSize());
+        assertTrue(model.supportsNativeStructuredOutput());
+
+        ((OpenAIChatModel) model).stream(userMessages(), null, null).blockLast();
+
+        assertEquals("https://api.orcarouter.ai/v1/chat/completions", transport.request.getUrl());
+        assertEquals(
+                "Bearer test-orcarouter-key", transport.request.getHeaders().get("Authorization"));
+
+        Map<String, Object> body = parseBody(transport.request.getBody());
+        assertEquals("openai/gpt-5.5", body.get("model"));
+        assertEquals(false, body.get("stream"));
+    }
+
+    @Test
+    @DisplayName("Applies base URL and endpoint path overrides")
+    void createAppliesEndpointAndStructuredOutputOverrides() throws Exception {
+        CapturingTransport transport = new CapturingTransport();
+        ModelCreationContext context =
+                ModelCreationContext.builder()
+                        .apiKey("test-orcarouter-key")
+                        .baseUrl("https://orcarouter.example.com")
+                        .endpointPath("/custom/chat")
+                        .stream(false)
+                        .component(HttpTransport.class, transport)
+                        .build();
+
+        OpenAIChatModel model =
+                (OpenAIChatModel)
+                        new OrcaRouterModelProvider()
+                                .create("orcarouter:anthropic/claude-opus-4.8", context);
+
+        model.stream(userMessages(), null, null).blockLast();
+
+        assertEquals("https://orcarouter.example.com/custom/chat", transport.request.getUrl());
+        Map<String, Object> body = parseBody(transport.request.getBody());
+        assertEquals("anthropic/claude-opus-4.8", body.get("model"));
+    }
+
+    @Test
+    @DisplayName("Rejects invalid advanced option types")
+    void createRejectsInvalidAdvancedOptionTypes() {
+        OrcaRouterModelProvider provider = new OrcaRouterModelProvider();
+
+        assertThrows(
+                IllegalArgumentException.class,
+                () ->
+                        provider.create(
+                                "orcarouter:openai/gpt-5.5",
+                                ModelCreationContext.builder()
+                                        .apiKey("test-orcarouter-key")
+                                        .option("contextWindowSize", "large")
+                                        .build()));
+        assertThrows(
+                IllegalArgumentException.class,
+                () ->
+                        provider.create(
+                                "orcarouter:openai/gpt-5.5",
+                                ModelCreationContext.builder()
+                                        .apiKey("test-orcarouter-key")
+                                        .option("nativeStructuredOutput", "true")
+                                        .build()));
+    }
+
+    @Test
+    @DisplayName("Allows context formatter to override provider default")
+    void contextFormatterOverrideTakesPrecedenceOverProviderDefault() throws Exception {
+        CapturingTransport transport = new CapturingTransport();
+        Formatter<OpenAIMessage, OpenAIResponse, OpenAIRequest> formatter =
+                new OpenAIChatFormatter();
+        ModelCreationContext context =
+                ModelCreationContext.builder().apiKey("test-orcarouter-key").stream(false)
+                        .component(Formatter.class, formatter)
+                        .component(HttpTransport.class, transport)
+                        .build();
+        OpenAIChatModel model =
+                (OpenAIChatModel)
+                        new OrcaRouterModelProvider().create("orcarouter:openai/gpt-5.5", context);
+
+        model.stream(
+                        List.of(
+                                Msg.builder()
+                                        .role(MsgRole.SYSTEM)
+                                        .content(
+                                                List.of(
+                                                        TextBlock.builder()
+                                                                .text("System instruction")
+                                                                .build()))
+                                        .build(),
+                                Msg.builder()
+                                        .role(MsgRole.USER)
+                                        .content(
+                                                List.of(
+                                                        TextBlock.builder()
+                                                                .text("Reply with pong")
+                                                                .build()))
+                                        .build()),
+                        null,
+                        null)
+                .blockLast();
+
+        Map<String, Object> body = parseBody(transport.request.getBody());
+        @SuppressWarnings("unchecked")
+        List<Map<String, Object>> messages = (List<Map<String, Object>>) body.get("messages");
+        assertEquals("system", messages.get(0).get("role"));
+    }
+
+    @Test
+    @DisplayName("Registers through ServiceLoader")
+    void modelRegistryFindsOrcaRouterProviderFromServiceLoader() {
+        assertTrue(ModelRegistry.canResolve("orcarouter:openai/gpt-5.5"));
+    }
+
+    private static List<Msg> userMessages() {
+        return List.of(
+                Msg.builder()
+                        .role(MsgRole.USER)
+                        .content(List.of(TextBlock.builder().text("Reply with pong").build()))
+                        .build());
+    }
+
+    private static Map<String, Object> parseBody(String body) throws Exception {
+        return MAPPER.readValue(body, new TypeReference<Map<String, Object>>() {});
+    }
+
+    private static final class CapturingTransport implements HttpTransport {
+        private HttpRequest request;
+
+        @Override
+        public HttpResponse execute(HttpRequest request) {
+            this.request = request;
+            return HttpResponse.builder()
+                    .statusCode(200)
+                    .body(
+                            """
+                            {
+                              "id": "orcarouter-test",
+                              "object": "chat.completion",
+                              "created": 1,
+                              "model": "openai/gpt-5.5",
+                              "choices": [{
+                                "index": 0,
+                                "message": {
+                                  "role": "assistant",
+                                  "content": "pong"
+                                },
+                                "finish_reason": "stop"
+                              }],
+                              "usage": {
+                                "prompt_tokens": 1,
+                                "completion_tokens": 1,
+                                "total_tokens": 2
+                              }
+                            }
+                            """)
+                    .build();
+        }
+
+        @Override
+        public Flux<String> stream(HttpRequest request) {
+            this.request = request;
+            return Flux.empty();
+        }
+
+        @Override
+        public void close() {}
+    }
+}

--- a/docs/v2/en/integration/model/index.md
+++ b/docs/v2/en/integration/model/index.md
@@ -7,6 +7,7 @@ Model provider extensions connect AgentScope Java to hosted or local chat model 
 - [GLM](glm.md)
 - [Kimi](kimi.md)
 - [MiniMax](minimax.md)
+- [OrcaRouter](orcarouter.md)
 - [DashScope](dashscope.md)
 - [Gemini](gemini.md)
 - [Anthropic](anthropic.md)

--- a/docs/v2/en/integration/model/orcarouter.md
+++ b/docs/v2/en/integration/model/orcarouter.md
@@ -1,0 +1,34 @@
+# OrcaRouter Model
+
+`agentscope-extensions-model-openai` provides first-class [OrcaRouter](https://www.orcarouter.ai) support through the OpenAI-compatible model stack. Add the OpenAI model extension module, then use `orcarouter:<model>` with `ModelRegistry`.
+
+OrcaRouter is an OpenAI-compatible AI gateway that exposes a provider/model namespace across many models — like OpenRouter — but also combines adaptive routing, automatic failover, zero-markup inference, observability, guardrails, and agent-tool governance behind the same endpoint. It runs gateway-level, zero-trust security for AI agents on the same endpoint, screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.
+
+## Add the dependency
+
+```xml
+<dependency>
+    <groupId>io.agentscope</groupId>
+    <artifactId>agentscope-extensions-model-openai</artifactId>
+    <version>${agentscope.version}</version>
+</dependency>
+```
+
+## ModelRegistry
+
+Set `ORCAROUTER_API_KEY`, then use the `orcarouter:<model>` id:
+
+```java
+ReActAgent agent = ReActAgent.builder()
+    .name("assistant")
+    .model("orcarouter:openai/gpt-5.5") // Resolved internally by ModelRegistry.resolve(modelId)
+    .build();
+```
+
+The provider defaults to `https://api.orcarouter.ai/v1`, strips the `orcarouter:` prefix before sending the model name, and uses the standard OpenAI chat formatter from `io.agentscope.extensions.model.openai.formatter`. Model names use the `provider/model` namespace, e.g. `openai/gpt-5.5`, `anthropic/claude-opus-4.8`, `deepseek/deepseek-v4-pro`, or the `orcarouter/auto` adaptive router. See the full catalog at <https://www.orcarouter.ai/models>.
+
+## Compatibility notes
+
+Because OrcaRouter routes to a mix of upstream providers whose `response_format` support varies, native structured output defaults to disabled and the agent falls back to the normal AgentScope `generate_response` tool. If you configure a route that reliably supports `json_schema`, pass `nativeStructuredOutput` or a formatter override through `ModelCreationContext`.
+
+For self-hosted or custom gateways, pass `baseUrl`, `endpointPath`, generation options, or formatter overrides through `ModelCreationContext`.

--- a/docs/v2/en/integration/overview.md
+++ b/docs/v2/en/integration/overview.md
@@ -15,6 +15,7 @@ All model providers have moved to independent model extension modules, while `ag
 | GLM | `agentscope-extensions-model-openai` | `glm:<model>` | `ZAI_API_KEY` / `GLM_API_KEY` / `ZHIPUAI_API_KEY` | <a class="reference internal" href="model/glm.html">GLM</a> |
 | Kimi | `agentscope-extensions-model-openai` | `kimi:<model>` | `MOONSHOT_API_KEY` / `KIMI_API_KEY` | <a class="reference internal" href="model/kimi.html">Kimi</a> |
 | MiniMax | `agentscope-extensions-model-openai` | `minimax:<model>` | `MINIMAX_API_KEY` | <a class="reference internal" href="model/minimax.html">MiniMax</a> |
+| OrcaRouter | `agentscope-extensions-model-openai` | `orcarouter:<model>` | `ORCAROUTER_API_KEY` | <a class="reference internal" href="model/orcarouter.html">OrcaRouter</a> |
 | DashScope | `agentscope-extensions-model-dashscope` | `dashscope:<model>` / `qwen*` | `DASHSCOPE_API_KEY` | <a class="reference internal" href="model/dashscope.html">DashScope</a> |
 | Gemini | `agentscope-extensions-model-gemini` | `gemini:<model>` | `GEMINI_API_KEY` | <a class="reference internal" href="model/gemini.html">Gemini</a> |
 | Anthropic | `agentscope-extensions-model-anthropic` | `anthropic:<model>` | `ANTHROPIC_API_KEY` | <a class="reference internal" href="model/anthropic.html">Anthropic</a> |

--- a/docs/v2/zh/integration/model/index.md
+++ b/docs/v2/zh/integration/model/index.md
@@ -7,6 +7,7 @@
 - [GLM](glm.md)
 - [Kimi](kimi.md)
 - [MiniMax](minimax.md)
+- [OrcaRouter](orcarouter.md)
 - [DashScope](dashscope.md)
 - [Gemini](gemini.md)
 - [Anthropic](anthropic.md)

--- a/docs/v2/zh/integration/model/orcarouter.md
+++ b/docs/v2/zh/integration/model/orcarouter.md
@@ -1,0 +1,34 @@
+# OrcaRouter 模型
+
+`agentscope-extensions-model-openai` 通过 OpenAI 兼容模型栈提供 [OrcaRouter](https://www.orcarouter.ai) 的一等支持。引入 OpenAI 模型扩展模块后，可以通过 `ModelRegistry` 使用 `orcarouter:<model>`。
+
+OrcaRouter 是一个 OpenAI 兼容的 AI 网关，像 OpenRouter 一样在同一端点暴露 provider/model 命名空间，覆盖众多模型；同时还把自适应路由、自动故障转移、零加价推理、可观测性、护栏和 agent 工具治理整合在同一个端点后面。该端点还内置了网关级、零信任的 AI Agent 安全能力——对每次 prompt/response 进行筛查，并以默认拒绝的方式治理每一次工具调用，无需任何应用代码改动。
+
+## 添加依赖
+
+```xml
+<dependency>
+    <groupId>io.agentscope</groupId>
+    <artifactId>agentscope-extensions-model-openai</artifactId>
+    <version>${agentscope.version}</version>
+</dependency>
+```
+
+## ModelRegistry
+
+设置 `ORCAROUTER_API_KEY` 后，使用 `orcarouter:<model>` 字符串 id：
+
+```java
+ReActAgent agent = ReActAgent.builder()
+    .name("assistant")
+    .model("orcarouter:openai/gpt-5.5") // 底层由 ModelRegistry.resolve(modelId) 解析
+    .build();
+```
+
+Provider 默认使用 `https://api.orcarouter.ai/v1`，发送请求前会去掉 `orcarouter:` 前缀，并使用 `io.agentscope.extensions.model.openai.formatter` 下的标准 OpenAI chat formatter。模型名采用 `provider/model` 命名空间，例如 `openai/gpt-5.5`、`anthropic/claude-opus-4.8`、`deepseek/deepseek-v4-pro`，或使用 `orcarouter/auto` 自适应路由。完整模型列表见 <https://www.orcarouter.ai/models>。
+
+## 兼容性说明
+
+由于 OrcaRouter 会路由到一批上游 provider，其 `response_format` 支持程度不一，因此 native structured output 默认关闭，agent 回退到 AgentScope 标准的 `generate_response` 工具。如果你配置的路线可靠支持 `json_schema`，可以通过 `ModelCreationContext` 传入 `nativeStructuredOutput` 或 formatter 覆盖。
+
+使用自建或自定义网关时，可以通过 `ModelCreationContext` 传入 `baseUrl`、`endpointPath`、生成参数或 formatter 覆盖。

--- a/docs/v2/zh/integration/overview.md
+++ b/docs/v2/zh/integration/overview.md
@@ -15,6 +15,7 @@
 | GLM | `agentscope-extensions-model-openai` | `glm:<model>` | `ZAI_API_KEY` / `GLM_API_KEY` / `ZHIPUAI_API_KEY` | <a class="reference internal" href="model/glm.html">GLM</a> |
 | Kimi | `agentscope-extensions-model-openai` | `kimi:<model>` | `MOONSHOT_API_KEY` / `KIMI_API_KEY` | <a class="reference internal" href="model/kimi.html">Kimi</a> |
 | MiniMax | `agentscope-extensions-model-openai` | `minimax:<model>` | `MINIMAX_API_KEY` | <a class="reference internal" href="model/minimax.html">MiniMax</a> |
+| OrcaRouter | `agentscope-extensions-model-openai` | `orcarouter:<model>` | `ORCAROUTER_API_KEY` | <a class="reference internal" href="model/orcarouter.html">OrcaRouter</a> |
 | DashScope | `agentscope-extensions-model-dashscope` | `dashscope:<model>` / `qwen*` | `DASHSCOPE_API_KEY` | <a class="reference internal" href="model/dashscope.html">DashScope</a> |
 | Gemini | `agentscope-extensions-model-gemini` | `gemini:<model>` | `GEMINI_API_KEY` | <a class="reference internal" href="model/gemini.html">Gemini</a> |
 | Anthropic | `agentscope-extensions-model-anthropic` | `anthropic:<model>` | `ANTHROPIC_API_KEY` | <a class="reference internal" href="model/anthropic.html">Anthropic</a> |


### PR DESCRIPTION
## Summary

AgentScope Java's `agentscope-extensions-model-openai` already ships OpenAI-compatible providers such as Kimi, MiniMax and DeepSeek via `ModelRegistry` ids. This PR adds [OrcaRouter](https://www.orcarouter.ai) the same way, mirroring `compat/kimi`/`compat/deepseek`: an `orcarouter:<model>` provider (e.g. `orcarouter:openai/gpt-5.5`, `orcarouter:orcarouter/auto`) that defaults to `https://api.orcarouter.ai/v1`, reads `ORCAROUTER_API_KEY`, and is registered through `ServiceLoader`. OrcaRouter is an OpenAI-compatible AI gateway built for both models and agents. Like OpenRouter, it exposes a provider/model namespace across many models — but it also combines adaptive routing, automatic failover, zero-markup inference, observability, guardrails, and agent-tool governance behind the same endpoint. Adding orcarouter as a first-class provider means this project's users can use that stack directly, without treating OrcaRouter as an anonymous custom base URL. It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

## Verification

- `mvn -pl agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-openai -am test` → BUILD SUCCESS, 566 tests, 0 failures (includes new unit + e2e tests).
- Live e2e against `https://api.orcarouter.ai/v1` (`orcarouter:openai/gpt-5.5`) → HTTP 200.
- EN + ZH docs and provider tables updated.

I'm an engineer on the OrcaRouter team. · Discord: discord.gg/YEubt8enRA · X: https://x.com/OrcaRouter
