### PR TITLE
fix(core): persist state after empty agent results

### DIFF
--- a/agentscope-core/src/main/java/io/agentscope/core/ReActAgent.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/ReActAgent.java
@@ -1215,7 +1215,12 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
                     }
                     return scope.doCallInner(msgs)
                             .onErrorResume(error -> saveStateAfterCallFailure(scope, error))
-                            .flatMap(result -> saveStateToSession(scope).thenReturn(result));
+                            .flatMap(result -> saveStateToSession(scope).thenReturn(result))
+                            .switchIfEmpty(
+                                    Mono.defer(
+                                            () ->
+                                                    saveStateToSession(scope)
+                                                            .then(Mono.<Msg>empty())));
                 });
     }
 
@@ -1311,6 +1316,11 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
                                         Msg out = wrapNativeStructuredResult(result);
                                         return saveStateToSession(scope).thenReturn(out);
                                     })
+                            .switchIfEmpty(
+                                    Mono.defer(
+                                            () ->
+                                                    saveStateToSession(scope)
+                                                            .then(Mono.<Msg>empty())))
                             .doOnError(
                                     e -> {
                                         List<Msg> ctx = scope.state.contextMutable();
@@ -1371,7 +1381,12 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
                                             scope.state.contextMutable().add(out);
                                         }
                                         return saveStateToSession(scope).thenReturn(out);
-                                    });
+                                    })
+                            .switchIfEmpty(
+                                    Mono.defer(
+                                            () ->
+                                                    saveStateToSession(scope)
+                                                            .then(Mono.<Msg>empty())));
                 });
     }
 

--- a/agentscope-core/src/test/java/io/agentscope/core/agent/ReActAgentCallFailurePersistenceTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/agent/ReActAgentCallFailurePersistenceTest.java
@@ -17,6 +17,7 @@ package io.agentscope.core.agent;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -190,6 +191,56 @@ class ReActAgentCallFailurePersistenceTest {
         assertFalse(textContents(persisted.getContext()).contains("incomplete answer"));
     }
 
+    @Test
+    @DisplayName("empty model response persists the user input")
+    void emptyModelResponsePersistsUserInput() {
+        InMemoryAgentStateStore store = new InMemoryAgentStateStore();
+        ReActAgent agent = agent(new EmptyResponseModel(), store);
+
+        assertNull(
+                agent.call(List.of(userMsg("empty response request"))).block(),
+                "an empty model response should complete without a result message");
+
+        AgentState persisted =
+                store.get(null, agent.getDefaultSessionId(), "agent_state", AgentState.class)
+                        .orElseThrow();
+        assertEquals(List.of("empty response request"), textContents(persisted.getContext()));
+        assertEquals(
+                List.of(MsgRole.USER), persisted.getContext().stream().map(Msg::getRole).toList());
+    }
+
+    @Test
+    @DisplayName("empty fallback structured response persists the user input")
+    void emptyFallbackStructuredResponsePersistsUserInput() {
+        InMemoryAgentStateStore store = new InMemoryAgentStateStore();
+        ReActAgent agent = agent(new EmptyResponseModel(), store);
+
+        assertNull(
+                agent.call(List.of(userMsg("empty fallback request")), StructuredReply.class)
+                        .block());
+
+        AgentState persisted =
+                store.get(null, agent.getDefaultSessionId(), "agent_state", AgentState.class)
+                        .orElseThrow();
+        assertEquals(List.of("empty fallback request"), textContents(persisted.getContext()));
+    }
+
+    @Test
+    @DisplayName("empty native structured response persists the user input")
+    void emptyNativeStructuredResponsePersistsUserInput() {
+        InMemoryAgentStateStore store = new InMemoryAgentStateStore();
+        ReActAgent agent = agent(new EmptyResponseModel(true), store);
+
+        assertNull(
+                agent.call(List.of(userMsg("empty native request")), StructuredReply.class)
+                        .block());
+
+        AgentState persisted =
+                store.get(null, agent.getDefaultSessionId(), "agent_state", AgentState.class)
+                        .orElseThrow();
+        assertEquals(List.of("empty native request"), textContents(persisted.getContext()));
+    }
+
     private static ReActAgent agent(ChatModelBase model, InMemoryAgentStateStore store) {
         return ReActAgent.builder()
                 .name("asst")
@@ -299,6 +350,34 @@ class ReActAgentCallFailurePersistenceTest {
 
         private List<List<Msg>> calls() {
             return calls;
+        }
+    }
+
+    private static final class EmptyResponseModel extends ChatModelBase {
+        private final boolean nativeStructuredOutput;
+
+        private EmptyResponseModel() {
+            this(false);
+        }
+
+        private EmptyResponseModel(boolean nativeStructuredOutput) {
+            this.nativeStructuredOutput = nativeStructuredOutput;
+        }
+
+        @Override
+        public boolean supportsNativeStructuredOutput() {
+            return nativeStructuredOutput;
+        }
+
+        @Override
+        public String getModelName() {
+            return "empty-response";
+        }
+
+        @Override
+        protected Flux<ChatResponse> doStream(
+                List<Msg> messages, List<ToolSchema> tools, GenerateOptions options) {
+            return Flux.just(ChatResponse.builder().content(List.of()).build());
         }
     }
 


### PR DESCRIPTION
**背景**: ReActAgent 执行完后，结果为空（`buildFinalMessage()`返回 null）时，外层调用生命周期不会执行`saveStateToSession()`，重建会话后用户输入就会丢失。

**解决方法**：空响应依然保存State
Related to #2702.