### PR TITLE
fix(harness): isolate memory flush and maintenance throttles

### DIFF
--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/coordination/PeriodicGate.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/coordination/PeriodicGate.java
@@ -28,7 +28,8 @@ public interface PeriodicGate {
     /**
      * Attempts to claim the named periodic slot.
      *
-     * @param name logical slot identifier (e.g. {@code "USER:alice"} or {@code "skill-curator"})
+     * @param name logical slot identifier (e.g. {@code "memory-flush:USER:alice"} or
+     *     {@code "skill-curator"})
      * @param minGap minimum elapsed time since the last successful claim
      * @return {@code true} if the caller won the claim and may proceed, {@code false} otherwise
      */

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/memory/MemoryConfig.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/memory/MemoryConfig.java
@@ -42,6 +42,10 @@ import java.util.Objects;
  *       configure via {@code .compaction(CompactionConfig...)} rather than here.</li>
  * </ol>
  *
+ * <p>Flush and consolidation use independent throttle windows. A throttled policy allows the
+ * first eligible call immediately; its minimum gap applies only between subsequent runs and is
+ * not an initial delay. {@link FlushTrigger#never()} disables only the per-call flush.
+ *
  * <p>All fields have sensible defaults; {@link #defaults()} returns a config equivalent
  * to the harness's historical behavior so adopting this class is a no-op upgrade.
  */
@@ -71,6 +75,10 @@ public final class MemoryConfig {
 
     /**
      * Trigger policy for {@link io.agentscope.harness.agent.middleware.MemoryFlushMiddleware}.
+     *
+     * <p>A throttled trigger allows the first eligible call immediately. Its minimum gap is
+     * measured between subsequent per-call flushes, independently of consolidation maintenance.
+     * {@link #never()} disables only this per-call flush path.
      *
      * <p>{@code throttled(Duration.ZERO)} normalises to {@link #always()} so callers do not
      * need a special branch for the degenerate case.
@@ -190,6 +198,11 @@ public final class MemoryConfig {
         return consolidationMaxTokens;
     }
 
+    /**
+     * Minimum gap between consolidation/maintenance runs. The first eligible call runs
+     * immediately; this duration is not an initial delay and is independent of
+     * {@link #flushTrigger()}.
+     */
     public Duration consolidationMinGap() {
         return consolidationMinGap;
     }
@@ -290,7 +303,11 @@ public final class MemoryConfig {
             return this;
         }
 
-        /** Minimum gap between two consolidation/maintenance runs. Must not be null. */
+        /**
+         * Minimum gap between consolidation/maintenance runs. The first eligible call runs
+         * immediately; this duration is not an initial delay and is independent of
+         * {@link MemoryConfig#flushTrigger()}. Must not be null.
+         */
         public Builder consolidationMinGap(Duration consolidationMinGap) {
             if (consolidationMinGap == null) {
                 throw new IllegalArgumentException("consolidationMinGap must not be null");

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/middleware/MemoryFlushMiddleware.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/middleware/MemoryFlushMiddleware.java
@@ -303,12 +303,12 @@ public class MemoryFlushMiddleware implements HarnessRuntimeMiddleware {
 
     /**
      * Builds a composite key from {@link IsolationScope} name and the per-call identity returned
-     * by {@link #timerKeyFor(RuntimeContext)}. The scope prefix ensures that throttle windows
-     * from different isolation dimensions are never conflated — e.g. a {@code userId} that
-     * happens to equal a {@code sessionId} must not share a slot.
+     * by {@link #timerKeyFor(RuntimeContext)}. The operation prefix keeps flush independent
+     * of maintenance when both use the same {@link PeriodicGate}. The scope prefix keeps
+     * different isolation dimensions from sharing a slot.
      */
     private String compositeTimerKey(RuntimeContext rc) {
-        return isolationScope.name() + ":" + timerKeyFor(rc);
+        return "memory-flush:" + isolationScope.name() + ":" + timerKeyFor(rc);
     }
 
     /** The conversation a queued flush reads when it executes: agent instance, user, session. */

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/middleware/MemoryMaintenanceMiddleware.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/middleware/MemoryMaintenanceMiddleware.java
@@ -173,11 +173,12 @@ public class MemoryMaintenanceMiddleware implements HarnessRuntimeMiddleware {
 
     /**
      * Builds a composite key from {@link IsolationScope} name and the per-call identity returned
-     * by {@link #timerKeyFor(RuntimeContext)}. The scope prefix ensures that throttle windows
-     * from different isolation dimensions are never conflated.
+     * by {@link #timerKeyFor(RuntimeContext)}. The operation prefix keeps maintenance independent
+     * of flush when both use the same {@link PeriodicGate}. The scope prefix keeps different
+     * isolation dimensions from sharing a slot.
      */
     private String compositeTimerKey(RuntimeContext rc) {
-        return isolationScope.name() + ":" + timerKeyFor(rc);
+        return "memory-maintenance:" + isolationScope.name() + ":" + timerKeyFor(rc);
     }
 
     /**

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/middleware/MemoryMiddlewareThrottleIsolationTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/middleware/MemoryMiddlewareThrottleIsolationTest.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.harness.agent.middleware;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.agentscope.core.agent.RuntimeContext;
+import io.agentscope.core.event.AgentEndEvent;
+import io.agentscope.core.middleware.AgentInput;
+import io.agentscope.harness.agent.IsolationScope;
+import io.agentscope.harness.agent.coordination.LocalPeriodicGate;
+import io.agentscope.harness.agent.coordination.PeriodicGate;
+import io.agentscope.harness.agent.coordination.StoreBackedPeriodicGate;
+import io.agentscope.harness.agent.filesystem.remote.store.InMemoryStore;
+import io.agentscope.harness.agent.memory.MemoryBackgroundTasks;
+import io.agentscope.harness.agent.memory.MemoryConfig;
+import io.agentscope.harness.agent.memory.MemoryConsolidator;
+import io.agentscope.harness.agent.workspace.WorkspaceManager;
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+/** Flush and maintenance must retain independent windows when sharing a periodic gate. */
+class MemoryMiddlewareThrottleIsolationTest {
+
+    private static final RuntimeContext RC =
+            RuntimeContext.builder().userId("alice").sessionId("session-1").build();
+
+    @BeforeEach
+    void resetLocalGate() {
+        LocalPeriodicGate.clearForTests();
+    }
+
+    @AfterEach
+    void awaitBackgroundTasks() {
+        assertTrue(MemoryBackgroundTasks.awaitQuiescence(5, TimeUnit.SECONDS));
+        LocalPeriodicGate.clearForTests();
+    }
+
+    static Stream<Arguments> gateConfigurations() {
+        return Stream.of(false, true)
+                .flatMap(
+                        storeBacked ->
+                                Arrays.stream(IsolationScope.values())
+                                        .flatMap(
+                                                scope ->
+                                                        Stream.of(false, true)
+                                                                .map(
+                                                                        maintenanceFirst ->
+                                                                                Arguments.of(
+                                                                                        storeBacked,
+                                                                                        scope,
+                                                                                        maintenanceFirst))));
+    }
+
+    @ParameterizedTest
+    @MethodSource("gateConfigurations")
+    void flushAndMaintenanceHaveIndependentWindows(
+            boolean storeBacked, IsolationScope scope, boolean maintenanceFirst) {
+        PeriodicGate gate =
+                storeBacked
+                        ? new StoreBackedPeriodicGate(new InMemoryStore())
+                        : new LocalPeriodicGate();
+        WorkspaceManager workspace = mock(WorkspaceManager.class);
+        MemoryConsolidator consolidator = mock(MemoryConsolidator.class);
+        when(consolidator.consolidate(RC)).thenReturn(Mono.empty());
+        MemoryFlushMiddleware flush = flush(scope, gate);
+        MemoryMaintenanceMiddleware maintenance = maintenance(workspace, consolidator, scope, gate);
+
+        if (maintenanceFirst) {
+            runMaintenance(maintenance);
+            verify(consolidator).consolidate(RC);
+            assertTrue(
+                    flush.shouldFlushNow(RC), "maintenance must not consume the first flush slot");
+        } else {
+            assertTrue(flush.shouldFlushNow(RC));
+            runMaintenance(maintenance);
+            verify(consolidator).consolidate(RC);
+        }
+
+        assertFalse(flush.shouldFlushNow(RC), "repeated flush must respect its own gap");
+        runMaintenance(maintenance);
+        verify(consolidator, times(1)).consolidate(RC);
+
+        // Rebuilding middleware must preserve both windows for the same isolation key.
+        assertFalse(flush(scope, gate).shouldFlushNow(RC));
+        runMaintenance(maintenance(workspace, consolidator, scope, gate));
+        verify(consolidator, times(1)).consolidate(RC);
+    }
+
+    private static MemoryFlushMiddleware flush(IsolationScope scope, PeriodicGate gate) {
+        return new MemoryFlushMiddleware(
+                null,
+                null,
+                null,
+                MemoryConfig.FlushTrigger.throttled(Duration.ofHours(1)),
+                scope,
+                gate);
+    }
+
+    private static MemoryMaintenanceMiddleware maintenance(
+            WorkspaceManager workspace,
+            MemoryConsolidator consolidator,
+            IsolationScope scope,
+            PeriodicGate gate) {
+        return new MemoryMaintenanceMiddleware(
+                workspace, consolidator, 90, 180, Duration.ofHours(24), scope, gate);
+    }
+
+    private static void runMaintenance(MemoryMaintenanceMiddleware middleware) {
+        middleware
+                .onAgent(
+                        null,
+                        RC,
+                        new AgentInput(List.of()),
+                        input -> Flux.just(new AgentEndEvent("reply-1")))
+                .collectList()
+                .block(Duration.ofSeconds(5));
+        assertTrue(
+                MemoryBackgroundTasks.awaitQuiescence(5, TimeUnit.SECONDS),
+                "maintenance must finish before verifying consolidation");
+    }
+}

--- a/docs/v2/en/docs/harness/memory.md
+++ b/docs/v2/en/docs/harness/memory.md
@@ -107,6 +107,8 @@ CompactionConfig.builder()
 
 `MemoryConfig` is the single place to configure flush / consolidation prompts, throttling, retention, and the per-call flush trigger. Every field has a default; not calling `.memory(...)` reproduces the historical behaviour bit-for-bit.
 
+Per-call flush and background consolidation have independent throttle windows. In both cases, the first eligible `call()` runs the work immediately; a minimum gap limits only subsequent runs and is not an initial delay.
+
 ### Example 1: throttle per-call flush to save tokens
 
 A flush LLM call after every agent invocation can add up on long sessions. Throttle it to at most once every 10 minutes:
@@ -123,6 +125,7 @@ HarnessAgent.builder()
 Notes:
 
 - `THROTTLED` only affects **path 1** (per-call flush). The flush embedded in compaction (path 2) and the overflow flush (path 3) still fire on their own triggers — compaction is rare, so those two are infrequent by construction.
+- The first eligible call flushes immediately; `Duration.ofMinutes(10)` limits only later per-call flushes.
 - **Offload is unaffected**, the session JSONL is still written in full every call. `session_search` and session resumption keep working.
 
 ### Example 2: disable per-call flush entirely
@@ -168,7 +171,7 @@ Now flush only happens when compaction does (same cost as raw compaction).
 
 ```java
 .memory(MemoryConfig.builder()
-    .consolidationMinGap(Duration.ofHours(2))   // background merge at most every 2h
+    .consolidationMinGap(Duration.ofHours(2))   // first call may run; later runs at least 2h apart
     .dailyFileRetentionDays(30)                 // archive daily logs after 30 days
     .sessionRetentionDays(60)                   // prune session JSONL after 60 days
     .consolidationMaxTokens(8_000)              // raise MEMORY.md cap to 8K tokens
@@ -201,7 +204,7 @@ HarnessAgent.builder()
 | `flushPrompt` | `null` (uses `DEFAULT_FLUSH_PROMPT`) | SYSTEM prompt for path 1 |
 | `consolidationPrompt` | `null` (uses `DEFAULT_CONSOLIDATION_PROMPT`) | Template for path 2 (must contain two `%d`) |
 | `consolidationMaxTokens` | `4_000` | Token cap for `MEMORY.md` |
-| `consolidationMinGap` | `30 min` | Throttle gap for background maintenance |
+| `consolidationMinGap` | `30 min` | Gap between background maintenance runs; the first eligible call runs immediately |
 | `dailyFileRetentionDays` | `90` | Days before a daily log moves to `memory/archive/` |
 | `sessionRetentionDays` | `180` | Days before a `*.log.jsonl` is pruned |
 | `flushTrigger` | `FlushTrigger.always()` | `ALWAYS` / `NEVER` / `THROTTLED(Duration)` |
@@ -236,11 +239,13 @@ When the model sees a "MEMORY truncated" note in the prompt, it typically calls 
 
 ## Background maintenance
 
-When memory is enabled, a throttled background job also runs (triggered at each `call()` end with a minimum gap, default ~30 minutes max):
+When memory is enabled, a throttled background job also runs. The first eligible `call()` runs it immediately; later calls observe the minimum gap (30 minutes by default):
 
 - Archives daily logs older than `dailyFileRetentionDays` (default 90 days) to `memory/archive/`
 - Runs one `MEMORY.md` consolidation pass
 - Prunes session logs older than `sessionRetentionDays` (default 180 days)
+
+Entering maintenance does not necessarily call the model: consolidation skips the LLM request when there are no new daily ledger entries since the last successful consolidation. `FlushTrigger.never()` does not disable this maintenance path.
 
 All thresholds are tunable via `.memory(MemoryConfig.builder()...)`, though most projects don't need to touch them.
 

--- a/docs/v2/zh/docs/harness/memory.md
+++ b/docs/v2/zh/docs/harness/memory.md
@@ -107,6 +107,8 @@ CompactionConfig.builder()
 
 `MemoryConfig` 集中管理 flush / consolidation 两条路径的 prompt、节流、保留时长，以及 per-call flush 的触发策略。所有字段都有默认值，不调 `.memory(...)` 时与历史行为完全一致。
 
+Per-call flush 与后台 consolidation 使用两套独立的节流窗口。两者第一次符合条件的 `call()` 都会立即放行；最小间隔只限制后续运行，不表示首次运行前需要等待。
+
 ### 例 1：节流 per-call flush，省 token
 
 每次 agent 调用结束都做一次 flush LLM 调用，对长会话来说成本不低。把它节流到「最多每 10 分钟一次」：
@@ -123,6 +125,7 @@ HarnessAgent.builder()
 注意：
 
 - `THROTTLED` 只影响**路径 1**（per-call flush）。压缩内嵌的 flush（路径 2）和兜底 flush（路径 3）按各自的触发条件照常跑——压缩很少发生，那两条本来就不频繁。
+- 第一次符合条件的 call 会立即 flush；`Duration.ofMinutes(10)` 只限制后续的 per-call flush。
 - **Offload 不受影响**，session JSONL 仍然每次写完整。`session_search` 和会话恢复正常工作。
 
 ### 例 2：完全关掉 per-call flush
@@ -168,7 +171,7 @@ HarnessAgent.builder()
 
 ```java
 .memory(MemoryConfig.builder()
-    .consolidationMinGap(Duration.ofHours(2))   // 后台合并最少 2 小时一次
+    .consolidationMinGap(Duration.ofHours(2))   // 首次可立即运行，之后至少间隔 2 小时
     .dailyFileRetentionDays(30)                 // 30 天就归档
     .sessionRetentionDays(60)                   // 60 天后删 session JSONL
     .consolidationMaxTokens(8_000)              // MEMORY.md 上限放宽到 8K tokens
@@ -201,7 +204,7 @@ HarnessAgent.builder()
 | `flushPrompt` | `null`（使用 `DEFAULT_FLUSH_PROMPT`） | 路径 1 的 SYSTEM prompt |
 | `consolidationPrompt` | `null`（使用 `DEFAULT_CONSOLIDATION_PROMPT`） | 路径 2 的 prompt 模板（必须含两个 `%d`） |
 | `consolidationMaxTokens` | `4_000` | `MEMORY.md` token 上限 |
-| `consolidationMinGap` | `30 min` | 后台维护节流间隔 |
+| `consolidationMinGap` | `30 min` | 后台维护运行间隔；第一次符合条件的 call 立即放行 |
 | `dailyFileRetentionDays` | `90` | 多少天后把日流水账归档到 `memory/archive/` |
 | `sessionRetentionDays` | `180` | 多少天后清掉 `*.log.jsonl` |
 | `flushTrigger` | `FlushTrigger.always()` | `ALWAYS` / `NEVER` / `THROTTLED(Duration)` |
@@ -236,11 +239,13 @@ HarnessAgent.builder()
 
 ## 后台维护
 
-启用记忆能力时还会跑一个后台节流任务（每个 `call()` 结束时按最小间隔触发，默认 30 分钟一次最多）：
+启用记忆能力时还会跑一个后台节流任务。第一次符合条件的 `call()` 会立即运行，后续调用遵守最小间隔（默认 30 分钟）：
 
 - 把超过 `dailyFileRetentionDays`（默认 90 天）的日流水账归档到 `memory/archive/`
 - 跑一次 `MEMORY.md` 合并（consolidation）
 - 清理超过 `sessionRetentionDays`（默认 180 天）的会话日志
+
+进入维护流程不一定会调用模型：如果自上次成功合并以来没有新增日流水账内容，consolidation 会跳过 LLM 请求。`FlushTrigger.never()` 不会关闭这条维护路径。
 
 所有阈值都可以通过 `.memory(MemoryConfig.builder()...)` 调，绝大多数项目不需要碰。
 


### PR DESCRIPTION
THROTTLED memory flush and background maintenance share the same periodic gate key, so either operation can suppress the other even though they have separate configured intervals.

This change gives each operation a distinct key prefix and adds regression coverage for local/store-backed gates, all isolation scopes, and both execution orders.

It also clarifies first-call behavior in MemoryConfig and the English/Chinese documentation: minimum gaps limit subsequent runs; they do not delay the first eligible call. FlushTrigger.never() only disables per-call flush.

Validation:
- 16 new regression cases fail before the fix and pass afterward.
- Core: 2,318 tests, 0 failures/errors, 9 skipped.
- Harness: 935 tests, 0 failures/errors, 5 skipped.
- Spotless and git diff --check pass.

Upgrade note: existing store-backed entries use the old shared key. Each new operation key starts a fresh throttle window after upgrade.

Related to #2982.
