### PR TITLE
fix(sandbox): handle SIGTERM in docker keep-alive to avoid 30s stop delay

### DIFF
--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/sandbox/impl/docker/DockerSandbox.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/sandbox/impl/docker/DockerSandbox.java
@@ -522,10 +522,14 @@ public class DockerSandbox extends AbstractBaseSandbox {
         }
 
         cmd.add(dockerState.getImage());
-        // Keep the container alive with an idle shell loop
+        // Keep the container alive with an idle shell loop. Install a SIGTERM trap and
+        // background the sleep with `wait`, so PID 1 (sh) exits promptly on `docker stop`
+        // instead of blocking in a foreground `sleep` until the stop timeout forces a
+        // SIGKILL. Relies only on `sh` + integer `sleep`, so it stays portable across
+        // minimal images (e.g. BusyBox/Alpine) where `sleep infinity` is unsupported.
         cmd.add("sh");
         cmd.add("-c");
-        cmd.add("while :; do sleep 3600; done");
+        cmd.add("trap 'exit 0' TERM; while :; do sleep 3600 & wait $!; done");
 
         return cmd;
     }

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/sandbox/impl/docker/DockerSandboxRunCommandTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/sandbox/impl/docker/DockerSandboxRunCommandTest.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.harness.agent.sandbox.impl.docker;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.agentscope.harness.agent.sandbox.WorkspaceSpec;
+import java.lang.reflect.Method;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for the {@code docker run} command assembled by {@link DockerSandbox}, focused on
+ * the container keep-alive entrypoint.
+ *
+ * <p>Regression guard for issue #2884: the old entrypoint {@code while :; do sleep 3600; done}
+ * left PID 1 ({@code sh}) blocked in a foreground {@code sleep} that never observed SIGTERM, so
+ * {@code docker stop --time=30} waited the full 30s before SIGKILL and every agent turn paid a
+ * ~30s teardown delay. The entrypoint must instead install a SIGTERM trap and wait on a
+ * backgrounded sleep so PID 1 exits promptly.
+ */
+class DockerSandboxRunCommandTest {
+
+    @SuppressWarnings("unchecked")
+    private static List<String> buildRunCommand(DockerSandboxState state, String containerName)
+            throws Exception {
+        DockerSandbox sandbox = new DockerSandbox(state);
+        Method m = DockerSandbox.class.getDeclaredMethod("buildDockerRunCommand", String.class);
+        m.setAccessible(true);
+        return (List<String>) m.invoke(sandbox, containerName);
+    }
+
+    private static DockerSandboxState minimalState() {
+        DockerSandboxState state = new DockerSandboxState();
+        state.setImage("ubuntu:22.04");
+        state.setWorkspaceRoot("/workspace");
+        state.setWorkspaceSpec(new WorkspaceSpec());
+        return state;
+    }
+
+    @Test
+    void entrypointInstallsSigtermTrapSoDockerStopReturnsPromptly() throws Exception {
+        List<String> cmd = buildRunCommand(minimalState(), "agentscope-sandbox-test");
+
+        // The entrypoint is the last three tokens: sh -c <script>.
+        int n = cmd.size();
+        assertEquals("sh", cmd.get(n - 3));
+        assertEquals("-c", cmd.get(n - 2));
+
+        String script = cmd.get(n - 1);
+        // A SIGTERM trap must be installed so PID 1 (sh) exits on `docker stop`.
+        assertTrue(script.contains("trap"), "entrypoint must install a signal trap: " + script);
+        assertTrue(script.contains("TERM"), "entrypoint must trap SIGTERM: " + script);
+        // The sleep must be backgrounded and waited on, so the trap can interrupt the wait
+        // (a foreground sleep would defer the trap until it returns).
+        assertTrue(
+                script.contains("sleep 3600 &"),
+                "sleep must be backgrounded so wait is interruptible: " + script);
+        assertTrue(
+                script.contains("wait"),
+                "entrypoint must wait on the backgrounded sleep: " + script);
+    }
+
+    @Test
+    void entrypointDoesNotUseForegroundSleepLoop() throws Exception {
+        List<String> cmd = buildRunCommand(minimalState(), "agentscope-sandbox-test");
+        String script = cmd.get(cmd.size() - 1);
+
+        // Regression: the old foreground-sleep loop swallowed SIGTERM.
+        assertFalse(
+                script.equals("while :; do sleep 3600; done"),
+                "must not use the SIGTERM-ignoring foreground sleep loop");
+    }
+
+    @Test
+    void entrypointUsesOnlyPortableShellPrimitives() throws Exception {
+        List<String> cmd = buildRunCommand(minimalState(), "agentscope-sandbox-test");
+        String script = cmd.get(cmd.size() - 1);
+
+        // `sleep infinity` is a GNU coreutils extension rejected by BusyBox/Alpine, which would
+        // prevent the container from starting on minimal images. The entrypoint must avoid it.
+        assertFalse(
+                script.contains("sleep infinity"),
+                "entrypoint must not depend on non-portable `sleep infinity`: " + script);
+    }
+
+    @Test
+    void runCommandStartsWithDetachedNamedRun() throws Exception {
+        List<String> cmd = buildRunCommand(minimalState(), "agentscope-sandbox-test");
+
+        assertEquals(
+                List.of("docker", "run", "-d", "--name", "agentscope-sandbox-test"),
+                cmd.subList(0, 5));
+        // Image precedes the entrypoint tokens.
+        assertEquals("ubuntu:22.04", cmd.get(cmd.size() - 4));
+    }
+}


### PR DESCRIPTION
## Problem

In Docker sandbox mode, every agent turn incurs a ~30s delay between the agent's last emitted event and the `agent.call()` Flux terminal signal (onComplete), blocking SSE stream completion.

**Root cause:** the container keep-alive entrypoint `sh -c "while :; do sleep 3600; done"` leaves PID 1 (`sh`) blocked in a foreground `sleep` that never observes SIGTERM. In a PID namespace the kernel drops signals to PID 1 that have no installed handler, so when `SandboxManager.release()` → `sandbox.shutdown()` runs `docker stop --time=30` (synchronously, on the `Flux.using()` teardown path), Docker waits the full 30s grace period before escalating to SIGKILL. This happens on **every turn** regardless of conversation length. Fixes #2884.

## Fix

Change the entrypoint to install an explicit SIGTERM trap and wait on a backgrounded sleep:

```
sh -c "trap 'exit 0' TERM; while :; do sleep 3600 & wait $!; done"
```

- `trap 'exit 0' TERM` registers a handler on PID 1, so the kernel delivers SIGTERM instead of dropping it.
- `sleep 3600 &` + `wait $!` makes `sh` block on an **interruptible** `wait` (EINTR). SIGTERM interrupts the wait, the trap runs `exit 0`, and `docker stop` returns in <1s. A foreground `sleep` would defer the trap until the command returns.

### Why not `exec sleep infinity`

`sleep infinity` is a GNU coreutils extension that BusyBox/Alpine `sleep` rejects, so it would break container startup on minimal images. Bare `sleep` as PID 1 also has no SIGTERM handler and would still rely on `--init` to be reliable. The trap approach uses only `sh` + integer `sleep` — the exact same runtime primitives as the old entrypoint — so it stays portable and needs no extra `docker run` flag.

## Verification

Measured real `docker stop --time=30` with `sh -c` as PID 1 across images:

| image | shell | new (trap+wait) | old (foreground) |
|---|---|---|---|
| alpine:latest | BusyBox ash | 0.33s, exit 0 | 30.21s, exit 137 |
| ubuntu:22.04 | dash | 0.14s, exit 0 | 30.16s, exit 137 |
| busybox:latest | BusyBox ash | 0.12s, exit 0 | — |
| debian:bookworm-slim | dash | 0.18s, exit 0 | — |

Old entrypoint consistently hits the 30s grace period then SIGKILL (exit 137); new entrypoint exits cleanly in <0.35s.

## Tests

Adds `DockerSandboxRunCommandTest` asserting the generated `docker run` entrypoint installs the SIGTERM trap, waits on a backgrounded sleep, does not revert to the foreground sleep loop, and avoids the non-portable `sleep infinity`.
