### PR TITLE
fix(harness): 保留跳过摘要时的轻量上下文裁剪结果

### DIFF
--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/memory/compaction/ConversationCompactor.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/memory/compaction/ConversationCompactor.java
@@ -43,6 +43,8 @@ import reactor.core.publisher.Mono;
 /**
  * <h2>Algorithm</h2>
  * <ol>
+ *   <li><b>Lightweight reduction</b> — truncate configured tool arguments and prune tool
+ *       results; retain these changes even when summarization is skipped</li>
  *   <li><b>Check trigger</b> — token count or message count exceeds threshold</li>
  *   <li><b>Determine cutoff</b> — find the earliest index that keeps the tail within the
  *       "keep" budget; never split an ASSISTANT tool-call from its TOOL result(s)</li>
@@ -86,8 +88,9 @@ public class ConversationCompactor {
      * @param config               compaction configuration
      * @param agentId              agent identifier used for the memory offload path
      * @param sessionId            session identifier used for the memory offload path
-     * @return {@code Optional.empty()} when no compaction was needed; otherwise the replacement
-     *         message list consisting of {@code [summaryUserMsg] + preservedTail}
+     * @return {@code Optional.empty()} when the conversation is unchanged; otherwise the
+     *         replacement message list, containing lightweight reductions only when summarization
+     *         is skipped, or {@code [summaryUserMsg] + preservedTail} when it runs
      */
     public Mono<Optional<List<Msg>>> compactIfNeeded(
             RuntimeContext rc,
@@ -106,16 +109,19 @@ public class ConversationCompactor {
                 pruneToolResults(
                         truncateArgs(conversationMessages, config.getTruncateArgsConfig()),
                         config.getPruneConfig());
+        // Both lightweight passes return the original list when they make no changes.
+        Optional<List<Msg>> lightweightResult =
+                messages == conversationMessages ? Optional.empty() : Optional.of(messages);
 
         int totalTokens = TokenCounterUtil.calculateToken(messages);
         if (!shouldCompact(messages, totalTokens, config)) {
-            return Mono.just(Optional.empty());
+            return Mono.just(lightweightResult);
         }
 
         int cutoff = determineCutoffIndex(messages, totalTokens, config);
         if (cutoff <= 0) {
-            log.debug("Compaction triggered but safe cutoff is 0 — skipping");
-            return Mono.just(Optional.empty());
+            log.debug("Compaction triggered but safe cutoff is 0 — skipping summarization");
+            return Mono.just(lightweightResult);
         }
 
         // Keep prior summaries in the summarization input so each compaction builds on the

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/middleware/CompactionMiddlewareTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/middleware/CompactionMiddlewareTest.java
@@ -17,8 +17,11 @@ package io.agentscope.harness.agent.middleware;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import io.agentscope.core.ReActAgent;
@@ -28,26 +31,192 @@ import io.agentscope.core.message.GenerateReason;
 import io.agentscope.core.message.Msg;
 import io.agentscope.core.message.MsgRole;
 import io.agentscope.core.message.TextBlock;
+import io.agentscope.core.message.ToolResultBlock;
+import io.agentscope.core.message.ToolUseBlock;
 import io.agentscope.core.middleware.ReasoningInput;
 import io.agentscope.core.model.ChatModelBase;
 import io.agentscope.core.model.ChatResponse;
 import io.agentscope.core.model.GenerateOptions;
+import io.agentscope.core.model.Model;
 import io.agentscope.core.model.ToolSchema;
+import io.agentscope.core.state.AgentState;
 import io.agentscope.harness.agent.memory.compaction.CompactionConfig;
+import io.agentscope.harness.agent.memory.compaction.TokenCounterUtil;
 import java.time.Duration;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import reactor.core.publisher.Flux;
 import reactor.core.scheduler.Schedulers;
 import reactor.test.StepVerifier;
 
 /** Verifies that compaction fallback does not swallow interrupts or rerun downstream reasoning. */
 class CompactionMiddlewareTest {
+
+    /** Lightweight reductions must reach both reasoning and state even without a summary. */
+    @ParameterizedTest
+    @CsvSource({"false, 0", "false, 3", "true, 0", "true, 3"})
+    void lightweightCompactionReachesReasoningAndState(boolean truncateArgs, int triggerMessages) {
+        Model model = mock(Model.class);
+        String largeText = "x".repeat(10_000);
+        Msg system = Msg.builder().role(MsgRole.SYSTEM).textContent("system").build();
+        Msg user = userMessage("write a file");
+        Msg call =
+                Msg.builder()
+                        .role(MsgRole.ASSISTANT)
+                        .content(
+                                ToolUseBlock.builder()
+                                        .id("call-1")
+                                        .name("write_file")
+                                        .input(
+                                                Map.of(
+                                                        "content",
+                                                        truncateArgs ? largeText : "small"))
+                                        .build())
+                        .build();
+        Msg result =
+                Msg.builder()
+                        .role(MsgRole.TOOL)
+                        .content(
+                                ToolResultBlock.builder()
+                                        .id("call-1")
+                                        .name("write_file")
+                                        .output(
+                                                List.of(
+                                                        TextBlock.builder()
+                                                                .text(
+                                                                        truncateArgs
+                                                                                ? "done"
+                                                                                : largeText)
+                                                                .build()))
+                                        .build())
+                        .build();
+        List<Msg> conversation = List.of(user, call, result);
+        AgentState state = AgentState.builder().context(conversation).build();
+        RuntimeContext rc = context("user", "session");
+        rc.setAgentState(state);
+        ReasoningInput original =
+                new ReasoningInput(
+                        List.of(system, user, call, result),
+                        List.of(),
+                        GenerateOptions.builder().build());
+        CompactionConfig config =
+                CompactionConfig.builder()
+                        .triggerTokens(1_000)
+                        .triggerMessages(triggerMessages)
+                        .keepTokens(0)
+                        .keepMessages(20)
+                        .truncateArgs(
+                                truncateArgs
+                                        ? CompactionConfig.TruncateArgsConfig.builder()
+                                                .triggerTokens(1)
+                                                .keepMessages(1)
+                                                .maxArgLength(100)
+                                                .build()
+                                        : null)
+                        .prune(
+                                truncateArgs
+                                        ? null
+                                        : CompactionConfig.PruneConfig.builder()
+                                                .protectTokens(0)
+                                                .minimumTokens(1)
+                                                .maxOutputChars(100)
+                                                .build())
+                        .build();
+        CompactionMiddleware middleware = new CompactionMiddleware(null, model, config);
+        AtomicInteger nextCalls = new AtomicInteger();
+        assertTrue(TokenCounterUtil.calculateToken(conversation) > config.getTriggerTokens());
+
+        StepVerifier.create(
+                        middleware.onReasoning(
+                                agent(),
+                                rc,
+                                original,
+                                next -> {
+                                    nextCalls.incrementAndGet();
+                                    assertNotSame(original, next);
+                                    assertSame(system, next.messages().get(0));
+                                    assertSame(user, next.messages().get(1));
+                                    assertSame(original.tools(), next.tools());
+                                    assertSame(original.options(), next.options());
+                                    assertEquals(4, next.messages().size());
+                                    assertEquals(
+                                            next.messages().subList(1, 4), state.contextMutable());
+                                    assertTrue(
+                                            TokenCounterUtil.calculateToken(state.contextMutable())
+                                                    < config.getTriggerTokens());
+                                    ToolUseBlock reducedCall =
+                                            (ToolUseBlock)
+                                                    next.messages().get(2).getContent().get(0);
+                                    ToolResultBlock reducedResult =
+                                            (ToolResultBlock)
+                                                    next.messages().get(3).getContent().get(0);
+                                    assertEquals("call-1", reducedCall.getId());
+                                    assertEquals(reducedCall.getId(), reducedResult.getId());
+                                    if (truncateArgs) {
+                                        assertTrue(
+                                                ((String) reducedCall.getInput().get("content"))
+                                                                .length()
+                                                        < 100);
+                                    } else {
+                                        assertTrue(
+                                                ((TextBlock) reducedResult.getOutput().get(0))
+                                                        .getText()
+                                                        .contains("chars pruned"));
+                                    }
+                                    return Flux.empty();
+                                }))
+                .verifyComplete();
+
+        assertEquals(1, nextCalls.get());
+        assertTrue(TokenCounterUtil.calculateToken(conversation) > config.getTriggerTokens());
+        verifyNoInteractions(model);
+    }
+
+    /** A true no-op must keep the original request and state, with or without a safe cutoff. */
+    @ParameterizedTest
+    @ValueSource(ints = {0, 1})
+    void unchangedConversationKeepsOriginalInput(int triggerMessages) {
+        Model model = mock(Model.class);
+        ReasoningInput original = input();
+        AgentState state = AgentState.builder().context(original.messages()).build();
+        RuntimeContext rc = context("user", "session");
+        rc.setAgentState(state);
+        CompactionConfig config =
+                CompactionConfig.builder()
+                        .triggerTokens(1_000)
+                        .triggerMessages(triggerMessages)
+                        .keepTokens(0)
+                        .keepMessages(20)
+                        .build();
+        AtomicInteger nextCalls = new AtomicInteger();
+
+        StepVerifier.create(
+                        new CompactionMiddleware(null, model, config)
+                                .onReasoning(
+                                        agent(),
+                                        rc,
+                                        original,
+                                        next -> {
+                                            nextCalls.incrementAndGet();
+                                            assertSame(original, next);
+                                            assertEquals(
+                                                    original.messages(), state.contextMutable());
+                                            return Flux.empty();
+                                        }))
+                .verifyComplete();
+
+        assertEquals(1, nextCalls.get());
+        verifyNoInteractions(model);
+    }
 
     /** An ordinary compaction failure skips compaction and invokes original reasoning once. */
     @Test


### PR DESCRIPTION
## 关联问题

Fixes #2970

## AgentScope-Java Version

`2.0.3-SNAPSHOT`，基于 `main` 的 `ea511ec2f68ca929a6bbc4e92cd0c0952a38c592`。

## 背景与必要性

`ConversationCompactor.compactIfNeeded()` 在判断是否需要 LLM 摘要前，先执行工具参数截断和工具结果裁剪。但下面两个提前返回分支会丢弃已经生成的裁剪结果：

1. 裁剪后的 token 数低于摘要触发阈值；
2. 触发了摘要，但安全切分点为 0，没有可摘要的前缀。

这两个分支都返回 `Optional.empty()`。`CompactionMiddleware` 因此继续传递原始 `ReasoningInput`，也不更新工作 `AgentState`。结果是：轻量裁剪确实执行了，下一次模型请求却仍携带原始大段内容，可能继续触发上下文超限。

这与 #2267 / #2319 修复的 `ToolResultEvictionMiddleware` 状态和输入不同步问题不同；本次问题位于 `ConversationCompactor` 的提前返回路径。

## 变更内容

1. 保存轻量裁剪产生的替换列表，在上述两个分支中返回；只有消息未变化时才返回 `Optional.empty()`。
2. 复用现有调用方处理非空结果的逻辑，使模型输入和工作状态都得到裁剪后的消息，无需修改 Middleware 或新增返回类型。
3. 更新公开方法的 Javadoc：非空结果既可能是轻量裁剪后的消息，也可能是摘要加保留尾部。
4. 增加真实 Middleware 调用边界的回归测试，不 mock compactor。

两个轻量处理方法在无改动时都会返回原列表，因此这里只比较列表引用，不对大段消息做深度比较。

## 复现与验证

最小输入为一条用户消息、一条工具调用及其匹配结果。工具结果含 `"x".repeat(10_000)`；配置 `triggerTokens(1_000)`、`keepTokens(0)`、`keepMessages(20)`，以及 `protectTokens(0)`、`minimumTokens(1)`、`maxOutputChars(100)` 的裁剪策略。裁剪后低于阈值，但原实现仍把原始请求传给 `next`。

设置 `triggerMessages(3)` 可覆盖安全切分点为 0 的分支；将大段内容放到 `write_file` 参数并启用参数截断，可复现参数截断对应的两个分支。

新增 6 个参数化场景：

- 工具结果裁剪 / 工具参数截断 × 低于摘要阈值 / 安全切分点为 0，共 4 个场景；
- 两个提前返回分支下消息确实未变化的 2 个对照场景。

修复前：4 个裁剪场景全部失败，2 个无变化场景通过。修复后：`ConversationCompactorTest` 和 `CompactionMiddlewareTest` 共 23 项全部通过。

此外，`mvn -pl agentscope-harness -am test` 构建成功：Core 共 2,318 项（跳过 9 项），Harness 共 925 项（跳过 5 项），均为 0 failures / 0 errors。验证环境为 Java 17 / Maven 3.8.7，运行时状态目录隔离到临时测试目录。

断言同时检查下游输入、工作状态、原输入不被修改、系统消息和工具调用配对保留、tools/options 透传，并确认轻量裁剪不触发模型调用。测试使用 mock model，不需要模型凭证或网络调用。

```bash
mvn -pl agentscope-harness spotless:apply
mvn -pl agentscope-harness -am \
  -Dtest=ConversationCompactorTest,CompactionMiddlewareTest \
  -Dsurefire.failIfNoSpecifiedTests=false test
mvn -pl agentscope-harness -am test
```

## 当前范围与兼容性

- 保留现有方法签名，不新增依赖、配置或 LLM 调用。
- 不改摘要逻辑、异常降级和中断传播。
- 不改变默认参数截断开关、裁剪阈值、排除工具和最近消息保护窗口。
- 本 PR 只保证“已经做出的裁剪能被使用”，不保证所有超大上下文都能降到模型窗口内；处于保护窗口的内容、未启用参数截断的工具输入，仍需按原有策略处理。

## 想请维护者确认的取舍

这里保留 `Optional<List<Msg>>`，将非空结果解释为“存在应应用的替换消息”，不再隐含“一定生成了摘要”。目前仓内两个生产调用点都按替换列表使用结果。希望确认这一返回语义是否符合项目预期；若外部调用方需要区分轻量裁剪和摘要，可另行讨论显式结果类型，本 PR 暂不扩大 API 改动范围。

## Checklist

- [x] 已执行 Harness 模块的 `mvn spotless:apply`。
- [x] 已运行并通过本次改动对应的聚焦测试。
- [x] Core/Harness 全量测试构建成功；跳过项数量见验证结果。
- [x] 已更新 Javadoc，说明轻量裁剪结果的返回语义。
- [x] 无需修改公开配置文档或使用示例。
- [x] 代码可供审查。

验证范围为 Core/Harness，未宣称其他所有模块的全仓 `mvn test` 已通过。
