### PR TITLE
fix(core): preserve usage in structured output messages

### DIFF
--- a/agentscope-core/src/main/java/io/agentscope/core/ReActAgent.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/ReActAgent.java
@@ -1395,6 +1395,7 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
                     .content(result.getContent())
                     .metadata(metadata)
                     .timestamp(result.getTimestamp())
+                    .usage(result.getUsage())
                     .build();
         } catch (Exception e) {
             log.warn("Failed to parse native structured output as JSON: {}", e.getMessage());
@@ -1613,6 +1614,7 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
                 .content(newContent)
                 .metadata(metadata)
                 .timestamp(msg.getTimestamp())
+                .usage(chatUsage)
                 .build();
     }
 

--- a/agentscope-core/src/test/java/io/agentscope/core/agent/ReActAgentStructuredOutputTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/agent/ReActAgentStructuredOutputTest.java
@@ -436,6 +436,12 @@ class ReActAgentStructuredOutputTest {
         assertEquals(100, usage.getInputTokens(), "Input tokens should be preserved");
         assertEquals(50, usage.getOutputTokens(), "Output tokens should be preserved");
         assertEquals(1.5, usage.getTime(), 0.01, "Time should be preserved");
+
+        ChatUsage canonicalUsage = responseMsg.getUsage();
+        assertNotNull(canonicalUsage, "Canonical usage field should be preserved");
+        assertEquals(100, canonicalUsage.getInputTokens());
+        assertEquals(50, canonicalUsage.getOutputTokens());
+        assertEquals(1.5, canonicalUsage.getTime(), 0.01);
     }
 
     @Test

--- a/agentscope-core/src/test/java/io/agentscope/core/agent/ReActAgentStructuredOutputWithToolsTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/agent/ReActAgentStructuredOutputWithToolsTest.java
@@ -275,6 +275,12 @@ class ReActAgentStructuredOutputWithToolsTest {
         assertFalse(
                 model.toolListContainsGenerateResponse(),
                 "Native path should not inject generate_response tool");
+
+        ChatUsage usage = result.getUsage();
+        assertNotNull(usage, "Native structured output should preserve usage");
+        assertEquals(10, usage.getInputTokens());
+        assertEquals(20, usage.getOutputTokens());
+        assertEquals(0.5, usage.getTime(), 0.01);
     }
 
     @Test


### PR DESCRIPTION
## AgentScope-Java Version

2.0.3-SNAPSHOT (current main)

## Description

Fixes #2960.

Structured-output responses were rebuilt without preserving the canonical `Msg.usage` field:

- The native structured-output path copied content, metadata, and timestamp, but omitted `result.getUsage()`.
- The fallback path exposed aggregated usage only through metadata, leaving `Msg.getUsage()` null.

This change propagates usage through both message builders and adds regression assertions for the native and fallback structured-output paths.

Validation:

- `mvn -pl agentscope-core test` — 2318 tests run, 0 failures, 0 errors, 9 skipped.
- `mvn -pl agentscope-core spotless:apply` — successful, with no formatting changes required.

## Checklist

- [x] Code has been formatted with `mvn spotless:apply`
- [x] All tests are passing (`mvn test`)
- [x] Javadoc comments are complete and follow project conventions (no public API changes)
- [x] Related documentation has been updated (not applicable; behavior fix with regression coverage)
- [x] Code is ready for review
