### PR TITLE
fix(harness): bound hung memory background tasks without losing final flushes

### DIFF
--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/memory/MemoryBackgroundTasks.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/memory/MemoryBackgroundTasks.java
@@ -29,6 +29,12 @@ import org.slf4j.LoggerFactory;
  * in-flight count is process-wide: {@code close()} blocks until every background task started
  * before the call has finished, so async workspace writes do not race with resource cleanup
  * (e.g. temp workspace deletion in tests).
+ *
+ * <p>Quiescence waiting deliberately <em>abandons</em> rather than cancels: a task that is
+ * still running when the caller's budget elapses keeps running and typically completes, so a
+ * close during an in-flight extraction does not silently drop the last turn's memories. Genuinely
+ * hung work is bounded — and cancelled — by the per-pipeline timeouts in
+ * {@code MemoryFlushMiddleware} / {@code MemoryMaintenanceMiddleware}, not here.
  */
 public final class MemoryBackgroundTasks {
 

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/middleware/MemoryFlushMiddleware.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/middleware/MemoryFlushMiddleware.java
@@ -29,6 +29,7 @@ import io.agentscope.harness.agent.memory.MemoryBackgroundTasks;
 import io.agentscope.harness.agent.memory.MemoryConfig;
 import io.agentscope.harness.agent.memory.MemoryFlushManager;
 import io.agentscope.harness.agent.workspace.WorkspaceManager;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
@@ -85,6 +86,13 @@ import reactor.core.scheduler.Schedulers;
 public class MemoryFlushMiddleware implements HarnessRuntimeMiddleware {
 
     private static final Logger log = LoggerFactory.getLogger(MemoryFlushMiddleware.class);
+
+    /**
+     * Upper bound on the flush LLM call, so a hung model provider cannot pin the conversation's
+     * coalescing slot forever (every later flush of that conversation would queue behind it) or
+     * keep the JVM-wide quiescence count above zero for the rest of the process lifetime.
+     */
+    static final Duration FLUSH_TIMEOUT = Duration.ofMinutes(5);
 
     private final WorkspaceManager workspaceManager;
     private final Model model;
@@ -149,6 +157,14 @@ public class MemoryFlushMiddleware implements HarnessRuntimeMiddleware {
         this.periodicGate = periodicGate != null ? periodicGate : new LocalPeriodicGate();
     }
 
+    /** Timeout applied to the flush pipeline; production builds use {@link #FLUSH_TIMEOUT}. */
+    private Duration flushTimeout = FLUSH_TIMEOUT;
+
+    /** Test hook to shrink the flush timeout; keeps timeout behaviour unit-testable. */
+    void setFlushTimeoutForTests(Duration timeout) {
+        this.flushTimeout = timeout != null ? timeout : FLUSH_TIMEOUT;
+    }
+
     @Override
     public Flux<AgentEvent> onAgent(
             Agent agent,
@@ -203,6 +219,7 @@ public class MemoryFlushMiddleware implements HarnessRuntimeMiddleware {
     private void runFlush(String key, Agent agent, RuntimeContext rc) {
         Mono.defer(() -> doFlush(agent, rc))
                 .subscribeOn(Schedulers.boundedElastic())
+                .timeout(flushTimeout)
                 .doFinally(
                         signal -> {
                             MemoryBackgroundTasks.end();

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/middleware/MemoryMaintenanceMiddleware.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/middleware/MemoryMaintenanceMiddleware.java
@@ -130,6 +130,24 @@ public class MemoryMaintenanceMiddleware implements HarnessRuntimeMiddleware {
         this.periodicGate = periodicGate != null ? periodicGate : new LocalPeriodicGate();
     }
 
+    /**
+     * Upper bound on the maintenance run (gate claim + retention sweep + consolidation LLM
+     * call), so a hung model cannot keep the JVM-wide quiescence count above zero for the rest
+     * of the process lifetime. Mirrors {@code MemoryFlushMiddleware#FLUSH_TIMEOUT}.
+     */
+    static final Duration MAINTENANCE_TIMEOUT = Duration.ofMinutes(5);
+
+    /**
+     * Timeout applied to the maintenance pipeline; production uses {@link
+     * #MAINTENANCE_TIMEOUT}.
+     */
+    private Duration maintenanceTimeout = MAINTENANCE_TIMEOUT;
+
+    /** Test hook to shrink the maintenance timeout; keeps timeout behaviour unit-testable. */
+    void setMaintenanceTimeoutForTests(Duration timeout) {
+        this.maintenanceTimeout = timeout != null ? timeout : MAINTENANCE_TIMEOUT;
+    }
+
     public MemoryMaintenanceMiddleware(
             WorkspaceManager workspaceManager, MemoryConsolidator consolidator) {
         this(workspaceManager, consolidator, 90, 180, DEFAULT_MIN_GAP);
@@ -152,6 +170,7 @@ public class MemoryMaintenanceMiddleware implements HarnessRuntimeMiddleware {
                             MemoryBackgroundTasks.begin();
                             Mono.defer(() -> doMaintenance(rc))
                                     .subscribeOn(Schedulers.boundedElastic())
+                                    .timeout(maintenanceTimeout)
                                     .doFinally(signal -> MemoryBackgroundTasks.end())
                                     .subscribe(
                                             null,
@@ -163,12 +182,37 @@ public class MemoryMaintenanceMiddleware implements HarnessRuntimeMiddleware {
     }
 
     private Mono<Void> doMaintenance(RuntimeContext rc) {
-        if (!periodicGate.tryClaim(compositeTimerKey(rc), minGap)) {
-            // Throttled out; the in-flight slot acquired at dispatch is released when this
-            // Mono completes.
+        return Mono.defer(
+                () -> {
+                    if (!periodicGate.tryClaim(compositeTimerKey(rc), minGap)) {
+                        // Throttled out; the in-flight slot acquired at dispatch is released
+                        // when this Mono completes.
+                        return Mono.empty();
+                    }
+                    // The pipeline stays reactive end-to-end: the pipeline timeout's cancel
+                    // propagates into the consolidation model stream instead of stranding the
+                    // worker on an inner .block() that no outer dispose can reach.
+                    return Mono.fromRunnable(() -> expireDailyFiles(rc))
+                            .then(consolidateReactive(rc))
+                            .then(Mono.fromRunnable(() -> pruneOldSessions(rc)));
+                });
+    }
+
+    /**
+     * Consolidation segment of the maintenance pipeline. Reactive so cancellation reaches the
+     * underlying model stream; a consolidation failure logs and lets the retention steps still
+     * run, matching the previous try/catch semantics around {@code consolidate().block()}.
+     */
+    private Mono<Void> consolidateReactive(RuntimeContext rc) {
+        if (consolidator == null) {
             return Mono.empty();
         }
-        return Mono.fromRunnable(() -> runMaintenance(rc));
+        return Mono.defer(() -> consolidator.consolidate(rc))
+                .onErrorResume(
+                        e -> {
+                            log.warn("Memory consolidation failed: {}", e.getMessage());
+                            return Mono.empty();
+                        });
     }
 
     /**
@@ -193,14 +237,6 @@ public class MemoryMaintenanceMiddleware implements HarnessRuntimeMiddleware {
                     MemoryFlushMiddleware.blankToEmpty(rc != null ? rc.getSessionId() : null);
             case AGENT, GLOBAL -> "";
         };
-    }
-
-    private void runMaintenance(RuntimeContext rc) {
-        log.debug("Running memory maintenance...");
-        expireDailyFiles(rc);
-        consolidateMemory(rc);
-        pruneOldSessions(rc);
-        log.debug("Memory maintenance completed");
     }
 
     private void expireDailyFiles(RuntimeContext rc) {
@@ -237,17 +273,6 @@ public class MemoryMaintenanceMiddleware implements HarnessRuntimeMiddleware {
             } catch (Exception e) {
                 // not a date-named file, skip
             }
-        }
-    }
-
-    private void consolidateMemory(RuntimeContext rc) {
-        if (consolidator == null) {
-            return;
-        }
-        try {
-            consolidator.consolidate(rc).block();
-        } catch (Exception e) {
-            log.warn("Memory consolidation failed: {}", e.getMessage());
         }
     }
 

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/middleware/MemoryBackgroundHardeningTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/middleware/MemoryBackgroundHardeningTest.java
@@ -1,0 +1,239 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.harness.agent.middleware;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.agentscope.core.agent.Agent;
+import io.agentscope.core.agent.RuntimeContext;
+import io.agentscope.core.event.AgentEvent;
+import io.agentscope.core.message.Msg;
+import io.agentscope.core.message.MsgRole;
+import io.agentscope.core.message.TextBlock;
+import io.agentscope.core.middleware.AgentInput;
+import io.agentscope.core.model.ChatResponse;
+import io.agentscope.core.model.Model;
+import io.agentscope.core.state.AgentState;
+import io.agentscope.harness.agent.coordination.LocalPeriodicGate;
+import io.agentscope.harness.agent.memory.MemoryBackgroundTasks;
+import io.agentscope.harness.agent.memory.MemoryConfig;
+import io.agentscope.harness.agent.memory.MemoryConsolidator;
+import io.agentscope.harness.agent.memory.MemoryFlushManager;
+import io.agentscope.harness.agent.workspace.WorkspaceManager;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+/**
+ * Hardening tests for the fire-and-forget memory background work introduced with the detach
+ * (#2777): a hung model call must not pin the conversation's coalescing slot (or a
+ * boundedElastic worker) forever. Cancellation belongs to the per-pipeline timeouts only —
+ * {@link MemoryBackgroundTasks#awaitQuiescence} deliberately abandons in-flight work when its
+ * budget elapses so a close during a healthy flush never drops the last turn's memory
+ * extraction.
+ */
+@Tag("unit")
+class MemoryBackgroundHardeningTest {
+
+    @BeforeEach
+    void resetSharedTimerMap() {
+        LocalPeriodicGate.clearForTests();
+    }
+
+    /** Polls until quiescence is reached within the given budget; fails the test on timeout. */
+    private static boolean pollQuiescence(Duration budget) throws InterruptedException {
+        long deadline = System.nanoTime() + budget.toNanos();
+        while (System.nanoTime() < deadline) {
+            if (MemoryBackgroundTasks.awaitQuiescence(500, TimeUnit.MILLISECONDS)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * N1 invariant: quiescence waiting must <em>abandon</em>, not cancel. A close() during an
+     * in-flight flush is the common case with fire-and-forget memory work, and the last turn's
+     * extraction must keep running and complete after the caller's budget elapses — genuinely
+     * hung work is the pipeline timeout's job, not the quiescence sweep's.
+     */
+    @Test
+    void awaitQuiescence_timeout_doesNotCancelHealthyFlush(@TempDir Path tmp) throws Exception {
+        WorkspaceManager wsm = new WorkspaceManager(tmp);
+        CountDownLatch flushStarted = new CountDownLatch(1);
+        CountDownLatch releaseFlush = new CountDownLatch(1);
+        AtomicBoolean flushCancelled = new AtomicBoolean(false);
+        Model slowModel = mock(Model.class);
+        when(slowModel.stream(any(), any(), any()))
+                .thenAnswer(
+                        inv ->
+                                Flux.<ChatResponse>create(
+                                                sink -> {
+                                                    flushStarted.countDown();
+                                                    try {
+                                                        releaseFlush.await(10, TimeUnit.SECONDS);
+                                                    } catch (InterruptedException e) {
+                                                        Thread.currentThread().interrupt();
+                                                    }
+                                                    sink.complete();
+                                                })
+                                        .doOnCancel(() -> flushCancelled.set(true)));
+
+        MemoryFlushMiddleware mw =
+                new MemoryFlushMiddleware(
+                        wsm,
+                        slowModel,
+                        MemoryFlushManager.DEFAULT_FLUSH_PROMPT,
+                        MemoryConfig.FlushTrigger.always());
+        mw.setFlushTimeoutForTests(Duration.ofMinutes(5));
+
+        RuntimeContext rc = RuntimeContext.builder().sessionId("s1").userId("u1").build();
+        rc.setAgentState(stateWithMessages(userMsg("hello")));
+        AgentInput input = new AgentInput(List.of(userMsg("hello")));
+
+        mw.onAgent((Agent) null, rc, input, in -> Flux.<AgentEvent>empty())
+                .collectList()
+                .block(Duration.ofSeconds(5));
+        assertTrue(flushStarted.await(2, TimeUnit.SECONDS), "flush should be in flight");
+
+        // A short quiescence budget (like HarnessAgent.close()'s 5s) must give up waiting...
+        assertFalse(
+                MemoryBackgroundTasks.awaitQuiescence(150, TimeUnit.MILLISECONDS),
+                "quiescence must report failure while the flush is still running");
+
+        // ...but the flush itself must survive the abandoned wait and complete afterwards.
+        releaseFlush.countDown();
+        assertTrue(
+                pollQuiescence(Duration.ofSeconds(5)),
+                "the abandoned flush must complete on its own");
+        assertFalse(
+                flushCancelled.get(),
+                "quiescence must never cancel healthy in-flight work (final-memory loss)");
+        wsm.close();
+    }
+
+    @Test
+    void hungFlush_timesOut_releasesQuiescenceAndQueueRecovers(@TempDir Path tmp) throws Exception {
+        WorkspaceManager wsm = new WorkspaceManager(tmp);
+        AtomicInteger modelCalls = new AtomicInteger();
+        Model hungModel = mock(Model.class);
+        when(hungModel.stream(any(), any(), any()))
+                .thenAnswer(
+                        inv -> {
+                            modelCalls.incrementAndGet();
+                            return Flux.<ChatResponse>never();
+                        });
+
+        MemoryFlushMiddleware mw =
+                new MemoryFlushMiddleware(
+                        wsm,
+                        hungModel,
+                        MemoryFlushManager.DEFAULT_FLUSH_PROMPT,
+                        MemoryConfig.FlushTrigger.always());
+        mw.setFlushTimeoutForTests(Duration.ofMillis(200));
+
+        RuntimeContext rc = RuntimeContext.builder().sessionId("s1").userId("u1").build();
+        rc.setAgentState(stateWithMessages(userMsg("hello")));
+        AgentInput input = new AgentInput(List.of(userMsg("hello")));
+
+        mw.onAgent((Agent) null, rc, input, in -> Flux.<AgentEvent>empty())
+                .collectList()
+                .block(Duration.ofSeconds(5));
+
+        // Without the timeout, a hung model pins the in-flight counter forever and every
+        // later awaitQuiescence call (e.g. HarnessAgent.close()) waits its full budget, gives
+        // up, and leaves the task running.
+        assertTrue(
+                pollQuiescence(Duration.ofSeconds(5)),
+                "flush timeout must release the in-flight slot");
+
+        // Queue recovery: after the hung flush timed out, a fresh call for the same
+        // conversation must reach the model again instead of queueing behind the dead slot.
+        mw.onAgent((Agent) null, rc, input, in -> Flux.<AgentEvent>empty())
+                .collectList()
+                .block(Duration.ofSeconds(5));
+        long deadline = System.nanoTime() + Duration.ofSeconds(5).toNanos();
+        while (modelCalls.get() < 2 && System.nanoTime() < deadline) {
+            Thread.sleep(10);
+        }
+        assertTrue(modelCalls.get() >= 2, "queue must recover after the flush timeout");
+
+        assertTrue(pollQuiescence(Duration.ofSeconds(5)));
+        wsm.close();
+    }
+
+    @Test
+    void hungMaintenance_timesOut_releasesQuiescence(@TempDir Path tmp) throws Exception {
+        WorkspaceManager wsm = new WorkspaceManager(tmp);
+        AtomicBoolean consolidationCancelled = new AtomicBoolean(false);
+        MemoryConsolidator consolidator = mock(MemoryConsolidator.class);
+        when(consolidator.consolidate(any()))
+                .thenAnswer(
+                        inv ->
+                                Mono.<Void>never()
+                                        .doOnCancel(() -> consolidationCancelled.set(true)));
+
+        MemoryMaintenanceMiddleware mw = new MemoryMaintenanceMiddleware(wsm, consolidator);
+        mw.setMaintenanceTimeoutForTests(Duration.ofMillis(200));
+        AgentInput input = new AgentInput(List.of(userMsg("hi")));
+
+        mw.onAgent((Agent) null, RuntimeContext.empty(), input, in -> Flux.<AgentEvent>empty())
+                .collectList()
+                .block(Duration.ofSeconds(5));
+
+        assertTrue(
+                pollQuiescence(Duration.ofSeconds(5)),
+                "maintenance timeout must release the in-flight slot");
+        assertTrue(
+                consolidationCancelled.get(),
+                "the timeout must cancel the consolidation subscription itself, freeing the"
+                        + " worker — not just the in-flight counter (the old .block() variant"
+                        + " released the counter while the worker stayed stuck)");
+        wsm.close();
+    }
+
+    // ── helpers ──────────────────────────────────────────────────────────────
+
+    private static Msg userMsg(String text) {
+        return Msg.builder()
+                .name("user")
+                .role(MsgRole.USER)
+                .content(List.of(TextBlock.builder().text(text).build()))
+                .build();
+    }
+
+    private static AgentState stateWithMessages(Msg... msgs) {
+        AgentState.Builder b = AgentState.builder().sessionId("s1");
+        for (Msg m : msgs) {
+            b.addMessage(m);
+        }
+        return b.build();
+    }
+}


### PR DESCRIPTION
## Problem

Since #2777 the per-call memory flush and maintenance run fire-and-forget, but a hung model call has no bound and no escape:

- `runFlush`'s pipeline has no timeout, so a hung flush keeps the conversation's coalescing slot in `FLUSH_QUEUES` **running forever** — every later flush of that conversation queues behind the dead slot and memory extraction permanently stops for it;
- `MemoryBackgroundTasks.inFlight` never returns to zero, so every subsequent `close()` in the JVM waits its full 5s budget forever after;
- maintenance consolidation runs `consolidator.consolidate(rc).block()` inside `Mono.fromRunnable`, so a hung consolidation **leaks a boundedElastic worker for the rest of the process**: the inner block subscription is unreachable from any outer dispose, and once the model eventually returns, the same worker keeps writing retention/prune results into the workspace.

## Fix

- Both pipelines get a **5-minute timeout** — the only cancellation mechanism. The budget runs from subscription (including any `boundedElastic` pickup wait): under scheduler saturation a healthy-but-slow run may be skipped and logged, the safe direction for fire-and-forget work.
- `doMaintenance` becomes a **reactive composition** (`expire → consolidator.consolidate → prune`), so the timeout's cancel propagates down the chain into the consolidation model stream and the worker is actually freed. Consolidation failures log and let the retention steps still run, matching the previous try/catch semantics.

## Deliberately NOT changed: quiescence keeps its abandon semantics

Cancelling whatever is still in flight when `close()`'s 5s budget elapses would kill **healthy** flushes: with the pipeline timeout in place, anything that survives to that moment is by definition still within its 5-minute bound, and an LLM flush routinely outlives 5s — with fire-and-forget memory work, a close-during-flush is the common case, not the exception. A close-time sweep would therefore routinely drop the last turn's memory extraction. Instead, an abandoned task keeps running and typically completes; only work hung past the pipeline timeout dies. `MemoryBackgroundTasks` is unchanged apart from a javadoc note documenting this division of responsibilities.

## Boundary

The #2935-style window of a background task writing against an already-torn-down workspace is **not eliminated** — it is bounded from *unbounded* down to at most 5 minutes (the pipeline timeout). That is the inherent cost of the abandon semantics, and strictly better than before this change.

## Test evidence

New `MemoryBackgroundHardeningTest` (3 cases): a short quiescence budget gives up **without cancelling** a healthy in-flight flush, which then completes on its own (the abandon invariant, locked); a hung flush times out, releases the quiescence count and the conversation queue recovers; a hung consolidation times out and the cancellation is asserted to reach the consolidation subscription itself (the old `.block()` variant released the counter while the worker stayed stuck). Timeouts are injectable via package-private test hooks; production uses the 5-minute default. Regression: `MemoryFlushMiddlewareAsyncFlushTest` / `MemoryMaintenanceMiddlewareAsyncGateTest` green; full harness suite 888/888.

## Checklist

- [x] Code has been formatted with `mvn spotless:apply`
- [x] All tests are passing (`mvn test`)
- [x] Javadoc comments are complete and follow project conventions
- [x] Related documentation has been updated (class javadocs document the abandon/timeout division; no user-facing behavior or config changed)
- [x] Code is ready for review