### PR TITLE
docs(tool): fix ToolBase builder javadoc example (no build() method)

### DIFF
--- a/agentscope-core/src/main/java/io/agentscope/core/tool/ToolBase.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/tool/ToolBase.java
@@ -53,8 +53,7 @@ import reactor.core.publisher.Mono;
  *         .description("Read a file")
  *         .inputSchema(schema)
  *         .readOnly(true)
- *         .concurrencySafe(true)
- *         .build());
+ *         .concurrencySafe(true));
  * }</pre>
  */
 public abstract class ToolBase implements AgentTool {


### PR DESCRIPTION
`ToolBase.Builder` has no `build()` terminal method — the builder is passed directly to the `ToolBase(Builder)` constructor (as `ToolBaseTest` already does), so the class javadoc example did not compile.

Removes the stray `.build()` from the example. Same class of issue as #2497 (javadoc not matching code).