### PR TITLE
fix(transport): make JDK HTTP streaming non-blocking

### DIFF
--- a/agentscope-core/src/main/java/io/agentscope/core/model/transport/JdkHttpTransport.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/model/transport/JdkHttpTransport.java
@@ -15,10 +15,7 @@
  */
 package io.agentscope.core.model.transport;
 
-import java.io.BufferedReader;
 import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
 import java.net.Authenticator;
 import java.net.InetSocketAddress;
 import java.net.PasswordAuthentication;
@@ -29,6 +26,9 @@ import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpClient.Redirect;
 import java.net.http.HttpResponse.BodyHandlers;
+import java.net.http.HttpResponse.BodySubscriber;
+import java.net.http.HttpResponse.BodySubscribers;
+import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.security.KeyManagementException;
 import java.security.NoSuchAlgorithmException;
@@ -40,6 +40,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.CompletionException;
+import java.util.concurrent.Flow;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
@@ -49,6 +50,7 @@ import javax.net.ssl.X509TrustManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import reactor.core.publisher.Flux;
+import reactor.core.publisher.FluxSink;
 import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Schedulers;
 
@@ -199,36 +201,33 @@ public class JdkHttpTransport implements HttpTransport {
 
         return Flux.defer(
                 () -> {
-                    AtomicReference<InputStream> responseBody = new AtomicReference<>();
                     long requestStartNanos = System.nanoTime();
-                    return sendInputStreamAsync(jdkRequest, responseBody)
+                    return sendPublisherAsync(jdkRequest)
                             .timeout(Mono.delay(streamResponseTimeout()))
                             .flatMapMany(
                                     response ->
                                             handleStreamResponse(
-                                                    response,
-                                                    request,
-                                                    responseBody,
-                                                    requestStartNanos))
-                            .doFinally(signal -> closeQuietly(responseBody.getAndSet(null)))
+                                                    response, request, requestStartNanos))
                             .onErrorMap(this::mapStreamError);
                 });
     }
 
     /**
-     * Send a streaming request and propagate Reactor cancellation to the JDK future/socket.
+     * Send a streaming request and propagate Reactor cancellation to the JDK future/body publisher.
      */
-    private Mono<java.net.http.HttpResponse<InputStream>> sendInputStreamAsync(
-            java.net.http.HttpRequest request, AtomicReference<InputStream> responseBody) {
+    private Mono<java.net.http.HttpResponse<Flow.Publisher<List<ByteBuffer>>>> sendPublisherAsync(
+            java.net.http.HttpRequest request) {
         return Mono.create(
                 sink -> {
                     AtomicBoolean cancelled = new AtomicBoolean(false);
-                    var future = client.sendAsync(request, BodyHandlers.ofInputStream());
+                    AtomicReference<Flow.Publisher<List<ByteBuffer>>> responseBody =
+                            new AtomicReference<>();
+                    var future = client.sendAsync(request, BodyHandlers.ofPublisher());
                     sink.onCancel(
                             () -> {
                                 cancelled.set(true);
                                 future.cancel(true);
-                                closeQuietly(responseBody.getAndSet(null));
+                                cancelBodyPublisher(responseBody.getAndSet(null));
                             });
                     future.whenComplete(
                             (response, error) -> {
@@ -241,7 +240,7 @@ public class JdkHttpTransport implements HttpTransport {
 
                                 responseBody.set(response.body());
                                 if (cancelled.get()) {
-                                    closeQuietly(responseBody.getAndSet(null));
+                                    cancelBodyPublisher(responseBody.getAndSet(null));
                                     return;
                                 }
                                 sink.success(response);
@@ -253,16 +252,14 @@ public class JdkHttpTransport implements HttpTransport {
      * Validate the streaming response and apply first-chunk and inter-chunk timeouts.
      */
     private Flux<String> handleStreamResponse(
-            java.net.http.HttpResponse<InputStream> response,
+            java.net.http.HttpResponse<Flow.Publisher<List<ByteBuffer>>> response,
             HttpRequest request,
-            AtomicReference<InputStream> responseBody,
             long requestStartNanos) {
-        InputStream inputStream = response.body();
-        responseBody.set(inputStream);
+        Flow.Publisher<List<ByteBuffer>> responseBody = response.body();
 
         int statusCode = response.statusCode();
         if (statusCode < 200 || statusCode >= 300) {
-            return readInputStreamAsync(inputStream)
+            return readBodyAsString(responseBody)
                     .timeout(streamResponseTimeout())
                     .onErrorReturn("")
                     .flatMapMany(
@@ -283,7 +280,7 @@ public class JdkHttpTransport implements HttpTransport {
                             });
         }
 
-        return processStreamResponse(inputStream, request)
+        return processStreamResponse(responseBody, request)
                 .timeout(
                         // Timeout strategy 1: Time To First Chunk.
                         // This uses the remaining response timeout budget from request start.
@@ -295,10 +292,11 @@ public class JdkHttpTransport implements HttpTransport {
     }
 
     /**
-     * Parse SSE or NDJSON lines on a bounded elastic worker because BufferedReader blocks.
+     * Decode and parse SSE or NDJSON lines without blocking a worker while waiting for bytes.
      */
-    private Flux<String> processStreamResponse(InputStream inputStream, HttpRequest request) {
-        if (inputStream == null) {
+    private Flux<String> processStreamResponse(
+            Flow.Publisher<List<ByteBuffer>> responseBody, HttpRequest request) {
+        if (responseBody == null) {
             return Flux.empty();
         }
 
@@ -307,23 +305,15 @@ public class JdkHttpTransport implements HttpTransport {
                 TransportConstants.STREAM_FORMAT_NDJSON.equals(
                         request.getHeaders().get(TransportConstants.STREAM_FORMAT_HEADER));
 
-        // Use Flux.using to manage resource lifecycle
-        return Flux.using(
-                        () ->
-                                new BufferedReader(
-                                        new InputStreamReader(inputStream, StandardCharsets.UTF_8)),
-                        reader -> isNdjson ? readNdJsonLines(reader) : readSseLines(reader),
-                        this::closeQuietly)
-                // reader.lines() uses blocking I/O internally
-                .subscribeOn(Schedulers.boundedElastic());
+        Flux<String> lines = readLinesAsync(responseBody);
+        return isNdjson ? readNdJsonLines(lines) : readSseLines(lines);
     }
 
     /**
      * Extract non-empty SSE data payloads and stop before the terminal marker.
      */
-    private Flux<String> readSseLines(BufferedReader reader) {
-        return Flux.fromStream(reader.lines())
-                .filter(line -> line.startsWith(SSE_DATA_PREFIX))
+    private Flux<String> readSseLines(Flux<String> lines) {
+        return lines.filter(line -> line.startsWith(SSE_DATA_PREFIX))
                 .map(line -> line.substring(SSE_DATA_PREFIX.length()).trim())
                 .takeWhile(data -> !SSE_DONE_MARKER.equals(data))
                 .doOnNext(data -> log.debug("Received SSE data chunk"))
@@ -333,10 +323,40 @@ public class JdkHttpTransport implements HttpTransport {
     /**
      * Extract non-empty NDJSON records as already-delimited stream chunks.
      */
-    private Flux<String> readNdJsonLines(BufferedReader reader) {
-        return Flux.fromStream(reader.lines())
-                .doOnNext(line -> log.debug("Received NDJSON line"))
+    private Flux<String> readNdJsonLines(Flux<String> lines) {
+        return lines.doOnNext(line -> log.debug("Received NDJSON line"))
                 .filter(line -> !line.isEmpty());
+    }
+
+    /**
+     * Adapt the JDK response publisher to a demand-aware Flux of UTF-8 lines.
+     *
+     * <p>The JDK line subscriber owns incremental character decoding and recognizes the same line
+     * delimiters as {@link java.io.BufferedReader#readLine()}. The publishOn boundary prevents user
+     * callbacks from running on the HttpClient executor. Unlike the old blocking read, the bounded
+     * elastic worker is used only while dispatching a line and is not retained while the network is
+     * idle.
+     */
+    private Flux<String> readLinesAsync(Flow.Publisher<List<ByteBuffer>> responseBody) {
+        return Flux.<String>create(
+                        sink -> {
+                            LineSubscriber lineSubscriber = new LineSubscriber(sink);
+                            sink.onRequest(lineSubscriber::request);
+                            sink.onDispose(lineSubscriber::cancel);
+
+                            BodySubscriber<Void> bodySubscriber =
+                                    BodySubscribers.fromLineSubscriber(
+                                            lineSubscriber,
+                                            ignored -> null,
+                                            StandardCharsets.UTF_8,
+                                            null);
+                            try {
+                                responseBody.subscribe(bodySubscriber);
+                            } catch (Throwable error) {
+                                lineSubscriber.onError(error);
+                            }
+                        })
+                .publishOn(Schedulers.boundedElastic(), 1);
     }
 
     @Override
@@ -437,25 +457,38 @@ public class JdkHttpTransport implements HttpTransport {
         return builder.build();
     }
 
-    private String readInputStream(InputStream inputStream) {
-        if (inputStream == null) {
-            return null;
-        }
-        try (inputStream) {
-            return new String(inputStream.readAllBytes(), StandardCharsets.UTF_8);
-        } catch (IOException e) {
-            log.warn("Failed to read response body: {}", e.getMessage());
-            return null;
-        }
-    }
-
     /**
-     * Read an error response body away from the JDK HTTP worker threads.
+     * Decode an error response without blocking a worker thread.
      */
-    private Mono<String> readInputStreamAsync(InputStream inputStream) {
-        return Mono.fromCallable(() -> readInputStream(inputStream))
-                .defaultIfEmpty("")
-                .subscribeOn(Schedulers.boundedElastic());
+    private Mono<String> readBodyAsString(Flow.Publisher<List<ByteBuffer>> responseBody) {
+        if (responseBody == null) {
+            return Mono.just("");
+        }
+
+        return Mono.<String>create(
+                        sink -> {
+                            BodySubscriber<String> delegate =
+                                    BodySubscribers.ofString(StandardCharsets.UTF_8);
+                            TrackingBodySubscriber<String> subscriber =
+                                    new TrackingBodySubscriber<>(delegate);
+                            sink.onCancel(subscriber::cancel);
+                            delegate.getBody()
+                                    .whenComplete(
+                                            (body, error) -> {
+                                                if (error != null) {
+                                                    sink.error(error);
+                                                } else {
+                                                    sink.success(body);
+                                                }
+                                            });
+
+                            try {
+                                responseBody.subscribe(subscriber);
+                            } catch (Throwable error) {
+                                sink.error(error);
+                            }
+                        })
+                .defaultIfEmpty("");
     }
 
     /**
@@ -502,12 +535,207 @@ public class JdkHttpTransport implements HttpTransport {
         return new HttpTransportException("SSE/NDJSON stream failed: " + e.getMessage(), e);
     }
 
-    private void closeQuietly(AutoCloseable closeable) {
-        if (closeable != null) {
-            try {
-                closeable.close();
-            } catch (Exception e) {
-                log.debug("Error closing resource: {}", e.getMessage());
+    /** Cancel a response publisher that arrived after the Reactor subscriber was cancelled. */
+    private void cancelBodyPublisher(Flow.Publisher<List<ByteBuffer>> responseBody) {
+        if (responseBody == null) {
+            return;
+        }
+
+        try {
+            responseBody.subscribe(
+                    new Flow.Subscriber<List<ByteBuffer>>() {
+                        @Override
+                        public void onSubscribe(Flow.Subscription subscription) {
+                            subscription.cancel();
+                        }
+
+                        @Override
+                        public void onNext(List<ByteBuffer> item) {
+                            // Cancellation happens in onSubscribe, so no item is expected.
+                        }
+
+                        @Override
+                        public void onError(Throwable throwable) {
+                            log.debug(
+                                    "Error while cancelling streaming response body: {}",
+                                    throwable.getMessage());
+                        }
+
+                        @Override
+                        public void onComplete() {
+                            // Nothing to release after normal completion.
+                        }
+                    });
+        } catch (Throwable error) {
+            log.debug("Error while subscribing to cancel response body: {}", error.getMessage());
+        }
+    }
+
+    /** Bridge JDK line delivery and Reactor demand without unbounded buffering. */
+    private static final class LineSubscriber implements Flow.Subscriber<String> {
+
+        private final FluxSink<String> sink;
+        private Flow.Subscription subscription;
+        private long pendingDemand;
+        private volatile boolean cancelled;
+        private boolean terminated;
+
+        private LineSubscriber(FluxSink<String> sink) {
+            this.sink = sink;
+        }
+
+        @Override
+        public void onSubscribe(Flow.Subscription newSubscription) {
+            long demand;
+            synchronized (this) {
+                if (cancelled || terminated) {
+                    newSubscription.cancel();
+                    return;
+                }
+                if (subscription != null) {
+                    newSubscription.cancel();
+                    return;
+                }
+                subscription = newSubscription;
+                demand = pendingDemand;
+                pendingDemand = 0L;
+            }
+
+            if (demand > 0L) {
+                newSubscription.request(demand);
+            }
+        }
+
+        private void request(long demand) {
+            if (demand <= 0L) {
+                return;
+            }
+
+            Flow.Subscription current;
+            synchronized (this) {
+                if (cancelled || terminated) {
+                    return;
+                }
+                current = subscription;
+                if (current == null) {
+                    pendingDemand = addCap(pendingDemand, demand);
+                    return;
+                }
+            }
+            current.request(demand);
+        }
+
+        @Override
+        public void onNext(String line) {
+            if (!cancelled && !terminated && !sink.isCancelled()) {
+                sink.next(line);
+            }
+        }
+
+        @Override
+        public void onError(Throwable error) {
+            synchronized (this) {
+                if (cancelled || terminated) {
+                    return;
+                }
+                terminated = true;
+            }
+            sink.error(error);
+        }
+
+        @Override
+        public void onComplete() {
+            synchronized (this) {
+                if (cancelled || terminated) {
+                    return;
+                }
+                terminated = true;
+            }
+            sink.complete();
+        }
+
+        private void cancel() {
+            Flow.Subscription current;
+            synchronized (this) {
+                if (cancelled) {
+                    return;
+                }
+                cancelled = true;
+                current = subscription;
+                subscription = null;
+            }
+            if (current != null) {
+                current.cancel();
+            }
+        }
+
+        private static long addCap(long current, long toAdd) {
+            long result = current + toAdd;
+            return result < 0L ? Long.MAX_VALUE : result;
+        }
+    }
+
+    /** Capture the body subscription so Reactor cancellation can stop the HTTP exchange. */
+    private static final class TrackingBodySubscriber<T> implements BodySubscriber<T> {
+
+        private final BodySubscriber<T> delegate;
+        private Flow.Subscription subscription;
+        private volatile boolean cancelled;
+
+        private TrackingBodySubscriber(BodySubscriber<T> delegate) {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public java.util.concurrent.CompletionStage<T> getBody() {
+            return delegate.getBody();
+        }
+
+        @Override
+        public void onSubscribe(Flow.Subscription newSubscription) {
+            synchronized (this) {
+                if (cancelled || subscription != null) {
+                    newSubscription.cancel();
+                    return;
+                }
+                subscription = newSubscription;
+            }
+            delegate.onSubscribe(newSubscription);
+        }
+
+        @Override
+        public void onNext(List<ByteBuffer> item) {
+            if (!cancelled) {
+                delegate.onNext(item);
+            }
+        }
+
+        @Override
+        public void onError(Throwable error) {
+            if (!cancelled) {
+                delegate.onError(error);
+            }
+        }
+
+        @Override
+        public void onComplete() {
+            if (!cancelled) {
+                delegate.onComplete();
+            }
+        }
+
+        private void cancel() {
+            Flow.Subscription current;
+            synchronized (this) {
+                if (cancelled) {
+                    return;
+                }
+                cancelled = true;
+                current = subscription;
+                subscription = null;
+            }
+            if (current != null) {
+                current.cancel();
             }
         }
     }

--- a/agentscope-core/src/test/java/io/agentscope/core/model/transport/JdkHttpTransportBoundedElasticConcurrencyTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/model/transport/JdkHttpTransportBoundedElasticConcurrencyTest.java
@@ -1,0 +1,529 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.core.model.transport;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpServer;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+import reactor.core.Disposable;
+import reactor.core.publisher.Flux;
+import reactor.core.scheduler.Schedulers;
+
+/**
+ * Opt-in integration test that verifies concurrent SSE streams do not retain workers from the
+ * shared bounded elastic scheduler while waiting for network data.
+ *
+ * <p>Run this test in a fresh JVM. For example:
+ *
+ * <pre>{@code
+ * mvn -pl agentscope-core -am \
+ *   -Dtest=JdkHttpTransportBoundedElasticConcurrencyTest \
+ *   -Dagentscope.test.sse.concurrency.enabled=true \
+ *   -Dagentscope.test.sse.requests=40 \
+ *   -Dreactor.schedulers.defaultBoundedElasticSize=20 \
+ *   -Dreactor.schedulers.defaultBoundedElasticOnVirtualThreads=false \
+ *   -DforkCount=1 -DreuseForks=false test
+ * }</pre>
+ */
+@EnabledIfSystemProperty(named = "agentscope.test.sse.concurrency.enabled", matches = "true")
+class JdkHttpTransportBoundedElasticConcurrencyTest {
+
+    private static final String REQUEST_COUNT_PROPERTY = "agentscope.test.sse.requests";
+    private static final String CHUNK_COUNT_PROPERTY = "agentscope.test.sse.chunks";
+    private static final String CHUNK_INTERVAL_PROPERTY = "agentscope.test.sse.chunkIntervalMillis";
+    private static final String BOUNDED_ELASTIC_SIZE_PROPERTY =
+            "reactor.schedulers.defaultBoundedElasticSize";
+    private static final String BOUNDED_ELASTIC_VIRTUAL_THREADS_PROPERTY =
+            "reactor.schedulers.defaultBoundedElasticOnVirtualThreads";
+
+    private static final int DEFAULT_REQUEST_COUNT = 40;
+    private static final int DEFAULT_CHUNK_COUNT = 30;
+    private static final long DEFAULT_CHUNK_INTERVAL_MILLIS = 1_000L;
+    private static final long EARLY_WINDOW_MILLIS = 5_000L;
+    private static final long MAX_CANARY_DELAY_MILLIS = 2_000L;
+
+    private final AtomicInteger mockThreadId = new AtomicInteger();
+    private final AtomicInteger serverAccepted = new AtomicInteger();
+    private final AtomicInteger completedRequests = new AtomicInteger();
+    private final AtomicLong canaryDelayMillis = new AtomicLong(-1L);
+    private final AtomicReference<Throwable> clientFailure = new AtomicReference<>();
+    private final ConcurrentLinkedQueue<Throwable> serverFailures = new ConcurrentLinkedQueue<>();
+    private final Map<Integer, AtomicInteger> chunkCounts = new ConcurrentHashMap<>();
+    private final Map<Integer, Long> firstChunkTimesMillis = new ConcurrentHashMap<>();
+    private final Set<Integer> firstChunkRequests = ConcurrentHashMap.newKeySet();
+    private final Set<String> readerThreads = ConcurrentHashMap.newKeySet();
+
+    private int requestCount;
+    private int chunkCount;
+    private int boundedElasticSize;
+    private long chunkIntervalMillis;
+    private long testStartNanos;
+    private String endpoint;
+    private HttpServer server;
+    private ExecutorService modelExecutor;
+    private ScheduledExecutorService monitorExecutor;
+    private JdkHttpTransport transport;
+    private CountDownLatch acceptedLatch;
+    private CountDownLatch initialWaveLatch;
+    private CountDownLatch firstChunkLatch;
+    private CountDownLatch streamsTerminatedLatch;
+    private CountDownLatch canaryExecutedLatch;
+    private Disposable allStreams;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        requestCount = Integer.getInteger(REQUEST_COUNT_PROPERTY, DEFAULT_REQUEST_COUNT);
+        chunkCount = Integer.getInteger(CHUNK_COUNT_PROPERTY, DEFAULT_CHUNK_COUNT);
+        chunkIntervalMillis = Long.getLong(CHUNK_INTERVAL_PROPERTY, DEFAULT_CHUNK_INTERVAL_MILLIS);
+
+        assertTrue(requestCount > 0, REQUEST_COUNT_PROPERTY + " must be greater than zero");
+        assertTrue(chunkCount > 0, CHUNK_COUNT_PROPERTY + " must be greater than zero");
+        assertTrue(chunkIntervalMillis > 0, CHUNK_INTERVAL_PROPERTY + " must be greater than zero");
+
+        String configuredSize = System.getProperty(BOUNDED_ELASTIC_SIZE_PROPERTY);
+        assertFalse(
+                configuredSize == null || configuredSize.isBlank(),
+                "Run the test with -D" + BOUNDED_ELASTIC_SIZE_PROPERTY + "=<size>");
+
+        int requestedBoundedElasticSize = Integer.parseInt(configuredSize);
+        boundedElasticSize = Schedulers.DEFAULT_BOUNDED_ELASTIC_SIZE;
+        assertEquals(
+                requestedBoundedElasticSize,
+                boundedElasticSize,
+                "The boundedElastic size was initialized before the requested JVM property took"
+                        + " effect. Run this test in a fresh forked JVM.");
+        assertFalse(
+                Boolean.getBoolean(BOUNDED_ELASTIC_VIRTUAL_THREADS_PROPERTY),
+                "This experiment requires the platform-thread boundedElastic implementation");
+
+        acceptedLatch = new CountDownLatch(requestCount);
+        initialWaveLatch = new CountDownLatch(Math.min(requestCount, boundedElasticSize));
+        firstChunkLatch = new CountDownLatch(requestCount);
+        streamsTerminatedLatch = new CountDownLatch(1);
+        canaryExecutedLatch = new CountDownLatch(1);
+        testStartNanos = System.nanoTime();
+
+        startMockModelServer();
+
+        HttpTransportConfig config =
+                HttpTransportConfig.builder()
+                        .connectTimeout(Duration.ofSeconds(5))
+                        .responseTimeout(Duration.ofMinutes(2))
+                        .streamIdleTimeout(Duration.ofSeconds(5))
+                        .httpVersion(HttpVersion.HTTP_1_1)
+                        .build();
+        transport = JdkHttpTransport.builder().config(config).build();
+
+        monitorExecutor =
+                Executors.newSingleThreadScheduledExecutor(
+                        runnable -> {
+                            Thread thread = new Thread(runnable, "sse-probe-monitor");
+                            thread.setDaemon(true);
+                            return thread;
+                        });
+        monitorExecutor.scheduleAtFixedRate(this::printProgress, 0, 1, TimeUnit.SECONDS);
+
+        event(
+                "CONFIG",
+                "pid=%d requests=%d chunks=%d intervalMs=%d boundedElasticSize=%d"
+                        + " virtualThreads=%s",
+                ProcessHandle.current().pid(),
+                requestCount,
+                chunkCount,
+                chunkIntervalMillis,
+                boundedElasticSize,
+                System.getProperty(BOUNDED_ELASTIC_VIRTUAL_THREADS_PROPERTY, "false"));
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (allStreams != null) {
+            allStreams.dispose();
+        }
+        if (monitorExecutor != null) {
+            monitorExecutor.shutdownNow();
+        }
+        if (transport != null) {
+            transport.close();
+        }
+        if (server != null) {
+            server.stop(0);
+        }
+        if (modelExecutor != null) {
+            modelExecutor.shutdownNow();
+        }
+    }
+
+    @Test
+    void concurrentSseStreamsDoNotExhaustBoundedElasticCapacity() throws Exception {
+        allStreams =
+                Flux.range(1, requestCount)
+                        .flatMap(requestId -> runOneStream(requestId).then(), requestCount)
+                        .then()
+                        .subscribe(
+                                ignored -> {},
+                                error -> {
+                                    clientFailure.compareAndSet(null, error);
+                                    event(
+                                            "CLIENT_ERROR",
+                                            "type=%s message=%s",
+                                            error.getClass().getName(),
+                                            error.getMessage());
+                                    streamsTerminatedLatch.countDown();
+                                },
+                                () -> {
+                                    event(
+                                            "ALL_STREAMS_COMPLETE",
+                                            "completed=%d elapsedMs=%d",
+                                            completedRequests.get(),
+                                            elapsedMillis());
+                                    streamsTerminatedLatch.countDown();
+                                });
+
+        assertTrue(
+                acceptedLatch.await(10, TimeUnit.SECONDS),
+                () ->
+                        "The mock model accepted only "
+                                + serverAccepted.get()
+                                + " of "
+                                + requestCount
+                                + " requests");
+        assertEquals(requestCount, serverAccepted.get());
+
+        assertTrue(
+                initialWaveLatch.await(10, TimeUnit.SECONDS),
+                "The initial reader wave did not receive its first chunks");
+        enqueueBoundedElasticCanary();
+
+        // Sample between model emissions. A non-blocking implementation may briefly dispatch
+        // signals on boundedElastic, but no worker should wait inside BufferedReader.readLine().
+        Thread.sleep(Math.min(2_500L, Math.max(250L, chunkIntervalMillis / 2)));
+
+        Set<String> blockedReaders = captureBlockedReaderThreads();
+        event(
+                "THREAD_DUMP_SUMMARY",
+                "blockedReaders=%d names=%s",
+                blockedReaders.size(),
+                blockedReaders.stream().sorted().toList());
+
+        boolean allStreamsStartedInEarlyWindow =
+                firstChunkLatch.await(EARLY_WINDOW_MILLIS, TimeUnit.MILLISECONDS);
+        int firstChunksInEarlyWindow = firstChunkRequests.size();
+        event(
+                "EARLY_WINDOW",
+                "allStarted=%s firstChunks=%d expected=%d",
+                allStreamsStartedInEarlyWindow,
+                firstChunksInEarlyWindow,
+                requestCount);
+
+        long streamDurationMillis = Math.multiplyExact(chunkCount, chunkIntervalMillis);
+        long completionTimeoutMillis = Math.max(20_000L, streamDurationMillis + 20_000L);
+        assertTrue(
+                streamsTerminatedLatch.await(completionTimeoutMillis, TimeUnit.MILLISECONDS),
+                () ->
+                        "Streams did not terminate within "
+                                + completionTimeoutMillis
+                                + " ms; completed="
+                                + completedRequests.get());
+
+        assertNull(clientFailure.get(), () -> "Client stream failed: " + clientFailure.get());
+        assertTrue(serverFailures.isEmpty(), () -> "Mock model failed: " + serverFailures.peek());
+        assertEquals(requestCount, completedRequests.get());
+        assertEquals(requestCount, firstChunkTimesMillis.size());
+        chunkCounts.forEach(
+                (requestId, count) ->
+                        assertEquals(
+                                chunkCount,
+                                count.get(),
+                                () -> "Unexpected chunk count for request " + requestId));
+
+        assertTrue(
+                canaryExecutedLatch.await(5, TimeUnit.SECONDS),
+                "The boundedElastic canary never executed");
+
+        List<Long> sortedFirstChunkTimes =
+                firstChunkTimesMillis.values().stream().sorted(Comparator.naturalOrder()).toList();
+        long slowestFirstChunkMillis = sortedFirstChunkTimes.get(sortedFirstChunkTimes.size() - 1);
+        printResultSummary(sortedFirstChunkTimes, blockedReaders.size());
+
+        assertTrue(
+                allStreamsStartedInEarlyWindow,
+                () ->
+                        "Only "
+                                + firstChunksInEarlyWindow
+                                + " streams received a first chunk within the early window;"
+                                + " expected "
+                                + requestCount);
+        assertEquals(
+                0,
+                blockedReaders.size(),
+                "No boundedElastic worker should be blocked in BufferedReader.readLine()");
+        assertTrue(
+                slowestFirstChunkMillis < EARLY_WINDOW_MILLIS,
+                () ->
+                        "A stream took too long to receive its first chunk: "
+                                + slowestFirstChunkMillis
+                                + " ms");
+
+        assertTrue(
+                canaryDelayMillis.get() < MAX_CANARY_DELAY_MILLIS,
+                () ->
+                        "The scheduler canary should execute promptly but queued for "
+                                + canaryDelayMillis.get()
+                                + " ms");
+    }
+
+    private void startMockModelServer() throws IOException {
+        modelExecutor =
+                Executors.newFixedThreadPool(
+                        requestCount + 8,
+                        runnable -> {
+                            Thread thread =
+                                    new Thread(
+                                            runnable,
+                                            "mock-model-" + mockThreadId.incrementAndGet());
+                            thread.setDaemon(true);
+                            return thread;
+                        });
+
+        server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+        server.setExecutor(modelExecutor);
+        server.createContext("/v1/chat/completions", this::handleMockModelRequest);
+        server.start();
+        endpoint = "http://127.0.0.1:" + server.getAddress().getPort() + "/v1/chat/completions";
+    }
+
+    private void handleMockModelRequest(HttpExchange exchange) throws IOException {
+        String requestId = exchange.getRequestHeaders().getFirst("X-Test-Request-Id");
+        exchange.getRequestBody().readAllBytes();
+        exchange.getResponseHeaders().add("Content-Type", "text/event-stream");
+        exchange.getResponseHeaders().add("Cache-Control", "no-cache");
+        exchange.sendResponseHeaders(200, 0);
+
+        int accepted = serverAccepted.incrementAndGet();
+        acceptedLatch.countDown();
+        event(
+                "SERVER_ACCEPT",
+                "request=%s accepted=%d thread=%s",
+                requestId,
+                accepted,
+                Thread.currentThread().getName());
+
+        try (OutputStream output = exchange.getResponseBody()) {
+            for (int sequence = 1; sequence <= chunkCount; sequence++) {
+                Thread.sleep(chunkIntervalMillis);
+                String data =
+                        "data: {\"requestId\":\"" + requestId + "\",\"seq\":" + sequence + "}\n\n";
+                output.write(data.getBytes(StandardCharsets.UTF_8));
+                output.flush();
+
+                if (sequence == 1 || sequence == 10 || sequence == 20 || sequence == chunkCount) {
+                    event(
+                            "SERVER_SEND",
+                            "request=%s seq=%d elapsedMs=%d",
+                            requestId,
+                            sequence,
+                            elapsedMillis());
+                }
+            }
+            output.write("data: [DONE]\n\n".getBytes(StandardCharsets.UTF_8));
+            output.flush();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            serverFailures.add(e);
+            event("SERVER_INTERRUPTED", "request=%s", requestId);
+        } catch (IOException e) {
+            serverFailures.add(e);
+            event("SERVER_ERROR", "request=%s message=%s", requestId, e.getMessage());
+        } finally {
+            exchange.close();
+        }
+    }
+
+    private Flux<String> runOneStream(int requestId) {
+        HttpRequest request =
+                HttpRequest.builder()
+                        .url(endpoint)
+                        .method("POST")
+                        .header("Content-Type", "application/json")
+                        .header("X-Test-Request-Id", Integer.toString(requestId))
+                        .body("{\"stream\":true}")
+                        .build();
+        AtomicLong subscribedNanos = new AtomicLong();
+
+        return transport.stream(request)
+                .doOnSubscribe(
+                        ignored -> {
+                            subscribedNanos.set(System.nanoTime());
+                            event(
+                                    "CLIENT_SUBSCRIBE",
+                                    "request=%d elapsedMs=%d",
+                                    requestId,
+                                    elapsedMillis());
+                        })
+                .doOnNext(
+                        data -> {
+                            int received =
+                                    chunkCounts
+                                            .computeIfAbsent(
+                                                    requestId, ignored -> new AtomicInteger())
+                                            .incrementAndGet();
+                            String threadName = Thread.currentThread().getName();
+                            readerThreads.add(threadName);
+
+                            if (received == 1 && firstChunkRequests.add(requestId)) {
+                                initialWaveLatch.countDown();
+                                long firstChunkMillis =
+                                        TimeUnit.NANOSECONDS.toMillis(
+                                                System.nanoTime() - subscribedNanos.get());
+                                firstChunkTimesMillis.put(requestId, firstChunkMillis);
+                                firstChunkLatch.countDown();
+                                event(
+                                        "CLIENT_FIRST_CHUNK",
+                                        "request=%d firstChunkMs=%d thread=%s data=%s",
+                                        requestId,
+                                        firstChunkMillis,
+                                        threadName,
+                                        data);
+                            }
+                        })
+                .doOnComplete(
+                        () -> {
+                            int completed = completedRequests.incrementAndGet();
+                            int received =
+                                    chunkCounts.getOrDefault(requestId, new AtomicInteger()).get();
+                            event(
+                                    "CLIENT_COMPLETE",
+                                    "request=%d chunks=%d completed=%d elapsedMs=%d",
+                                    requestId,
+                                    received,
+                                    completed,
+                                    elapsedMillis());
+                        });
+    }
+
+    private void enqueueBoundedElasticCanary() {
+        long enqueuedNanos = System.nanoTime();
+        event("CANARY_ENQUEUE", "elapsedMs=%d", elapsedMillis());
+        Schedulers.boundedElastic()
+                .schedule(
+                        () -> {
+                            long delayMillis =
+                                    TimeUnit.NANOSECONDS.toMillis(
+                                            System.nanoTime() - enqueuedNanos);
+                            canaryDelayMillis.set(delayMillis);
+                            event(
+                                    "CANARY_EXECUTE",
+                                    "queueDelayMs=%d thread=%s",
+                                    delayMillis,
+                                    Thread.currentThread().getName());
+                            canaryExecutedLatch.countDown();
+                        });
+    }
+
+    private Set<String> captureBlockedReaderThreads() throws InterruptedException {
+        Set<String> blockedReaders = ConcurrentHashMap.newKeySet();
+
+        // A few samples avoid landing exactly in the small window where a worker is delivering a
+        // chunk downstream instead of waiting for the next BufferedReader.readLine() call.
+        for (int sample = 0; sample < 10; sample++) {
+            Thread.getAllStackTraces()
+                    .forEach(
+                            (thread, stack) -> {
+                                if (thread.getName().startsWith("boundedElastic-")
+                                        && containsBufferedReaderRead(stack)) {
+                                    blockedReaders.add(thread.getName());
+                                }
+                            });
+            Thread.sleep(50L);
+        }
+        return blockedReaders;
+    }
+
+    private boolean containsBufferedReaderRead(StackTraceElement[] stack) {
+        return Arrays.stream(stack)
+                .anyMatch(
+                        frame ->
+                                frame.getClassName().equals("java.io.BufferedReader")
+                                        && frame.getMethodName().startsWith("readLine"));
+    }
+
+    private void printProgress() {
+        event(
+                "MONITOR",
+                "accepted=%d firstChunks=%d completed=%d readerThreads=%d",
+                serverAccepted.get(),
+                firstChunkRequests.size(),
+                completedRequests.get(),
+                readerThreads.size());
+    }
+
+    private void printResultSummary(List<Long> sortedFirstChunkTimes, int blockedReaderCount) {
+        long fastest = sortedFirstChunkTimes.get(0);
+        long slowest = sortedFirstChunkTimes.get(sortedFirstChunkTimes.size() - 1);
+
+        event(
+                "RESULT",
+                "pool=%d requests=%d fastestFirstChunkMs=%d slowestFirstChunkMs=%d "
+                        + "canaryDelayMs=%d signalThreads=%d blockedReaders=%d",
+                boundedElasticSize,
+                requestCount,
+                fastest,
+                slowest,
+                canaryDelayMillis.get(),
+                readerThreads.size(),
+                blockedReaderCount);
+    }
+
+    private long elapsedMillis() {
+        return TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - testStartNanos);
+    }
+
+    private synchronized void event(String type, String format, Object... arguments) {
+        String message = String.format(Locale.ROOT, format, arguments);
+        System.out.printf(
+                Locale.ROOT, "[SSE-PROBE][%6dms][%-19s] %s%n", elapsedMillis(), type, message);
+    }
+}

--- a/agentscope-core/src/test/java/io/agentscope/core/model/transport/JdkHttpTransportTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/model/transport/JdkHttpTransportTest.java
@@ -22,8 +22,6 @@ import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.io.IOException;
-import java.io.InputStream;
 import java.net.Authenticator;
 import java.net.CookieHandler;
 import java.net.ProxySelector;
@@ -31,6 +29,7 @@ import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpClient.Redirect;
 import java.net.http.HttpClient.Version;
+import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.ArrayList;
@@ -40,6 +39,7 @@ import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executor;
+import java.util.concurrent.Flow;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -251,6 +251,130 @@ class JdkHttpTransportTest {
         StepVerifier.create(transport.stream(request))
                 .expectNextMatches(data -> data.contains("\"id\":\"1\""))
                 .verifyComplete();
+    }
+
+    @Test
+    void testStreamDecodesUtf8AndLineEndingsAcrossByteBuffersWithBackpressure() {
+        HttpTransportConfig customConfig =
+                HttpTransportConfig.builder()
+                        .responseTimeout(Duration.ofSeconds(2))
+                        .streamIdleTimeout(Duration.ofSeconds(2))
+                        .build();
+        AtomicReference<
+                        CompletableFuture<
+                                java.net.http.HttpResponse<Flow.Publisher<List<ByteBuffer>>>>>
+                futureRef = new AtomicReference<>();
+        JdkHttpTransport customTransport =
+                new JdkHttpTransport(new DeferredBodyHttpClient(futureRef), customConfig);
+
+        byte[] body =
+                "data: \u4F60\u597D\uD83C\uDF0D\r\n\r\ndata: second\ndata: [DONE]\r\n"
+                        .getBytes(StandardCharsets.UTF_8);
+        List<ByteBuffer> oneByteBuffers = new ArrayList<>(body.length);
+        for (byte value : body) {
+            oneByteBuffers.add(ByteBuffer.wrap(new byte[] {value}));
+        }
+        SingleItemBodyPublisher publisher = new SingleItemBodyPublisher(oneByteBuffers);
+
+        HttpRequest request =
+                HttpRequest.builder()
+                        .url("http://localhost/split-utf8-body")
+                        .method("POST")
+                        .body("{}")
+                        .build();
+
+        try {
+            StepVerifier.create(customTransport.stream(request), 0)
+                    .then(() -> futureRef.get().complete(new TestHttpResponse(200, publisher)))
+                    .expectNoEvent(Duration.ofMillis(50))
+                    .thenRequest(1)
+                    .expectNext("\u4F60\u597D\uD83C\uDF0D")
+                    .thenRequest(1)
+                    .expectNext("second")
+                    // Allow the parser to consume the non-emitted [DONE] marker.
+                    .thenRequest(1)
+                    .verifyComplete();
+        } finally {
+            customTransport.close();
+        }
+    }
+
+    @Test
+    void testStreamCancelsResponseBodyAfterDoneMarker() {
+        HttpTransportConfig customConfig =
+                HttpTransportConfig.builder()
+                        .responseTimeout(Duration.ofSeconds(2))
+                        .streamIdleTimeout(Duration.ofSeconds(2))
+                        .build();
+        AtomicReference<
+                        CompletableFuture<
+                                java.net.http.HttpResponse<Flow.Publisher<List<ByteBuffer>>>>>
+                futureRef = new AtomicReference<>();
+        JdkHttpTransport customTransport =
+                new JdkHttpTransport(new DeferredBodyHttpClient(futureRef), customConfig);
+        HoldingBodyPublisher publisher =
+                new HoldingBodyPublisher(
+                        List.of(
+                                ByteBuffer.wrap(
+                                        "data: first\n\ndata: [DONE]\n\n"
+                                                .getBytes(StandardCharsets.UTF_8))));
+
+        HttpRequest request =
+                HttpRequest.builder()
+                        .url("http://localhost/holding-body")
+                        .method("POST")
+                        .body("{}")
+                        .build();
+
+        try {
+            StepVerifier.create(customTransport.stream(request))
+                    .then(() -> futureRef.get().complete(new TestHttpResponse(200, publisher)))
+                    .expectNext("first")
+                    .verifyComplete();
+            assertTrue(
+                    publisher.awaitCancelled(),
+                    "The response body must be cancelled after the terminal marker");
+        } finally {
+            customTransport.close();
+        }
+    }
+
+    @Test
+    void testStreamFirstChunkTimeoutCancelsSubscribedResponseBody() {
+        HttpTransportConfig customConfig =
+                HttpTransportConfig.builder()
+                        .responseTimeout(Duration.ofMillis(100))
+                        .streamIdleTimeout(Duration.ofSeconds(1))
+                        .build();
+        AtomicReference<
+                        CompletableFuture<
+                                java.net.http.HttpResponse<Flow.Publisher<List<ByteBuffer>>>>>
+                futureRef = new AtomicReference<>();
+        JdkHttpTransport customTransport =
+                new JdkHttpTransport(new DeferredBodyHttpClient(futureRef), customConfig);
+        HoldingBodyPublisher publisher = new HoldingBodyPublisher(List.of());
+
+        HttpRequest request =
+                HttpRequest.builder()
+                        .url("http://localhost/silent-body")
+                        .method("POST")
+                        .body("{}")
+                        .build();
+
+        try {
+            StepVerifier.create(customTransport.stream(request))
+                    .then(() -> futureRef.get().complete(new TestHttpResponse(200, publisher)))
+                    .expectErrorMatches(
+                            error ->
+                                    error instanceof HttpTransportException
+                                            && error.getMessage().contains("Stream timeout"))
+                    .verify(Duration.ofSeconds(2));
+            assertTrue(
+                    publisher.awaitCancelled(),
+                    "The response body must be cancelled after the first-chunk timeout");
+        } finally {
+            customTransport.close();
+        }
     }
 
     @Test
@@ -1182,17 +1306,19 @@ class JdkHttpTransportTest {
     }
 
     @Test
-    void testStreamTimeoutClosesBodyWhenFutureCompletesAfterCancellation() {
+    void testStreamTimeoutCancelsBodyWhenFutureCompletesAfterCancellation() {
         HttpTransportConfig customConfig =
                 HttpTransportConfig.builder()
                         .responseTimeout(Duration.ofMillis(100))
                         .streamIdleTimeout(Duration.ofSeconds(1))
                         .build();
-        BlockingInputStream body = new BlockingInputStream();
-        AtomicReference<CompletableFuture<java.net.http.HttpResponse<InputStream>>> futureRef =
-                new AtomicReference<>();
+        CancellableBodyPublisher body = new CancellableBodyPublisher();
+        AtomicReference<
+                        CompletableFuture<
+                                java.net.http.HttpResponse<Flow.Publisher<List<ByteBuffer>>>>>
+                futureRef = new AtomicReference<>();
         JdkHttpTransport customTransport =
-                new JdkHttpTransport(new DeferredBodyHttpClient(futureRef, body), customConfig);
+                new JdkHttpTransport(new DeferredBodyHttpClient(futureRef), customConfig);
 
         try {
             HttpRequest request =
@@ -1209,12 +1335,14 @@ class JdkHttpTransportTest {
                                             && e.getMessage().contains("Stream timeout"))
                     .verify(Duration.ofSeconds(2));
 
-            CompletableFuture<java.net.http.HttpResponse<InputStream>> future = futureRef.get();
+            CompletableFuture<java.net.http.HttpResponse<Flow.Publisher<List<ByteBuffer>>>> future =
+                    futureRef.get();
             assertNotNull(future);
             assertTrue(future.isCancelled(), "Timeout should cancel the pending async request");
 
             future.complete(new TestHttpResponse(200, body));
-            assertTrue(body.awaitClosed(), "Response body must be closed after late completion");
+            assertTrue(
+                    body.awaitCancelled(), "Response body must be cancelled after late completion");
         } finally {
             customTransport.close();
         }
@@ -1254,16 +1382,18 @@ class JdkHttpTransportTest {
     }
 
     private static class DeferredBodyHttpClient extends HttpClient {
-        private final AtomicReference<CompletableFuture<java.net.http.HttpResponse<InputStream>>>
+        private final AtomicReference<
+                        CompletableFuture<
+                                java.net.http.HttpResponse<Flow.Publisher<List<ByteBuffer>>>>>
                 futureRef;
-        private final InputStream body;
 
         DeferredBodyHttpClient(
-                AtomicReference<CompletableFuture<java.net.http.HttpResponse<InputStream>>>
-                        futureRef,
-                InputStream body) {
+                AtomicReference<
+                                CompletableFuture<
+                                        java.net.http.HttpResponse<
+                                                Flow.Publisher<List<ByteBuffer>>>>>
+                        futureRef) {
             this.futureRef = futureRef;
-            this.body = body;
         }
 
         @Override
@@ -1325,7 +1455,8 @@ class JdkHttpTransportTest {
                 java.net.http.HttpResponse.BodyHandler<T> responseBodyHandler) {
             CompletableFuture<java.net.http.HttpResponse<T>> future = new LateCompletableFuture<>();
             futureRef.set(
-                    (CompletableFuture<java.net.http.HttpResponse<InputStream>>)
+                    (CompletableFuture<
+                                    java.net.http.HttpResponse<Flow.Publisher<List<ByteBuffer>>>>)
                             (CompletableFuture<?>) future);
             return future;
         }
@@ -1354,11 +1485,12 @@ class JdkHttpTransportTest {
         }
     }
 
-    private static class TestHttpResponse implements java.net.http.HttpResponse<InputStream> {
+    private static class TestHttpResponse
+            implements java.net.http.HttpResponse<Flow.Publisher<List<ByteBuffer>>> {
         private final int statusCode;
-        private final InputStream body;
+        private final Flow.Publisher<List<ByteBuffer>> body;
 
-        TestHttpResponse(int statusCode, InputStream body) {
+        TestHttpResponse(int statusCode, Flow.Publisher<List<ByteBuffer>> body) {
             this.statusCode = statusCode;
             this.body = body;
         }
@@ -1374,7 +1506,8 @@ class JdkHttpTransportTest {
         }
 
         @Override
-        public Optional<java.net.http.HttpResponse<InputStream>> previousResponse() {
+        public Optional<java.net.http.HttpResponse<Flow.Publisher<List<ByteBuffer>>>>
+                previousResponse() {
             return Optional.empty();
         }
 
@@ -1384,7 +1517,7 @@ class JdkHttpTransportTest {
         }
 
         @Override
-        public InputStream body() {
+        public Flow.Publisher<List<ByteBuffer>> body() {
             return body;
         }
 
@@ -1404,28 +1537,99 @@ class JdkHttpTransportTest {
         }
     }
 
-    private static class BlockingInputStream extends InputStream {
-        private final CountDownLatch closed = new CountDownLatch(1);
+    private static class CancellableBodyPublisher implements Flow.Publisher<List<ByteBuffer>> {
+        private final CountDownLatch cancelled = new CountDownLatch(1);
 
         @Override
-        public int read() {
-            return -1;
+        public void subscribe(Flow.Subscriber<? super List<ByteBuffer>> subscriber) {
+            subscriber.onSubscribe(
+                    new Flow.Subscription() {
+                        @Override
+                        public void request(long count) {
+                            // This publisher exists only to verify cancellation.
+                        }
+
+                        @Override
+                        public void cancel() {
+                            cancelled.countDown();
+                        }
+                    });
         }
 
-        @Override
-        public byte[] readAllBytes() {
-            return "closed".getBytes(StandardCharsets.UTF_8);
-        }
-
-        @Override
-        public void close() throws IOException {
-            closed.countDown();
-            super.close();
-        }
-
-        boolean awaitClosed() {
+        boolean awaitCancelled() {
             try {
-                return closed.await(1, TimeUnit.SECONDS);
+                return cancelled.await(1, TimeUnit.SECONDS);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                return false;
+            }
+        }
+    }
+
+    private static class SingleItemBodyPublisher implements Flow.Publisher<List<ByteBuffer>> {
+        private final List<ByteBuffer> buffers;
+
+        private SingleItemBodyPublisher(List<ByteBuffer> buffers) {
+            this.buffers = buffers;
+        }
+
+        @Override
+        public void subscribe(Flow.Subscriber<? super List<ByteBuffer>> subscriber) {
+            subscriber.onSubscribe(
+                    new Flow.Subscription() {
+                        private final AtomicBoolean emitted = new AtomicBoolean(false);
+                        private final AtomicBoolean cancelled = new AtomicBoolean(false);
+
+                        @Override
+                        public void request(long count) {
+                            if (count <= 0L || !emitted.compareAndSet(false, true)) {
+                                return;
+                            }
+                            subscriber.onNext(buffers);
+                            if (!cancelled.get()) {
+                                subscriber.onComplete();
+                            }
+                        }
+
+                        @Override
+                        public void cancel() {
+                            cancelled.set(true);
+                        }
+                    });
+        }
+    }
+
+    private static class HoldingBodyPublisher implements Flow.Publisher<List<ByteBuffer>> {
+        private final List<ByteBuffer> buffers;
+        private final CountDownLatch cancelled = new CountDownLatch(1);
+
+        private HoldingBodyPublisher(List<ByteBuffer> buffers) {
+            this.buffers = buffers;
+        }
+
+        @Override
+        public void subscribe(Flow.Subscriber<? super List<ByteBuffer>> subscriber) {
+            subscriber.onSubscribe(
+                    new Flow.Subscription() {
+                        private final AtomicBoolean emitted = new AtomicBoolean(false);
+
+                        @Override
+                        public void request(long count) {
+                            if (count > 0L && emitted.compareAndSet(false, true)) {
+                                subscriber.onNext(buffers);
+                            }
+                        }
+
+                        @Override
+                        public void cancel() {
+                            cancelled.countDown();
+                        }
+                    });
+        }
+
+        boolean awaitCancelled() {
+            try {
+                return cancelled.await(1, TimeUnit.SECONDS);
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
                 return false;


### PR DESCRIPTION
## AgentScope-Java Version

2.0.3-SNAPSHOT

## Description

Closes #2991.

`JdkHttpTransport` previously parsed SSE/NDJSON with a blocking `BufferedReader` scheduled on the
shared boundedElastic pool. Every slow stream retained one worker while waiting for the next
network chunk, delaying additional streams and unrelated boundedElastic tasks.

This change:

- receives streaming bodies with `BodyHandlers.ofPublisher()`;
- incrementally decodes UTF-8 lines with `BodySubscribers.fromLineSubscriber(...)`;
- bridges JDK Flow demand and cancellation to Reactor without unbounded request demand;
- retains the boundedElastic downstream signal boundary without blocking it on network reads;
- reads non-2xx bodies asynchronously;
- preserves SSE, NDJSON, timeout, error mapping, and synchronous request behavior; and
- adds no dependency or public API change.

The opt-in mock-model test sends 30 chunks at one-second intervals to 40 concurrent requests.

## Reproduction and verification

The standalone
[reproduction test](https://github.com/LeePui/agentscope-java/blob/codex/test-jdk-http-bounded-elastic/agentscope-core/src/test/java/io/agentscope/core/model/transport/JdkHttpTransportBoundedElasticConcurrencyTest.java)
is published in `LeePui/agentscope-java`, branch `codex/test-jdk-http-bounded-elastic`:

```bash
git clone --single-branch \
  --branch codex/test-jdk-http-bounded-elastic \
  https://github.com/LeePui/agentscope-java.git \
  agentscope-java-jdk-http-repro
cd agentscope-java-jdk-http-repro

mvn -pl agentscope-core \
  -Dtest=JdkHttpTransportBoundedElasticConcurrencyTest \
  -Dagentscope.test.sse.concurrency.enabled=true \
  -Dagentscope.test.sse.requests=40 \
  -Dagentscope.test.sse.chunks=30 \
  -Dagentscope.test.sse.chunkIntervalMillis=1000 \
  -Dreactor.schedulers.defaultBoundedElasticSize=20 \
  -Dreactor.schedulers.defaultBoundedElasticOnVirtualThreads=false \
  -DforkCount=1 -DreuseForks=false test
```

This branch is expected to report scheduler starvation and fail its assertion after printing the
result. The fixed implementation can be checked independently from branch
`codex/perf-jdk-http-async-streaming`:

```bash
cd ..
git clone --single-branch \
  --branch codex/perf-jdk-http-async-streaming \
  https://github.com/LeePui/agentscope-java.git \
  agentscope-java-jdk-http-fixed
cd agentscope-java-jdk-http-fixed

mvn -pl agentscope-core \
  -Dtest=JdkHttpTransportBoundedElasticConcurrencyTest \
  -Dagentscope.test.sse.concurrency.enabled=true \
  -Dagentscope.test.sse.requests=40 \
  -Dagentscope.test.sse.chunks=30 \
  -Dagentscope.test.sse.chunkIntervalMillis=1000 \
  -Dreactor.schedulers.defaultBoundedElasticSize=20 \
  -Dreactor.schedulers.defaultBoundedElasticOnVirtualThreads=false \
  -DforkCount=1 -DreuseForks=false test
```

The fixed branch should complete with `BUILD SUCCESS`, with all 40 streams receiving their first
chunk in the early window, zero blocked readers, and prompt canary execution.

Before, with a boundedElastic size of 20:

```text
pool=20 requests=40 slowestFirstChunkMs=30182 canaryDelayMs=29076 blockedReaders=20
```

After:

```text
pool=20 requests=40 slowestFirstChunkMs=1116 canaryDelayMs=1 blockedReaders=0
```

The 40-worker control changed from 40 blocked readers and a 29-second canary delay to zero blocked
readers and immediate canary execution.

Tests cover split UTF-8 byte buffers, CRLF/LF decoding, backpressure, `[DONE]` cancellation,
first-chunk timeout cancellation, late responses, SSE/NDJSON regression, and OpenAI/Ollama model
streaming integration.

## Local validation

Validated on Oracle JDK 25.0.3 with Java sources compiled for `--release 17`:

- `agentscope-core` verification: 2,318 tests, 0 failures, 0 errors, 10 skipped;
- OpenAI model extension: 555 tests, 0 failures, 0 errors, 11 skipped;
- Ollama model extension: 164 tests, 0 failures, 0 errors, 1 skipped;
- Spotless, JaCoCo, JAR, sources, test-JAR, Javadoc, shade/BOM consistency, and
  `git diff --check` all passed.

The repository CI is expected to run the full module and JDK matrix.

## Checklist

Please check the following items before code is ready to be reviewed.

- [x]  Code has been formatted with `mvn spotless:apply`
- [ ]  All tests are passing (`mvn test`) — affected modules pass locally; full repository CI is
  pending
- [x]  Javadoc comments are complete and follow project conventions
- [x]  Related documentation has been updated (not applicable: no user-facing API or configuration
  changes)
- [x]  Code is ready for review