### PR TITLE
fix(harness): preserve bytes in cross-backend file moves

### DIFF
--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/filesystem/AbstractFilesystem.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/filesystem/AbstractFilesystem.java
@@ -25,9 +25,15 @@ import io.agentscope.harness.agent.filesystem.model.GlobResult;
 import io.agentscope.harness.agent.filesystem.model.GrepResult;
 import io.agentscope.harness.agent.filesystem.model.LsResult;
 import io.agentscope.harness.agent.filesystem.model.ReadResult;
+import io.agentscope.harness.agent.filesystem.model.UploadMode;
 import io.agentscope.harness.agent.filesystem.model.WriteResult;
+import java.nio.ByteBuffer;
+import java.nio.charset.CharacterCodingException;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * Abstract filesystem API for agents: list, read, write, edit, grep, glob, upload, download.
@@ -122,6 +128,56 @@ public interface AbstractFilesystem {
             RuntimeContext runtimeContext, List<Map.Entry<String, byte[]>> files);
 
     /**
+     * Upload files using the requested destination write policy.
+     *
+     * <p>{@link UploadMode#OVERWRITE} delegates to the existing upload method. The default
+     * {@link UploadMode#CREATE_NEW} implementation accepts strictly valid UTF-8 bytes and uses
+     * {@link #write}, preserving that backend's creation and layer semantics. Backends must override
+     * this method to support other byte sequences in create-only mode. Atomic creation depends on
+     * the backend; this default does not add locking or a transaction.
+     *
+     * @param runtimeContext per-call agent runtime
+     * @param files path-to-content mappings; an empty byte array represents an empty file
+     * @param mode destination write policy
+     * @return one response per input file, in the same order
+     */
+    default List<FileUploadResponse> uploadFiles(
+            RuntimeContext runtimeContext, List<Map.Entry<String, byte[]>> files, UploadMode mode) {
+        Objects.requireNonNull(mode, "mode");
+        if (mode == UploadMode.OVERWRITE) {
+            return uploadFiles(runtimeContext, files);
+        }
+        List<FileUploadResponse> responses = new ArrayList<>(files.size());
+        for (Map.Entry<String, byte[]> file : files) {
+            if (file.getValue() == null) {
+                responses.add(
+                        FileUploadResponse.fail(file.getKey(), "File content must not be null"));
+                continue;
+            }
+            String content;
+            try {
+                content =
+                        StandardCharsets.UTF_8
+                                .newDecoder()
+                                .decode(ByteBuffer.wrap(file.getValue()))
+                                .toString();
+            } catch (CharacterCodingException e) {
+                responses.add(
+                        FileUploadResponse.fail(
+                                file.getKey(),
+                                "Backend does not support create-only binary uploads"));
+                continue;
+            }
+            WriteResult result = write(runtimeContext, file.getKey(), content);
+            responses.add(
+                    result.isSuccess()
+                            ? FileUploadResponse.success(file.getKey())
+                            : FileUploadResponse.fail(file.getKey(), result.error()));
+        }
+        return responses;
+    }
+
+    /**
      * Download multiple files.
      *
      * @param runtimeContext per-call agent runtime; {@link RuntimeContext#empty()} when none
@@ -145,8 +201,9 @@ public interface AbstractFilesystem {
      * Move (rename) a file or directory from {@code fromPath} to {@code toPath}.
      *
      * <p>Implementations that span multiple stores (e.g. {@code CompositeFilesystem}) may
-     * fall back to a read + write + delete sequence when source and destination live in
-     * different backend filesystems.
+     * copy the original bytes before deleting the source. Cross-backend file moves require raw
+     * download support and create-only upload support for the source content. They are not atomic;
+     * a source deletion failure can leave both copies and must be reported as a failure.
      *
      * @param runtimeContext per-call agent runtime; {@link RuntimeContext#empty()} when none
      * @param fromPath absolute source path

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/filesystem/BakedContextFilesystem.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/filesystem/BakedContextFilesystem.java
@@ -23,6 +23,7 @@ import io.agentscope.harness.agent.filesystem.model.GlobResult;
 import io.agentscope.harness.agent.filesystem.model.GrepResult;
 import io.agentscope.harness.agent.filesystem.model.LsResult;
 import io.agentscope.harness.agent.filesystem.model.ReadResult;
+import io.agentscope.harness.agent.filesystem.model.UploadMode;
 import io.agentscope.harness.agent.filesystem.model.WriteResult;
 import java.util.List;
 import java.util.Map;
@@ -88,6 +89,12 @@ public final class BakedContextFilesystem implements AbstractFilesystem {
     public List<FileUploadResponse> uploadFiles(
             RuntimeContext runtimeContext, List<Map.Entry<String, byte[]>> files) {
         return delegate.uploadFiles(bakedRc, files);
+    }
+
+    @Override
+    public List<FileUploadResponse> uploadFiles(
+            RuntimeContext runtimeContext, List<Map.Entry<String, byte[]>> files, UploadMode mode) {
+        return delegate.uploadFiles(bakedRc, files, mode);
     }
 
     @Override

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/filesystem/CompositeFilesystem.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/filesystem/CompositeFilesystem.java
@@ -26,6 +26,7 @@ import io.agentscope.harness.agent.filesystem.model.GrepMatch;
 import io.agentscope.harness.agent.filesystem.model.GrepResult;
 import io.agentscope.harness.agent.filesystem.model.LsResult;
 import io.agentscope.harness.agent.filesystem.model.ReadResult;
+import io.agentscope.harness.agent.filesystem.model.UploadMode;
 import io.agentscope.harness.agent.filesystem.model.WriteResult;
 import io.agentscope.harness.agent.filesystem.sandbox.AbstractSandboxFilesystem;
 import java.nio.file.FileSystems;
@@ -36,6 +37,7 @@ import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * Routes file operations to different {@link AbstractFilesystem} stores by path prefix.
@@ -397,6 +399,13 @@ public class CompositeFilesystem implements AbstractFilesystem {
     @Override
     public List<FileUploadResponse> uploadFiles(
             RuntimeContext runtimeContext, List<Map.Entry<String, byte[]>> files) {
+        return uploadFiles(runtimeContext, files, UploadMode.OVERWRITE);
+    }
+
+    @Override
+    public List<FileUploadResponse> uploadFiles(
+            RuntimeContext runtimeContext, List<Map.Entry<String, byte[]>> files, UploadMode mode) {
+        Objects.requireNonNull(mode, "mode");
         FileUploadResponse[] results = new FileUploadResponse[files.size()];
         Map<AbstractFilesystem, List<IndexedFile>> batches = new HashMap<>();
 
@@ -413,7 +422,9 @@ public class CompositeFilesystem implements AbstractFilesystem {
                 batchFiles.add(Map.entry(f.backendPath(), f.content()));
             }
             List<FileUploadResponse> responses =
-                    batch.getKey().uploadFiles(runtimeContext, batchFiles);
+                    mode == UploadMode.OVERWRITE
+                            ? batch.getKey().uploadFiles(runtimeContext, batchFiles)
+                            : batch.getKey().uploadFiles(runtimeContext, batchFiles, mode);
             List<IndexedFile> indexed = batch.getValue();
             for (int i = 0; i < responses.size() && i < indexed.size(); i++) {
                 FileUploadResponse backendResp = responses.get(i);
@@ -488,22 +499,75 @@ public class CompositeFilesystem implements AbstractFilesystem {
             return result;
         }
 
-        // Cross-backend move: read → write → delete
-        var readResult = srcRoute.backend().read(runtimeContext, srcRoute.backendPath(), 0, 0);
-        if (!readResult.isSuccess() || readResult.fileData() == null) {
-            return WriteResult.fail("Cannot read source for cross-backend move: " + fromPath);
-        }
-        String content = readResult.fileData().content();
-        if (content == null) {
-            content = "";
-        }
-        WriteResult writeResult =
-                dstRoute.backend().write(runtimeContext, dstRoute.backendPath(), content);
-        if (!writeResult.isSuccess()) {
+        // Transfer original bytes; read() may return a formatted view of the file.
+        List<FileDownloadResponse> downloads;
+        try {
+            downloads =
+                    srcRoute.backend()
+                            .downloadFiles(runtimeContext, List.of(srcRoute.backendPath()));
+        } catch (RuntimeException e) {
             return WriteResult.fail(
-                    "Cross-backend move write failed for '" + toPath + "': " + writeResult.error());
+                    "Cannot download source for cross-backend move: "
+                            + fromPath
+                            + ": "
+                            + e.getMessage());
         }
-        srcRoute.backend().delete(runtimeContext, srcRoute.backendPath());
+        if (downloads == null || downloads.size() != 1 || downloads.get(0) == null) {
+            return WriteResult.fail(
+                    "Invalid download response for cross-backend move: " + fromPath);
+        }
+        FileDownloadResponse download = downloads.get(0);
+        if (!download.isSuccess() || download.content() == null) {
+            return WriteResult.fail(
+                    "Cannot download source for cross-backend move: "
+                            + fromPath
+                            + (download.error() == null
+                                    ? " (missing content)"
+                                    : ": " + download.error()));
+        }
+        List<FileUploadResponse> uploads;
+        try {
+            uploads =
+                    dstRoute.backend()
+                            .uploadFiles(
+                                    runtimeContext,
+                                    List.of(Map.entry(dstRoute.backendPath(), download.content())),
+                                    UploadMode.CREATE_NEW);
+        } catch (RuntimeException e) {
+            return WriteResult.fail(
+                    "Cross-backend move upload failed for '" + toPath + "': " + e.getMessage());
+        }
+        if (uploads == null || uploads.size() != 1 || uploads.get(0) == null) {
+            return WriteResult.fail("Invalid upload response for cross-backend move: " + toPath);
+        }
+        if (!uploads.get(0).isSuccess()) {
+            return WriteResult.fail(
+                    "Cross-backend move upload failed for '"
+                            + toPath
+                            + "': "
+                            + uploads.get(0).error());
+        }
+        WriteResult deleted;
+        try {
+            deleted = srcRoute.backend().delete(runtimeContext, srcRoute.backendPath());
+        } catch (RuntimeException e) {
+            return WriteResult.fail(
+                    "Copied to '"
+                            + toPath
+                            + "' but could not delete source '"
+                            + fromPath
+                            + "': "
+                            + e.getMessage());
+        }
+        if (deleted == null || !deleted.isSuccess()) {
+            return WriteResult.fail(
+                    "Copied to '"
+                            + toPath
+                            + "' but could not delete source '"
+                            + fromPath
+                            + "': "
+                            + (deleted == null ? "missing delete response" : deleted.error()));
+        }
         return WriteResult.ok(toPath);
     }
 

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/filesystem/RoutedSandboxFilesystem.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/filesystem/RoutedSandboxFilesystem.java
@@ -24,6 +24,7 @@ import io.agentscope.harness.agent.filesystem.model.GlobResult;
 import io.agentscope.harness.agent.filesystem.model.GrepResult;
 import io.agentscope.harness.agent.filesystem.model.LsResult;
 import io.agentscope.harness.agent.filesystem.model.ReadResult;
+import io.agentscope.harness.agent.filesystem.model.UploadMode;
 import io.agentscope.harness.agent.filesystem.model.WriteResult;
 import io.agentscope.harness.agent.filesystem.sandbox.AbstractSandboxFilesystem;
 import java.util.List;
@@ -113,6 +114,12 @@ public final class RoutedSandboxFilesystem implements AbstractSandboxFilesystem 
     public List<FileUploadResponse> uploadFiles(
             RuntimeContext runtimeContext, List<Map.Entry<String, byte[]>> files) {
         return composite.uploadFiles(runtimeContext, files);
+    }
+
+    @Override
+    public List<FileUploadResponse> uploadFiles(
+            RuntimeContext runtimeContext, List<Map.Entry<String, byte[]>> files, UploadMode mode) {
+        return composite.uploadFiles(runtimeContext, files, mode);
     }
 
     @Override

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/filesystem/local/LocalFilesystem.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/filesystem/local/LocalFilesystem.java
@@ -27,6 +27,7 @@ import io.agentscope.harness.agent.filesystem.model.GrepMatch;
 import io.agentscope.harness.agent.filesystem.model.GrepResult;
 import io.agentscope.harness.agent.filesystem.model.LsResult;
 import io.agentscope.harness.agent.filesystem.model.ReadResult;
+import io.agentscope.harness.agent.filesystem.model.UploadMode;
 import io.agentscope.harness.agent.filesystem.model.WriteResult;
 import io.agentscope.harness.agent.filesystem.remote.store.NamespaceFactory;
 import io.agentscope.harness.agent.filesystem.util.FilesystemUtils;
@@ -45,6 +46,7 @@ import java.nio.file.Path;
 import java.nio.file.PathMatcher;
 import java.nio.file.SimpleFileVisitor;
 import java.nio.file.StandardCopyOption;
+import java.nio.file.StandardOpenOption;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -52,6 +54,7 @@ import java.util.Base64;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.regex.Pattern;
@@ -489,6 +492,37 @@ public class LocalFilesystem implements AbstractFilesystem {
                     Files.createDirectories(resolved.getParent());
                 }
                 Files.write(resolved, content);
+                responses.add(FileUploadResponse.success(filePath));
+            } catch (IOException e) {
+                responses.add(FileUploadResponse.fail(filePath, e.getMessage()));
+            } catch (SecurityException | IllegalArgumentException e) {
+                responses.add(FileUploadResponse.fail(filePath, "permission_denied"));
+            }
+        }
+        return responses;
+    }
+
+    @Override
+    public List<FileUploadResponse> uploadFiles(
+            RuntimeContext runtimeContext, List<Map.Entry<String, byte[]>> files, UploadMode mode) {
+        Objects.requireNonNull(mode, "mode must not be null");
+        if (mode == UploadMode.OVERWRITE) {
+            return uploadFiles(runtimeContext, files);
+        }
+        List<FileUploadResponse> responses = new ArrayList<>();
+        for (Map.Entry<String, byte[]> entry : files) {
+            String filePath = entry.getKey();
+            byte[] content = entry.getValue();
+            if (content == null) {
+                responses.add(FileUploadResponse.fail(filePath, "content must not be null"));
+                continue;
+            }
+            try {
+                Path resolved = resolvePath(runtimeContext, filePath);
+                if (resolved.getParent() != null) {
+                    Files.createDirectories(resolved.getParent());
+                }
+                Files.write(resolved, content, StandardOpenOption.CREATE_NEW);
                 responses.add(FileUploadResponse.success(filePath));
             } catch (IOException e) {
                 responses.add(FileUploadResponse.fail(filePath, e.getMessage()));

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/filesystem/model/UploadMode.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/filesystem/model/UploadMode.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.harness.agent.filesystem.model;
+
+/** Destination write policy for byte uploads. */
+public enum UploadMode {
+    /** Use the backend's existing upload behavior, replacing destination content. */
+    OVERWRITE,
+    /** Use the backend's create-only write semantics; an existing writable target is an error. */
+    CREATE_NEW
+}

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/filesystem/remote/RemoteFilesystem.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/filesystem/remote/RemoteFilesystem.java
@@ -27,12 +27,15 @@ import io.agentscope.harness.agent.filesystem.model.GrepMatch;
 import io.agentscope.harness.agent.filesystem.model.GrepResult;
 import io.agentscope.harness.agent.filesystem.model.LsResult;
 import io.agentscope.harness.agent.filesystem.model.ReadResult;
+import io.agentscope.harness.agent.filesystem.model.UploadMode;
 import io.agentscope.harness.agent.filesystem.model.WriteResult;
 import io.agentscope.harness.agent.filesystem.remote.store.BaseStore;
 import io.agentscope.harness.agent.filesystem.remote.store.NamespaceFactory;
 import io.agentscope.harness.agent.filesystem.remote.store.StoreItem;
 import io.agentscope.harness.agent.filesystem.util.FilesystemUtils;
 import io.agentscope.harness.agent.workspace.WorkspaceIndex;
+import java.nio.ByteBuffer;
+import java.nio.charset.CharacterCodingException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.FileSystems;
 import java.nio.file.Path;
@@ -44,6 +47,7 @@ import java.util.HashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 
 /**
@@ -517,6 +521,57 @@ public class RemoteFilesystem implements AbstractFilesystem {
             // CAS-create-if-absent for the tool-surface write path.
             store.put(ns, filePath, fileDataToStoreValue(fileData));
             responses.add(FileUploadResponse.success(filePath));
+        }
+        return responses;
+    }
+
+    @Override
+    public List<FileUploadResponse> uploadFiles(
+            RuntimeContext runtimeContext, List<Map.Entry<String, byte[]>> files, UploadMode mode) {
+        Objects.requireNonNull(mode, "mode must not be null");
+        if (mode == UploadMode.OVERWRITE) {
+            return uploadFiles(runtimeContext, files);
+        }
+        List<String> ns = getNamespace(runtimeContext);
+        List<FileUploadResponse> responses = new ArrayList<>();
+        for (Map.Entry<String, byte[]> entry : files) {
+            String filePath = entry.getKey();
+            byte[] content = entry.getValue();
+            if (content == null) {
+                responses.add(FileUploadResponse.fail(filePath, "content must not be null"));
+                continue;
+            }
+            try {
+                String contentStr;
+                String encoding;
+                try {
+                    contentStr =
+                            StandardCharsets.UTF_8
+                                    .newDecoder()
+                                    .decode(ByteBuffer.wrap(content))
+                                    .toString();
+                    encoding = "utf-8";
+                } catch (CharacterCodingException e) {
+                    contentStr = Base64.getEncoder().encodeToString(content);
+                    encoding = "base64";
+                }
+                FileData fileData = FileData.create(contentStr, encoding);
+                boolean written =
+                        store.putIfVersion(ns, filePath, fileDataToStoreValue(fileData), 0L);
+                if (written) {
+                    responses.add(FileUploadResponse.success(filePath));
+                } else {
+                    responses.add(
+                            FileUploadResponse.fail(
+                                    filePath,
+                                    "Cannot create file because it already exists or the store does"
+                                            + " not support conditional writes"));
+                }
+            } catch (RuntimeException e) {
+                responses.add(
+                        FileUploadResponse.fail(
+                                filePath, "Error creating file: " + e.getMessage()));
+            }
         }
         return responses;
     }

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/filesystem/BackendUploadModeFailureTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/filesystem/BackendUploadModeFailureTest.java
@@ -1,0 +1,174 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.harness.agent.filesystem;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.agentscope.core.agent.RuntimeContext;
+import io.agentscope.harness.agent.filesystem.local.LocalFilesystem;
+import io.agentscope.harness.agent.filesystem.model.FileDownloadResponse;
+import io.agentscope.harness.agent.filesystem.model.FileUploadResponse;
+import io.agentscope.harness.agent.filesystem.model.UploadMode;
+import io.agentscope.harness.agent.filesystem.remote.RemoteFilesystem;
+import io.agentscope.harness.agent.filesystem.remote.store.InMemoryStore;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.AbstractMap.SimpleImmutableEntry;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+/** Failed create-only uploads protect existing data and do not abort the remaining batch. */
+class BackendUploadModeFailureTest {
+
+    private static final RuntimeContext RT = RuntimeContext.empty();
+    private static final byte[] CONTENT = new byte[] {0, (byte) 0xff, 1, (byte) 0xfe};
+
+    @TempDir Path workspace;
+
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    void nullContentPreservesExistingFileAndContinuesBatch(boolean remote) {
+        AbstractFilesystem fs =
+                remote ? new RemoteFilesystem(new InMemoryStore()) : local(workspace);
+        byte[] original = "original".getBytes(StandardCharsets.UTF_8);
+        assertTrue(fs.write(RT, "/existing.txt", "original").isSuccess());
+
+        List<FileUploadResponse> responses =
+                fs.uploadFiles(
+                        RT,
+                        List.of(
+                                new SimpleImmutableEntry<String, byte[]>("/existing.txt", null),
+                                Map.entry("/valid.bin", CONTENT)),
+                        UploadMode.CREATE_NEW);
+
+        assertEquals(2, responses.size());
+        assertEquals("/existing.txt", responses.get(0).path());
+        assertFalse(responses.get(0).isSuccess());
+        assertTrue(responses.get(0).error().contains("content"));
+        assertEquals("/valid.bin", responses.get(1).path());
+        assertTrue(responses.get(1).isSuccess(), responses.get(1).error());
+        assertArrayEquals(original, download(fs, "/existing.txt"));
+        assertArrayEquals(CONTENT, download(fs, "/valid.bin"));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"/../outside.bin", "/invalid\0name.bin"})
+    void localInvalidPathPreservesOutsideFileAndContinuesBatch(String invalidPath)
+            throws Exception {
+        Path root = Files.createDirectory(workspace.resolve("root"));
+        Path outside = workspace.resolve("outside.bin");
+        byte[] original = new byte[] {2, 3, 4};
+        Files.write(outside, original);
+        LocalFilesystem fs = local(root);
+
+        List<FileUploadResponse> responses =
+                fs.uploadFiles(
+                        RT,
+                        List.of(Map.entry(invalidPath, CONTENT), Map.entry("/valid.bin", CONTENT)),
+                        UploadMode.CREATE_NEW);
+
+        assertEquals(2, responses.size());
+        assertEquals(invalidPath, responses.get(0).path());
+        assertFalse(responses.get(0).isSuccess());
+        assertEquals("permission_denied", responses.get(0).error());
+        assertEquals("/valid.bin", responses.get(1).path());
+        assertTrue(responses.get(1).isSuccess(), responses.get(1).error());
+        assertArrayEquals(original, Files.readAllBytes(outside));
+        assertArrayEquals(CONTENT, Files.readAllBytes(root.resolve("valid.bin")));
+    }
+
+    @Test
+    void localFileAsParentPreservesParentAndContinuesBatch() throws Exception {
+        Path blockedParent = workspace.resolve("blocked");
+        byte[] original = "parent is a file".getBytes(StandardCharsets.UTF_8);
+        Files.write(blockedParent, original);
+        LocalFilesystem fs = local(workspace);
+
+        List<FileUploadResponse> responses =
+                fs.uploadFiles(
+                        RT,
+                        List.of(
+                                Map.entry("/blocked/file.bin", CONTENT),
+                                Map.entry("/valid.bin", CONTENT)),
+                        UploadMode.CREATE_NEW);
+
+        assertEquals(2, responses.size());
+        assertEquals("/blocked/file.bin", responses.get(0).path());
+        assertFalse(responses.get(0).isSuccess());
+        assertEquals("/valid.bin", responses.get(1).path());
+        assertTrue(responses.get(1).isSuccess(), responses.get(1).error());
+        assertTrue(Files.isRegularFile(blockedParent));
+        assertArrayEquals(original, Files.readAllBytes(blockedParent));
+        assertArrayEquals(CONTENT, Files.readAllBytes(workspace.resolve("valid.bin")));
+    }
+
+    @Test
+    void remoteStoreFailureIsReportedAndContinuesBatch() {
+        InMemoryStore store =
+                new InMemoryStore() {
+                    @Override
+                    public boolean putIfVersion(
+                            List<String> namespace,
+                            String key,
+                            Map<String, Object> value,
+                            long expectedVersion) {
+                        if ("/unavailable.bin".equals(key)) {
+                            throw new IllegalStateException("store unavailable");
+                        }
+                        return super.putIfVersion(namespace, key, value, expectedVersion);
+                    }
+                };
+        RemoteFilesystem fs = new RemoteFilesystem(store);
+
+        List<FileUploadResponse> responses =
+                fs.uploadFiles(
+                        RT,
+                        List.of(
+                                Map.entry("/unavailable.bin", CONTENT),
+                                Map.entry("/valid.bin", CONTENT)),
+                        UploadMode.CREATE_NEW);
+
+        assertEquals(2, responses.size());
+        assertEquals("/unavailable.bin", responses.get(0).path());
+        assertFalse(responses.get(0).isSuccess());
+        assertTrue(responses.get(0).error().contains("store unavailable"));
+        assertEquals("/valid.bin", responses.get(1).path());
+        assertTrue(responses.get(1).isSuccess(), responses.get(1).error());
+        assertNull(store.get(List.of("filesystem"), "/unavailable.bin"));
+        assertArrayEquals(CONTENT, download(fs, "/valid.bin"));
+    }
+
+    private static LocalFilesystem local(Path root) {
+        return new LocalFilesystem(root, true, 10);
+    }
+
+    private static byte[] download(AbstractFilesystem fs, String path) {
+        List<FileDownloadResponse> responses = fs.downloadFiles(RT, List.of(path));
+        assertEquals(1, responses.size());
+        FileDownloadResponse response = responses.get(0);
+        assertTrue(response.isSuccess(), response.error());
+        return response.content();
+    }
+}

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/filesystem/CompositeFilesystemMoveTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/filesystem/CompositeFilesystemMoveTest.java
@@ -1,0 +1,361 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.harness.agent.filesystem;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.agentscope.core.agent.RuntimeContext;
+import io.agentscope.harness.agent.filesystem.local.LocalFilesystem;
+import io.agentscope.harness.agent.filesystem.model.FileDownloadResponse;
+import io.agentscope.harness.agent.filesystem.model.FileUploadResponse;
+import io.agentscope.harness.agent.filesystem.model.UploadMode;
+import io.agentscope.harness.agent.filesystem.model.WriteResult;
+import io.agentscope.harness.agent.filesystem.remote.RemoteFilesystem;
+import io.agentscope.harness.agent.filesystem.remote.store.InMemoryStore;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Base64;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+/** Cross-backend moves must preserve file bytes and report incomplete moves. */
+class CompositeFilesystemMoveTest {
+
+    private static final RuntimeContext RT = RuntimeContext.empty();
+    private static final List<String> NAMESPACE = List.of("move-test");
+
+    @TempDir Path workspace;
+
+    static Stream<Arguments> fileContents() {
+        byte[] allBytes = new byte[256];
+        for (int i = 0; i < allBytes.length; i++) {
+            allBytes[i] = (byte) i;
+        }
+        return Stream.of(
+                Arguments.of("invalid-utf8.bin", new byte[] {(byte) 0xff}),
+                Arguments.of(
+                        "image.png",
+                        Base64.getDecoder()
+                                .decode(
+                                        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+jRZkAAAAASUVORK5CYII=")),
+                Arguments.of("empty.txt", new byte[0]),
+                Arguments.of("whitespace.txt", " \t\r\n".getBytes(StandardCharsets.UTF_8)),
+                Arguments.of(
+                        "utf8-crlf.txt",
+                        "hello 世界\r\nlast line\r\n".getBytes(StandardCharsets.UTF_8)),
+                Arguments.of("all-bytes.bin", allBytes));
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("fileContents")
+    void moveBetweenLocalBackendsPreservesBytes(String fileName, byte[] content) throws Exception {
+        Path sourceRoot = Files.createDirectory(workspace.resolve("source"));
+        Path targetRoot = Files.createDirectory(workspace.resolve("target"));
+        Files.write(sourceRoot.resolve(fileName), content);
+        CompositeFilesystem fs =
+                new CompositeFilesystem(local(sourceRoot), Map.of("/target/", local(targetRoot)));
+
+        WriteResult result = fs.move(RT, "/" + fileName, "/target/" + fileName);
+
+        assertTrue(result.isSuccess(), result.error());
+        assertEquals("/target/" + fileName, result.path());
+        assertArrayEquals(content, Files.readAllBytes(targetRoot.resolve(fileName)));
+        assertFalse(Files.exists(sourceRoot.resolve(fileName)));
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("fileContents")
+    void moveFromLocalToRemotePreservesBytes(String fileName, byte[] content) throws Exception {
+        Files.write(workspace.resolve(fileName), content);
+        RemoteFilesystem remote = new RemoteFilesystem(new InMemoryStore(), NAMESPACE);
+        CompositeFilesystem fs =
+                new CompositeFilesystem(local(workspace), Map.of("/target/", remote));
+
+        WriteResult result = fs.move(RT, "/" + fileName, "/target/" + fileName);
+
+        assertTrue(result.isSuccess(), result.error());
+        assertArrayEquals(content, download(remote, "/" + fileName));
+        assertFalse(Files.exists(workspace.resolve(fileName)));
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("fileContents")
+    void moveFromRemoteToLocalPreservesBytes(String fileName, byte[] content) throws Exception {
+        InMemoryStore store = new InMemoryStore();
+        putBytes(store, "/" + fileName, content);
+        RemoteFilesystem remote = new RemoteFilesystem(store, NAMESPACE);
+        CompositeFilesystem fs =
+                new CompositeFilesystem(remote, Map.of("/target/", local(workspace)));
+
+        WriteResult result = fs.move(RT, "/" + fileName, "/target/" + fileName);
+
+        assertTrue(result.isSuccess(), result.error());
+        assertArrayEquals(content, Files.readAllBytes(workspace.resolve(fileName)));
+        assertNull(store.get(NAMESPACE, "/" + fileName));
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("fileContents")
+    void moveWithinSameBackendPreservesBytes(String fileName, byte[] content) throws Exception {
+        Files.write(workspace.resolve(fileName), content);
+        LocalFilesystem backend = local(workspace);
+        CompositeFilesystem fs = new CompositeFilesystem(backend, Map.of("/target/", backend));
+
+        WriteResult result = fs.move(RT, "/" + fileName, "/target/moved-" + fileName);
+
+        assertTrue(result.isSuccess(), result.error());
+        assertArrayEquals(content, Files.readAllBytes(workspace.resolve("moved-" + fileName)));
+        assertFalse(Files.exists(workspace.resolve(fileName)));
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    void moveDoesNotOverwriteExistingTarget(boolean remoteTarget) throws Exception {
+        byte[] source = new byte[] {(byte) 0xff, 1, 2};
+        byte[] existing = new byte[] {3, 4, (byte) 0xfe};
+        Path sourceRoot = Files.createDirectory(workspace.resolve("source"));
+        Files.write(sourceRoot.resolve("file.bin"), source);
+        AbstractFilesystem target;
+        if (remoteTarget) {
+            InMemoryStore store = new InMemoryStore();
+            putBytes(store, "/file.bin", existing);
+            target = new RemoteFilesystem(store, NAMESPACE);
+        } else {
+            Path targetRoot = Files.createDirectory(workspace.resolve("target"));
+            Files.write(targetRoot.resolve("file.bin"), existing);
+            target = local(targetRoot);
+        }
+        CompositeFilesystem fs =
+                new CompositeFilesystem(local(sourceRoot), Map.of("/target/", target));
+
+        WriteResult result = fs.move(RT, "/file.bin", "/target/file.bin");
+
+        assertFalse(result.isSuccess());
+        assertArrayEquals(source, Files.readAllBytes(sourceRoot.resolve("file.bin")));
+        assertArrayEquals(existing, download(target, "/file.bin"));
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    void moveReportsSourceDeletionFailureAndPreservesBothCopies(boolean throwsException)
+            throws Exception {
+        byte[] content = "preserve both copies\r\n".getBytes(StandardCharsets.UTF_8);
+        Path sourceRoot = Files.createDirectory(workspace.resolve("source"));
+        Path targetRoot = Files.createDirectory(workspace.resolve("target"));
+        Files.write(sourceRoot.resolve("file.txt"), content);
+        LocalFilesystem source =
+                new LocalFilesystem(sourceRoot, true, 10) {
+                    @Override
+                    public WriteResult delete(RuntimeContext runtimeContext, String path) {
+                        if (throwsException) {
+                            throw new IllegalStateException("source deletion denied");
+                        }
+                        return WriteResult.fail("source deletion denied");
+                    }
+                };
+        CompositeFilesystem fs =
+                new CompositeFilesystem(source, Map.of("/target/", local(targetRoot)));
+
+        WriteResult result = fs.move(RT, "/file.txt", "/target/file.txt");
+
+        assertFalse(result.isSuccess(), "a copy without source deletion is not a successful move");
+        assertTrue(result.error().contains("source deletion denied"));
+        assertArrayEquals(content, Files.readAllBytes(sourceRoot.resolve("file.txt")));
+        assertArrayEquals(content, Files.readAllBytes(targetRoot.resolve("file.txt")));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"unsupported", "null-content", "missing-response"})
+    void movePreservesSourceWhenDownloadCannotProvideBytes(String failure) throws Exception {
+        byte[] content = new byte[] {(byte) 0xff, 1, 2};
+        Path sourceRoot = Files.createDirectory(workspace.resolve("source"));
+        Path targetRoot = Files.createDirectory(workspace.resolve("target"));
+        Files.write(sourceRoot.resolve("file.bin"), content);
+        LocalFilesystem source =
+                new LocalFilesystem(sourceRoot, true, 10) {
+                    @Override
+                    public List<FileDownloadResponse> downloadFiles(
+                            RuntimeContext runtimeContext, List<String> paths) {
+                        return switch (failure) {
+                            case "unsupported" ->
+                                    throw new UnsupportedOperationException(
+                                            "binary download is unavailable");
+                            case "null-content" ->
+                                    List.of(FileDownloadResponse.success(paths.get(0), null));
+                            default -> List.of();
+                        };
+                    }
+                };
+        CompositeFilesystem fs =
+                new CompositeFilesystem(source, Map.of("/target/", local(targetRoot)));
+
+        WriteResult result = fs.move(RT, "/file.bin", "/target/file.bin");
+
+        assertFalse(result.isSuccess());
+        assertArrayEquals(content, Files.readAllBytes(sourceRoot.resolve("file.bin")));
+        assertFalse(Files.exists(targetRoot.resolve("file.bin")));
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    void movePreservesSourceWhenTargetUploadFails(boolean throwsException) throws Exception {
+        byte[] content = new byte[] {(byte) 0xff, 1, 2};
+        Path sourceRoot = Files.createDirectory(workspace.resolve("source"));
+        Path targetRoot = Files.createDirectory(workspace.resolve("target"));
+        Files.write(sourceRoot.resolve("file.bin"), content);
+        LocalFilesystem target =
+                new LocalFilesystem(targetRoot, true, 10) {
+                    @Override
+                    public List<FileUploadResponse> uploadFiles(
+                            RuntimeContext runtimeContext,
+                            List<Map.Entry<String, byte[]>> files,
+                            UploadMode mode) {
+                        if (throwsException) {
+                            throw new IllegalStateException("upload denied");
+                        }
+                        return List.of(
+                                FileUploadResponse.fail(files.get(0).getKey(), "upload denied"));
+                    }
+                };
+        CompositeFilesystem fs =
+                new CompositeFilesystem(local(sourceRoot), Map.of("/target/", target));
+
+        WriteResult result = fs.move(RT, "/file.bin", "/target/file.bin");
+
+        assertFalse(result.isSuccess());
+        assertTrue(result.error().contains("upload denied"));
+        assertArrayEquals(content, Files.readAllBytes(sourceRoot.resolve("file.bin")));
+        assertFalse(Files.exists(targetRoot.resolve("file.bin")));
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    void concurrentMovesOnlyDeleteTheWinningSource(boolean remoteTarget) throws Exception {
+        byte[] firstContent = new byte[] {(byte) 0xff, 1, 2};
+        byte[] secondContent = new byte[] {3, 4, (byte) 0xfe};
+        Path firstRoot = Files.createDirectory(workspace.resolve("first"));
+        Path secondRoot = Files.createDirectory(workspace.resolve("second"));
+        Files.write(firstRoot.resolve("file.bin"), firstContent);
+        Files.write(secondRoot.resolve("file.bin"), secondContent);
+        CountDownLatch uploadsReady = new CountDownLatch(2);
+        AbstractFilesystem target;
+        if (remoteTarget) {
+            target =
+                    new RemoteFilesystem(new InMemoryStore(), NAMESPACE) {
+                        @Override
+                        public List<FileUploadResponse> uploadFiles(
+                                RuntimeContext runtimeContext,
+                                List<Map.Entry<String, byte[]>> files,
+                                UploadMode mode) {
+                            awaitUploads(uploadsReady);
+                            return super.uploadFiles(runtimeContext, files, mode);
+                        }
+                    };
+        } else {
+            Path targetRoot = Files.createDirectory(workspace.resolve("target"));
+            target =
+                    new LocalFilesystem(targetRoot, true, 10) {
+                        @Override
+                        public List<FileUploadResponse> uploadFiles(
+                                RuntimeContext runtimeContext,
+                                List<Map.Entry<String, byte[]>> files,
+                                UploadMode mode) {
+                            awaitUploads(uploadsReady);
+                            return super.uploadFiles(runtimeContext, files, mode);
+                        }
+                    };
+        }
+        CompositeFilesystem first =
+                new CompositeFilesystem(local(firstRoot), Map.of("/target/", target));
+        CompositeFilesystem second =
+                new CompositeFilesystem(local(secondRoot), Map.of("/target/", target));
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+        try {
+            Future<WriteResult> firstMove =
+                    executor.submit(() -> first.move(RT, "/file.bin", "/target/file.bin"));
+            Future<WriteResult> secondMove =
+                    executor.submit(() -> second.move(RT, "/file.bin", "/target/file.bin"));
+            WriteResult firstResult = firstMove.get(15, TimeUnit.SECONDS);
+            WriteResult secondResult = secondMove.get(15, TimeUnit.SECONDS);
+
+            assertEquals(
+                    1,
+                    (firstResult.isSuccess() ? 1 : 0) + (secondResult.isSuccess() ? 1 : 0),
+                    "exactly one move may create the destination");
+            Path winningRoot = firstResult.isSuccess() ? firstRoot : secondRoot;
+            Path losingRoot = firstResult.isSuccess() ? secondRoot : firstRoot;
+            byte[] winningContent = firstResult.isSuccess() ? firstContent : secondContent;
+            byte[] losingContent = firstResult.isSuccess() ? secondContent : firstContent;
+            assertFalse(Files.exists(winningRoot.resolve("file.bin")));
+            assertArrayEquals(losingContent, Files.readAllBytes(losingRoot.resolve("file.bin")));
+            assertArrayEquals(winningContent, download(target, "/file.bin"));
+        } finally {
+            executor.shutdownNow();
+            assertTrue(executor.awaitTermination(5, TimeUnit.SECONDS));
+        }
+    }
+
+    private static void awaitUploads(CountDownLatch uploadsReady) {
+        uploadsReady.countDown();
+        try {
+            assertTrue(
+                    uploadsReady.await(10, TimeUnit.SECONDS),
+                    "both moves should reach the destination before either upload begins");
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new AssertionError("interrupted while waiting for concurrent uploads", e);
+        }
+    }
+
+    private static LocalFilesystem local(Path root) {
+        return new LocalFilesystem(root, true, 10);
+    }
+
+    private static void putBytes(InMemoryStore store, String path, byte[] content) {
+        store.put(
+                NAMESPACE,
+                path,
+                Map.of(
+                        "content",
+                        Base64.getEncoder().encodeToString(content),
+                        "encoding",
+                        "base64"));
+    }
+
+    private static byte[] download(AbstractFilesystem fs, String path) {
+        List<FileDownloadResponse> responses = fs.downloadFiles(RT, List.of(path));
+        assertEquals(1, responses.size());
+        FileDownloadResponse response = responses.get(0);
+        assertTrue(response.isSuccess(), response.error());
+        return response.content();
+    }
+}

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/filesystem/CompositeFilesystemMoveTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/filesystem/CompositeFilesystemMoveTest.java
@@ -33,6 +33,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Base64;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
@@ -165,9 +166,8 @@ class CompositeFilesystemMoveTest {
     }
 
     @ParameterizedTest
-    @ValueSource(booleans = {false, true})
-    void moveReportsSourceDeletionFailureAndPreservesBothCopies(boolean throwsException)
-            throws Exception {
+    @ValueSource(strings = {"failure", "exception", "missing-response"})
+    void moveReportsSourceDeletionFailureAndPreservesBothCopies(String failure) throws Exception {
         byte[] content = "preserve both copies\r\n".getBytes(StandardCharsets.UTF_8);
         Path sourceRoot = Files.createDirectory(workspace.resolve("source"));
         Path targetRoot = Files.createDirectory(workspace.resolve("target"));
@@ -176,8 +176,11 @@ class CompositeFilesystemMoveTest {
                 new LocalFilesystem(sourceRoot, true, 10) {
                     @Override
                     public WriteResult delete(RuntimeContext runtimeContext, String path) {
-                        if (throwsException) {
+                        if (failure.equals("exception")) {
                             throw new IllegalStateException("source deletion denied");
+                        }
+                        if (failure.equals("missing-response")) {
+                            return null;
                         }
                         return WriteResult.fail("source deletion denied");
                     }
@@ -188,13 +191,27 @@ class CompositeFilesystemMoveTest {
         WriteResult result = fs.move(RT, "/file.txt", "/target/file.txt");
 
         assertFalse(result.isSuccess(), "a copy without source deletion is not a successful move");
-        assertTrue(result.error().contains("source deletion denied"));
+        assertTrue(result.error().contains("could not delete source"));
+        assertTrue(
+                result.error()
+                        .contains(
+                                failure.equals("missing-response")
+                                        ? "missing delete response"
+                                        : "source deletion denied"));
         assertArrayEquals(content, Files.readAllBytes(sourceRoot.resolve("file.txt")));
         assertArrayEquals(content, Files.readAllBytes(targetRoot.resolve("file.txt")));
     }
 
     @ParameterizedTest
-    @ValueSource(strings = {"unsupported", "null-content", "missing-response"})
+    @ValueSource(
+            strings = {
+                "unsupported",
+                "null-content",
+                "missing-response",
+                "null-list",
+                "null-entry",
+                "failure"
+            })
     void movePreservesSourceWhenDownloadCannotProvideBytes(String failure) throws Exception {
         byte[] content = new byte[] {(byte) 0xff, 1, 2};
         Path sourceRoot = Files.createDirectory(workspace.resolve("source"));
@@ -211,6 +228,12 @@ class CompositeFilesystemMoveTest {
                                             "binary download is unavailable");
                             case "null-content" ->
                                     List.of(FileDownloadResponse.success(paths.get(0), null));
+                            case "null-list" -> null;
+                            case "null-entry" -> Collections.singletonList(null);
+                            case "failure" ->
+                                    List.of(
+                                            FileDownloadResponse.fail(
+                                                    paths.get(0), "download denied"));
                             default -> List.of();
                         };
                     }
@@ -221,13 +244,17 @@ class CompositeFilesystemMoveTest {
         WriteResult result = fs.move(RT, "/file.bin", "/target/file.bin");
 
         assertFalse(result.isSuccess());
+        assertTrue(result.error().contains("/file.bin"));
+        if (failure.equals("failure")) {
+            assertTrue(result.error().contains("download denied"));
+        }
         assertArrayEquals(content, Files.readAllBytes(sourceRoot.resolve("file.bin")));
         assertFalse(Files.exists(targetRoot.resolve("file.bin")));
     }
 
     @ParameterizedTest
-    @ValueSource(booleans = {false, true})
-    void movePreservesSourceWhenTargetUploadFails(boolean throwsException) throws Exception {
+    @ValueSource(strings = {"failure", "exception", "null-list", "null-entry", "missing-response"})
+    void movePreservesSourceWhenTargetUploadFails(String failure) throws Exception {
         byte[] content = new byte[] {(byte) 0xff, 1, 2};
         Path sourceRoot = Files.createDirectory(workspace.resolve("source"));
         Path targetRoot = Files.createDirectory(workspace.resolve("target"));
@@ -239,11 +266,16 @@ class CompositeFilesystemMoveTest {
                             RuntimeContext runtimeContext,
                             List<Map.Entry<String, byte[]>> files,
                             UploadMode mode) {
-                        if (throwsException) {
-                            throw new IllegalStateException("upload denied");
-                        }
-                        return List.of(
-                                FileUploadResponse.fail(files.get(0).getKey(), "upload denied"));
+                        return switch (failure) {
+                            case "exception" -> throw new IllegalStateException("upload denied");
+                            case "null-list" -> null;
+                            case "null-entry" -> Collections.singletonList(null);
+                            case "missing-response" -> List.of();
+                            default ->
+                                    List.of(
+                                            FileUploadResponse.fail(
+                                                    files.get(0).getKey(), "upload denied"));
+                        };
                     }
                 };
         CompositeFilesystem fs =
@@ -252,7 +284,8 @@ class CompositeFilesystemMoveTest {
         WriteResult result = fs.move(RT, "/file.bin", "/target/file.bin");
 
         assertFalse(result.isSuccess());
-        assertTrue(result.error().contains("upload denied"));
+        assertTrue(result.error().contains("upload"));
+        assertTrue(result.error().contains("/target/file.bin"));
         assertArrayEquals(content, Files.readAllBytes(sourceRoot.resolve("file.bin")));
         assertFalse(Files.exists(targetRoot.resolve("file.bin")));
     }

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/filesystem/FilesystemUploadModeTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/filesystem/FilesystemUploadModeTest.java
@@ -34,6 +34,7 @@ import io.agentscope.harness.agent.filesystem.remote.store.InMemoryStore;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.AbstractMap.SimpleImmutableEntry;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
@@ -49,10 +50,16 @@ class FilesystemUploadModeTest {
     @TempDir Path workspace;
 
     @ParameterizedTest
-    @ValueSource(booleans = {false, true})
-    void overwriteModeReplacesFilesCreatedByLegacyUpload(boolean remote) {
+    @ValueSource(strings = {"local", "remote", "overlay"})
+    void overwriteModeReplacesFilesCreatedByLegacyUpload(String backend) {
         AbstractFilesystem fs =
-                remote ? new RemoteFilesystem(new InMemoryStore()) : local(workspace);
+                switch (backend) {
+                    case "remote" -> new RemoteFilesystem(new InMemoryStore());
+                    case "overlay" ->
+                            new OverlayFilesystem(
+                                    local(workspace), new RemoteFilesystem(new InMemoryStore()));
+                    default -> local(workspace);
+                };
         byte[] original = "original".getBytes(StandardCharsets.UTF_8);
         byte[] replacement = "replacement\r\n".getBytes(StandardCharsets.UTF_8);
         FileUploadResponse initial =
@@ -68,6 +75,30 @@ class FilesystemUploadModeTest {
 
         assertTrue(result.isSuccess(), result.error());
         assertArrayEquals(replacement, download(fs, RT, "/file.txt"));
+    }
+
+    @Test
+    void defaultCreateNewRejectsNullContentAndContinuesBatch() throws Exception {
+        OverlayFilesystem fs =
+                new OverlayFilesystem(local(workspace), new RemoteFilesystem(new InMemoryStore()));
+        byte[] content = "valid content\r\n".getBytes(StandardCharsets.UTF_8);
+
+        List<FileUploadResponse> responses =
+                fs.uploadFiles(
+                        RT,
+                        List.of(
+                                new SimpleImmutableEntry<String, byte[]>("/missing.txt", null),
+                                Map.entry("/valid.txt", content)),
+                        UploadMode.CREATE_NEW);
+
+        assertEquals(2, responses.size());
+        assertEquals("/missing.txt", responses.get(0).path());
+        assertFalse(responses.get(0).isSuccess());
+        assertNotNull(responses.get(0).error());
+        assertEquals("/valid.txt", responses.get(1).path());
+        assertTrue(responses.get(1).isSuccess(), responses.get(1).error());
+        assertFalse(Files.exists(workspace.resolve("missing.txt")));
+        assertArrayEquals(content, Files.readAllBytes(workspace.resolve("valid.txt")));
     }
 
     @Test

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/filesystem/FilesystemUploadModeTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/filesystem/FilesystemUploadModeTest.java
@@ -1,0 +1,206 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.harness.agent.filesystem;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.agentscope.core.agent.RuntimeContext;
+import io.agentscope.harness.agent.filesystem.local.LocalFilesystem;
+import io.agentscope.harness.agent.filesystem.local.LocalFilesystemWithShell;
+import io.agentscope.harness.agent.filesystem.model.FileDownloadResponse;
+import io.agentscope.harness.agent.filesystem.model.FileUploadResponse;
+import io.agentscope.harness.agent.filesystem.model.UploadMode;
+import io.agentscope.harness.agent.filesystem.model.WriteResult;
+import io.agentscope.harness.agent.filesystem.remote.RemoteFilesystem;
+import io.agentscope.harness.agent.filesystem.remote.store.InMemoryStore;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+/** Upload modes preserve existing backend behavior through filesystem wrappers. */
+class FilesystemUploadModeTest {
+
+    private static final RuntimeContext RT = RuntimeContext.empty();
+
+    @TempDir Path workspace;
+
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    void overwriteModeReplacesFilesCreatedByLegacyUpload(boolean remote) {
+        AbstractFilesystem fs =
+                remote ? new RemoteFilesystem(new InMemoryStore()) : local(workspace);
+        byte[] original = "original".getBytes(StandardCharsets.UTF_8);
+        byte[] replacement = "replacement\r\n".getBytes(StandardCharsets.UTF_8);
+        FileUploadResponse initial =
+                fs.uploadFiles(RT, List.of(Map.entry("/file.txt", original))).get(0);
+        assertTrue(initial.isSuccess(), initial.error());
+
+        FileUploadResponse result =
+                fs.uploadFiles(
+                                RT,
+                                List.of(Map.entry("/file.txt", replacement)),
+                                UploadMode.OVERWRITE)
+                        .get(0);
+
+        assertTrue(result.isSuccess(), result.error());
+        assertArrayEquals(replacement, download(fs, RT, "/file.txt"));
+    }
+
+    @Test
+    void defaultCreateNewCreatesUtf8InUpperWithoutChangingSharedLower() throws Exception {
+        Path upperRoot = Files.createDirectory(workspace.resolve("upper"));
+        Path lowerRoot = Files.createDirectory(workspace.resolve("lower"));
+        byte[] shared = "shared original".getBytes(StandardCharsets.UTF_8);
+        byte[] customized = " \t用户内容\r\n".getBytes(StandardCharsets.UTF_8);
+        Files.write(lowerRoot.resolve("file.txt"), shared);
+        OverlayFilesystem overlay = new OverlayFilesystem(local(upperRoot), local(lowerRoot));
+
+        FileUploadResponse result =
+                overlay.uploadFiles(
+                                RT,
+                                List.of(Map.entry("/file.txt", customized)),
+                                UploadMode.CREATE_NEW)
+                        .get(0);
+
+        assertTrue(result.isSuccess(), result.error());
+        assertArrayEquals(customized, Files.readAllBytes(upperRoot.resolve("file.txt")));
+        assertArrayEquals(shared, Files.readAllBytes(lowerRoot.resolve("file.txt")));
+        assertArrayEquals(customized, download(overlay, RT, "/file.txt"));
+    }
+
+    @Test
+    void defaultCreateNewRejectsExistingUpperFile() throws Exception {
+        Path upperRoot = Files.createDirectory(workspace.resolve("upper"));
+        Path lowerRoot = Files.createDirectory(workspace.resolve("lower"));
+        byte[] original = "existing customization".getBytes(StandardCharsets.UTF_8);
+        Files.write(upperRoot.resolve("file.txt"), original);
+        OverlayFilesystem overlay = new OverlayFilesystem(local(upperRoot), local(lowerRoot));
+
+        FileUploadResponse result =
+                overlay.uploadFiles(
+                                RT,
+                                List.of(
+                                        Map.entry(
+                                                "/file.txt",
+                                                "replacement".getBytes(StandardCharsets.UTF_8))),
+                                UploadMode.CREATE_NEW)
+                        .get(0);
+
+        assertFalse(result.isSuccess());
+        assertArrayEquals(original, Files.readAllBytes(upperRoot.resolve("file.txt")));
+        assertFalse(Files.exists(lowerRoot.resolve("file.txt")));
+    }
+
+    @Test
+    void defaultCreateNewRejectsInvalidUtf8AndMoveRetainsSource() throws Exception {
+        Path sourceRoot = Files.createDirectory(workspace.resolve("source"));
+        Path upperRoot = Files.createDirectory(workspace.resolve("upper"));
+        Path lowerRoot = Files.createDirectory(workspace.resolve("lower"));
+        byte[] content = new byte[] {(byte) 0xff, 1, 2};
+        Files.write(sourceRoot.resolve("file.bin"), content);
+        OverlayFilesystem overlay = new OverlayFilesystem(local(upperRoot), local(lowerRoot));
+        FileUploadResponse upload =
+                overlay.uploadFiles(
+                                RT, List.of(Map.entry("/file.bin", content)), UploadMode.CREATE_NEW)
+                        .get(0);
+        assertFalse(upload.isSuccess());
+        CompositeFilesystem fs =
+                new CompositeFilesystem(local(sourceRoot), Map.of("/target/", overlay));
+
+        WriteResult result = fs.move(RT, "/file.bin", "/target/file.bin");
+
+        assertFalse(result.isSuccess());
+        assertArrayEquals(content, Files.readAllBytes(sourceRoot.resolve("file.bin")));
+        assertFalse(Files.exists(upperRoot.resolve("file.bin")));
+        assertFalse(Files.exists(lowerRoot.resolve("file.bin")));
+    }
+
+    @Test
+    void binaryCreateNewUsesNestedRoutesAndBakedNamespace() throws Exception {
+        RuntimeContext baked = RuntimeContext.builder().userId("alice").build();
+        RuntimeContext caller = RuntimeContext.builder().userId("bob").build();
+        InMemoryStore store = new InMemoryStore();
+        RemoteFilesystem remote =
+                new RemoteFilesystem(store, context -> List.of("files", context.getUserId()));
+        Path innerRoot = Files.createDirectory(workspace.resolve("inner-default"));
+        Path outerRoot = Files.createDirectory(workspace.resolve("outer-default"));
+        CompositeFilesystem inner =
+                new CompositeFilesystem(local(innerRoot), Map.of("/objects/", remote));
+        CompositeFilesystem outer =
+                new CompositeFilesystem(local(outerRoot), Map.of("/archive/", inner));
+        BakedContextFilesystem fs = new BakedContextFilesystem(outer, baked);
+        byte[] content = new byte[] {0, (byte) 0xff, 1, (byte) 0xfe};
+        String path = "/archive/objects/file.bin";
+
+        List<FileUploadResponse> responses =
+                fs.uploadFiles(caller, List.of(Map.entry(path, content)), UploadMode.CREATE_NEW);
+
+        assertEquals(1, responses.size());
+        assertTrue(responses.get(0).isSuccess(), responses.get(0).error());
+        assertEquals(path, responses.get(0).path());
+        assertNotNull(store.get(List.of("files", "alice"), "/file.bin"));
+        assertNull(store.get(List.of("files", "bob"), "/file.bin"));
+        assertArrayEquals(content, download(remote, baked, "/file.bin"));
+        assertFalse(Files.exists(innerRoot.resolve("objects/file.bin")));
+        assertFalse(Files.exists(outerRoot.resolve("archive/objects/file.bin")));
+    }
+
+    @Test
+    void routedSandboxForwardsBinaryCreateNewToMountedBackend() throws Exception {
+        Path primaryRoot = Files.createDirectory(workspace.resolve("primary"));
+        Path mountedRoot = Files.createDirectory(workspace.resolve("mounted"));
+        LocalFilesystemWithShell primary =
+                new LocalFilesystemWithShell(primaryRoot, true, 10, 1024, Map.of(), false);
+        RoutedSandboxFilesystem fs =
+                new RoutedSandboxFilesystem(primary, Map.of("/mounted/", local(mountedRoot)));
+        byte[] content = new byte[] {(byte) 0xff, 0, (byte) 0xfe};
+
+        List<FileUploadResponse> responses =
+                fs.uploadFiles(
+                        RT,
+                        List.of(Map.entry("/mounted/file.bin", content)),
+                        UploadMode.CREATE_NEW);
+
+        assertEquals(1, responses.size());
+        assertTrue(responses.get(0).isSuccess(), responses.get(0).error());
+        assertEquals("/mounted/file.bin", responses.get(0).path());
+        assertArrayEquals(content, Files.readAllBytes(mountedRoot.resolve("file.bin")));
+        assertFalse(Files.exists(primaryRoot.resolve("mounted/file.bin")));
+    }
+
+    private static LocalFilesystem local(Path root) {
+        return new LocalFilesystem(root, true, 10);
+    }
+
+    private static byte[] download(AbstractFilesystem fs, RuntimeContext context, String path) {
+        List<FileDownloadResponse> responses = fs.downloadFiles(context, List.of(path));
+        assertEquals(1, responses.size());
+        FileDownloadResponse response = responses.get(0);
+        assertTrue(response.isSuccess(), response.error());
+        return response.content();
+    }
+}

--- a/docs/v2/en/docs/harness/filesystem.md
+++ b/docs/v2/en/docs/harness/filesystem.md
@@ -486,6 +486,14 @@ All file tools call through the `AbstractFilesystem` interface, passing the curr
 | Shared store | `CompositeFilesystem`: routed paths go through KV overlay (remote upper + local template lower); others go local |
 | Sandbox | All file operations forwarded into the sandbox container |
 
+#### Moving files across backends
+
+When the source and destination resolve to different backends, `CompositeFilesystem.move(...)` downloads the original bytes, uploads them with `UploadMode.CREATE_NEW`, and deletes the source only after the upload succeeds. `LocalFilesystem` and `RemoteFilesystem` support this transfer for binary files as well as empty and whitespace-only text. An existing destination is not overwritten; the original `uploadFiles(...)` overload retains its overwrite behavior.
+
+Backends must support raw-byte downloads and create-only uploads for the source content to participate in cross-backend moves. The default `CREATE_NEW` implementation accepts valid UTF-8 bytes through the backend's existing `write(...)` method; other byte sequences require an override. Creation and layer semantics depend on that backend. If a required capability is unavailable, the move fails without deleting the source. This includes sources such as the service's `MemoryStoreFilesystem`, which does not implement downloads. `RemoteFilesystem` also requires its `BaseStore` to support conditional creation (`putIfVersion` with version `0`).
+
+A cross-backend move is not atomic. If the destination has been written but deleting the source fails, the result reports that the copy succeeded and source deletion failed; the destination is retained. Check the result before retrying, since both copies may now exist. Moves within the same backend continue to use that backend's own `move(...)` implementation.
+
 ### Shell execution (execute)
 
 | Mode | Shell available? | Where it runs |

--- a/docs/v2/zh/docs/harness/filesystem.md
+++ b/docs/v2/zh/docs/harness/filesystem.md
@@ -486,6 +486,14 @@ workspace/
 | 共享存储 | `CompositeFilesystem`：命中路由的路径走 KV overlay（远端上层 + 本地模板下层），其余走本地 |
 | 沙箱 | 所有文件操作转发到沙箱容器内 |
 
+#### 跨后端移动文件
+
+源和目标被路由到不同后端时，`CompositeFilesystem.move(...)` 先下载原始字节，再以 `UploadMode.CREATE_NEW` 上传，上传成功后才删除源文件。`LocalFilesystem` 和 `RemoteFilesystem` 支持按此方式移动二进制文件、空文件和纯空白文本。已有目标不会被覆盖；原有 `uploadFiles(...)` 重载仍保留覆盖写入行为。
+
+后端需要支持原始字节下载，以及对源内容的仅创建上传，才能参与跨后端移动。默认 `CREATE_NEW` 实现会将合法 UTF-8 字节交给后端原有的 `write(...)` 方法，其他字节序列需要后端重写该接口；创建和分层语义由具体后端决定。缺少所需能力时，移动失败并保留源文件。例如，服务侧的 `MemoryStoreFilesystem` 尚未实现下载，因此不能作为跨后端移动的源。`RemoteFilesystem` 还要求底层 `BaseStore` 支持条件创建（`putIfVersion` 的版本参数为 `0`）。
+
+跨后端移动不是原子操作。如果目标已经写入，但源文件删除失败，结果会说明复制成功、源删除失败，并保留目标文件。重试前请检查结果，此时可能同时存在两份文件。同一后端内的移动仍调用该后端自己的 `move(...)` 实现。
+
 ### Shell 执行（execute）
 
 | 模式 | Shell 可用？ | 执行位置 |


### PR DESCRIPTION
## AgentScope-Java Version

2.0.3-SNAPSHOT, synchronized with main at `97696a3a`.

## Description

Fixes #3042.

Cross-backend `CompositeFilesystem.move` copies the display-oriented `read` result, which can contain Base64 or an empty-file reminder instead of the original bytes. A 68-byte PNG becomes 92 bytes of Base64 text, and an empty file becomes 51 bytes of reminder text; the source is then deleted.

This change downloads the original bytes, uploads them with `UploadMode.CREATE_NEW`, and deletes the source only after a successful upload. It reports download, upload, and deletion failures. If source deletion fails after the copy, the destination is retained and the result identifies the partial failure. Cross-backend moves remain non-atomic, and the original upload overload keeps its existing behavior.

The API Javadoc and English and Chinese filesystem docs describe the supported backends and limits:

- Local, including LocalWithShell, and Remote preserve arbitrary bytes. Remote uses reversible UTF-8 or Base64 encoding and requires `BaseStore.putIfVersion(..., 0)` for conditional creation.
- Composite, BakedContext, and RoutedSandbox forward the selected backend's capability. Overlay and SandboxBacked, including PinnedSandbox, currently use the strict UTF-8 default for create-only uploads and reject other byte sequences.
- Concurrent-writer protection depends on the backend's atomic creation support. Overlay may create an upper-layer file that shadows a lower-layer file without changing the lower-layer original.
- A backend without raw downloads, such as the service's `MemoryStoreFilesystem`, fails the move without deleting the source.

Includes 60 regression cases for byte preservation, empty and whitespace-only text, existing destinations, competing writers, transfer and deletion failures, legacy uploads, wrapper routing, and runtime context. The branch includes the upstream truncated-download safeguard from #2923, with three additional cases that verify source retention, unchanged destinations, and continuation of later downloads in a batch.

## Validation

- Before the original fix, the initial 27-case regression suite had 16 expected failures. The three sandbox truncation cases also failed on `c54be700`, reproducing a 400,000-byte source reduced to 388,110 bytes and then deleted; they pass with the upstream safeguard.
- `mvn -B -pl agentscope-harness -am spotless:apply clean verify` passed on `5b0d6102`: Core 2,344 tests / 9 skipped; AG-UI 509 tests / 0 skipped; Harness 1,100 tests / 14 skipped; zero failures or errors. This included Spotless checks and Javadoc generation.
- The final commit `59299437` changes only the two filesystem docs. A fresh targeted run of `CompositeFilesystemMoveTest`, `FilesystemUploadModeTest`, `BackendUploadModeFailureTest`, and `SandboxBackedFilesystemTest` passed all 77 cases, including all 60 PR regression cases, with `spotless:check`.
- `git diff --check` passed. All seven upstream checks passed for the final head `59299437`: Linux and Windows builds, Codecov patch coverage, documentation validation, license, module sync, and CLA. See [CI](https://github.com/agentscope-ai/agentscope-java/actions/runs/34975957830).

## Checklist

- [x] Code has been formatted with `mvn spotless:apply`
- [x] All tests are passing (`mvn test`) — local validation and upstream Linux and Windows builds passed for the final head.
- [x] Javadoc comments are complete and follow project conventions
- [x] Related documentation has been updated
- [x] Code is ready for review