### PR TITLE
fix(models): route Qwen3.8 variants to DashScope multimodal API

### DIFF
--- a/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-dashscope/src/main/java/io/agentscope/extensions/model/dashscope/DashScopeHttpClient.java
+++ b/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-dashscope/src/main/java/io/agentscope/extensions/model/dashscope/DashScopeHttpClient.java
@@ -372,7 +372,8 @@ public class DashScopeHttpClient {
      *   <li>Models starting with "qwen3.5" (e.g., qwen3.5-plus, qwen3.5-flash)</li>
      *   <li>Models starting with "qwen3.6" (e.g., qwen3.6-plus, qwen3.6-flash)</li>
      *   <li>Models starting with "qwen3.7" where not "qwen3.7-max" (e.g., qwen3.7-plus)</li>
-     *   <li>Models starting with "qwen3.8-max" (e.g., qwen3.8-max)</li>
+     *   <li>Models starting with "qwen3.8" where not "qwen3.8-2.4t-a95b"
+     *       (e.g., qwen3.8-max, qwen3.8-flash, qwen3.8-27b)</li>
      *   <li>Models containing "kimi-k2.5"/"kimi-k2.6" (e.g., kimi-k2.6, kimi/kimi-k2.5)</li>
      * </ul>
      *
@@ -381,6 +382,8 @@ public class DashScopeHttpClient {
      *   <li>"qwen3.6-max-preview" — text-only preview model.</li>
      *   <li>Models starting with "qwen3.7-max" (e.g., qwen3.7-max, qwen3.7-max-2026-05-20)
      *       — text-only models that use the text-generation endpoint.</li>
+     *   <li>Models starting with "qwen3.8-2.4t-a95b" — text-only models that use the
+     *       text-generation endpoint.</li>
      * </ul>
      *
      * @param modelName the model name
@@ -393,7 +396,8 @@ public class DashScopeHttpClient {
         String lowerModelName = modelName.toLowerCase();
         // Reverse exclusions: text-only models whose prefix would otherwise match.
         if (lowerModelName.equals("qwen3.6-max-preview")
-                || lowerModelName.startsWith("qwen3.7-max")) {
+                || lowerModelName.startsWith("qwen3.7-max")
+                || lowerModelName.startsWith("qwen3.8-2.4t-a95b")) {
             return false;
         }
         return lowerModelName.startsWith("qvq")
@@ -402,7 +406,7 @@ public class DashScopeHttpClient {
                 || lowerModelName.startsWith("qwen3.5")
                 || lowerModelName.startsWith("qwen3.6")
                 || lowerModelName.startsWith("qwen3.7")
-                || lowerModelName.startsWith("qwen3.8-max")
+                || lowerModelName.startsWith("qwen3.8")
                 || lowerModelName.contains("kimi-k2.5")
                 || lowerModelName.contains("kimi-k2.6");
     }

--- a/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-dashscope/src/test/java/io/agentscope/extensions/model/dashscope/DashScopeChatModelTest.java
+++ b/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-dashscope/src/test/java/io/agentscope/extensions/model/dashscope/DashScopeChatModelTest.java
@@ -34,6 +34,7 @@ import io.agentscope.core.model.ToolSchema;
 import io.agentscope.core.model.test.ModelTestUtils;
 import io.agentscope.core.model.transport.OkHttpTransport;
 import io.agentscope.core.model.transport.ProxyConfig;
+import io.agentscope.core.util.JsonUtils;
 import io.agentscope.extensions.model.dashscope.dto.DashScopeParameters;
 import io.agentscope.extensions.model.dashscope.dto.DashScopeRequest;
 import io.agentscope.extensions.model.dashscope.dto.DashScopeSearchOptions;
@@ -42,9 +43,11 @@ import io.agentscope.extensions.model.dashscope.formatter.DashScopeMultiAgentFor
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
 import okhttp3.mockwebserver.RecordedRequest;
@@ -53,6 +56,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import reactor.core.publisher.Flux;
 import reactor.test.StepVerifier;
 
@@ -548,6 +553,50 @@ class DashScopeChatModelTest {
                         .build();
 
         assertNotNull(thinkingModel);
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    @DisplayName("Qwen3.8 Flash AUTO routing uses multimodal endpoint and text content parts")
+    void testQwen38FlashAutoRoutingAndMessageFormat(boolean streaming) throws Exception {
+        String responseJson =
+                """
+                {"output":{"choices":[{"message":{"role":"assistant","content":[{"text":"Hi"}]},"finish_reason":"stop"}]}}
+                """;
+        mockServer.enqueue(
+                new MockResponse()
+                        .setHeader(
+                                "Content-Type",
+                                streaming ? "text/event-stream" : "application/json")
+                        .setBody(
+                                streaming
+                                        ? "data: " + responseJson.trim() + "\n\n"
+                                        : responseJson));
+
+        DashScopeChatModel chatModel =
+                DashScopeChatModel.builder()
+                        .apiKey(mockApiKey)
+                        .modelName("qwen3.8-flash")
+                        .baseUrl(mockServer.url("/").toString().replaceAll("/$", ""))
+                        .stream(streaming)
+                        .build();
+        Msg userMsg = Msg.builder().role(MsgRole.USER).textContent("Hello").build();
+
+        StepVerifier.create(chatModel.doStream(List.of(userMsg), List.of(), null))
+                .expectNextCount(1)
+                .expectComplete()
+                .verify(Duration.ofSeconds(10));
+
+        RecordedRequest recorded = mockServer.takeRequest(5, TimeUnit.SECONDS);
+        assertNotNull(recorded);
+        assertEquals(DashScopeHttpClient.MULTIMODAL_GENERATION_ENDPOINT, recorded.getPath());
+        DashScopeRequest request =
+                JsonUtils.getJsonCodec()
+                        .fromJson(recorded.getBody().readUtf8(), DashScopeRequest.class);
+        assertEquals("qwen3.8-flash", request.getModel());
+        assertEquals(
+                List.of(Map.of("text", "Hello")),
+                request.getInput().getMessages().get(0).getContent());
     }
 
     @Test

--- a/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-dashscope/src/test/java/io/agentscope/extensions/model/dashscope/DashScopeHttpClientTest.java
+++ b/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-dashscope/src/test/java/io/agentscope/extensions/model/dashscope/DashScopeHttpClientTest.java
@@ -56,6 +56,8 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import reactor.core.publisher.Flux;
 import reactor.test.StepVerifier;
 
@@ -225,12 +227,40 @@ class DashScopeHttpClientTest {
         assertFalse(DashScopeHttpClient.isMultimodalModel("qwen-3.6-plus"));
     }
 
+    @ParameterizedTest
+    @ValueSource(
+            strings = {
+                "qwen3.8-max",
+                "Qwen3.8-Max",
+                "qwen3.8-max-2026-08-01",
+                "qwen3.8-flash",
+                "Qwen3.8-Flash",
+                "qwen3.8-flash-2026-09-01",
+                "qwen3.8-27b"
+            })
+    void testQwen38MultimodalRouting(String modelName) {
+        assertTrue(DashScopeHttpClient.isMultimodalModel(modelName));
+        assertTrue(client.requiresMultimodalApi(modelName, EndpointType.AUTO));
+        assertEquals(
+                DashScopeHttpClient.MULTIMODAL_GENERATION_ENDPOINT,
+                client.selectEndpoint(modelName, EndpointType.AUTO));
+    }
+
+    @ParameterizedTest
+    @ValueSource(
+            strings = {"qwen3.8-2.4t-a95b", "Qwen3.8-2.4T-A95B", "qwen3.8-2.4t-a95b-2026-09-01"})
+    void testQwen38TextOnlyRouting(String modelName) {
+        assertFalse(DashScopeHttpClient.isMultimodalModel(modelName));
+        assertFalse(client.requiresMultimodalApi(modelName, EndpointType.AUTO));
+        assertEquals(
+                DashScopeHttpClient.TEXT_GENERATION_ENDPOINT,
+                client.selectEndpoint(modelName, EndpointType.AUTO));
+    }
+
     @Test
-    void testIsMultimodalModelIncludesQwen38MaxFamily() {
-        assertTrue(DashScopeHttpClient.isMultimodalModel("qwen3.8-max"));
-        assertTrue(DashScopeHttpClient.isMultimodalModel("Qwen3.8-Max"));
-        assertTrue(DashScopeHttpClient.isMultimodalModel("qwen3.8-max-2026-08-01"));
+    void testQwen38ModelNameWithExtraHyphenDoesNotMatch() {
         assertFalse(DashScopeHttpClient.isMultimodalModel("qwen-3.8-max"));
+        assertFalse(DashScopeHttpClient.isMultimodalModel("qwen-3.8-flash"));
     }
 
     @Test


### PR DESCRIPTION
## AgentScope-Java Version

2.0.3-SNAPSHOT

## Description

Fixes #2981.

With the default `EndpointType.AUTO`, `qwen3.8-flash` is not recognized as multimodal, so requests use the text-generation endpoint and simple text message formatting. Match the Qwen3.8 family to select the multimodal endpoint and content-part formatting, while explicitly preserving text-generation routing for `qwen3.8-2.4t-a95b` and its variants.

The [DashScope documentation](https://help.aliyun.com/zh/model-studio/text-generation) lists `qwen3.8-max`, `qwen3.8-flash`, and `qwen3.8-27b` as requiring the multimodal API, and `qwen3.8-2.4t-a95b` as requiring the text API. The exclusion avoids changing the latter when widening the prefix match.

Add regression coverage for model names, case and snapshot suffixes, the text-only exclusion, and the actual HTTP endpoint and message content format for streaming and non-streaming Flash requests.

### Validation

Java 17 on Windows:

```sh
mvn -pl agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-dashscope -am test -Dtest=DashScope*Test
```

- Before the fix: 6 of the 13 targeted regression cases fail, including both Flash HTTP routing cases.
- After the fix: all 13 regression cases pass. The DashScope suite reports 460 tests, 0 failures, 0 errors, and 2 existing disabled tests (458 passed).
- Spotless checks bound to compilation pass, and `git diff --check` passes.
- Tests use local mock services; no live model API was called. Broader repository results are recorded below.

### Full repository validation (local)

A subsequent run covered the repository's default Maven test scope on Windows with Java 17: **8,417 tests, 8,244 passed, 0 failures, 2 errors, and 171 skipped**. Counts were checked against both XML test cases and Maven module summaries.

```sh
mvn -B -ntp -fae -Dmaven.test.failure.ignore=true test
```

The initial 89-module reactor stalled at the examples' npm audit requests. Its completed test reports were retained, and all 28 test classes in the remaining examples were run with `-pl` / `-am` and a complete `-Dtest` class list. The retry used process-local `npm_config_fetch_timeout=15000` and `npm_config_fetch_retries=0`, retaining npm auditing. Paw, DataAgent, CodingAgent, and CopilotKit then completed successfully, including their frontend builds. Thus the results combine the root run and the remaining-example retry; the root command did not finish successfully in a single invocation.

The two errors are in the existing Core `DangerousPathBypassTest.symlinkToSshIsDetected` and `symlinkToDotEnvIsDetected` tests. Both fail during setup at `Files.createSymbolicLink` because the Windows account lacks the required privilege, before reaching their assertions. All other executed tests passed. Existing skip conditions, including disabled model E2E tests, were retained; no live model API was called.

`maven.test.failure.ignore` was used only to continue collecting test results after errors. The all-tests-passing checkbox remains unchecked.

## Checklist

- [x] Code has been formatted with `mvn spotless:apply`
- [ ] All tests are passing (`mvn test`) — 2 existing Core tests error on local Windows symlink privileges; details above
- [x] Javadoc comments are complete and follow project conventions
- [x] Related documentation has been updated (routing Javadoc)
- [x] Code is ready for review
