### PR TITLE
feat(tool): add execution-guarded circuit breaker and schema filtering

### DIFF
--- a/agentscope-core/src/main/java/io/agentscope/core/middleware/CircuitBreakerMiddleware.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/middleware/CircuitBreakerMiddleware.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.core.middleware;
+
+import io.agentscope.core.agent.Agent;
+import io.agentscope.core.agent.RuntimeContext;
+import io.agentscope.core.event.AgentEvent;
+import io.agentscope.core.tool.CircuitBreakerTool;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import reactor.core.publisher.Flux;
+
+/**
+ * Hides unavailable circuit-breaking tools from each reasoning request without mutating Toolkit.
+ *
+ * <p>Register the same decorator instances with the Toolkit and this middleware. Probe admission
+ * happens in the decorator at execution time: advertising a recovered tool does not reserve it or
+ * leave a lease behind when the model chooses a different tool. Concurrent requests can see the
+ * recovered schema, but only one probe can execute.
+ */
+public final class CircuitBreakerMiddleware implements MiddlewareBase {
+    private final Map<String, CircuitBreakerTool> tools;
+
+    /**
+     * @param tools the exact decorated tools registered with the agent's toolkit
+     * @throws IllegalArgumentException if tool names are duplicated
+     */
+    public CircuitBreakerMiddleware(List<CircuitBreakerTool> tools) {
+        Map<String, CircuitBreakerTool> byName = new HashMap<>();
+        for (CircuitBreakerTool tool : tools) {
+            if (byName.putIfAbsent(tool.getName(), tool) != null) {
+                throw new IllegalArgumentException(
+                        "Duplicate circuit breaker tool: " + tool.getName());
+            }
+        }
+        this.tools = Map.copyOf(byName);
+    }
+
+    @Override
+    public Flux<AgentEvent> onReasoning(
+            Agent agent,
+            RuntimeContext ctx,
+            ReasoningInput input,
+            Function<ReasoningInput, Flux<AgentEvent>> next) {
+        return Flux.defer(
+                () -> {
+                    if (input.tools() == null) {
+                        return next.apply(input);
+                    }
+                    return next.apply(
+                            new ReasoningInput(
+                                    input.messages(),
+                                    input.tools().stream()
+                                            .filter(
+                                                    schema ->
+                                                            !tools.containsKey(schema.getName())
+                                                                    || tools.get(schema.getName())
+                                                                            .isAvailable())
+                                            .toList(),
+                                    input.options()));
+                });
+    }
+}

--- a/agentscope-core/src/main/java/io/agentscope/core/tool/CircuitBreakerTool.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/tool/CircuitBreakerTool.java
@@ -1,0 +1,284 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.core.tool;
+
+import io.agentscope.core.message.ToolResultBlock;
+import io.agentscope.core.message.ToolResultState;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Consumer;
+import java.util.function.Predicate;
+import reactor.core.publisher.Mono;
+
+/**
+ * Opt-in, in-memory circuit breaker around one tool.
+ *
+ * <p>State belongs to this decorator instance. Share it only between callers that share the same
+ * dependency and credentials. Open circuits reject calls before invoking the delegate. After the
+ * cooldown, exactly one subscription may probe recovery; cancellation releases that probe.
+ * Calls already running when the circuit opens are not cancelled, and their stale outcomes cannot
+ * change the new circuit generation. No background timers or threads are created.
+ *
+ * <p>Pair with {@link io.agentscope.core.middleware.CircuitBreakerMiddleware} to also withhold
+ * unavailable tools from the model. The execution guard works without that middleware.
+ */
+public final class CircuitBreakerTool implements AgentTool {
+    private final AgentTool delegate;
+    private final int failureThreshold;
+    private final Duration initialCooldown;
+    private final Duration maxCooldown;
+    private final double multiplier;
+    private final Predicate<ToolResultBlock> failurePredicate;
+    private final Clock clock;
+    private int failures;
+    private long epoch;
+    private Duration cooldown;
+    private Instant retryAt;
+    private boolean probing;
+
+    private CircuitBreakerTool(Builder builder) {
+        delegate = builder.delegate;
+        failureThreshold = builder.failureThreshold;
+        initialCooldown = builder.initialCooldown;
+        maxCooldown = builder.maxCooldown;
+        multiplier = builder.multiplier;
+        failurePredicate = builder.failurePredicate;
+        clock = builder.clock;
+    }
+
+    /** @param delegate the tool to protect; wrapping is explicitly opt-in
+     * @return a builder with three failures and a 60-second initial cooldown
+     */
+    public static Builder builder(AgentTool delegate) {
+        return new Builder(delegate);
+    }
+
+    /**
+     * Whether a new call could be admitted now. This does not reserve a recovery probe.
+     * @return false during cooldown or while a recovery probe is running
+     */
+    public synchronized boolean isAvailable() {
+        return retryAt == null || (!probing && !clock.instant().isBefore(retryAt));
+    }
+
+    private synchronized long acquire() {
+        if (!isAvailable()) {
+            return -1;
+        }
+        if (retryAt != null) {
+            probing = true;
+        }
+        return epoch;
+    }
+
+    private synchronized void complete(long admittedEpoch, Boolean failed) {
+        if (admittedEpoch != epoch) {
+            return;
+        }
+        if (retryAt != null) {
+            probing = false;
+            if (failed == null) {
+                return;
+            }
+            if (failed) {
+                open();
+            } else {
+                retryAt = null;
+                cooldown = null;
+                failures = 0;
+                epoch++;
+            }
+        } else if (failed != null) {
+            if (!failed) {
+                failures = 0;
+            } else if (++failures >= failureThreshold) {
+                open();
+            }
+        }
+    }
+
+    private void open() {
+        long millis =
+                cooldown == null
+                        ? initialCooldown.toMillis()
+                        : (long)
+                                Math.min(
+                                        maxCooldown.toMillis(),
+                                        Math.ceil(cooldown.toMillis() * multiplier));
+        cooldown = Duration.ofMillis(millis);
+        retryAt = clock.instant().plus(cooldown);
+        probing = false;
+        failures = 0;
+        epoch++;
+    }
+
+    @Override
+    public Mono<ToolResultBlock> callAsync(ToolCallParam param) {
+        return Mono.defer(
+                () -> {
+                    long admittedEpoch = acquire();
+                    if (admittedEpoch < 0) {
+                        return Mono.just(
+                                ToolResultBlock.error(
+                                        "Tool temporarily unavailable: circuit breaker open for "
+                                                + getName()));
+                    }
+                    // Each subscription has one outcome, including cancellation and an empty
+                    // publisher.
+                    AtomicBoolean settled = new AtomicBoolean();
+                    Consumer<Boolean> settle =
+                            failed -> {
+                                if (settled.compareAndSet(false, true)) {
+                                    complete(admittedEpoch, failed);
+                                }
+                            };
+                    return Mono.defer(() -> delegate.callAsync(param))
+                            .doOnNext(
+                                    result -> {
+                                        ToolResultState state = result.getState();
+                                        if (state == ToolResultState.DENIED
+                                                || state == ToolResultState.INTERRUPTED
+                                                || result.isSuspended()) {
+                                            settle.accept(null);
+                                        } else {
+                                            settle.accept(failurePredicate.test(result));
+                                        }
+                                    })
+                            .doOnError(
+                                    error ->
+                                            settle.accept(
+                                                    error instanceof ToolSuspendException
+                                                            ? null
+                                                            : true))
+                            .doFinally(signal -> settle.accept(null));
+                });
+    }
+
+    @Override
+    public String getName() {
+        return delegate.getName();
+    }
+
+    @Override
+    public String getDescription() {
+        return delegate.getDescription();
+    }
+
+    @Override
+    public Map<String, Object> getParameters() {
+        return delegate.getParameters();
+    }
+
+    @Override
+    public Boolean getStrict() {
+        return delegate.getStrict();
+    }
+
+    @Override
+    public Map<String, Object> getOutputSchema() {
+        return delegate.getOutputSchema();
+    }
+
+    @Override
+    public boolean isReadOnly() {
+        return delegate.isReadOnly();
+    }
+
+    /** Configuration for a single decorated tool. */
+    public static final class Builder {
+        private final AgentTool delegate;
+        private int failureThreshold = 3;
+        private Duration initialCooldown = Duration.ofSeconds(60);
+        private Duration maxCooldown = Duration.ofSeconds(600);
+        private double multiplier = 2;
+        private Predicate<ToolResultBlock> failurePredicate =
+                result -> result.getState() == ToolResultState.ERROR;
+        private Clock clock = Clock.systemUTC();
+
+        private Builder(AgentTool delegate) {
+            this.delegate = Objects.requireNonNull(delegate);
+        }
+
+        /** @param value consecutive failures required to open; must be positive
+         * @return this builder
+         */
+        public Builder failureThreshold(int value) {
+            failureThreshold = value;
+            return this;
+        }
+
+        /** @param value first cooldown, at least one millisecond
+         * @return this builder
+         */
+        public Builder initialCooldown(Duration value) {
+            initialCooldown = Objects.requireNonNull(value);
+            return this;
+        }
+
+        /** @param value cooldown ceiling, at least the initial cooldown
+         * @return this builder
+         */
+        public Builder maxCooldown(Duration value) {
+            maxCooldown = Objects.requireNonNull(value);
+            return this;
+        }
+
+        /** @param value finite multiplier, at least one
+         * @return this builder
+         */
+        public Builder backoffMultiplier(double value) {
+            multiplier = value;
+            return this;
+        }
+
+        /**
+         * Classifies terminal results. Exceptions always count as failures; denied, interrupted,
+         * and suspended results never count. The predicate must be thread-safe and must not throw.
+         * @param value result classifier, defaulting to ERROR state
+         * @return this builder
+         */
+        public Builder failurePredicate(Predicate<ToolResultBlock> value) {
+            failurePredicate = Objects.requireNonNull(value);
+            return this;
+        }
+
+        Builder clock(Clock value) {
+            clock = Objects.requireNonNull(value);
+            return this;
+        }
+
+        /** @return the configured decorator
+         * @throws IllegalArgumentException if the threshold or cooldown policy is invalid
+         */
+        public CircuitBreakerTool build() {
+            if (failureThreshold < 1
+                    || initialCooldown.isNegative()
+                    || initialCooldown.toMillis() < 1
+                    || maxCooldown.compareTo(initialCooldown) < 0
+                    || !Double.isFinite(multiplier)
+                    || multiplier < 1) {
+                throw new IllegalArgumentException(
+                        "Invalid circuit breaker threshold or cooldown policy");
+            }
+            maxCooldown.toMillis(); // Validate that the configured duration fits the arithmetic.
+            return new CircuitBreakerTool(this);
+        }
+    }
+}

--- a/agentscope-core/src/test/java/io/agentscope/core/tool/CircuitBreakerToolTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/tool/CircuitBreakerToolTest.java
@@ -1,0 +1,344 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.core.tool;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.agentscope.core.message.ToolResultBlock;
+import io.agentscope.core.message.ToolResultState;
+import io.agentscope.core.middleware.CircuitBreakerMiddleware;
+import io.agentscope.core.middleware.ReasoningInput;
+import io.agentscope.core.model.ToolSchema;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.core.publisher.Sinks;
+
+class CircuitBreakerToolTest {
+    private final AgentTool delegate = mock(AgentTool.class);
+    private final MutableClock clock = new MutableClock();
+    private final ToolCallParam param = ToolCallParam.builder().input(Map.of()).build();
+
+    private CircuitBreakerTool tool(int threshold) {
+        when(delegate.getName()).thenReturn("weather");
+        return CircuitBreakerTool.builder(delegate)
+                .failureThreshold(threshold)
+                .initialCooldown(Duration.ofSeconds(1))
+                .maxCooldown(Duration.ofSeconds(4))
+                .clock(clock)
+                .build();
+    }
+
+    @Test
+    void successBreaksFailureStreakAndOpenCallsDoNotReachDelegate() {
+        CircuitBreakerTool tool = tool(2);
+        when(delegate.callAsync(param))
+                .thenReturn(
+                        Mono.just(ToolResultBlock.error("offline")),
+                        Mono.just(ToolResultBlock.text("ok")),
+                        Mono.just(ToolResultBlock.error("offline")));
+        for (int i = 0; i < 3; i++) tool.callAsync(param).block();
+        assertTrue(tool.isAvailable());
+        tool.callAsync(param).block();
+        assertFalse(tool.isAvailable());
+        assertEquals(ToolResultState.ERROR, tool.callAsync(param).block().getState());
+        verify(delegate, times(4)).callAsync(param);
+    }
+
+    @Test
+    void cooldownBacksOffCapsAndResetsAfterRecovery() {
+        CircuitBreakerTool tool = tool(1);
+        when(delegate.callAsync(param)).thenReturn(Mono.just(ToolResultBlock.error("offline")));
+        tool.callAsync(param).block();
+        for (int seconds : new int[] {1, 2, 4, 4}) {
+            clock.advance(seconds * 1000L - 1);
+            assertFalse(tool.isAvailable());
+            clock.advance(1);
+            assertTrue(tool.isAvailable());
+            tool.callAsync(param).block();
+        }
+        clock.advance(4000);
+        when(delegate.callAsync(param)).thenReturn(Mono.just(ToolResultBlock.text("ok")));
+        tool.callAsync(param).block();
+        assertTrue(tool.isAvailable());
+        when(delegate.callAsync(param)).thenReturn(Mono.just(ToolResultBlock.error("offline")));
+        tool.callAsync(param).block();
+        clock.advance(1000);
+        assertTrue(tool.isAvailable());
+    }
+
+    @Test
+    void onlyOneConcurrentProbeReachesDelegate() throws Exception {
+        CircuitBreakerTool tool = tool(1);
+        when(delegate.callAsync(param)).thenReturn(Mono.just(ToolResultBlock.error("offline")));
+        tool.callAsync(param).block();
+        clock.advance(1000);
+        Sinks.One<ToolResultBlock> pending = Sinks.one();
+        AtomicInteger admitted = new AtomicInteger();
+        when(delegate.callAsync(param))
+                .thenAnswer(
+                        invocation -> {
+                            admitted.incrementAndGet();
+                            return pending.asMono();
+                        });
+        var pool = Executors.newFixedThreadPool(8);
+        CountDownLatch start = new CountDownLatch(1);
+        try {
+            var futures =
+                    java.util.stream.IntStream.range(0, 8)
+                            .mapToObj(
+                                    i ->
+                                            pool.submit(
+                                                    () -> {
+                                                        start.await();
+                                                        return tool.callAsync(param).subscribe();
+                                                    }))
+                            .toList();
+            start.countDown();
+            var subscriptions = new java.util.ArrayList<reactor.core.Disposable>();
+            for (var future : futures)
+                subscriptions.add(future.get(5, java.util.concurrent.TimeUnit.SECONDS));
+            assertEquals(1, admitted.get());
+            assertFalse(tool.isAvailable());
+            pending.tryEmitValue(ToolResultBlock.text("recovered"));
+            assertTrue(tool.isAvailable());
+            subscriptions.forEach(reactor.core.Disposable::dispose);
+        } finally {
+            pool.shutdownNow();
+        }
+    }
+
+    @Test
+    void staleSuccessCannotCloseANewerCircuit() {
+        CircuitBreakerTool tool = tool(1);
+        Sinks.One<ToolResultBlock> old = Sinks.one();
+        when(delegate.callAsync(param))
+                .thenReturn(old.asMono(), Mono.just(ToolResultBlock.error("offline")));
+        tool.callAsync(param).subscribe();
+        tool.callAsync(param).block();
+        old.tryEmitValue(ToolResultBlock.text("late success"));
+        assertFalse(tool.isAvailable());
+    }
+
+    @Test
+    void cancellationEmptyAndNonTerminalResultsReleaseProbe() {
+        CircuitBreakerTool tool = tool(1);
+        when(delegate.callAsync(param)).thenReturn(Mono.just(ToolResultBlock.error("offline")));
+        tool.callAsync(param).block();
+        clock.advance(1000);
+        when(delegate.callAsync(param)).thenReturn(Mono.never());
+        var subscription = tool.callAsync(param).subscribe();
+        assertFalse(tool.isAvailable());
+        subscription.dispose();
+        assertTrue(tool.isAvailable());
+        when(delegate.callAsync(param)).thenReturn(Mono.empty());
+        tool.callAsync(param).block();
+        assertTrue(tool.isAvailable());
+        for (ToolResultState state : List.of(ToolResultState.DENIED, ToolResultState.INTERRUPTED)) {
+            when(delegate.callAsync(param))
+                    .thenReturn(Mono.just(ToolResultBlock.text("ignored").withState(state)));
+            tool.callAsync(param).block();
+            assertTrue(tool.isAvailable());
+        }
+    }
+
+    @Test
+    void bothSynchronousAndReactiveExceptionsCount() {
+        CircuitBreakerTool tool = tool(2);
+        when(delegate.callAsync(param))
+                .thenThrow(new IllegalStateException("sync"))
+                .thenReturn(Mono.error(new IllegalStateException("async")));
+        assertThrows(IllegalStateException.class, () -> tool.callAsync(param).block());
+        assertTrue(tool.isAvailable());
+        assertThrows(IllegalStateException.class, () -> tool.callAsync(param).block());
+        assertFalse(tool.isAvailable());
+    }
+
+    @Test
+    void customPredicateClassifiesBusinessFailure() {
+        CircuitBreakerTool tool =
+                CircuitBreakerTool.builder(delegate)
+                        .failureThreshold(1)
+                        .failurePredicate(result -> true)
+                        .build();
+        when(delegate.callAsync(param))
+                .thenReturn(Mono.just(ToolResultBlock.text("business failure")));
+        tool.callAsync(param).block();
+        assertFalse(tool.isAvailable());
+    }
+
+    @Test
+    void schemasAndPermissionAttributesArePreserved() {
+        CircuitBreakerTool tool = tool(1);
+        when(delegate.getDescription()).thenReturn("lookup");
+        when(delegate.getParameters()).thenReturn(Map.of("type", "object"));
+        when(delegate.getOutputSchema()).thenReturn(Map.of("type", "string"));
+        when(delegate.getStrict()).thenReturn(true);
+        when(delegate.isReadOnly()).thenReturn(true);
+        assertEquals("weather", tool.getName());
+        assertEquals("lookup", tool.getDescription());
+        assertEquals(delegate.getParameters(), tool.getParameters());
+        assertEquals(delegate.getOutputSchema(), tool.getOutputSchema());
+        assertTrue(tool.getStrict());
+        assertTrue(tool.isReadOnly());
+    }
+
+    @Test
+    void filteringIsLazyAndNeverMutatesToolkitOrOriginalRequest() {
+        CircuitBreakerTool tool = tool(1);
+        Toolkit toolkit = new Toolkit();
+        when(delegate.getDescription()).thenReturn("lookup");
+        when(delegate.getParameters()).thenReturn(Map.of());
+        toolkit.registerAgentTool(tool);
+        var schemas =
+                List.of(
+                        ToolSchema.builder().name("weather").description("lookup").build(),
+                        ToolSchema.builder().name("other").description("other").build());
+        var input = new ReasoningInput(List.of(), schemas, null);
+        var middleware = new CircuitBreakerMiddleware(List.of(tool));
+        AtomicReference<ReasoningInput> seen = new AtomicReference<>();
+        var stream =
+                middleware.onReasoning(
+                        null,
+                        null,
+                        input,
+                        value -> {
+                            seen.set(value);
+                            return Flux.empty();
+                        });
+        when(delegate.callAsync(param)).thenReturn(Mono.just(ToolResultBlock.error("offline")));
+        tool.callAsync(param).block();
+        stream.blockLast();
+        assertEquals(
+                List.of("other"), seen.get().tools().stream().map(ToolSchema::getName).toList());
+        assertSame(input.messages(), seen.get().messages());
+        assertEquals(2, schemas.size());
+        assertSame(tool, toolkit.getTool("weather"));
+        clock.advance(1000);
+        stream.blockLast();
+        assertEquals(schemas, seen.get().tools());
+        // A model turn that does not call the tool never claims a probe.
+        assertTrue(tool.isAvailable());
+    }
+
+    @Test
+    void validatesConfigurationAndDuplicateNames() {
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> CircuitBreakerTool.builder(delegate).failureThreshold(0).build());
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> CircuitBreakerTool.builder(delegate).initialCooldown(Duration.ZERO).build());
+        assertThrows(
+                IllegalArgumentException.class,
+                () ->
+                        CircuitBreakerTool.builder(delegate)
+                                .maxCooldown(Duration.ofSeconds(1))
+                                .build());
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> CircuitBreakerTool.builder(delegate).backoffMultiplier(Double.NaN).build());
+        CircuitBreakerTool tool = tool(1);
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> new CircuitBreakerMiddleware(List.of(tool, tool)));
+    }
+
+    @Test
+    void suspendedCallsAreNotDependencyFailures() {
+        CircuitBreakerTool tool = tool(1);
+        when(delegate.callAsync(param)).thenThrow(new ToolSuspendException());
+        assertThrows(ToolSuspendException.class, () -> tool.callAsync(param).block());
+        assertTrue(tool.isAvailable());
+        var use =
+                io.agentscope.core.message.ToolUseBlock.builder()
+                        .id("call")
+                        .name("weather")
+                        .input(Map.of())
+                        .build();
+        doReturn(Mono.just(ToolResultBlock.suspended(use))).when(delegate).callAsync(param);
+        tool.callAsync(param).block();
+        assertTrue(tool.isAvailable());
+    }
+
+    @Test
+    void retryingAnOpenDecoratorDoesNotRetryTheDependency() {
+        CircuitBreakerTool tool = tool(1);
+        when(delegate.callAsync(param))
+                .thenReturn(Mono.error(new IllegalStateException("offline")));
+        ToolResultBlock result = tool.callAsync(param).retry(3).block();
+        assertEquals(ToolResultState.ERROR, result.getState());
+        verify(delegate, times(1)).callAsync(param);
+    }
+
+    @Test
+    void staleFailureDoesNotIncreaseCooldownAfterRecovery() {
+        CircuitBreakerTool tool = tool(1);
+        Sinks.One<ToolResultBlock> old = Sinks.one();
+        when(delegate.callAsync(param))
+                .thenReturn(old.asMono(), Mono.just(ToolResultBlock.error("offline")));
+        tool.callAsync(param).subscribe();
+        tool.callAsync(param).block();
+        clock.advance(1000);
+        when(delegate.callAsync(param)).thenReturn(Mono.just(ToolResultBlock.text("ok")));
+        tool.callAsync(param).block();
+        old.tryEmitValue(ToolResultBlock.error("late failure"));
+        assertTrue(tool.isAvailable());
+    }
+
+    private static class MutableClock extends Clock {
+        private Instant now = Instant.EPOCH;
+
+        void advance(long millis) {
+            now = now.plusMillis(millis);
+        }
+
+        @Override
+        public ZoneId getZone() {
+            return ZoneOffset.UTC;
+        }
+
+        @Override
+        public Clock withZone(ZoneId zone) {
+            return this;
+        }
+
+        @Override
+        public Instant instant() {
+            return now;
+        }
+    }
+}

--- a/docs/v2/en/docs/building-blocks/middleware.md
+++ b/docs/v2/en/docs/building-blocks/middleware.md
@@ -522,3 +522,63 @@ ReActAgent agent =
                 .middlewares(List.of(new StopOnAllDeniedMiddleware()))
                 .build();
 ```
+
+## Tool circuit breaking
+
+Per-call retries cannot stop a model from selecting a broken tool on the next reasoning turn.
+`CircuitBreakerTool` protects an explicitly wrapped `AgentTool`, while `CircuitBreakerMiddleware`
+withholds its schema during cooldown. Toolkit registrations and unrelated tools are unchanged.
+
+```java
+import io.agentscope.core.middleware.CircuitBreakerMiddleware;
+import io.agentscope.core.tool.CircuitBreakerTool;
+import java.time.Duration;
+import java.util.List;
+
+// weatherTool is an AgentTool; register the decorator, not the original tool.
+CircuitBreakerTool protectedWeather = CircuitBreakerTool.builder(weatherTool)
+        .failureThreshold(3)
+        .initialCooldown(Duration.ofSeconds(60))
+        .backoffMultiplier(2.0)
+        .maxCooldown(Duration.ofMinutes(10))
+        .build();
+toolkit.registerAgentTool(protectedWeather);
+
+ReActAgent agent = ReActAgent.builder()
+        .model(model)
+        .toolkit(toolkit)
+        .middleware(new CircuitBreakerMiddleware(List.of(protectedWeather)))
+        .build();
+```
+
+Three consecutive failures open the circuit. A success resets the failure streak. Cooldowns grow
+from 60 to 120, 240, 480 and finally 600 seconds with the example configuration. After cooldown,
+the tool is offered again; only one actual subscription may execute a recovery probe. A successful
+probe closes the circuit and resets backoff. A failed probe reopens it. Other concurrent calls
+receive an error result without reaching the delegate. Already-running calls are not cancelled,
+and their late outcomes cannot overwrite a newer circuit generation.
+
+State is local to each decorator instance, not automatically per user or session. Share an instance
+only for callers using the same dependency/credentials; construct separate instances for isolation.
+State does not survive process restart and is not shared across replicas. There is no scheduler:
+recovery is evaluated on the next model request or tool subscription.
+
+The execution guard also protects direct calls and calls generated before a circuit opened.
+Retries that resubscribe to the decorator count as separate attempts; once open, the decorator
+returns an error result rather than invoking the dependency again. Configure the threshold with
+this interaction in mind. Timeouts implemented outside the decorator appear as cancellation and
+do not count as failures. Apply a dependency timeout inside the wrapped tool if it should count.
+
+By default, exceptions and `ERROR` results count as failures. `failurePredicate(...)` can classify
+business failures returned as ordinary results. Permission denials, interruptions and suspended
+results (including `ToolSuspendException`) do not count. The decorator observes the completed
+`Mono`, so an ordinary `ToolResultBlock.text(...)` is a successful result even though its initial
+state is `RUNNING` before runtime normalization. Empty or cancelled publishers release any probe
+without declaring recovery. A suspended probe also releases its slot; its later external completion
+is not tracked. This wrapper is intended for synchronous-result tools, not long-running external
+jobs. Use the tool executor's timeout to bound a hung probe; no independent probe lease is created.
+
+The decorator forwards the delegate's name, description, input/output schemas, strict mode and
+read-only flag. Register the same decorator instance in the Toolkit and middleware. A recovery
+schema can be visible to multiple concurrent model requests; the single-probe guarantee applies
+to execution, not schema advertisement.

--- a/docs/v2/zh/docs/building-blocks/middleware.md
+++ b/docs/v2/zh/docs/building-blocks/middleware.md
@@ -522,3 +522,50 @@ ReActAgent agent =
                 .middlewares(List.of(new StopOnAllDeniedMiddleware()))
                 .build();
 ```
+
+## 工具熔断
+
+单次调用的重试不能阻止模型在下一轮再次选择故障工具。用 `CircuitBreakerTool` 包装需要保护的
+`AgentTool`，再注册 `CircuitBreakerMiddleware`，可以在冷却期过滤本轮工具 Schema，同时在实际执行前拦截调用。
+Toolkit 注册和其他工具不受影响。
+
+```java
+import io.agentscope.core.middleware.CircuitBreakerMiddleware;
+import io.agentscope.core.tool.CircuitBreakerTool;
+import java.time.Duration;
+import java.util.List;
+
+// weatherTool is an AgentTool; register the decorator, not the original tool.
+CircuitBreakerTool protectedWeather = CircuitBreakerTool.builder(weatherTool)
+        .failureThreshold(3)
+        .initialCooldown(Duration.ofSeconds(60))
+        .backoffMultiplier(2.0)
+        .maxCooldown(Duration.ofMinutes(10))
+        .build();
+toolkit.registerAgentTool(protectedWeather);
+
+ReActAgent agent = ReActAgent.builder()
+        .model(model)
+        .toolkit(toolkit)
+        .middleware(new CircuitBreakerMiddleware(List.of(protectedWeather)))
+        .build();
+```
+
+连续失败达到阈值后熔断；成功会清空连续失败计数。上述配置的冷却时长为 60、120、240、480、600 秒，
+到达上限后不再增长。冷却结束后重新提供工具，但只允许一个实际订阅执行探测。探测成功恢复并重置退避，
+失败则重新熔断。并发的其他调用直接返回错误结果。已在执行的调用不会被取消，其迟到结果不能覆盖新的熔断代次。
+
+状态属于包装器实例，不自动按用户或会话隔离，也不跨进程持久化或共享。只有使用相同依赖和凭据的调用者
+才应共享实例。注册到 Toolkit 和中间件的应为同一个包装器实例。没有后台定时器，恢复在后续推理或订阅时判断。
+
+对包装器的重试订阅算作独立尝试，熔断后不会继续调用底层依赖。包装器之外的超时表现为取消，不累计失败；
+需要计入失败的超时应在被包装工具内部实现。取消和空结果会释放探测名额，但不会声明恢复。可用工具执行器
+超时来限制挂起的探测；本实现不另外创建探测租约。
+
+默认统计异常及 `ERROR` 结果，可用 `failurePredicate(...)` 判定普通返回值中的业务错误。
+拒绝、打断和挂起（包括 `ToolSuspendException`）不算依赖失败。普通 `ToolResultBlock.text(...)` 在
+Mono 返回时算成功，即使运行时归一化之前状态仍是 `RUNNING`。挂起结果会释放探测名额，后续外部完成不在
+包装器追踪范围内，因此适用于直接返回结果的工具，不适用于长期外部作业。
+
+包装器保留工具名、描述、输入/输出 Schema、strict 和只读属性。半开时多个模型请求可能看到同一个工具，
+单探测保证作用于实际执行，而非 Schema 展示。


### PR DESCRIPTION
## AgentScope-Java Version

2.0.3-SNAPSHOT

## Description

Repeated tool failures can consume subsequent reasoning turns even after per-call retries are exhausted. This adds an opt-in `CircuitBreakerTool` decorator and a companion `CircuitBreakerMiddleware`.

The decorator guards actual execution, counts consecutive failures, applies a capped exponential cooldown, and admits one recovery probe. The middleware filters only the current model request; it never edits Toolkit registrations. Admission happens at subscription time, so a model that ignores an advertised tool cannot leave a probe claim behind. Existing calls may finish, but completions from an older circuit generation cannot reset a newer circuit.

State is local to the decorator instance. There are no new dependencies, background threads, distributed storage, or changes to default retry behavior. The decorator preserves schema and read-only permission attributes. Applications can classify business failures with a predicate; denied, interrupted and suspended results are not treated as dependency failures.

Closes #3023.

## Validation

- `mvn -pl agentscope-core -am test`: 2,334 tests, 0 failures, 0 errors, 9 skips (13 new tests).
- `mvn -pl agentscope-core spotless:check`: passed.
- `git diff --check`: passed.

The full multi-module reactor was not tested locally. Tests use an injected clock and coordinated concurrent subscriptions, without sleeps or external services. The documentation states the scope of in-memory sharing, timeout/retry interaction, and suspended-call limitations.

## Checklist

- [x] Code has been formatted with Spotless
- [x] Relevant tests pass
- [x] Public API has Javadoc
- [x] Documentation includes a usage example
- [x] Code is ready for review
