### PR TITLE
feat(harness): support multi-keyword search modes

### DIFF
--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/tool/MemorySearchTool.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/tool/MemorySearchTool.java
@@ -21,7 +21,6 @@ import io.agentscope.core.tool.ToolParam;
 import io.agentscope.harness.agent.workspace.WorkspaceManager;
 import java.util.List;
 import java.util.StringJoiner;
-import java.util.regex.Pattern;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -52,22 +51,30 @@ public class MemorySearchTool {
     public String memorySearch(
             RuntimeContext runtimeContext,
             @ToolParam(name = "query", description = "Keywords to search for in memory files")
-                    String query) {
+                    String query,
+            @ToolParam(
+                            name = "matchMode",
+                            description = "Matching mode: phrase (default), all, or any",
+                            required = false)
+                    String matchMode) {
         if (query == null || query.isBlank()) {
             return "No query provided";
         }
 
         RuntimeContext rc = runtimeContext != null ? runtimeContext : RuntimeContext.empty();
-        return keywordSearch(rc, query);
+        return keywordSearch(rc, query, SearchMatchMode.parse(matchMode));
     }
 
-    private String keywordSearch(RuntimeContext rc, String query) {
+    /** Preserves the pre-matchMode Java entry point for direct callers. */
+    public String memorySearch(RuntimeContext runtimeContext, String query) {
+        return memorySearch(runtimeContext, query, null);
+    }
+
+    private String keywordSearch(RuntimeContext rc, String query, SearchMatchMode matchMode) {
         StringJoiner results = new StringJoiner("\n");
         int matchCount = 0;
 
         List<String> memoryPaths = workspaceManager.listMemoryFilePaths(rc);
-        Pattern pattern = Pattern.compile(Pattern.quote(query), Pattern.CASE_INSENSITIVE);
-
         for (String relativePath : memoryPaths) {
             String content = workspaceManager.readManagedWorkspaceFileUtf8(rc, relativePath);
             if (content == null || content.isEmpty()) {
@@ -75,7 +82,7 @@ public class MemorySearchTool {
             }
             String[] lines = content.split("\n", -1);
             for (int i = 0; i < lines.length; i++) {
-                if (pattern.matcher(lines[i]).find()) {
+                if (matchMode.matches(lines[i], query)) {
                     results.add(String.format("Source: %s#%d: %s", relativePath, i + 1, lines[i]));
                     matchCount++;
                 }

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/tool/SearchMatchMode.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/tool/SearchMatchMode.java
@@ -6,6 +6,12 @@
  * You may obtain a copy of the License at
  *
  *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package io.agentscope.harness.agent.tool;
 

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/tool/SearchMatchMode.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/tool/SearchMatchMode.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.agentscope.harness.agent.tool;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Locale;
+import java.util.regex.Pattern;
+
+/** Matching modes shared by the memory and session search tools. */
+enum SearchMatchMode {
+    PHRASE,
+    ALL,
+    ANY;
+
+    static SearchMatchMode parse(String value) {
+        if (value == null || value.isBlank()) {
+            return PHRASE;
+        }
+        try {
+            return valueOf(value.trim().toUpperCase(Locale.ROOT));
+        } catch (IllegalArgumentException ignored) {
+            return PHRASE;
+        }
+    }
+
+    boolean matches(String text, String query) {
+        if (text == null || query == null) {
+            return false;
+        }
+        if (this == PHRASE) {
+            return Pattern.compile(Pattern.quote(query), Pattern.CASE_INSENSITIVE)
+                    .matcher(text)
+                    .find();
+        }
+        List<String> keywords =
+                Arrays.stream(query.trim().split("\\s+"))
+                        .filter(keyword -> !keyword.isEmpty())
+                        .toList();
+        if (keywords.isEmpty()) {
+            return false;
+        }
+        String lowerText = text.toLowerCase(Locale.ROOT);
+        return this == ALL
+                ? keywords.stream()
+                        .allMatch(keyword -> lowerText.contains(keyword.toLowerCase(Locale.ROOT)))
+                : keywords.stream()
+                        .anyMatch(keyword -> lowerText.contains(keyword.toLowerCase(Locale.ROOT)));
+    }
+}

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/tool/SessionSearchTool.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/tool/SessionSearchTool.java
@@ -68,7 +68,12 @@ public class SessionSearchTool {
                             name = "maxResults",
                             description = "Maximum number of results to return (default: 10)",
                             required = false)
-                    Integer maxResults) {
+                    Integer maxResults,
+            @ToolParam(
+                            name = "matchMode",
+                            description = "Matching mode: phrase (default), all, or any",
+                            required = false)
+                    String matchMode) {
         if (query == null || query.isBlank()) {
             return "Error: query is required";
         }
@@ -76,7 +81,7 @@ public class SessionSearchTool {
         RuntimeContext rc = runtimeContext != null ? runtimeContext : RuntimeContext.empty();
         int limit = maxResults != null && maxResults > 0 ? maxResults : 10;
         String effectiveAgentId = agentId != null && !agentId.isBlank() ? agentId : null;
-        String lowerQuery = query.toLowerCase();
+        SearchMatchMode searchMatchMode = SearchMatchMode.parse(matchMode);
 
         List<String> results = new ArrayList<>();
 
@@ -85,7 +90,7 @@ public class SessionSearchTool {
             if (results.size() >= limit) {
                 break;
             }
-            searchInSessionFile(file, lowerQuery, results, limit);
+            searchInSessionFile(file, query, searchMatchMode, results, limit);
         }
 
         if (results.isEmpty()) {
@@ -98,6 +103,12 @@ public class SessionSearchTool {
             sb.append(result).append("\n");
         }
         return sb.toString();
+    }
+
+    /** Preserves the pre-matchMode Java entry point for direct callers. */
+    public String sessionSearch(
+            RuntimeContext runtimeContext, String query, String agentId, Integer maxResults) {
+        return sessionSearch(runtimeContext, query, agentId, maxResults, null);
     }
 
     @Tool(
@@ -267,7 +278,11 @@ public class SessionSearchTool {
     }
 
     private void searchInSessionFile(
-            Path logFile, String lowerQuery, List<String> results, int limit) {
+            Path logFile,
+            String query,
+            SearchMatchMode matchMode,
+            List<String> results,
+            int limit) {
         try {
             Path contextFile =
                     logFile.resolveSibling(
@@ -285,7 +300,7 @@ public class SessionSearchTool {
                     break;
                 }
                 String content = searchableText(entry);
-                if (content != null && content.toLowerCase().contains(lowerQuery)) {
+                if (matchMode.matches(content, query)) {
                     String preview =
                             content.length() > 200 ? content.substring(0, 200) + "..." : content;
                     String roleLabel =

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/tool/SearchMatchModeTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/tool/SearchMatchModeTest.java
@@ -6,6 +6,12 @@
  * You may obtain a copy of the License at
  *
  *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package io.agentscope.harness.agent.tool;
 

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/tool/SearchMatchModeTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/tool/SearchMatchModeTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.agentscope.harness.agent.tool;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+class SearchMatchModeTest {
+
+    @Test
+    void defaultsToPhraseAndTreatsQueryLiterally() {
+        assertTrue(SearchMatchMode.parse(null).matches("deploy [blue]", "deploy [blue]"));
+        assertFalse(SearchMatchMode.parse(null).matches("deploy blue", "deploy [blue]"));
+    }
+
+    @Test
+    void allMatchesEveryKeywordWithinOneRecord() {
+        assertTrue(SearchMatchMode.ALL.matches("Deploy using Blue Whale", "deploy whale"));
+        assertFalse(SearchMatchMode.ALL.matches("Deploy using Blue", "deploy whale"));
+    }
+
+    @Test
+    void anyMatchesAtLeastOneKeywordWithinOneRecord() {
+        assertTrue(SearchMatchMode.ANY.matches("port is 9580", "deploy 9580"));
+        assertFalse(SearchMatchMode.ANY.matches("port is 9580", "deploy whale"));
+    }
+
+    @Test
+    void blankAndUnknownModesPreservePhraseSemantics() {
+        assertTrue(SearchMatchMode.parse(" ").matches("a b", "a b"));
+        assertTrue(SearchMatchMode.parse("future").matches("a b", "a b"));
+        assertFalse(SearchMatchMode.parse("future").matches("a b", "a c"));
+    }
+}


### PR DESCRIPTION
Closes #3054

## What does this PR do?

Adds an optional `matchMode` parameter to `memory_search` and `session_search`.

- `phrase` (default) preserves the existing literal full-query behavior.
- `all` matches records containing every whitespace-separated keyword.
- `any` matches records containing at least one keyword.

Matching remains case-insensitive and literal. Memory searches remain line-scoped, session searches remain entry-scoped, and keywords are never combined across records.

## Compatibility

- Existing Java overloads remain available.
- Missing, blank, or unknown modes fall back to `phrase`.
- No tokenizer, semantic search dependency, or storage format change.

## Verification

`mvn -s /Users/yohanes/.m2/settings-public-central.xml -pl agentscope-harness -am -Dtest=SearchMatchModeTest -Dsurefire.failIfNoSpecifiedTests=false -Dcheckstyle.skip=true -Dspotless.check.skip=true test`

Result: 4 tests passed.
