### PR TITLE
fix(a2a): suppress cancellation after final event

### DIFF
--- a/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-a2a/agentscope-extensions-a2a-client/src/main/java/io/agentscope/core/a2a/agent/A2aAgent.java
+++ b/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-a2a/agentscope-extensions-a2a-client/src/main/java/io/agentscope/core/a2a/agent/A2aAgent.java
@@ -188,7 +188,9 @@ public class A2aAgent extends AgentBase {
         ClientBuilder builder = Client.builder(this.agentCardResolver.getAgentCard(name));
         if (this.a2aAgentConfig.clientTransports().isEmpty()) {
             // Default Add The Basic JSON-RPC Transport
-            builder.withTransport(JSONRPCTransport.class, new JSONRPCTransportConfig());
+            builder.withTransport(
+                    JSONRPCTransport.class,
+                    new JSONRPCTransportConfig(new CancellationSuppressingA2aHttpClient()));
         } else {
             this.a2aAgentConfig.clientTransports().forEach(builder::withTransport);
         }

--- a/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-a2a/agentscope-extensions-a2a-client/src/main/java/io/agentscope/core/a2a/agent/CancellationSuppressingA2aHttpClient.java
+++ b/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-a2a/agentscope-extensions-a2a-client/src/main/java/io/agentscope/core/a2a/agent/CancellationSuppressingA2aHttpClient.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.agentscope.core.a2a.agent;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.a2a.client.http.A2AHttpClient;
+import io.a2a.client.http.A2AHttpResponse;
+import io.a2a.client.http.JdkA2AHttpClient;
+import io.a2a.util.Utils;
+import java.io.IOException;
+import java.util.Map;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Consumer;
+
+/**
+ * Applies the A2A Java SDK 1.1 SSE cancellation fix to the v0.3 client API.
+ *
+ * <p>The v0.3.3 SDK cancels its HTTP future after delivering a final status update. The JDK HTTP
+ * client can report that internal cleanup as a {@link CancellationException}, which is then passed
+ * to the streaming error callback. This decorator keeps the v0.3 SDK/API and suppresses only that
+ * cancellation after a final status-update event has been received.
+ *
+ * <p>This class is intentionally package-private. It is an implementation detail of the default
+ * JSON-RPC transport and can be removed when AgentScope moves to a v0.3-compatible SDK release
+ * containing the upstream fix.
+ */
+final class CancellationSuppressingA2aHttpClient implements A2AHttpClient {
+
+    private final A2AHttpClient delegate;
+
+    CancellationSuppressingA2aHttpClient() {
+        this(new JdkA2AHttpClient());
+    }
+
+    CancellationSuppressingA2aHttpClient(A2AHttpClient delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public GetBuilder createGet() {
+        return delegate.createGet();
+    }
+
+    @Override
+    public PostBuilder createPost() {
+        return new CancellationSuppressingPostBuilder(delegate.createPost());
+    }
+
+    @Override
+    public DeleteBuilder createDelete() {
+        return delegate.createDelete();
+    }
+
+    private static boolean isCancellation(Throwable throwable) {
+        for (Throwable current = throwable; current != null; current = current.getCause()) {
+            if (current instanceof CancellationException) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static boolean isFinalStatusUpdate(String message) {
+        try {
+            JsonNode root = Utils.OBJECT_MAPPER.readTree(message);
+            JsonNode result = root.get("result");
+            return result != null
+                    && "status-update".equals(result.path("kind").asText())
+                    && result.path("final").asBoolean(false);
+        } catch (IOException | RuntimeException ignored) {
+            return false;
+        }
+    }
+
+    private static final class CancellationSuppressingPostBuilder implements PostBuilder {
+
+        private final PostBuilder delegate;
+
+        private final AtomicBoolean completed = new AtomicBoolean();
+
+        private CancellationSuppressingPostBuilder(PostBuilder delegate) {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public PostBuilder url(String url) {
+            delegate.url(url);
+            return this;
+        }
+
+        @Override
+        public PostBuilder addHeaders(Map<String, String> headers) {
+            delegate.addHeaders(headers);
+            return this;
+        }
+
+        @Override
+        public PostBuilder addHeader(String name, String value) {
+            delegate.addHeader(name, value);
+            return this;
+        }
+
+        @Override
+        public PostBuilder body(String body) {
+            delegate.body(body);
+            return this;
+        }
+
+        @Override
+        public A2AHttpResponse post() throws IOException, InterruptedException {
+            return delegate.post();
+        }
+
+        @Override
+        public CompletableFuture<Void> postAsyncSSE(
+                Consumer<String> messageConsumer,
+                Consumer<Throwable> errorConsumer,
+                Runnable completeRunnable)
+                throws IOException, InterruptedException {
+            completed.set(false);
+            return delegate.postAsyncSSE(
+                    message -> {
+                        if (isFinalStatusUpdate(message)) {
+                            completed.set(true);
+                        }
+                        messageConsumer.accept(message);
+                    },
+                    error -> {
+                        if (!completed.get() || !isCancellation(error)) {
+                            errorConsumer.accept(error);
+                        }
+                    },
+                    completeRunnable);
+        }
+    }
+}

--- a/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-a2a/agentscope-extensions-a2a-client/src/test/java/io/agentscope/core/a2a/agent/CancellationSuppressingA2aHttpClientTest.java
+++ b/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-a2a/agentscope-extensions-a2a-client/src/test/java/io/agentscope/core/a2a/agent/CancellationSuppressingA2aHttpClientTest.java
@@ -17,12 +17,15 @@
 package io.agentscope.core.a2a.agent;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.a2a.client.http.A2AHttpClient;
+import io.a2a.client.http.A2AHttpResponse;
 import java.io.IOException;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
@@ -71,6 +74,119 @@ class CancellationSuppressingA2aHttpClientTest {
     }
 
     @Test
+    void delegatesOtherHttpClientBuilders() {
+        A2AHttpClient delegate = mock(A2AHttpClient.class);
+        A2AHttpClient.GetBuilder getBuilder = mock(A2AHttpClient.GetBuilder.class);
+        A2AHttpClient.DeleteBuilder deleteBuilder = mock(A2AHttpClient.DeleteBuilder.class);
+        when(delegate.createGet()).thenReturn(getBuilder);
+        when(delegate.createDelete()).thenReturn(deleteBuilder);
+
+        A2AHttpClient client = new CancellationSuppressingA2aHttpClient(delegate);
+
+        assertSame(getBuilder, client.createGet());
+        assertSame(deleteBuilder, client.createDelete());
+        verify(delegate).createGet();
+        verify(delegate).createDelete();
+    }
+
+    @Test
+    void delegatesPostBuilderConfigurationAndSynchronousRequests() throws Exception {
+        A2AHttpClient delegate = mock(A2AHttpClient.class);
+        A2AHttpClient.PostBuilder postBuilder = mock(A2AHttpClient.PostBuilder.class);
+        A2AHttpResponse response = mock(A2AHttpResponse.class);
+        when(delegate.createPost()).thenReturn(postBuilder);
+        when(postBuilder.post()).thenReturn(response);
+
+        A2AHttpClient.PostBuilder wrapped =
+                new CancellationSuppressingA2aHttpClient(delegate).createPost();
+
+        assertSame(wrapped, wrapped.url("https://example.test"));
+        assertSame(wrapped, wrapped.addHeader("Authorization", "Bearer token"));
+        assertSame(wrapped, wrapped.addHeaders(java.util.Map.of("Accept", "application/json")));
+        assertSame(wrapped, wrapped.body("{}"));
+        assertSame(response, wrapped.post());
+        verify(postBuilder).url("https://example.test");
+        verify(postBuilder).addHeader("Authorization", "Bearer token");
+        verify(postBuilder).addHeaders(java.util.Map.of("Accept", "application/json"));
+        verify(postBuilder).body("{}");
+        verify(postBuilder).post();
+    }
+
+    @Test
+    void forwardsCompletionCallback() throws Exception {
+        CallbackCapture callbacks = new CallbackCapture();
+        A2AHttpClient client = newClient(callbacks);
+        AtomicInteger completionCount = new AtomicInteger();
+
+        client.createPost()
+                .postAsyncSSE(message -> {}, error -> {}, completionCount::incrementAndGet);
+
+        callbacks.completeRunnable.get().run();
+
+        assertEquals(1, completionCount.get());
+    }
+
+    @Test
+    void forwardsCancellationForNonFinalStatusUpdate() throws Exception {
+        CallbackCapture callbacks = new CallbackCapture();
+        A2AHttpClient client = newClient(callbacks);
+        AtomicInteger errorCount = new AtomicInteger();
+
+        client.createPost()
+                .postAsyncSSE(message -> {}, error -> errorCount.incrementAndGet(), () -> {});
+
+        callbacks
+                .messageConsumer
+                .get()
+                .accept(
+                        "{\"jsonrpc\":\"2.0\",\"result\":{\"kind\":\"status-update\",\"final\":false}}");
+        callbacks.errorConsumer.get().accept(new CancellationException("Request cancelled"));
+
+        assertEquals(1, errorCount.get());
+    }
+
+    @Test
+    void ignoresMalformedAndNonResultMessagesWhenDetectingFinalStatus() throws Exception {
+        CallbackCapture malformedCallbacks = new CallbackCapture();
+        A2AHttpClient malformedClient = newClient(malformedCallbacks);
+        AtomicInteger malformedErrorCount = new AtomicInteger();
+        malformedClient
+                .createPost()
+                .postAsyncSSE(
+                        message -> {}, error -> malformedErrorCount.incrementAndGet(), () -> {});
+
+        malformedCallbacks.messageConsumer.get().accept("not-json");
+        malformedCallbacks
+                .errorConsumer
+                .get()
+                .accept(new CancellationException("Request cancelled"));
+
+        CallbackCapture missingResultCallbacks = new CallbackCapture();
+        A2AHttpClient missingResultClient = newClient(missingResultCallbacks);
+        AtomicInteger missingResultErrorCount = new AtomicInteger();
+        missingResultClient
+                .createPost()
+                .postAsyncSSE(
+                        message -> {},
+                        error -> missingResultErrorCount.incrementAndGet(),
+                        () -> {});
+
+        missingResultCallbacks.messageConsumer.get().accept("{\"jsonrpc\":\"2.0\"}");
+        missingResultCallbacks
+                .messageConsumer
+                .get()
+                .accept(
+                        "{\"jsonrpc\":\"2.0\",\"result\":{\"kind\":\"artifact-update\",\"final\":true}}");
+        missingResultCallbacks
+                .errorConsumer
+                .get()
+                .accept(new CancellationException("Request cancelled"));
+
+        assertEquals(1, malformedErrorCount.get());
+        assertEquals(1, missingResultErrorCount.get());
+    }
+
+    @Test
     void forwardsNonCancellationErrorsAfterFinalStatusUpdate() throws Exception {
         CallbackCapture callbacks = new CallbackCapture();
         A2AHttpClient client = newClient(callbacks);
@@ -93,6 +209,7 @@ class CancellationSuppressingA2aHttpClientTest {
                         invocation -> {
                             callbacks.messageConsumer.set(invocation.getArgument(0));
                             callbacks.errorConsumer.set(invocation.getArgument(1));
+                            callbacks.completeRunnable.set(invocation.getArgument(2));
                             return new CompletableFuture<>();
                         })
                 .when(postBuilder)
@@ -103,5 +220,6 @@ class CancellationSuppressingA2aHttpClientTest {
     private static final class CallbackCapture {
         private final AtomicReference<Consumer<String>> messageConsumer = new AtomicReference<>();
         private final AtomicReference<Consumer<Throwable>> errorConsumer = new AtomicReference<>();
+        private final AtomicReference<Runnable> completeRunnable = new AtomicReference<>();
     }
 }

--- a/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-a2a/agentscope-extensions-a2a-client/src/test/java/io/agentscope/core/a2a/agent/CancellationSuppressingA2aHttpClientTest.java
+++ b/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-a2a/agentscope-extensions-a2a-client/src/test/java/io/agentscope/core/a2a/agent/CancellationSuppressingA2aHttpClientTest.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.agentscope.core.a2a.agent;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.a2a.client.http.A2AHttpClient;
+import java.io.IOException;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+import org.junit.jupiter.api.Test;
+
+class CancellationSuppressingA2aHttpClientTest {
+
+    private static final String FINAL_STATUS_UPDATE =
+            "{\"jsonrpc\":\"2.0\",\"id\":\"request-id\","
+                    + "\"result\":{\"kind\":\"status-update\",\"final\":true}}";
+
+    @Test
+    void suppressesCancellationAfterFinalStatusUpdate() throws Exception {
+        CallbackCapture callbacks = new CallbackCapture();
+        A2AHttpClient client = newClient(callbacks);
+        AtomicInteger errorCount = new AtomicInteger();
+
+        client.createPost()
+                .postAsyncSSE(message -> {}, error -> errorCount.incrementAndGet(), () -> {});
+
+        callbacks.messageConsumer.get().accept(FINAL_STATUS_UPDATE);
+        callbacks
+                .errorConsumer
+                .get()
+                .accept(new CompletionException(new CancellationException("Request cancelled")));
+
+        assertEquals(0, errorCount.get());
+    }
+
+    @Test
+    void forwardsCancellationBeforeFinalStatusUpdate() throws Exception {
+        CallbackCapture callbacks = new CallbackCapture();
+        A2AHttpClient client = newClient(callbacks);
+        AtomicInteger errorCount = new AtomicInteger();
+
+        client.createPost()
+                .postAsyncSSE(message -> {}, error -> errorCount.incrementAndGet(), () -> {});
+
+        callbacks.errorConsumer.get().accept(new CancellationException("Request cancelled"));
+
+        assertEquals(1, errorCount.get());
+    }
+
+    @Test
+    void forwardsNonCancellationErrorsAfterFinalStatusUpdate() throws Exception {
+        CallbackCapture callbacks = new CallbackCapture();
+        A2AHttpClient client = newClient(callbacks);
+        AtomicReference<Throwable> receivedError = new AtomicReference<>();
+
+        client.createPost().postAsyncSSE(message -> {}, receivedError::set, () -> {});
+
+        callbacks.messageConsumer.get().accept(FINAL_STATUS_UPDATE);
+        IOException expected = new IOException("transport failed");
+        callbacks.errorConsumer.get().accept(expected);
+
+        assertEquals(expected, receivedError.get());
+    }
+
+    private A2AHttpClient newClient(CallbackCapture callbacks) throws Exception {
+        A2AHttpClient delegate = mock(A2AHttpClient.class);
+        A2AHttpClient.PostBuilder postBuilder = mock(A2AHttpClient.PostBuilder.class);
+        when(delegate.createPost()).thenReturn(postBuilder);
+        doAnswer(
+                        invocation -> {
+                            callbacks.messageConsumer.set(invocation.getArgument(0));
+                            callbacks.errorConsumer.set(invocation.getArgument(1));
+                            return new CompletableFuture<>();
+                        })
+                .when(postBuilder)
+                .postAsyncSSE(any(), any(), any());
+        return new CancellationSuppressingA2aHttpClient(delegate);
+    }
+
+    private static final class CallbackCapture {
+        private final AtomicReference<Consumer<String>> messageConsumer = new AtomicReference<>();
+        private final AtomicReference<Consumer<Throwable>> errorConsumer = new AtomicReference<>();
+    }
+}


### PR DESCRIPTION
## Summary

- Keep `a2a-java-sdk 0.3.3.Final` and A2A Protocol v0.3 compatibility.
- Wrap the default JSON-RPC HTTP client to suppress the internal `CancellationException` emitted after a final status update.
- Continue forwarding cancellations received before a final event and real transport errors.
- Add regression tests for the callback behavior.

## Testing

- `mvn -pl agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-a2a/agentscope-extensions-a2a-client -am test`

Fixes #2927
