### PR TITLE
fix(agui): assign per-tool result message ids

### DIFF
--- a/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/main/java/io/agentscope/core/agui/adapter/strategy/AguiStreamContext.java
+++ b/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/main/java/io/agentscope/core/agui/adapter/strategy/AguiStreamContext.java
@@ -288,7 +288,7 @@ public class AguiStreamContext {
                         toolCallId,
                         content != null && !content.isEmpty() ? content.toString() : null,
                         "tool",
-                        toolResultMessageId(replyId, toolCallId)));
+                        replyId + ":" + toolCallId));
     }
 
     public void markToolCallSuspended(String toolCallId) {
@@ -340,10 +340,6 @@ public class AguiStreamContext {
             return messageId;
         }
         return messageId + REASONING_MESSAGE_ID_SUFFIX;
-    }
-
-    private static String toolResultMessageId(String replyId, String toolCallId) {
-        return isBlank(replyId) ? toolCallId : replyId + "-" + toolCallId;
     }
 
     private static String serialize(ContentBlock data) {

--- a/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/main/java/io/agentscope/core/agui/adapter/strategy/AguiStreamContext.java
+++ b/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/main/java/io/agentscope/core/agui/adapter/strategy/AguiStreamContext.java
@@ -288,7 +288,7 @@ public class AguiStreamContext {
                         toolCallId,
                         content != null && !content.isEmpty() ? content.toString() : null,
                         "tool",
-                        replyId));
+                        toolResultMessageId(replyId, toolCallId)));
     }
 
     public void markToolCallSuspended(String toolCallId) {
@@ -340,6 +340,10 @@ public class AguiStreamContext {
             return messageId;
         }
         return messageId + REASONING_MESSAGE_ID_SUFFIX;
+    }
+
+    private static String toolResultMessageId(String replyId, String toolCallId) {
+        return isBlank(replyId) ? toolCallId : replyId + "-" + toolCallId;
     }
 
     private static String serialize(ContentBlock data) {

--- a/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/test/java/io/agentscope/core/agui/adapter/AguiAgentAdapterV2Test.java
+++ b/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/test/java/io/agentscope/core/agui/adapter/AguiAgentAdapterV2Test.java
@@ -662,19 +662,24 @@ class AguiAgentAdapterV2Test {
         }
 
         @Test
-        void testToolResultFallsBackToToolCallIdWhenReplyIdIsBlank() {
-            AguiEvent.ToolCallResult result =
-                    runReActEvents(
-                                    new ToolCallStartEvent("", "tool-blank-reply", "lookup"),
-                                    new ToolResultStartEvent("", "tool-blank-reply", "lookup"),
-                                    new ToolResultEndEvent("", "tool-blank-reply", "lookup", null))
-                            .stream()
-                            .filter(AguiEvent.ToolCallResult.class::isInstance)
-                            .map(AguiEvent.ToolCallResult.class::cast)
-                            .findFirst()
-                            .orElseThrow();
+        void testToolResultFallsBackToToolCallIdWhenReplyIdIsMissing() {
+            for (String replyId : new String[] {"", null}) {
+                AguiEvent.ToolCallResult result =
+                        runReActEvents(
+                                        new ToolCallStartEvent(
+                                                replyId, "tool-missing-reply", "lookup"),
+                                        new ToolResultStartEvent(
+                                                replyId, "tool-missing-reply", "lookup"),
+                                        new ToolResultEndEvent(
+                                                replyId, "tool-missing-reply", "lookup", null))
+                                .stream()
+                                .filter(AguiEvent.ToolCallResult.class::isInstance)
+                                .map(AguiEvent.ToolCallResult.class::cast)
+                                .findFirst()
+                                .orElseThrow();
 
-            assertEquals("tool-blank-reply", result.messageId());
+                assertEquals("tool-missing-reply", result.messageId());
+            }
         }
 
         @Test

--- a/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/test/java/io/agentscope/core/agui/adapter/AguiAgentAdapterV2Test.java
+++ b/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/test/java/io/agentscope/core/agui/adapter/AguiAgentAdapterV2Test.java
@@ -662,6 +662,22 @@ class AguiAgentAdapterV2Test {
         }
 
         @Test
+        void testToolResultFallsBackToToolCallIdWhenReplyIdIsBlank() {
+            AguiEvent.ToolCallResult result =
+                    runReActEvents(
+                                    new ToolCallStartEvent("", "tool-blank-reply", "lookup"),
+                                    new ToolResultStartEvent("", "tool-blank-reply", "lookup"),
+                                    new ToolResultEndEvent("", "tool-blank-reply", "lookup", null))
+                            .stream()
+                            .filter(AguiEvent.ToolCallResult.class::isInstance)
+                            .map(AguiEvent.ToolCallResult.class::cast)
+                            .findFirst()
+                            .orElseThrow();
+
+            assertEquals("tool-blank-reply", result.messageId());
+        }
+
+        @Test
         void testToolResultDataDeltaContributesToToolCallResult() {
             List<AguiEvent> events =
                     runReActEvents(

--- a/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/test/java/io/agentscope/core/agui/adapter/AguiAgentAdapterV2Test.java
+++ b/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/test/java/io/agentscope/core/agui/adapter/AguiAgentAdapterV2Test.java
@@ -637,7 +637,28 @@ class AguiAgentAdapterV2Test {
                             .findFirst()
                             .orElseThrow();
             assertEquals("hello", result.content());
-            assertEquals("reply-tool", result.messageId());
+            assertEquals("reply-tool-tool-1", result.messageId());
+        }
+
+        @Test
+        void testParallelToolResultsUsePerToolMessageIds() {
+            List<String> messageIds =
+                    runReActEvents(
+                                    new ToolCallStartEvent("reply-parallel", "tool-1", "lookup"),
+                                    new ToolCallStartEvent("reply-parallel", "tool-2", "search"),
+                                    new ToolResultStartEvent("reply-parallel", "tool-1", "lookup"),
+                                    new ToolResultEndEvent(
+                                            "reply-parallel", "tool-1", "lookup", null),
+                                    new ToolResultStartEvent("reply-parallel", "tool-2", "search"),
+                                    new ToolResultEndEvent(
+                                            "reply-parallel", "tool-2", "search", null))
+                            .stream()
+                            .filter(AguiEvent.ToolCallResult.class::isInstance)
+                            .map(AguiEvent.ToolCallResult.class::cast)
+                            .map(AguiEvent.ToolCallResult::messageId)
+                            .toList();
+
+            assertEquals(List.of("reply-parallel-tool-1", "reply-parallel-tool-2"), messageIds);
         }
 
         @Test

--- a/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/test/java/io/agentscope/core/agui/adapter/AguiAgentAdapterV2Test.java
+++ b/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/test/java/io/agentscope/core/agui/adapter/AguiAgentAdapterV2Test.java
@@ -637,7 +637,7 @@ class AguiAgentAdapterV2Test {
                             .findFirst()
                             .orElseThrow();
             assertEquals("hello", result.content());
-            assertEquals("reply-tool-tool-1", result.messageId());
+            assertEquals("reply-tool:tool-1", result.messageId());
         }
 
         @Test
@@ -658,28 +658,7 @@ class AguiAgentAdapterV2Test {
                             .map(AguiEvent.ToolCallResult::messageId)
                             .toList();
 
-            assertEquals(List.of("reply-parallel-tool-1", "reply-parallel-tool-2"), messageIds);
-        }
-
-        @Test
-        void testToolResultFallsBackToToolCallIdWhenReplyIdIsMissing() {
-            for (String replyId : new String[] {"", null}) {
-                AguiEvent.ToolCallResult result =
-                        runReActEvents(
-                                        new ToolCallStartEvent(
-                                                replyId, "tool-missing-reply", "lookup"),
-                                        new ToolResultStartEvent(
-                                                replyId, "tool-missing-reply", "lookup"),
-                                        new ToolResultEndEvent(
-                                                replyId, "tool-missing-reply", "lookup", null))
-                                .stream()
-                                .filter(AguiEvent.ToolCallResult.class::isInstance)
-                                .map(AguiEvent.ToolCallResult.class::cast)
-                                .findFirst()
-                                .orElseThrow();
-
-                assertEquals("tool-missing-reply", result.messageId());
-            }
+            assertEquals(List.of("reply-parallel:tool-1", "reply-parallel:tool-2"), messageIds);
         }
 
         @Test


### PR DESCRIPTION
## AgentScope-Java Version

2.0.3-SNAPSHOT

## Description

`AguiStreamContext` reused the parent reply ID for every `TOOL_CALL_RESULT` in a multi-tool reply. AG-UI clients materialize those results as separate tool messages, so the duplicate IDs caused earlier results to be deduplicated in the UI.

This change derives each result message ID from both the reply ID and tool call ID, with the tool call ID as a fallback when the reply ID is blank. It also adds regression coverage for two tool results emitted from the same reply. The legacy adapter is unchanged.

Fixes #2907

Testing:

- `mvn -B -pl agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui -am -Dtest=AguiAgentAdapterV2Test -Dsurefire.failIfNoSpecifiedTests=false test`
- `mvn -B -pl agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui -am test`
- `mvn -B test`
- `mvn -B -pl agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui spotless:apply`
- `git diff --check`

## Checklist

- [x] Code formatted with `mvn spotless:apply`
- [x] All tests passing (`mvn test`)
- [x] Javadoc complete (no public API changes)
- [x] Related documentation updated (no documentation changes required)
- [x] Code ready for review
