### PR TITLE
fix(core): add ToolUseBlock.getSuggestedRules() implementation

### DIFF
--- a/agentscope-core/src/main/java/io/agentscope/core/ReActAgent.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/ReActAgent.java
@@ -2830,6 +2830,14 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
                     .flatMapMany(
                             gate -> {
                                 List<ToolUseBlock> pending = gate.pendingAsk();
+                                Map<String, List<PermissionRule>> pendToolMap =
+                                        pending.stream()
+                                                .collect(
+                                                        Collectors.toMap(
+                                                                ToolUseBlock::getId,
+                                                                ToolUseBlock::getSuggestedRules,
+                                                                (a, b) -> a));
+
                                 Set<String> autoDenied = gate.autoDeniedIds();
 
                                 // Mark ToolUseBlock.state in context for every gated tool. ALLOWED
@@ -2844,17 +2852,11 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
                                     }
                                     stateUpdates.put(
                                             tc.getId(),
-                                            pending.stream()
-                                                            .anyMatch(
-                                                                    p ->
-                                                                            p.getId()
-                                                                                    .equals(
-                                                                                            tc
-                                                                                                    .getId()))
+                                            pendToolMap.containsKey(tc.getId())
                                                     ? ToolCallState.ASKING
                                                     : ToolCallState.ALLOWED);
                                 }
-                                updateToolCallStates(stateUpdates);
+                                updateToolCallStatesAndRules(stateUpdates, pendToolMap);
 
                                 if (pending.isEmpty()) {
                                     return runToolBatch(
@@ -3186,12 +3188,20 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
                 return permissionEngine
                         .checkPermission(tb, input)
                         .map(
-                                decision ->
-                                        new PermissionVerdict(
-                                                use,
-                                                decision == null
-                                                        ? PermissionBehavior.ASK
-                                                        : decision.getBehavior()));
+                                decision -> {
+                                    if (decision == null) {
+                                        return new PermissionVerdict(use, PermissionBehavior.ASK);
+                                    }
+
+                                    // Carry the engine's suggested rules on the ToolUseBlock
+                                    List<PermissionRule> suggested = decision.getSuggestedRules();
+                                    ToolUseBlock toolUseBlock = use;
+                                    if (suggested != null && !suggested.isEmpty()) {
+                                        toolUseBlock = use.withSuggestedRules(suggested);
+                                    }
+                                    return new PermissionVerdict(
+                                            toolUseBlock, decision.getBehavior());
+                                });
             }
             return tb.checkPermissions(input, state.getPermissionContext())
                     .map(
@@ -3902,11 +3912,12 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
         // ==================== Tool call state helpers (Permission HITL) ====================
 
         /**
-         * Locate the last assistant Msg in context and replace the {@code state} of every
+         * Locate the last assistant Msg in context and replace the {@code state,suggestedRules} of every
          * {@link ToolUseBlock} whose id matches the given map's key. Mirrors Python's
          * {@code _update_tool_call_state} but operates in bulk to minimise list rebuilds.
          */
-        private void updateToolCallStates(Map<String, ToolCallState> updates) {
+        private void updateToolCallStatesAndRules(
+                Map<String, ToolCallState> updates, Map<String, List<PermissionRule>> pendToolMap) {
             if (updates == null || updates.isEmpty()) {
                 return;
             }
@@ -3928,7 +3939,8 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
                 List<ContentBlock> rebuilt = new ArrayList<>(m.getContent().size());
                 for (ContentBlock block : m.getContent()) {
                     if (block instanceof ToolUseBlock t && updates.containsKey(t.getId())) {
-                        rebuilt.add(t.withState(updates.get(t.getId())));
+                        List<PermissionRule> rules = pendToolMap.getOrDefault(t.getId(), List.of());
+                        rebuilt.add(t.withStateAndSuggestedRules(updates.get(t.getId()), rules));
                     } else {
                         rebuilt.add(block);
                     }
@@ -3940,7 +3952,7 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
 
         /** Convenience overload for a single tool call. */
         private void updateToolCallState(String toolCallId, ToolCallState newState) {
-            updateToolCallStates(Map.of(toolCallId, newState));
+            updateToolCallStatesAndRules(Map.of(toolCallId, newState), Map.of());
         }
 
         /** Whether any ToolUseBlock in the last assistant Msg is in ASKING state. */

--- a/agentscope-core/src/main/java/io/agentscope/core/ReActAgent.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/ReActAgent.java
@@ -3216,11 +3216,14 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
                                 // honoured.
                                 return switch (decision.getBehavior()) {
                                     case ASK ->
-                                            new PermissionVerdict(newToolUse, PermissionBehavior.ASK);
+                                            new PermissionVerdict(
+                                                    newToolUse, PermissionBehavior.ASK);
                                     case DENY ->
-                                            new PermissionVerdict(newToolUse, PermissionBehavior.DENY);
+                                            new PermissionVerdict(
+                                                    newToolUse, PermissionBehavior.DENY);
                                     default ->
-                                            new PermissionVerdict(newToolUse, PermissionBehavior.ALLOW);
+                                            new PermissionVerdict(
+                                                    newToolUse, PermissionBehavior.ALLOW);
                                 };
                             });
         }

--- a/agentscope-core/src/main/java/io/agentscope/core/message/ToolUseBlock.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/message/ToolUseBlock.java
@@ -17,8 +17,11 @@ package io.agentscope.core.message;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.agentscope.core.permission.PermissionRule;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -42,6 +45,7 @@ public final class ToolUseBlock extends ContentBlock {
     private final String content; // Raw content for streaming tool calls
     private final Map<String, Object> metadata; // Provider-specific metadata
     private final ToolCallState state;
+    private final List<PermissionRule> suggestedRules; // Rules suggested when gated by ASK
 
     /**
      * Creates a new tool use block for JSON deserialization.
@@ -53,7 +57,7 @@ public final class ToolUseBlock extends ContentBlock {
      */
     public ToolUseBlock(
             String id, String name, Map<String, Object> input, Map<String, Object> metadata) {
-        this(id, name, input, null, metadata, null);
+        this(id, name, input, null, metadata, null, null);
     }
 
     /**
@@ -64,7 +68,7 @@ public final class ToolUseBlock extends ContentBlock {
      * @param input Input parameters for the tool (will be defensively copied)
      */
     public ToolUseBlock(String id, String name, Map<String, Object> input) {
-        this(id, name, input, null, null, null);
+        this(id, name, input, null, null, null, null);
     }
 
     /**
@@ -82,7 +86,7 @@ public final class ToolUseBlock extends ContentBlock {
             Map<String, Object> input,
             String content,
             Map<String, Object> metadata) {
-        this(id, name, input, content, metadata, null);
+        this(id, name, input, content, metadata, null, null);
     }
 
     /**
@@ -95,6 +99,27 @@ public final class ToolUseBlock extends ContentBlock {
      * @param metadata Provider-specific metadata (will be defensively copied)
      * @param state The tool call state, defaults to PENDING if null
      */
+    public ToolUseBlock(
+            String id,
+            String name,
+            Map<String, Object> input,
+            String content,
+            Map<String, Object> metadata,
+            ToolCallState state) {
+        this(id, name, input, content, metadata, state, null);
+    }
+
+    /**
+     * Creates a new tool use block with all fields.
+     *
+     * @param id Unique identifier for this tool call
+     * @param name Name of the tool to execute
+     * @param input Input parameters for the tool (will be defensively copied)
+     * @param content Raw content for streaming tool calls
+     * @param metadata Provider-specific metadata (will be defensively copied)
+     * @param state The tool call state, defaults to PENDING if null
+     * @param suggestedRules Permission rules suggested for this call (will be defensively copied)
+     */
     @JsonCreator
     public ToolUseBlock(
             @JsonProperty("id") String id,
@@ -102,7 +127,8 @@ public final class ToolUseBlock extends ContentBlock {
             @JsonProperty("input") Map<String, Object> input,
             @JsonProperty("content") String content,
             @JsonProperty("metadata") Map<String, Object> metadata,
-            @JsonProperty("state") ToolCallState state) {
+            @JsonProperty("state") ToolCallState state,
+            @JsonProperty("suggested_rules") List<PermissionRule> suggestedRules) {
         this.id = id;
         this.name = name;
         // Defensive copy to prevent external modifications
@@ -116,6 +142,10 @@ public final class ToolUseBlock extends ContentBlock {
                         ? Collections.emptyMap()
                         : Collections.unmodifiableMap(new HashMap<>(metadata));
         this.state = state != null ? state : ToolCallState.PENDING;
+        this.suggestedRules =
+                suggestedRules == null
+                        ? Collections.emptyList()
+                        : Collections.unmodifiableList(new ArrayList<>(suggestedRules));
     }
 
     /**
@@ -176,13 +206,66 @@ public final class ToolUseBlock extends ContentBlock {
     }
 
     /**
+     * Gets the permission rules suggested for this tool call.
+     *
+     * <p>Populated when the permission engine gates this call with
+     * {@link io.agentscope.core.permission.PermissionBehavior#ASK}: the owning tool derives
+     * candidate rules from the actual invocation via
+     * {@link io.agentscope.core.tool.ToolBase#generateSuggestions}. Passing them back in a
+     * {@code ConfirmResult} registers them with the engine, so future matching calls resolve
+     * without another prompt.
+     *
+     * @return The suggested rules, or an empty list when none were suggested
+     */
+    @JsonProperty("suggested_rules")
+    public List<PermissionRule> getSuggestedRules() {
+        return suggestedRules;
+    }
+
+    /**
      * Returns a copy of this block with the given state.
      *
      * @param state The new state
      * @return A new ToolUseBlock with the updated state
      */
     public ToolUseBlock withState(ToolCallState state) {
-        return new ToolUseBlock(this.id, this.name, this.input, this.content, this.metadata, state);
+        return new ToolUseBlock(
+                this.id,
+                this.name,
+                this.input,
+                this.content,
+                this.metadata,
+                state,
+                this.suggestedRules);
+    }
+
+    /**
+     * Returns a copy of this block with the given suggested rules.
+     *
+     * @param suggestedRules The suggested permission rules
+     * @return A new ToolUseBlock with the updated suggested rules
+     */
+    public ToolUseBlock withSuggestedRules(List<PermissionRule> suggestedRules) {
+        return new ToolUseBlock(
+                this.id,
+                this.name,
+                this.input,
+                this.content,
+                this.metadata,
+                this.state,
+                suggestedRules);
+    }
+
+    /**
+     * Returns a copy of this block with the given suggested rules.
+     * @param state The new state
+     * @param suggestedRules The suggested permission rules
+     * @return A new ToolUseBlock with the updated suggested rules and state
+     */
+    public ToolUseBlock withStateAndSuggestedRules(
+            ToolCallState state, List<PermissionRule> suggestedRules) {
+        return new ToolUseBlock(
+                this.id, this.name, this.input, this.content, this.metadata, state, suggestedRules);
     }
 
     /**
@@ -204,6 +287,7 @@ public final class ToolUseBlock extends ContentBlock {
         private String content;
         private Map<String, Object> metadata;
         private ToolCallState state;
+        private List<PermissionRule> suggestedRules;
 
         /**
          * Sets the unique identifier for the tool call.
@@ -275,12 +359,23 @@ public final class ToolUseBlock extends ContentBlock {
         }
 
         /**
+         * Sets the permission rules suggested for this tool call.
+         *
+         * @param suggestedRules The suggested permission rules
+         * @return This builder for chaining
+         */
+        public Builder suggestedRules(List<PermissionRule> suggestedRules) {
+            this.suggestedRules = suggestedRules;
+            return this;
+        }
+
+        /**
          * Builds a new ToolUseBlock with the configured properties.
          *
          * @return A new ToolUseBlock instance
          */
         public ToolUseBlock build() {
-            return new ToolUseBlock(id, name, input, content, metadata, state);
+            return new ToolUseBlock(id, name, input, content, metadata, state, suggestedRules);
         }
     }
 }

--- a/agentscope-core/src/test/java/io/agentscope/core/agent/ReActAgentHitlTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/agent/ReActAgentHitlTest.java
@@ -700,26 +700,31 @@ class ReActAgentHitlTest {
                     ToolBase.builder()
                             .name("send_money")
                             .description("Sends a money to the user")
-                            .inputSchema(Map.of(
-                                    "type", "object",
-                                    "properties", Map.of(
-                                            "user", Map.of("type", "string"),
-                                            "money", Map.of("type", "string")),
-                                    "required", List.of("user", "money")))
-            );
+                            .inputSchema(
+                                    Map.of(
+                                            "type", "object",
+                                            "properties",
+                                                    Map.of(
+                                                            "user", Map.of("type", "string"),
+                                                            "money", Map.of("type", "string")),
+                                            "required", List.of("user", "money"))));
         }
 
         @Override
-        public Mono<PermissionDecision> checkPermissions(Map<String, Object> toolInput, PermissionContextState context) {
-            return Mono.just(PermissionDecision.ask("Requesting permission for send_money tool").withSuggestedRules(generateSuggestions(toolInput)));
+        public Mono<PermissionDecision> checkPermissions(
+                Map<String, Object> toolInput, PermissionContextState context) {
+            return Mono.just(
+                    PermissionDecision.ask("Requesting permission for send_money tool")
+                            .withSuggestedRules(generateSuggestions(toolInput)));
         }
 
         @Override
         public Mono<ToolResultBlock> callAsync(ToolCallParam param) {
-            return Mono.just(ToolResultBlock.builder()
-                    .name("send_money")
-                    .output(TextBlock.builder().text("send success!").build())
-                    .build());
+            return Mono.just(
+                    ToolResultBlock.builder()
+                            .name("send_money")
+                            .output(TextBlock.builder().text("send success!").build())
+                            .build());
         }
     }
 }

--- a/agentscope-core/src/test/java/io/agentscope/core/message/ToolUseBlockTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/message/ToolUseBlockTest.java
@@ -22,6 +22,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.agentscope.core.permission.PermissionBehavior;
+import io.agentscope.core.permission.PermissionRule;
+import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 
@@ -292,5 +295,82 @@ class ToolUseBlockTest {
         assertNotNull(toolUseBlock.getMetadata());
         assertTrue(toolUseBlock.getMetadata().isEmpty());
         assertEquals(null, toolUseBlock.getContent());
+    }
+
+    @Test
+    void testSuggestedRulesDefaultsToEmptyList() {
+        ToolUseBlock toolUseBlock = new ToolUseBlock("tool-1000", "no-rules", Map.of());
+
+        assertNotNull(toolUseBlock.getSuggestedRules());
+        assertTrue(toolUseBlock.getSuggestedRules().isEmpty());
+    }
+
+    @Test
+    void testWithSuggestedRulesKeepsStateAndCopiesRules() {
+        PermissionRule rule =
+                new PermissionRule("calculator", "add(*)", PermissionBehavior.ALLOW, "tool");
+        ToolUseBlock original =
+                ToolUseBlock.builder()
+                        .id("tool-1001")
+                        .name("calculator")
+                        .state(ToolCallState.ASKING)
+                        .build();
+
+        ToolUseBlock updated = original.withSuggestedRules(List.of(rule));
+
+        assertTrue(original.getSuggestedRules().isEmpty());
+        assertEquals(ToolCallState.ASKING, updated.getState());
+        assertEquals(List.of(rule), updated.getSuggestedRules());
+    }
+
+    @Test
+    void testWithStateAndSuggestedRules() {
+        PermissionRule rule =
+                new PermissionRule("calculator", "add(*)", PermissionBehavior.ALLOW, "tool");
+        ToolUseBlock original = ToolUseBlock.builder().id("tool-1002").name("calculator").build();
+
+        ToolUseBlock updated =
+                original.withStateAndSuggestedRules(ToolCallState.ASKING, List.of(rule));
+
+        assertEquals(ToolCallState.ASKING, updated.getState());
+        assertEquals(List.of(rule), updated.getSuggestedRules());
+    }
+
+    @Test
+    void testWithStatePreservesSuggestedRules() {
+        PermissionRule rule =
+                new PermissionRule("calculator", "add(*)", PermissionBehavior.ALLOW, "tool");
+        ToolUseBlock asking =
+                ToolUseBlock.builder()
+                        .id("tool-1003")
+                        .name("calculator")
+                        .state(ToolCallState.ASKING)
+                        .suggestedRules(List.of(rule))
+                        .build();
+
+        ToolUseBlock allowed = asking.withState(ToolCallState.ALLOWED);
+
+        assertEquals(ToolCallState.ALLOWED, allowed.getState());
+        assertEquals(List.of(rule), allowed.getSuggestedRules());
+    }
+
+    @Test
+    void testSuggestedRulesRoundTrip() throws JsonProcessingException {
+        PermissionRule rule =
+                new PermissionRule("calculator", "add(*)", PermissionBehavior.ALLOW, "tool");
+        ToolUseBlock toolUseBlock =
+                ToolUseBlock.builder()
+                        .id("tool-1004")
+                        .name("calculator")
+                        .state(ToolCallState.ASKING)
+                        .suggestedRules(List.of(rule))
+                        .build();
+
+        String json = objectMapper.writeValueAsString(toolUseBlock);
+        assertTrue(json.contains("\"suggested_rules\""));
+
+        ToolUseBlock parsed = objectMapper.readValue(json, ToolUseBlock.class);
+        assertEquals(List.of(rule), parsed.getSuggestedRules());
+        assertEquals(ToolCallState.ASKING, parsed.getState());
     }
 }

--- a/agentscope-examples/documentation/src/main/java/io/agentscope/examples/documentation2/hitl/PermissionHITLExample.java
+++ b/agentscope-examples/documentation/src/main/java/io/agentscope/examples/documentation2/hitl/PermissionHITLExample.java
@@ -179,7 +179,9 @@ public class PermissionHITLExample {
 
                 // Build ConfirmResult from the extracted ToolUseBlocks and resume
                 List<ConfirmResult> confirmResults =
-                        askingTools.stream().map(t -> new ConfirmResult(approved, t)).toList();
+                        askingTools.stream()
+                                .map(t -> new ConfirmResult(approved, t, t.getSuggestedRules()))
+                                .toList();
                 Map<String, Object> meta = new HashMap<>();
                 meta.put(Msg.METADATA_CONFIRM_RESULTS, confirmResults);
                 Msg resumeMsg =


### PR DESCRIPTION
实现了 ToolUseBlock.getSuggestedRules() 的完整功能，该功能已在文档中描述但尚未实现。

**变更内容**
关闭: #1592
核心实现

- ToolUseBlock.java:
  - 添加 suggestedRules 字段用于存储权限引擎建议的规则
  - 实现 getSuggestedRules() 方法
  - 实现 withSuggestedRules() 和 withStateAndSuggestedRules() 方法
  - 支持 JSON 序列化/反序列化（字段名：suggested_rules）
- ReActAgent.java:
  - 在权限检查流程中调用 decision.getSuggestedRules()
  - 将建议的规则附加到 ToolUseBlock 上
测试
- ToolUseBlockTest.java:
  - 添加 6 个新测试用例覆盖 suggestedRules 相关功能
  - 测试默认值、设置规则、状态保持、JSON 序列化等场景

示例

- PermissionHITLExample.java:
- 更新示例代码使用 getSuggestedRules() 方法

测试

# 已通过的测试
mvn test -Dtest=ToolUseBlockTest
mvn spotless:check

所有新功能都包含了单元测试，代码格式符合项目规范。

相关 Issue

此 PR 实现了已在 javadoc 中承诺但缺失的功能，修复了代码与文档不一致的问题。

检查清单

- [x] 代码已使用 mvn spotless:apply 格式化
- [x] 添加了相应的单元测试
- [x] 所有测试通过
- [x] 提交信息遵循 Conventional Commits 规范
- [x] 保持向后兼容性