### PR TITLE
Fix wordreader blank

### DIFF
--- a/agentscope-extensions/agentscope-extensions-rag/agentscope-extensions-rag-simple/src/main/java/io/agentscope/core/rag/reader/WordReader.java
+++ b/agentscope-extensions/agentscope-extensions-rag/agentscope-extensions-rag-simple/src/main/java/io/agentscope/core/rag/reader/WordReader.java
@@ -24,14 +24,6 @@ import io.agentscope.core.rag.model.Document;
 import io.agentscope.core.rag.model.DocumentMetadata;
 import io.agentscope.core.util.JsonException;
 import io.agentscope.core.util.JsonUtils;
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.util.ArrayList;
-import java.util.Base64;
-import java.util.List;
 import org.apache.poi.xwpf.usermodel.BodyElementType;
 import org.apache.poi.xwpf.usermodel.IBodyElement;
 import org.apache.poi.xwpf.usermodel.XWPFDocument;
@@ -42,6 +34,15 @@ import org.apache.poi.xwpf.usermodel.XWPFTable;
 import org.apache.poi.xwpf.usermodel.XWPFTableCell;
 import org.apache.poi.xwpf.usermodel.XWPFTableRow;
 import reactor.core.publisher.Mono;
+
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.List;
 
 /**
  * Word document reader that extracts text, tables, and images from Word files.
@@ -243,6 +244,13 @@ public class WordReader extends AbstractChunkingReader {
                             blocks.add(TextBlock.builder().text(text).build());
                         }
                         lastType = "text";
+                    }else{
+                        // 修复:空段落不跳过,追加 \n 用于保留段落边界
+                        if (!blocks.isEmpty() && "text".equals(lastType)) {
+                            int idx = blocks.size() - 1;
+                            TextBlock last = (TextBlock)blocks.get(idx);
+                            blocks.set(idx, TextBlock.builder().text(last.getText() + "\n").build());
+                        }
                     }
 
                 } else if (element.getElementType() == BodyElementType.TABLE) {

--- a/agentscope-extensions/agentscope-extensions-rag/agentscope-extensions-rag-simple/src/main/java/io/agentscope/core/rag/reader/WordReader.java
+++ b/agentscope-extensions/agentscope-extensions-rag/agentscope-extensions-rag-simple/src/main/java/io/agentscope/core/rag/reader/WordReader.java
@@ -24,6 +24,14 @@ import io.agentscope.core.rag.model.Document;
 import io.agentscope.core.rag.model.DocumentMetadata;
 import io.agentscope.core.util.JsonException;
 import io.agentscope.core.util.JsonUtils;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.List;
 import org.apache.poi.xwpf.usermodel.BodyElementType;
 import org.apache.poi.xwpf.usermodel.IBodyElement;
 import org.apache.poi.xwpf.usermodel.XWPFDocument;
@@ -34,15 +42,6 @@ import org.apache.poi.xwpf.usermodel.XWPFTable;
 import org.apache.poi.xwpf.usermodel.XWPFTableCell;
 import org.apache.poi.xwpf.usermodel.XWPFTableRow;
 import reactor.core.publisher.Mono;
-
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.util.ArrayList;
-import java.util.Base64;
-import java.util.List;
 
 /**
  * Word document reader that extracts text, tables, and images from Word files.
@@ -244,12 +243,13 @@ public class WordReader extends AbstractChunkingReader {
                             blocks.add(TextBlock.builder().text(text).build());
                         }
                         lastType = "text";
-                    }else{
+                    } else {
                         // 修复:空段落不跳过,追加 \n 用于保留段落边界
                         if (!blocks.isEmpty() && "text".equals(lastType)) {
                             int idx = blocks.size() - 1;
-                            TextBlock last = (TextBlock)blocks.get(idx);
-                            blocks.set(idx, TextBlock.builder().text(last.getText() + "\n").build());
+                            TextBlock last = (TextBlock) blocks.get(idx);
+                            blocks.set(
+                                    idx, TextBlock.builder().text(last.getText() + "\n").build());
                         }
                     }
 

--- a/agentscope-extensions/agentscope-extensions-rag/agentscope-extensions-rag-simple/src/test/java/io/agentscope/core/rag/reader/RagWordFixCorpusTest.java
+++ b/agentscope-extensions/agentscope-extensions-rag/agentscope-extensions-rag-simple/src/test/java/io/agentscope/core/rag/reader/RagWordFixCorpusTest.java
@@ -1,0 +1,69 @@
+package io.agentscope.core.rag.reader;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.agentscope.core.rag.model.Document;
+import java.net.URL;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * @Description: Unit tests for WordReader.
+ **/
+@DisplayName("WordReader Test Unit")
+public class RagWordFixCorpusTest {
+    @Test
+    @DisplayName("Fix the deleted blank paragraphs")
+    void shouldParsePolicyDocxWithKnownKeyword() {
+        assertDocxReadable("/rag-test.docx", "This technical report");
+    }
+
+    private void assertDocxReadable(String classpathLocation, String expectedKeyword) {
+        Path docxPath = resolveClasspathFile(classpathLocation);
+        List<Document> docs = new WordReader().read(ReaderInput.fromPath(docxPath)).block();
+        assertNotNull(docs, classpathLocation + " parse result is null");
+        assertFalse(docs.isEmpty(), classpathLocation + " parsed 0 chunks, corpus may be empty");
+
+        for (Document doc : docs) {
+            String text = doc.getMetadata().getContentText();
+            assertTrue(
+                    text != null && !text.isBlank(),
+                    classpathLocation
+                            + " contains a blank chunk (docId="
+                            + doc.getMetadata().getDocId()
+                            + ")");
+        }
+
+        // Concatenate all chunks in order before searching the keyword, to avoid false negatives
+        // when the keyword is split across chunk boundaries
+        String fullText =
+                docs.stream()
+                        .map(doc -> doc.getMetadata().getContentText())
+                        .collect(Collectors.joining());
+        assertTrue(
+                fullText.contains(expectedKeyword),
+                String.format(
+                        "%s full text (%d chunks, %d chars) does not contain keyword '%s'",
+                        classpathLocation, docs.size(), fullText.length(), expectedKeyword));
+    }
+
+    private Path resolveClasspathFile(String classpathLocation) {
+        URL url = getClass().getResource(classpathLocation);
+        assertNotNull(
+                url,
+                "Resource not found: "
+                        + classpathLocation
+                        + ", ensure the file exists under src/test/resources/");
+        try {
+            return Paths.get(url.toURI());
+        } catch (Exception e) {
+            throw new IllegalStateException("Failed to resolve " + classpathLocation + " path", e);
+        }
+    }
+}

--- a/agentscope-extensions/agentscope-extensions-rag/agentscope-extensions-rag-simple/src/test/java/io/agentscope/core/rag/reader/RagWordFixCorpusTest.java
+++ b/agentscope-extensions/agentscope-extensions-rag/agentscope-extensions-rag-simple/src/test/java/io/agentscope/core/rag/reader/RagWordFixCorpusTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.agentscope.core.rag.reader;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;


### PR DESCRIPTION
## AgentScope-Java Version

[The version of AgentScope-Java you are working on, e.g. 1.0.12, check your pom.xml dependency version or run `mvn dependency:tree | grep agentscope-parent:pom`(only mac/linux)]

## Description

[修复WordReader类读取文档时,段落之间的空白段落被删除,导致段落分段与实际文档不同
<img width="1491" height="452" alt="问题截图" src="https://github.com/user-attachments/assets/15cdaeeb-8c5d-4829-8d5c-e696d5ce5769" />
<img width="1471" height="473" alt="修复后截图" src="https://github.com/user-attachments/assets/d5585535-f28e-4042-85b4-058874afef36" />

]

## Checklist

Please check the following items before code is ready to be reviewed.

- [ ]  Code has been formatted with `mvn spotless:apply`
- [ ]  All tests are passing (`mvn test`)
- [ ]  Javadoc comments are complete and follow project conventions
- [ ]  Related documentation has been updated (e.g. links, examples, etc.)
- [ ]  Code is ready for review
<img width="1471" height="473" alt="修复后截图" src="https://github.com/user-attachments/assets/5f57d2c4-0926-4b48-bdf7-bfe83206944b" />
