### PR TITLE
fix(nacos): make skill source paths Windows-safe

### DIFF
--- a/agentscope-extensions/agentscope-extensions-nacos/agentscope-extensions-nacos-skill/src/main/java/io/agentscope/core/nacos/skill/NacosSkillRepository.java
+++ b/agentscope-extensions/agentscope-extensions-nacos/agentscope-extensions-nacos-skill/src/main/java/io/agentscope/core/nacos/skill/NacosSkillRepository.java
@@ -144,7 +144,7 @@ public class NacosSkillRepository implements AgentSkillRepository {
         this.aiService = aiService;
 
         this.namespaceId = StringUtils.isBlank(namespaceId) ? "public" : namespaceId.trim();
-        this.source = REPO_TYPE + ":" + this.namespaceId;
+        this.source = REPO_TYPE + "@" + this.namespaceId;
         this.location = LOCATION_PREFIX + this.namespaceId;
         this.skillVersion =
                 firstNonBlank(

--- a/agentscope-extensions/agentscope-extensions-nacos/agentscope-extensions-nacos-skill/src/test/java/io/agentscope/core/nacos/skill/NacosSkillRepositoryTest.java
+++ b/agentscope-extensions/agentscope-extensions-nacos/agentscope-extensions-nacos-skill/src/test/java/io/agentscope/core/nacos/skill/NacosSkillRepositoryTest.java
@@ -16,8 +16,10 @@
 
 package io.agentscope.core.nacos.skill;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -29,10 +31,14 @@ import static org.mockito.Mockito.when;
 import com.alibaba.nacos.api.ai.AiService;
 import com.alibaba.nacos.api.exception.NacosException;
 import io.agentscope.core.skill.AgentSkill;
+import io.agentscope.core.skill.SkillBox;
 import io.agentscope.core.skill.repository.AgentSkillRepositoryInfo;
+import io.agentscope.core.tool.Toolkit;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.List;
 import java.util.Properties;
 import java.util.zip.ZipEntry;
@@ -41,6 +47,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -147,7 +154,7 @@ class NacosSkillRepositoryTest {
         assertEquals("test-skill", result.getName());
         assertEquals("A test skill", result.getDescription());
         assertEquals("Do something", result.getSkillContent());
-        assertEquals("nacos:public", result.getSource());
+        assertEquals("nacos@public", result.getSource());
     }
 
     @Test
@@ -374,16 +381,52 @@ class NacosSkillRepositoryTest {
     @Test
     @DisplayName("Should return correct source")
     void testGetSource() {
-        assertEquals("nacos:public", repository.getSource());
+        assertEquals("nacos@public", repository.getSource());
+    }
+
+    @Test
+    @DisplayName("Should encode namespace characters without delimiter ambiguity")
+    void testSourceEncodesNamespaceCharacters() {
+        NacosSkillRepository hyphenRepo = new NacosSkillRepository(aiService, "team-a");
+        NacosSkillRepository underscoreRepo = new NacosSkillRepository(aiService, "team_a");
+
+        assertEquals("nacos@team-a", hyphenRepo.getSource());
+        assertEquals("nacos@team_a", underscoreRepo.getSource());
+        assertNotEquals(hyphenRepo.getSource(), underscoreRepo.getSource());
     }
 
     @Test
     @DisplayName("Should use default namespace when namespaceId is blank")
     void testDefaultNamespace() {
         try (NacosSkillRepository repo = new NacosSkillRepository(aiService, null)) {
-            assertEquals("nacos:public", repo.getSource());
+            assertEquals("nacos@public", repo.getSource());
             assertEquals("namespace:public", repo.getRepositoryInfo().getLocation());
         }
+    }
+
+    @Test
+    @DisplayName("Should upload skill resources using a Windows-safe skill ID")
+    void testUploadSkillResourcesWithWindowsSafeSkillId(@TempDir Path tempDir)
+            throws NacosException, IOException {
+        when(aiService.downloadSkillZip("resource-skill"))
+                .thenReturn(
+                        createSkillZip(
+                                "resource-skill",
+                                "Resource skill",
+                                "Use the script",
+                                "scripts/run.sh",
+                                "echo hello"));
+        AgentSkill skill = repository.getSkill("resource-skill");
+        SkillBox skillBox = new SkillBox(new Toolkit());
+        skillBox.setWorkDir(tempDir);
+        skillBox.registerSkill(skill);
+
+        assertDoesNotThrow(skillBox::uploadSkillFiles);
+
+        Path uploadedResource =
+                tempDir.resolve("skills").resolve(skill.getSkillId()).resolve("scripts/run.sh");
+        assertTrue(Files.isRegularFile(uploadedResource));
+        assertEquals("echo hello", Files.readString(uploadedResource));
     }
 
     @Test


### PR DESCRIPTION
## AgentScope-Java Version

2.0.3-SNAPSHOT

## Description

### Background

`NacosSkillRepository` used `nacos:<namespaceId>` as its source identifier. `AgentSkill#getSkillId()` includes that source, and `SkillBox#uploadSkillFiles()` uses the resulting skill ID as a directory name. On Windows, the embedded `:` is illegal inside a path segment, so skills containing additional resources fail with `InvalidPathException` during materialization.

### Changes

- Replace the Nacos source separator with `@`, producing identifiers such as `nacos@public`.
- Keep namespace IDs containing `-` or `_` distinct and unchanged.
- Add a regression test that loads a Nacos skill ZIP with `scripts/run.sh`, registers it in `SkillBox`, and verifies that the resource is actually written to disk.
- Update source assertions for the new identifier format.

### Why this approach

`@` is valid in file names on Windows, Linux, and macOS, while remaining visually distinct from the `-` and `_` characters commonly present in Nacos namespace IDs. Fixing the source identifier addresses the complete failure chain without changing the generic skill ID or resource-upload behavior.

### Test

```shell
mvn -pl agentscope-extensions/agentscope-extensions-nacos/agentscope-extensions-nacos-skill -am test -Dtest=NacosSkillRepositoryTest -DfailIfNoTests=false
```

Result: 36 tests passed.

Closes #1158
Closes #1339
Related to #842

## Checklist

- [x] Code has been formatted with `mvn spotless:apply`
- [x] All relevant tests are passing
- [x] Javadoc comments are complete and follow project conventions
- [x] Related documentation is not required for this internal identifier fix
- [x] Code is ready for review