### PR TITLE
fix(rag): preserve structurally empty Word paragraph boundaries

### DIFF
--- a/agentscope-extensions/agentscope-extensions-rag/agentscope-extensions-rag-simple/src/main/java/io/agentscope/core/rag/reader/WordReader.java
+++ b/agentscope-extensions/agentscope-extensions-rag/agentscope-extensions-rag-simple/src/main/java/io/agentscope/core/rag/reader/WordReader.java
@@ -41,6 +41,8 @@ import org.apache.poi.xwpf.usermodel.XWPFRun;
 import org.apache.poi.xwpf.usermodel.XWPFTable;
 import org.apache.poi.xwpf.usermodel.XWPFTableCell;
 import org.apache.poi.xwpf.usermodel.XWPFTableRow;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
 import reactor.core.publisher.Mono;
 
 /**
@@ -243,7 +245,8 @@ public class WordReader extends AbstractChunkingReader {
                             blocks.add(TextBlock.builder().text(text).build());
                         }
                         lastType = "text";
-                    } else if (!blocks.isEmpty()
+                    } else if (isTrulyBlankParagraph(para)
+                            && !blocks.isEmpty()
                             && ("text".equals(lastType)
                                     || ("table".equals(lastType) && !separateTable))) {
                         // Blank paragraph: append a newline so that consecutive paragraphs
@@ -286,6 +289,17 @@ public class WordReader extends AbstractChunkingReader {
         } catch (IOException e) {
             throw new ReaderException("Failed to parse Word document: " + wordPath, e);
         }
+    }
+
+    private boolean isTrulyBlankParagraph(XWPFParagraph para) {
+        NodeList children = para.getCTP().getDomNode().getChildNodes();
+        for (int i = 0; i < children.getLength(); i++) {
+            Node child = children.item(i);
+            if (child.getNodeType() == Node.ELEMENT_NODE && !"pPr".equals(child.getLocalName())) {
+                return false;
+            }
+        }
+        return true;
     }
 
     /**

--- a/agentscope-extensions/agentscope-extensions-rag/agentscope-extensions-rag-simple/src/main/java/io/agentscope/core/rag/reader/WordReader.java
+++ b/agentscope-extensions/agentscope-extensions-rag/agentscope-extensions-rag-simple/src/main/java/io/agentscope/core/rag/reader/WordReader.java
@@ -243,6 +243,16 @@ public class WordReader extends AbstractChunkingReader {
                             blocks.add(TextBlock.builder().text(text).build());
                         }
                         lastType = "text";
+                    } else if (!blocks.isEmpty()
+                            && ("text".equals(lastType)
+                                    || ("table".equals(lastType) && !separateTable))) {
+                        // Blank paragraph: append a newline so that consecutive paragraphs
+                        // are joined with "\n\n", preserving the paragraph boundary that
+                        // TextChunker relies on when splitting by PARAGRAPH strategy
+                        TextBlock lastBlock = (TextBlock) blocks.get(blocks.size() - 1);
+                        TextBlock mergedBlock =
+                                TextBlock.builder().text(lastBlock.getText() + "\n").build();
+                        blocks.set(blocks.size() - 1, mergedBlock);
                     }
 
                 } else if (element.getElementType() == BodyElementType.TABLE) {

--- a/agentscope-extensions/agentscope-extensions-rag/agentscope-extensions-rag-simple/src/test/java/io/agentscope/core/rag/reader/WordReaderTest.java
+++ b/agentscope-extensions/agentscope-extensions-rag/agentscope-extensions-rag-simple/src/test/java/io/agentscope/core/rag/reader/WordReaderTest.java
@@ -20,11 +20,18 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import io.agentscope.core.message.TextBlock;
 import io.agentscope.core.rag.exception.ReaderException;
+import io.agentscope.core.rag.model.Document;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.file.Path;
 import java.util.List;
+import org.apache.poi.xwpf.usermodel.XWPFDocument;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import reactor.test.StepVerifier;
 
 /**
@@ -33,6 +40,8 @@ import reactor.test.StepVerifier;
 @Tag("unit")
 @DisplayName("WordReader Unit Tests")
 class WordReaderTest {
+
+    @TempDir Path tempDir;
 
     @Test
     @DisplayName("Should create WordReader with default settings")
@@ -132,5 +141,123 @@ class WordReaderTest {
         ReaderInput input = ReaderInput.fromString("/non/existent/file.docx");
 
         StepVerifier.create(reader.read(input)).expectError(ReaderException.class).verify();
+    }
+
+    @Test
+    @DisplayName("Should preserve blank paragraphs as paragraph boundaries when chunking")
+    void testBlankParagraphsPreserveChunkBoundaries() throws IOException {
+        // Each paragraph is long enough that any two of them exceed the chunk size,
+        // so every paragraph must end up in its own chunk when boundaries are detected.
+        // WordReader trims each paragraph's trailing whitespace, so expect trimmed text.
+        String paragraph1 = "First travel policy paragraph. ".repeat(7).trim();
+        String paragraph2 = "Second travel policy paragraph. ".repeat(7).trim();
+        String paragraph3 = "Third travel policy paragraph. ".repeat(7).trim();
+
+        Path file = tempDir.resolve("blank-paragraphs.docx");
+        try (XWPFDocument doc = new XWPFDocument();
+                FileOutputStream fos = new FileOutputStream(file.toFile())) {
+            doc.createParagraph().createRun().setText(paragraph1);
+            doc.createParagraph(); // blank paragraph (empty line in Word)
+            doc.createParagraph().createRun().setText(paragraph2);
+            doc.createParagraph(); // blank paragraph (empty line in Word)
+            doc.createParagraph().createRun().setText(paragraph3);
+            doc.write(fos);
+        }
+
+        WordReader reader =
+                new WordReader(300, SplitStrategy.PARAGRAPH, 0, true, true, TableFormat.MARKDOWN);
+        List<Document> documents = reader.read(ReaderInput.fromString(file.toString())).block();
+
+        assertEquals(3, documents.size());
+        assertEquals(
+                paragraph1, ((TextBlock) documents.get(0).getMetadata().getContent()).getText());
+        assertEquals(
+                paragraph2, ((TextBlock) documents.get(1).getMetadata().getContent()).getText());
+        assertEquals(
+                paragraph3, ((TextBlock) documents.get(2).getMetadata().getContent()).getText());
+    }
+
+    @Test
+    @DisplayName("Should join adjacent paragraphs without blank line using a single newline")
+    void testAdjacentParagraphsJoinedWithSingleNewline() throws IOException {
+        String paragraph1 = "First short paragraph. ".repeat(4).trim();
+        String paragraph2 = "Second short paragraph. ".repeat(4).trim();
+
+        Path file = tempDir.resolve("adjacent-paragraphs.docx");
+        try (XWPFDocument doc = new XWPFDocument();
+                FileOutputStream fos = new FileOutputStream(file.toFile())) {
+            doc.createParagraph().createRun().setText(paragraph1);
+            doc.createParagraph().createRun().setText(paragraph2);
+            doc.write(fos);
+        }
+
+        WordReader reader =
+                new WordReader(300, SplitStrategy.PARAGRAPH, 0, true, true, TableFormat.MARKDOWN);
+        List<Document> documents = reader.read(ReaderInput.fromString(file.toString())).block();
+
+        assertEquals(1, documents.size());
+        assertEquals(
+                paragraph1 + "\n" + paragraph2,
+                ((TextBlock) documents.get(0).getMetadata().getContent()).getText());
+    }
+
+    @Test
+    @DisplayName("Should return no documents for a document containing only blank paragraphs")
+    void testDocumentWithOnlyBlankParagraphs() throws IOException {
+        Path file = tempDir.resolve("only-blank-paragraphs.docx");
+        try (XWPFDocument doc = new XWPFDocument();
+                FileOutputStream fos = new FileOutputStream(file.toFile())) {
+            doc.createParagraph();
+            doc.createParagraph();
+            doc.write(fos);
+        }
+
+        WordReader reader = new WordReader();
+        List<Document> documents = reader.read(ReaderInput.fromString(file.toString())).block();
+
+        assertTrue(documents.isEmpty());
+    }
+
+    @Test
+    @DisplayName("Should preserve blank line between a merged table and the following paragraph")
+    void testBlankParagraphBetweenTableAndText() throws IOException {
+        String paragraph = "Travel policy paragraph after the table. ".repeat(5).trim();
+        String tableMarkdown = "| Header |\n| --- |\n";
+
+        Path file = tempDir.resolve("table-blank-paragraph.docx");
+        try (XWPFDocument doc = new XWPFDocument();
+                FileOutputStream fos = new FileOutputStream(file.toFile())) {
+            doc.createTable(1, 1).getRow(0).getCell(0).setText("Header");
+            doc.createParagraph(); // blank paragraph (empty line in Word)
+            doc.createParagraph().createRun().setText(paragraph);
+            doc.write(fos);
+        }
+
+        // separateTable=false: the table is merged into the text block, and the blank
+        // paragraph must be preserved as "\n\n" so the table/paragraph boundary is
+        // detectable by paragraph-based chunking
+        WordReader mergedReader =
+                new WordReader(300, SplitStrategy.PARAGRAPH, 0, true, false, TableFormat.MARKDOWN);
+        List<Document> merged = mergedReader.read(ReaderInput.fromString(file.toString())).block();
+
+        assertEquals(1, merged.size());
+        assertEquals(
+                tableMarkdown + "\n" + paragraph,
+                ((TextBlock) merged.get(0).getMetadata().getContent()).getText());
+
+        // separateTable=true: the table stays a separate chunk and the blank
+        // paragraph must not introduce any extra newline
+        WordReader separatedReader =
+                new WordReader(300, SplitStrategy.PARAGRAPH, 0, true, true, TableFormat.MARKDOWN);
+        List<Document> separated =
+                separatedReader.read(ReaderInput.fromString(file.toString())).block();
+
+        assertEquals(2, separated.size());
+        // trailing newline of the table markdown is trimmed by paragraph chunking
+        assertEquals(
+                tableMarkdown.trim(),
+                ((TextBlock) separated.get(0).getMetadata().getContent()).getText());
+        assertEquals(
+                paragraph, ((TextBlock) separated.get(1).getMetadata().getContent()).getText());
     }
 }

--- a/agentscope-extensions/agentscope-extensions-rag/agentscope-extensions-rag-simple/src/test/java/io/agentscope/core/rag/reader/WordReaderTest.java
+++ b/agentscope-extensions/agentscope-extensions-rag/agentscope-extensions-rag-simple/src/test/java/io/agentscope/core/rag/reader/WordReaderTest.java
@@ -178,6 +178,32 @@ class WordReaderTest {
     }
 
     @Test
+    @DisplayName("Should treat a paragraph containing only properties as a blank boundary")
+    void testParagraphPropertiesOnlyPreserveChunkBoundary() throws IOException {
+        String paragraph1 = "First travel policy paragraph. ".repeat(7).trim();
+        String paragraph2 = "Second travel policy paragraph. ".repeat(7).trim();
+
+        Path file = tempDir.resolve("paragraph-properties-only.docx");
+        try (XWPFDocument doc = new XWPFDocument();
+                FileOutputStream fos = new FileOutputStream(file.toFile())) {
+            doc.createParagraph().createRun().setText(paragraph1);
+            doc.createParagraph().getCTP().addNewPPr();
+            doc.createParagraph().createRun().setText(paragraph2);
+            doc.write(fos);
+        }
+
+        WordReader reader =
+                new WordReader(300, SplitStrategy.PARAGRAPH, 0, true, true, TableFormat.MARKDOWN);
+        List<Document> documents = reader.read(ReaderInput.fromString(file.toString())).block();
+
+        assertEquals(2, documents.size());
+        assertEquals(
+                paragraph1, ((TextBlock) documents.get(0).getMetadata().getContent()).getText());
+        assertEquals(
+                paragraph2, ((TextBlock) documents.get(1).getMetadata().getContent()).getText());
+    }
+
+    @Test
     @DisplayName("Should join adjacent paragraphs without blank line using a single newline")
     void testAdjacentParagraphsJoinedWithSingleNewline() throws IOException {
         String paragraph1 = "First short paragraph. ".repeat(4).trim();
@@ -187,6 +213,31 @@ class WordReaderTest {
         try (XWPFDocument doc = new XWPFDocument();
                 FileOutputStream fos = new FileOutputStream(file.toFile())) {
             doc.createParagraph().createRun().setText(paragraph1);
+            doc.createParagraph().createRun().setText(paragraph2);
+            doc.write(fos);
+        }
+
+        WordReader reader =
+                new WordReader(300, SplitStrategy.PARAGRAPH, 0, true, true, TableFormat.MARKDOWN);
+        List<Document> documents = reader.read(ReaderInput.fromString(file.toString())).block();
+
+        assertEquals(1, documents.size());
+        assertEquals(
+                paragraph1 + "\n" + paragraph2,
+                ((TextBlock) documents.get(0).getMetadata().getContent()).getText());
+    }
+
+    @Test
+    @DisplayName("Should not treat a break-only paragraph as a blank paragraph boundary")
+    void testBreakOnlyParagraphDoesNotCreateBlankParagraphBoundary() throws IOException {
+        String paragraph1 = "First short paragraph. ".repeat(4).trim();
+        String paragraph2 = "Second short paragraph. ".repeat(4).trim();
+
+        Path file = tempDir.resolve("break-only-paragraph.docx");
+        try (XWPFDocument doc = new XWPFDocument();
+                FileOutputStream fos = new FileOutputStream(file.toFile())) {
+            doc.createParagraph().createRun().setText(paragraph1);
+            doc.createParagraph().createRun().addBreak();
             doc.createParagraph().createRun().setText(paragraph2);
             doc.write(fos);
         }


### PR DESCRIPTION
## AgentScope-Java Version

2.0.3-SNAPSHOT (current main)

## Description

Word represents a blank line as an empty `w:p` paragraph. `WordReader` now preserves that structural boundary so paragraph chunking receives `\n\n` between surrounding text.

The blank-paragraph check is deliberately structural: a paragraph containing only `w:pPr` properties remains blank, while a paragraph with any other OOXML body element (for example a run containing `w:br`) is not treated as an extra blank-line boundary. This prevents trim-normalized but structurally non-empty paragraphs from changing chunk boundaries.

## Testing

- `WordReaderTest`: 15 tests, 0 failures, 0 errors.
- Includes real Apache POI round-trip coverage for empty paragraphs, `w:pPr`-only paragraphs, and break-only paragraphs.
- `spotless:check` and `git diff --check` pass.

## Checklist

- [x] Code formatting verified with `mvn spotless:check`
- [x] All relevant tests are passing
- [x] Javadoc comments follow project conventions; no public API changed
- [x] Related documentation is not required for this internal behavior fix
- [x] Code is ready for review