### PR TITLE
feat(a2a): route remote reasoning events through middleware

### DIFF
--- a/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-a2a/agentscope-extensions-a2a-client/src/main/java/io/agentscope/core/a2a/agent/A2aAgent.java
+++ b/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-a2a/agentscope-extensions-a2a-client/src/main/java/io/agentscope/core/a2a/agent/A2aAgent.java
@@ -43,7 +43,9 @@ import io.agentscope.core.memory.InMemoryMemory;
 import io.agentscope.core.memory.Memory;
 import io.agentscope.core.message.Msg;
 import io.agentscope.core.message.TextBlock;
+import io.agentscope.core.middleware.MiddlewareBase;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.CancellationException;
@@ -81,6 +83,8 @@ public class A2aAgent extends AgentBase {
 
     private final Memory memory;
 
+    private final List<MiddlewareBase> middlewares;
+
     private final ClientEventHandlerRouter clientEventHandlerRouter;
 
     private Client a2aClient;
@@ -101,10 +105,14 @@ public class A2aAgent extends AgentBase {
             boolean checkRunning,
             Memory memory,
             List<Hook> hooks,
+            List<MiddlewareBase> middlewares,
             AgentCardResolver agentCardResolver,
             A2aAgentConfig a2aAgentConfig) {
         super(name, description, checkRunning, hooks);
         this.a2aAgentConfig = a2aAgentConfig;
+        List<MiddlewareBase> sortedMiddlewares = new ArrayList<>(middlewares);
+        sortedMiddlewares.sort(Comparator.comparingInt(MiddlewareBase::order).reversed());
+        this.middlewares = List.copyOf(sortedMiddlewares);
         this.agentCardResolver = agentCardResolver;
         this.memory = memory;
         LoggerUtil.debug(log, "A2aAgent init with config: {}", a2aAgentConfig);
@@ -121,6 +129,7 @@ public class A2aAgent extends AgentBase {
         LoggerUtil.debug(log, "[{}] A2aAgent call with input messages: ", currentRequestId);
         LoggerUtil.logTextMsgDetail(log, memory.getMessages());
         clientEventContext.setHooks(getSortedHooks());
+        clientEventContext.setMiddlewares(middlewares);
         clientEventContext.setInputMessages(memory.getMessages());
         return Mono.defer(
                         () -> {
@@ -182,6 +191,15 @@ public class A2aAgent extends AgentBase {
 
     public Memory getMemory() {
         return memory;
+    }
+
+    /**
+     * Returns the immutable list of registered middlewares.
+     *
+     * @return the configured middlewares in execution order
+     */
+    public List<MiddlewareBase> getMiddlewares() {
+        return middlewares;
     }
 
     private Client buildA2aClient(String name) {
@@ -300,6 +318,8 @@ public class A2aAgent extends AgentBase {
 
         private final List<Hook> hooks = new ArrayList<>();
 
+        private final List<MiddlewareBase> middlewares = new ArrayList<>();
+
         /**
          * Set the name of the A2aAgent.
          *
@@ -408,6 +428,28 @@ public class A2aAgent extends AgentBase {
         }
 
         /**
+         * Add a middleware for intercepting A2A reasoning events.
+         *
+         * @param middleware the middleware to add
+         * @return the current Builder instance for method chaining
+         */
+        public Builder middleware(MiddlewareBase middleware) {
+            this.middlewares.add(middleware);
+            return this;
+        }
+
+        /**
+         * Add multiple middlewares for intercepting A2A reasoning events.
+         *
+         * @param middlewares the middlewares to add
+         * @return the current Builder instance for method chaining
+         */
+        public Builder middlewares(List<? extends MiddlewareBase> middlewares) {
+            this.middlewares.addAll(middlewares);
+            return this;
+        }
+
+        /**
          * Build the A2aAgent instance.
          *
          * @return the built A2aAgent instance
@@ -426,6 +468,7 @@ public class A2aAgent extends AgentBase {
                     this.checkRunning,
                     this.memory,
                     this.hooks,
+                    this.middlewares,
                     this.agentCardResolver,
                     this.a2aAgentConfig);
         }

--- a/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-a2a/agentscope-extensions-a2a-client/src/main/java/io/agentscope/core/a2a/agent/event/ClientEventContext.java
+++ b/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-a2a/agentscope-extensions-a2a-client/src/main/java/io/agentscope/core/a2a/agent/event/ClientEventContext.java
@@ -18,13 +18,20 @@ package io.agentscope.core.a2a.agent.event;
 
 import io.a2a.spec.Task;
 import io.agentscope.core.a2a.agent.A2aAgent;
+import io.agentscope.core.event.AgentEvent;
+import io.agentscope.core.event.CustomEvent;
 import io.agentscope.core.hook.Hook;
 import io.agentscope.core.hook.PostReasoningEvent;
 import io.agentscope.core.hook.PreReasoningEvent;
 import io.agentscope.core.hook.ReasoningChunkEvent;
 import io.agentscope.core.message.Msg;
+import io.agentscope.core.middleware.MiddlewareBase;
+import io.agentscope.core.middleware.MiddlewareChain;
+import io.agentscope.core.middleware.ReasoningInput;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
+import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.core.publisher.MonoSink;
 
@@ -35,6 +42,10 @@ import reactor.core.publisher.MonoSink;
  */
 public class ClientEventContext {
 
+    private static final String A2A_REASONING_START = "a2a.reasoning.start";
+    private static final String A2A_REASONING_CHUNK = "a2a.reasoning.chunk";
+    private static final String A2A_REASONING_END = "a2a.reasoning.end";
+
     private final String currentRequestId;
 
     private final A2aAgent agent;
@@ -42,6 +53,8 @@ public class ClientEventContext {
     private MonoSink<Msg> sink;
 
     private List<Hook> hooks;
+
+    private List<MiddlewareBase> middlewares = List.of();
 
     private Task task;
 
@@ -85,6 +98,10 @@ public class ClientEventContext {
         this.hooks = hooks;
     }
 
+    public void setMiddlewares(List<MiddlewareBase> middlewares) {
+        this.middlewares = middlewares != null ? middlewares : List.of();
+    }
+
     public Task getTask() {
         return task;
     }
@@ -124,8 +141,12 @@ public class ClientEventContext {
      * Trigger PreReasoningEvent (triggered only once)
      */
     void publishPreReasoning() {
-        if (hooks != null && !hooks.isEmpty() && preReasoningFired.compareAndSet(false, true)) {
-            List<Msg> msgs = inputMessages == null ? List.of() : inputMessages;
+        if (!preReasoningFired.compareAndSet(false, true)) {
+            return;
+        }
+
+        List<Msg> msgs = inputMessages == null ? List.of() : inputMessages;
+        if (hooks != null && !hooks.isEmpty()) {
             PreReasoningEvent preEvent = new PreReasoningEvent(agent, "A2A", null, msgs);
 
             Mono<PreReasoningEvent> eventMono = Mono.just(preEvent);
@@ -134,14 +155,15 @@ public class ClientEventContext {
             }
             eventMono.block();
         }
+        publishMiddlewareEvent(A2A_REASONING_START, Map.of("messages", msgs));
     }
 
     /**
      * Trigger ReasoningChunkEvent (streaming process)
      */
     void publishReasoningChunk(Msg chunkMsg) {
+        publishPreReasoning(); // If not sent Pre before, send Pre first
         if (hooks != null && !hooks.isEmpty()) {
-            publishPreReasoning(); // If not sent Pre before, send Pre first
             ReasoningChunkEvent chunkEvent =
                     new ReasoningChunkEvent(agent, "A2A", null, chunkMsg, chunkMsg);
 
@@ -151,6 +173,7 @@ public class ClientEventContext {
             }
             eventMono.block();
         }
+        publishMiddlewareEvent(A2A_REASONING_CHUNK, Map.of("message", chunkMsg));
     }
 
     /**
@@ -162,8 +185,13 @@ public class ClientEventContext {
      * modification was applied
      */
     Msg publishPostReasoning(Msg finalMsg) {
-        if (hooks != null && !hooks.isEmpty() && postReasoningFired.compareAndSet(false, true)) {
-            publishPreReasoning();
+        if (!postReasoningFired.compareAndSet(false, true)) {
+            return finalMsg;
+        }
+
+        publishPreReasoning();
+        Msg result = finalMsg;
+        if (hooks != null && !hooks.isEmpty()) {
             PostReasoningEvent postEvent = new PostReasoningEvent(agent, "A2A", null, finalMsg);
 
             Mono<PostReasoningEvent> eventMono = Mono.just(postEvent);
@@ -172,11 +200,39 @@ public class ClientEventContext {
             }
 
             postEvent = eventMono.block();
-            if (postEvent != null) {
-                Msg modifiedMsg = postEvent.getReasoningMessage();
-                return modifiedMsg != null ? modifiedMsg : finalMsg;
+            if (postEvent != null && postEvent.getReasoningMessage() != null) {
+                result = postEvent.getReasoningMessage();
             }
         }
-        return finalMsg;
+        publishMiddlewareEvent(A2A_REASONING_END, Map.of("message", result));
+        return result;
+    }
+
+    /**
+     * Sends the remote reasoning lifecycle event through the configured middleware chain.
+     *
+     * <p>The initial A2A bridge intentionally keeps the existing Hook and {@code stream()} paths
+     * unchanged. Middleware receives a {@link CustomEvent} describing the A2A phase; its returned
+     * stream is consumed so normal Reactor lifecycle operators (for example logging and metrics)
+     * are executed.
+     */
+    private void publishMiddlewareEvent(String name, Map<String, Object> value) {
+        if (middlewares.isEmpty()) {
+            return;
+        }
+        AgentEvent event = new CustomEvent(name, value);
+        Flux<AgentEvent> stream =
+                MiddlewareChain.build(
+                                middlewares,
+                                agent,
+                                null,
+                                MiddlewareBase::onReasoning,
+                                input -> Flux.just(event))
+                        .apply(
+                                new ReasoningInput(
+                                        inputMessages == null ? List.of() : inputMessages,
+                                        List.of(),
+                                        null));
+        stream.then().block();
     }
 }

--- a/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-a2a/agentscope-extensions-a2a-client/src/test/java/io/agentscope/core/a2a/agent/A2aAgentBuilderTest.java
+++ b/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-a2a/agentscope-extensions-a2a-client/src/test/java/io/agentscope/core/a2a/agent/A2aAgentBuilderTest.java
@@ -34,6 +34,7 @@ import io.agentscope.core.a2a.agent.card.FixedAgentCardResolver;
 import io.agentscope.core.hook.Hook;
 import io.agentscope.core.memory.InMemoryMemory;
 import io.agentscope.core.memory.Memory;
+import io.agentscope.core.middleware.MiddlewareBase;
 import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -181,6 +182,29 @@ class A2aAgentBuilderTest {
         List<Hook> hooks = getFieldValue(agent, "hooks", List.class);
         assertTrue(hooks.containsAll(inputHooks));
     }
+
+    @Test
+    @DisplayName("Should add and order middlewares")
+    void testMiddlewares() {
+        MiddlewareBase defaultMiddleware = new OrderedMiddleware(1);
+        MiddlewareBase highPriorityMiddleware = new OrderedMiddleware(2);
+        MiddlewareBase lowPriorityMiddleware = new OrderedMiddleware(-1);
+
+        A2aAgent agent =
+                A2aAgent.builder()
+                        .name("test-agent")
+                        .agentCardResolver(agentCardResolver)
+                        .a2aAgentConfig(a2aAgentConfig)
+                        .middleware(defaultMiddleware)
+                        .middlewares(List.of(lowPriorityMiddleware, highPriorityMiddleware))
+                        .build();
+
+        assertEquals(
+                List.of(highPriorityMiddleware, defaultMiddleware, lowPriorityMiddleware),
+                agent.getMiddlewares());
+    }
+
+    private record OrderedMiddleware(int order) implements MiddlewareBase {}
 
     @Test
     @DisplayName("Should support builder method chaining")

--- a/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-a2a/agentscope-extensions-a2a-client/src/test/java/io/agentscope/core/a2a/agent/A2aAgentTest.java
+++ b/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-a2a/agentscope-extensions-a2a-client/src/test/java/io/agentscope/core/a2a/agent/A2aAgentTest.java
@@ -56,6 +56,9 @@ import io.a2a.spec.TaskStatusUpdateEvent;
 import io.a2a.spec.TextPart;
 import io.agentscope.core.agent.Agent;
 import io.agentscope.core.agent.Event;
+import io.agentscope.core.agent.RuntimeContext;
+import io.agentscope.core.event.AgentEvent;
+import io.agentscope.core.event.CustomEvent;
 import io.agentscope.core.hook.Hook;
 import io.agentscope.core.hook.HookEvent;
 import io.agentscope.core.hook.PostReasoningEvent;
@@ -63,6 +66,8 @@ import io.agentscope.core.hook.PreCallEvent;
 import io.agentscope.core.hook.PreReasoningEvent;
 import io.agentscope.core.hook.ReasoningChunkEvent;
 import io.agentscope.core.message.Msg;
+import io.agentscope.core.middleware.MiddlewareBase;
+import io.agentscope.core.middleware.ReasoningInput;
 import java.lang.reflect.Field;
 import java.util.HashMap;
 import java.util.List;
@@ -75,10 +80,12 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
+import java.util.function.Function;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.stubbing.Answer;
+import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 /**
@@ -469,6 +476,7 @@ public class A2aAgentTest {
         AtomicInteger preCount = new AtomicInteger(0);
         AtomicInteger chunkCount = new AtomicInteger(0);
         AtomicInteger postCount = new AtomicInteger(0);
+        List<String> middlewareEvents = new java.util.concurrent.CopyOnWriteArrayList<>();
 
         Hook lifecycleMonitorHook =
                 new Hook() {
@@ -490,12 +498,29 @@ public class A2aAgentTest {
                     }
                 };
 
+        MiddlewareBase middlewareMonitor =
+                new MiddlewareBase() {
+                    @Override
+                    public Flux<AgentEvent> onReasoning(
+                            Agent agent,
+                            RuntimeContext context,
+                            ReasoningInput input,
+                            Function<ReasoningInput, Flux<AgentEvent>> next) {
+                        return next.apply(input)
+                                .doOnNext(
+                                        event ->
+                                                middlewareEvents.add(
+                                                        ((CustomEvent) event).getName()));
+                    }
+                };
+
         A2aAgent agent =
                 A2aAgent.builder()
                         .name("test-lifecycle-agent")
                         .agentCard(agentCard)
                         .hook(new ReplaceA2aClientHook())
                         .hook(lifecycleMonitorHook)
+                        .middleware(middlewareMonitor)
                         .build();
 
         Answer<Void> mockTaskResponse =
@@ -568,6 +593,9 @@ public class A2aAgentTest {
         assertEquals(1, preCount.get());
         assertEquals(1, chunkCount.get());
         assertEquals(1, postCount.get());
+        assertEquals(
+                List.of("a2a.reasoning.start", "a2a.reasoning.chunk", "a2a.reasoning.end"),
+                middlewareEvents);
     }
 
     private Answer<Void> mockSuccessMessage() {


### PR DESCRIPTION
## Summary

- add `middleware()` and `middlewares()` configuration to `A2aAgent.Builder`
- keep registered middlewares in the same order convention as `ReActAgent`
- bridge the A2A reasoning lifecycle (`start`, `chunk`, `end`) into `MiddlewareBase.onReasoning()`
- preserve the existing Hook API and deprecated `stream()` behavior
- add focused builder and event-order compatibility tests

## Intentionally limited scope

This is a small draft implementation to validate the integration direction with maintainers.

- No `streamEvents()` API is added.
- `onActing()`, `onModelCall()`, and `onSystemPrompt()` are unchanged.
- Existing Hook dispatch and legacy response behavior are retained.
- The A2A bridge currently exposes the remote lifecycle entries as `CustomEvent`s to the reasoning middleware; the returned middleware event stream is consumed for lifecycle operators, while response rewriting remains out of scope for this first pass.

Refs #2612

## Tests

- `mvn -pl agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-a2a/agentscope-extensions-a2a-client -am -DskipITs test`
  - agentscope-core: 2316 tests, 0 failures, 9 skipped
  - A2A client: 112 tests, 0 failures
