### PR TITLE
fix(agui): use unique message IDs for discontinuous text segments

### DIFF
--- a/agentscope-core/src/main/java/io/agentscope/core/ReActAgent.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/ReActAgent.java
@@ -2593,7 +2593,10 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
                 blockLifecycle.startText(events);
                 if (tb.getText() != null && !tb.getText().isEmpty()) {
                     events.add(
-                            new TextBlockDeltaEvent(blockLifecycle.replyId, "text", tb.getText()));
+                            new TextBlockDeltaEvent(
+                                    blockLifecycle.replyId,
+                                    blockLifecycle.currentTextBlockId(),
+                                    tb.getText()));
                 }
             } else if (block instanceof ThinkingBlock tb) {
                 blockLifecycle.startThinking(events);
@@ -2628,6 +2631,8 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
         private final class ModelCallBlockLifecycle {
             private final String replyId;
             private final AtomicBoolean textStarted = new AtomicBoolean(false);
+            private final AtomicLong textSegmentSequence = new AtomicLong(0);
+            private final AtomicReference<String> currentTextBlockId = new AtomicReference<>();
             private final AtomicBoolean thinkingStarted = new AtomicBoolean(false);
             private final Map<String, String> startedToolCalls = new ConcurrentHashMap<>();
 
@@ -2638,8 +2643,15 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
             private void startText(List<AgentEvent> events) {
                 flushThinking(events);
                 if (textStarted.compareAndSet(false, true)) {
-                    events.add(new TextBlockStartEvent(replyId, "text"));
+                    long segment = textSegmentSequence.incrementAndGet();
+                    String blockId = segment == 1 ? "text" : "text-" + segment;
+                    currentTextBlockId.set(blockId);
+                    events.add(new TextBlockStartEvent(replyId, blockId));
                 }
+            }
+
+            private String currentTextBlockId() {
+                return currentTextBlockId.get();
             }
 
             private void startThinking(List<AgentEvent> events) {
@@ -2663,7 +2675,8 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
 
             private void flushText(List<AgentEvent> events) {
                 if (textStarted.compareAndSet(true, false)) {
-                    events.add(new TextBlockEndEvent(replyId, "text"));
+                    String blockId = currentTextBlockId.getAndSet(null);
+                    events.add(new TextBlockEndEvent(replyId, blockId));
                 }
             }
 
@@ -3652,7 +3665,8 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
                                                                             new TextBlockDeltaEvent(
                                                                                     blockLifecycle
                                                                                             .replyId,
-                                                                                    "text",
+                                                                                    blockLifecycle
+                                                                                            .currentTextBlockId(),
                                                                                     tb.getText()));
                                                                 }
                                                             } else if (block

--- a/agentscope-core/src/main/java/io/agentscope/core/ReActAgent.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/ReActAgent.java
@@ -2603,7 +2603,9 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
                 if (tb.getThinking() != null && !tb.getThinking().isEmpty()) {
                     events.add(
                             new ThinkingBlockDeltaEvent(
-                                    blockLifecycle.replyId, "thinking", tb.getThinking()));
+                                    blockLifecycle.replyId,
+                                    blockLifecycle.currentThinkingBlockId(),
+                                    tb.getThinking()));
                 }
             } else if (withToolEvents && block instanceof ToolUseBlock tub) {
                 String toolId = resolveToolCallId(tub, context);
@@ -2625,8 +2627,8 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
          *
          * <p>The model stream is consumed through {@code concatMap}, but the state holders keep the
          * previous thread-safe shape because model providers may deliver chunk content
-         * unpredictably. This helper only changes when pending end events are flushed; it does not
-         * change the block identity or event payloads.
+         * unpredictably. Each contiguous text or thinking segment receives its own block ID so its
+         * start, delta, and end events can be correlated independently.
          */
         private final class ModelCallBlockLifecycle {
             private final String replyId;
@@ -2634,6 +2636,8 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
             private final AtomicLong textSegmentSequence = new AtomicLong(0);
             private final AtomicReference<String> currentTextBlockId = new AtomicReference<>();
             private final AtomicBoolean thinkingStarted = new AtomicBoolean(false);
+            private final AtomicLong thinkingSegmentSequence = new AtomicLong(0);
+            private final AtomicReference<String> currentThinkingBlockId = new AtomicReference<>();
             private final Map<String, String> startedToolCalls = new ConcurrentHashMap<>();
 
             private ModelCallBlockLifecycle(String replyId) {
@@ -2656,8 +2660,15 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
 
             private void startThinking(List<AgentEvent> events) {
                 if (thinkingStarted.compareAndSet(false, true)) {
-                    events.add(new ThinkingBlockStartEvent(replyId, "thinking"));
+                    long segment = thinkingSegmentSequence.incrementAndGet();
+                    String blockId = segment == 1 ? "thinking" : "thinking-" + segment;
+                    currentThinkingBlockId.set(blockId);
+                    events.add(new ThinkingBlockStartEvent(replyId, blockId));
                 }
+            }
+
+            private String currentThinkingBlockId() {
+                return currentThinkingBlockId.get();
             }
 
             private void startToolCall(String toolId, String toolName, List<AgentEvent> events) {
@@ -2682,7 +2693,8 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
 
             private void flushThinking(List<AgentEvent> events) {
                 if (thinkingStarted.compareAndSet(true, false)) {
-                    events.add(new ThinkingBlockEndEvent(replyId, "thinking"));
+                    String blockId = currentThinkingBlockId.getAndSet(null);
+                    events.add(new ThinkingBlockEndEvent(replyId, blockId));
                 }
             }
 
@@ -3680,7 +3692,8 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
                                                                             new ThinkingBlockDeltaEvent(
                                                                                     blockLifecycle
                                                                                             .replyId,
-                                                                                    "thinking",
+                                                                                    blockLifecycle
+                                                                                            .currentThinkingBlockId(),
                                                                                     tb
                                                                                             .getThinking()));
                                                                 }

--- a/agentscope-core/src/test/java/io/agentscope/core/agent/ReActAgentNewLoopReplyTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/agent/ReActAgentNewLoopReplyTest.java
@@ -32,6 +32,7 @@ import io.agentscope.core.event.RequireExternalExecutionEvent;
 import io.agentscope.core.event.TextBlockDeltaEvent;
 import io.agentscope.core.event.TextBlockEndEvent;
 import io.agentscope.core.event.TextBlockStartEvent;
+import io.agentscope.core.event.ThinkingBlockDeltaEvent;
 import io.agentscope.core.event.ThinkingBlockEndEvent;
 import io.agentscope.core.event.ThinkingBlockStartEvent;
 import io.agentscope.core.event.ToolCallEndEvent;
@@ -572,6 +573,66 @@ class ReActAgentNewLoopReplyTest {
         assertEquals(
                 List.of("text", "text-2"),
                 ends.stream().map(TextBlockEndEvent::getBlockId).toList());
+    }
+
+    @Test
+    void thinkingSeparatedByToolCallUsesDistinctBlockIds() {
+        ChatModelBase model =
+                new ScriptedModel(
+                        List.of(
+                                () ->
+                                        Flux.just(
+                                                chatResponse(
+                                                        ThinkingBlock.builder()
+                                                                .thinking("before")
+                                                                .build()),
+                                                chatResponse(
+                                                        ToolUseBlock.builder()
+                                                                .id("tc1")
+                                                                .name("echo")
+                                                                .input(Map.of("query", "ping"))
+                                                                .build()),
+                                                chatResponse(
+                                                        ThinkingBlock.builder()
+                                                                .thinking("after")
+                                                                .build())),
+                                () -> Flux.just(textResponse("done"))));
+        ReActAgent agent =
+                ReActAgent.builder()
+                        .name("asst")
+                        .model(model)
+                        .toolkit(toolkitWith(new EchoTool()))
+                        .build();
+
+        List<AgentEvent> events = agent.streamEvents(List.of()).collectList().block();
+        assertNotNull(events);
+
+        int firstModelEnd = indexOf(events, ModelCallEndEvent.class);
+        List<ThinkingBlockStartEvent> starts =
+                events.subList(0, firstModelEnd).stream()
+                        .filter(ThinkingBlockStartEvent.class::isInstance)
+                        .map(ThinkingBlockStartEvent.class::cast)
+                        .toList();
+        List<ThinkingBlockEndEvent> ends =
+                events.subList(0, firstModelEnd).stream()
+                        .filter(ThinkingBlockEndEvent.class::isInstance)
+                        .map(ThinkingBlockEndEvent.class::cast)
+                        .toList();
+        List<ThinkingBlockDeltaEvent> deltas =
+                events.subList(0, firstModelEnd).stream()
+                        .filter(ThinkingBlockDeltaEvent.class::isInstance)
+                        .map(ThinkingBlockDeltaEvent.class::cast)
+                        .toList();
+
+        assertEquals(
+                List.of("thinking", "thinking-2"),
+                starts.stream().map(ThinkingBlockStartEvent::getBlockId).toList());
+        assertEquals(
+                List.of("thinking", "thinking-2"),
+                deltas.stream().map(ThinkingBlockDeltaEvent::getBlockId).toList());
+        assertEquals(
+                List.of("thinking", "thinking-2"),
+                ends.stream().map(ThinkingBlockEndEvent::getBlockId).toList());
     }
 
     @Test

--- a/agentscope-core/src/test/java/io/agentscope/core/agent/ReActAgentNewLoopReplyTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/agent/ReActAgentNewLoopReplyTest.java
@@ -29,6 +29,7 @@ import io.agentscope.core.event.ExternalExecutionResultEvent;
 import io.agentscope.core.event.ModelCallEndEvent;
 import io.agentscope.core.event.ModelCallStartEvent;
 import io.agentscope.core.event.RequireExternalExecutionEvent;
+import io.agentscope.core.event.TextBlockDeltaEvent;
 import io.agentscope.core.event.TextBlockEndEvent;
 import io.agentscope.core.event.TextBlockStartEvent;
 import io.agentscope.core.event.ThinkingBlockEndEvent;
@@ -515,6 +516,62 @@ class ReActAgentNewLoopReplyTest {
         assertTrue(
                 indexOf(events, TextBlockEndEvent.class)
                         < indexOf(events, ModelCallEndEvent.class));
+    }
+
+    @Test
+    void textSeparatedByToolCallUsesDistinctBlockIds() {
+        ChatModelBase model =
+                new ScriptedModel(
+                        List.of(
+                                () ->
+                                        Flux.just(
+                                                chatResponse(
+                                                        TextBlock.builder().text("before").build()),
+                                                chatResponse(
+                                                        ToolUseBlock.builder()
+                                                                .id("tc1")
+                                                                .name("echo")
+                                                                .input(Map.of("query", "ping"))
+                                                                .build()),
+                                                chatResponse(
+                                                        TextBlock.builder().text("after").build())),
+                                () -> Flux.just(textResponse("done"))));
+        ReActAgent agent =
+                ReActAgent.builder()
+                        .name("asst")
+                        .model(model)
+                        .toolkit(toolkitWith(new EchoTool()))
+                        .build();
+
+        List<AgentEvent> events = agent.streamEvents(List.of()).collectList().block();
+        assertNotNull(events);
+
+        int firstModelEnd = indexOf(events, ModelCallEndEvent.class);
+        List<TextBlockStartEvent> starts =
+                events.subList(0, firstModelEnd).stream()
+                        .filter(TextBlockStartEvent.class::isInstance)
+                        .map(TextBlockStartEvent.class::cast)
+                        .toList();
+        List<TextBlockEndEvent> ends =
+                events.subList(0, firstModelEnd).stream()
+                        .filter(TextBlockEndEvent.class::isInstance)
+                        .map(TextBlockEndEvent.class::cast)
+                        .toList();
+        List<TextBlockDeltaEvent> deltas =
+                events.subList(0, firstModelEnd).stream()
+                        .filter(TextBlockDeltaEvent.class::isInstance)
+                        .map(TextBlockDeltaEvent.class::cast)
+                        .toList();
+
+        assertEquals(
+                List.of("text", "text-2"),
+                starts.stream().map(TextBlockStartEvent::getBlockId).toList());
+        assertEquals(
+                List.of("text", "text-2"),
+                deltas.stream().map(TextBlockDeltaEvent::getBlockId).toList());
+        assertEquals(
+                List.of("text", "text-2"),
+                ends.stream().map(TextBlockEndEvent::getBlockId).toList());
     }
 
     @Test

--- a/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/main/java/io/agentscope/core/agui/adapter/strategy/AguiStreamContext.java
+++ b/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/main/java/io/agentscope/core/agui/adapter/strategy/AguiStreamContext.java
@@ -57,6 +57,8 @@ public class AguiStreamContext {
     private final Map<String, String> firstTextBlockByReply = new LinkedHashMap<>();
     private final Set<String> startedReasoningMessages = new LinkedHashSet<>();
     private final Set<String> endedReasoningMessages = new LinkedHashSet<>();
+    private final Map<ThinkingBlockKey, String> reasoningMessageIds = new LinkedHashMap<>();
+    private final Map<String, String> firstThinkingBlockByReply = new LinkedHashMap<>();
     private final Set<String> startedToolCalls = new LinkedHashSet<>();
     private final Set<String> endedToolCalls = new LinkedHashSet<>();
     private String currentTextMessageId;
@@ -191,7 +193,7 @@ public class AguiStreamContext {
     }
 
     public void startReasoningMessage(String messageId) {
-        String reasoningMessageId = reasoningMessageId(messageId);
+        String reasoningMessageId = withReasoningSuffix(messageId);
         if (startedReasoningMessages.add(reasoningMessageId)) {
             emit(
                     new AguiEvent.ReasoningMessageStart(
@@ -205,8 +207,34 @@ public class AguiStreamContext {
             startReasoningMessage(messageId);
             emit(
                     new AguiEvent.ReasoningMessageContent(
-                            threadId, runId, reasoningMessageId(messageId), delta));
+                            threadId, runId, withReasoningSuffix(messageId), delta));
         }
+    }
+
+    public String reasoningMessageId(String replyId, String blockId) {
+        String normalizedBlockId = isBlank(blockId) ? "thinking" : blockId;
+        ThinkingBlockKey key = new ThinkingBlockKey(replyId, normalizedBlockId);
+        String messageId =
+                reasoningMessageIds.computeIfAbsent(
+                        key,
+                        ignored -> {
+                            String firstBlockId =
+                                    firstThinkingBlockByReply.putIfAbsent(
+                                            replyId, normalizedBlockId);
+                            if (firstBlockId == null
+                                    || Objects.equals(firstBlockId, normalizedBlockId)) {
+                                return replyId;
+                            }
+                            return replyId + "-" + normalizedBlockId;
+                        });
+        return withReasoningSuffix(messageId);
+    }
+
+    public String existingReasoningMessageId(String replyId, String blockId) {
+        String normalizedBlockId = isBlank(blockId) ? "thinking" : blockId;
+        String messageId =
+                reasoningMessageIds.get(new ThinkingBlockKey(replyId, normalizedBlockId));
+        return messageId == null ? null : withReasoningSuffix(messageId);
     }
 
     public void closeActiveReasoningMessage() {
@@ -217,7 +245,7 @@ public class AguiStreamContext {
     }
 
     public void closeReasoningMessage(String messageId) {
-        String reasoningMessageId = reasoningMessageId(messageId);
+        String reasoningMessageId = withReasoningSuffix(messageId);
         if (reasoningMessageId == null
                 || !startedReasoningMessages.contains(reasoningMessageId)
                 || endedReasoningMessages.contains(reasoningMessageId)) {
@@ -357,7 +385,10 @@ public class AguiStreamContext {
         return toolCallName != null && !toolCallName.isBlank() ? toolCallName : "unknown";
     }
 
-    private static String reasoningMessageId(String messageId) {
+    private static String withReasoningSuffix(String messageId) {
+        if (messageId == null) {
+            return null;
+        }
         if (messageId.endsWith(REASONING_MESSAGE_ID_SUFFIX)) {
             return messageId;
         }
@@ -380,6 +411,8 @@ public class AguiStreamContext {
     }
 
     private record TextBlockKey(String replyId, String blockId) {}
+
+    private record ThinkingBlockKey(String replyId, String blockId) {}
 
     private void warnMissingToolCallId(String eventName) {
         if (!warnedMissingToolCallIdOperations.add(eventName)) {

--- a/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/main/java/io/agentscope/core/agui/adapter/strategy/AguiStreamContext.java
+++ b/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/main/java/io/agentscope/core/agui/adapter/strategy/AguiStreamContext.java
@@ -38,10 +38,6 @@ import org.slf4j.LoggerFactory;
 
 public class AguiStreamContext {
 
-    // CopilotKit will merge reasoning and text with the same messageId, adding suffixes to the
-    // reasoning to distinguish them
-    public static final String REASONING_MESSAGE_ID_SUFFIX = "-reasoning";
-
     private static final Logger logger = LoggerFactory.getLogger(AguiStreamContext.class);
 
     private final String threadId;
@@ -53,12 +49,8 @@ public class AguiStreamContext {
 
     private final Set<String> startedTextMessages = new LinkedHashSet<>();
     private final Set<String> endedTextMessages = new LinkedHashSet<>();
-    private final Map<TextBlockKey, String> textMessageIds = new LinkedHashMap<>();
-    private final Map<String, String> firstTextBlockByReply = new LinkedHashMap<>();
     private final Set<String> startedReasoningMessages = new LinkedHashSet<>();
     private final Set<String> endedReasoningMessages = new LinkedHashSet<>();
-    private final Map<ThinkingBlockKey, String> reasoningMessageIds = new LinkedHashMap<>();
-    private final Map<String, String> firstThinkingBlockByReply = new LinkedHashMap<>();
     private final Set<String> startedToolCalls = new LinkedHashSet<>();
     private final Set<String> endedToolCalls = new LinkedHashSet<>();
     private String currentTextMessageId;
@@ -152,26 +144,6 @@ public class AguiStreamContext {
         }
     }
 
-    public String textMessageId(String replyId, String blockId) {
-        String normalizedBlockId = isBlank(blockId) ? "text" : blockId;
-        TextBlockKey key = new TextBlockKey(replyId, normalizedBlockId);
-        return textMessageIds.computeIfAbsent(
-                key,
-                ignored -> {
-                    String firstBlockId =
-                            firstTextBlockByReply.putIfAbsent(replyId, normalizedBlockId);
-                    if (firstBlockId == null || Objects.equals(firstBlockId, normalizedBlockId)) {
-                        return replyId;
-                    }
-                    return replyId + "-" + normalizedBlockId;
-                });
-    }
-
-    public String existingTextMessageId(String replyId, String blockId) {
-        String normalizedBlockId = isBlank(blockId) ? "text" : blockId;
-        return textMessageIds.get(new TextBlockKey(replyId, normalizedBlockId));
-    }
-
     public void closeActiveTextMessage() {
         if (currentTextMessageId == null) {
             return;
@@ -193,48 +165,17 @@ public class AguiStreamContext {
     }
 
     public void startReasoningMessage(String messageId) {
-        String reasoningMessageId = withReasoningSuffix(messageId);
-        if (startedReasoningMessages.add(reasoningMessageId)) {
-            emit(
-                    new AguiEvent.ReasoningMessageStart(
-                            threadId, runId, reasoningMessageId, "reasoning"));
+        if (startedReasoningMessages.add(messageId)) {
+            emit(new AguiEvent.ReasoningMessageStart(threadId, runId, messageId, "reasoning"));
         }
-        currentReasoningMessageId = reasoningMessageId;
+        currentReasoningMessageId = messageId;
     }
 
     public void appendReasoningDelta(String messageId, String delta) {
         if (delta != null && !delta.isEmpty()) {
             startReasoningMessage(messageId);
-            emit(
-                    new AguiEvent.ReasoningMessageContent(
-                            threadId, runId, withReasoningSuffix(messageId), delta));
+            emit(new AguiEvent.ReasoningMessageContent(threadId, runId, messageId, delta));
         }
-    }
-
-    public String reasoningMessageId(String replyId, String blockId) {
-        String normalizedBlockId = isBlank(blockId) ? "thinking" : blockId;
-        ThinkingBlockKey key = new ThinkingBlockKey(replyId, normalizedBlockId);
-        String messageId =
-                reasoningMessageIds.computeIfAbsent(
-                        key,
-                        ignored -> {
-                            String firstBlockId =
-                                    firstThinkingBlockByReply.putIfAbsent(
-                                            replyId, normalizedBlockId);
-                            if (firstBlockId == null
-                                    || Objects.equals(firstBlockId, normalizedBlockId)) {
-                                return replyId;
-                            }
-                            return replyId + "-" + normalizedBlockId;
-                        });
-        return withReasoningSuffix(messageId);
-    }
-
-    public String existingReasoningMessageId(String replyId, String blockId) {
-        String normalizedBlockId = isBlank(blockId) ? "thinking" : blockId;
-        String messageId =
-                reasoningMessageIds.get(new ThinkingBlockKey(replyId, normalizedBlockId));
-        return messageId == null ? null : withReasoningSuffix(messageId);
     }
 
     public void closeActiveReasoningMessage() {
@@ -245,17 +186,16 @@ public class AguiStreamContext {
     }
 
     public void closeReasoningMessage(String messageId) {
-        String reasoningMessageId = withReasoningSuffix(messageId);
-        if (reasoningMessageId == null
-                || !startedReasoningMessages.contains(reasoningMessageId)
-                || endedReasoningMessages.contains(reasoningMessageId)) {
+        if (messageId == null
+                || !startedReasoningMessages.contains(messageId)
+                || endedReasoningMessages.contains(messageId)) {
             return;
         }
-        endedReasoningMessages.add(reasoningMessageId);
-        if (Objects.equals(reasoningMessageId, currentReasoningMessageId)) {
+        endedReasoningMessages.add(messageId);
+        if (Objects.equals(messageId, currentReasoningMessageId)) {
             currentReasoningMessageId = null;
         }
-        emit(new AguiEvent.ReasoningMessageEnd(threadId, runId, reasoningMessageId));
+        emit(new AguiEvent.ReasoningMessageEnd(threadId, runId, messageId));
     }
 
     public void startToolCall(String toolCallId, String toolCallName) {
@@ -329,7 +269,6 @@ public class AguiStreamContext {
         if (endedToolCalls.add(toolCallId)) {
             emit(new AguiEvent.ToolCallEnd(threadId, runId, toolCallId));
         }
-
         StringBuilder content = toolResultContent.remove(toolCallId);
         emit(
                 new AguiEvent.ToolCallResult(
@@ -385,16 +324,6 @@ public class AguiStreamContext {
         return toolCallName != null && !toolCallName.isBlank() ? toolCallName : "unknown";
     }
 
-    private static String withReasoningSuffix(String messageId) {
-        if (messageId == null) {
-            return null;
-        }
-        if (messageId.endsWith(REASONING_MESSAGE_ID_SUFFIX)) {
-            return messageId;
-        }
-        return messageId + REASONING_MESSAGE_ID_SUFFIX;
-    }
-
     private static String serialize(ContentBlock data) {
         if (data instanceof TextBlock textBlock) {
             return textBlock.getText();
@@ -409,10 +338,6 @@ public class AguiStreamContext {
     private static boolean isBlank(String value) {
         return value == null || value.isBlank();
     }
-
-    private record TextBlockKey(String replyId, String blockId) {}
-
-    private record ThinkingBlockKey(String replyId, String blockId) {}
 
     private void warnMissingToolCallId(String eventName) {
         if (!warnedMissingToolCallIdOperations.add(eventName)) {
@@ -455,7 +380,6 @@ public class AguiStreamContext {
     }
 
     static final class TokenUsageAccumulator {
-
         private long cumulativeInputTokens;
         private long cumulativeOutputTokens;
         private long cumulativeCachedTokens;
@@ -483,7 +407,6 @@ public class AguiStreamContext {
     record TokenUsageSnapshot(TokenUsage delta, TokenUsage cumulative) {}
 
     record TokenUsage(long inputTokens, long outputTokens, long cachedTokens, double time) {
-
         long totalTokens() {
             return inputTokens + outputTokens;
         }

--- a/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/main/java/io/agentscope/core/agui/adapter/strategy/AguiStreamContext.java
+++ b/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/main/java/io/agentscope/core/agui/adapter/strategy/AguiStreamContext.java
@@ -53,6 +53,8 @@ public class AguiStreamContext {
 
     private final Set<String> startedTextMessages = new LinkedHashSet<>();
     private final Set<String> endedTextMessages = new LinkedHashSet<>();
+    private final Map<TextBlockKey, String> textMessageIds = new LinkedHashMap<>();
+    private final Map<String, String> firstTextBlockByReply = new LinkedHashMap<>();
     private final Set<String> startedReasoningMessages = new LinkedHashSet<>();
     private final Set<String> endedReasoningMessages = new LinkedHashSet<>();
     private final Set<String> startedToolCalls = new LinkedHashSet<>();
@@ -146,6 +148,26 @@ public class AguiStreamContext {
             startTextMessage(messageId);
             emit(new AguiEvent.TextMessageContent(threadId, runId, messageId, delta));
         }
+    }
+
+    public String textMessageId(String replyId, String blockId) {
+        String normalizedBlockId = isBlank(blockId) ? "text" : blockId;
+        TextBlockKey key = new TextBlockKey(replyId, normalizedBlockId);
+        return textMessageIds.computeIfAbsent(
+                key,
+                ignored -> {
+                    String firstBlockId =
+                            firstTextBlockByReply.putIfAbsent(replyId, normalizedBlockId);
+                    if (firstBlockId == null || Objects.equals(firstBlockId, normalizedBlockId)) {
+                        return replyId;
+                    }
+                    return replyId + "-" + normalizedBlockId;
+                });
+    }
+
+    public String existingTextMessageId(String replyId, String blockId) {
+        String normalizedBlockId = isBlank(blockId) ? "text" : blockId;
+        return textMessageIds.get(new TextBlockKey(replyId, normalizedBlockId));
     }
 
     public void closeActiveTextMessage() {
@@ -356,6 +378,8 @@ public class AguiStreamContext {
     private static boolean isBlank(String value) {
         return value == null || value.isBlank();
     }
+
+    private record TextBlockKey(String replyId, String blockId) {}
 
     private void warnMissingToolCallId(String eventName) {
         if (!warnedMissingToolCallIdOperations.add(eventName)) {

--- a/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/main/java/io/agentscope/core/agui/adapter/strategy/TextBlockEventConverter.java
+++ b/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/main/java/io/agentscope/core/agui/adapter/strategy/TextBlockEventConverter.java
@@ -33,11 +33,14 @@ final class TextBlockEventConverter implements AgentEventConverter {
     public void convert(AgentEvent event, AguiStreamContext context) {
         if (event instanceof TextBlockDeltaEvent delta) {
             // AguiEvent.TextMessageStart delays sending when content arrives
-            String messageId = context.textMessageId(delta.getReplyId(), delta.getBlockId());
-            context.appendTextDelta(messageId, delta.getDelta());
+            context.appendTextDelta(
+                    messageId(delta.getReplyId(), delta.getBlockId()), delta.getDelta());
         } else if (event instanceof TextBlockEndEvent end) {
-            String messageId = context.existingTextMessageId(end.getReplyId(), end.getBlockId());
-            context.closeTextMessage(messageId);
+            context.closeTextMessage(messageId(end.getReplyId(), end.getBlockId()));
         }
+    }
+
+    private String messageId(String replyId, String blockId) {
+        return replyId + "-" + blockId;
     }
 }

--- a/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/main/java/io/agentscope/core/agui/adapter/strategy/TextBlockEventConverter.java
+++ b/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/main/java/io/agentscope/core/agui/adapter/strategy/TextBlockEventConverter.java
@@ -33,9 +33,11 @@ final class TextBlockEventConverter implements AgentEventConverter {
     public void convert(AgentEvent event, AguiStreamContext context) {
         if (event instanceof TextBlockDeltaEvent delta) {
             // AguiEvent.TextMessageStart delays sending when content arrives
-            context.appendTextDelta(delta.getReplyId(), delta.getDelta());
+            String messageId = context.textMessageId(delta.getReplyId(), delta.getBlockId());
+            context.appendTextDelta(messageId, delta.getDelta());
         } else if (event instanceof TextBlockEndEvent end) {
-            context.closeTextMessage(end.getReplyId());
+            String messageId = context.existingTextMessageId(end.getReplyId(), end.getBlockId());
+            context.closeTextMessage(messageId);
         }
     }
 }

--- a/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/main/java/io/agentscope/core/agui/adapter/strategy/ThinkingBlockEventConverter.java
+++ b/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/main/java/io/agentscope/core/agui/adapter/strategy/ThinkingBlockEventConverter.java
@@ -40,9 +40,12 @@ final class ThinkingBlockEventConverter implements AgentEventConverter {
 
         if (event instanceof ThinkingBlockDeltaEvent delta) {
             // AguiEvent.ReasoningMessageStart delays sending when content arrives
-            context.appendReasoningDelta(delta.getReplyId(), delta.getDelta());
+            String messageId = context.reasoningMessageId(delta.getReplyId(), delta.getBlockId());
+            context.appendReasoningDelta(messageId, delta.getDelta());
         } else if (event instanceof ThinkingBlockEndEvent end) {
-            context.closeReasoningMessage(end.getReplyId());
+            String messageId =
+                    context.existingReasoningMessageId(end.getReplyId(), end.getBlockId());
+            context.closeReasoningMessage(messageId);
         }
     }
 }

--- a/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/main/java/io/agentscope/core/agui/adapter/strategy/ThinkingBlockEventConverter.java
+++ b/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/main/java/io/agentscope/core/agui/adapter/strategy/ThinkingBlockEventConverter.java
@@ -40,12 +40,14 @@ final class ThinkingBlockEventConverter implements AgentEventConverter {
 
         if (event instanceof ThinkingBlockDeltaEvent delta) {
             // AguiEvent.ReasoningMessageStart delays sending when content arrives
-            String messageId = context.reasoningMessageId(delta.getReplyId(), delta.getBlockId());
-            context.appendReasoningDelta(messageId, delta.getDelta());
+            context.appendReasoningDelta(
+                    messageId(delta.getReplyId(), delta.getBlockId()), delta.getDelta());
         } else if (event instanceof ThinkingBlockEndEvent end) {
-            String messageId =
-                    context.existingReasoningMessageId(end.getReplyId(), end.getBlockId());
-            context.closeReasoningMessage(messageId);
+            context.closeReasoningMessage(messageId(end.getReplyId(), end.getBlockId()));
         }
+    }
+
+    private String messageId(String replyId, String blockId) {
+        return replyId + "-" + blockId;
     }
 }

--- a/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/test/java/io/agentscope/core/agui/adapter/AguiAgentAdapterV2Test.java
+++ b/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/test/java/io/agentscope/core/agui/adapter/AguiAgentAdapterV2Test.java
@@ -374,9 +374,9 @@ class AguiAgentAdapterV2Test {
                             .toList();
             assertEquals(
                     List.of(
-                            "reply-mixed",
-                            "reply-mixed",
-                            "reply-mixed",
+                            "reply-mixed-text",
+                            "reply-mixed-text",
+                            "reply-mixed-text",
                             "reply-mixed-text-2",
                             "reply-mixed-text-2",
                             "reply-mixed-text-2"),
@@ -436,12 +436,12 @@ class AguiAgentAdapterV2Test {
                             .toList();
             assertEquals(
                     List.of(
-                            "reply-mixed-reasoning",
-                            "reply-mixed-reasoning",
-                            "reply-mixed-reasoning",
-                            "reply-mixed-thinking-2-reasoning",
-                            "reply-mixed-thinking-2-reasoning",
-                            "reply-mixed-thinking-2-reasoning"),
+                            "reply-mixed-thinking",
+                            "reply-mixed-thinking",
+                            "reply-mixed-thinking",
+                            "reply-mixed-thinking-2",
+                            "reply-mixed-thinking-2",
+                            "reply-mixed-thinking-2"),
                     messageIds);
         }
 
@@ -463,9 +463,9 @@ class AguiAgentAdapterV2Test {
             List<AguiEvent> events =
                     runReActEvents(
                             AguiAdapterConfig.builder().enableReasoning(true).build(),
-                            new ThinkingBlockStartEvent("reply-thinking", "block-1"),
-                            new ThinkingBlockDeltaEvent("reply-thinking", "block-1", "visible"),
-                            new ThinkingBlockEndEvent("reply-thinking", "block-1"));
+                            new ThinkingBlockStartEvent("reply-thinking", "thinking"),
+                            new ThinkingBlockDeltaEvent("reply-thinking", "thinking", "visible"),
+                            new ThinkingBlockEndEvent("reply-thinking", "thinking"));
 
             assertEquals(
                     List.of(
@@ -479,8 +479,7 @@ class AguiAgentAdapterV2Test {
                     assertInstanceOf(AguiEvent.ReasoningMessageContent.class, events.get(1));
             AguiEvent.ReasoningMessageEnd end =
                     assertInstanceOf(AguiEvent.ReasoningMessageEnd.class, events.get(2));
-            String expectedMessageId =
-                    "reply-thinking" + AguiStreamContext.REASONING_MESSAGE_ID_SUFFIX;
+            String expectedMessageId = "reply-thinking-thinking";
             assertEquals(expectedMessageId, start.messageId());
             assertEquals(expectedMessageId, content.messageId());
             assertEquals(expectedMessageId, end.messageId());
@@ -491,10 +490,10 @@ class AguiAgentAdapterV2Test {
             List<AguiEvent> events =
                     runReActEvents(
                             AguiAdapterConfig.builder().enableReasoning(true).build(),
-                            new ThinkingBlockDeltaEvent("reply-shared", "thinking-1", "think"),
-                            new ThinkingBlockEndEvent("reply-shared", "thinking-1"),
-                            new TextBlockDeltaEvent("reply-shared", "text-1", "answer"),
-                            new TextBlockEndEvent("reply-shared", "text-1"));
+                            new ThinkingBlockDeltaEvent("reply-shared", "thinking", "think"),
+                            new ThinkingBlockEndEvent("reply-shared", "thinking"),
+                            new TextBlockDeltaEvent("reply-shared", "text", "answer"),
+                            new TextBlockEndEvent("reply-shared", "text"));
 
             AguiEvent.ReasoningMessageContent reasoningContent =
                     events.stream()
@@ -509,10 +508,8 @@ class AguiAgentAdapterV2Test {
                             .findFirst()
                             .orElseThrow();
 
-            assertEquals("reply-shared", textContent.messageId());
-            assertEquals(
-                    "reply-shared" + AguiStreamContext.REASONING_MESSAGE_ID_SUFFIX,
-                    reasoningContent.messageId());
+            assertEquals("reply-shared-text", textContent.messageId());
+            assertEquals("reply-shared-thinking", reasoningContent.messageId());
         }
 
         @Test

--- a/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/test/java/io/agentscope/core/agui/adapter/AguiAgentAdapterV2Test.java
+++ b/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/test/java/io/agentscope/core/agui/adapter/AguiAgentAdapterV2Test.java
@@ -384,6 +384,68 @@ class AguiAgentAdapterV2Test {
         }
 
         @Test
+        void testReasoningSegmentsSeparatedByToolCallUseDistinctMessageIds() {
+            List<AguiEvent> events =
+                    runReActEvents(
+                            AguiAdapterConfig.builder().enableReasoning(true).build(),
+                            new ThinkingBlockStartEvent("reply-mixed", "thinking"),
+                            new ThinkingBlockDeltaEvent("reply-mixed", "thinking", "before"),
+                            new ThinkingBlockEndEvent("reply-mixed", "thinking"),
+                            new ToolCallStartEvent("reply-mixed", "tool-1", "lookup"),
+                            new ToolCallEndEvent("reply-mixed", "tool-1", "lookup"),
+                            new ThinkingBlockStartEvent("reply-mixed", "thinking-2"),
+                            new ThinkingBlockDeltaEvent("reply-mixed", "thinking-2", "after"),
+                            new ThinkingBlockEndEvent("reply-mixed", "thinking-2"));
+
+            assertEquals(
+                    List.of(
+                            AguiEventType.REASONING_MESSAGE_START,
+                            AguiEventType.REASONING_MESSAGE_CONTENT,
+                            AguiEventType.REASONING_MESSAGE_END,
+                            AguiEventType.TOOL_CALL_START,
+                            AguiEventType.TOOL_CALL_END,
+                            AguiEventType.REASONING_MESSAGE_START,
+                            AguiEventType.REASONING_MESSAGE_CONTENT,
+                            AguiEventType.REASONING_MESSAGE_END),
+                    types(events));
+
+            List<String> messageIds =
+                    events.stream()
+                            .filter(
+                                    event ->
+                                            event instanceof AguiEvent.ReasoningMessageStart
+                                                    || event
+                                                            instanceof
+                                                            AguiEvent.ReasoningMessageContent
+                                                    || event
+                                                            instanceof
+                                                            AguiEvent.ReasoningMessageEnd)
+                            .map(
+                                    event -> {
+                                        if (event
+                                                instanceof AguiEvent.ReasoningMessageStart start) {
+                                            return start.messageId();
+                                        }
+                                        if (event
+                                                instanceof
+                                                AguiEvent.ReasoningMessageContent content) {
+                                            return content.messageId();
+                                        }
+                                        return ((AguiEvent.ReasoningMessageEnd) event).messageId();
+                                    })
+                            .toList();
+            assertEquals(
+                    List.of(
+                            "reply-mixed-reasoning",
+                            "reply-mixed-reasoning",
+                            "reply-mixed-reasoning",
+                            "reply-mixed-thinking-2-reasoning",
+                            "reply-mixed-thinking-2-reasoning",
+                            "reply-mixed-thinking-2-reasoning"),
+                    messageIds);
+        }
+
+        @Test
         void testThinkingEventsAreIgnoredWhenReasoningDisabled() {
             List<AguiEvent> events =
                     runReActEvents(

--- a/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/test/java/io/agentscope/core/agui/adapter/AguiAgentAdapterV2Test.java
+++ b/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/test/java/io/agentscope/core/agui/adapter/AguiAgentAdapterV2Test.java
@@ -330,6 +330,60 @@ class AguiAgentAdapterV2Test {
         }
 
         @Test
+        void testTextSegmentsSeparatedByToolCallUseDistinctMessageIds() {
+            List<AguiEvent> events =
+                    runReActEvents(
+                            new TextBlockStartEvent("reply-mixed", "text"),
+                            new TextBlockDeltaEvent("reply-mixed", "text", "before"),
+                            new TextBlockEndEvent("reply-mixed", "text"),
+                            new ToolCallStartEvent("reply-mixed", "tool-1", "lookup"),
+                            new ToolCallEndEvent("reply-mixed", "tool-1", "lookup"),
+                            new TextBlockStartEvent("reply-mixed", "text-2"),
+                            new TextBlockDeltaEvent("reply-mixed", "text-2", "after"),
+                            new TextBlockEndEvent("reply-mixed", "text-2"));
+
+            assertEquals(
+                    List.of(
+                            AguiEventType.TEXT_MESSAGE_START,
+                            AguiEventType.TEXT_MESSAGE_CONTENT,
+                            AguiEventType.TEXT_MESSAGE_END,
+                            AguiEventType.TOOL_CALL_START,
+                            AguiEventType.TOOL_CALL_END,
+                            AguiEventType.TEXT_MESSAGE_START,
+                            AguiEventType.TEXT_MESSAGE_CONTENT,
+                            AguiEventType.TEXT_MESSAGE_END),
+                    types(events));
+
+            List<String> messageIds =
+                    events.stream()
+                            .filter(
+                                    event ->
+                                            event instanceof AguiEvent.TextMessageStart
+                                                    || event instanceof AguiEvent.TextMessageContent
+                                                    || event instanceof AguiEvent.TextMessageEnd)
+                            .map(
+                                    event -> {
+                                        if (event instanceof AguiEvent.TextMessageStart start) {
+                                            return start.messageId();
+                                        }
+                                        if (event instanceof AguiEvent.TextMessageContent content) {
+                                            return content.messageId();
+                                        }
+                                        return ((AguiEvent.TextMessageEnd) event).messageId();
+                                    })
+                            .toList();
+            assertEquals(
+                    List.of(
+                            "reply-mixed",
+                            "reply-mixed",
+                            "reply-mixed",
+                            "reply-mixed-text-2",
+                            "reply-mixed-text-2",
+                            "reply-mixed-text-2"),
+                    messageIds);
+        }
+
+        @Test
         void testThinkingEventsAreIgnoredWhenReasoningDisabled() {
             List<AguiEvent> events =
                     runReActEvents(


### PR DESCRIPTION
## AgentScope-Java Version

2.0.3-SNAPSHOT

## Description

Fixes #2988.

当单次模型调用先输出文本、后输出工具调用、接着再输出文本（或推理内容）时，核心层之前对所有片段重用了相同的块 ID (`"text"` / `"thinking"`)。AG-UI 适配器随后也重用了相同的消息 ID，导致在对应的 `TEXT_MESSAGE_END` 之后发出了第二个 `TEXT_MESSAGE_CONTENT` / `REASONING_MESSAGE_CONTENT`，且缺少匹配的 `TEXT_MESSAGE_START` / `REASONING_MESSAGE_START`，从而引发了客户端错误：*"No active text message found with ID"*。

此更改：

- 在 `ModelCallBlockLifecycle` 内部为每个连续的文本或推理片段分配一个不同的块 ID (`"text"`, `"text-2"`, ... / `"thinking"`, `"thinking-2"`, ...)。通过 `AtomicLong` 计数器跟踪的片段序列在每次 `startText` / `startThinking` 时（在之前的 `flushText` / `flushThinking` 关闭当前片段后）都会递增；
- 在 AG-UI 适配器中统一推导消息 ID，作为 `replyId + "-" + blockId` —— 一个没有特殊情况或后缀的纯函数。第一段文本片段变为 `replyId-text`，第一段推理片段变为 `replyId-thinking`，后续片段变为 `replyId-text-2` / `replyId-thinking-2` 等；
- 移除了 `REASONING_MESSAGE_ID_SUFFIX` (`"-reasoning"`) 常量和 `withReasoningSuffix` 方法。文本和推理消息天然具有不同的 ID，因为它们的块 ID 不同 (`"text"` 与 `"thinking"`)，这使得后缀变得多余；
- 为 `text → tool call → text` 和 `thinking → tool call → thinking` 序列添加了核心和 AG-UI 回归测试，并更新了现有的 AG-UI 测试以符合新的消息 ID 方案。

## 测试

- `ReActAgentNewLoopReplyTest`: 14 通过，0 失败。
- AG-UI 模块测试套件：500 通过，0 失败。

## Checklist

- [x] Code passes Spotless checks.
- [x] Relevant core and AG-UI tests pass.
- [x] Javadoc is complete and clear.
- [x] Documentation changes are not required for this internal lifecycle fix.
- [x] The pull request is ready for review.