### PR TITLE
fix(harness): count thinking block tokens

### DIFF
--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/memory/compaction/TokenCounterUtil.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/memory/compaction/TokenCounterUtil.java
@@ -18,6 +18,7 @@ package io.agentscope.harness.agent.memory.compaction;
 import io.agentscope.core.message.ContentBlock;
 import io.agentscope.core.message.Msg;
 import io.agentscope.core.message.TextBlock;
+import io.agentscope.core.message.ThinkingBlock;
 import io.agentscope.core.message.ToolResultBlock;
 import io.agentscope.core.message.ToolUseBlock;
 import java.util.List;
@@ -33,6 +34,7 @@ import java.util.Map;
  * <p>Token estimation strategy:
  * <ul>
  *   <li>Text content: ~1 token per 2-4 characters (varies by language)
+ *   <li>Thinking content: Uses the same character-based estimate as text content
  *   <li>Tool calls: Includes tool name, parameters, and structure overhead
  *   <li>Tool results: Includes output content and structure overhead
  *   <li>Message structure: Role, name, and formatting overhead
@@ -127,6 +129,8 @@ public class TokenCounterUtil {
 
         if (block instanceof TextBlock textBlock) {
             return estimateTextTokens(textBlock.getText());
+        } else if (block instanceof ThinkingBlock thinkingBlock) {
+            return estimateTextTokens(thinkingBlock.getThinking());
         } else if (block instanceof ToolUseBlock toolUseBlock) {
             return estimateToolUseBlockTokens(toolUseBlock);
         } else if (block instanceof ToolResultBlock toolResultBlock) {

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/memory/compaction/TokenCounterUtilTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/memory/compaction/TokenCounterUtilTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.harness.agent.memory.compaction;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import io.agentscope.core.message.Msg;
+import io.agentscope.core.message.MsgRole;
+import io.agentscope.core.message.ThinkingBlock;
+import io.agentscope.core.message.ToolResultBlock;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class TokenCounterUtilTest {
+
+    @Test
+    void calculateToken_countsThinkingContent() {
+        Msg message =
+                Msg.builder()
+                        .role(MsgRole.ASSISTANT)
+                        .content(ThinkingBlock.builder().thinking("x".repeat(1_000)).build())
+                        .build();
+
+        assertEquals(409, TokenCounterUtil.calculateToken(List.of(message)));
+    }
+
+    @Test
+    void calculateToken_countsThinkingContentInsideToolResults() {
+        Msg message =
+                Msg.builder()
+                        .role(MsgRole.TOOL)
+                        .content(
+                                ToolResultBlock.builder()
+                                        .id("call-1")
+                                        .name("search")
+                                        .output(
+                                                ThinkingBlock.builder()
+                                                        .thinking("x".repeat(1_000))
+                                                        .build())
+                                        .build())
+                        .build();
+
+        assertEquals(421, TokenCounterUtil.calculateToken(List.of(message)));
+    }
+}


### PR DESCRIPTION
## Summary

- Estimate `ThinkingBlock` tokens from its thinking content instead of using the fixed fallback overhead.
- Count thinking content nested inside `ToolResultBlock`.
- Add regression tests for direct and nested thinking blocks.

This addresses the `ThinkingBlock` undercounting described in #1525.

## Tests

```bash
mvn -pl agentscope-harness -am \
-Dtest=TokenCounterUtilTest,ConversationCompactorTest \
-Dsurefire.failIfNoSpecifiedTests=false test
```

Tests run: 9, Failures: 0, Errors: 0, Skipped: 0