### PR TITLE
fix(rag): preserve paragraph boundaries across empty paragraphs in WordReader

### DIFF
--- a/agentscope-extensions/agentscope-extensions-rag/agentscope-extensions-rag-simple/src/main/java/io/agentscope/core/rag/reader/WordReader.java
+++ b/agentscope-extensions/agentscope-extensions-rag/agentscope-extensions-rag-simple/src/main/java/io/agentscope/core/rag/reader/WordReader.java
@@ -243,6 +243,18 @@ public class WordReader extends AbstractChunkingReader {
                             blocks.add(TextBlock.builder().text(text).build());
                         }
                         lastType = "text";
+                    } else {
+                        // Empty paragraph (e.g. a blank line in Word, represented by an empty
+                        // <w:p> element). Preserve the paragraph boundary by appending a line
+                        // feed; otherwise adjacent non-empty paragraphs are joined with a single
+                        // "\n" and TextChunker's PARAGRAPH strategy (separated by "\n\s*\n")
+                        // cannot detect the boundary, degrading to character splitting.
+                        if ("text".equals(lastType)) {
+                            TextBlock lastBlock = (TextBlock) blocks.get(blocks.size() - 1);
+                            blocks.set(
+                                    blocks.size() - 1,
+                                    TextBlock.builder().text(lastBlock.getText() + "\n").build());
+                        }
                     }
 
                 } else if (element.getElementType() == BodyElementType.TABLE) {

--- a/agentscope-extensions/agentscope-extensions-rag/agentscope-extensions-rag-simple/src/test/java/io/agentscope/core/rag/reader/WordReaderTest.java
+++ b/agentscope-extensions/agentscope-extensions-rag/agentscope-extensions-rag-simple/src/test/java/io/agentscope/core/rag/reader/WordReaderTest.java
@@ -21,7 +21,13 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.agentscope.core.rag.exception.ReaderException;
+import io.agentscope.core.rag.model.Document;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
 import java.util.List;
+import org.apache.poi.xwpf.usermodel.XWPFDocument;
+import org.apache.poi.xwpf.usermodel.XWPFParagraph;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -132,5 +138,39 @@ class WordReaderTest {
         ReaderInput input = ReaderInput.fromString("/non/existent/file.docx");
 
         StepVerifier.create(reader.read(input)).expectError(ReaderException.class).verify();
+    }
+
+    @Test
+    @DisplayName(
+            "Should preserve paragraph boundaries across empty paragraphs for PARAGRAPH strategy")
+    void testParagraphBoundaryPreservedAcrossBlankLine() throws IOException {
+        // Build a docx with "First\n\nSecond" where the blank line is an empty <w:p> element.
+        File file = File.createTempFile("wordreader-paragraph", ".docx");
+        file.deleteOnExit();
+
+        try (XWPFDocument doc = new XWPFDocument()) {
+            XWPFParagraph first = doc.createParagraph();
+            first.createRun().setText("First paragraph.");
+            doc.createParagraph(); // empty paragraph (blank line in Word)
+            XWPFParagraph second = doc.createParagraph();
+            second.createRun().setText("Second paragraph.");
+
+            try (FileOutputStream fos = new FileOutputStream(file)) {
+                doc.write(fos);
+            }
+        }
+
+        // Images disabled to keep the test focused on text.
+        WordReader reader =
+                new WordReader(1000, SplitStrategy.PARAGRAPH, 0, false, true, TableFormat.MARKDOWN);
+        List<Document> documents =
+                reader.read(ReaderInput.fromString(file.getAbsolutePath())).block();
+
+        assertEquals(1, documents.size());
+        // The blank line must produce "\n\n" so TextChunker's PARAGRAPH strategy can detect
+        // the boundary instead of degrading to character splitting.
+        assertEquals(
+                "First paragraph.\n\nSecond paragraph.",
+                documents.get(0).getMetadata().getContentText());
     }
 }


### PR DESCRIPTION
Fixes #2964

## Problem

`WordReader.getDataBlocks()` skips empty `<w:p>` paragraphs (blank lines in Word) entirely:

```java
String text = extractTextFromParagraph(para);
if (text != null && !text.isEmpty()) {   // empty paragraph -> skipped, blank line lost
```

Consecutive non-empty paragraphs are therefore joined with a single `"\n"`. Meanwhile `TextChunker` detects paragraph boundaries only via `Pattern.compile("\\n\\s*\\n")` (two newlines). Since the reader never emits `\n\n`, `SplitStrategy.PARAGRAPH` — the default for `WordReader` — silently degrades to character chunking: the document becomes one giant "paragraph", exceeds the chunk size, and falls back to `chunkByCharacter()`.

## Fix

When an empty paragraph is encountered, preserve the boundary by appending a line feed to the current text block, so adjacent paragraphs yield `\n\n` and paragraph-aware chunking actually works. Image and table handling are untouched.

```java
} else {
    // Empty paragraph -> keep the <w:p> boundary as "\n\n"
    if ("text".equals(lastType)) {
        TextBlock lastBlock = (TextBlock) blocks.get(blocks.size() - 1);
        blocks.set(blocks.size() - 1,
                TextBlock.builder().text(lastBlock.getText() + "\n").build());
    }
}
```

## Test

Adds `WordReaderTest.testParagraphBoundaryPreservedAcrossBlankLine`, which builds a docx containing `paragraph -> blank line -> paragraph`, reads it with `SplitStrategy.PARAGRAPH`, and asserts the output is `"First paragraph.\n\nSecond paragraph."`. This fails on the previous code (which yields a single `\n`).