### PR TITLE
fix(harness): inherit pending tool recovery in subagents

### DIFF
--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/HarnessAgent.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/HarnessAgent.java
@@ -1199,6 +1199,7 @@ public class HarnessAgent implements Agent, AutoCloseable {
         String description;
         String sysPrompt;
         boolean checkRunning = true;
+        boolean enablePendingToolRecovery = false;
         Model model;
         Toolkit toolkit = newDefaultToolkit();
         int maxIters = 10;
@@ -1651,7 +1652,16 @@ public class HarnessAgent implements Agent, AutoCloseable {
             return this;
         }
 
+        /**
+         * Enables recovery of orphaned tool calls when a new message arrives. Automatically
+         * constructed local subagents inherit this setting unless their declaration overrides it.
+         * Pending permission confirmations still require an explicit confirmation result.
+         *
+         * @param enable whether to synthesize error results for orphaned tool calls
+         * @return this builder
+         */
         public Builder enablePendingToolRecovery(boolean enable) {
+            this.enablePendingToolRecovery = enable;
             inner.enablePendingToolRecovery(enable);
             return this;
         }

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/HarnessAgentBuilderSupport.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/HarnessAgentBuilderSupport.java
@@ -290,6 +290,7 @@ final class HarnessAgentBuilderSupport {
     static SubagentFactory buildGeneralPurposeFactory(
             HarnessAgent.Builder b, Path workspace, SandboxBackedFilesystem sandboxFs) {
         final Model capturedModel = b.model;
+        final boolean capturedPendingToolRecovery = b.enablePendingToolRecovery;
         final Toolkit capturedParentToolkit =
                 b.toolkit != null ? b.toolkit.copy() : HarnessAgent.Builder.newDefaultToolkit();
         final AbstractFilesystem capturedBackend =
@@ -335,6 +336,7 @@ final class HarnessAgentBuilderSupport {
             HarnessAgent.Builder sub =
                     HarnessAgent.builder()
                             .name("general-purpose-subagent")
+                            .enablePendingToolRecovery(capturedPendingToolRecovery)
                             .description("General-purpose subagent for isolated task execution")
                             .sysPrompt(buildSubagentSysPrompt(null))
                             .model(capturedModel)
@@ -395,6 +397,10 @@ final class HarnessAgentBuilderSupport {
             Path mainWorkspace,
             SandboxBackedFilesystem sandboxFs) {
         final Model capturedModel = b.model;
+        final boolean capturedPendingToolRecovery =
+                decl.getEnablePendingToolRecovery() != null
+                        ? decl.getEnablePendingToolRecovery()
+                        : b.enablePendingToolRecovery;
         final Toolkit capturedParentToolkit =
                 b.toolkit != null ? b.toolkit.copy() : HarnessAgent.Builder.newDefaultToolkit();
         final Function<String, Model> capturedResolver = b.modelResolver;
@@ -454,6 +460,7 @@ final class HarnessAgentBuilderSupport {
             HarnessAgent.Builder sub =
                     HarnessAgent.builder()
                             .name(decl.getName())
+                            .enablePendingToolRecovery(capturedPendingToolRecovery)
                             .description(decl.getDescription())
                             .model(effectiveModel)
                             .toolkit(

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/subagent/AgentSpecLoader.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/subagent/AgentSpecLoader.java
@@ -311,6 +311,11 @@ public final class AgentSpecLoader {
         if (exposeToUser == null) {
             exposeToUser = asNullableBoolean(fm.get("exposeToUser"));
         }
+        Boolean enablePendingToolRecovery =
+                asNullableBoolean(fm.get("enable_pending_tool_recovery"));
+        if (enablePendingToolRecovery == null) {
+            enablePendingToolRecovery = asNullableBoolean(fm.get("enablePendingToolRecovery"));
+        }
 
         List<String> tools = parseToolNames(asString(fm.get("tools")));
         List<String> skills = parseToolNames(asString(fm.get("skills")));
@@ -328,6 +333,7 @@ public final class AgentSpecLoader {
                         .mode(declMode)
                         .hidden(hidden)
                         .exposeToUser(exposeToUser)
+                        .enablePendingToolRecovery(enablePendingToolRecovery)
                         .tools(tools.isEmpty() ? null : tools)
                         .skills(skills.isEmpty() ? null : skills);
 

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/subagent/SubagentDeclaration.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/subagent/SubagentDeclaration.java
@@ -96,6 +96,7 @@ public final class SubagentDeclaration {
     private final boolean persistSession;
     private final boolean inheritParentPermissions;
     private final Boolean exposeToUser;
+    private final Boolean enablePendingToolRecovery;
     private final List<String> tools;
     private final List<String> skills;
 
@@ -141,6 +142,7 @@ public final class SubagentDeclaration {
         this.persistSession = b.persistSession;
         this.inheritParentPermissions = b.inheritParentPermissions;
         this.exposeToUser = b.exposeToUser;
+        this.enablePendingToolRecovery = b.enablePendingToolRecovery;
         this.tools = b.tools != null ? List.copyOf(b.tools) : List.of();
         this.skills = b.skills != null ? List.copyOf(b.skills) : List.of();
         this.url = b.url;
@@ -301,6 +303,15 @@ public final class SubagentDeclaration {
     }
 
     /**
+     * Recovery policy for orphaned tool calls in an automatically constructed local subagent.
+     * {@code null} (default) inherits the parent's setting; {@code true} or {@code false}
+     * explicitly overrides it. Remote subagents configure recovery on their own server.
+     */
+    public Boolean getEnablePendingToolRecovery() {
+        return enablePendingToolRecovery;
+    }
+
+    /**
      * Optional tool allowlist. When non-empty, only inherited parent tools whose names are listed
      * remain on the subagent's inherited toolkit. Empty means inherit all parent tools.
      */
@@ -396,6 +407,7 @@ public final class SubagentDeclaration {
         private boolean persistSession = false;
         private boolean inheritParentPermissions = true;
         private Boolean exposeToUser;
+        private Boolean enablePendingToolRecovery;
         private List<String> tools;
         private List<String> skills;
         private String url;
@@ -558,6 +570,18 @@ public final class SubagentDeclaration {
          */
         public Builder exposeToUser(Boolean exposeToUser) {
             this.exposeToUser = exposeToUser;
+            return this;
+        }
+
+        /**
+         * Overrides pending-tool recovery for this local subagent. Pass {@code null} to inherit
+         * the parent setting (the default). Permission confirmations are never auto-recovered.
+         *
+         * @param enable whether to enable recovery, or {@code null} to inherit
+         * @return this builder
+         */
+        public Builder enablePendingToolRecovery(Boolean enable) {
+            this.enablePendingToolRecovery = enable;
             return this;
         }
 

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/SubagentPendingToolRecoveryTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/SubagentPendingToolRecoveryTest.java
@@ -1,0 +1,374 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.harness.agent;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.agentscope.core.ReActAgent;
+import io.agentscope.core.agent.Agent;
+import io.agentscope.core.agent.RuntimeContext;
+import io.agentscope.core.agent.test.MockModel;
+import io.agentscope.core.event.AgentEvent;
+import io.agentscope.core.message.Msg;
+import io.agentscope.core.message.MsgRole;
+import io.agentscope.core.message.TextBlock;
+import io.agentscope.core.message.ToolResultBlock;
+import io.agentscope.core.message.ToolResultState;
+import io.agentscope.core.message.ToolUseBlock;
+import io.agentscope.core.middleware.ActingInput;
+import io.agentscope.core.middleware.MiddlewareBase;
+import io.agentscope.core.model.ChatResponse;
+import io.agentscope.core.model.Model;
+import io.agentscope.core.state.AgentState;
+import io.agentscope.core.state.AgentStateStore;
+import io.agentscope.core.state.InMemoryAgentStateStore;
+import io.agentscope.core.state.JsonFileAgentStateStore;
+import io.agentscope.harness.agent.middleware.SubagentEntry;
+import io.agentscope.harness.agent.subagent.SubagentDeclaration;
+import io.agentscope.harness.agent.subagent.WorkspaceMode;
+import io.agentscope.harness.agent.testing.HarnessQuiescence;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import reactor.core.Disposable;
+import reactor.core.publisher.Flux;
+
+/** Regression coverage for Issue #3016: recovery must reach automatically built subagents. */
+@HarnessQuiescence
+class SubagentPendingToolRecoveryTest {
+
+    private static final String CALL_ID = "interrupted-call";
+    private static final RuntimeContext CONTEXT =
+            RuntimeContext.builder().userId("user").sessionId("child-session").build();
+    private static final Duration TIMEOUT = Duration.ofSeconds(10);
+
+    @TempDir Path workspace;
+
+    @ParameterizedTest
+    @CsvSource({"true,true", "true,false", "false,true", "false,false"})
+    void automaticSubagentInheritsParentSetting(boolean declared, boolean enabled) {
+        HarnessAgent.Builder parent =
+                parent(new MockModel("unused"), new InMemoryAgentStateStore())
+                        .enablePendingToolRecovery(enabled);
+        try (HarnessAgent child = child(parent, declared)) {
+            assertEquals(enabled, child.getDelegate().isPendingToolRecoveryEnabled());
+        }
+    }
+
+    @ParameterizedTest
+    @CsvSource({"true,true", "true,false", "false,true", "false,false"})
+    void declaredSubagentCanOverrideParentSetting(boolean parentEnabled, boolean override) {
+        HarnessAgent.Builder parent =
+                parent(new MockModel("unused"), new InMemoryAgentStateStore())
+                        .enablePendingToolRecovery(parentEnabled);
+        try (HarnessAgent child = child(parent, true, override)) {
+            assertEquals(override, child.getDelegate().isPendingToolRecoveryEnabled());
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void workspaceSpecOverrideReachesConstructedChild(boolean override) throws Exception {
+        Path specs = Files.createDirectories(workspace.resolve("subagents"));
+        Files.writeString(
+                specs.resolve("worker.md"),
+                "---\ndescription: Worker\nenable_pending_tool_recovery: "
+                        + override
+                        + "\n---\nComplete the task.\n");
+        SubagentEntry entry =
+                parent(new MockModel("unused"), new InMemoryAgentStateStore())
+                        .enablePendingToolRecovery(!override)
+                        .buildSubagentEntries(workspace)
+                        .stream()
+                        .filter(candidate -> "worker".equals(candidate.name()))
+                        .findFirst()
+                        .orElseThrow();
+        try (HarnessAgent child = (HarnessAgent) entry.factory().create(CONTEXT)) {
+            assertEquals(override, child.getDelegate().isPendingToolRecoveryEnabled());
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void recoveryRemainsDisabledByDefault(boolean declared) {
+        try (HarnessAgent child =
+                child(parent(new MockModel("unused"), new InMemoryAgentStateStore()), declared)) {
+            assertEquals(false, child.getDelegate().isPendingToolRecoveryEnabled());
+        }
+    }
+
+    @Test
+    void disablingRecoveryAgainUpdatesBothDelegateAndChildConfiguration() {
+        HarnessAgent.Builder parent =
+                parent(new MockModel("unused"), new InMemoryAgentStateStore())
+                        .enablePendingToolRecovery(true)
+                        .enablePendingToolRecovery(false);
+        try (HarnessAgent child = child(parent, true)) {
+            assertEquals(false, child.getDelegate().isPendingToolRecoveryEnabled());
+        }
+    }
+
+    @ParameterizedTest
+    @CsvSource({"true,true", "true,false", "false,true", "false,false"})
+    void fromAgentPreservesSettingForAutomaticSubagents(boolean declared, boolean enabled) {
+        try (ReActAgent source =
+                ReActAgent.builder()
+                        .name("source")
+                        .model(new MockModel("unused"))
+                        .enablePendingToolRecovery(enabled)
+                        .build()) {
+            HarnessAgent.Builder parent =
+                    HarnessAgent.Builder.fromAgent(source)
+                            .workspace(workspace)
+                            .stateStore(new InMemoryAgentStateStore())
+                            .disableMemoryHooks();
+            try (HarnessAgent child = child(parent, declared)) {
+                assertEquals(enabled, child.getDelegate().isPendingToolRecoveryEnabled());
+            }
+        }
+    }
+
+    @ParameterizedTest
+    @CsvSource({"true,true", "true,false", "false,true", "false,false"})
+    void rebuiltChildRespectsRecoveryAfterPersistedActingFailure(
+            boolean declared, boolean enabled) {
+        Path stateDirectory = workspace.resolve("state");
+        RuntimeException failure = new IllegalStateException("acting failed before tool execution");
+        HarnessAgent.Builder failingParent =
+                parent(
+                                MockModel.withToolCall("unfinished_tool", CALL_ID, Map.of()),
+                                new JsonFileAgentStateStore(stateDirectory))
+                        .enablePendingToolRecovery(true)
+                        .middleware(
+                                new MiddlewareBase() {
+                                    @Override
+                                    public Flux<AgentEvent> onActing(
+                                            Agent agent,
+                                            RuntimeContext context,
+                                            ActingInput input,
+                                            Function<ActingInput, Flux<AgentEvent>> next) {
+                                        return Flux.error(failure);
+                                    }
+                                });
+
+        try (HarnessAgent child = child(failingParent, declared)) {
+            assertSame(
+                    failure,
+                    assertThrows(
+                            IllegalStateException.class,
+                            () -> child.call(List.of(user("start")), CONTEXT).block(TIMEOUT)));
+        }
+
+        // Reopen the on-disk store and rebuild the child; an in-memory cache cannot hide the bug.
+        JsonFileAgentStateStore reopenedStore = new JsonFileAgentStateStore(stateDirectory);
+        AgentState persisted =
+                reopenedStore
+                        .get("user", "child-session", "agent_state", AgentState.class)
+                        .orElseThrow();
+        assertTrue(
+                persisted.getContext().stream()
+                        .flatMap(msg -> msg.getContentBlocks(ToolUseBlock.class).stream())
+                        .anyMatch(tool -> CALL_ID.equals(tool.getId())));
+        assertTrue(results(persisted.getContext()).isEmpty());
+
+        MockModel recoveryModel = new MockModel("recovered");
+        HarnessAgent.Builder recoveryParent =
+                parent(recoveryModel, reopenedStore).enablePendingToolRecovery(enabled);
+        try (HarnessAgent child = child(recoveryParent, declared)) {
+            if (!enabled) {
+                IllegalStateException thrown =
+                        assertThrows(
+                                IllegalStateException.class,
+                                () ->
+                                        child.call(List.of(user("continue")), CONTEXT)
+                                                .block(TIMEOUT));
+                assertTrue(
+                        thrown.getMessage().contains("Pending tool calls exist without results"));
+                assertEquals(0, recoveryModel.getCallCount());
+                assertTrue(
+                        results(
+                                        child.getDelegate()
+                                                .getAgentState("user", "child-session")
+                                                .getContext())
+                                .isEmpty());
+                return;
+            }
+            assertEquals(
+                    "recovered",
+                    child.call(List.of(user("continue")), CONTEXT).block(TIMEOUT).getTextContent());
+            List<ToolResultBlock> patchedResults = results(recoveryModel.getLastMessages());
+            assertEquals(1, patchedResults.size());
+            assertEquals(CALL_ID, patchedResults.get(0).getId());
+            assertEquals(ToolResultState.ERROR, patchedResults.get(0).getState());
+            assertTrue(
+                    patchedResults.get(0).getOutput().stream()
+                            .filter(TextBlock.class::isInstance)
+                            .map(TextBlock.class::cast)
+                            .anyMatch(
+                                    text -> text.getText().contains("failed or was interrupted")));
+            assertTrue(
+                    recoveryModel.getLastMessages().stream()
+                            .anyMatch(msg -> "continue".equals(msg.getTextContent())));
+        }
+        assertEquals(
+                1,
+                results(
+                                reopenedStore
+                                        .get(
+                                                "user",
+                                                "child-session",
+                                                "agent_state",
+                                                AgentState.class)
+                                        .orElseThrow()
+                                        .getContext())
+                        .size());
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void childRecoversPendingCallAfterSubscriptionCancellation(boolean declared) throws Exception {
+        CountDownLatch actingSubscribed = new CountDownLatch(1);
+        CountDownLatch actingCancelled = new CountDownLatch(1);
+        AtomicInteger calls = new AtomicInteger();
+        MockModel model =
+                new MockModel(
+                        messages ->
+                                List.of(
+                                        ChatResponse.builder()
+                                                .content(
+                                                        calls.incrementAndGet() == 2
+                                                                ? List.of(
+                                                                        ToolUseBlock.builder()
+                                                                                .id(CALL_ID)
+                                                                                .name(
+                                                                                        "unfinished_tool")
+                                                                                .input(Map.of())
+                                                                                .build())
+                                                                : List.of(
+                                                                        TextBlock.builder()
+                                                                                .text("recovered")
+                                                                                .build()))
+                                                .build()));
+        HarnessAgent.Builder parent =
+                parent(model, new InMemoryAgentStateStore())
+                        .enablePendingToolRecovery(true)
+                        .middleware(
+                                new MiddlewareBase() {
+                                    @Override
+                                    public Flux<AgentEvent> onActing(
+                                            Agent agent,
+                                            RuntimeContext context,
+                                            ActingInput input,
+                                            Function<ActingInput, Flux<AgentEvent>> next) {
+                                        return Flux.<AgentEvent>never()
+                                                .doOnSubscribe(
+                                                        ignored -> actingSubscribed.countDown())
+                                                .doOnCancel(actingCancelled::countDown);
+                                    }
+                                });
+        try (HarnessAgent child = child(parent, declared)) {
+            // Establish a reusable session in the reference-backed in-memory store.
+            child.call(List.of(user("initialize")), CONTEXT).block(TIMEOUT);
+            Disposable subscription = child.call(List.of(user("start")), CONTEXT).subscribe();
+            try {
+                assertTrue(actingSubscribed.await(10, TimeUnit.SECONDS));
+            } finally {
+                subscription.dispose();
+            }
+            assertTrue(actingCancelled.await(10, TimeUnit.SECONDS));
+            AgentState cancelledState = child.getDelegate().getAgentState("user", "child-session");
+            assertTrue(results(cancelledState.getContext()).isEmpty());
+            assertTrue(
+                    cancelledState.getContext().stream()
+                            .flatMap(msg -> msg.getContentBlocks(ToolUseBlock.class).stream())
+                            .anyMatch(tool -> CALL_ID.equals(tool.getId())));
+
+            assertEquals(
+                    "recovered",
+                    child.call(List.of(user("continue")), CONTEXT).block(TIMEOUT).getTextContent());
+            assertEquals(3, model.getCallCount());
+            assertEquals(ToolResultState.ERROR, results(model.getLastMessages()).get(0).getState());
+            assertEquals(
+                    List.of(CALL_ID),
+                    results(model.getLastMessages()).stream().map(ToolResultBlock::getId).toList());
+        }
+    }
+
+    private HarnessAgent.Builder parent(Model model, AgentStateStore store) {
+        return HarnessAgent.builder()
+                .model(model)
+                .workspace(workspace)
+                .stateStore(store)
+                .disableFilesystemTools()
+                .disableShellTool()
+                .disableMemoryTools()
+                .disableMemoryHooks()
+                .disableCompaction()
+                .disableToolResultEviction();
+    }
+
+    private HarnessAgent child(HarnessAgent.Builder parent, boolean declared) {
+        return child(parent, declared, null);
+    }
+
+    private HarnessAgent child(HarnessAgent.Builder parent, boolean declared, Boolean override) {
+        String name = declared ? "worker" : "general-purpose";
+        if (declared) {
+            parent.subagent(
+                    SubagentDeclaration.builder()
+                            .name(name)
+                            .description("Worker")
+                            .inlineAgentsBody("Complete the task.")
+                            .enablePendingToolRecovery(override)
+                            .workspaceMode(WorkspaceMode.SHARED)
+                            .build());
+        }
+        SubagentEntry entry =
+                parent.buildSubagentEntries(workspace).stream()
+                        .filter(candidate -> name.equals(candidate.name()))
+                        .findFirst()
+                        .orElseThrow();
+        return (HarnessAgent) entry.factory().create(CONTEXT);
+    }
+
+    private static List<ToolResultBlock> results(List<Msg> messages) {
+        return messages.stream()
+                .flatMap(msg -> msg.getContentBlocks(ToolResultBlock.class).stream())
+                .toList();
+    }
+
+    private static Msg user(String text) {
+        return Msg.builder()
+                .name("user")
+                .role(MsgRole.USER)
+                .content(TextBlock.builder().text(text).build())
+                .build();
+    }
+}

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/subagent/SubagentPendingToolRecoveryDeclarationTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/subagent/SubagentPendingToolRecoveryDeclarationTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.harness.agent.subagent;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class SubagentPendingToolRecoveryDeclarationTest {
+
+    @ParameterizedTest
+    @NullSource
+    @ValueSource(booleans = {true, false})
+    void builderPreservesTriState(Boolean enabled) {
+        SubagentDeclaration declaration =
+                SubagentDeclaration.builder()
+                        .name("worker")
+                        .description("Worker")
+                        .inlineAgentsBody("Complete the task.")
+                        .enablePendingToolRecovery(enabled)
+                        .build();
+        assertEquals(enabled, declaration.getEnablePendingToolRecovery());
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+        "enable_pending_tool_recovery,true",
+        "enable_pending_tool_recovery,false",
+        "enablePendingToolRecovery,true",
+        "enablePendingToolRecovery,false"
+    })
+    void loaderParsesBothSpellings(String key, boolean enabled) {
+        SubagentDeclaration declaration = parse(key + ": " + enabled);
+        assertEquals(enabled, declaration.getEnablePendingToolRecovery());
+    }
+
+    @Test
+    void omittedOrNullSettingInheritsParent() {
+        assertNull(parse("").getEnablePendingToolRecovery());
+        assertNull(parse("enable_pending_tool_recovery: null").getEnablePendingToolRecovery());
+    }
+
+    @Test
+    void explicitSnakeCaseFalseTakesPrecedenceOverCamelCaseTrue() {
+        assertEquals(
+                false,
+                parse("enable_pending_tool_recovery: false\nenablePendingToolRecovery: true")
+                        .getEnablePendingToolRecovery());
+    }
+
+    private static SubagentDeclaration parse(String setting) {
+        return AgentSpecLoader.parse(
+                "---\ndescription: Worker\n" + setting + "\n---\nComplete the task.\n",
+                "worker",
+                null);
+    }
+}

--- a/docs/v2/en/docs/harness/subagent.md
+++ b/docs/v2/en/docs/harness/subagent.md
@@ -59,6 +59,7 @@ top_p: 0.95                   # optional
 hidden: false                 # true = not listed to the model (still callable programmatically)
 mode: subagent                # primary / subagent / all (default all); primary can't be spawned
 expose_to_user: true          # optional tri-state; force/forbid user exposure (omit = no opinion)
+enable_pending_tool_recovery: true # optional; omit to inherit the parent's recovery setting
 tools: [read_file, grep_files]   # optional; allowlist over inherited tools
 ---
 
@@ -91,6 +92,15 @@ HarnessAgent.builder()
 ```
 
 Three sources are mutually exclusive: `workspace(...)`, `inlineAgentsBody(...)`, `url(...)` — pick one.
+
+Automatically built local subagents, including `general-purpose`, inherit the parent's
+`HarnessAgent.Builder.enablePendingToolRecovery(...)` setting (default `false`). A declaration can
+override it with `.enablePendingToolRecovery(true)` or `.enablePendingToolRecovery(false)`; `null`
+inherits. Workspace specs accept `enable_pending_tool_recovery` (or `enablePendingToolRecovery`).
+When enabled, a new ordinary message repairs orphaned pending tool calls with synthetic error
+results, including calls loaded from a failed session. Pending permission confirmations still
+require confirmation; empty-input resume and caller-supplied tool results retain their existing
+behavior. Remote agents and custom factories configure recovery themselves.
 
 ### Built-in `general-purpose`
 

--- a/docs/v2/zh/docs/harness/subagent.md
+++ b/docs/v2/zh/docs/harness/subagent.md
@@ -59,6 +59,7 @@ top_p: 0.95                   # 可选
 hidden: false                 # true 时不出现在 agent 可见列表（仍可程序化 spawn）
 mode: subagent                # primary / subagent / all，默认 all；primary 不允许被 spawn
 expose_to_user: true          # 可选三态；强制/禁止向用户暴露（不写表示不表态）
+enable_pending_tool_recovery: true # 可选；不写则继承父 agent 的恢复配置
 tools: [read_file, grep_files]   # 可选；继承工具的白名单
 ---
 
@@ -91,6 +92,14 @@ HarnessAgent.builder()
 ```
 
 三种来源互斥：`workspace(...)`、`inlineAgentsBody(...)`、`url(...)` **三选一**。
+
+框架自动构建的本地子 agent（包括 `general-purpose`）会继承父级
+`HarnessAgent.Builder.enablePendingToolRecovery(...)` 配置，默认关闭。声明中可用
+`.enablePendingToolRecovery(true)` 或 `.enablePendingToolRecovery(false)` 显式覆盖，
+`null` 表示继承。工作区 spec 支持 `enable_pending_tool_recovery`，也兼容
+`enablePendingToolRecovery` 写法。开启后，新的普通消息会为悬空工具调用补充错误结果，
+也适用于从失败会话中重新加载的工具调用。等待人工审批的工具仍须提供审批结果；空输入恢复执行、
+调用方补交工具结果的行为保持原有语义。远端 agent 和自定义工厂需自行配置恢复策略。
 
 ### 内置 `general-purpose`
 


### PR DESCRIPTION
Fixes #3016

### 问题
父 HarnessAgent 开启 enablePendingToolRecovery 后，声明子代理和内置
general-purpose 子代理未继承该配置。异常留下悬空工具调用并持久化后，
后续普通文本请求持续报错。

### 修复
- 将父级恢复配置传递到声明子代理和 general-purpose 子代理。
- 支持子代理声明独立覆盖：null 继承父级，true/false 显式覆盖。
- Markdown 声明支持 enable_pending_tool_recovery 和 enablePendingToolRecovery。
- 保持默认关闭，以及现有人工审批、外部工具结果回填语义。
- 更新中英文文档。

### 验证
- 新增 32 项回归测试，覆盖配置继承、声明覆盖、磁盘会话重建恢复和取消后继续调用。
- Spotless、git diff --check 通过。
- Core：2,319 项，0 failures、0 errors，9 项跳过。
- Harness：987 项，0 failures、0 errors，5 项跳过。