### PR TITLE
fix(harness): sanitize session ids used in workspace file names

### DIFF
--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/workspace/WorkspaceManager.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/workspace/WorkspaceManager.java
@@ -59,6 +59,7 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.locks.ReentrantLock;
+import java.util.regex.Pattern;
 import java.util.stream.Stream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -104,6 +105,18 @@ public class WorkspaceManager implements AutoCloseable {
                     .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
     private static final TypeReference<Map<String, TaskRecord>> TASK_MAP_TYPE =
             new TypeReference<>() {};
+
+    /**
+     * Characters that Windows/NTFS reserves inside a single path segment. Ids such as the session
+     * id can legitimately contain a colon (for example {@code agent:<id>:main:<uuid>}), and using
+     * one verbatim in a file name turns path construction into an {@link
+     * java.nio.file.InvalidPathException} on Windows. Reserved characters are replaced with '-'
+     * rather than rejected, so ids keep working unchanged on every platform.
+     *
+     * <p>Forward slash and backslash are included as well: an id is a single file-name segment
+     * here, so either would otherwise be read as a directory separator.
+     */
+    private static final Pattern UNSAFE_SEGMENT_CHARS = Pattern.compile("[<>:\"/\\\\|?*]");
 
     /**
      * Per-path locks for workspace-relative files to prevent concurrent read-modify-write races.
@@ -343,18 +356,19 @@ public class WorkspaceManager implements AutoCloseable {
      */
     @Deprecated
     public Path resolveSessionFile(RuntimeContext rc, String agentId, String sessionId) {
-        return getSessionDir(rc, agentId).resolve(sessionId + ".json");
+        return getSessionDir(rc, agentId).resolve(safeSegment(sessionId) + ".json");
     }
 
     /** Returns the JSONL session context file path (LLM-facing, compacted). */
     public Path resolveSessionContextFile(RuntimeContext rc, String agentId, String sessionId) {
         return getSessionDir(rc, agentId)
-                .resolve(sessionId + WorkspaceConstants.SESSION_CONTEXT_EXT);
+                .resolve(safeSegment(sessionId) + WorkspaceConstants.SESSION_CONTEXT_EXT);
     }
 
     /** Returns the JSONL session log file path (full history, append-only). */
     public Path resolveSessionLogFile(RuntimeContext rc, String agentId, String sessionId) {
-        return getSessionDir(rc, agentId).resolve(sessionId + WorkspaceConstants.SESSION_LOG_EXT);
+        return getSessionDir(rc, agentId)
+                .resolve(safeSegment(sessionId) + WorkspaceConstants.SESSION_LOG_EXT);
     }
 
     /**
@@ -596,8 +610,27 @@ public class WorkspaceManager implements AutoCloseable {
         }
     }
 
+    /**
+     * Replaces characters that are illegal in a Windows/NTFS file-name segment with '-'.
+     *
+     * <p>Session ids are caller-supplied and carry no documented character constraint, yet they are
+     * used verbatim to build file names. Sanitising here keeps an unexpected id from surfacing as a
+     * raw {@link java.nio.file.InvalidPathException} from deep inside the workspace layer, with no
+     * hint that the caller-supplied id is the problem.
+     */
+    private static String safeSegment(String segment) {
+        return segment == null ? null : UNSAFE_SEGMENT_CHARS.matcher(segment).replaceAll("-");
+    }
+
     private String taskRecordPath(String agentId, String sessionId) {
-        return AGENTS_DIR + "/" + agentId + "/" + TASKS_DIR + "/" + sessionId + ".json";
+        return AGENTS_DIR
+                + "/"
+                + agentId
+                + "/"
+                + TASKS_DIR
+                + "/"
+                + safeSegment(sessionId)
+                + ".json";
     }
 
     /**

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/workspace/WorkspaceManagerPathSafetyTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/workspace/WorkspaceManagerPathSafetyTest.java
@@ -89,4 +89,62 @@ class WorkspaceManagerPathSafetyTest {
                 "LITERAL",
                 Files.readString(backend.resolve("some..dir/note.txt"), StandardCharsets.UTF_8));
     }
+
+    @Test
+    void sessionFileNamesReplaceWindowsReservedCharacters(@TempDir Path root) throws Exception {
+        Path template = root.resolve("template");
+        Path backend = root.resolve("backend");
+        Files.createDirectories(template);
+        Files.createDirectories(backend);
+        RuntimeContext rc = RuntimeContext.empty();
+
+        try (WorkspaceManager manager =
+                new WorkspaceManager(
+                        template,
+                        new LocalFilesystem(
+                                backend, LocalFsMode.ROOTED, PathPolicy.empty(), 10, null))) {
+            // The shape from #2937: a session id built from namespaced parts.
+            String sessionId = "agent:abc-123:main:main-9f3c";
+            String sanitized = "agent-abc-123-main-main-9f3c";
+
+            assertFileNameIsSanitized(
+                    manager.resolveSessionFile(rc, "agent-1", sessionId), sanitized);
+            assertFileNameIsSanitized(
+                    manager.resolveSessionContextFile(rc, "agent-1", sessionId), sanitized);
+            assertFileNameIsSanitized(
+                    manager.resolveSessionLogFile(rc, "agent-1", sessionId), sanitized);
+
+            // Every character NTFS reserves, plus both separators, is replaced.
+            String allReserved = "a<b>c:d\"e/f\\g|h?i*j";
+            String allSanitized = "a-b-c-d-e-f-g-h-i-j";
+            assertFileNameIsSanitized(
+                    manager.resolveSessionFile(rc, "agent-1", allReserved), allSanitized);
+        }
+    }
+
+    @Test
+    void sessionFileNamesLeaveOrdinaryIdsUnchanged(@TempDir Path root) throws Exception {
+        Path template = root.resolve("template");
+        Path backend = root.resolve("backend");
+        Files.createDirectories(template);
+        Files.createDirectories(backend);
+        RuntimeContext rc = RuntimeContext.empty();
+
+        try (WorkspaceManager manager =
+                new WorkspaceManager(
+                        template,
+                        new LocalFilesystem(
+                                backend, LocalFsMode.ROOTED, PathPolicy.empty(), 10, null))) {
+            assertFileNameIsSanitized(
+                    manager.resolveSessionFile(rc, "agent-1", "main-9f3c7a2e"), "main-9f3c7a2e");
+        }
+    }
+
+    private static void assertFileNameIsSanitized(Path file, String sanitizedBaseName) {
+        String name = file.getFileName().toString();
+        assertEquals(sanitizedBaseName, name.substring(0, sanitizedBaseName.length()));
+        assertFalse(
+                name.substring(sanitizedBaseName.length()).matches(".*[<>:\"/\\\\|?*].*"),
+                "file name still contains a reserved character: " + name);
+    }
 }


### PR DESCRIPTION
## AgentScope-Java Version

`2.0.3-SNAPSHOT` (current `main`)

## Description

Closes #2937.

**Background.** `RuntimeContext.sessionId` is caller-supplied and carries no documented
character constraint, yet `WorkspaceManager` uses it verbatim to build file names
(`agents/{agentId}/sessions/{sessionId}.jsonl`, `agents/{agentId}/tasks/{sessionId}.json`).
A namespaced id such as `agent:abc-123:main:main-9f3c` is perfectly legal as an identifier,
but the colon is reserved by Windows/NTFS, so path construction fails on Windows with a bare
`InvalidPathException` thrown from deep inside the workspace layer — with no hint that the
caller-supplied id is the problem.

Reproduced locally on Windows 11 / JDK 17:

```
java.nio.file.InvalidPathException: Illegal char <:> at index 5: agent:abc-123:main:main-9f3c.json
```

**Change.** Reserved characters are replaced with `-` in the file-name segment rather than
rejected, so existing ids keep working unchanged on every platform:

- new `UNSAFE_SEGMENT_CHARS` pattern `[<>:"/\\|?*]` plus a small `safeSegment(String)` helper
- applied at the four places where `sessionId` becomes part of a file name:
  `resolveSessionFile`, `resolveSessionContextFile`, `resolveSessionLogFile`, `taskRecordPath`

`/` and `\` are included deliberately: `sessionId` is a single file-name segment here, so either
one would otherwise be read as a directory separator and silently write outside the session
directory. This follows the same approach as the already-merged #1031 and #2921, which stripped
Windows-reserved characters from skill source paths.

**No on-disk data changes shape.** Writes (`SessionTranscriptWriter`) and reads
(`SessionSearchTool`) both go through these same helpers, so the sanitized name is symmetric —
there is no way to write a transcript that can no longer be found. Ids that work today contain
no reserved character and are returned unchanged; ids that do contain one could not produce a
file on Windows in the first place, since they threw before any file was created.

Scope is kept to `sessionId`, as the issue describes. `agentId` reaches path construction the
same way and would benefit from the same treatment — happy to extend this PR if you would
prefer the two handled together.

**How to test.** `WorkspaceManagerPathSafetyTest` gains two cases, both platform-independent
(they assert the replacement behaviour rather than relying on a Windows-only crash):

- `sessionFileNamesReplaceWindowsReservedCharacters` — the `#2937` id shape plus every reserved
  character and both separators
- `sessionFileNamesLeaveOrdinaryIdsUnchanged` — regression guard: an ordinary id is untouched

```
mvn -pl agentscope-harness test -Dtest=WorkspaceManagerPathSafetyTest
```

Verified locally on Windows 11 / JDK 17.0.18 / Maven 3.9.4:
`mvn -pl agentscope-harness spotless:check` passes, and the full harness suite
(`mvn -pl agentscope-harness test`) is green — 895 tests, 0 failures, 0 errors.

## Checklist

Please check the following items before code is ready to be reviewed.

- [x]  Code has been formatted with `mvn spotless:apply`
- [x]  All tests are passing (`mvn test`)
- [x]  Javadoc comments are complete and follow project conventions
- [x]  Related documentation has been updated (e.g. links, examples, etc.)
- [x]  Code is ready for review
