### PR TITLE
fix(rag): preserve blank lines between paragraphs in WordReader

### DIFF
--- a/agentscope-extensions/agentscope-extensions-rag/agentscope-extensions-rag-simple/src/main/java/io/agentscope/core/rag/reader/WordReader.java
+++ b/agentscope-extensions/agentscope-extensions-rag/agentscope-extensions-rag-simple/src/main/java/io/agentscope/core/rag/reader/WordReader.java
@@ -243,6 +243,15 @@ public class WordReader extends AbstractChunkingReader {
                             blocks.add(TextBlock.builder().text(text).build());
                         }
                         lastType = "text";
+                    } else if (!blocks.isEmpty() && "text".equals(lastType)) {
+                        // An empty <w:p> is a blank line the user typed in Word. Append a
+                        // line break so the paragraph boundary survives: the next paragraph
+                        // is merged with another "\n", which together form the blank line.
+                        int lastIndex = blocks.size() - 1;
+                        TextBlock lastBlock = (TextBlock) blocks.get(lastIndex);
+                        blocks.set(
+                                lastIndex,
+                                TextBlock.builder().text(lastBlock.getText() + "\n").build());
                     }
 
                 } else if (element.getElementType() == BodyElementType.TABLE) {

--- a/agentscope-extensions/agentscope-extensions-rag/agentscope-extensions-rag-simple/src/test/java/io/agentscope/core/rag/reader/WordReaderTest.java
+++ b/agentscope-extensions/agentscope-extensions-rag/agentscope-extensions-rag-simple/src/test/java/io/agentscope/core/rag/reader/WordReaderTest.java
@@ -17,14 +17,23 @@ package io.agentscope.core.rag.reader;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.agentscope.core.rag.exception.ReaderException;
+import io.agentscope.core.rag.model.Document;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.List;
+import java.util.function.Consumer;
+import org.apache.poi.xwpf.usermodel.XWPFDocument;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import reactor.test.StepVerifier;
 
 /**
@@ -132,5 +141,59 @@ class WordReaderTest {
         ReaderInput input = ReaderInput.fromString("/non/existent/file.docx");
 
         StepVerifier.create(reader.read(input)).expectError(ReaderException.class).verify();
+    }
+
+    @Test
+    @DisplayName("Should keep a blank paragraph as a blank line")
+    void testBlankParagraphIsPreservedAsBlankLine(@TempDir Path tempDir) throws Exception {
+        Path docx =
+                writeDocx(
+                        tempDir.resolve("blank-line.docx"),
+                        doc -> {
+                            doc.createParagraph().createRun().setText("Paragraph one.");
+                            doc.createParagraph(); // blank line: a single Enter in Word
+                            doc.createParagraph().createRun().setText("Paragraph two.");
+                        });
+
+        assertEquals("Paragraph one.\n\nParagraph two.", readSingleChunk(new WordReader(), docx));
+    }
+
+    @Test
+    @DisplayName("Should keep consecutive blank paragraphs as consecutive blank lines")
+    void testConsecutiveBlankParagraphsArePreserved(@TempDir Path tempDir) throws Exception {
+        Path docx =
+                writeDocx(
+                        tempDir.resolve("two-blank-lines.docx"),
+                        doc -> {
+                            doc.createParagraph().createRun().setText("Paragraph one.");
+                            doc.createParagraph();
+                            doc.createParagraph();
+                            doc.createParagraph().createRun().setText("Paragraph two.");
+                        });
+
+        // CHARACTER keeps the extracted text verbatim; PARAGRAPH would collapse any run of
+        // blank lines back to a single one when it re-joins the split paragraphs.
+        WordReader reader =
+                new WordReader(512, SplitStrategy.CHARACTER, 50, true, false, TableFormat.MARKDOWN);
+
+        assertEquals("Paragraph one.\n\n\nParagraph two.", readSingleChunk(reader, docx));
+    }
+
+    /** Authors a .docx fixture in memory, so that no binary test resource is required. */
+    private static Path writeDocx(Path target, Consumer<XWPFDocument> author) throws IOException {
+        try (XWPFDocument doc = new XWPFDocument()) {
+            author.accept(doc);
+            try (OutputStream out = Files.newOutputStream(target)) {
+                doc.write(out);
+            }
+        }
+        return target;
+    }
+
+    private static String readSingleChunk(WordReader reader, Path docx) {
+        List<Document> docs = reader.read(ReaderInput.fromPath(docx)).block();
+        assertNotNull(docs);
+        assertEquals(1, docs.size(), "fixture is expected to fit into a single chunk");
+        return docs.get(0).getMetadata().getContentText();
     }
 }


### PR DESCRIPTION
## AgentScope-Java Version

2.0.0 (also reproduced on 1.0.12; `WordReader.java` is unchanged on `main`)

## Description

#2964.

**Problem.** An empty `<w:p>` element is how Word represents a blank line. `getDataBlocks()` discarded it: `extractTextFromParagraph()` returns `""` for such a paragraph (there are no runs, so both the `para.getText()` path and the run-concatenation fallback yield an empty string), and the `if (text != null && !text.isEmpty())` guard then skipped the whole branch without writing a character or setting a flag. The fact that a paragraph existed there became unrecoverable, so `A / blank line / B` came out as `"A\nB"` with the blank line silently gone.

**Change.** Append a `"\n"` when an empty paragraph is encountered. The following paragraph is merged with another `"\n"`, so the two together reproduce the blank line the user typed, and consecutive blank paragraphs are preserved one for one.

**Testing**

Fixtures are authored in memory with `XWPFDocument` and written to `@TempDir`, so no binary test resource is added to the repository.

1. One blank paragraph between two text paragraphs, under the default `PARAGRAPH` strategy → `"Paragraph one.\n\nParagraph two."`
2. Two consecutive blank paragraphs, under `CHARACTER` → `"Paragraph one.\n\n\nParagraph two."`

The second case uses `CHARACTER` deliberately. `chunkByParagraph()` splits on `\n\s*\n` and re-joins the pieces with a fixed `"\n\n"`, so under `PARAGRAPH` any run of blank lines is normalised back to a single one and the preserved count cannot be observed through the public API. `CHARACTER` returns the extracted text verbatim, which is what makes the assertion meaningful.

Full module suite after the change: 446 tests, 0 failures, 0 errors.

## Checklist

Please check the following items before code is ready to be reviewed.

- [x]  Code has been formatted with `mvn spotless:apply`
- [x]  All tests are passing (`mvn test`)
- [x]  Javadoc comments are complete and follow project conventions
- [x]  Related documentation has been updated (e.g. links, examples, etc.) — n/a, no public API or documented behaviour surface changed
- [x]  Code is ready for review
