### PR TITLE
perf(harness): batch heartbeat task-record persistence per session store

### DIFF
--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/filesystem/AbstractFilesystem.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/filesystem/AbstractFilesystem.java
@@ -170,6 +170,26 @@ public interface AbstractFilesystem {
     // ==================== Path validation utility ====================
 
     /**
+     * Returns an identity object for the storage location that workspace IO for {@code path}
+     * under {@code rc} resolves to. Two operations whose keys compare equal are guaranteed to
+     * target the same physical storage, which lets callers safely batch them into one
+     * read-modify-write.
+     *
+     * <p>The conservative default isolates per context instance: it only reports equal keys for
+     * the very same {@code RuntimeContext} and path, which is always safe for backends whose
+     * routing may depend on the context. Backends that locate content purely by path should
+     * override this to return the normalized path, and backends that derive the location from
+     * the context (e.g. a per-user namespace) must include that derived location in the key.
+     *
+     * @param runtimeContext per-call agent runtime; {@link RuntimeContext#empty()} when none
+     * @param path the workspace-relative path of the operation
+     * @return an object with value equality reflecting the storage identity
+     */
+    default Object storageKey(RuntimeContext runtimeContext, String path) {
+        return java.util.Arrays.asList(runtimeContext, path);
+    }
+
+    /**
      * Validates that {@code path} is safe (non-null, non-blank, no {@code ..} traversal).
      *
      * @param path the path to validate

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/filesystem/BakedContextFilesystem.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/filesystem/BakedContextFilesystem.java
@@ -110,4 +110,11 @@ public final class BakedContextFilesystem implements AbstractFilesystem {
     public boolean exists(RuntimeContext runtimeContext, String path) {
         return delegate.exists(bakedRc, path);
     }
+
+    @Override
+    public Object storageKey(RuntimeContext runtimeContext, String path) {
+        // Storage identity follows the substituted context, not the caller's: every delegated
+        // operation (and therefore its write target) is resolved under bakedRc.
+        return delegate.storageKey(bakedRc, path);
+    }
 }

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/filesystem/CompositeFilesystem.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/filesystem/CompositeFilesystem.java
@@ -105,6 +105,12 @@ public class CompositeFilesystem implements AbstractFilesystem {
         return routeForPath(path).backend();
     }
 
+    @Override
+    public Object storageKey(RuntimeContext runtimeContext, String path) {
+        RouteResult route = routeForPath(path);
+        return route.backend().storageKey(runtimeContext, route.backendPath());
+    }
+
     private RouteResult routeForPath(String path) {
         // Canonicalize both sides by stripping any leading slash before matching so callers can
         // pass either "/skills/foo" (the {@link AbstractFilesystem} contract) or "skills/foo"

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/filesystem/OverlayFilesystem.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/filesystem/OverlayFilesystem.java
@@ -299,4 +299,9 @@ public class OverlayFilesystem implements AbstractFilesystem {
     public AbstractFilesystem getLower() {
         return lower;
     }
+
+    @Override
+    public Object storageKey(RuntimeContext runtimeContext, String path) {
+        return upper.storageKey(runtimeContext, path);
+    }
 }

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/filesystem/RoutedSandboxFilesystem.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/filesystem/RoutedSandboxFilesystem.java
@@ -135,4 +135,9 @@ public final class RoutedSandboxFilesystem implements AbstractSandboxFilesystem 
     public boolean exists(RuntimeContext runtimeContext, String path) {
         return composite.exists(runtimeContext, path);
     }
+
+    @Override
+    public Object storageKey(RuntimeContext runtimeContext, String path) {
+        return composite.storageKey(runtimeContext, path);
+    }
 }

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/filesystem/local/LocalFilesystem.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/filesystem/local/LocalFilesystem.java
@@ -922,4 +922,12 @@ public class LocalFilesystem implements AbstractFilesystem {
 
         return matches;
     }
+
+    @Override
+    public Object storageKey(RuntimeContext runtimeContext, String path) {
+        // The exact path this backend's IO resolves to — namespace prefix (when a
+        // NamespaceFactory is configured) and mode included — so contexts that store in
+        // different namespace directories never share a batch.
+        return resolvePath(runtimeContext, path).normalize();
+    }
 }

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/filesystem/remote/RemoteFilesystem.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/filesystem/remote/RemoteFilesystem.java
@@ -725,4 +725,9 @@ public class RemoteFilesystem implements AbstractFilesystem {
         }
         return key.equals(normalizedPath) || key.startsWith(normalizedPath + "/");
     }
+
+    @Override
+    public Object storageKey(RuntimeContext runtimeContext, String path) {
+        return List.of(getNamespace(runtimeContext), path);
+    }
 }

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/subagent/task/WorkspaceTaskRepository.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/subagent/task/WorkspaceTaskRepository.java
@@ -26,6 +26,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -679,30 +680,80 @@ public class WorkspaceTaskRepository implements TaskRepository {
      * running. Called on a fixed schedule so the orphan sweeper can distinguish a genuinely
      * running task from one whose originating node has disappeared.
      *
+     * <p>Tasks whose records share one session store file are refreshed in a single batched
+     * read-modify-write (see {@link WorkspaceManager#updateTaskRecordStatuses}): a per-task
+     * refresh would re-parse and re-write the whole store once per running task every cycle.
+     * Batches are grouped by the backend's storage identity (see
+     * {@link WorkspaceManager#taskRecordStoreKey}): context-free backends merge every context
+     * of a session into one write, while context-partitioned backends (e.g. per-user remote
+     * namespaces) get one batch per derived storage location, each written under the context
+     * that produced it.
+     *
      * <p>Package-private for direct invocation in unit tests.
      */
     void heartbeat() {
+        Map<Object, StoreBatch> batches = new LinkedHashMap<>();
         localTasks.forEach(
                 (key, task) -> {
                     if (!task.isCompleted()) {
                         String sid = localTaskSessionIds.get(key);
-                        if (sid == null) {
+                        if (sid == null || sid.isBlank()) {
                             return;
                         }
-                        RuntimeContext rc = localTaskContexts.get(key);
-                        if (rc == null) {
-                            rc = RuntimeContext.empty();
-                        }
+                        // Per-task isolation, matching the pre-batching heartbeat: grouping
+                        // calls into pluggable code (namespace resolution) on the maintenance
+                        // scheduler, where an escaped exception would permanently suppress
+                        // every later heartbeat execution.
                         try {
-                            updateStatus(rc, sid, task.getTaskId(), TaskStatus.RUNNING, null, null);
+                            RuntimeContext rc =
+                                    localTaskContexts.getOrDefault(key, RuntimeContext.empty());
+                            Object storeKey =
+                                    workspaceManager.taskRecordStoreKey(rc, parentAgentId, sid);
+                            batches.computeIfAbsent(storeKey, k -> new StoreBatch(rc, sid))
+                                    .taskIds
+                                    .add(task.getTaskId());
                         } catch (Exception e) {
-                            log.debug(
-                                    "Heartbeat update failed for task {}: {}",
+                            // A task whose grouping persistently fails is never refreshed,
+                            // so it is eventually orphan-swept to FAILED — deterministic
+                            // loss for that task, at least as severe as a batch failure.
+                            log.warn(
+                                    "Heartbeat grouping failed for task {}: {}",
                                     task.getTaskId(),
                                     e.getMessage());
                         }
                     }
                 });
+        for (StoreBatch batch : batches.values()) {
+            try {
+                Map<String, TaskStatus> statuses = new LinkedHashMap<>();
+                for (String taskId : batch.taskIds) {
+                    statuses.put(taskId, TaskStatus.RUNNING);
+                }
+                workspaceManager.updateTaskRecordStatuses(
+                        batch.rc, parentAgentId, batch.sessionId, statuses);
+            } catch (Exception e) {
+                // A batch covers every running task of one session for this cycle, so a
+                // failure's blast radius is the whole session — surface it at warn like
+                // persistRecord does, not at the old per-task debug level.
+                log.warn(
+                        "Heartbeat update failed for {} tasks in session {}: {}",
+                        batch.taskIds.size(),
+                        batch.sessionId,
+                        e.getMessage());
+            }
+        }
+    }
+
+    /** Running-task refreshes that resolve to the same session store file. */
+    private static final class StoreBatch {
+        final RuntimeContext rc;
+        final String sessionId;
+        final List<String> taskIds = new ArrayList<>();
+
+        StoreBatch(RuntimeContext rc, String sessionId) {
+            this.rc = rc;
+            this.sessionId = sessionId;
+        }
     }
 
     /** Package-private entry point for unit tests that need to invoke the default sweep path. */

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/workspace/WorkspaceManager.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/workspace/WorkspaceManager.java
@@ -42,6 +42,7 @@ import io.agentscope.harness.agent.filesystem.model.WriteResult;
 import io.agentscope.harness.agent.filesystem.remote.store.NamespaceFactory;
 import io.agentscope.harness.agent.filesystem.sandbox.SandboxBackedFilesystem;
 import io.agentscope.harness.agent.subagent.task.TaskRecord;
+import io.agentscope.harness.agent.subagent.task.TaskStatus;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -491,6 +492,126 @@ public class WorkspaceManager implements AutoCloseable {
             record.touch();
             map.put(record.getTaskId(), record);
             persistTaskMap(rc, rel, map);
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    /**
+     * Returns the storage identity of a session's task-record store under the given context.
+     * This is the identity callers use to group per-record refreshes into one batched
+     * read-modify-write: keys that compare equal are guaranteed to hit the same physical
+     * storage.
+     *
+     * <p>The identity follows the routing the store IO actually takes: the host-disk fallback
+     * of the per-call sandbox route serves the workspace-relative path regardless of context,
+     * and every other backend is asked through
+     * {@link AbstractFilesystem#storageKey(RuntimeContext, String)}. A backend whose resolved
+     * storage location does not depend on the context batches every context of a session
+     * together (e.g. a {@code LocalFilesystem} without a {@code NamespaceFactory}); a backend
+     * that derives the location from the context splits per derived location, each batch
+     * written back under the context that produced it — a {@code RemoteFilesystem} with a
+     * per-user {@code NamespaceFactory}, or a {@code LocalFilesystem} configured with one,
+     * keeps per-user stores in separate batches.
+     *
+     * @param rc per-call agent runtime; {@link RuntimeContext#empty()} when none
+     * @param agentId the parent agent identifier
+     * @param sessionId the session identifier
+     * @return an object with value equality reflecting the store's storage identity
+     */
+    public Object taskRecordStoreKey(RuntimeContext rc, String agentId, String sessionId) {
+        String rel = taskRecordPath(agentId, sessionId);
+        if (taskRecordsRouteToLiveSandbox(rel)) {
+            return rel;
+        }
+        return filesystem != null ? filesystem.storageKey(rc, rel) : rel;
+    }
+
+    /**
+     * Refreshes the status of several {@link TaskRecord}s of one session store in a single
+     * read-modify-write cycle.
+     *
+     * <p>Batched sibling of {@link #writeTaskRecord} for callers that refresh many records of
+     * the same session — the heartbeat of
+     * {@link io.agentscope.harness.agent.subagent.task.WorkspaceTaskRepository} touches every
+     * running task every cycle. One lock acquisition, one parse and one whole-file persist
+     * regardless of how many records are refreshed, instead of a full cycle per record.
+     *
+     * <p>The per-record guards mirror {@code WorkspaceTaskRepository.updateStatus}: terminal
+     * records are immutable, and a record with a pending cancellation request refuses
+     * non-terminal refreshes. Unlike the single-record path they are evaluated against the same
+     * in-lock snapshot that is written back, so a terminal transition that landed earlier can
+     * never be clobbered by the batch.
+     *
+     * <p>Entries with a null or blank task ID or a null status are skipped, mirroring the
+     * defensive input handling of {@link #writeTaskRecord}.
+     *
+     * @param rc per-call agent runtime; {@link RuntimeContext#empty()} when none
+     * @param agentId the parent agent identifier
+     * @param sessionId the session identifier
+     * @param statusByTaskId the status to persist per task ID
+     */
+    public void updateTaskRecordStatuses(
+            RuntimeContext rc,
+            String agentId,
+            String sessionId,
+            Map<String, TaskStatus> statusByTaskId) {
+        if (agentId == null
+                || agentId.isBlank()
+                || sessionId == null
+                || sessionId.isBlank()
+                || statusByTaskId == null
+                || statusByTaskId.isEmpty()) {
+            return;
+        }
+        String rel = taskRecordPath(agentId, sessionId);
+        ReentrantLock lock = pathLocks.computeIfAbsent(rel, k -> new ReentrantLock());
+        lock.lock();
+        try {
+            Map<String, TaskRecord> map;
+            try {
+                map = readTaskMap(rc, rel); // already holding lock
+            } catch (IOException e) {
+                // Never overwrite a malformed store with partial data from a failed parse.
+                log.error(
+                        "Failed to parse task record store {}, aborting batched status update to"
+                                + " avoid data loss.",
+                        rel,
+                        e);
+                return;
+            }
+            boolean changed = false;
+            for (Map.Entry<String, TaskStatus> entry : statusByTaskId.entrySet()) {
+                String taskId = entry.getKey();
+                if (taskId == null || taskId.isBlank() || entry.getValue() == null) {
+                    continue;
+                }
+                TaskRecord existing = map.get(taskId);
+                if (existing != null
+                        && existing.getStatus() != null
+                        && existing.getStatus().isTerminal()) {
+                    continue;
+                }
+                if (!entry.getValue().isTerminal()
+                        && existing != null
+                        && existing.isCancelRequested()) {
+                    continue;
+                }
+                TaskRecord record = existing;
+                if (record == null) {
+                    record = new TaskRecord();
+                    record.setTaskId(taskId);
+                    record.setParentAgentId(agentId);
+                    record.setParentSessionId(sessionId);
+                }
+                record.setStatus(entry.getValue());
+                record.touch();
+                map.put(taskId, record);
+                changed = true;
+            }
+            if (changed) {
+                persistTaskMap(rc, rel, map);
+            }
         } finally {
             lock.unlock();
         }

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/subagent/task/WorkspaceTaskRepositoryHeartbeatBatchTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/subagent/task/WorkspaceTaskRepositoryHeartbeatBatchTest.java
@@ -1,0 +1,1005 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.harness.agent.subagent.task;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.agentscope.core.agent.RuntimeContext;
+import io.agentscope.harness.agent.filesystem.AbstractFilesystem;
+import io.agentscope.harness.agent.filesystem.RoutedSandboxFilesystem;
+import io.agentscope.harness.agent.filesystem.model.EditResult;
+import io.agentscope.harness.agent.filesystem.model.FileData;
+import io.agentscope.harness.agent.filesystem.model.FileDownloadResponse;
+import io.agentscope.harness.agent.filesystem.model.FileInfo;
+import io.agentscope.harness.agent.filesystem.model.FileUploadResponse;
+import io.agentscope.harness.agent.filesystem.model.GlobResult;
+import io.agentscope.harness.agent.filesystem.model.GrepResult;
+import io.agentscope.harness.agent.filesystem.model.LsResult;
+import io.agentscope.harness.agent.filesystem.model.ReadResult;
+import io.agentscope.harness.agent.filesystem.model.WriteResult;
+import io.agentscope.harness.agent.filesystem.sandbox.SandboxBackedFilesystem;
+import io.agentscope.harness.agent.workspace.WorkspaceManager;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Batching contract for the heartbeat's task-record persistence.
+ *
+ * <p>Every heartbeat refresh used to run one full read-modify-write of the session's task store
+ * <em>per running task</em>: with {@code R} running tasks sharing one store file the sweeper-scale
+ * cost is {@code O(R x store)} parses, serializations and whole-file writes per 30s cycle. The
+ * heartbeat now batches all refreshes that resolve to the same store file into a single
+ * read-modify-write. These tests pin the batching by counting backend writes, and lock the
+ * behavioural contracts that must not change: all tasks are still refreshed, terminal records
+ * are never clobbered, and per-task {@link RuntimeContext} instances that resolve to the same
+ * store file still share one batch.
+ */
+class WorkspaceTaskRepositoryHeartbeatBatchTest {
+
+    @TempDir java.nio.file.Path tempDir;
+
+    private WorkspaceTaskRepository repo;
+    private WorkspaceManager workspaceManager;
+    private CountingMapFs persistent;
+
+    @AfterEach
+    void tearDown() throws Exception {
+        if (repo != null) {
+            repo.shutdown();
+        }
+        if (workspaceManager != null) {
+            workspaceManager.close();
+        }
+    }
+
+    @Test
+    @DisplayName("heartbeat persists one store write per session file, not per task")
+    void heartbeat_batchesRefreshesPerSessionFile() throws Exception {
+        assembleRouted();
+        CountDownLatch running = new CountDownLatch(3);
+        CountDownLatch release = new CountDownLatch(1);
+        try {
+            for (int i = 1; i <= 3; i++) {
+                // Distinct RuntimeContext instances on purpose: batching groups by resolved
+                // store path, not by context identity.
+                repo.putTask(
+                        RuntimeContext.empty(),
+                        "task-" + i,
+                        "sub-" + i,
+                        "sess",
+                        blockingSpec(running, release));
+            }
+            assertTrue(running.await(5, TimeUnit.SECONDS), "tasks never started");
+            awaitWriteQuiescence();
+
+            long before = persistent.writesOf("test-agent/tasks/sess.json");
+            repo.heartbeat();
+
+            assertEquals(
+                    before + 1,
+                    persistent.writesOf("test-agent/tasks/sess.json"),
+                    "three running tasks in one session file must produce exactly one store"
+                            + " write per heartbeat cycle, not one per task");
+
+            for (int i = 1; i <= 3; i++) {
+                Optional<TaskRecord> record =
+                        workspaceManager.readTaskRecord(
+                                RuntimeContext.empty(), "test-agent", "sess", "task-" + i);
+                assertTrue(record.isPresent(), "task-" + i + " record must survive batching");
+                assertEquals(TaskStatus.RUNNING, record.get().getStatus());
+                assertTrue(
+                        record.get().getLastUpdatedAt().isAfter(Instant.now().minusSeconds(60)),
+                        "task-" + i + " lastUpdatedAt must be refreshed by the heartbeat");
+            }
+        } finally {
+            release.countDown();
+        }
+    }
+
+    @Test
+    @DisplayName("heartbeat writes once per session file across different sessions")
+    void heartbeat_oneWritePerSessionFileAcrossSessions() throws Exception {
+        assembleRouted();
+        CountDownLatch running = new CountDownLatch(2);
+        CountDownLatch release = new CountDownLatch(1);
+        try {
+            repo.putTask(
+                    RuntimeContext.empty(),
+                    "task-a1",
+                    "sub-a1",
+                    "sess-a",
+                    blockingSpec(running, release));
+            repo.putTask(
+                    RuntimeContext.empty(),
+                    "task-a2",
+                    "sub-a2",
+                    "sess-a",
+                    blockingSpec(running, release));
+            repo.putTask(
+                    RuntimeContext.empty(),
+                    "task-b1",
+                    "sub-b1",
+                    "sess-b",
+                    blockingSpec(running, release));
+            assertTrue(running.await(5, TimeUnit.SECONDS), "tasks never started");
+            awaitWriteQuiescence();
+
+            long beforeA = persistent.writesOf("test-agent/tasks/sess-a.json");
+            long beforeB = persistent.writesOf("test-agent/tasks/sess-b.json");
+            repo.heartbeat();
+
+            assertEquals(
+                    beforeA + 1,
+                    persistent.writesOf("test-agent/tasks/sess-a.json"),
+                    "sess-a holds two running tasks and must be written once");
+            assertEquals(
+                    beforeB + 1,
+                    persistent.writesOf("test-agent/tasks/sess-b.json"),
+                    "sess-b holds one running task and must be written once");
+        } finally {
+            release.countDown();
+        }
+    }
+
+    @Test
+    @DisplayName("heartbeat never clobbers terminal records while batching")
+    void heartbeat_doesNotClobberTerminalRecords() throws Exception {
+        assembleRouted();
+        CountDownLatch running = new CountDownLatch(2);
+        CountDownLatch release = new CountDownLatch(1);
+        try {
+            repo.putTask(
+                    RuntimeContext.empty(),
+                    "task-1",
+                    "sub-1",
+                    "sess",
+                    blockingSpec(running, release));
+            repo.putTask(
+                    RuntimeContext.empty(),
+                    "task-2",
+                    "sub-2",
+                    "sess",
+                    blockingSpec(running, release));
+            assertTrue(running.await(5, TimeUnit.SECONDS), "tasks never started");
+
+            // Take task-1 terminal behind the repository's back, then heartbeat.
+            TaskRecord terminal =
+                    workspaceManager
+                            .readTaskRecord(RuntimeContext.empty(), "test-agent", "sess", "task-1")
+                            .orElseThrow();
+            terminal.setStatus(TaskStatus.COMPLETED);
+            workspaceManager.writeTaskRecord(
+                    RuntimeContext.empty(), "test-agent", "sess", terminal);
+            Instant terminalStamp =
+                    workspaceManager
+                            .readTaskRecord(RuntimeContext.empty(), "test-agent", "sess", "task-1")
+                            .orElseThrow()
+                            .getLastUpdatedAt();
+
+            repo.heartbeat();
+
+            TaskRecord after =
+                    workspaceManager
+                            .readTaskRecord(RuntimeContext.empty(), "test-agent", "sess", "task-1")
+                            .orElseThrow();
+            assertEquals(
+                    TaskStatus.COMPLETED,
+                    after.getStatus(),
+                    "terminal records are immutable and must be skipped by the heartbeat");
+            assertEquals(
+                    terminalStamp,
+                    after.getLastUpdatedAt(),
+                    "a skipped terminal record must not even be touched");
+            TaskRecord survivor =
+                    workspaceManager
+                            .readTaskRecord(RuntimeContext.empty(), "test-agent", "sess", "task-2")
+                            .orElseThrow();
+            assertEquals(
+                    TaskStatus.RUNNING,
+                    survivor.getStatus(),
+                    "non-terminal siblings must still be refreshed in the same batch");
+        } finally {
+            release.countDown();
+        }
+    }
+
+    @Test
+    @DisplayName("a grouping failure skips one task but never kills the heartbeat")
+    void heartbeat_survivesGroupingFailure() throws Exception {
+        // The backend's storageKey throws on its second resolution: one task's grouping
+        // fails, the other must still be batched and persisted. Before per-task isolation
+        // this escaped the forEach and permanently suppressed every later heartbeat on the
+        // scheduler.
+        java.util.concurrent.atomic.AtomicInteger calls =
+                new java.util.concurrent.atomic.AtomicInteger();
+        CountingMapFs flakyKey =
+                new CountingMapFs() {
+                    @Override
+                    public Object storageKey(RuntimeContext rc, String path) {
+                        if (calls.incrementAndGet() == 2) {
+                            throw new IllegalStateException("storage key resolution boom");
+                        }
+                        return super.storageKey(rc, path);
+                    }
+                };
+        RoutedSandboxFilesystem routed =
+                new RoutedSandboxFilesystem(
+                        new SandboxBackedFilesystem(), java.util.Map.of("agents/", flakyKey));
+        workspaceManager = new WorkspaceManager(tempDir, routed);
+        repo = WorkspaceTaskRepository.forTests(workspaceManager, "test-agent");
+
+        CountDownLatch running = new CountDownLatch(2);
+        CountDownLatch release = new CountDownLatch(1);
+        try {
+            for (int i = 1; i <= 2; i++) {
+                repo.putTask(
+                        RuntimeContext.empty(),
+                        "task-" + i,
+                        "sub-" + i,
+                        "sess",
+                        blockingSpec(running, release));
+            }
+            assertTrue(running.await(5, TimeUnit.SECONDS), "tasks never started");
+
+            java.util.Map<String, Instant> stampsBefore = new java.util.LinkedHashMap<>();
+            for (int i = 1; i <= 2; i++) {
+                stampsBefore.put(
+                        "task-" + i,
+                        workspaceManager
+                                .readTaskRecord(
+                                        RuntimeContext.empty(), "test-agent", "sess", "task-" + i)
+                                .orElseThrow()
+                                .getLastUpdatedAt());
+            }
+            Thread.sleep(50); // guarantee the clock advances past the seeded stamps
+
+            repo.heartbeat(); // must not throw
+
+            int refreshed = 0;
+            for (int i = 1; i <= 2; i++) {
+                Optional<TaskRecord> record =
+                        workspaceManager.readTaskRecord(
+                                RuntimeContext.empty(), "test-agent", "sess", "task-" + i);
+                assertTrue(record.isPresent(), "task-" + i + " record must survive");
+                if (record.get().getLastUpdatedAt().isAfter(stampsBefore.get("task-" + i))) {
+                    refreshed++;
+                }
+            }
+            assertEquals(
+                    1,
+                    refreshed,
+                    "exactly the successfully grouped task must be refreshed; the failed one"
+                            + " is skipped for this cycle only");
+        } finally {
+            release.countDown();
+        }
+    }
+
+    @Test
+    @DisplayName("heartbeat does not refresh records with a pending cancellation request")
+    void heartbeat_doesNotRefreshCancelRequestedRecords() throws Exception {
+        assembleRouted();
+        CountDownLatch running = new CountDownLatch(2);
+        CountDownLatch release = new CountDownLatch(1);
+        try {
+            repo.putTask(
+                    RuntimeContext.empty(),
+                    "task-1",
+                    "sub-1",
+                    "sess",
+                    blockingSpec(running, release));
+            repo.putTask(
+                    RuntimeContext.empty(),
+                    "task-2",
+                    "sub-2",
+                    "sess",
+                    blockingSpec(running, release));
+            assertTrue(running.await(5, TimeUnit.SECONDS), "tasks never started");
+
+            TaskRecord cancelling =
+                    workspaceManager
+                            .readTaskRecord(RuntimeContext.empty(), "test-agent", "sess", "task-1")
+                            .orElseThrow();
+            cancelling.setCancelRequested(true);
+            workspaceManager.writeTaskRecord(
+                    RuntimeContext.empty(), "test-agent", "sess", cancelling);
+            Instant cancelStamp =
+                    workspaceManager
+                            .readTaskRecord(RuntimeContext.empty(), "test-agent", "sess", "task-1")
+                            .orElseThrow()
+                            .getLastUpdatedAt();
+
+            repo.heartbeat();
+
+            TaskRecord after =
+                    workspaceManager
+                            .readTaskRecord(RuntimeContext.empty(), "test-agent", "sess", "task-1")
+                            .orElseThrow();
+            assertTrue(after.isCancelRequested(), "the cancellation flag must survive");
+            assertEquals(
+                    cancelStamp,
+                    after.getLastUpdatedAt(),
+                    "a record with a pending cancellation request must refuse non-terminal"
+                            + " refreshes, without even being touched");
+            TaskRecord survivor =
+                    workspaceManager
+                            .readTaskRecord(RuntimeContext.empty(), "test-agent", "sess", "task-2")
+                            .orElseThrow();
+            assertEquals(
+                    TaskStatus.RUNNING,
+                    survivor.getStatus(),
+                    "siblings without a cancellation request must still be refreshed");
+        } finally {
+            release.countDown();
+        }
+    }
+
+    @Test
+    @DisplayName("heartbeat never reinitializes a corrupt store while batching")
+    void heartbeat_doesNotOverwriteCorruptStore() throws Exception {
+        assembleRouted();
+        CountDownLatch running = new CountDownLatch(1);
+        CountDownLatch release = new CountDownLatch(1);
+        try {
+            repo.putTask(
+                    RuntimeContext.empty(),
+                    "task-1",
+                    "sub-1",
+                    "sess",
+                    blockingSpec(running, release));
+            assertTrue(running.await(5, TimeUnit.SECONDS), "task never started");
+
+            String corrupt = "{\"task-1\": {\"brok";
+            persistent.putRaw("test-agent/tasks/sess.json", corrupt);
+            long writesBefore = persistent.writesOf("test-agent/tasks/sess.json");
+
+            repo.heartbeat();
+
+            assertEquals(
+                    corrupt,
+                    persistent.contentOf("test-agent/tasks/sess.json"),
+                    "a failed parse must abort the batched write — never overwrite a malformed"
+                            + " store with partial data");
+            assertEquals(
+                    writesBefore,
+                    persistent.writesOf("test-agent/tasks/sess.json"),
+                    "no write may reach the backend when the store cannot be parsed");
+        } finally {
+            release.countDown();
+        }
+    }
+
+    @Test
+    @DisplayName("batched status update skips invalid entries instead of failing")
+    void updateTaskRecordStatuses_skipsInvalidEntries() throws Exception {
+        assembleRouted();
+        WorkspaceManager wm = workspaceManager;
+
+        TaskRecord seeded = new TaskRecord("task-1", "sub-1", "test-agent", "sess", null);
+        seeded.setStatus(TaskStatus.RUNNING);
+        seeded.setLastUpdatedAt(Instant.now().minusSeconds(60));
+        wm.writeTaskRecord(RuntimeContext.empty(), "test-agent", "sess", seeded);
+        // writeTaskRecord touches the record, so the persisted stamp is the write-time now —
+        // read it back as the baseline the batched refresh must advance past.
+        Instant persistedStamp =
+                wm.readTaskRecord(RuntimeContext.empty(), "test-agent", "sess", "task-1")
+                        .orElseThrow()
+                        .getLastUpdatedAt();
+        Thread.sleep(50); // guarantee the clock advances past the persisted stamp
+
+        java.util.Map<String, TaskStatus> mixed = new java.util.LinkedHashMap<>();
+        mixed.put("task-1", TaskStatus.RUNNING);
+        mixed.put("", TaskStatus.RUNNING); // blank task ID
+        mixed.put(null, TaskStatus.RUNNING); // null task ID
+        mixed.put("task-2", null); // null status
+
+        wm.updateTaskRecordStatuses(RuntimeContext.empty(), "test-agent", "sess", mixed);
+
+        TaskRecord refreshed =
+                wm.readTaskRecord(RuntimeContext.empty(), "test-agent", "sess", "task-1")
+                        .orElseThrow();
+        assertTrue(
+                refreshed.getLastUpdatedAt().isAfter(persistedStamp),
+                "the one valid entry must still be refreshed");
+        assertTrue(
+                wm.readTaskRecord(RuntimeContext.empty(), "test-agent", "sess", "task-2").isEmpty(),
+                "an entry with a null status must be skipped, not persisted");
+    }
+
+    @Test
+    @DisplayName("a context-free backend batches across contexts even with manager namespaces")
+    void heartbeat_contextFreeBackend_mergesAcrossManagerNamespaces() throws Exception {
+        // A manager-level NamespaceFactory does not partition task-record storage: the
+        // routed persistent backend is context-free, so both contexts share one batch.
+        io.agentscope.harness.agent.filesystem.remote.store.NamespaceFactory ns =
+                rc ->
+                        java.util.List.of(
+                                "user", rc.getSessionId() == null ? "anon" : rc.getSessionId());
+        persistent = new CountingMapFs();
+        RoutedSandboxFilesystem routed =
+                new RoutedSandboxFilesystem(
+                        new SandboxBackedFilesystem(), java.util.Map.of("agents/", persistent));
+        workspaceManager = new WorkspaceManager(tempDir, routed, null, ns);
+        repo = WorkspaceTaskRepository.forTests(workspaceManager, "test-agent");
+
+        RuntimeContext alice = RuntimeContext.builder().sessionId("alice").build();
+        RuntimeContext bob = RuntimeContext.builder().sessionId("bob").build();
+        CountDownLatch running = new CountDownLatch(2);
+        CountDownLatch release = new CountDownLatch(1);
+        try {
+            repo.putTask(alice, "task-1", "sub-1", "sess", blockingSpec(running, release));
+            repo.putTask(bob, "task-2", "sub-2", "sess", blockingSpec(running, release));
+            assertTrue(running.await(5, TimeUnit.SECONDS), "tasks never started");
+            awaitWriteQuiescence();
+
+            long before = persistent.writesOf("test-agent/tasks/sess.json");
+
+            repo.heartbeat();
+
+            assertEquals(
+                    before + 1,
+                    persistent.writesOf("test-agent/tasks/sess.json"),
+                    "a context-free backend serves one physical store, so both contexts must"
+                            + " share a single batched write");
+            for (int i = 1; i <= 2; i++) {
+                assertTrue(
+                        workspaceManager
+                                .readTaskRecord(
+                                        RuntimeContext.empty(), "test-agent", "sess", "task-" + i)
+                                .isPresent(),
+                        "task-" + i + " record must survive");
+            }
+        } finally {
+            release.countDown();
+        }
+    }
+
+    @Test
+    @DisplayName("per-user remote namespaces never receive each other's task records")
+    void heartbeat_userNamespacedRemoteStore_keepsRecordsPerUser() throws Exception {
+        io.agentscope.harness.agent.filesystem.remote.store.InMemoryStore store =
+                new io.agentscope.harness.agent.filesystem.remote.store.InMemoryStore();
+        io.agentscope.harness.agent.filesystem.remote.RemoteFilesystem remoteFs =
+                new io.agentscope.harness.agent.filesystem.remote.RemoteFilesystem(
+                        store,
+                        rc ->
+                                java.util.List.of(
+                                        "user", rc.getUserId() == null ? "anon" : rc.getUserId()));
+        workspaceManager = new WorkspaceManager(tempDir, remoteFs);
+        repo = WorkspaceTaskRepository.forTests(workspaceManager, "test-agent");
+
+        RuntimeContext alice = RuntimeContext.builder().userId("alice").build();
+        RuntimeContext bob = RuntimeContext.builder().userId("bob").build();
+        CountDownLatch running = new CountDownLatch(2);
+        CountDownLatch release = new CountDownLatch(1);
+        try {
+            repo.putTask(alice, "task-1", "sub-1", "sess", blockingSpec(running, release));
+            repo.putTask(bob, "task-2", "sub-2", "sess", blockingSpec(running, release));
+            assertTrue(running.await(5, TimeUnit.SECONDS), "tasks never started");
+
+            java.util.Map<String, Instant> stampsBefore = new java.util.LinkedHashMap<>();
+            for (RuntimeContext view : new RuntimeContext[] {alice, bob}) {
+                stampsBefore.put(
+                        view.getUserId(),
+                        workspaceManager
+                                .readTaskRecord(
+                                        view,
+                                        "test-agent",
+                                        "sess",
+                                        "task-" + (view == alice ? 1 : 2))
+                                .orElseThrow()
+                                .getLastUpdatedAt());
+            }
+            Thread.sleep(50);
+
+            repo.heartbeat();
+
+            // Alice's namespace: her task refreshed, Bob's record must not leak into it.
+            TaskRecord aliceOwn =
+                    workspaceManager
+                            .readTaskRecord(alice, "test-agent", "sess", "task-1")
+                            .orElseThrow();
+            assertTrue(
+                    aliceOwn.getLastUpdatedAt().isAfter(stampsBefore.get("alice")),
+                    "alice's own task must be refreshed in her namespace");
+            assertFalse(
+                    remoteStoreContains(store, alice, "task-2"),
+                    "bob's task record must never be written into alice's namespace");
+            assertFalse(
+                    remoteStoreContains(store, bob, "task-1"),
+                    "alice's task record must never be written into bob's namespace");
+            // Bob's namespace: his task refreshed under his own context.
+            TaskRecord bobOwn =
+                    workspaceManager
+                            .readTaskRecord(bob, "test-agent", "sess", "task-2")
+                            .orElseThrow();
+            assertTrue(
+                    bobOwn.getLastUpdatedAt().isAfter(stampsBefore.get("bob")),
+                    "bob's own task must be refreshed in his own namespace");
+        } finally {
+            release.countDown();
+        }
+    }
+
+    private static boolean remoteStoreContains(
+            io.agentscope.harness.agent.filesystem.remote.store.InMemoryStore store,
+            RuntimeContext user,
+            String taskId) {
+        io.agentscope.harness.agent.filesystem.remote.store.StoreItem item =
+                store.get(
+                        java.util.List.of("user", user.getUserId()),
+                        "agents/test-agent/tasks/sess.json");
+        return item != null && String.valueOf(item.value()).contains("\"" + taskId + "\"");
+    }
+
+    @Test
+    @DisplayName("a baked-context view batches across caller contexts")
+    void heartbeat_bakedContextView_batchesAcrossCallerContexts() throws Exception {
+        // BakedContextFilesystem substitutes its baked context on every delegated call, so the
+        // storage identity follows the baked context — distinct caller contexts must share one
+        // batch instead of being split per caller rc instance.
+        persistent = new CountingMapFs();
+        io.agentscope.harness.agent.filesystem.BakedContextFilesystem baked =
+                new io.agentscope.harness.agent.filesystem.BakedContextFilesystem(
+                        persistent, RuntimeContext.builder().userId("baked-user").build());
+        workspaceManager = new WorkspaceManager(tempDir, baked);
+        repo = WorkspaceTaskRepository.forTests(workspaceManager, "test-agent");
+
+        CountDownLatch running = new CountDownLatch(2);
+        CountDownLatch release = new CountDownLatch(1);
+        try {
+            // Distinct caller contexts on purpose.
+            repo.putTask(
+                    RuntimeContext.empty(),
+                    "task-1",
+                    "sub-1",
+                    "sess",
+                    blockingSpec(running, release));
+            repo.putTask(
+                    RuntimeContext.empty(),
+                    "task-2",
+                    "sub-2",
+                    "sess",
+                    blockingSpec(running, release));
+            assertTrue(running.await(5, TimeUnit.SECONDS), "tasks never started");
+            awaitWriteQuiescence();
+
+            // No routing composite in front of the backend, so MapFs keys carry the full
+            // workspace-relative path including the agents/ prefix.
+            long before = persistent.writesOf("agents/test-agent/tasks/sess.json");
+
+            repo.heartbeat();
+
+            assertEquals(
+                    before + 1,
+                    persistent.writesOf("agents/test-agent/tasks/sess.json"),
+                    "a baked-context view resolves storage under the baked context, so both"
+                            + " caller contexts must share a single batched write");
+            for (int i = 1; i <= 2; i++) {
+                assertTrue(
+                        workspaceManager
+                                .readTaskRecord(
+                                        RuntimeContext.empty(), "test-agent", "sess", "task-" + i)
+                                .isPresent(),
+                        "task-" + i + " record must survive");
+            }
+        } finally {
+            release.countDown();
+        }
+    }
+
+    @Test
+    @DisplayName("per-user local namespaces never receive each other's task records")
+    void heartbeat_userNamespacedLocalStore_keepsRecordsPerUser() throws Exception {
+        java.nio.file.Path backend =
+                java.nio.file.Files.createDirectories(tempDir.resolve("backend"));
+        io.agentscope.harness.agent.filesystem.local.LocalFilesystem localFs =
+                new io.agentscope.harness.agent.filesystem.local.LocalFilesystem(
+                        backend,
+                        io.agentscope.harness.agent.workspace.LocalFsMode.ROOTED,
+                        io.agentscope.harness.agent.workspace.PathPolicy.empty(),
+                        10,
+                        rc ->
+                                java.util.List.of(
+                                        "user-"
+                                                + (rc.getUserId() == null
+                                                        ? "anon"
+                                                        : rc.getUserId())));
+        workspaceManager = new WorkspaceManager(tempDir.resolve("ws"), localFs);
+        repo = WorkspaceTaskRepository.forTests(workspaceManager, "test-agent");
+
+        RuntimeContext alice = RuntimeContext.builder().userId("alice").build();
+        RuntimeContext bob = RuntimeContext.builder().userId("bob").build();
+        CountDownLatch running = new CountDownLatch(2);
+        CountDownLatch release = new CountDownLatch(1);
+        try {
+            repo.putTask(alice, "task-1", "sub-1", "sess", blockingSpec(running, release));
+            repo.putTask(bob, "task-2", "sub-2", "sess", blockingSpec(running, release));
+            assertTrue(running.await(5, TimeUnit.SECONDS), "tasks never started");
+
+            java.util.Map<String, Instant> stampsBefore = new java.util.LinkedHashMap<>();
+            stampsBefore.put(
+                    "alice",
+                    workspaceManager
+                            .readTaskRecord(alice, "test-agent", "sess", "task-1")
+                            .orElseThrow()
+                            .getLastUpdatedAt());
+            stampsBefore.put(
+                    "bob",
+                    workspaceManager
+                            .readTaskRecord(bob, "test-agent", "sess", "task-2")
+                            .orElseThrow()
+                            .getLastUpdatedAt());
+            Thread.sleep(50);
+
+            repo.heartbeat();
+
+            TaskRecord aliceOwn =
+                    workspaceManager
+                            .readTaskRecord(alice, "test-agent", "sess", "task-1")
+                            .orElseThrow();
+            assertTrue(
+                    aliceOwn.getLastUpdatedAt().isAfter(stampsBefore.get("alice")),
+                    "alice's own task must be refreshed in her namespace directory");
+            TaskRecord bobOwn =
+                    workspaceManager
+                            .readTaskRecord(bob, "test-agent", "sess", "task-2")
+                            .orElseThrow();
+            assertTrue(
+                    bobOwn.getLastUpdatedAt().isAfter(stampsBefore.get("bob")),
+                    "bob's own task must be refreshed in his own namespace directory");
+            String aliceFile =
+                    java.nio.file.Files.readString(
+                            backend.resolve("user-alice/agents/test-agent/tasks/sess.json"),
+                            java.nio.charset.StandardCharsets.UTF_8);
+            String bobFile =
+                    java.nio.file.Files.readString(
+                            backend.resolve("user-bob/agents/test-agent/tasks/sess.json"),
+                            java.nio.charset.StandardCharsets.UTF_8);
+            assertFalse(
+                    aliceFile.contains("\"task-2\""),
+                    "bob's task record must never be written into alice's namespace file");
+            assertFalse(
+                    bobFile.contains("\"task-1\""),
+                    "alice's task record must never be written into bob's namespace file");
+        } finally {
+            release.countDown();
+        }
+    }
+
+    private io.agentscope.harness.agent.filesystem.local.LocalFilesystem userNamespacedLocal(
+            java.nio.file.Path backend) {
+        return new io.agentscope.harness.agent.filesystem.local.LocalFilesystem(
+                backend,
+                io.agentscope.harness.agent.workspace.LocalFsMode.ROOTED,
+                io.agentscope.harness.agent.workspace.PathPolicy.empty(),
+                10,
+                rc ->
+                        java.util.List.of(
+                                "user-" + (rc.getUserId() == null ? "anon" : rc.getUserId())));
+    }
+
+    @Test
+    @DisplayName("a routed store batches under the leaf's actual path semantics")
+    void heartbeat_routedStore_followsLeafPathSemantics() throws Exception {
+        // CompositeFilesystem hands the leaf a slash-prefixed backend path, and
+        // LocalFilesystem deliberately skips namespace scoping for absolute-form paths —
+        // so through a route, a namespaced leaf serves every context from one shared file.
+        // The grouping key mirrors exactly that resolution (no key/IO divergence); this test
+        // pins the composed behaviour end to end through a real routed LocalFilesystem.
+        java.nio.file.Path backend =
+                java.nio.file.Files.createDirectories(tempDir.resolve("backend"));
+        RoutedSandboxFilesystem routed =
+                new RoutedSandboxFilesystem(
+                        new SandboxBackedFilesystem(),
+                        java.util.Map.of("agents/", userNamespacedLocal(backend)));
+        workspaceManager = new WorkspaceManager(tempDir.resolve("ws"), routed);
+        repo = WorkspaceTaskRepository.forTests(workspaceManager, "test-agent");
+
+        RuntimeContext alice = RuntimeContext.builder().userId("alice").build();
+        RuntimeContext bob = RuntimeContext.builder().userId("bob").build();
+        CountDownLatch running = new CountDownLatch(2);
+        CountDownLatch release = new CountDownLatch(1);
+        try {
+            repo.putTask(alice, "task-1", "sub-1", "sess", blockingSpec(running, release));
+            repo.putTask(bob, "task-2", "sub-2", "sess", blockingSpec(running, release));
+            assertTrue(running.await(5, TimeUnit.SECONDS), "tasks never started");
+
+            java.util.Map<String, Instant> stampsBefore = new java.util.LinkedHashMap<>();
+            stampsBefore.put(
+                    "alice",
+                    workspaceManager
+                            .readTaskRecord(alice, "test-agent", "sess", "task-1")
+                            .orElseThrow()
+                            .getLastUpdatedAt());
+            stampsBefore.put(
+                    "bob",
+                    workspaceManager
+                            .readTaskRecord(bob, "test-agent", "sess", "task-2")
+                            .orElseThrow()
+                            .getLastUpdatedAt());
+            Thread.sleep(50);
+
+            repo.heartbeat();
+
+            assertTrue(
+                    workspaceManager
+                            .readTaskRecord(alice, "test-agent", "sess", "task-1")
+                            .orElseThrow()
+                            .getLastUpdatedAt()
+                            .isAfter(stampsBefore.get("alice")),
+                    "alice's task must be refreshed through the routed backend");
+            assertTrue(
+                    workspaceManager
+                            .readTaskRecord(bob, "test-agent", "sess", "task-2")
+                            .orElseThrow()
+                            .getLastUpdatedAt()
+                            .isAfter(stampsBefore.get("bob")),
+                    "bob's task must be refreshed through the routed backend");
+            // The agents/ route prefix is stripped and the leaf receives a slash-prefixed
+            // path, so namespace scoping is skipped by the leaf's own semantics: one shared
+            // file holds both users' records, and the grouping key resolves identically.
+            String sharedFile =
+                    java.nio.file.Files.readString(
+                            backend.resolve("test-agent/tasks/sess.json"),
+                            java.nio.charset.StandardCharsets.UTF_8);
+            assertTrue(sharedFile.contains("\"task-1\""), "alice's record must be persisted");
+            assertTrue(sharedFile.contains("\"task-2\""), "bob's record must be persisted");
+        } finally {
+            release.countDown();
+        }
+    }
+
+    @Test
+    @DisplayName("an overlay over a namespaced upper layer keeps per-user files isolated")
+    void heartbeat_overlayNamespacedUpper_keepsRecordsPerUser() throws Exception {
+        java.nio.file.Path upper = java.nio.file.Files.createDirectories(tempDir.resolve("upper"));
+        java.nio.file.Path lower = java.nio.file.Files.createDirectories(tempDir.resolve("lower"));
+        io.agentscope.harness.agent.filesystem.OverlayFilesystem overlay =
+                new io.agentscope.harness.agent.filesystem.OverlayFilesystem(
+                        userNamespacedLocal(upper),
+                        new io.agentscope.harness.agent.filesystem.local.LocalFilesystem(lower));
+        workspaceManager = new WorkspaceManager(tempDir.resolve("ws"), overlay);
+        repo = WorkspaceTaskRepository.forTests(workspaceManager, "test-agent");
+
+        RuntimeContext alice = RuntimeContext.builder().userId("alice").build();
+        RuntimeContext bob = RuntimeContext.builder().userId("bob").build();
+        CountDownLatch running = new CountDownLatch(2);
+        CountDownLatch release = new CountDownLatch(1);
+        try {
+            repo.putTask(alice, "task-1", "sub-1", "sess", blockingSpec(running, release));
+            repo.putTask(bob, "task-2", "sub-2", "sess", blockingSpec(running, release));
+            assertTrue(running.await(5, TimeUnit.SECONDS), "tasks never started");
+
+            java.util.Map<String, Instant> stampsBefore = new java.util.LinkedHashMap<>();
+            stampsBefore.put(
+                    "alice",
+                    workspaceManager
+                            .readTaskRecord(alice, "test-agent", "sess", "task-1")
+                            .orElseThrow()
+                            .getLastUpdatedAt());
+            stampsBefore.put(
+                    "bob",
+                    workspaceManager
+                            .readTaskRecord(bob, "test-agent", "sess", "task-2")
+                            .orElseThrow()
+                            .getLastUpdatedAt());
+            Thread.sleep(50);
+
+            repo.heartbeat();
+
+            assertTrue(
+                    workspaceManager
+                            .readTaskRecord(alice, "test-agent", "sess", "task-1")
+                            .orElseThrow()
+                            .getLastUpdatedAt()
+                            .isAfter(stampsBefore.get("alice")),
+                    "alice's task must be refreshed in the overlay's namespaced upper");
+            assertTrue(
+                    workspaceManager
+                            .readTaskRecord(bob, "test-agent", "sess", "task-2")
+                            .orElseThrow()
+                            .getLastUpdatedAt()
+                            .isAfter(stampsBefore.get("bob")),
+                    "bob's task must be refreshed in the overlay's namespaced upper");
+            String aliceFile =
+                    java.nio.file.Files.readString(
+                            upper.resolve("user-alice/agents/test-agent/tasks/sess.json"),
+                            java.nio.charset.StandardCharsets.UTF_8);
+            String bobFile =
+                    java.nio.file.Files.readString(
+                            upper.resolve("user-bob/agents/test-agent/tasks/sess.json"),
+                            java.nio.charset.StandardCharsets.UTF_8);
+            assertFalse(aliceFile.contains("\"task-2\""), "no cross-user write into alice");
+            assertFalse(bobFile.contains("\"task-1\""), "no cross-user write into bob");
+        } finally {
+            release.countDown();
+        }
+    }
+
+    /**
+     * Waits until backend write activity settles. A task supplier's own start-up RUNNING
+     * transition writes asynchronously and can otherwise land inside a test's counting window.
+     */
+    private void awaitWriteQuiescence() throws InterruptedException {
+        long previous = persistent.totalWrites();
+        for (int i = 0; i < 25; i++) {
+            Thread.sleep(100);
+            long current = persistent.totalWrites();
+            if (current == previous) {
+                return;
+            }
+            previous = current;
+        }
+    }
+
+    private TaskRunSpec blockingSpec(CountDownLatch running, CountDownLatch release) {
+        return new TaskRunSpec.LocalTaskRunSpec(
+                () -> {
+                    running.countDown();
+                    try {
+                        release.await();
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                    }
+                    return "done";
+                });
+    }
+
+    private void assembleRouted() {
+        persistent = new CountingMapFs();
+        RoutedSandboxFilesystem routed =
+                new RoutedSandboxFilesystem(
+                        new SandboxBackedFilesystem(), Map.of("agents/", persistent));
+        workspaceManager = new WorkspaceManager(tempDir, routed);
+        repo = WorkspaceTaskRepository.forTests(workspaceManager, "test-agent");
+    }
+
+    /**
+     * Minimal in-memory persistent backend that counts store writes per workspace-relative
+     * path. Paths arrive prefix-stripped from {@code CompositeFilesystem} routing, so keys are
+     * stored as received — the assertions go through the counters, never inspect them directly.
+     */
+    private static class CountingMapFs implements AbstractFilesystem {
+        private final Map<String, String> files = new ConcurrentHashMap<>();
+        private final Map<String, AtomicInteger> writes = new ConcurrentHashMap<>();
+
+        void putRaw(String path, String content) {
+            files.put(normalize(path), content);
+        }
+
+        String contentOf(String path) {
+            return files.get(normalize(path));
+        }
+
+        long totalWrites() {
+            return writes.values().stream().mapToLong(AtomicInteger::get).sum();
+        }
+
+        int writesOf(String path) {
+            AtomicInteger n = writes.get(normalize(path));
+            return n == null ? 0 : n.get();
+        }
+
+        @Override
+        public ReadResult read(RuntimeContext rc, String filePath, int offset, int limit) {
+            String content = files.get(normalize(filePath));
+            return content == null
+                    ? ReadResult.fail("not found: " + filePath)
+                    : ReadResult.success(new FileData(content, "utf-8"));
+        }
+
+        @Override
+        public List<FileUploadResponse> uploadFiles(
+                RuntimeContext rc, List<Map.Entry<String, byte[]>> filesToUpload) {
+            List<FileUploadResponse> results = new ArrayList<>();
+            for (Map.Entry<String, byte[]> f : filesToUpload) {
+                String key = normalize(f.getKey());
+                files.put(key, new String(f.getValue(), StandardCharsets.UTF_8));
+                writes.computeIfAbsent(key, k -> new AtomicInteger()).incrementAndGet();
+                results.add(FileUploadResponse.success(f.getKey()));
+            }
+            return results;
+        }
+
+        @Override
+        public GlobResult glob(RuntimeContext rc, String pattern, String path) {
+            String base = normalize(path);
+            List<FileInfo> matches = new ArrayList<>();
+            for (Map.Entry<String, String> e : files.entrySet()) {
+                if ((base.isEmpty() || e.getKey().startsWith(base + "/"))
+                        && e.getKey().endsWith(".json")
+                        && "*.json".equals(pattern)) {
+                    matches.add(
+                            FileInfo.ofFile(
+                                    "/" + e.getKey(),
+                                    e.getValue().length(),
+                                    System.currentTimeMillis()));
+                }
+            }
+            return GlobResult.success(matches);
+        }
+
+        private static String normalize(String p) {
+            String s = p == null ? "" : p;
+            while (s.startsWith("/")) {
+                s = s.substring(1);
+            }
+            return s;
+        }
+
+        // Unused in these tests.
+        @Override
+        public LsResult ls(RuntimeContext rc, String path) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public WriteResult write(RuntimeContext rc, String filePath, String content) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public EditResult edit(
+                RuntimeContext rc, String filePath, String old, String newStr, boolean all) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public GrepResult grep(RuntimeContext rc, String pattern, String path, String glob) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public List<FileDownloadResponse> downloadFiles(RuntimeContext rc, List<String> paths) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public WriteResult delete(RuntimeContext rc, String path) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public WriteResult move(RuntimeContext rc, String from, String to) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean exists(RuntimeContext rc, String path) {
+            return files.containsKey(normalize(path));
+        }
+
+        @Override
+        public Object storageKey(RuntimeContext rc, String path) {
+            return path;
+        }
+    }
+}

--- a/agentscope-service/service-dataplane/src/main/java/io/agentscope/builder/web/managed/MemoryStoreFilesystem.java
+++ b/agentscope-service/service-dataplane/src/main/java/io/agentscope/builder/web/managed/MemoryStoreFilesystem.java
@@ -414,6 +414,13 @@ public final class MemoryStoreFilesystem implements AbstractFilesystem {
         }
     }
 
+    @Override
+    public Object storageKey(RuntimeContext runtimeContext, String path) {
+        // Context-free backend: the store is fixed by (ownerId, storeId) at construction, so
+        // every context can be batched together — keyed strictly per store instance.
+        return java.util.List.of(ownerId, storeId, path);
+    }
+
     private static FileInfo toFileInfo(MemoryDto memory) {
         long size = memory.content() == null ? 0 : memory.content().length();
         return FileInfo.ofFile("/" + memory.path(), size, memory.updatedAt());


### PR DESCRIPTION
Fixes #3018

## Description

Every 30-second heartbeat cycle refreshed each running local task with its own full read-modify-write of the session's task-record store: with `R` running tasks sharing `agents/<id>/tasks/<sid>.json`, one cycle performed `R` parses, `R` pretty-print serializations and `R` whole-file writes of the same file — each update even parses the store twice (`updateStatus`'s terminal-state guard read, then `writeTaskRecord`'s in-lock read). On the per-path `ReentrantLock` this is `O(R x store)` work and bytes per cycle, and it grows with both the running count and the accumulated history of finished tasks in the same session.

The heartbeat now groups the refreshes that resolve to the same store file and persists them in a single read-modify-write:

- `WorkspaceManager.updateTaskRecordStatuses(rc, agentId, sessionId, statusByTaskId)` — one lock acquisition, one parse, one whole-file persist regardless of how many records are refreshed. The per-record guards mirror `WorkspaceTaskRepository.updateStatus` (terminal records are immutable; a pending cancellation request blocks non-terminal refreshes), but are evaluated against the same in-lock snapshot that is written back — so a terminal transition that landed earlier can no longer be clobbered mid-cycle, a slightly *stronger* guarantee than the per-task path.
- `WorkspaceManager.taskRecordStorePath(rc, agentId, sessionId)` — the resolved store-path identity used for grouping. Tasks captured with different `RuntimeContext` instances that map to the same store file still share one batch.
- `WorkspaceTaskRepository.heartbeat()` builds the batches and calls the new method once per store file; failure isolation moves from per-task to per-batch (grouping keeps per-task isolation, and both levels surface at `warn`).

No persistence format change, no API signature change; `writeTaskRecord` / `updateStatus` keep their exact semantics for single-record paths (task completion, cancellation, remote delivery).

## Benchmark

Standalone replica of the store mechanics (JDK 17, Jackson 2.21.1 — the project's BOM version —, `TaskRecord` mirrored field-for-field, finished records carrying ~2 KB result text, one cycle = R sequential refreshes of a store holding T records, median of 5 runs):

| Scenario (total / running) | Before: cycle / bytes written | After: cycle / bytes written |
|---|---|---|
| 20 / 5 | 4.8 ms / 283 KB | 0.7 ms / 57 KB |
| 100 / 25 | 76 ms / 7.1 MB | 2.9 ms / 285 KB |
| 400 / 100 | 1113 ms / 114 MB | 7.5 ms / 1.1 MB |

At the stress point that is ~114 MB written **per 30-second cycle** (≈328 GB/day while tasks are in flight) reduced to one whole-file rewrite per cycle, with the per-path lock hold going from one full read-modify-write per task to one per store file.

## Failure isolation

The pre-batching heartbeat could not throw (per-task try/catch); the batched version preserves that contract and widens it where the blast radius grew:

- grouping keeps a **per-task** try/catch — an exception escaping the grouping loop on the maintenance scheduler would permanently suppress every later heartbeat execution (`scheduleAtFixedRate` semantics), so a pluggable `NamespaceFactory` throwing for one task only skips that task's refresh for the cycle; a **grouping** failure logs at `warn`, because a task whose grouping persistently fails is never refreshed and is eventually orphan-swept;
- a **batch** failure (whole session for one cycle) also logs at `warn`, aligned with `persistRecord`;
- a batched write whose store cannot be parsed **aborts without writing** — a malformed store is never overwritten with partial data (same stance as `writeTaskRecord`);
- `updateTaskRecordStatuses` skips entries with a null/blank task ID or a null status instead of failing the batch (defensive input handling mirroring `writeTaskRecord`);
- the grouping-key contract — the resolved runtime-data path must be the write target, i.e. backends must not derive storage location from the `RuntimeContext` itself — is documented on `taskRecordStorePath`.

## Test evidence (TDD red → green)

New `WorkspaceTaskRepositoryHeartbeatBatchTest` (8 cases, counting backend writes through a routed in-memory filesystem):

| Case | Before (main) | After |
|---|---|---|
| 3 running tasks in one session → one store write per heartbeat | ❌ 3 writes | ✅ 1 write, all records refreshed |
| tasks across two sessions → one write per session file | ❌ 2 + 1 writes | ✅ 1 + 1 writes |
| terminal record never clobbered while siblings refresh (incl. no `touch`) | — (behaviour lock) | ✅ |
| record with pending cancellation not refreshed (incl. no `touch`) | — (behaviour lock) | ✅ |
| corrupt store: batch aborts, content untouched, no backend write | — (behaviour lock) | ✅ |
| grouping exception (throwing `NamespaceFactory`) skips one task, heartbeat survives, other task still refreshed | ❌ exception escapes `heartbeat()` | ✅ |
| `updateTaskRecordStatuses` skips entries with null/blank task ID or null status | ❌ NPE on null status | ✅ valid entries still persist |
| same-session tasks under two namespaces → two batches on the same physical store, both refreshed | — (pins the documented split) | ✅ |

The grouping test deliberately uses distinct `RuntimeContext` instances per task to pin the resolved-path grouping contract; the namespace test pins the documented one-cycle-per-namespace split (task-record IO is namespace-agnostic, so both batches target one physical file).

Regression: full harness suite green (963 tests, 6 skipped pre-existing), `spotless:check` clean.

## Known pre-existing limitation (not addressed here)

The single-record path (`updateStatus` → `writeTaskRecord`) still evaluates its terminal/cancellation guards against a read taken **outside** the write lock, so a cancellation landing between guard-read and write can in principle be overwritten by a concurrent completion. The batched path closes this window for heartbeats; converging the single-record path on the same in-lock guard evaluation is planned as a follow-up.

## Checklist

- [x] Code has been formatted with `mvn spotless:apply`
- [x] All tests are passing (`mvn test`)
- [x] Javadoc comments are complete and follow project conventions
- [ ] Related documentation has been updated (e.g. links, examples, etc.)
- [x] Code is ready for review