### PR TITLE
fix(harness/examples): Fix the reading of historical sessions of the data agent in examples

### DIFF
--- a/agentscope-examples/agents/agentscope-dataagent/src/main/java/io/agentscope/dataagent/runtime/gateway/HarnessGateway.java
+++ b/agentscope-examples/agents/agentscope-dataagent/src/main/java/io/agentscope/dataagent/runtime/gateway/HarnessGateway.java
@@ -293,7 +293,7 @@ public final class HarnessGateway implements Gateway {
                             "HarnessGateway.bindMainAgent must be called before run(...)"));
         }
 
-        String sessionKey = resolveOrCreateMainSession(gateKey, ha, ctx.userId());
+        String sessionKey = resolveOrCreateMainSession(gateKey, ha, ctx.userId(), requestedAgentId);
         String sessionId =
                 sessionAgentManager
                         .viewSession(sessionKey)
@@ -312,7 +312,8 @@ public final class HarnessGateway implements Gateway {
         if (ctx.userId() != null) {
             rtcBuilder.userId(ctx.userId());
         }
-        attachUserSandboxContext(rtcBuilder, ctx.userId(), resolveAgentId(ha));
+        attachUserSandboxContext(
+                rtcBuilder, ctx.userId(), resolveSandboxAgentId(requestedAgentId, ha));
         RuntimeContext runtimeContext = rtcBuilder.build();
         return withGatedTurn(gateKey, () -> ha.call(messages, runtimeContext));
     }
@@ -376,7 +377,8 @@ public final class HarnessGateway implements Gateway {
         String sessionUserId =
                 sessionAgentManager.getSession(requesterKey).map(SessionEntry::userId).orElse(null);
 
-        String sessionKey = resolveOrCreateMainSession(gateKey, ha, sessionUserId);
+        String sessionKey =
+                resolveOrCreateMainSession(gateKey, ha, sessionUserId, requesterAgentId);
         String sessionId =
                 sessionAgentManager
                         .viewSession(sessionKey)
@@ -392,7 +394,8 @@ public final class HarnessGateway implements Gateway {
         if (sessionUserId != null) {
             ctxBuilder.userId(sessionUserId);
         }
-        attachUserSandboxContext(ctxBuilder, sessionUserId, resolveAgentId(ha));
+        attachUserSandboxContext(
+                ctxBuilder, sessionUserId, resolveSandboxAgentId(requesterAgentId, ha));
         RuntimeContext ctx = ctxBuilder.build();
 
         OutboundAddress lastRoute = lastRouteBySessionKey.get(requesterKey);
@@ -451,7 +454,8 @@ public final class HarnessGateway implements Gateway {
         return defaultAgentId != null ? agentRegistry.get(defaultAgentId) : null;
     }
 
-    private String resolveOrCreateMainSession(String gateKey, HarnessAgent ha, String userId) {
+    private String resolveOrCreateMainSession(
+            String gateKey, HarnessAgent ha, String userId, String routingAgentId) {
         return contextKeyToSessionKey.compute(
                 gateKey,
                 (k, existingSessionKey) -> {
@@ -464,24 +468,31 @@ public final class HarnessGateway implements Gateway {
                                 gateKey,
                                 existingSessionKey);
                     }
-                    String aid = resolveAgentId(ha);
+                    String harnessAgentId = resolveAgentId(ha);
+                    String sandboxAgentId = resolveSandboxAgentId(routingAgentId, ha);
                     SpawnResult r =
-                            sessionAgentManager.registerMainSession(aid, null, gateKey, userId);
+                            sessionAgentManager.registerMainSession(
+                                    harnessAgentId, null, gateKey, userId);
                     sessionKeyToGateKey.put(r.sessionKey(), gateKey);
-                    sessionKeyToAgentId.put(r.sessionKey(), aid);
+                    // Prefer gateway/catalog id so announce turns borrow the same sandbox as
+                    // chat/UI.
+                    sessionKeyToAgentId.put(r.sessionKey(), sandboxAgentId);
                     return r.sessionKey();
                 });
     }
 
     private boolean isSessionFresh(String sessionKey) {
-        SessionResetPolicy policy = sessionAgentManager.getConfig().sessionResetPolicy();
-        if (policy.mode() == SessionResetPolicy.ResetMode.NEVER) {
-            return true;
-        }
+        // Deleted sessions must not keep the gateKey → sessionKey mapping alive. NEVER mode
+        // skips idle/daily checks but still requires the session to exist in the manager.
         return sessionAgentManager
                 .getSession(sessionKey)
                 .map(
                         entry -> {
+                            SessionResetPolicy policy =
+                                    sessionAgentManager.getConfig().sessionResetPolicy();
+                            if (policy.mode() == SessionResetPolicy.ResetMode.NEVER) {
+                                return true;
+                            }
                             SessionFreshness f =
                                     SessionFreshnessEvaluator.evaluate(
                                             entry.lastActivityMs(),
@@ -495,6 +506,42 @@ public final class HarnessGateway implements Gateway {
     private static String resolveAgentId(HarnessAgent ha) {
         String id = ha != null ? ha.getAgentId() : null;
         return (id != null && !id.isBlank()) ? id : "main";
+    }
+
+    /**
+     * Sandbox registry key shared with workspace/history HTTP readers.
+     *
+     * <p>Prefer the gateway/catalog id from routing ({@code MsgContext} {@code agentId}, e.g.
+     * {@code data-agent} or {@code uca-...}). Falling back to {@link HarnessAgent#getAgentId()}
+     * (internal UUID) would open a different container than UI reads, so history looks empty.
+     */
+    private String resolveSandboxAgentId(String preferredGatewayId, HarnessAgent ha) {
+        if (preferredGatewayId != null && !preferredGatewayId.isBlank()) {
+            // Ignore internal UUID masquerading as a routing id (legacy sessionKeyToAgentId).
+            if (ha == null || !preferredGatewayId.equals(ha.getAgentId())) {
+                return preferredGatewayId;
+            }
+        }
+        if (ha == null) {
+            return "main";
+        }
+        String uuid = ha.getAgentId();
+        String uuidKey = null;
+        for (var e : agentRegistry.entrySet()) {
+            if (e.getValue() != ha) {
+                continue;
+            }
+            String key = e.getKey();
+            if (uuid != null && uuid.equals(key)) {
+                uuidKey = key;
+                continue;
+            }
+            return key;
+        }
+        if (uuidKey != null) {
+            return uuidKey;
+        }
+        return resolveAgentId(ha);
     }
 
     /**

--- a/agentscope-examples/agents/agentscope-dataagent/src/main/java/io/agentscope/dataagent/web/api/SessionController.java
+++ b/agentscope-examples/agents/agentscope-dataagent/src/main/java/io/agentscope/dataagent/web/api/SessionController.java
@@ -25,13 +25,18 @@ import io.agentscope.dataagent.runtime.session.SessionKind;
 import io.agentscope.dataagent.web.catalog.AgentCatalogService;
 import io.agentscope.dataagent.web.session.SessionReadStateStore;
 import io.agentscope.dataagent.web.session.SessionTurnParser;
+import io.agentscope.dataagent.web.workspace.WorkspaceManagerFactory;
 import io.agentscope.harness.agent.HarnessAgent;
-import io.agentscope.harness.agent.filesystem.remote.store.BaseStore;
 import io.agentscope.harness.agent.workspace.WorkspaceManager;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -65,19 +70,24 @@ import reactor.core.publisher.Mono;
 @RequestMapping("/api/agents/{agentId}/sessions")
 public class SessionController {
 
+    private static final Logger log = LoggerFactory.getLogger(SessionController.class);
+
     private final DataAgentBootstrap bootstrap;
     private final SessionAgentManager sessionAgentManager;
     private final SessionReadStateStore readStateStore;
     private final AgentCatalogService catalogService;
+    private final WorkspaceManagerFactory workspaceManagerFactory;
 
     public SessionController(
             DataAgentBootstrap builderBootstrap,
             SessionReadStateStore readStateStore,
-            AgentCatalogService catalogService) {
+            AgentCatalogService catalogService,
+            WorkspaceManagerFactory workspaceManagerFactory) {
         this.bootstrap = builderBootstrap;
         this.sessionAgentManager = builderBootstrap.gateway().sessionAgentManager();
         this.readStateStore = readStateStore;
         this.catalogService = catalogService;
+        this.workspaceManagerFactory = workspaceManagerFactory;
     }
 
     @GetMapping("/inbox")
@@ -287,45 +297,177 @@ public class SessionController {
     }
 
     /**
-     * Reads the chat content for a session. The actual transcript lives at the per-agent workspace
-     * under {@code agents/<innerAgentId>/sessions/<sessionId>.log.jsonl}, written by the harness
-     * memory hooks. The {@link SessionAgentManager} registry stores a stale legacy path
-     * ({@code .json}) keyed by the harness UUID rooted at the main-agent workspace, so its
-     * {@code history(...)} cannot be used here.
+     * Reads the chat content for a session. The transcript lives at {@code
+     * agents/<innerAgentId>/sessions/<sessionId>.log.jsonl}.
      *
-     * <p>Reads go through the per-agent {@link WorkspaceManager}'s composite filesystem (which is
-     * what the harness writes through), so multi-tenant deployments backed by the shared
-     * {@link BaseStore} stay correct. Falls back to
-     * {@link SessionAgentManager#history} only if the WorkspaceManager cannot be resolved
-     * (e.g. the agent has been unloaded).
+     * <p>Order: (1) borrow the per-(user, gatewayAgentId) sandbox via {@link
+     * WorkspaceManagerFactory} — does not require an agent call binding; (2) if empty, read the
+     * same relative path from the Agent's host workspace; (3) fall back to {@link
+     * SessionAgentManager#history}. Never routes through call-scoped sandbox proxies that throw
+     * {@code No active sandbox} outside a turn.
      */
     private String readSessionLogContent(String urlAgentId, SessionEntry entry) {
         String gatewayAgentId = catalogService.peekGatewayAgentId(entry.userId(), urlAgentId);
         HarnessAgent ha =
                 gatewayAgentId != null ? bootstrap.gateway().findAgent(gatewayAgentId) : null;
-        if (ha != null) {
-            WorkspaceManager wm = ha.getWorkspaceManager();
-            String innerAgentId = ha.getName();
-            if (wm != null && innerAgentId != null && !innerAgentId.isBlank()) {
-                String relLog =
-                        "agents/" + innerAgentId + "/sessions/" + entry.sessionId() + ".log.jsonl";
-                String fromLog = wm.readManagedWorkspaceFileUtf8(RuntimeContext.empty(), relLog);
-                if (fromLog != null && !fromLog.isEmpty()) {
-                    return fromLog;
-                }
-                String relCtx =
-                        "agents/" + innerAgentId + "/sessions/" + entry.sessionId() + ".jsonl";
-                String fromCtx = wm.readManagedWorkspaceFileUtf8(RuntimeContext.empty(), relCtx);
-                if (fromCtx != null && !fromCtx.isEmpty()) {
-                    return fromCtx;
-                }
+        String innerAgentId = ha != null ? ha.getName() : null;
+        if (innerAgentId != null && !innerAgentId.isBlank() && entry.sessionId() != null) {
+            String relLog =
+                    "agents/" + innerAgentId + "/sessions/" + entry.sessionId() + ".log.jsonl";
+            String relCtx = "agents/" + innerAgentId + "/sessions/" + entry.sessionId() + ".jsonl";
+
+            String fromSandbox = readViaSharedSandbox(entry.userId(), gatewayAgentId, relLog);
+            String sandboxPathUsed = relLog;
+            if (fromSandbox == null || fromSandbox.isEmpty()) {
+                fromSandbox = readViaSharedSandbox(entry.userId(), gatewayAgentId, relCtx);
+                sandboxPathUsed = relCtx;
             }
+            if (fromSandbox != null && !fromSandbox.isEmpty()) {
+                log.info(
+                        "[session-history] source=sandbox userId={} gatewayAgentId={} sessionId={}"
+                                + " path={} bytes={}",
+                        entry.userId(),
+                        gatewayAgentId,
+                        entry.sessionId(),
+                        sandboxPathUsed,
+                        fromSandbox.length());
+                return fromSandbox;
+            }
+            log.info(
+                    "[session-history] sandbox miss userId={} gatewayAgentId={} sessionId={}"
+                            + " tried=[{}, {}]",
+                    entry.userId(),
+                    gatewayAgentId,
+                    entry.sessionId(),
+                    relLog,
+                    relCtx);
+
+            Path localLog =
+                    resolveAgentLocalPath(
+                            ha, entry.userId(), innerAgentId, entry.sessionId(), true);
+            Path localCtx =
+                    resolveAgentLocalPath(
+                            ha, entry.userId(), innerAgentId, entry.sessionId(), false);
+            String fromLocal = readLocalPath(localLog);
+            Path localPathUsed = localLog;
+            if (fromLocal == null || fromLocal.isEmpty()) {
+                fromLocal = readLocalPath(localCtx);
+                localPathUsed = localCtx;
+            }
+            if (fromLocal != null && !fromLocal.isEmpty()) {
+                log.info(
+                        "[session-history] source=local userId={} gatewayAgentId={} sessionId={}"
+                                + " path={} bytes={}",
+                        entry.userId(),
+                        gatewayAgentId,
+                        entry.sessionId(),
+                        localPathUsed,
+                        fromLocal.length());
+                return fromLocal;
+            }
+            log.info(
+                    "[session-history] local miss userId={} sessionId={} tried=[{}, {}]",
+                    entry.userId(),
+                    entry.sessionId(),
+                    localLog,
+                    localCtx);
+        } else {
+            log.info(
+                    "[session-history] skip sandbox/local (agent unresolved) urlAgentId={}"
+                            + " gatewayAgentId={} sessionId={}",
+                    urlAgentId,
+                    gatewayAgentId,
+                    entry.sessionId());
         }
         HistoryResult raw = sessionAgentManager.history(entry.sessionKey(), 0);
         if (raw == null || raw.error() != null) {
+            log.info(
+                    "[session-history] source=empty sessionKey={} error={}",
+                    entry.sessionKey(),
+                    raw != null ? raw.error() : "null");
             return "";
         }
-        return raw.content() != null ? raw.content() : "";
+        String content = raw.content() != null ? raw.content() : "";
+        log.info(
+                "[session-history] source=sessionAgentManager sessionKey={} bytes={}",
+                entry.sessionKey(),
+                content.length());
+        return content;
+    }
+
+    /**
+     * Reads through the user sandbox registry (same key as chat write / workspace UI for catalog
+     * gateway ids). Failures return empty — never throw into the HTTP layer.
+     */
+    private String readViaSharedSandbox(String userId, String gatewayAgentId, String relativePath) {
+        if (userId == null
+                || userId.isBlank()
+                || gatewayAgentId == null
+                || gatewayAgentId.isBlank()
+                || relativePath == null) {
+            return "";
+        }
+        try {
+            WorkspaceManager wm = workspaceManagerFactory.forAgent(userId, gatewayAgentId);
+            String content = wm.readManagedWorkspaceFileUtf8(RuntimeContext.empty(), relativePath);
+            return content != null ? content : "";
+        } catch (RuntimeException e) {
+            log.warn(
+                    "[session-history] sandbox read failed userId={} gatewayAgentId={} path={}: {}",
+                    userId,
+                    gatewayAgentId,
+                    relativePath,
+                    e.toString());
+            return "";
+        }
+    }
+
+    /**
+     * Resolves the host path for a session transcript. Prefers namespaced
+     * {@link WorkspaceManager#resolveSessionLogFile} (e.g. {@code bob/agents/...}); falls back to
+     * non-namespaced workspace-relative path when the manager has no namespace factory.
+     */
+    private static Path resolveAgentLocalPath(
+            HarnessAgent ha,
+            String userId,
+            String innerAgentId,
+            String sessionId,
+            boolean logFile) {
+        if (ha == null) {
+            return null;
+        }
+        WorkspaceManager wm = ha.getWorkspaceManager();
+        if (wm == null || wm.getWorkspace() == null) {
+            return null;
+        }
+        RuntimeContext rc =
+                userId != null && !userId.isBlank()
+                        ? RuntimeContext.builder().userId(userId).build()
+                        : RuntimeContext.empty();
+        try {
+            return logFile
+                    ? wm.resolveSessionLogFile(rc, innerAgentId, sessionId)
+                    : wm.resolveSessionContextFile(rc, innerAgentId, sessionId);
+        } catch (RuntimeException e) {
+            String rel =
+                    "agents/"
+                            + innerAgentId
+                            + "/sessions/"
+                            + sessionId
+                            + (logFile ? ".log.jsonl" : ".jsonl");
+            return wm.getWorkspace().resolve(rel).normalize();
+        }
+    }
+
+    private static String readLocalPath(Path file) {
+        if (file == null || !Files.isRegularFile(file)) {
+            return "";
+        }
+        try {
+            return Files.readString(file, StandardCharsets.UTF_8);
+        } catch (Exception e) {
+            return "";
+        }
     }
 
     // -----------------------------------------------------------------

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/filesystem/sandbox/PinnedSandboxFilesystem.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/filesystem/sandbox/PinnedSandboxFilesystem.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.harness.agent.filesystem.sandbox;
+
+import io.agentscope.harness.agent.sandbox.Sandbox;
+import java.util.Objects;
+
+/**
+ * {@link SandboxBackedFilesystem} that holds a fixed {@link Sandbox} reference for the lifetime of
+ * the instance.
+ *
+ * <p>Used by asynchronous session mirrors so uploads can complete after the agent call releases
+ * its per-call binding on the shared agent proxy. Unlike the agent-level {@link
+ * SandboxBackedFilesystem}, {@link #clearSandboxIfCurrent} is a no-op — clearing the call proxy
+ * must not unpin this mirror filesystem.
+ *
+ * <p>Safe for DataAgent-style <em>user-managed</em> sandboxes that stay alive across
+ * acquire/release. Self-managed sandboxes that stop on release may still fail if the async upload
+ * races past shutdown.
+ */
+public final class PinnedSandboxFilesystem extends SandboxBackedFilesystem {
+
+    public PinnedSandboxFilesystem(Sandbox sandbox) {
+        Objects.requireNonNull(sandbox, "sandbox");
+        super.setSandbox(sandbox);
+    }
+
+    @Override
+    public synchronized void clearSandboxIfCurrent(Sandbox expected) {
+        // Keep the pin for out-of-call mirror uploads.
+    }
+}

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/memory/session/SessionTree.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/memory/session/SessionTree.java
@@ -19,6 +19,10 @@ import io.agentscope.core.agent.RuntimeContext;
 import io.agentscope.core.util.JsonUtils;
 import io.agentscope.harness.agent.filesystem.AbstractFilesystem;
 import io.agentscope.harness.agent.filesystem.model.ReadResult;
+import io.agentscope.harness.agent.filesystem.sandbox.PinnedSandboxFilesystem;
+import io.agentscope.harness.agent.sandbox.Sandbox;
+import io.agentscope.harness.agent.sandbox.SandboxAware;
+import io.agentscope.harness.agent.transcript.ObjectStoreTranscriptStore;
 import io.agentscope.harness.agent.transcript.TranscriptRef;
 import io.agentscope.harness.agent.transcript.TranscriptStore;
 import io.agentscope.harness.agent.workspace.WorkspaceIndex;
@@ -216,8 +220,9 @@ public class SessionTree {
      * Binds a {@link TranscriptStore} for segmented remote persistence. When set, {@link #flush()}
      * writes immutable segments instead of full-file mirrors, and {@link #syncFromRemote()} merges
      * from listed segments.
+     * history UI paths stay aligned with the local workspace. {@code null} disables segments
      *
-     * @param store segment store; {@code null} reverts to legacy full-file mirror
+     * @param store segment store; {@code null} disables segmented persistence
      * @param ref   transcript identity; required when {@code store} is non-null
      * @return this tree, for fluent chaining
      */
@@ -312,11 +317,11 @@ public class SessionTree {
     }
 
     /**
-     * Flushes pending entries to the local context and log files, then schedules an asynchronous
-     * remote mirror (segmented {@link TranscriptStore} when bound, else legacy full-file upload).
-     *
-     * <p>The remote mirror is fire-and-forget: failures are logged as warnings and do not affect
-     * the return of this method. The local write is always the primary guarantee.
+     * Flushes pending entries to the local context and log files, then schedules asynchronous
+     * remote mirrors. When a {@link TranscriptStore} is bound, both immutable segments and the
+     * canonical context/log files are mirrored. The remote mirror is fire-and-forget: failures are
+     * logged as warnings and do not affect the return of this method. The local write is always the
+     * primary guarantee.
      */
     public void flush() {
         if (pendingWrites.isEmpty()) {
@@ -335,9 +340,10 @@ public class SessionTree {
 
         if (transcriptStore != null && transcriptRef != null) {
             scheduleSegmentMirror(toWrite, seqStart, seqEnd);
-        } else {
-            scheduleMirror();
         }
+        // Align with the local session write logic and provide read access
+        // to the historical UI / sandbox
+        scheduleMirror();
     }
 
     /**
@@ -541,11 +547,13 @@ public class SessionTree {
     }
 
     private void scheduleSegmentMirror(List<SessionEntry> entries, long seqStart, long seqEnd) {
-        final TranscriptStore store = transcriptStore.withRuntimeContext(fsRc);
-        final TranscriptRef ref = transcriptRef;
-        if (store == null || ref == null || entries.isEmpty()) {
+        if (transcriptStore == null || transcriptRef == null || entries.isEmpty()) {
             return;
         }
+        // Same pin as scheduleMirror: async segment upload must survive call unbind.
+        final AbstractFilesystem mirrorFs = pinIfSandbox(filesystem);
+        final TranscriptStore store = transcriptStoreForMirror(mirrorFs);
+        final TranscriptRef ref = transcriptRef;
         StringBuilder sb = new StringBuilder();
         for (SessionEntry entry : entries) {
             sb.append(JsonUtils.getJsonCodec().toJson(entry)).append('\n');
@@ -569,16 +577,42 @@ public class SessionTree {
      * Schedules an asynchronous, best-effort mirror of both session files to the remote
      * filesystem. Uses a daemon single-thread executor to serialise uploads and avoid
      * blocking the caller on remote I/O.
+     * Avoid the situation where the asynchronous write sandbox pre-agent call has been completed,
+     * resulting in the unbinding of the sandbox and the error message "No active sandbox".
      */
     private void scheduleMirror() {
         if (filesystem == null || workspaceRoot == null) {
             return;
         }
+        final AbstractFilesystem mirrorFs = pinIfSandbox(filesystem);
+        final String contextRel = resolveRelativePath(contextFile);
+        final String logRel = resolveRelativePath(logFile);
         MIRROR_EXECUTOR.execute(
                 () -> {
-                    mirrorToFilesystem(contextFile, resolveRelativePath(contextFile));
-                    mirrorToFilesystem(logFile, resolveRelativePath(logFile));
+                    mirrorToFilesystem(mirrorFs, contextFile, contextRel);
+                    mirrorToFilesystem(mirrorFs, logFile, logRel);
                 });
+    }
+
+    /**
+     * When {@code fs} is a call-scoped sandbox proxy with an active binding, return a pinned
+     * filesystem that keeps that sandbox for async uploads. Otherwise return {@code fs} as-is.
+     */
+    private static AbstractFilesystem pinIfSandbox(AbstractFilesystem fs) {
+        if (fs instanceof SandboxAware aware) {
+            Sandbox sb = aware.getSandbox();
+            if (sb != null) {
+                return new PinnedSandboxFilesystem(sb);
+            }
+        }
+        return fs;
+    }
+
+    private TranscriptStore transcriptStoreForMirror(AbstractFilesystem mirrorFs) {
+        if (transcriptStore instanceof ObjectStoreTranscriptStore ost) {
+            return ost.withFilesystem(mirrorFs).withRuntimeContext(fsRc);
+        }
+        return transcriptStore.withRuntimeContext(fsRc);
     }
 
     /**
@@ -687,8 +721,8 @@ public class SessionTree {
      * Uploads {@code file} to the remote filesystem (full-file upload). Only called from the
      * mirror executor thread; failures are logged as warnings.
      */
-    private void mirrorToFilesystem(Path file, String relativePath) {
-        if (filesystem == null || workspaceRoot == null || !Files.isRegularFile(file)) {
+    private void mirrorToFilesystem(AbstractFilesystem fs, Path file, String relativePath) {
+        if (fs == null || workspaceRoot == null || !Files.isRegularFile(file)) {
             return;
         }
         if (relativePath == null || relativePath.isBlank()) {
@@ -696,12 +730,14 @@ public class SessionTree {
         }
         try {
             byte[] bytes = Files.readAllBytes(file);
-            filesystem.uploadFiles(fsRc, List.of(Map.entry(relativePath, bytes)));
+            fs.uploadFiles(fsRc, List.of(Map.entry(relativePath, bytes)));
             // Best-effort: the local file already exists — update index with its current stats
             if (index != null) {
                 index.upsertFromLocalFile(relativePath, file);
             }
         } catch (IOException e) {
+            log.warn("Failed to mirror session file {} to filesystem: {}", file, e.getMessage());
+        } catch (RuntimeException e) {
             log.warn("Failed to mirror session file {} to filesystem: {}", file, e.getMessage());
         }
     }

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/transcript/ObjectStoreTranscriptStore.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/transcript/ObjectStoreTranscriptStore.java
@@ -70,6 +70,14 @@ public class ObjectStoreTranscriptStore implements TranscriptStore {
         return new ObjectStoreTranscriptStore(filesystem, rc, rootPrefix);
     }
 
+    /**
+     * Returns a store that writes through {@code filesystem} while preserving this store's runtime
+     * context and root prefix. Used when session mirrors pin a sandbox reference for async upload.
+     */
+    public ObjectStoreTranscriptStore withFilesystem(AbstractFilesystem filesystem) {
+        return new ObjectStoreTranscriptStore(filesystem, rc, rootPrefix);
+    }
+
     @Override
     public String appendSegment(
             TranscriptRef ref, long seqStart, long seqEnd, String writerId, byte[] jsonl) {

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/memory/session/SessionTreeMirrorTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/memory/session/SessionTreeMirrorTest.java
@@ -23,6 +23,9 @@ import io.agentscope.harness.agent.filesystem.AbstractFilesystem;
 import io.agentscope.harness.agent.filesystem.BakedContextFilesystem;
 import io.agentscope.harness.agent.filesystem.remote.store.InMemoryStore;
 import io.agentscope.harness.agent.filesystem.spec.RemoteFilesystemSpec;
+import io.agentscope.harness.agent.transcript.ObjectStoreTranscriptStore;
+import io.agentscope.harness.agent.transcript.TranscriptRef;
+import io.agentscope.harness.agent.transcript.TranscriptStore;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
@@ -198,6 +201,40 @@ class SessionTreeMirrorTest {
         assertTrue(
                 Files.isRegularFile(tree.getLogFile()),
                 "local log file must exist immediately after flush()");
+    }
+
+    @Test
+    void flush_withTranscriptStore_stillMirrorsCanonicalFiles() throws Exception {
+        InMemoryStore store = new InMemoryStore();
+        AbstractFilesystem fs = buildFs(store);
+        Path context = workspace.resolve("agents/agent-a/sessions/s-canon.jsonl");
+
+        TranscriptStore segments = new ObjectStoreTranscriptStore(fs);
+        SessionTree tree = new SessionTree(context, workspace, fs);
+        tree.setRuntimeContext(RuntimeContext.builder().userId("user-1").build());
+        tree.setTranscriptStore(segments, new TranscriptRef("tenant", "agent-a", "s-canon"));
+        tree.append(new SessionEntry.MessageEntry(null, null, null, "USER", "hello", null));
+        tree.flush();
+        awaitMirror();
+
+        assertTrue(
+                Files.isRegularFile(tree.getLogFile()),
+                "local canonical log must exist after flush");
+        RuntimeContext rc = RuntimeContext.builder().userId("user-1").build();
+        var logRead = fs.read(rc, "agents/agent-a/sessions/s-canon.log.jsonl", 0, 0);
+        assertTrue(
+                logRead.isSuccess()
+                        && logRead.fileData() != null
+                        && logRead.fileData().content() != null
+                        && logRead.fileData().content().contains("hello"),
+                "canonical .log.jsonl must be mirrored even when TranscriptStore is bound");
+        var ctxRead = fs.read(rc, "agents/agent-a/sessions/s-canon.jsonl", 0, 0);
+        assertTrue(
+                ctxRead.isSuccess()
+                        && ctxRead.fileData() != null
+                        && ctxRead.fileData().content() != null
+                        && ctxRead.fileData().content().contains("hello"),
+                "canonical .jsonl must be mirrored even when TranscriptStore is bound");
     }
 
     // -----------------------------------------------------------------------


### PR DESCRIPTION
## AgentScope-Java Version

2.0.3-SNAPSHOT

## Description

**Background**
After the data-agent is launched locally, clicking on the history session fails to display any information and remains blank. An error message "No active sandbox" is also displayed. Please refer to the attached image.：
<img width="1791" height="369" alt="dataAgent-你好" src="https://github.com/user-attachments/assets/7b435258-a0f3-4ab4-a639-ad095038f25c" />
<img width="1785" height="760" alt="沙箱绑定出错" src="https://github.com/user-attachments/assets/6902a221-e62d-4238-adc5-980b7e6db44e" />


Fixes [#1626](https://github.com/agentscope-ai/agentscope-java/issues/2735)

Root causes:
There are issues throughout the entire read-write link. Looking at the current source code design, when writing messages, they are first written to the local workspace on the host machine, and then asynchronously segmented and written to the corresponding workspace in the sandbox. When reading, it starts by reading the sandbox, and if the sandbox cannot be read, it then reads the local fallback. The idea is fine, but there are flaws in the implementation:

1. Write: If the conversation content is normal, it will be written to agents/<agent>/sessions/<id>.log.jsonl. It is written locally normally. However, when the sandbox part is enabled and segment-based transcription is activated (default is enabled), flush only asynchronously writes events/segments. This does not align with the local content and misses the conversation content part. When the UI reads the sandbox, it will definitely not be able to read it (the content is empty []).
Also, there is an inconsistency in AgentId used for sandbox operations:
- When writing via gateway, the AgentId is obtained from `HarnessAgent.getAgentId()`;
- When reading sandbox content for history fetching and workspace‑UI rendering, the hard‑coded value `"data agent"` is used instead.
Even if data is asynchronously written into the sandbox successfully, reading will return empty results due to this mismatched sandbox AgentId.
2. Reading: "Get /api/agents/{agentId}/sessions/{key}", if it is done normally, it will first read the sandbox (SandboxBackedFilesystem). Before the agent reads the file, it will call requireSandbox (it must first obtain the "current round" bound sandbox), and the binding relationship of the sandbox only exists during the Agent.call execution phase. Reading history is a separate HTTP read request and will not start another round of Agent.call. If the binding relationship of the sandbox is obtained after the Agent.call execution is over, it will definitely be null → directly throw "No active sandbox", and the host machine's fallback will definitely not work.

**Repair Ideas**
1.When writing the sandbox asynchronously, you can directly use the existing (userId, agentId) → sandbox registration table (WorkspaceManagerFactory) to get the corresponding sandbox for the session, without relying on the sandbox dependency bound by the Agent.call phase. Avoid the problem of No active sandbox
2.Supplement the `.jsonl` / `.log.jsonl` session content during asynchronous segmented writes to the sandbox environment, aligning with local file paths to prevent loss of sandbox session data.
3.Make the agentId used by Gateway when mounting the sandbox consistent with `gatewayAgentId` used on the directory and UI side.
**Changes**

Aligned with the repair approach above:

1. **History read without call-bound sandbox**  
   `SessionController` no longer uses the call-scoped sandbox FS for `GET .../sessions/{key}`. It borrows the live sandbox from the existing `(userId, agentId)` registry via `WorkspaceManagerFactory`, so history HTTP never depends on an in-flight `Agent.call` binding and no longer throws `No active sandbox` before host fallback. If the sandbox is empty/unavailable, it falls back to the namespaced host workspace path.

2. **Async write: keep segments, also mirror canonical session files**  
   `SessionTree.flush` still appends `TranscriptStore` segments, and **also** async-mirrors canonical `.jsonl` / `.log.jsonl` (same relative paths as local). `PinnedSandboxFilesystem` (+ `ObjectStoreTranscriptStore#withFilesystem`) pins the sandbox at schedule time so the async upload can finish after call unbind. Window before the mirror lands is covered by local fallback.

3. **Same sandbox key for write and UI/history read**  
   `HarnessGateway` borrows the sandbox with catalog/UI `gatewayAgentId` (e.g. `data-agent`), not the internal harness UUID, so chat write and history/workspace read hit the same registry entry.

After fixing the above issue, I discovered another bug related to session deletion: new‑session entries could not be added after deleting historical sessions, and clicking to create a new session had no response.When deleting a session, entries are only removed from `SessionAgentManager`, while the in‑memory mapping `contextKeyToSessionKey` (gateKey → sessionKey) is not cleared.
This change also addresses this problem. `isSessionFresh` now treats deleted sessions as non‑fresh. Consequently, a new MAIN session will be re‑registered once the user clears history records, so the inbox can correctly display subsequent chat messages again.

**How to test**

After fix:
<img width="1797" height="517" alt="修复后-你好" src="https://github.com/user-attachments/assets/b17309ca-e83b-4140-91ee-a8357356ddd7" />
Now the session‑history sidebar can display correctly after deleting old sessions and creating new ones.

**How to test**
1. `mvn -pl agentscope-harness,agentscope-examples/agents/agentscope-dataagent -am test` (or at least `-Dtest=SessionTreeMirrorTest`).
2. Run DataAgent → chat → open history → turns load (no `No active sandbox`).
3. Delete all sessions → send again → inbox shows a new session.
4. Optional: same process after a turn → history hits sandbox; after JVM restart (empty registry) → local fallback still works.
## Checklist
Please check the following items before code is ready to be reviewed.
- [x]  Code has been formatted with `mvn spotless:apply`
- [x]  All tests are passing (`mvn test`) — verified: `mvn -pl agentscope-harness,agentscope-examples/agents/agentscope-dataagent -am test` (BUILD SUCCESS)
- [x]  Javadoc comments are complete and follow project conventions
- [x]  Related documentation has been updated (e.g. links, examples, etc.)
- [x]  Code is ready for review
