### PR TITLE
fix(rag): resolve ambiguous apiKey overload in OpenAITextEmbeddingEmbedTest after openai-java 4.52.0 upgrade

### DIFF
--- a/agentscope-extensions/agentscope-extensions-rag/agentscope-extensions-rag-simple/src/test/java/io/agentscope/core/embedding/openai/OpenAITextEmbeddingEmbedTest.java
+++ b/agentscope-extensions/agentscope-extensions-rag/agentscope-extensions-rag-simple/src/test/java/io/agentscope/core/embedding/openai/OpenAITextEmbeddingEmbedTest.java
@@ -84,7 +84,7 @@ class OpenAITextEmbeddingEmbedTest {
             EmbeddingService mockEmbeddings = mock(EmbeddingService.class);
 
             when(mockBuilder.build()).thenReturn(mockOpenAIClient);
-            when(mockBuilder.apiKey(any())).thenReturn(mockBuilder);
+            when(mockBuilder.apiKey(any(String.class))).thenReturn(mockBuilder);
             when(mockBuilder.baseUrl(any(String.class))).thenReturn(mockBuilder);
             when(mockBuilder.putHeader(any(), any())).thenReturn(mockBuilder);
 
@@ -121,7 +121,7 @@ class OpenAITextEmbeddingEmbedTest {
             EmbeddingService mockEmbeddings = mock(EmbeddingService.class);
 
             when(mockBuilder.build()).thenReturn(mockOpenAIClient);
-            when(mockBuilder.apiKey(any())).thenReturn(mockBuilder);
+            when(mockBuilder.apiKey(any(String.class))).thenReturn(mockBuilder);
             when(mockBuilder.baseUrl(any(String.class))).thenReturn(mockBuilder);
             when(mockBuilder.putHeader(any(), any())).thenReturn(mockBuilder);
 
@@ -163,7 +163,7 @@ class OpenAITextEmbeddingEmbedTest {
             EmbeddingService mockEmbeddings = mock(EmbeddingService.class);
 
             when(mockBuilder.build()).thenReturn(mockOpenAIClient);
-            when(mockBuilder.apiKey(any())).thenReturn(mockBuilder);
+            when(mockBuilder.apiKey(any(String.class))).thenReturn(mockBuilder);
             when(mockBuilder.baseUrl(any(String.class))).thenReturn(mockBuilder);
             when(mockBuilder.putHeader(any(), any())).thenReturn(mockBuilder);
 
@@ -205,7 +205,7 @@ class OpenAITextEmbeddingEmbedTest {
             EmbeddingService mockEmbeddings = mock(EmbeddingService.class);
 
             when(mockBuilder.build()).thenReturn(mockOpenAIClient);
-            when(mockBuilder.apiKey(any())).thenReturn(mockBuilder);
+            when(mockBuilder.apiKey(any(String.class))).thenReturn(mockBuilder);
             when(mockBuilder.baseUrl(any(String.class))).thenReturn(mockBuilder);
             when(mockBuilder.putHeader(any(), any())).thenReturn(mockBuilder);
 
@@ -248,7 +248,7 @@ class OpenAITextEmbeddingEmbedTest {
             EmbeddingService mockEmbeddings = mock(EmbeddingService.class);
 
             when(mockBuilder.build()).thenReturn(mockOpenAIClient);
-            when(mockBuilder.apiKey(any())).thenReturn(mockBuilder);
+            when(mockBuilder.apiKey(any(String.class))).thenReturn(mockBuilder);
             when(mockBuilder.baseUrl(any(String.class))).thenReturn(mockBuilder);
             when(mockBuilder.putHeader(any(), any())).thenReturn(mockBuilder);
 
@@ -291,7 +291,7 @@ class OpenAITextEmbeddingEmbedTest {
             EmbeddingService mockEmbeddings = mock(EmbeddingService.class);
 
             when(mockBuilder.build()).thenReturn(mockOpenAIClient);
-            when(mockBuilder.apiKey(any())).thenReturn(mockBuilder);
+            when(mockBuilder.apiKey(any(String.class))).thenReturn(mockBuilder);
             when(mockBuilder.baseUrl(any(String.class))).thenReturn(mockBuilder);
             when(mockBuilder.putHeader(any(), any())).thenReturn(mockBuilder);
 


### PR DESCRIPTION
## AgentScope-Java Version

[The version of AgentScope-Java you are working on, e.g. 1.0.12, check your pom.xml dependency version or run `mvn dependency:tree | grep agentscope-parent:pom`(only mac/linux)]

## Description

[Please describe the background, purpose, changes made, and how to test this PR]

## Checklist

Please check the following items before code is ready to be reviewed.

- [ ]  Code has been formatted with `mvn spotless:apply`
- [ ]  All tests are passing (`mvn test`)
- [ ]  Javadoc comments are complete and follow project conventions
- [ ]  Related documentation has been updated (e.g. links, examples, etc.)
- [ ]  Code is ready for review
