### PR TITLE
fix(core): fail model empty-completion before retry

### DIFF
--- a/agentscope-core/src/main/java/io/agentscope/core/model/ModelUtils.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/model/ModelUtils.java
@@ -16,10 +16,14 @@
 package io.agentscope.core.model;
 
 import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Predicate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 import reactor.util.retry.Retry;
 
 /**
@@ -42,6 +46,17 @@ public final class ModelUtils {
      * <p>This method wraps the original Flux with timeout and retry operators based on the
      * configuration in GenerateOptions. Both timeout and retry are optional and only applied if
      * configured.
+     *
+     * <p><b>Empty-completion detection:</b> A stream that completes without any content-bearing
+     * {@code ChatResponse} (no chunk carries a non-null, non-empty content list) is converted to
+     * a {@code ModelException} after the timeout check and before retry. Contentless chunks are
+     * withheld until the first content-bearing chunk arrives (then released in order), so an
+     * empty completion surfaces the error as the first downstream signal and switchOnFirst-based
+     * fallback models engage. The check is deliberately type-agnostic: any content block counts,
+     * so multimodal completions carrying only image/video/audio blocks are not misclassified as
+     * empty. This detection is unconditional (applies regardless of retry configuration), since
+     * an empty completion is an upstream transport anomaly that should always surface as an
+     * error.
      *
      * <p><b>Timeout Behavior:</b>
      * <ul>
@@ -77,9 +92,11 @@ public final class ModelUtils {
         GenerateOptions effectiveOptions = GenerateOptions.mergeOptions(options, defaultOptions);
 
         // Extract execution config
-        ExecutionConfig execConfig = effectiveOptions.getExecutionConfig();
+        ExecutionConfig execConfig =
+                effectiveOptions != null ? effectiveOptions.getExecutionConfig() : null;
+
+        // Apply timeout if configured
         if (execConfig != null) {
-            // Apply timeout if configured
             Duration timeout = execConfig.getTimeout();
             if (timeout != null) {
                 responseFlux =
@@ -92,8 +109,12 @@ public final class ModelUtils {
                                                 provider)));
                 LOG.debug("Applied timeout: {} for model: {}", timeout, modelName);
             }
+        }
 
-            // Apply retry if configured (maxAttempts > 1 means retry is enabled)
+        responseFlux = ensureNonEmptyCompletion(responseFlux, modelName, provider);
+
+        // Apply retry if configured
+        if (execConfig != null) {
             Integer maxAttempts = execConfig.getMaxAttempts();
             if (maxAttempts != null && maxAttempts > 1) {
                 Duration initialBackoff = execConfig.getInitialBackoff();
@@ -136,6 +157,83 @@ public final class ModelUtils {
         }
 
         return responseFlux;
+    }
+
+    /**
+     * Ensures the completion contains at least one content-bearing response.
+     *
+     * <p>Chunks that carry no content block are withheld until the first content-bearing chunk
+     * arrives (then released in order); a stream that completes without one — zero chunks, or
+     * only chunks whose {@code getContent()} is null/empty — is converted to a {@code
+     * ModelException}. Withholding is what keeps fallback effective: switchOnFirst-based
+     * fallback commits on the first downstream signal, so an empty completion must reach it as
+     * an error, not preceded by contentless chunks that would already commit the primary model.
+     * Any content block counts as content-bearing (multimodal blocks included). This detection
+     * sits after timeout (which would have already fired) and before retryWhen, so an empty
+     * completion triggers retry just like any other model error.
+     *
+     * @param responseFlux the response stream to guard
+     * @param modelName the model name for error messages
+     * @param provider the provider name for error messages
+     * @return guarded flux that errors on empty completions
+     */
+    private static Flux<ChatResponse> ensureNonEmptyCompletion(
+            Flux<ChatResponse> responseFlux, String modelName, String provider) {
+        // Per-subscription state: retryWhen resubscribes this chain on each attempt, so the
+        // withheld-chunk buffer and the released flag must be recreated per subscription —
+        // chunks withheld by an attempt that failed mid-stream must not leak into a later,
+        // empty attempt. Signals are delivered serially per subscriber, so unsynchronized state
+        // is safe.
+        return Flux.defer(
+                () -> {
+                    List<ChatResponse> withheld = new ArrayList<>();
+                    AtomicBoolean released = new AtomicBoolean(false);
+                    return responseFlux
+                            .concatMap(
+                                    chunk -> {
+                                        if (released.get()) {
+                                            return Flux.just(chunk);
+                                        }
+                                        withheld.add(chunk);
+                                        if (!isContentBearing(chunk)) {
+                                            return Flux.empty();
+                                        }
+                                        released.set(true);
+                                        return Flux.fromIterable(withheld);
+                                    })
+                            .concatWith(
+                                    Mono.defer(
+                                            () -> {
+                                                if (released.get()) {
+                                                    return Mono.empty();
+                                                }
+                                                LOG.warn(
+                                                        "Model {} ({}) returned an empty completion"
+                                                                + " (zero content-bearing chunks)",
+                                                        modelName,
+                                                        provider);
+                                                return Mono.error(
+                                                        new ModelException(
+                                                                "Model returned empty completion"
+                                                                        + " (zero content-bearing"
+                                                                        + " chunks)",
+                                                                modelName,
+                                                                provider));
+                                            }));
+                });
+    }
+
+    /**
+     * Returns whether the chunk carries any content block.
+     *
+     * <p>Type-agnostic by design: multimodal completions may carry only image/video/audio
+     * blocks, which are valid completions, not empty ones.
+     *
+     * @param chunk the response chunk to inspect
+     * @return true if the chunk carries at least one content block
+     */
+    private static boolean isContentBearing(ChatResponse chunk) {
+        return chunk.getContent() != null && !chunk.getContent().isEmpty();
     }
 
     /**

--- a/agentscope-core/src/test/java/io/agentscope/core/agent/ReActAgentTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/agent/ReActAgentTest.java
@@ -40,6 +40,10 @@ import io.agentscope.core.message.ToolResultBlock;
 import io.agentscope.core.message.ToolUseBlock;
 import io.agentscope.core.model.ChatResponse;
 import io.agentscope.core.model.ChatUsage;
+import io.agentscope.core.model.GenerateOptions;
+import io.agentscope.core.model.Model;
+import io.agentscope.core.model.ModelUtils;
+import io.agentscope.core.model.ToolSchema;
 import io.agentscope.core.tool.Toolkit;
 import io.agentscope.core.util.JsonUtils;
 import java.time.Duration;
@@ -52,6 +56,7 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 /**
@@ -575,6 +580,50 @@ class ReActAgentTest {
         assertNotNull(response, "Response should not be null");
         assertEquals("Fallback response", TestUtils.extractTextContent(response));
         assertEquals(1, primaryModel.getCallCount(), "Primary model should be tried once");
+        assertEquals(1, fallbackModel.getCallCount(), "Fallback model should be called once");
+    }
+
+    @Test
+    @DisplayName("Should switch to fallback model when the primary returns an empty completion")
+    void testFallbackModelOnEmptyCompletion() {
+        // Primary emits only contentless chunks (role-only gateway response) and completes —
+        // the empty-completion guard must surface the error as the first signal so the
+        // switchOnFirst fallback engages instead of the run ending as silent success
+        Model primaryModel =
+                new Model() {
+                    @Override
+                    public Flux<ChatResponse> stream(
+                            List<Msg> messages, List<ToolSchema> tools, GenerateOptions options) {
+                        Flux<ChatResponse> responseFlux =
+                                Flux.just(
+                                        new ChatResponse("chunk-1", List.of(), null, null, null),
+                                        new ChatResponse("chunk-2", null, null, null, null));
+                        return ModelUtils.applyTimeoutAndRetry(
+                                responseFlux, options, null, "empty-primary", "test");
+                    }
+
+                    @Override
+                    public String getModelName() {
+                        return "empty-primary";
+                    }
+                };
+        MockModel fallbackModel = new MockModel("Fallback response");
+
+        agent =
+                ReActAgent.builder()
+                        .name(TestConstants.TEST_REACT_AGENT_NAME)
+                        .sysPrompt(TestConstants.DEFAULT_SYS_PROMPT)
+                        .model(primaryModel)
+                        .fallbackModel(fallbackModel)
+                        .toolkit(mockToolkit)
+                        .build();
+
+        Msg userMsg = TestUtils.createUserMessage("User", TestConstants.TEST_USER_INPUT);
+        Msg response =
+                agent.call(userMsg).block(Duration.ofMillis(TestConstants.DEFAULT_TEST_TIMEOUT_MS));
+
+        assertNotNull(response, "Response should not be null");
+        assertEquals("Fallback response", TestUtils.extractTextContent(response));
         assertEquals(1, fallbackModel.getCallCount(), "Fallback model should be called once");
     }
 

--- a/agentscope-core/src/test/java/io/agentscope/core/model/ModelTimeoutRetryTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/model/ModelTimeoutRetryTest.java
@@ -17,13 +17,16 @@ package io.agentscope.core.model;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import io.agentscope.core.message.ImageBlock;
 import io.agentscope.core.message.Msg;
 import io.agentscope.core.message.MsgRole;
 import io.agentscope.core.message.TextBlock;
+import io.agentscope.core.message.URLSource;
 import java.time.Duration;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Predicate;
+import java.util.function.Supplier;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import reactor.core.publisher.Flux;
@@ -385,5 +388,239 @@ class ModelTimeoutRetryTest {
                 null,
                 null,
                 null);
+    }
+
+    /**
+     * Creates a mock model backed by the supplied flux supplier, wrapped with the shared
+     * timeout/retry/empty-completion handling. The supplier is re-invoked on every subscription,
+     * so retry attempts can vary their behavior.
+     *
+     * @param responseFlux supplies the response flux for each subscription
+     * @param modelName the model name for error messages
+     * @return a Model instance backed by the supplier
+     */
+    private Model createModelReturning(
+            Supplier<Flux<ChatResponse>> responseFlux, String modelName) {
+        return new Model() {
+            @Override
+            public Flux<ChatResponse> stream(
+                    List<Msg> messages, List<ToolSchema> tools, GenerateOptions options) {
+                return ModelUtils.applyTimeoutAndRetry(
+                        Flux.defer(responseFlux), options, null, modelName, "test");
+            }
+
+            @Override
+            public String getModelName() {
+                return modelName;
+            }
+        };
+    }
+
+    // ==================== Empty-completion detection (issue #2962) ====================
+
+    @Test
+    @DisplayName("Should fail when the model returns zero chunks")
+    void testEmptyCompletionZeroChunks() {
+        // Zero chunks — the [DONE]-only stream case
+        Model emptyModel = createModelReturning(() -> Flux.empty(), "empty-model");
+
+        Msg testMsg =
+                Msg.builder()
+                        .name("user")
+                        .role(MsgRole.USER)
+                        .content(TextBlock.builder().text("test").build())
+                        .build();
+
+        // Empty-completion detection is unconditional (no ExecutionConfig needed)
+        StepVerifier.create(emptyModel.stream(List.of(testMsg), null, null))
+                .expectErrorMatches(
+                        error ->
+                                error instanceof ModelException
+                                        && error.getMessage().contains("empty completion"))
+                .verify();
+    }
+
+    @Test
+    @DisplayName("Should fail when all chunks have null or empty content")
+    void testEmptyCompletionAllChunksEmpty() {
+        // Two chunks, both contentless — the role-only/usage-only chunks of a well-formed but
+        // empty gateway response
+        Model emptyContentModel =
+                createModelReturning(
+                        () ->
+                                Flux.just(
+                                        new ChatResponse("chunk-1", List.of(), null, null, null),
+                                        new ChatResponse("chunk-2", null, null, null, null)),
+                        "empty-content-model");
+
+        Msg testMsg =
+                Msg.builder()
+                        .name("user")
+                        .role(MsgRole.USER)
+                        .content(TextBlock.builder().text("test").build())
+                        .build();
+
+        // Contentless chunks are withheld, so the error must be the first downstream signal:
+        // any emitted chunk would commit a switchOnFirst-based fallback to the primary model
+        StepVerifier.create(emptyContentModel.stream(List.of(testMsg), null, null))
+                .expectErrorMatches(
+                        error ->
+                                error instanceof ModelException
+                                        && error.getMessage().contains("empty completion"))
+                .verify();
+    }
+
+    @Test
+    @DisplayName("Empty completion should trigger retry when maxAttempts > 1")
+    void testEmptyCompletionRetriesAndSucceeds() {
+        AtomicInteger attemptCount = new AtomicInteger(0);
+
+        Model retryingEmptyModel =
+                createModelReturning(
+                        () ->
+                                attemptCount.incrementAndGet() < 2
+                                        ? Flux.empty() // First attempt: empty
+                                        : Flux.just(createMockResponse()), // Then: success
+                        "retrying-empty-model");
+
+        ExecutionConfig executionConfig =
+                ExecutionConfig.builder()
+                        .maxAttempts(2)
+                        .initialBackoff(Duration.ofMillis(10))
+                        .build();
+
+        GenerateOptions options =
+                GenerateOptions.builder().executionConfig(executionConfig).build();
+
+        Msg testMsg =
+                Msg.builder()
+                        .name("user")
+                        .role(MsgRole.USER)
+                        .content(TextBlock.builder().text("test").build())
+                        .build();
+
+        // Should retry the empty completion and succeed on second attempt
+        StepVerifier.create(retryingEmptyModel.stream(List.of(testMsg), null, options))
+                .expectNextCount(1)
+                .verifyComplete();
+
+        assertEquals(2, attemptCount.get(), "Should have made exactly 2 attempts");
+    }
+
+    @Test
+    @DisplayName(
+            "Empty completion on retry must fail even if a content-bearing attempt errored first")
+    void testEmptyCompletionOnRetryAfterContentBearingFailure() {
+        AtomicInteger attemptCount = new AtomicInteger(0);
+
+        Model model =
+                createModelReturning(
+                        () -> {
+                            if (attemptCount.incrementAndGet() == 1) {
+                                // First attempt: content arrives, then the stream fails
+                                // mid-flight
+                                return Flux.concat(
+                                        Flux.just(createMockResponse()),
+                                        Flux.error(new RuntimeException("boom")));
+                            }
+                            // Retry: empty completion must still fail
+                            return Flux.empty();
+                        },
+                        "retry-after-content-model");
+
+        ExecutionConfig executionConfig =
+                ExecutionConfig.builder()
+                        .maxAttempts(2)
+                        .initialBackoff(Duration.ofMillis(10))
+                        .build();
+
+        GenerateOptions options =
+                GenerateOptions.builder().executionConfig(executionConfig).build();
+
+        Msg testMsg =
+                Msg.builder()
+                        .name("user")
+                        .role(MsgRole.USER)
+                        .content(TextBlock.builder().text("test").build())
+                        .build();
+
+        // The empty completion on the second attempt must surface as ModelException; the chunk
+        // seen on the first attempt must not satisfy the check for the retried attempt.
+        // Retry.backoff wraps the last failure in RetryExhaustedException when retries run out
+        StepVerifier.create(model.stream(List.of(testMsg), null, options))
+                .expectNextCount(1)
+                .expectErrorMatches(
+                        error ->
+                                error.getCause() instanceof ModelException
+                                        && error.getCause()
+                                                .getMessage()
+                                                .contains("empty completion"))
+                .verify();
+
+        assertEquals(2, attemptCount.get(), "Should have made exactly 2 attempts");
+    }
+
+    @Test
+    @DisplayName("Multimodal-only chunks (image blocks) are not empty completions")
+    void testMultimodalOnlyCompletionIsNotEmpty() {
+        ChatResponse imageChunk =
+                new ChatResponse(
+                        "chunk-1",
+                        List.of(
+                                ImageBlock.builder()
+                                        .source(
+                                                URLSource.builder()
+                                                        .url("https://example.com/image.jpg")
+                                                        .build())
+                                        .build()),
+                        null,
+                        null,
+                        null);
+        Model multimodalModel =
+                createModelReturning(() -> Flux.just(imageChunk), "multimodal-model");
+
+        Msg testMsg =
+                Msg.builder()
+                        .name("user")
+                        .role(MsgRole.USER)
+                        .content(TextBlock.builder().text("test").build())
+                        .build();
+
+        // Image-only chunks carry content; the stream must complete normally
+        StepVerifier.create(multimodalModel.stream(List.of(testMsg), null, null))
+                .expectNextCount(1)
+                .verifyComplete();
+    }
+
+    @Test
+    @DisplayName("Should release withheld contentless chunks in order once content arrives")
+    void testLeadingContentlessChunksReleasedWithFirstContentChunk() {
+        Model model =
+                createModelReturning(
+                        () ->
+                                Flux.just(
+                                        new ChatResponse("role-chunk", List.of(), null, null, null),
+                                        createMockResponse(),
+                                        new ChatResponse("usage-chunk", null, null, null, null)),
+                        "leading-contentless-model");
+
+        Msg testMsg =
+                Msg.builder()
+                        .name("user")
+                        .role(MsgRole.USER)
+                        .content(TextBlock.builder().text("test").build())
+                        .build();
+
+        // The withheld chunks stream out together with the first content-bearing chunk, and
+        // trailing contentless chunks pass through untouched
+        StepVerifier.create(model.stream(List.of(testMsg), null, null))
+                .expectNextMatches(chunk -> "role-chunk".equals(chunk.getId()))
+                .expectNextMatches(
+                        chunk ->
+                                "test-id".equals(chunk.getId())
+                                        && chunk.getContent() != null
+                                        && !chunk.getContent().isEmpty())
+                .expectNextMatches(chunk -> "usage-chunk".equals(chunk.getId()))
+                .verifyComplete();
     }
 }

--- a/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-dashscope/src/test/java/io/agentscope/extensions/model/dashscope/DashScopeChatModelTest.java
+++ b/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-dashscope/src/test/java/io/agentscope/extensions/model/dashscope/DashScopeChatModelTest.java
@@ -556,19 +556,16 @@ class DashScopeChatModelTest {
         MockWebServer mockServer = new MockWebServer();
         mockServer.start();
 
+        // The response must carry content: contentless completions are rejected as upstream
+        // anomalies (issue #2962)
         mockServer.enqueue(
                 new MockResponse()
                         .setResponseCode(200)
                         .setBody(
-                                """
-                                        {
-                                            "request_id": "test",
-                                            "output": {
-                                                "choices": []
-                                            }
-                                        }
-                                """)
-                        .setHeader("Content-Type", "application/json"));
+                                "data:"
+                                    + " {\"request_id\":\"test\",\"output\":{\"choices\":[{\"message\":{\"role\":\"assistant\",\"content\":\"ok\"}}]}}\n\n"
+                                    + "data: [DONE]\n\n")
+                        .setHeader("Content-Type", "text/event-stream"));
 
         DashScopeChatModel chatModel =
                 DashScopeChatModel.builder().apiKey(mockApiKey).modelName("qwen-plus").stream(true)
@@ -609,17 +606,25 @@ class DashScopeChatModelTest {
         MockWebServer mockServer = new MockWebServer();
         mockServer.start();
 
+        // The response must carry content: contentless completions are rejected as upstream
+        // anomalies (issue #2962)
         mockServer.enqueue(
                 new MockResponse()
                         .setResponseCode(200)
                         .setBody(
                                 """
-                                        {
-                                            "request_id": "test",
-                                            "output": {
-                                                "choices": []
+                                {
+                                    "request_id": "test",
+                                    "output": {
+                                        "choices": [{
+                                            "finish_reason": "stop",
+                                            "message": {
+                                                "role": "assistant",
+                                                "content": "ok"
                                             }
-                                        }
+                                        }]
+                                    }
+                                }
                                 """)
                         .setHeader("Content-Type", "application/json"));
 
@@ -940,12 +945,18 @@ class DashScopeChatModelTest {
                         .setResponseCode(200)
                         .setBody(
                                 """
-                                        {
-                                            "request_id": "test",
-                                            "output": {
-                                                "choices": []
+                                {
+                                    "request_id": "test",
+                                    "output": {
+                                        "choices": [{
+                                            "finish_reason": "stop",
+                                            "message": {
+                                                "role": "assistant",
+                                                "content": "ok"
                                             }
-                                        }
+                                        }]
+                                    }
+                                }
                                 """)
                         .setHeader("Content-Type", "application/json"));
 
@@ -996,12 +1007,18 @@ class DashScopeChatModelTest {
                         .setResponseCode(200)
                         .setBody(
                                 """
-                                        {
-                                            "request_id": "test",
-                                            "output": {
-                                                "choices": []
+                                {
+                                    "request_id": "test",
+                                    "output": {
+                                        "choices": [{
+                                            "finish_reason": "stop",
+                                            "message": {
+                                                "role": "assistant",
+                                                "content": "ok"
                                             }
-                                        }
+                                        }]
+                                    }
+                                }
                                 """)
                         .setHeader("Content-Type", "application/json"));
 
@@ -1099,19 +1116,17 @@ class DashScopeChatModelTest {
         DashScopeParameters parameters =
                 DashScopeParameters.builder().searchOptions(searchOptions).build();
 
+        // enableThinking forces streaming regardless of stream(false), so the mock must be an
+        // SSE body carrying content — contentless completions are rejected as upstream
+        // anomalies (issue #2962)
         mockServer.enqueue(
                 new MockResponse()
                         .setResponseCode(200)
                         .setBody(
-                                """
-                                        {
-                                            "request_id": "test",
-                                            "output": {
-                                                "choices": []
-                                            }
-                                        }
-                                """)
-                        .setHeader("Content-Type", "application/json"));
+                                "data:"
+                                    + " {\"request_id\":\"test\",\"output\":{\"choices\":[{\"message\":{\"role\":\"assistant\",\"content\":\"ok\"}}]}}\n\n"
+                                    + "data: [DONE]\n\n")
+                        .setHeader("Content-Type", "text/event-stream"));
 
         DashScopeChatModel chatModel =
                 DashScopeChatModel.builder().apiKey(mockApiKey).modelName("qwen-plus").stream(false)
@@ -1170,12 +1185,18 @@ class DashScopeChatModelTest {
                         .setResponseCode(200)
                         .setBody(
                                 """
-                                        {
-                                            "request_id": "test",
-                                            "output": {
-                                                "choices": []
+                                {
+                                    "request_id": "test",
+                                    "output": {
+                                        "choices": [{
+                                            "finish_reason": "stop",
+                                            "message": {
+                                                "role": "assistant",
+                                                "content": "ok"
                                             }
-                                        }
+                                        }]
+                                    }
+                                }
                                 """)
                         .setHeader("Content-Type", "application/json"));
 
@@ -1226,12 +1247,18 @@ class DashScopeChatModelTest {
                         .setResponseCode(200)
                         .setBody(
                                 """
-                                        {
-                                            "request_id": "test",
-                                            "output": {
-                                                "choices": []
+                                {
+                                    "request_id": "test",
+                                    "output": {
+                                        "choices": [{
+                                            "finish_reason": "stop",
+                                            "message": {
+                                                "role": "assistant",
+                                                "content": "ok"
                                             }
-                                        }
+                                        }]
+                                    }
+                                }
                                 """)
                         .setHeader("Content-Type", "application/json"));
 

--- a/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-dashscope/src/test/java/io/agentscope/extensions/model/dashscope/DashScopeNonStreamingBlockingBehaviorTest.java
+++ b/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-dashscope/src/test/java/io/agentscope/extensions/model/dashscope/DashScopeNonStreamingBlockingBehaviorTest.java
@@ -54,10 +54,15 @@ class DashScopeNonStreamingBlockingBehaviorTest {
     @Test
     @DisplayName("DashScopeChatModel - Should be NON-BLOCKING in non-streaming mode")
     void testDashScopeChatModelNonBlocking() throws Exception {
+        // The response must carry content: contentless completions are rejected as upstream
+        // anomalies (issue #2962), and this test needs an onNext to observe the delivering
+        // thread
         mockServer.enqueue(
                 new MockResponse()
                         .setResponseCode(200)
-                        .setBody("{\"request_id\":\"test\",\"output\":{\"choices\":[]}}")
+                        .setBody(
+                                "{\"request_id\":\"test\",\"output\":{\"choices\":[{\"finish_reason\":"
+                                    + "\"stop\",\"message\":{\"role\":\"assistant\",\"content\":\"ok\"}}]}}")
                         .setHeader("Content-Type", "application/json"));
 
         DashScopeChatModel model =

--- a/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-openai/src/test/java/io/agentscope/extensions/model/openai/OpenAIChatModelTest.java
+++ b/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-openai/src/test/java/io/agentscope/extensions/model/openai/OpenAIChatModelTest.java
@@ -600,6 +600,9 @@ class OpenAIChatModelTest {
     @Test
     @DisplayName("Should enable parallel tool calls when set parallel_tool_calls to true")
     void testEnableParallelToolCalls() throws Exception {
+        // The response must carry content: a completion with no content-bearing chunk is
+        // rejected as an upstream anomaly (issue #2962), and this test asserts on the request,
+        // not the response
         String responseJson =
                 """
                 {
@@ -607,7 +610,14 @@ class OpenAIChatModelTest {
                     "object": "chat.completion",
                     "created": 1677652280,
                     "model": "gpt-4",
-                    "choices": []
+                    "choices": [{
+                        "index": 0,
+                        "message": {
+                            "role": "assistant",
+                            "content": "ok"
+                        },
+                        "finish_reason": "stop"
+                    }]
                 }
                 """;
 


### PR DESCRIPTION
## AgentScope-Java Version

main @ `ea511ec2` (defect observed in production on 2.0.1)

## Description

Fixes #2962

When a model provider (or an LLM gateway in front of it) returns HTTP 200 with a stream that completes without any content-bearing chunk — e.g. only the `[DONE]` marker, or only well-formed chunks whose content parses to empty — the entire chain treated it as a normal successful completion: no error, no retry, no fallback, and no assistant message persisted. To the caller it looked like the model simply chose to say nothing.

### Changes

**`ModelUtils.applyTimeoutAndRetry`** — the shared path all model implementations route through — now detects empty completions and converts them to a `ModelException` before `retryWhen`:

- **Detection**: `ensureNonEmptyCompletion` (new private helper) rejects a stream that completes without any chunk carrying a non-null, non-empty `getContent()`. Any content block counts (multimodal blocks included); only a fully contentless stream is rejected.
- **Withholding**: contentless chunks are withheld until the first content-bearing chunk arrives, then released in order. This guarantees the error is the *first* downstream signal on an empty completion: `switchOnFirst`-based fallback commits on the first signal, and the common OpenAI-compatible empty shape (a role-only first chunk, then `[DONE]`) would otherwise emit a contentless chunk first and bypass the fallback model entirely. Healthy streams are unaffected — withheld chunks are released the moment content arrives, with order and metadata preserved.
- **Placement**: after timeout (a timed-out request goes straight to error) and before retry (an empty completion triggers retry like any other model error).
- **Unconditional**: the check applies regardless of retry configuration, so a bare `agent.call(...)` without an `ExecutionConfig` still surfaces the error instead of ending as silent success.
- **Hardening**: `applyTimeoutAndRetry` no longer NPEs when both `options` and `defaultOptions` are null — `GenerateOptions.mergeOptions` documents that it can return null, and both parameters are documented as nullable.

### Tests

**`ModelTimeoutRetryTest`** — 6 tests:

1. Zero chunks (`Flux.empty()`, the `[DONE]`-only case) → error.
2. Two contentless chunks → error **as the first downstream signal** (no chunk is emitted before it, so a `switchOnFirst`-based fallback still engages).
3. Empty first attempt, success on retry → retry engages, `attemptCount == 2`.
4. Content-then-mid-stream-error followed by an empty retry attempt → still fails (`RetryExhaustedException` wrapping `ModelException`).
5. Image-only (multimodal) chunks → completes normally.
6. Leading contentless chunks are released in order once content arrives; trailing contentless chunks pass through.

**`ReActAgentTest`**: primary model returns an empty completion (contentless chunks, then complete) → fallback model takes over and answers.

**Provider extension tests**: mocks that stubbed contentless responses (`choices: []`, or streaming bodies without any content-bearing delta) were updated to return realistic content-bearing responses, since a contentless completion is now an error by design (`OpenAIChatModelTest`, `DashScopeChatModelTest`, `DashScopeNonStreamingBlockingBehaviorTest`).

## Checklist

- [x] Code has been formatted with `mvn spotless:apply`
- [x] All tests are passing (`mvn test -pl agentscope-core`, plus the full `agentscope-extensions-model` reactor)
- [x] Javadoc comments are complete and follow project conventions
- [x] Related documentation has been updated (n/a — internal behavior change, covered by Javadoc)
- [x] Code is ready for review
