### PR TITLE
fix(transport): unblock backpressured SSE streams

### DIFF
--- a/agentscope-core/src/main/java/io/agentscope/core/model/transport/OkHttpTransport.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/model/transport/OkHttpTransport.java
@@ -307,7 +307,7 @@ public class OkHttpTransport implements HttpTransport {
                                 closeQuietly(response);
                             }
                         })
-                .subscribeOn(Schedulers.boundedElastic());
+                .subscribeOn(Schedulers.boundedElastic(), false);
     }
 
     @Override

--- a/agentscope-core/src/test/java/io/agentscope/core/model/transport/OkHttpTransportTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/model/transport/OkHttpTransportTest.java
@@ -21,16 +21,25 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.io.IOException;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
+import okhttp3.OkHttpClient;
+import okhttp3.Protocol;
+import okhttp3.Response;
+import okhttp3.ResponseBody;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
 import okhttp3.mockwebserver.RecordedRequest;
+import okio.BufferedSink;
+import okio.Okio;
+import okio.Pipe;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import reactor.core.scheduler.Schedulers;
 import reactor.test.StepVerifier;
 
 /**
@@ -138,6 +147,57 @@ class OkHttpTransportTest {
         assertEquals(2, events.size());
         assertTrue(events.get(0).contains("\"id\":\"1\""));
         assertTrue(events.get(1).contains("\"id\":\"2\""));
+    }
+
+    @Test
+    void testStreamEmitsBufferedEventsWhenDownstreamRequestsIncrementally() throws Exception {
+        Pipe responsePipe = new Pipe(1024);
+        BufferedSink responseSink = Okio.buffer(responsePipe.sink());
+        responseSink.writeUtf8("data: 1\n\ndata: 2\n\n").flush();
+
+        OkHttpClient client =
+                new OkHttpClient.Builder()
+                        .addInterceptor(
+                                chain ->
+                                        new Response.Builder()
+                                                .request(chain.request())
+                                                .protocol(Protocol.HTTP_1_1)
+                                                .code(200)
+                                                .message("OK")
+                                                .body(
+                                                        ResponseBody.create(
+                                                                Okio.buffer(responsePipe.source()),
+                                                                null,
+                                                                -1))
+                                                .build())
+                        .build();
+        OkHttpTransport customTransport =
+                new OkHttpTransport(client, HttpTransportConfig.defaults());
+        HttpRequest request =
+                HttpRequest.builder()
+                        .url("http://localhost/stream-backpressure")
+                        .method("POST")
+                        .body("{}")
+                        .build();
+
+        try {
+            StepVerifier.create(customTransport.stream(request).publishOn(Schedulers.parallel(), 1))
+                    .expectNext("1")
+                    .expectNext("2")
+                    .then(
+                            () -> {
+                                try {
+                                    responseSink.writeUtf8("data: [DONE]\n\n").close();
+                                } catch (IOException e) {
+                                    throw new RuntimeException(e);
+                                }
+                            })
+                    .expectComplete()
+                    .verify(Duration.ofSeconds(2));
+        } finally {
+            responseSink.close();
+            customTransport.close();
+        }
     }
 
     @Test


### PR DESCRIPTION
## AgentScope-Java Version

2.0.3-SNAPSHOT

## Description

Fixes #2957

`OkHttpTransport` runs its blocking SSE reader on `boundedElastic`, but the single-argument `subscribeOn` overload also schedules downstream request signals on that same worker. When a downstream operator requests items incrementally, those requests can remain queued behind the blocking `readLine()` loop until `[DONE]` is received.

This change:

- uses `subscribeOn(Schedulers.boundedElastic(), false)` so the blocking subscription remains off the caller thread without queueing downstream demand on the reader worker;
- adds a regression test with a streaming response and cross-thread incremental demand, verifying that the second SSE event is delivered while the reader is still waiting for `[DONE]`.

The regression test times out with the previous implementation and passes with this change.

### Testing

- `mvn -pl agentscope-core -Dtest=OkHttpTransportTest test`
- `mvn -pl agentscope-core test` (2317 tests passed, 9 skipped)

## Checklist

- [x] Code has been formatted with `mvn spotless:apply`
- [x] All relevant tests are passing
- [x] Javadoc comments are complete and follow project conventions (no public API changes)
- [x] Related documentation has been updated (not applicable; internal bug fix)
- [x] Code is ready for review
