### PR TITLE
fix(harness): fail sandbox filesystem read ops on non-successful execute responses

### DIFF
--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/filesystem/sandbox/AbstractSandboxFilesystem.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/filesystem/sandbox/AbstractSandboxFilesystem.java
@@ -40,7 +40,10 @@ public interface AbstractSandboxFilesystem extends AbstractFilesystem {
      * @param command full shell command string to execute
      * @param timeoutSeconds maximum time in seconds to wait for the command to complete;
      *                       {@code null} uses the filesystem's default timeout
-     * @return ExecuteResponse with combined output, exit code, and truncation flag
+     * @return ExecuteResponse with combined output, exit code, and truncation flag; a
+     *         non-successful response (see {@link ExecuteResponse#isSuccess()}) means the command
+     *         did not complete successfully, so {@code output} must not be parsed as normal
+     *         command output
      */
     ExecuteResponse execute(RuntimeContext runtimeContext, String command, Integer timeoutSeconds);
 }

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/filesystem/sandbox/BaseSandboxFilesystem.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/filesystem/sandbox/BaseSandboxFilesystem.java
@@ -93,6 +93,9 @@ public abstract class BaseSandboxFilesystem implements AbstractSandboxFilesystem
                         + "done; fi";
 
         ExecuteResponse result = execute(runtimeContext, cmd, null);
+        if (!result.isSuccess()) {
+            return LsResult.fail(executeFailureMessage(result, "listing", path));
+        }
         String output = result.output() != null ? result.output().strip() : "";
 
         if ("__NOT_EXISTS__".equals(output)) {
@@ -134,8 +137,18 @@ public abstract class BaseSandboxFilesystem implements AbstractSandboxFilesystem
         if (!"text".equals(fileType)) {
             String cmd = "base64 " + escapedPath + " 2>/dev/null";
             ExecuteResponse result = execute(runtimeContext, cmd, null);
-            if (result.exitCode() != null && result.exitCode() != 0) {
-                return ReadResult.fail("File '" + filePath + "': file_not_found");
+            if (!result.isSuccess()) {
+                // Positive exit codes other than 124 (the timeout(1) convention — the command
+                // did not complete) mean the command ran and base64 could not read the file;
+                // stderr is discarded, so report the designed file_not_found signal instead of
+                // an empty error.
+                boolean commandRanAndFailedToRead =
+                        result.exitCode() != null
+                                && result.exitCode() > 0
+                                && result.exitCode() != 124;
+                return commandRanAndFailedToRead
+                        ? ReadResult.fail("File '" + filePath + "': file_not_found")
+                        : ReadResult.fail(executeFailureMessage(result, "reading", filePath));
             }
             String encoded = result.output() != null ? result.output().strip() : "";
             return ReadResult.success(new FileData(encoded, "base64"));
@@ -159,6 +172,9 @@ public abstract class BaseSandboxFilesystem implements AbstractSandboxFilesystem
                         + "; fi";
 
         ExecuteResponse result = execute(runtimeContext, cmd, null);
+        if (!result.isSuccess()) {
+            return ReadResult.fail(executeFailureMessage(result, "reading", filePath));
+        }
         String output = result.output() != null ? result.output() : "";
 
         if (output.strip().equals("__NOT_FOUND__")) {
@@ -325,6 +341,10 @@ public abstract class BaseSandboxFilesystem implements AbstractSandboxFilesystem
                         + " 2>/dev/null || true";
 
         ExecuteResponse result = execute(runtimeContext, cmd, null);
+        if (!result.isSuccess()) {
+            return GrepResult.fail(
+                    executeFailureMessage(result, "searching", path != null ? path : "."));
+        }
         String output = result.output() != null ? result.output().strip() : "";
 
         if (output.isEmpty()) {
@@ -363,6 +383,10 @@ public abstract class BaseSandboxFilesystem implements AbstractSandboxFilesystem
                         + "done";
 
         ExecuteResponse result = execute(runtimeContext, cmd, null);
+        if (!result.isSuccess()) {
+            return GlobResult.fail(
+                    executeFailureMessage(result, "globbing", path != null ? path : "/"));
+        }
         String output = result.output() != null ? result.output().strip() : "";
 
         if (output.isEmpty()) {
@@ -424,6 +448,20 @@ public abstract class BaseSandboxFilesystem implements AbstractSandboxFilesystem
         ExecuteResponse result =
                 execute(runtimeContext, "test -e " + escapedPath + " && echo yes || echo no", null);
         return result.output() != null && result.output().strip().startsWith("yes");
+    }
+
+    /**
+     * Builds the failure message for a non-successful {@link #execute} response, prefixing the
+     * operation context and falling back to the exit code when the response carries no
+     * diagnostic output.
+     */
+    private static String executeFailureMessage(
+            ExecuteResponse result, String operation, String target) {
+        String detail =
+                result.output() != null && !result.output().isBlank()
+                        ? result.output()
+                        : "exit code " + result.exitCode();
+        return "Error " + operation + " '" + target + "': " + detail;
     }
 
     /**

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/filesystem/sandbox/BaseSandboxFilesystemTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/filesystem/sandbox/BaseSandboxFilesystemTest.java
@@ -25,7 +25,9 @@ import io.agentscope.harness.agent.filesystem.model.FileDownloadResponse;
 import io.agentscope.harness.agent.filesystem.model.FileInfo;
 import io.agentscope.harness.agent.filesystem.model.FileUploadResponse;
 import io.agentscope.harness.agent.filesystem.model.GlobResult;
+import io.agentscope.harness.agent.filesystem.model.GrepResult;
 import io.agentscope.harness.agent.filesystem.model.LsResult;
+import io.agentscope.harness.agent.filesystem.model.ReadResult;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -42,6 +44,15 @@ import org.junit.jupiter.api.io.TempDir;
 class BaseSandboxFilesystemTest {
 
     private static final RuntimeContext RT = RuntimeContext.empty();
+
+    /**
+     * The response {@code SandboxBackedFilesystem.execute} produces when the sandbox backend
+     * call itself fails (e.g. HTTP 504): the command never ran.
+     */
+    private static ExecuteResponse sandboxRequestFailed() {
+        return new ExecuteResponse(
+                "Internal sandbox error: Execute failed (status=504)", -1, false);
+    }
 
     // ================================================================
     // Unit tests — canned responses, run on all platforms
@@ -129,6 +140,129 @@ class BaseSandboxFilesystemTest {
                             .orElseThrow();
             assertTrue(dir.isDirectory());
             assertFalse(dir.modifiedAt().isEmpty(), "dir modifiedAt should be populated");
+        }
+
+        // ==================== Bug reproduction: execute failures masked as results (#2961)
+        // ====================
+
+        @Test
+        void ls_executeFailure_negativeExit_shouldFailWithCause() {
+            LsResult result =
+                    new FixedResponseFilesystem(sandboxRequestFailed()).ls(RT, "/workspace");
+
+            assertFalse(result.isSuccess(), "ls should fail when the command never ran");
+            assertTrue(result.error().contains("/workspace"), "error should locate the target");
+            assertTrue(result.error().contains("status=504"), "error should carry the cause");
+        }
+
+        @Test
+        void ls_executeFailure_nullOutput_shouldFailWithExitCodeFallback() {
+            LsResult result =
+                    new FixedResponseFilesystem(new ExecuteResponse(null, -1, false))
+                            .ls(RT, "/workspace");
+
+            assertFalse(result.isSuccess(), "a null-output failure must not collapse into success");
+            assertTrue(
+                    result.error().contains("exit code -1"),
+                    "error should fall back to the exit code when no diagnostic output exists");
+        }
+
+        @Test
+        void ls_executeFailure_unknownExitCode_shouldFail() {
+            LsResult result =
+                    new FixedResponseFilesystem(new ExecuteResponse("unknown state", null, false))
+                            .ls(RT, "/workspace");
+
+            assertFalse(result.isSuccess(), "ls should fail when the exit code is unknown");
+        }
+
+        @Test
+        void ls_executeFailure_timeout_shouldFailWithMessage() {
+            LsResult result =
+                    new FixedResponseFilesystem(
+                                    new ExecuteResponse("Command timed out after 30s", 124, false))
+                            .ls(RT, "/workspace");
+
+            assertFalse(result.isSuccess(), "ls should fail when execution times out");
+            assertTrue(result.error().contains("timed out"), "error should carry the cause");
+        }
+
+        @Test
+        void ls_commandFailure_positiveExit_shouldFailWithOutput() {
+            LsResult result =
+                    new FixedResponseFilesystem(
+                                    new ExecuteResponse("sh: stat: not found", 127, false))
+                            .ls(RT, "/workspace");
+
+            assertFalse(result.isSuccess(), "ls should fail when the command itself fails");
+            assertTrue(result.error().contains("stat"), "error should carry the command output");
+        }
+
+        @Test
+        void read_text_executeFailure_shouldFailInsteadOfErrorAsContent() {
+            ReadResult result =
+                    new FixedResponseFilesystem(sandboxRequestFailed())
+                            .read(RT, "/workspace/notes.txt", 0, 10);
+
+            assertFalse(result.isSuccess(), "read should fail when the command never ran");
+            assertTrue(result.error().contains("status=504"), "error should carry the cause");
+        }
+
+        @Test
+        void read_binary_executeFailure_shouldFailInsteadOfFileNotFound() {
+            ReadResult result =
+                    new FixedResponseFilesystem(sandboxRequestFailed())
+                            .read(RT, "/workspace/logo.png", 0, 10);
+
+            assertFalse(result.isSuccess(), "read should fail when the command never ran");
+            assertTrue(
+                    result.error().contains("status=504"),
+                    "execution failure must not be mislabeled as file_not_found");
+        }
+
+        @Test
+        void read_binary_commandFailure_shouldKeepFileNotFoundSignal() {
+            ReadResult result =
+                    new FixedResponseFilesystem(new ExecuteResponse("", 1, false))
+                            .read(RT, "/workspace/logo.png", 0, 10);
+
+            assertFalse(result.isSuccess(), "a missing file is still a failure");
+            assertTrue(
+                    result.error().contains("file_not_found"),
+                    "a real command failure keeps the designed signal");
+        }
+
+        @Test
+        void read_binary_timeout_shouldFailWithMessageInsteadOfFileNotFound() {
+            ReadResult result =
+                    new FixedResponseFilesystem(
+                                    new ExecuteResponse("Command timed out after 30s", 124, false))
+                            .read(RT, "/workspace/logo.png", 0, 10);
+
+            assertFalse(result.isSuccess(), "read should fail when execution times out");
+            assertTrue(
+                    result.error().contains("timed out"),
+                    "a timeout must not be mislabeled as file_not_found");
+        }
+
+        @Test
+        void grep_executeFailure_shouldFailInsteadOfEmptySuccess() {
+            GrepResult result =
+                    new FixedResponseFilesystem(sandboxRequestFailed())
+                            .grep(RT, "pattern", "/workspace", null);
+
+            assertFalse(result.isSuccess(), "grep should fail when the command never ran");
+            assertTrue(result.error().contains("status=504"), "error should carry the cause");
+        }
+
+        @Test
+        void glob_executeFailure_shouldFailInsteadOfErrorAsPaths() {
+            GlobResult result =
+                    new FixedResponseFilesystem(sandboxRequestFailed())
+                            .glob(RT, "*.md", "/workspace");
+
+            assertFalse(result.isSuccess(), "glob should fail when the command never ran");
+            assertTrue(result.error().contains("status=504"), "error should carry the cause");
         }
     }
 
@@ -258,6 +392,42 @@ class BaseSandboxFilesystemTest {
                         false);
             }
             return new ExecuteResponse("", 0, false);
+        }
+
+        @Override
+        public List<FileUploadResponse> uploadFiles(
+                RuntimeContext runtimeContext, List<Map.Entry<String, byte[]>> files) {
+            return List.of();
+        }
+
+        @Override
+        public List<FileDownloadResponse> downloadFiles(
+                RuntimeContext runtimeContext, List<String> paths) {
+            return List.of();
+        }
+    }
+
+    /**
+     * execute() always returns the fixed response, standing in for any execution-layer outcome
+     * (successful or failing) without a live sandbox.
+     */
+    private static final class FixedResponseFilesystem extends BaseSandboxFilesystem {
+
+        private final ExecuteResponse response;
+
+        FixedResponseFilesystem(ExecuteResponse response) {
+            this.response = response;
+        }
+
+        @Override
+        public String id() {
+            return "fixed-response";
+        }
+
+        @Override
+        public ExecuteResponse execute(
+                RuntimeContext runtimeContext, String command, Integer timeoutSeconds) {
+            return response;
         }
 
         @Override


### PR DESCRIPTION
## AgentScope-Java Version

main @ `ea511ec2` (defect observed in production on 2.0.1)

## Description

Fixes #2961

`BaseSandboxFilesystem`'s read paths (`ls` / `read` / `grep` / `glob`) parsed `output` without consulting the exit code, so any non-successful `execute()` response was masked as a successful result — a sandbox-backend timeout surfaced to the model as `Empty directory: <path>`, the raw error text as file content (`read`), or as fabricated file paths (`glob`).

### Changes

- All four read methods return `fail(...)` on `!ExecuteResponse.isSuccess()`, riding `FilesystemTool`'s existing `"Error: ..."` branch (the same path #2413 established for not-exists / not-a-directory). These methods' shell commands are constructed to exit 0 on every designed path, so any non-successful response means `output` is not the protocol output the parsers expect.
- Failure messages carry operation context (`Error listing '<path>': ...`) and fall back to the exit code when the response carries no diagnostic output — a null-output failure can no longer collapse back into a "success" (`error == null`).
- Binary `read` keeps its designed `file_not_found` signal for positive exit codes other than 124 (`timeout(1)` convention), where the command ran and `base64` could not read the file; null/negative/124 surface the execution-layer message instead.
- `AbstractSandboxFilesystem.execute()` Javadoc documents the non-success contract.
- 11 regression tests covering the four failure shapes (−1 backend failure, `null` exit code, 124 timeout, positive command failure) across all read methods.

### How to test

`mvn -pl agentscope-harness test -Dtest=BaseSandboxFilesystemTest` — 21 tests (16 run on non-Linux; 5 are the pre-existing Linux-only shell integration cases).

## Checklist

Please check the following items before code is ready to be reviewed.

- [x] Code has been formatted with `mvn spotless:apply`
- [x] All tests are passing (`mvn test`)
- [x] Javadoc comments are complete and follow project conventions
- [x] Related documentation has been updated (e.g. links, examples, etc.)
- [x] Code is ready for review
