### PR TITLE
chore(deps): bump mcp.version 0.17.0 → 0.17.2 in agentscope-dependencies-bom

### DIFF
--- a/agentscope-dependencies-bom/pom.xml
+++ b/agentscope-dependencies-bom/pom.xml
@@ -79,7 +79,7 @@
         <bailian.version>2.8.2</bailian.version>
         <openai-java.version>4.52.0</openai-java.version>
         <anthropic.version>2.14.0</anthropic.version>
-        <mcp.version>0.17.0</mcp.version>
+        <mcp.version>0.17.2</mcp.version>
         <slf4j.version>2.0.17</slf4j.version>
         <qdrant.version>1.17.0</qdrant.version>
         <milvus.version>2.6.17</milvus.version>


### PR DESCRIPTION
## Summary

Bump the MCP Java SDK managed in `agentscope-dependencies-bom` from `0.17.0` to `0.17.2`.

`io.modelcontextprotocol.sdk:mcp:0.17.0`'s `HttpClientStreamableHttpTransport` throws `Unknown media type: text/plain; charset=utf-8` when an MCP server answers `initialize` / `notifications/initialized` with a `202 Accepted` + `text/plain` + chunked (no `Content-Length`) empty body. This is the client-side mirror of modelcontextprotocol/java-sdk#748 (accept servers that reply that shape).

In AgentScope this surfaces through `McpServerRegistrar` / `McpClientBuilder` during toolkit registration: any agent pointed at such a server fails to register its tools.

## Change

One line in the BOM — the single constraint point (`mcp.version`) — from `0.17.0` to `0.17.2`:

```xml
<mcp.version>0.17.2</mcp.version>
```

- **0.17.2** fixes the regression by treating blank `Content-Type` / zero `Content-Length` / `202 Accepted` as a no-body fast path (java-sdk#748 fix), and stays binary-compatible on the 0.17.x line.
- All downstream `io.modelcontextprotocol.sdk:mcp` dependencies in `agentscope-core` / `agentscope-all` / `agentscope-extensions-higress` are versionless and resolve through the BOM, so this one bump covers the whole tree.

## Verification

- `mvn -pl agentscope-dependencies-bom,agentscope-core compile` — BUILD SUCCESS
- `dependency:tree` on `agentscope-core` resolves `mcp:jar:0.17.2` (plus `mcp-core` / `mcp-json` / `mcp-json-jackson2` all 0.17.2)
- Installed BOM (flatten-maven-plugin) exposes `<mcp.version>0.17.2</mcp.version>`; a clean consumer build against the installed BOM resolves 0.17.2
- The `0.17.2` upgrade is already proven safe by Consumers who hit the bug and pinned it explicitly (exclusions + explicit `0.17.2`)

## Why not 0.18.x / 1.x

0.17.2 is the minimal, verified, binary-compatible fix. Newer majors carry API changes and were not verified against this tree; a follow-up bump can be separate.