### PR TITLE
feat(core): add returnDirect terminal tool short-circuit

### DIFF
--- a/agentscope-core/src/main/java/io/agentscope/core/ReActAgent.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/ReActAgent.java
@@ -218,14 +218,16 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
     private static final GracefulShutdownManager shutdownManager =
             GracefulShutdownManager.getInstance();
 
-    /** Tool name used for the per-call structured-output {@code generate_response} tool. */
+    /**
+     * Tool name used for the per-call structured-output {@code generate_response} tool.
+     */
     public static final String STRUCTURED_OUTPUT_TOOL_NAME = "generate_response";
 
     /**
      * @deprecated Permission HITL no longer uses a Reactor Sink. Confirm results are now
-     *     delivered via a second {@code agent.call(msgs)} carrying a {@link ConfirmResult}
-     *     payload — see {@code applyConfirmResults}. This constant is retained as a
-     *     compile-time marker and will be removed in a future release.
+     * delivered via a second {@code agent.call(msgs)} carrying a {@link ConfirmResult}
+     * payload — see {@code applyConfirmResults}. This constant is retained as a
+     * compile-time marker and will be removed in a future release.
      */
     @Deprecated
     public static final String CONFIRM_SINK_KEY = "io.agentscope.core.ReActAgent.confirmSink";
@@ -246,7 +248,9 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
      */
     private final Toolkit toolkit;
 
-    /** Default active groups captured after builder-time toolkit configuration is complete. */
+    /**
+     * Default active groups captured after builder-time toolkit configuration is complete.
+     */
     private final List<String> initialActiveToolGroups;
 
     private final ToolExecutionContext toolExecutionContext;
@@ -279,10 +283,14 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
 
     // ==================== 2.0 Core Fields ====================
 
-    /** Active per-call RuntimeContext, set during call lifecycle only. */
+    /**
+     * Active per-call RuntimeContext, set during call lifecycle only.
+     */
     private volatile RuntimeContext activeRc;
 
-    /** Cache of state per {@code (userId, sessionId)} slot key. */
+    /**
+     * Cache of state per {@code (userId, sessionId)} slot key.
+     */
     private final ConcurrentHashMap<String, AgentState> stateCache = new ConcurrentHashMap<>();
 
     /**
@@ -292,7 +300,9 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
      */
     private final ConcurrentHashMap<String, Long> slotVersions = new ConcurrentHashMap<>();
 
-    /** Count of CAS conflicts observed during agent_state saves (metric / diagnostics). */
+    /**
+     * Count of CAS conflicts observed during agent_state saves (metric / diagnostics).
+     */
     private final AtomicLong stateConflictCount = new AtomicLong();
 
     /**
@@ -314,7 +324,9 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
      */
     private static final String EVENT_SINK_KEY = "io.agentscope.core.ReActAgent.eventSink";
 
-    /** Synthetic reminder injected when looping back to reasoning for an empty final response. */
+    /**
+     * Synthetic reminder injected when looping back to reasoning for an empty final response.
+     */
     private static final String EMPTY_RESPONSE_REMINDER_TEXT =
             "<system-reminder>Your previous reply had empty content - the full answer was written"
                     + " to the reasoning channel only. Reply again and write the final answer into"
@@ -399,7 +411,9 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
         return (userId == null || userId.isBlank() ? "__anon__" : userId) + "/" + sessionId;
     }
 
-    /** Reverse of {@link #slotKey}: the parsed {@code (userId, sessionId)} pair. */
+    /**
+     * Reverse of {@link #slotKey}: the parsed {@code (userId, sessionId)} pair.
+     */
     private record SlotRef(String userId, String sessionId) {
         static SlotRef parse(String slotKey) {
             int slash = slotKey.lastIndexOf('/');
@@ -416,7 +430,7 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
      * {@link LegacyStateLoader}, and finally a fresh state if neither yields anything.
      *
      * @return state paired with the store version ({@code 0} when absent on a versioning backend,
-     *     {@link AgentStateStore#UNVERSIONED} when the backend does not version)
+     * {@link AgentStateStore#UNVERSIONED} when the backend does not version)
      */
     private static VersionedState<AgentState> loadOrCreateAgentStateForSlot(
             AgentStateStore stateStore,
@@ -531,7 +545,7 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
      * CAS-aware persist of {@code agent_state}. Applies {@link #conflictPolicy} on conflict.
      *
      * @return the new store version, or {@link AgentStateStore#UNVERSIONED} when the backend does
-     *     not version / the write used unconditional overwrite without a version return
+     * not version / the write used unconditional overwrite without a version return
      */
     private long persistAgentStateCas(
             String userId,
@@ -870,9 +884,9 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
      * Calls the agent with a plain text input, structured output class, and per-call
      * {@link RuntimeContext}.
      *
-     * @param text                 input text (wrapped into a {@link UserMessage})
+     * @param text                  input text (wrapped into a {@link UserMessage})
      * @param structuredOutputClass class defining the structure
-     * @param context              per-call runtime context
+     * @param context               per-call runtime context
      * @return response message with structured data in metadata
      */
     public Mono<Msg> call(String text, Class<?> structuredOutputClass, RuntimeContext context) {
@@ -903,14 +917,18 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
         interrupt(null, defaultSessionId);
     }
 
-    /** @deprecated Use {@link #interrupt(String, String, Msg)} with explicit userId/sessionId. */
+    /**
+     * @deprecated Use {@link #interrupt(String, String, Msg)} with explicit userId/sessionId.
+     */
     @Deprecated
     @Override
     public void interrupt(Msg msg) {
         interrupt(null, defaultSessionId, msg);
     }
 
-    /** @deprecated Use {@link #interrupt(String, String)} with explicit userId/sessionId. */
+    /**
+     * @deprecated Use {@link #interrupt(String, String)} with explicit userId/sessionId.
+     */
     @Deprecated
     @Override
     public void interrupt(InterruptSource source) {
@@ -949,7 +967,7 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
     /**
      * Interrupts the in-flight call for a specific {@code (userId, sessionId)} session.
      *
-     * @param userId the user id ({@code null} = anonymous / single-tenant)
+     * @param userId    the user id ({@code null} = anonymous / single-tenant)
      * @param sessionId the session id
      */
     public void interrupt(String userId, String sessionId) {
@@ -966,8 +984,8 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
 
     /**
      * @deprecated since 2.0.0, for removal. Use {@link #streamEvents(List)} (and overloads that
-     *     accept {@link RuntimeContext} via {@code call()}-driven lifecycle) for the
-     *     fine-grained {@code AgentEvent} stream.
+     * accept {@link RuntimeContext} via {@code call()}-driven lifecycle) for the
+     * fine-grained {@code AgentEvent} stream.
      */
     @Deprecated(since = "2.0.0", forRemoval = true)
     public Flux<Event> stream(List<Msg> msgs, StreamOptions options, RuntimeContext context) {
@@ -976,7 +994,7 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
 
     /**
      * @deprecated since 2.0.0, for removal. Use {@link #streamEvents(List)} for the
-     *     fine-grained {@code AgentEvent} stream.
+     * fine-grained {@code AgentEvent} stream.
      */
     @Deprecated(since = "2.0.0", forRemoval = true)
     public Flux<Event> stream(
@@ -989,7 +1007,7 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
 
     /**
      * @deprecated since 2.0.0, for removal. Use {@link #streamEvents(List)} for the
-     *     fine-grained {@code AgentEvent} stream.
+     * fine-grained {@code AgentEvent} stream.
      */
     @Deprecated(since = "2.0.0", forRemoval = true)
     public Flux<Event> stream(
@@ -1029,10 +1047,10 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
      * before {@link AgentEndEvent}.  The {@code onAgent} middleware chain is applied exactly
      * once around this core.
      *
-     * @param msgs      input messages
-     * @param context   caller-supplied per-call {@link RuntimeContext}, or {@code null}
-     * @param doCallFn  the concrete call implementation ({@link #doCall} or a structured-output
-     *                  variant) passed straight through to {@link AgentBase#runLifecycle}
+     * @param msgs     input messages
+     * @param context  caller-supplied per-call {@link RuntimeContext}, or {@code null}
+     * @param doCallFn the concrete call implementation ({@link #doCall} or a structured-output
+     *                 variant) passed straight through to {@link AgentBase#runLifecycle}
      * @return event stream covering the full agent invocation lifecycle
      */
     private Flux<AgentEvent> buildAgentStream(
@@ -1131,7 +1149,7 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
      * Concurrent invocations do not share any state; each subscription gets its own event sink and
      * lifecycle execution.
      *
-     * @param msgs input messages
+     * @param msgs    input messages
      * @param context runtime context to propagate into the call
      * @return event stream covering the full agent invocation lifecycle
      */
@@ -1143,7 +1161,7 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
      * Stream fine-grained {@link AgentEvent}s for a single input message with a caller-supplied
      * {@link RuntimeContext}.
      *
-     * @param msg input message
+     * @param msg     input message
      * @param context runtime context to propagate into the call
      * @return event stream covering the full agent invocation lifecycle
      */
@@ -1553,7 +1571,9 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
         };
     }
 
-    /** Extract the structured result message from the {@code generate_response} tool result. */
+    /**
+     * Extract the structured result message from the {@code generate_response} tool result.
+     */
     private Msg extractStructuredResult(Msg hookResultMsg) {
         if (hookResultMsg == null) {
             return null;
@@ -1588,7 +1608,9 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
         return responseMsg;
     }
 
-    /** Merge aggregated {@link ChatUsage} / {@link ThinkingBlock} into the final message. */
+    /**
+     * Merge aggregated {@link ChatUsage} / {@link ThinkingBlock} into the final message.
+     */
     private Msg mergeCollectedMetadata(Msg msg, ChatUsage chatUsage, ThinkingBlock thinking) {
         Map<String, Object> metadata =
                 new HashMap<>(msg.getMetadata() != null ? msg.getMetadata() : Map.of());
@@ -1616,7 +1638,9 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
                 .build();
     }
 
-    /** Hoist {@code $defs}/{@code definitions} from a nested schema up to the params root. */
+    /**
+     * Hoist {@code $defs}/{@code definitions} from a nested schema up to the params root.
+     */
     @SuppressWarnings("unchecked")
     private static void hoistDefsKey(
             Map<String, Object> innerSchema, String key, Map<String, Object> target) {
@@ -1644,7 +1668,9 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
          */
         long loadedVersion;
 
-        /** Context size at load time; used by {@link ConflictPolicy#APPEND_MERGE}. */
+        /**
+         * Context size at load time; used by {@link ConflictPolicy#APPEND_MERGE}.
+         */
         int loadedContextSize;
 
         /**
@@ -1686,13 +1712,19 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
          */
         AgentTool soTool;
 
-        /** Set to {@code true} when the {@code generate_response} tool completes successfully. */
+        /**
+         * Set to {@code true} when the {@code generate_response} tool completes successfully.
+         */
         boolean soCompleted;
 
-        /** The tool result message from the successful {@code generate_response} call. */
+        /**
+         * The tool result message from the successful {@code generate_response} call.
+         */
         Msg soResultMsg;
 
-        /** Native structured-output format set on the per-call scope for native-path calls. */
+        /**
+         * Native structured-output format set on the per-call scope for native-path calls.
+         */
         ResponseFormat nativeResponseFormat;
 
         CallExecution(AgentState state, PermissionEngine permissionEngine, String slotKey) {
@@ -1899,7 +1931,9 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
             applyConfirmResults(normalized);
         }
 
-        /** Resolve the reply id for the pending HITL request stored on the last assistant message. */
+        /**
+         * Resolve the reply id for the pending HITL request stored on the last assistant message.
+         */
         private String resolvePendingRequestReplyId(String metadataKey) {
             Msg requestMsg = findLastAssistantMsg();
             if (requestMsg == null || requestMsg.getMetadata() == null) {
@@ -1925,7 +1959,9 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
             replaceLastAssistantMsg(lastAssistant.withMetadata(metadata));
         }
 
-        /** Remove HITL correlation metadata after the resume payload is accepted. */
+        /**
+         * Remove HITL correlation metadata after the resume payload is accepted.
+         */
         private void clearPendingRequestReplyId(String metadataKey) {
             Msg lastAssistant = findLastAssistantMsg();
             if (lastAssistant == null || lastAssistant.getMetadata() == null) {
@@ -2183,7 +2219,7 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
          *       completed)</li>
          * </ul>
          *
-         * @param msgs The input messages to validate
+         * @param msgs       The input messages to validate
          * @param pendingIds The set of pending tool use IDs
          * @throws IllegalStateException if validation fails
          */
@@ -2285,7 +2321,7 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
          * <p>This method streams from the model, accumulates chunks, notifies hooks, and
          * decides whether to continue to acting or return early (HITL stop, gotoReasoning, or finished).
          *
-         * @param iter Current iteration number
+         * @param iter           Current iteration number
          * @param ignoreMaxIters If true, skip maxIters check (for gotoReasoning)
          * @return Mono containing the final result message
          */
@@ -2486,10 +2522,10 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
          * ModelCallEndEvent}. The provided {@link ReasoningContext} is used to accumulate chunks
          * (for building the final {@link Msg}) and to notify legacy {@link Hook}s.
          *
-         * @param context   reasoning context for chunk accumulation
-         * @param messages  the messages to send to the model
-         * @param tools     the tool schemas available
-         * @param options   generation options
+         * @param context  reasoning context for chunk accumulation
+         * @param messages the messages to send to the model
+         * @param tools    the tool schemas available
+         * @param options  generation options
          * @return event stream from a single model call
          */
         Flux<AgentEvent> reasoningStream(
@@ -2804,6 +2840,10 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
                                                     }
 
                                                     syncToolkitToState(state);
+                                                    if (hasReturnDirect(successPairs)) {
+                                                        return Mono.just(
+                                                                buildReturnDirectMsg(successPairs));
+                                                    }
                                                     return executeIteration(iter + 1);
                                                 });
                             });
@@ -3129,9 +3169,9 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
         /**
          * Outcome of running every {@link ToolBase} call through the {@link PermissionEngine}.
          *
-         * @param pendingAsk tool calls that require user confirmation before execution.
+         * @param pendingAsk    tool calls that require user confirmation before execution.
          * @param autoDeniedIds ids of tool calls whose decision was {@code DENY}; the agent loop
-         *     synthesises denied results for them without invoking the tool.
+         *                      synthesises denied results for them without invoking the tool.
          */
         private record PermissionGate(List<ToolUseBlock> pendingAsk, Set<String> autoDeniedIds) {}
 
@@ -3293,6 +3333,56 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
                     .content(content)
                     .generateReason(GenerateReason.TOOL_SUSPENDED)
                     .build();
+        }
+
+        /**
+         * Whether any successfully executed tool is marked {@code returnDirect}.
+         */
+        private boolean hasReturnDirect(
+                List<Map.Entry<ToolUseBlock, ToolResultBlock>> successPairs) {
+            return successPairs.stream()
+                    .anyMatch(pair -> toolkit.isReturnDirect(pair.getKey().getName()));
+        }
+
+        /**
+         * End the turn after one or more {@code returnDirect} tools: surface every
+         * {@code returnResult} output in the original tool-call order (parallel execution still
+         * preserves that order), without another model call.
+         */
+        private Msg buildReturnDirectMsg(
+                List<Map.Entry<ToolUseBlock, ToolResultBlock>> successPairs) {
+            List<ContentBlock> content = new ArrayList<>();
+            List<ToolResultBlock> surfaced = new ArrayList<>();
+            for (Map.Entry<ToolUseBlock, ToolResultBlock> pair : successPairs) {
+                String toolName = pair.getKey().getName();
+                if (!toolkit.isReturnDirect(toolName) || !toolkit.isReturnResult(toolName)) {
+                    continue;
+                }
+                ToolResultBlock result = pair.getValue();
+                surfaced.add(result);
+                content.add(result);
+                List<ContentBlock> output = result.getOutput();
+                if (output != null) {
+                    for (ContentBlock block : output) {
+                        if (block instanceof TextBlock) {
+                            content.add(block);
+                        }
+                    }
+                }
+            }
+            Map<String, Object> metadata = new HashMap<>();
+            metadata.put(MessageMetadataKeys.RETURN_DIRECT_RESULTS, List.copyOf(surfaced));
+            Msg stopMsg =
+                    AssistantMessage.builder()
+                            .name(getName())
+                            .content(content)
+                            .metadata(metadata)
+                            .generateReason(GenerateReason.RETURN_DIRECT)
+                            .build();
+            if (!content.isEmpty()) {
+                state.contextMutable().add(stopMsg);
+            }
+            return stopMsg;
         }
 
         /**
@@ -3585,10 +3675,10 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
          * <p>Structurally identical to {@link #reasoningStream} but notifies summary-specific
          * hooks (SummaryChunkEvent) and does not pass tool schemas to the model.
          *
-         * @param context   reasoning context for chunk accumulation
-         * @param messages  the messages to send to the model
-         * @param options   generation options
-         * @param model     the model used for this summary call
+         * @param context  reasoning context for chunk accumulation
+         * @param messages the messages to send to the model
+         * @param options  generation options
+         * @param model    the model used for this summary call
          * @return event stream from the summary model call
          */
         Flux<AgentEvent> summaryStream(
@@ -3885,7 +3975,7 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
          * preventing duplicate execution when resuming from HITL or partial tool result scenarios.
          *
          * @return List of tool use blocks that don't have results yet, or empty list if all tools
-         *     have been executed
+         * have been executed
          */
         private List<ToolUseBlock> extractPendingToolCalls() {
             List<ToolUseBlock> allToolCalls = extractRecentToolCalls();
@@ -3938,17 +4028,23 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
             }
         }
 
-        /** Convenience overload for a single tool call. */
+        /**
+         * Convenience overload for a single tool call.
+         */
         private void updateToolCallState(String toolCallId, ToolCallState newState) {
             updateToolCallStates(Map.of(toolCallId, newState));
         }
 
-        /** Whether any ToolUseBlock in the last assistant Msg is in ASKING state. */
+        /**
+         * Whether any ToolUseBlock in the last assistant Msg is in ASKING state.
+         */
         private boolean hasAskingToolCalls() {
             return !askingToolCalls().isEmpty();
         }
 
-        /** The ToolUseBlocks in the last assistant Msg that are in ASKING state (HITL pending). */
+        /**
+         * The ToolUseBlocks in the last assistant Msg that are in ASKING state (HITL pending).
+         */
         private List<ToolUseBlock> askingToolCalls() {
             Msg last = findLastAssistantMsg();
             if (last == null) {
@@ -4085,7 +4181,9 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
 
     // ==================== Getters ====================
 
-    /** Returns this agent's toolkit (a per-instance deep copy made at build time). */
+    /**
+     * Returns this agent's toolkit (a per-instance deep copy made at build time).
+     */
     public Toolkit getToolkit() {
         return toolkit;
     }
@@ -4113,8 +4211,8 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
 
     /**
      * @deprecated Use {@link #getAgentState(RuntimeContext)} or
-     *     {@link #getAgentState(String, String)} with explicit session identity.
-     *     This method delegates to the default session slot.
+     * {@link #getAgentState(String, String)} with explicit session identity.
+     * This method delegates to the default session slot.
      */
     @Deprecated
     @Override
@@ -4190,7 +4288,7 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
      * {@code ctx}.
      *
      * @param ctx runtime context identifying the session; a missing session id uses the default
-     *     session id
+     *            session id
      */
     public void clearStateCache(RuntimeContext ctx) {
         String uid = ctx != null ? ctx.getUserId() : null;
@@ -4205,7 +4303,7 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
      * <p>This only releases local references. It does not delete the corresponding state from
      * the configured {@link AgentStateStore}; the next access reloads the persisted state.
      *
-     * @param userId user identity for the slot ({@code null} = anonymous / single-tenant)
+     * @param userId    user identity for the slot ({@code null} = anonymous / single-tenant)
      * @param sessionId session identity; {@code null} or blank uses the default session id
      */
     public void clearStateCache(String userId, String sessionId) {
@@ -4231,7 +4329,7 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
      * has completed so that the next call reliably starts with an empty conversation context.
      *
      * @param ctx runtime context identifying the session; a missing session id uses the default
-     *     session id
+     *            session id
      */
     public void clearContext(RuntimeContext ctx) {
         String uid = ctx != null ? ctx.getUserId() : null;
@@ -4254,7 +4352,7 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
      * <p>This method does not cancel an in-flight call. Invoke it after the session's current call
      * has completed so that the next call reliably starts with an empty conversation context.
      *
-     * @param userId user identity for the slot ({@code null} = anonymous / single-tenant)
+     * @param userId    user identity for the slot ({@code null} = anonymous / single-tenant)
      * @param sessionId session identity; {@code null} or blank uses the default session id
      */
     public void clearContext(String userId, String sessionId) {
@@ -4306,9 +4404,9 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
      * <p>An in-flight call keeps the engine it started with; the new mode applies to subsequent
      * calls on the slot.
      *
-     * @param userId user identity for the slot (may be {@code null})
+     * @param userId    user identity for the slot (may be {@code null})
      * @param sessionId session identity (falls back to the default session id when {@code null})
-     * @param mode the permission mode to switch to
+     * @param mode      the permission mode to switch to
      */
     public void setPermissionMode(String userId, String sessionId, PermissionMode mode) {
         Objects.requireNonNull(mode, "mode must not be null");
@@ -4324,8 +4422,8 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
      * <p>An in-flight call keeps the call-scoped engine it started with. The replacement applies
      * to subsequent calls on this slot and does not affect any other user or session.
      *
-     * @param userId user identity for the slot (may be {@code null})
-     * @param sessionId session identity (falls back to the default session id when {@code null})
+     * @param userId            user identity for the slot (may be {@code null})
+     * @param sessionId         session identity (falls back to the default session id when {@code null})
      * @param permissionContext complete replacement context
      */
     public void replacePermissionContext(
@@ -4351,7 +4449,7 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
      * Switches the {@link PermissionMode} for the session identified by the given
      * {@link RuntimeContext}. See {@link #setPermissionMode(String, String, PermissionMode)}.
      *
-     * @param ctx the runtime context identifying the session
+     * @param ctx  the runtime context identifying the session
      * @param mode the permission mode to switch to
      */
     public void setPermissionMode(RuntimeContext ctx, PermissionMode mode) {
@@ -4363,7 +4461,7 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
     /**
      * Returns the current {@link PermissionMode} for the given {@code (userId, sessionId)} session.
      *
-     * @param userId user identity for the slot (may be {@code null})
+     * @param userId    user identity for the slot (may be {@code null})
      * @param sessionId session identity (falls back to the default session id when {@code null})
      * @return the session's current permission mode
      */
@@ -4405,17 +4503,23 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
         }
     }
 
-    /** Returns how many optimistic-concurrency conflicts have been observed on this agent. */
+    /**
+     * Returns how many optimistic-concurrency conflicts have been observed on this agent.
+     */
     public long getStateConflictCount() {
         return stateConflictCount.get();
     }
 
-    /** Returns the configured {@link ConflictPolicy} for agent_state saves. */
+    /**
+     * Returns the configured {@link ConflictPolicy} for agent_state saves.
+     */
     public ConflictPolicy getConflictPolicy() {
         return conflictPolicy;
     }
 
-    /** Returns the {@link AgentStateStore} configured for state persistence, or {@code null}. */
+    /**
+     * Returns the {@link AgentStateStore} configured for state persistence, or {@code null}.
+     */
     public AgentStateStore getStateStore() {
         return stateStore;
     }
@@ -4434,17 +4538,23 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
         }
     }
 
-    /** Returns the model-call configuration (retries, timeouts). */
+    /**
+     * Returns the model-call configuration (retries, timeouts).
+     */
     public ModelConfig getModelConfig() {
         return modelConfig;
     }
 
-    /** Returns the reasoning-loop configuration (maxIters, stopOnReject). */
+    /**
+     * Returns the reasoning-loop configuration (maxIters, stopOnReject).
+     */
     public ReactConfig getReactConfig() {
         return reactConfig;
     }
 
-    /** @deprecated Use {@code getAgentState(userId, sessionId).getPermissionContext()} instead. */
+    /**
+     * @deprecated Use {@code getAgentState(userId, sessionId).getPermissionContext()} instead.
+     */
     @Deprecated
     public PermissionEngine getPermissionEngine() {
         String slot = slotKey(null, defaultSessionId);
@@ -4453,28 +4563,38 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
                 slot, k -> new PermissionEngine(s.getPermissionContext()));
     }
 
-    /** @deprecated Use {@code getAgentState(userId, sessionId).getPermissionContext()} instead. */
+    /**
+     * @deprecated Use {@code getAgentState(userId, sessionId).getPermissionContext()} instead.
+     */
     @Deprecated
     public PermissionContextState getPermissionContext() {
         return getAgentState().getPermissionContext();
     }
 
-    /** Returns the immutable list of registered middlewares. */
+    /**
+     * Returns the immutable list of registered middlewares.
+     */
     public List<MiddlewareBase> getMiddlewares() {
         return middlewares;
     }
 
-    /** Returns the per-model-call {@link ExecutionConfig}, or {@code null} if none was set. */
+    /**
+     * Returns the per-model-call {@link ExecutionConfig}, or {@code null} if none was set.
+     */
     public ExecutionConfig getModelExecutionConfig() {
         return modelExecutionConfig;
     }
 
-    /** Returns the per-tool-call {@link ExecutionConfig}, or {@code null} if none was set. */
+    /**
+     * Returns the per-tool-call {@link ExecutionConfig}, or {@code null} if none was set.
+     */
     public ExecutionConfig getToolExecutionConfig() {
         return toolExecutionConfig;
     }
 
-    /** Returns the {@link ToolExecutionContext} bound at build time, or {@code null} if none. */
+    /**
+     * Returns the {@link ToolExecutionContext} bound at build time, or {@code null} if none.
+     */
     public ToolExecutionContext getToolExecutionContext() {
         return toolExecutionContext;
     }
@@ -4487,7 +4607,9 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
         return enablePendingToolRecovery;
     }
 
-    /** Returns the system prompt (alias for {@link #getSysPrompt()}). */
+    /**
+     * Returns the system prompt (alias for {@link #getSysPrompt()}).
+     */
     public String getSystemPrompt() {
         return sysPrompt;
     }
@@ -4605,7 +4727,9 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
             return this;
         }
 
-        /** @deprecated No longer enforced; per-session serialization handles concurrency. */
+        /**
+         * @deprecated No longer enforced; per-session serialization handles concurrency.
+         */
         @Deprecated
         public Builder checkRunning(boolean checkRunning) {
             return this;
@@ -4857,7 +4981,7 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
          * @param toolExecutionContext The tool execution context
          * @return This builder instance for method chaining
          * @deprecated Use {@link RuntimeContext} with {@code agent.call(msg, runtimeContext)}
-         *     or register POJOs directly via {@code RuntimeContext.builder().put(Type, value)}.
+         * or register POJOs directly via {@code RuntimeContext.builder().put(Type, value)}.
          */
         @Deprecated
         public Builder toolExecutionContext(ToolExecutionContext toolExecutionContext) {
@@ -4956,7 +5080,7 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
 
         /**
          * @deprecated since 2.0.0. Long-term memory is being redesigned around the upcoming reme
-         *     base class. Hooks added through this path still work.
+         * base class. Hooks added through this path still work.
          */
         @Deprecated(forRemoval = true, since = "2.0.0")
         public Builder longTermMemory(LongTermMemory longTermMemory) {
@@ -5028,10 +5152,10 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
 
         /**
          * @deprecated since 2.0.0. Skills now flow through {@link #skillRepository} /
-         *     {@link #skillRepositories}; legacy {@link io.agentscope.core.skill.SkillBox}
-         *     instances are still accepted for source compatibility, but combining a
-         *     {@code skillBox(...)} with {@code skillRepository(...)} is untested — new code
-         *     should prefer {@link #skillRepository(AgentSkillRepository)}.
+         * {@link #skillRepositories}; legacy {@link io.agentscope.core.skill.SkillBox}
+         * instances are still accepted for source compatibility, but combining a
+         * {@code skillBox(...)} with {@code skillRepository(...)} is untested — new code
+         * should prefer {@link #skillRepository(AgentSkillRepository)}.
          */
         @Deprecated(since = "2.0.0")
         public Builder skillBox(SkillBox skillBox) {

--- a/agentscope-core/src/main/java/io/agentscope/core/message/GenerateReason.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/message/GenerateReason.java
@@ -35,23 +35,41 @@ package io.agentscope.core.message;
  */
 public enum GenerateReason {
 
-    /** Model stopped normally, task completed. */
+    /**
+     * Model stopped normally, task completed.
+     */
     MODEL_STOP,
 
-    /** Model returned tool calls (internal tools, framework will continue execution). */
+    /**
+     * Model returned tool calls (internal tools, framework will continue execution).
+     */
     TOOL_CALLS,
 
-    /** Structured output completed. */
+    /**
+     * Structured output completed.
+     */
     STRUCTURED_OUTPUT,
 
-    /** Tool execution was suspended, waiting for user to provide results. */
+    /**
+     * Tool execution was suspended, waiting for user to provide results.
+     */
     TOOL_SUSPENDED,
 
-    /** Reasoning phase was stopped by a Hook (PostReasoningEvent.stopAgent()). */
+    /**
+     * Reasoning phase was stopped by a Hook (PostReasoningEvent.stopAgent()).
+     */
     REASONING_STOP_REQUESTED,
 
-    /** Acting phase was stopped by a Hook (PostActingEvent.stopAgent()). */
+    /**
+     * Acting phase was stopped by a Hook (PostActingEvent.stopAgent()).
+     */
     ACTING_STOP_REQUESTED,
+
+    /**
+     * A tool marked {@code returnDirect} completed; the agent ended the turn without another
+     * model call (no summarizing / next reasoning).
+     */
+    RETURN_DIRECT,
 
     /**
      * Permission engine is asking the user to confirm one or more tool calls.
@@ -78,9 +96,13 @@ public enum GenerateReason {
      */
     ALL_TOOLS_DENIED,
 
-    /** Agent was interrupted. */
+    /**
+     * Agent was interrupted.
+     */
     INTERRUPTED,
 
-    /** Maximum iterations reached. */
+    /**
+     * Maximum iterations reached.
+     */
     MAX_ITERATIONS
 }

--- a/agentscope-core/src/main/java/io/agentscope/core/message/MessageMetadataKeys.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/message/MessageMetadataKeys.java
@@ -107,6 +107,17 @@ public final class MessageMetadataKeys {
     public static final String STRUCTURED_OUTPUT = "_structured_output";
 
     /**
+     * Metadata key for results of {@code returnDirect} tools that ended the turn.
+     *
+     * <p>When the model invokes one or more return-direct tools in the same acting batch,
+     * this list holds every surfaced {@link ToolResultBlock} in the original tool-call
+     * order (parallel execution still preserves that order).
+     *
+     * <p><b>Type:</b> {@code List<ToolResultBlock>}
+     */
+    public static final String RETURN_DIRECT_RESULTS = "_return_direct_results";
+
+    /**
      * Metadata key to explicitly mark a message for prompt caching or non-caching.
      *
      * <p>When set to {@code true}, the formatter adds <code>cache_control:

--- a/agentscope-core/src/main/java/io/agentscope/core/tool/AgentTool.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/tool/AgentTool.java
@@ -113,6 +113,35 @@ public interface AgentTool {
     }
 
     /**
+     * Whether invoking this tool ends the current agent turn without another model call.
+     *
+     * <p>When {@code true}, the tool still runs and its result is written to conversation
+     * context, but the ReAct loop does not go back to the model (no summarizing / next
+     * reasoning). The returned {@code Msg} uses
+     * {@link io.agentscope.core.message.GenerateReason#RETURN_DIRECT}.
+     *
+     * @return {@code true} if this is a terminal tool; {@code false} by default
+     */
+    default boolean isReturnDirect() {
+        return false;
+    }
+
+    /**
+     * Whether the tool result should be included in the agent's returned message.
+     *
+     * <p>Only consulted when {@link #isReturnDirect()} is {@code true}. When
+     * {@code returnDirect} is {@code false}, the result is always fed back to the model.
+     *
+     * <p>Set to {@code false} together with {@code returnDirect=true} to stop the turn
+     * silently: the caller gets an empty reply instead of the tool output as the answer.
+     *
+     * @return {@code true} to surface the tool output as the final reply; {@code true} by default
+     */
+    default boolean isReturnResult() {
+        return true;
+    }
+
+    /**
      * Execute the tool with the given parameters (asynchronous).
      *
      * <p>This method accepts a {@link ToolCallParam} object containing all necessary context for

--- a/agentscope-core/src/main/java/io/agentscope/core/tool/ReflectiveFunctionTool.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/tool/ReflectiveFunctionTool.java
@@ -63,7 +63,7 @@ final class ReflectiveFunctionTool extends ToolBase {
      * Build a {@code ReflectiveFunctionTool} from the {@code @Tool}-annotated method.
      *
      * @throws IllegalArgumentException if the {@code stateInjected} flag disagrees with the method
-     *     signature or if more than one {@link AgentState} parameter is declared.
+     *                                  signature or if more than one {@link AgentState} parameter is declared.
      */
     static ReflectiveFunctionTool create(
             Object toolObject,
@@ -137,6 +137,8 @@ final class ReflectiveFunctionTool extends ToolBase {
                         .readOnly(annotation.readOnly())
                         .concurrencySafe(annotation.concurrencySafe())
                         .externalTool(annotation.externalTool())
+                        .returnDirect(annotation.returnDirect())
+                        .returnResult(annotation.returnResult())
                         .stateInjected(annotation.stateInjected());
         if (annotation.dangerousFiles().length > 0) {
             builder.dangerousFiles(List.of(annotation.dangerousFiles()));

--- a/agentscope-core/src/main/java/io/agentscope/core/tool/Tool.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/tool/Tool.java
@@ -127,6 +127,31 @@ public @interface Tool {
     boolean externalTool() default false;
 
     /**
+     * Whether invoking this tool ends the current agent turn without another model call.
+     *
+     * <p>When {@code true}, the tool still runs and its result is written to conversation
+     * context, but the ReAct loop does not go back to the model (no summarizing / next
+     * reasoning). Pair with {@link #returnResult()} to control whether the tool output
+     * becomes the agent's returned message.
+     *
+     * @return true if this is a terminal tool
+     */
+    boolean returnDirect() default false;
+
+    /**
+     * Whether the tool result should be included in the agent's returned message.
+     *
+     * <p>Only consulted when {@link #returnDirect()} is {@code true}. When
+     * {@code returnDirect} is {@code false}, the result is always fed back to the model.
+     *
+     * <p>Set to {@code false} together with {@code returnDirect=true} to stop the turn
+     * without surfacing the tool output as the reply.
+     *
+     * @return true to surface the tool output as the final reply
+     */
+    boolean returnResult() default true;
+
+    /**
      * Whether the tool requires the agent state to be injected at call time.
      *
      * <p>When true, the method signature must declare exactly one

--- a/agentscope-core/src/main/java/io/agentscope/core/tool/ToolBase.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/tool/ToolBase.java
@@ -64,18 +64,26 @@ public abstract class ToolBase implements AgentTool {
     private final boolean concurrencySafe;
     private final boolean readOnly;
     private final boolean externalTool;
+    private final boolean returnDirect;
+    private final boolean returnResult;
     private final boolean stateInjected;
     private final boolean mcp;
     private final String mcpName;
 
-    /** Sensitive files; subclasses may replace this list to widen or narrow protection. */
+    /**
+     * Sensitive files; subclasses may replace this list to widen or narrow protection.
+     */
     protected List<String> dangerousFiles = ToolDangerousPathConstants.DEFAULT_DANGEROUS_FILES;
 
-    /** Sensitive directory names; segment-level matching applies to absolute paths. */
+    /**
+     * Sensitive directory names; segment-level matching applies to absolute paths.
+     */
     protected List<String> dangerousDirectories =
             ToolDangerousPathConstants.DEFAULT_DANGEROUS_DIRECTORIES;
 
-    /** Builder-based constructor (preferred). */
+    /**
+     * Builder-based constructor (preferred).
+     */
     protected ToolBase(Builder builder) {
         this(
                 builder.name,
@@ -86,6 +94,8 @@ public abstract class ToolBase implements AgentTool {
                 builder.mcp,
                 builder.mcpName,
                 builder.externalTool,
+                builder.returnDirect,
+                builder.returnResult,
                 builder.stateInjected);
         if (builder.dangerousFiles != null) {
             this.dangerousFiles = List.copyOf(builder.dangerousFiles);
@@ -109,6 +119,35 @@ public abstract class ToolBase implements AgentTool {
             String mcpName,
             boolean externalTool,
             boolean stateInjected) {
+        this(
+                name,
+                description,
+                inputSchema,
+                readOnly,
+                concurrencySafe,
+                mcp,
+                mcpName,
+                externalTool,
+                false,
+                true,
+                stateInjected);
+    }
+
+    /**
+     * Positional constructor including return-direct flags. Prefer {@link #builder()}.
+     */
+    protected ToolBase(
+            String name,
+            String description,
+            Map<String, Object> inputSchema,
+            boolean readOnly,
+            boolean concurrencySafe,
+            boolean mcp,
+            String mcpName,
+            boolean externalTool,
+            boolean returnDirect,
+            boolean returnResult,
+            boolean stateInjected) {
         this.name = Objects.requireNonNull(name, "name must not be null");
         this.description = Objects.requireNonNull(description, "description must not be null");
         this.inputSchema = Objects.requireNonNull(inputSchema, "inputSchema must not be null");
@@ -117,6 +156,8 @@ public abstract class ToolBase implements AgentTool {
         this.mcp = mcp;
         this.mcpName = mcpName;
         this.externalTool = externalTool;
+        this.returnDirect = returnDirect;
+        this.returnResult = returnResult;
         this.stateInjected = stateInjected;
         if (mcp && (mcpName == null || mcpName.isBlank())) {
             throw new IllegalArgumentException("mcpName is required when mcp is true");
@@ -149,6 +190,16 @@ public abstract class ToolBase implements AgentTool {
 
     public final boolean isExternalTool() {
         return externalTool;
+    }
+
+    @Override
+    public final boolean isReturnDirect() {
+        return returnDirect;
+    }
+
+    @Override
+    public final boolean isReturnResult() {
+        return returnResult;
     }
 
     public final boolean isStateInjected() {
@@ -190,7 +241,7 @@ public abstract class ToolBase implements AgentTool {
      * own ALLOW / ASK / DENY policy.
      *
      * @param toolInput the parsed tool arguments
-     * @param context current permission evaluation context
+     * @param context   current permission evaluation context
      * @return a Mono emitting the decision; never {@code null}
      */
     public Mono<PermissionDecision> checkPermissions(
@@ -217,9 +268,9 @@ public abstract class ToolBase implements AgentTool {
 
     /**
      * @return {@code true} when {@code filePath}'s filename matches one of {@link #dangerousFiles}
-     *     (case-insensitive), or when any segment matches one of {@link #dangerousDirectories}.
-     *     Also resolves symlinks and re-checks the real path to prevent bypass via symlink
-     *     pointing at a dangerous target.
+     * (case-insensitive), or when any segment matches one of {@link #dangerousDirectories}.
+     * Also resolves symlinks and re-checks the real path to prevent bypass via symlink
+     * pointing at a dangerous target.
      */
     protected boolean isDangerousPath(String filePath) {
         if (filePath == null || filePath.isBlank()) {
@@ -270,7 +321,9 @@ public abstract class ToolBase implements AgentTool {
         return new Builder();
     }
 
-    /** Fluent builder for {@link ToolBase} subclasses. */
+    /**
+     * Fluent builder for {@link ToolBase} subclasses.
+     */
     public static final class Builder {
         private String name;
         private String description;
@@ -278,6 +331,8 @@ public abstract class ToolBase implements AgentTool {
         private boolean readOnly = false;
         private boolean concurrencySafe = true;
         private boolean externalTool = false;
+        private boolean returnDirect = false;
+        private boolean returnResult = true;
         private boolean stateInjected = false;
         private boolean mcp = false;
         private String mcpName;
@@ -316,12 +371,32 @@ public abstract class ToolBase implements AgentTool {
             return this;
         }
 
+        /**
+         * Marks this tool as terminal: after it runs, the agent ends the turn without another
+         * model call.
+         */
+        public Builder returnDirect(boolean returnDirect) {
+            this.returnDirect = returnDirect;
+            return this;
+        }
+
+        /**
+         * When {@link #returnDirect(boolean)} is {@code true}, whether the tool output becomes
+         * the agent's returned message. Ignored when {@code returnDirect} is {@code false}.
+         */
+        public Builder returnResult(boolean returnResult) {
+            this.returnResult = returnResult;
+            return this;
+        }
+
         public Builder stateInjected(boolean stateInjected) {
             this.stateInjected = stateInjected;
             return this;
         }
 
-        /** Marks the tool as an MCP tool and records the MCP server name. */
+        /**
+         * Marks the tool as an MCP tool and records the MCP server name.
+         */
         public Builder mcp(String mcpName) {
             this.mcp = true;
             this.mcpName = mcpName;

--- a/agentscope-core/src/main/java/io/agentscope/core/tool/Toolkit.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/tool/Toolkit.java
@@ -149,6 +149,7 @@ public class Toolkit {
 
     /**
      * Register a tool object by scanning for methods annotated with @Tool.
+     *
      * @param toolObject the object containing tool methods
      */
     public void registerTool(Object toolObject) {
@@ -198,6 +199,7 @@ public class Toolkit {
 
     /**
      * Register an AgentTool instance directly.
+     *
      * @param tool the AgentTool to register
      */
     public void registerAgentTool(AgentTool tool) {
@@ -322,6 +324,34 @@ public class Toolkit {
     public boolean isExternalTool(String toolName) {
         AgentTool tool = getTool(toolName);
         return tool instanceof ToolBase tb && tb.isExternalTool();
+    }
+
+    /**
+     * Check if a tool is terminal ({@link AgentTool#isReturnDirect()}).
+     *
+     * <p>When this returns {@code true}, the agent executes the tool then ends the turn
+     * without another model call.
+     *
+     * @param toolName The name of the tool to check
+     * @return true if the tool is return-direct, false otherwise
+     */
+    public boolean isReturnDirect(String toolName) {
+        AgentTool tool = getTool(toolName);
+        return tool != null && tool.isReturnDirect();
+    }
+
+    /**
+     * Check whether a return-direct tool should surface its result as the agent reply.
+     *
+     * <p>Only meaningful when {@link #isReturnDirect(String)} is {@code true}. Tools that are
+     * not registered default to {@code true}.
+     *
+     * @param toolName The name of the tool to check
+     * @return true if the tool result should be included in the returned message
+     */
+    public boolean isReturnResult(String toolName) {
+        AgentTool tool = getTool(toolName);
+        return tool == null || tool.isReturnResult();
     }
 
     /**
@@ -502,10 +532,10 @@ public class Toolkit {
      * applies execution config (timeout, retry) from multiple levels. The agent context is
      * merged with toolkit default context during tool execution.
      *
-     * @param toolCalls List of tool calls to execute
+     * @param toolCalls            List of tool calls to execute
      * @param agentExecutionConfig Execution config from agent level (can be null)
-     * @param agent The agent making the calls (may be null)
-     * @param agentRuntimeContext The agent-level runtime context (may be null)
+     * @param agent                The agent making the calls (may be null)
+     * @param agentRuntimeContext  The agent-level runtime context (may be null)
      * @return Mono containing list of tool responses
      */
     public Mono<List<ToolResultBlock>> callTools(
@@ -554,9 +584,9 @@ public class Toolkit {
     /**
      * Create a new tool group with specified activation status and default META scope.
      *
-     * @param groupName Name of the tool group
+     * @param groupName   Name of the tool group
      * @param description Description of the tool group
-     * @param active Whether the group should be active by default
+     * @param active      Whether the group should be active by default
      * @throws IllegalArgumentException if group already exists
      */
     public void createToolGroup(String groupName, String description, boolean active) {
@@ -566,11 +596,11 @@ public class Toolkit {
     /**
      * Create a new tool group with specified activation status and scope.
      *
-     * @param groupName Name of the tool group
+     * @param groupName   Name of the tool group
      * @param description Description of the tool group
-     * @param active Whether the group should be active by default
-     * @param scope Whether the group is managed by the meta tool ({@link ToolGroupScope#META})
-     *              or by developer code ({@link ToolGroupScope#EXTERNAL})
+     * @param active      Whether the group should be active by default
+     * @param scope       Whether the group is managed by the meta tool ({@link ToolGroupScope#META})
+     *                    or by developer code ({@link ToolGroupScope#EXTERNAL})
      * @throws IllegalArgumentException if group already exists
      */
     public void createToolGroup(
@@ -581,7 +611,7 @@ public class Toolkit {
     /**
      * Create a new tool group (active by default, META scope).
      *
-     * @param groupName Name of the tool group
+     * @param groupName   Name of the tool group
      * @param description Description of the tool group
      * @throws IllegalArgumentException if group already exists
      */
@@ -596,9 +626,9 @@ public class Toolkit {
      * via {@code reset_equipped_tools}. The description shown to the model will include a
      * reminder that this group must be activated when the bound skill is in use.
      *
-     * @param groupName Name of the tool group
-     * @param description Description of the tool group
-     * @param active Whether the group should be active by default
+     * @param groupName       Name of the tool group
+     * @param description     Description of the tool group
+     * @param active          Whether the group should be active by default
      * @param activateOnSkill The skill name that this group is bound to
      * @throws IllegalArgumentException if group already exists
      */
@@ -638,7 +668,7 @@ public class Toolkit {
      * once has no additional effect.
      *
      * @param groupName Name of the existing tool group
-     * @param toolName Name of the registered tool
+     * @param toolName  Name of the registered tool
      * @throws IllegalArgumentException if the group or tool doesn't exist
      */
     public void addToolToGroup(String groupName, String toolName) {
@@ -656,7 +686,7 @@ public class Toolkit {
      * will be ignored and a warning will be logged.
      *
      * @param groupNames List of tool group names to update
-     * @param active Whether to activate (true) or deactivate (false) the groups
+     * @param active     Whether to activate (true) or deactivate (false) the groups
      * @throws IllegalArgumentException if any group doesn't exist
      */
     public void updateToolGroups(List<String> groupNames, boolean active) {
@@ -754,7 +784,7 @@ public class Toolkit {
 
     /**
      * Register the meta tool that allows agents to dynamically manage tool groups.
-     *
+     * <p>
      * This creates a tool that wraps the toolkit's resetEquippedTools method,
      * allowing the agent to activate tool groups during execution.
      */
@@ -774,7 +804,7 @@ public class Toolkit {
      * tool. This is useful for updating session-specific context (like session IDs or timestamps)
      * or refreshing credentials.
      *
-     * @param toolName The name of the tool to update
+     * @param toolName            The name of the tool to update
      * @param newPresetParameters The new preset parameters (null will be treated as empty map)
      * @throws IllegalArgumentException if the tool is not found
      */
@@ -927,8 +957,8 @@ public class Toolkit {
          * }</pre>
          *
          * @param provider Factory for creating agent instances (called for each session)
-         * @param config Configuration for the sub-agent tool, or null to use defaults (tool name
-         *     derived from agent name, InMemoryAgentStateStore for state, events forwarded)
+         * @param config   Configuration for the sub-agent tool, or null to use defaults (tool name
+         *                 derived from agent name, InMemoryAgentStateStore for state, events forwarded)
          * @return This builder for chaining
          * @see SubAgentConfig
          * @see SubAgentConfig#defaults()

--- a/agentscope-core/src/test/java/io/agentscope/core/agent/ReActAgentNewLoopReplyTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/agent/ReActAgentNewLoopReplyTest.java
@@ -39,6 +39,7 @@ import io.agentscope.core.event.ToolResultEndEvent;
 import io.agentscope.core.event.ToolResultStartEvent;
 import io.agentscope.core.message.ContentBlock;
 import io.agentscope.core.message.GenerateReason;
+import io.agentscope.core.message.MessageMetadataKeys;
 import io.agentscope.core.message.Msg;
 import io.agentscope.core.message.MsgRole;
 import io.agentscope.core.message.TextBlock;
@@ -67,7 +68,9 @@ import org.junit.jupiter.api.Test;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
-/** End-to-end tests for the ReAct reply loop. */
+/**
+ * End-to-end tests for the ReAct reply loop.
+ */
 class ReActAgentNewLoopReplyTest {
 
     private static AgentState newState() {
@@ -76,7 +79,7 @@ class ReActAgentNewLoopReplyTest {
 
     private static final class ScriptedModel extends ChatModelBase {
         private final List<Supplier<Flux<ChatResponse>>> scripts;
-        private final AtomicInteger idx = new AtomicInteger(0);
+        final AtomicInteger idx = new AtomicInteger(0);
 
         ScriptedModel(List<Supplier<Flux<ChatResponse>>> scripts) {
             this.scripts = scripts;
@@ -140,7 +143,7 @@ class ReActAgentNewLoopReplyTest {
         return toolkit;
     }
 
-    private static final class EchoTool implements AgentTool {
+    private static class EchoTool implements AgentTool {
         @Override
         public String getName() {
             return "echo";
@@ -167,6 +170,43 @@ class ReActAgentNewLoopReplyTest {
         public Mono<ToolResultBlock> callAsync(ToolCallParam param) {
             Object q = param.getInput() == null ? "" : param.getInput().get("query");
             return Mono.just(ToolResultBlock.text("echo:" + q));
+        }
+    }
+
+    private static final class ReturnDirectEchoTool extends EchoTool {
+        @Override
+        public boolean isReturnDirect() {
+            return true;
+        }
+    }
+
+    private static final class SilentReturnDirectTool extends EchoTool {
+        @Override
+        public boolean isReturnDirect() {
+            return true;
+        }
+
+        @Override
+        public boolean isReturnResult() {
+            return false;
+        }
+    }
+
+    private static final class NamedReturnDirectTool extends EchoTool {
+        private final String name;
+
+        NamedReturnDirectTool(String name) {
+            this.name = name;
+        }
+
+        @Override
+        public String getName() {
+            return name;
+        }
+
+        @Override
+        public boolean isReturnDirect() {
+            return true;
         }
     }
 
@@ -248,6 +288,97 @@ class ReActAgentNewLoopReplyTest {
         int firstModelStart = indexOf(events, ModelCallStartEvent.class);
         int secondModelStart = indexOfFrom(events, ModelCallStartEvent.class, firstModelStart + 1);
         assertTrue(secondModelStart > iToolResultEnd, "second iteration should follow tool result");
+    }
+
+    @Test
+    void returnDirectToolEndsTurnWithoutSecondModelCall() {
+        ChatModelBase model =
+                new ScriptedModel(
+                        List.of(
+                                () -> Flux.just(toolUseResponse("tc1", "echo", "ping")),
+                                () -> Flux.just(textResponse("should-not-run"))));
+        ReActAgent agent =
+                ReActAgent.builder()
+                        .name("asst")
+                        .model(model)
+                        .toolkit(toolkitWith(new ReturnDirectEchoTool()))
+                        .build();
+
+        Msg result = agent.call(List.of()).block();
+
+        assertNotNull(result);
+        assertEquals(GenerateReason.RETURN_DIRECT, result.getGenerateReason());
+        assertEquals("echo:ping", result.getTextContent());
+        assertEquals(1, ((ScriptedModel) model).idx.get(), "model must not be called again");
+    }
+
+    @Test
+    void returnDirectWithoutResultSurfacesEmptyReply() {
+        ChatModelBase model =
+                new ScriptedModel(List.of(() -> Flux.just(toolUseResponse("tc1", "echo", "ping"))));
+        ReActAgent agent =
+                ReActAgent.builder()
+                        .name("asst")
+                        .model(model)
+                        .toolkit(toolkitWith(new SilentReturnDirectTool()))
+                        .build();
+
+        Msg result = agent.call(List.of()).block();
+
+        assertNotNull(result);
+        assertEquals(GenerateReason.RETURN_DIRECT, result.getGenerateReason());
+        String text = result.getTextContent();
+        assertTrue(
+                text == null || text.isBlank(), "silent returnDirect must not surface tool text");
+        assertEquals(1, ((ScriptedModel) model).idx.get());
+    }
+
+    @Test
+    void concurrentReturnDirectToolsAllSurfaceInReply() {
+        ChatResponse batch =
+                ChatResponse.builder()
+                        .content(
+                                List.of(
+                                        ToolUseBlock.builder()
+                                                .id("a1")
+                                                .name("alpha")
+                                                .input(Map.of("query", "one"))
+                                                .build(),
+                                        ToolUseBlock.builder()
+                                                .id("b1")
+                                                .name("beta")
+                                                .input(Map.of("query", "two"))
+                                                .build()))
+                        .build();
+        ChatModelBase model = new ScriptedModel(List.of(() -> Flux.just(batch)));
+        Toolkit toolkit = new Toolkit();
+        toolkit.registerAgentTool(new NamedReturnDirectTool("alpha"));
+        toolkit.registerAgentTool(new NamedReturnDirectTool("beta"));
+        ReActAgent agent = ReActAgent.builder().name("asst").model(model).toolkit(toolkit).build();
+
+        Msg result = agent.call(List.of()).block();
+
+        assertNotNull(result);
+        assertEquals(GenerateReason.RETURN_DIRECT, result.getGenerateReason());
+        assertEquals(1, ((ScriptedModel) model).idx.get(), "model must not be called again");
+
+        List<ToolResultBlock> blocks = result.getContentBlocks(ToolResultBlock.class);
+        assertEquals(2, blocks.size());
+        assertEquals("a1", blocks.get(0).getId());
+        assertEquals("alpha", blocks.get(0).getName());
+        assertEquals("b1", blocks.get(1).getId());
+        assertEquals("beta", blocks.get(1).getName());
+        assertTrue(result.getTextContent().contains("echo:one"));
+        assertTrue(result.getTextContent().contains("echo:two"));
+
+        @SuppressWarnings("unchecked")
+        List<ToolResultBlock> fromMeta =
+                (List<ToolResultBlock>)
+                        result.getMetadata().get(MessageMetadataKeys.RETURN_DIRECT_RESULTS);
+        assertNotNull(fromMeta);
+        assertEquals(2, fromMeta.size());
+        assertEquals("alpha", fromMeta.get(0).getName());
+        assertEquals("beta", fromMeta.get(1).getName());
     }
 
     @Test

--- a/agentscope-core/src/test/java/io/agentscope/core/message/GenerateReasonTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/message/GenerateReasonTest.java
@@ -35,7 +35,7 @@ class GenerateReasonTest {
     @DisplayName("Should have all expected enum values")
     void testEnumValues() {
         GenerateReason[] values = GenerateReason.values();
-        assertEquals(11, values.length);
+        assertEquals(12, values.length);
 
         // Verify all expected values exist
         assertNotNull(GenerateReason.MODEL_STOP);
@@ -44,6 +44,7 @@ class GenerateReasonTest {
         assertNotNull(GenerateReason.TOOL_SUSPENDED);
         assertNotNull(GenerateReason.REASONING_STOP_REQUESTED);
         assertNotNull(GenerateReason.ACTING_STOP_REQUESTED);
+        assertNotNull(GenerateReason.RETURN_DIRECT);
         assertNotNull(GenerateReason.PERMISSION_ASKING);
         assertNotNull(GenerateReason.MIDDLEWARE_STOP_REQUESTED);
         assertNotNull(GenerateReason.INTERRUPTED);

--- a/agentscope-core/src/test/java/io/agentscope/core/tool/ToolBaseTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/tool/ToolBaseTest.java
@@ -92,9 +92,31 @@ class ToolBaseTest {
         assertTrue(tool.isReadOnly());
         assertTrue(tool.isConcurrencySafe());
         assertFalse(tool.isExternalTool());
+        assertFalse(tool.isReturnDirect());
+        assertTrue(tool.isReturnResult());
         assertFalse(tool.isStateInjected());
         assertFalse(tool.isMcp());
         assertNull(tool.getMcpName());
+    }
+
+    @Test
+    void returnDirectFlagsPropagateFromBuilder() {
+        ToolBase tool =
+                new ToolBase(
+                        ToolBase.builder()
+                                .name("submit")
+                                .description("submit")
+                                .inputSchema(emptySchema())
+                                .returnDirect(true)
+                                .returnResult(false)) {
+                    @Override
+                    public Mono<PermissionDecision> checkPermissions(
+                            Map<String, Object> toolInput, PermissionContextState context) {
+                        return Mono.just(PermissionDecision.passthrough("ok"));
+                    }
+                };
+        assertTrue(tool.isReturnDirect());
+        assertFalse(tool.isReturnResult());
     }
 
     @Test

--- a/agentscope-core/src/test/java/io/agentscope/core/tool/ToolkitTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/tool/ToolkitTest.java
@@ -191,6 +191,80 @@ class ToolkitTest {
     }
 
     @Test
+    @DisplayName("Should propagate returnDirect flags from @Tool and AgentTool")
+    void testReturnDirectRegistration() {
+        toolkit.registerTool(new ReturnDirectAnnotatedTools());
+        AgentTool annotated = toolkit.getTool("submit_answer");
+        assertNotNull(annotated);
+        assertTrue(annotated.isReturnDirect());
+        assertTrue(annotated.isReturnResult());
+        assertTrue(toolkit.isReturnDirect("submit_answer"));
+        assertTrue(toolkit.isReturnResult("submit_answer"));
+
+        AgentTool silent = toolkit.getTool("handoff");
+        assertNotNull(silent);
+        assertTrue(silent.isReturnDirect());
+        assertFalse(silent.isReturnResult());
+        assertTrue(toolkit.isReturnDirect("handoff"));
+        assertFalse(toolkit.isReturnResult("handoff"));
+
+        toolkit.registerAgentTool(
+                new AgentTool() {
+                    @Override
+                    public String getName() {
+                        return "plain_finish";
+                    }
+
+                    @Override
+                    public String getDescription() {
+                        return "plain finish";
+                    }
+
+                    @Override
+                    public Map<String, Object> getParameters() {
+                        return Map.of("type", "object");
+                    }
+
+                    @Override
+                    public boolean isReturnDirect() {
+                        return true;
+                    }
+
+                    @Override
+                    public boolean isReturnResult() {
+                        return false;
+                    }
+
+                    @Override
+                    public Mono<ToolResultBlock> callAsync(ToolCallParam param) {
+                        return Mono.just(ToolResultBlock.text("done"));
+                    }
+                });
+        assertTrue(toolkit.isReturnDirect("plain_finish"));
+        assertFalse(toolkit.isReturnResult("plain_finish"));
+        assertFalse(toolkit.isReturnDirect("missing"));
+        assertTrue(toolkit.isReturnResult("missing"));
+    }
+
+    public static class ReturnDirectAnnotatedTools {
+
+        @Tool(name = "submit_answer", description = "Submit the final answer", returnDirect = true)
+        public String submitAnswer(
+                @ToolParam(name = "answer", description = "final answer") String answer) {
+            return answer;
+        }
+
+        @Tool(
+                name = "handoff",
+                description = "Hand off without a reply",
+                returnDirect = true,
+                returnResult = false)
+        public String handoff(@ToolParam(name = "reason", description = "reason") String reason) {
+            return reason;
+        }
+    }
+
+    @Test
     @DisplayName("Should handle empty toolkit")
     void testEmptyToolkit() {
         // Empty toolkit

--- a/docs/v2/en/docs/building-blocks/message-and-event.md
+++ b/docs/v2/en/docs/building-blocks/message-and-event.md
@@ -31,7 +31,7 @@ The core fields on `Msg` (via getters):
 | `getMetadata()` | `Map<String, Object>` | Arbitrary key/value metadata |
 | `getTimestamp()` | `String` | Creation time (`yyyy-MM-dd HH:mm:ss.SSS`) |
 | `getUsage()` | `ChatUsage` | Token usage (assistant messages only) |
-| `getGenerateReason()` | `GenerateReason` | Termination reason: `MODEL_STOP` / `TOOL_SUSPENDED` / `REASONING_STOP_REQUESTED` / `ACTING_STOP_REQUESTED` / `ALL_TOOLS_DENIED` / `INTERRUPTED` / `MAX_ITERATIONS` |
+| `getGenerateReason()` | `GenerateReason` | Termination reason: `MODEL_STOP` / `TOOL_SUSPENDED` / `REASONING_STOP_REQUESTED` / `ACTING_STOP_REQUESTED` / `RETURN_DIRECT` / `ALL_TOOLS_DENIED` / `INTERRUPTED` / `MAX_ITERATIONS` |
 
 ### Content blocks
 

--- a/docs/v2/en/docs/building-blocks/tool.md
+++ b/docs/v2/en/docs/building-blocks/tool.md
@@ -42,6 +42,8 @@ Properties exposed to the agent and runtime:
 | `isConcurrencySafe()` | `boolean` | Can the tool be called concurrently? |
 | `isReadOnly()` | `boolean` | Is the tool read-only / side-effect-free? |
 | `isExternalTool()` | `boolean` | When `true`, execution is delegated externally (see [external execution](#external-execution-tools)) |
+| `isReturnDirect()` | `boolean` | When `true`, the turn ends after this tool runs — no further model call (see [Terminal tools](#terminal-tools-returndirect)) |
+| `isReturnResult()` | `boolean` | Only used when `returnDirect` is `true`: whether the tool output becomes the agent reply (default `true`) |
 | `isStateInjected()` | `boolean` | When `true`, the framework injects `AgentState` as an extra parameter |
 | `isMcp()` | `boolean` | Did the tool come from an MCP server? |
 | `getMcpName()` | `String` | The MCP server name when `isMcp()` is `true` |
@@ -114,8 +116,60 @@ Common `@Tool` attributes:
 | `readOnly` | `boolean` | Whether the tool is read-only (default `false`) |
 | `concurrencySafe` | `boolean` | Whether the tool is safe for concurrent calls (default `false`) |
 | `stateInjected` | `boolean` | Inject `AgentState` as an extra parameter (default `false`) |
+| `returnDirect` | `boolean` | End the turn after this tool; no further model call / summary (default `false`) |
+| `returnResult` | `boolean` | Only when `returnDirect=true`: whether the tool output becomes the reply (default `true`); `false` ends silently |
 | `dangerousFiles` / `dangerousDirectories` | `String[]` | Append custom dangerous paths |
 | `converter` | `Class<? extends ToolResultConverter>` | Custom conversion of return values into `ToolResultBlock` |
+
+### Terminal tools (`returnDirect`)
+
+By default the ReAct loop is: run the tool → feed the result back to the model → reason again (or `summarizing` when `maxIters` is hit). Mark a tool as terminal and **the turn ends as soon as it finishes** — the model is not called again.
+
+All three registration paths share the same semantics:
+
+```java
+// 1) @Tool
+@Tool(name = "submit_answer", description = "Submit the final answer", returnDirect = true)
+public String submitAnswer(@ToolParam(name = "answer") String answer) {
+    return answer;
+}
+
+// Silent stop: end the loop but do not use the tool output as the agent reply
+@Tool(name = "handoff", description = "Hand off to a human", returnDirect = true, returnResult = false)
+public String handoff(@ToolParam(name = "reason") String reason) {
+    return reason;
+}
+
+// 2) ToolBase
+super(ToolBase.builder()
+        .name("submit_answer")
+        .description("Submit the final answer")
+        .inputSchema(schema)
+        .returnDirect(true)
+        .returnResult(true));
+
+// 3) Implement AgentTool directly
+@Override
+public boolean isReturnDirect() {
+    return true;
+}
+
+@Override
+public boolean isReturnResult() {  // default true; false = silent stop
+    return true;
+}
+```
+
+After the turn ends, `Msg.getGenerateReason()` is `RETURN_DIRECT`:
+
+- `returnResult=true` (default): the returned message text is the tool output
+- `returnResult=false`: the reply is empty. The tool result is still written to session context so `tool_use` / `tool_result` stay paired
+
+When the model calls several `returnDirect` tools in the same turn, **every result is returned** (they run in parallel; order follows the original tool-call list):
+
+- `result.getTextContent()`: text outputs joined by `\n`
+- `result.getContentBlocks(ToolResultBlock.class)`: each result keeps `id` / `name`
+- `result.getMetadata().get(MessageMetadataKeys.RETURN_DIRECT_RESULTS)`: the same `List<ToolResultBlock>`
 
 ### Custom tools (extending `ToolBase`)
 

--- a/docs/v2/zh/docs/building-blocks/message-and-event.md
+++ b/docs/v2/zh/docs/building-blocks/message-and-event.md
@@ -31,7 +31,7 @@ description: "智能体通信，与前端流式数据传输"
 | `getMetadata()` | `Map<String, Object>` | 任意键值元数据 |
 | `getTimestamp()` | `String` | 创建时间（`yyyy-MM-dd HH:mm:ss.SSS`） |
 | `getUsage()` | `ChatUsage` | Token 用量（仅 assistant 消息） |
-| `getGenerateReason()` | `GenerateReason` | 退出原因：`MODEL_STOP` / `TOOL_SUSPENDED` / `REASONING_STOP_REQUESTED` / `ACTING_STOP_REQUESTED` / `ALL_TOOLS_DENIED` / `INTERRUPTED` / `MAX_ITERATIONS` |
+| `getGenerateReason()` | `GenerateReason` | 退出原因：`MODEL_STOP` / `TOOL_SUSPENDED` / `REASONING_STOP_REQUESTED` / `ACTING_STOP_REQUESTED` / `RETURN_DIRECT` / `ALL_TOOLS_DENIED` / `INTERRUPTED` / `MAX_ITERATIONS` |
 
 ### 内容块
 

--- a/docs/v2/zh/docs/building-blocks/tool.md
+++ b/docs/v2/zh/docs/building-blocks/tool.md
@@ -42,6 +42,8 @@ Java tool 是任意满足 `AgentTool` 契约的对象。AgentScope 同时提供�
 | `isConcurrencySafe()` | `boolean` | 是否可并发调用 |
 | `isReadOnly()` | `boolean` | 是否只读、不产生副作用 |
 | `isExternalTool()` | `boolean` | 为 `true` 时执行委派给外部（见 [定义外部执行 Tool](#定义外部执行-tool)） |
+| `isReturnDirect()` | `boolean` | 为 `true` 时本轮在该 tool 执行完后结束，不再回调模型（见 [终态 Tool](#终态-toolreturndirect)） |
+| `isReturnResult()` | `boolean` | 仅在 `returnDirect` 为 `true` 时生效：是否把 tool 输出作为 agent 的返回消息（默认 `true`） |
 | `isStateInjected()` | `boolean` | 为 `true` 时框架注入 `AgentState` 参数 |
 | `isMcp()` | `boolean` | 是否来自 MCP 服务 |
 | `getMcpName()` | `String` | `isMcp()` 为 `true` 时所属 MCP 服务名 |
@@ -114,8 +116,60 @@ toolkit.registerTool(new SimpleTools());
 | `readOnly` | `boolean` | 是否只读（默认 `false`） |
 | `concurrencySafe` | `boolean` | 是否可并发调用（默认 `false`） |
 | `stateInjected` | `boolean` | 是否在调用时注入 `AgentState` 作为额外参数（默认 `false`） |
+| `returnDirect` | `boolean` | 调用后结束本轮，不再回调模型做总结（默认 `false`） |
+| `returnResult` | `boolean` | 仅在 `returnDirect=true` 时生效：是否把 tool 输出作为返回消息（默认 `true`）；设为 `false` 则静默结束 |
 | `dangerousFiles` / `dangerousDirectories` | `String[]` | 追加自定义危险路径列表 |
 | `converter` | `Class<? extends ToolResultConverter>` | 自定义返回值到 `ToolResultBlock` 的转换器 |
+
+### 终态 Tool（`returnDirect`）
+
+默认 ReAct 循环是：执行 tool → 把结果回传给模型 → 再推理（或撞到 `maxIters` 后 `summarizing`）。把 tool 标成终态后，**执行完立刻结束本轮**，不再回调模型。
+
+三种注册方式语义相同：
+
+```java
+// 1) @Tool
+@Tool(name = "submit_answer", description = "提交最终答案", returnDirect = true)
+public String submitAnswer(@ToolParam(name = "answer") String answer) {
+    return answer;
+}
+
+// 静默结束：停循环，但不把 tool 输出当作 agent 回复
+@Tool(name = "handoff", description = "转交人工", returnDirect = true, returnResult = false)
+public String handoff(@ToolParam(name = "reason") String reason) {
+    return reason;
+}
+
+// 2) ToolBase
+super(ToolBase.builder()
+        .name("submit_answer")
+        .description("提交最终答案")
+        .inputSchema(schema)
+        .returnDirect(true)
+        .returnResult(true));
+
+// 3) 直接实现 AgentTool
+@Override
+public boolean isReturnDirect() {
+    return true;
+}
+
+@Override
+public boolean isReturnResult() {  // 默认 true；false 表示静默结束
+    return true;
+}
+```
+
+结束后 `Msg.getGenerateReason()` 为 `RETURN_DIRECT`：
+
+- `returnResult=true`（默认）：返回消息的文本就是 tool 输出
+- `returnResult=false`：返回空回复。tool 结果仍会写入会话上下文，保证 `tool_use` / `tool_result` 成对
+
+同一轮里模型并发调用多个 `returnDirect` 工具时，**全部都会返回**（并行执行，结果按原始 tool-call 顺序排列）：
+
+- `result.getTextContent()`：各工具文本输出按 `\n` 拼接
+- `result.getContentBlocks(ToolResultBlock.class)`：每条结果带 `id` / `name`，可区分来源
+- `result.getMetadata().get(MessageMetadataKeys.RETURN_DIRECT_RESULTS)`：同样的 `List<ToolResultBlock>`
 
 ### 自定义 Tool（继承 `ToolBase`）
 


### PR DESCRIPTION
## AgentScope-Java Version

2.0.3-SNAPSHOT

Closes #1408
Related to #2362

## Description

Adds first-class `returnDirect` / `returnResult` on `@Tool`, `AgentTool`, and `ToolBase` so a tool can end the ReAct turn after execution without another model call or `summarizing()` step.

- `returnDirect=true`: persist `tool_use` / `tool_result`, then stop with `GenerateReason.RETURN_DIRECT`
- `returnResult=false`: silent stop (empty reply)
- Concurrent `returnDirect` tools in one batch: all surfaced results are returned in original tool-call order (`TextBlock`s plus `MessageMetadataKeys.RETURN_DIRECT_RESULTS`)

This differs from #2891, which short-circuits only when every successful tool in the batch is `returnDirect`. This PR short-circuits when any successful tool is `returnDirect`.

## Why this is a draft (not ready to land)

Do **not** merge yet.

After a `returnDirect` tool finishes, AG-UI clients with server-side memory (CopilotKit and similar) still replay the full transcript:

`user -> assistant(tool_calls) -> tool -> next user`

`AguiRequestProcessor.extractLatestUserMessage` treats everything after the last assistant message as a follow-up. The already-persisted `tool` result is extracted again and appended to server memory, so the next turn receives an extra tool message.

HITL resume still depends on trailing tool-only messages after the last assistant, so a correct fix has to drop the completed `returnDirect` tool turn without breaking interrupt approval. That follow-up is out of scope here.

## Checklist

- [x] Code has been formatted with `mvn spotless:apply`
- [ ] All tests are passing (`mvn test`)
- [x] Javadoc comments are complete and follow project conventions
- [x] Related documentation has been updated (e.g. links, examples, etc.)
- [ ] Code is ready for review
